### PR TITLE
Add quirk for Eurotronic Spirit Zigbee

### DIFF
--- a/zhaquirks/eurotronic/__init__.py
+++ b/zhaquirks/eurotronic/__init__.py
@@ -83,7 +83,6 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
     async def read_attributes_raw(self, attributes, manufacturer=None):
         """Override wrong attribute reports from the thermostat."""
-
         success = []
         error = []
 
@@ -144,7 +143,6 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
     def write_attributes(self, attributes, manufacturer=None):
         """Override wrong writes to thermostat attributes."""
-
         if "system_mode" in attributes:
 
             host_flags = self._attr_cache.get(HOST_FLAGS_ATTR, 1)

--- a/zhaquirks/eurotronic/__init__.py
+++ b/zhaquirks/eurotronic/__init__.py
@@ -1,3 +1,176 @@
 """Eurotronic devices."""
 
+import logging
+from zigpy.profiles import PROFILES, zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as types
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    Ota,
+    PowerConfiguration,
+    Time,
+)
+from zigpy.zcl.clusters.hvac import Thermostat
+
+from zigpy.types.basic import enum8
+
+from zhaquirks.const import (
+    ARGS,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_STEP,
+    DEVICE_TYPE,
+    DIM_DOWN,
+    DIM_UP,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+    TURN_OFF,
+    TURN_ON,
+)
+
 EUROTRONIC = "Eurotronic"
+
+THERMOSTAT_CHANNEL = "thermostat"
+
+MANUFACTURER                    = 0x1037 # 4151
+
+OCCUPIED_HEATING_SETPOINT_ATTR  = 0x0012
+CTRL_SEQ_OF_OPER_ATTR           = 0x001B
+SYSTEM_MODE_ATTR                = 0x001C
+
+TRV_MODE_ATTR                   = 0x4000
+SET_VALVE_POS_ATTR              = 0x4001
+ERRORS_ATTR                     = 0x4002
+CURRENT_TEMP_SETPOINT_ATTR      = 0x4003
+HOST_FLAGS_ATTR                 = 0x4008
+
+
+# Host Flags
+# unknown (defaults to 1)       = 0b00000001 # 1
+MIRROR_SCREEN_FLAG              = 0b00000010 # 2
+BOOST_FLAG                      = 0b00000100 # 4
+# unknown                       = 0b00001000 # 8
+CLR_OFF_MODE_FLAG               = 0b00010000 # 16
+SET_OFF_MODE_FLAG               = 0b00100000 # 32, reported back as 16
+# unknown                       = 0b01000000 # 64
+CHILD_LOCK_FLAG                 = 0b10000000 # 128
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ThermostatCluster(CustomCluster, Thermostat):
+    """Thermostat cluster."""
+
+    cluster_id = Thermostat.cluster_id
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+
+        # manufacturer specific attributes
+        self.attributes.update({
+            TRV_MODE_ATTR:              ('trv_mode', types.enum8),
+            SET_VALVE_POS_ATTR:         ('set_valve_position', types.uint8_t),
+            ERRORS_ATTR:                ('errors', types.uint8_t),
+            CURRENT_TEMP_SETPOINT_ATTR: ('current_temperature_setpoint', types.int16s),
+            HOST_FLAGS_ATTR:            ('host_flags', types.uint24_t),
+        })
+        self._attridx = {
+            attrname: attrid for attrid, (attrname, datatype)
+            in self.attributes.items()
+        }
+
+
+    def _update_attribute(self, attrid, value):
+        _LOGGER.debug("update attribute %04x to %s... ", attrid, value)
+
+        if attrid == CURRENT_TEMP_SETPOINT_ATTR:
+            print("setting occupied heating setpoint now...")
+            super()._update_attribute(OCCUPIED_HEATING_SETPOINT_ATTR, value)
+        elif attrid == HOST_FLAGS_ATTR:
+            if value & CLR_OFF_MODE_FLAG == CLR_OFF_MODE_FLAG:
+                super()._update_attribute(SYSTEM_MODE_ATTR, 0x0)
+                _LOGGER.debug("set system_mode to [off ]")
+            else:
+                super()._update_attribute(SYSTEM_MODE_ATTR, 0x4)
+                _LOGGER.debug("set system_mode to [heat]")
+
+        _LOGGER.debug("update attribute %04x to %s... [ ok ]", attrid, value)
+        super()._update_attribute(attrid, value)
+
+    async def read_attributes_raw(self, attributes, manufacturer=None):
+        """Override wrong attribute reports from the thermostat."""
+
+        success = []
+        error = []
+
+        if CTRL_SEQ_OF_OPER_ATTR in attributes:
+            rar = foundation.ReadAttributeRecord(
+                CTRL_SEQ_OF_OPER_ATTR, foundation.Status.SUCCESS, foundation.TypeValue()
+            )
+            rar.value.value = 0x2
+            success.append(rar)
+
+        if SYSTEM_MODE_ATTR in attributes:
+            rar = foundation.ReadAttributeRecord(
+                SYSTEM_MODE_ATTR, foundation.Status.SUCCESS, foundation.TypeValue()
+            )
+            rar.value.value = 0x4
+            success.append(rar)
+
+        if OCCUPIED_HEATING_SETPOINT_ATTR in attributes:
+
+            _LOGGER.debug("intercepting OCC_HS")
+
+            values = await super().read_attributes_raw([CURRENT_TEMP_SETPOINT_ATTR], manufacturer=MANUFACTURER)
+
+            if len(values) == 2:
+                current_temp_setpoint = values[1][0]
+                current_temp_setpoint.attrid = OCCUPIED_HEATING_SETPOINT_ATTR
+
+                error.extend(values[1])
+            else:
+                current_temp_setpoint = values[0][0]
+                current_temp_setpoint.attrid = OCCUPIED_HEATING_SETPOINT_ATTR
+
+                success.extend(values[0])
+
+
+
+        attributes = list(filter(lambda x: x not in (CTRL_SEQ_OF_OPER_ATTR, SYSTEM_MODE_ATTR, OCCUPIED_HEATING_SETPOINT_ATTR), attributes))
+        
+        if attributes:
+            values = await super().read_attributes_raw(attributes, manufacturer)
+
+            success.extend(values[0])
+            
+            if len(values) == 2:
+                error.extend(values[1])
+
+        return success, error
+
+
+    def write_attributes(self, attributes, manufacturer=None):
+
+        if 'system_mode' in attributes:
+
+            host_flags = self._attr_cache.get(HOST_FLAGS_ATTR, 1)
+            _LOGGER.debug("current host_flags: %s", host_flags)
+
+            if attributes.get('system_mode') == 0x0:
+                return super().write_attributes({'host_flags': host_flags | SET_OFF_MODE_FLAG}, MANUFACTURER)
+            if attributes.get('system_mode') == 0x4:
+                return super().write_attributes({'host_flags': host_flags | CLR_OFF_MODE_FLAG}, MANUFACTURER)
+
+        return super().write_attributes(attributes, manufacturer)

