### PR TITLE
Add leading whitespaces to Legrand Dimmer switch w/o neutral manufacturer and model strings

### DIFF
--- a/zhaquirks/legrand/__init__.py
+++ b/zhaquirks/legrand/__init__.py
@@ -1,2 +1,2 @@
 """Module for Legrand devices."""
-LEGRAND = "Legrand"
+LEGRAND = " Legrand"

--- a/zhaquirks/legrand/dimmer.py
+++ b/zhaquirks/legrand/dimmer.py
@@ -50,7 +50,7 @@ class DimmerWithoutNeutral(CustomDevice):
         # device_version=1
         # input_clusters=[0, 3, 4, 8, 6, 5, 15, 64513]
         # output_clusters=[0, 64513, 25]>
-        MODELS_INFO: [(LEGRAND, "Dimmer switch w/o neutral")],
+        MODELS_INFO: [(LEGRAND, " Dimmer switch w/o neutral")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
Just a hack for #330, so submitted as a draft PR for now.