### PR TITLE
Add Quirk For Konke Contact Sensor - Battery

### DIFF
--- a/zhaquirks/konke/magnet.py
+++ b/zhaquirks/konke/magnet.py
@@ -18,6 +18,7 @@ from ..const import (
 
 KONKE_CLUSTER_ID = 0xFCC0
 
+
 class KonkeMagnet(CustomDevice):
     """Custom device representing konke magnet sensors."""
 

--- a/zhaquirks/konke/magnet.py
+++ b/zhaquirks/konke/magnet.py
@@ -39,7 +39,7 @@ class KonkeMagnet(CustomDevice):
                     IasZone.cluster_id,
                     KONKE_CLUSTER_ID,
                 ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, KONKE_CLUSTER_ID,],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, KONKE_CLUSTER_ID],
             }
         },
     }
@@ -56,7 +56,7 @@ class KonkeMagnet(CustomDevice):
                     IasZone.cluster_id,
                     KONKE_CLUSTER_ID,
                 ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, KONKE_CLUSTER_ID,],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, KONKE_CLUSTER_ID],
             }
         }
     }


### PR DESCRIPTION
Added a new quirk for the Konke 3AFE270104020015 contact sensor so it can report battery percentage in HA. Tested and working with sensor I just received recently. Is there any way to set the battery size via quirk - temp sensor also shows unknown for battery size? (Its a 3v CR1632 for the sensor.)

<img width="905" alt="Screen Shot 2020-05-25 at 11 39 22 PM" src="https://user-images.githubusercontent.com/11084412/82858705-a79b6d00-9ee2-11ea-9a6b-865efa2a7d13.png">