--- a/zhaquirks/eurotronic/__init__.py
+++ b/zhaquirks/eurotronic/__init__.py
@@ -1,69 +1,39 @@
 """Eurotronic devices."""
 
 import logging
-from zigpy.profiles import PROFILES, zha
-from zigpy.quirks import CustomCluster, CustomDevice
+
 import zigpy.types as types
+from zigpy.quirks import CustomCluster
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    Ota,
-    PowerConfiguration,
-    Time,
-)
 from zigpy.zcl.clusters.hvac import Thermostat
 
-from zigpy.types.basic import enum8
-
-from zhaquirks.const import (
-    ARGS,
-    CLUSTER_ID,
-    COMMAND,
-    COMMAND_OFF,
-    COMMAND_ON,
-    COMMAND_STEP,
-    DEVICE_TYPE,
-    DIM_DOWN,
-    DIM_UP,
-    ENDPOINT_ID,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-    SHORT_PRESS,
-    TURN_OFF,
-    TURN_ON,
-)
 
 EUROTRONIC = "Eurotronic"
 
 THERMOSTAT_CHANNEL = "thermostat"
 
-MANUFACTURER                    = 0x1037 # 4151
+MANUFACTURER = 0x1037  # 4151
 
-OCCUPIED_HEATING_SETPOINT_ATTR  = 0x0012
-CTRL_SEQ_OF_OPER_ATTR           = 0x001B
-SYSTEM_MODE_ATTR                = 0x001C
+OCCUPIED_HEATING_SETPOINT_ATTR = 0x0012
+CTRL_SEQ_OF_OPER_ATTR = 0x001B
+SYSTEM_MODE_ATTR = 0x001C
 
