### PR TITLE
IKEA 5 button remove dev version 2 quirk.

### DIFF
--- a/zhaquirks/ikea/fivebtnremotezha.py
+++ b/zhaquirks/ikea/fivebtnremotezha.py
@@ -2,6 +2,7 @@
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
+    Alarms,
     Basic,
     Groups,
     Identify,
@@ -11,6 +12,7 @@ from zigpy.zcl.clusters.general import (
     PollControl,
     PowerConfiguration,
 )
+from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.lightlink import LightLink
 
 from .. import DoublingPowerConfigurationCluster
@@ -165,4 +167,63 @@ class IkeaTradfriRemote(CustomDevice):
             ENDPOINT_ID: 1,
             ARGS: [3328, 0],
         },
+    }
+
+
+class IkeaTradfriRemote2(IkeaTradfriRemote):
+    """Custom device representing IKEA of Sweden TRADFRI 5 button remote control."""
+
+    signature = {
+        # <SimpleDescriptor endpoint = 1 profile = 260 device_type = 2064
+        # device_version = 2 input_clusters = [0, 1, 3, 9, 2821, 4096]
+        # output_clusters = [3, 4, 5, 6, 8, 25, 4096]
+        MODELS_INFO: [(IKEA, "TRADFRI remote control")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Alarms.cluster_id,
+                    Diagnostic.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    ScenesCluster.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DoublingPowerConfigurationCluster,
+                    Identify.cluster_id,
+                    Alarms.cluster_id,
+                    LightLinkCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    ScenesCluster,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        }
     }


### PR DESCRIPTION
Add signature for

```
Node Descriptor: <Optional byte1=2 byte2=64 mac_capability_flags=128 manufacturer_code=4476 maximum_buffer_size=82 maximum_incoming_transfer_size=82 server_mask=0 maximum_outgoing_transfer_size=82 descriptor_capability_field=0>
Discovered endpoints: [1]
Discovered endpoint information: <SimpleDescriptor endpoint=1 profile=260 device_type=2064 device_version=2 input_clusters=[0, 1, 3, 9, 2821, 4096] output_clusters=[3, 4, 5, 6, 8, 25, 4096]>
Manufacturer: IKEA of Sweden
Model: TRADFRI remote control
```

Fixes https://github.com/zigpy/zha-device-handlers/issues/355