### PR TITLE
LocalDataCluster bind

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -34,23 +34,16 @@ class LocalDataCluster(CustomCluster):
     """Cluster meant to prevent remote calls."""
 
     async def bind(self):
-        """Bind cluster."""
+        """Prevent bind."""
         return (foundation.Status.SUCCESS,)
 
     async def unbind(self):
-        """Unbind cluster."""
+        """Prevent unbind."""
         return (foundation.Status.SUCCESS,)
 
-    async def configure_reporting(
-        self,
-        attribute,
-        min_interval,
-        max_interval,
-        reportable_change,
-        manufacturer=None,
-    ):
-        """Configure reporting."""
-        return foundation.Status.SUCCESS
+    async def _configure_reporting(self, *args, **kwargs):
+        """Prevent remote configure reporting."""
+        return foundation.ConfigureReportingResponse.deserialize(b"\x00")[0]
 
     async def read_attributes_raw(self, attributes, manufacturer=None):
         """Prevent remote reads."""

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -33,6 +33,25 @@ class Bus(ListenableMixin):
 class LocalDataCluster(CustomCluster):
     """Cluster meant to prevent remote calls."""
 
+    async def bind(self):
+        """Bind cluster."""
+        return (foundation.Status.SUCCESS,)
+
+    async def unbind(self):
+        """Unbind cluster."""
+        return (foundation.Status.SUCCESS,)
+
+    async def configure_reporting(
+        self,
+        attribute,
+        min_interval,
+        max_interval,
+        reportable_change,
+        manufacturer=None,
+    ):
+        """Configure reporting."""
+        return foundation.Status.SUCCESS
+
     async def read_attributes_raw(self, attributes, manufacturer=None):
         """Prevent remote reads."""
         records = [


### PR DESCRIPTION
As per @Adminiuga comment on https://github.com/zigpy/zha-device-handlers/issues/308#issuecomment-607319082 it is worth to implement `bind` and `configure_reporting` methods to prevent sending the requests to the device because they would fail. However I think they are best fit on the `LocalDataCluster` level to allow other devices to benefit from this as well. Also added `unbind` for completeness.