-TRV_MODE_ATTR                   = 0x4000
-SET_VALVE_POS_ATTR              = 0x4001
-ERRORS_ATTR                     = 0x4002
-CURRENT_TEMP_SETPOINT_ATTR      = 0x4003
-HOST_FLAGS_ATTR                 = 0x4008
+TRV_MODE_ATTR = 0x4000
+SET_VALVE_POS_ATTR = 0x4001
+ERRORS_ATTR = 0x4002
+CURRENT_TEMP_SETPOINT_ATTR = 0x4003
+HOST_FLAGS_ATTR = 0x4008
 
 
 # Host Flags
 # unknown (defaults to 1)       = 0b00000001 # 1
-MIRROR_SCREEN_FLAG              = 0b00000010 # 2
-BOOST_FLAG                      = 0b00000100 # 4
+MIRROR_SCREEN_FLAG = 0b00000010  # 2
+BOOST_FLAG = 0b00000100  # 4
 # unknown                       = 0b00001000 # 8
-CLR_OFF_MODE_FLAG               = 0b00010000 # 16
-SET_OFF_MODE_FLAG               = 0b00100000 # 32, reported back as 16
+CLR_OFF_MODE_FLAG = 0b00010000  # 16
+SET_OFF_MODE_FLAG = 0b00100000  # 32, reported back as 16
 # unknown                       = 0b01000000 # 64
-CHILD_LOCK_FLAG                 = 0b10000000 # 128
+CHILD_LOCK_FLAG = 0b10000000  # 128
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -79,18 +49,21 @@ class ThermostatCluster(CustomCluster, Thermostat):
         super().__init__(*args, **kwargs)
 
         # manufacturer specific attributes
-        self.attributes.update({
-            TRV_MODE_ATTR:              ('trv_mode', types.enum8),
-            SET_VALVE_POS_ATTR:         ('set_valve_position', types.uint8_t),
-            ERRORS_ATTR:                ('errors', types.uint8_t),
-            CURRENT_TEMP_SETPOINT_ATTR: ('current_temperature_setpoint', types.int16s),
-            HOST_FLAGS_ATTR:            ('host_flags', types.uint24_t),
-        })
+        self.attributes.update(
+            {
+                TRV_MODE_ATTR: ("trv_mode", types.enum8),
+                SET_VALVE_POS_ATTR: ("set_valve_position", types.uint8_t),
+                ERRORS_ATTR: ("errors", types.uint8_t),
+                CURRENT_TEMP_SETPOINT_ATTR: (
+                    "current_temperature_setpoint",
+                    types.int16s,
+                ),
+                HOST_FLAGS_ATTR: ("host_flags", types.uint24_t),
+            }
+        )
         self.attridx = {
-            attrname: attrid for attrid, (attrname, datatype)
-            in self.attributes.items()
+            attrname: attrid for attrid, (attrname, datatype) in self.attributes.items()
         }
-
 
     def _update_attribute(self, attrid, value):
         _LOGGER.debug("update attribute %04x to %s... ", attrid, value)
@@ -132,7 +105,9 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
             _LOGGER.debug("intercepting OCC_HS")
 
-            values = await super().read_attributes_raw([CURRENT_TEMP_SETPOINT_ATTR], manufacturer=MANUFACTURER)
+            values = await super().read_attributes_raw(
+                [CURRENT_TEMP_SETPOINT_ATTR], manufacturer=MANUFACTURER
+            )
 
             if len(values) == 2:
                 current_temp_setpoint = values[1][0]
@@ -145,31 +120,43 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
                 success.extend(values[0])
 
+        attributes = list(
+            filter(
+                lambda x: x
+                not in (
+                    CTRL_SEQ_OF_OPER_ATTR,
+                    SYSTEM_MODE_ATTR,
+                    OCCUPIED_HEATING_SETPOINT_ATTR,
+                ),
+                attributes,
+            )
+        )
 
-
-        attributes = list(filter(lambda x: x not in (CTRL_SEQ_OF_OPER_ATTR, SYSTEM_MODE_ATTR, OCCUPIED_HEATING_SETPOINT_ATTR), attributes))
-        
         if attributes:
             values = await super().read_attributes_raw(attributes, manufacturer)
 
             success.extend(values[0])
