### PR TITLE
New Konke model of temp/humidity sensor.

### DIFF
--- a/zhaquirks/konke/temp.py
+++ b/zhaquirks/konke/temp.py
@@ -25,7 +25,7 @@ class KonkeTempHumidity(CustomDevice):
         # device_version=0
         # input_clusters=[0, 1, 3, 1026, 1029]
         # output_clusters=[3]>
-        MODELS_INFO: [(KONKE, "3AFE140103020000")],
+        MODELS_INFO: [(KONKE, "3AFE140103020000"), (KONKE, "3AFE220103020000")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
This is the same Temperature/Humidity sensor, but reports a different model. 
At the back of the sensor:
```
Kit Pro-FT Temp/Humidity Sensor
FCC-ID: 2AJZ4- KPFT
IC-ID: 23777-KPFT
```

During joining it reports the following signature:
```
Node Descriptor: <Optional byte1=2 byte2=64 mac_capability_flags=128 manufacturer_code=4712 maximum_buffer_size=82 maximum_incoming_transfer_size=82 server_mask=11264 maximum_outgoing_transfer_size=82 descriptor_capability_field=0>
Discovered endpoints: [1]
<SimpleDescriptor endpoint=1 profile=260 device_type=770 device_version=0 input_clusters=[0, 1, 3, 1026, 1029] output_clusters=[3]>
Manufacturer: Konke
Model: 3AFE220103020000
```

For now adding another model, until we get more feedback about how many different versions are there.
