### PR TITLE
Add support for IKEA Tradfri Light bulbs

### DIFF
--- a/zhaquirks/ikea/tradfrilight.py
+++ b/zhaquirks/ikea/tradfrilight.py
@@ -23,7 +23,6 @@ class TradfriColorTempLightBulb(CustomDevice):
     Tradfri light bulbs, dimmable, white spectrum.
 
     This quirk has been testeed the LED1545G12 but should work with a range of those bulbs.
-    It changes the profile_id from ZHA to ZLL.
     """
 
     signature = {
@@ -60,8 +59,8 @@ class TradfriColorTempLightBulb(CustomDevice):
     replacement = {
         "endpoints": {
             1: {
-                "profile_id": zll.PROFILE_ID,
-                "device_type": zll.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                "profile_id": zha.PROFILE_ID,
+                "device_type": zha.DeviceType.COLOR_TEMPERATURE_LIGHT,
                 "input_clusters": [
                     Basic.cluster_id,
                     Identify.cluster_id,

--- a/zhaquirks/ikea/tradfrilight.py
+++ b/zhaquirks/ikea/tradfrilight.py
@@ -1,0 +1,84 @@
+"""Tradfri Light Quirks."""
+from zigpy.profiles import zha, zll
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    PollControl,
+    Scenes,
+)
+from zigpy.zcl.clusters.homeautomation import Diagnostic
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from . import IKEA
+
+
+class TradfriColorTempLightBulb(CustomDevice):
+    """
+    Tradfri light bulbs, dimmable, white spectrum.
+
+    This quirk has been testeed the LED1545G12 but should work with a range of those bulbs.
+    It changes the profile_id from ZHA to ZLL.
+    """
+
+    signature = {
+        "endpoints": {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=544
+            # device_version=2
+            # input_clusters=[0, 3, 4, 5, 6, 8, 768, 2821, 4096]
+            # output_clusters=[5, 25, 32, 4096]>
+            1: {
+                "profile_id": zha.PROFILE_ID,
+                "device_type": zll.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                "input_clusters": [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    Diagnostic.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                "output_clusters": [
+                    Scenes.cluster_id,
+                    Ota.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        },
+        "manufacturer": IKEA,
+    }
+
+    replacement = {
+        "endpoints": {
+            1: {
+                "profile_id": zll.PROFILE_ID,
+                "device_type": zll.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                "input_clusters": [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    Diagnostic.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                "output_clusters": [
+                    Scenes.cluster_id,
+                    Ota.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        }
+    }


### PR DESCRIPTION
I noticed the IKEA Trafri light bulbs (I think I have [this one](https://www.ikea.com/gb/en/p/tradfri-led-bulb-e27-1000-lumen-wireless-dimmable-white-spectrum-opal-white-60408483/)) reported the ZHA profile (260) while having a ZLL device type (COLOR_TEMPERATURE_LIGHT / 0x0220). I added a quirk that changes the profile id to the ZLL one (49246)

Not sure if it is the right thing to do, but with this patch the light bulb shows up correctly with brightness and color temperature control in Home Assistant