-            
+
             if len(values) == 2:
                 error.extend(values[1])
 
         return success, error
 
-
     def write_attributes(self, attributes, manufacturer=None):
+        """Override wrong writes to thermostat attributes."""
 
-        if 'system_mode' in attributes:
+        if "system_mode" in attributes:
 
             host_flags = self._attr_cache.get(HOST_FLAGS_ATTR, 1)
             _LOGGER.debug("current host_flags: %s", host_flags)
 
-            if attributes.get('system_mode') == 0x0:
-                return super().write_attributes({'host_flags': host_flags | SET_OFF_MODE_FLAG}, MANUFACTURER)
-            if attributes.get('system_mode') == 0x4:
-                return super().write_attributes({'host_flags': host_flags | CLR_OFF_MODE_FLAG}, MANUFACTURER)
+            if attributes.get("system_mode") == 0x0:
+                return super().write_attributes(
+                    {"host_flags": host_flags | SET_OFF_MODE_FLAG}, MANUFACTURER
+                )
+            if attributes.get("system_mode") == 0x4:
+                return super().write_attributes(
+                    {"host_flags": host_flags | CLR_OFF_MODE_FLAG}, MANUFACTURER
+                )
 
         return super().write_attributes(attributes, manufacturer)

--- a/zhaquirks/eurotronic/__init__.py
+++ b/zhaquirks/eurotronic/__init__.py
@@ -44,26 +44,14 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
     cluster_id = Thermostat.cluster_id
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-
-        # manufacturer specific attributes
-        self.attributes.update(
-            {
-                TRV_MODE_ATTR: ("trv_mode", types.enum8),
-                SET_VALVE_POS_ATTR: ("set_valve_position", types.uint8_t),
-                ERRORS_ATTR: ("errors", types.uint8_t),
-                CURRENT_TEMP_SETPOINT_ATTR: (
-                    "current_temperature_setpoint",
-                    types.int16s,
-                ),
-                HOST_FLAGS_ATTR: ("host_flags", types.uint24_t),
-            }
-        )
-        self.attridx = {
-            attrname: attrid for attrid, (attrname, datatype) in self.attributes.items()
-        }
+    attributes = {
+        TRV_MODE_ATTR: ("trv_mode", types.enum8),
+        SET_VALVE_POS_ATTR: ("set_valve_position", types.uint8_t),
+        ERRORS_ATTR: ("errors", types.uint8_t),
+        CURRENT_TEMP_SETPOINT_ATTR: ("current_temperature_setpoint", types.int16s),
+        HOST_FLAGS_ATTR: ("host_flags", types.uint24_t),
+    }
+    attributes.update(Thermostat.attributes)
 
     def _update_attribute(self, attrid, value):
         _LOGGER.debug("update attribute %04x to %s... ", attrid, value)

--- a/zhaquirks/eurotronic/__init__.py
+++ b/zhaquirks/eurotronic/__init__.py
@@ -86,7 +86,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
             CURRENT_TEMP_SETPOINT_ATTR: ('current_temperature_setpoint', types.int16s),
             HOST_FLAGS_ATTR:            ('host_flags', types.uint24_t),
         })
-        self._attridx = {
+        self.attridx = {
             attrname: attrid for attrid, (attrname, datatype)
             in self.attributes.items()
         }
@@ -96,7 +96,6 @@ class ThermostatCluster(CustomCluster, Thermostat):
         _LOGGER.debug("update attribute %04x to %s... ", attrid, value)
 
         if attrid == CURRENT_TEMP_SETPOINT_ATTR:
-            print("setting occupied heating setpoint now...")
             super()._update_attribute(OCCUPIED_HEATING_SETPOINT_ATTR, value)
         elif attrid == HOST_FLAGS_ATTR:
             if value & CLR_OFF_MODE_FLAG == CLR_OFF_MODE_FLAG:

--- a/zhaquirks/eurotronic/__init__.py
+++ b/zhaquirks/eurotronic/__init__.py
@@ -1,0 +1,3 @@
+"""Eurotronic devices."""
+
+EUROTRONIC = "Eurotronic"

--- a/zhaquirks/eurotronic/spzb0001.py
+++ b/zhaquirks/eurotronic/spzb0001.py
@@ -1,0 +1,99 @@
+
+from zigpy.profiles import PROFILES, zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as types
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    Ota,
+    PowerConfiguration,
+    Time,
+)
+from zigpy.zcl.clusters.hvac import Thermostat
+
+from zhaquirks.const import (
+    ARGS,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_STEP,
+    DEVICE_TYPE,
+    DIM_DOWN,
+    DIM_UP,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+    TURN_OFF,
+    TURN_ON,
+)
+
+from . import EUROTRONIC
+
+THERMOSTAT_CHANNEL = "thermostat"
+
+
+class SPZB0001(CustomDevice):
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=769
+        # device_version=1
+        # input_clusters=[0, 1, 3, 513, 25, 10]
+        # output_clusters=[0, 1, 3, 4, 513, 25, 10]>
+        MODELS_INFO: [(EUROTRONIC, "SPZB0001")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.THERMOSTAT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Thermostat.cluster_id,
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Thermostat.cluster_id,
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.THERMOSTAT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Thermostat.cluster_id,
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Thermostat.cluster_id,
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                ],
+            }
+        }
+    }

--- a/zhaquirks/eurotronic/spzb0001.py
+++ b/zhaquirks/eurotronic/spzb0001.py
@@ -1,4 +1,7 @@
-from zigpy.profiles import PROFILES, zha
+"""Eurotronic Spirit Zigbee quirk."""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -8,34 +11,21 @@ from zigpy.zcl.clusters.general import (
     Time,
 )
 from zigpy.zcl.clusters.hvac import Thermostat
-from zigpy.quirks import CustomCluster, CustomDevice
-from zigpy.zcl import foundation
 
 from zhaquirks.const import (
-    ARGS,
-    CLUSTER_ID,
-    COMMAND,
-    COMMAND_OFF,
-    COMMAND_ON,
-    COMMAND_STEP,
     DEVICE_TYPE,
-    DIM_DOWN,
-    DIM_UP,
-    ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    SHORT_PRESS,
-    TURN_OFF,
-    TURN_ON,
 )
 
 from . import EUROTRONIC, ThermostatCluster
 
 
 class SPZB0001(CustomDevice):
+    """Eurotronic Spirit Zigbee device."""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=769
@@ -93,4 +83,3 @@ class SPZB0001(CustomDevice):
             }
         }
     }
-

--- a/zhaquirks/eurotronic/spzb0001.py
+++ b/zhaquirks/eurotronic/spzb0001.py
@@ -1,8 +1,4 @@
-
 from zigpy.profiles import PROFILES, zha
-from zigpy.quirks import CustomCluster, CustomDevice
-import zigpy.types as types
-from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -12,6 +8,8 @@ from zigpy.zcl.clusters.general import (
     Time,
 )
 from zigpy.zcl.clusters.hvac import Thermostat
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl import foundation
 
 from zhaquirks.const import (
     ARGS,
@@ -34,9 +32,7 @@ from zhaquirks.const import (
     TURN_ON,
 )
 
-from . import EUROTRONIC
-
-THERMOSTAT_CHANNEL = "thermostat"
+from . import EUROTRONIC, ThermostatCluster
 
 
 class SPZB0001(CustomDevice):
@@ -81,7 +77,7 @@ class SPZB0001(CustomDevice):
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
-                    Thermostat.cluster_id,
+                    ThermostatCluster,
                     Ota.cluster_id,
                     Time.cluster_id,
                 ],
@@ -90,10 +86,11 @@ class SPZB0001(CustomDevice):
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
-                    Thermostat.cluster_id,
+                    ThermostatCluster,
                     Ota.cluster_id,
                     Time.cluster_id,
                 ],
             }
         }
     }
+


### PR DESCRIPTION
This quirk adds support for the thermostat "Eurotronic Spirit Zigbee".
Manual: https://eurotronic.org/wp-content/uploads/2019/11/Spirit_ZigBee_BAL_web_DE_Okt.-2019.pdf (German, but the last pages containing the Zigbee information are in English)

Related issue: #356

The thermostat works without the quirk, but not well. This quirk adds support for:

- OFF: Ability to turn off the thermostat using system mode
- Bidirectional temperature: Temperature set on the thermostat will be reported back into HA

After joining, HA needs to be restarted for the thermostat to be working properly. It seems that some attributes are not read on first join (including system_mode). Other than that, the quirk should work well.