### PR TITLE
Fix PowerConfig cluster reporting 0V

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -154,15 +154,13 @@ class PowerConfigurationCluster(CustomCluster, PowerConfiguration):
 
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
-        if attrid == self.BATTERY_VOLTAGE_ATTR:
+        if attrid == self.BATTERY_VOLTAGE_ATTR and value not in (0, 255):
             super()._update_attribute(
                 self.BATTERY_PERCENTAGE_REMAINING,
                 self._calculate_battery_percentage(value),
             )
 
     def _calculate_battery_percentage(self, raw_value):
-        if raw_value in (0, 255):
-            return -1
         volts = raw_value / 10
         volts = max(volts, self.MIN_VOLTS)
         volts = min(volts, self.MAX_VOLTS)


### PR DESCRIPTION
Don't update `battery_percentage_remaining` attribute if the reported battery voltage is  0V or 25.5V

Fixes Plaid soils sensor reporting -1% battery remaining.
```
2020-06-12 18:49:45 DEBUG (MainThread) [zigpy.zcl] [0x25fb:1:0x0001] ZCL deserialize: <ZCLHeader frame_control=<FrameControl frame_type=GLOBAL_COMM
AND manufacturer_specific=False is_reply=False disable_default_response=False> manufacturer=None tsn=17 command_id=Command.Report_Attributes>
2020-06-12 18:49:45 DEBUG (MainThread) [zigpy.zcl] [0x25fb:1:0x0001] ZCL request 0x000a: [[<Attribute attrid=32 value=<TypeValue type=uint8_t, valu
e=0>>]]
2020-06-12 18:49:45 DEBUG (MainThread) [zigpy.zcl] [0x25fb:1:0x0001] Attribute report received: battery_voltage=0
2020-06-12 18:49:45 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=sensor.plaid_systems_ps_sprzms_slp3_148
06e0e_power, old_state=<state sensor.plaid_systems_ps_sprzms_slp3_14806e0e_power=100; battery_voltage=3.2, unit_of_measurement=%, friendly_name=PLA
ID SYSTEMS PS-SPRZMS-SLP3 14806e0e power, device_class=battery @ 2020-06-12T16:24:37.008386-04:00>, new_state=<state sensor.plaid_systems_ps_sprzms
_slp3_14806e0e_power=100; battery_voltage=0.0, unit_of_measurement=%, friendly_name=PLAID SYSTEMS PS-SPRZMS-SLP3 14806e0e power, device_class=batte
ry @ 2020-06-12T16:24:37.008386-04:00>>
2020-06-12 18:49:45 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=sensor.plaid_systems_ps_sprzms_slp3_148
06e0e_power, old_state=<state sensor.plaid_systems_ps_sprzms_slp3_14806e0e_power=100; battery_voltage=0.0, unit_of_measurement=%, friendly_name=PLA
ID SYSTEMS PS-SPRZMS-SLP3 14806e0e power, device_class=battery @ 2020-06-12T16:24:37.008386-04:00>, new_state=<state sensor.plaid_systems_ps_sprzms
_slp3_14806e0e_power=-1; battery_voltage=0.0, unit_of_measurement=%, friendly_name=PLAID SYSTEMS PS-SPRZMS-SLP3 14806e0e power, device_class=batter
y @ 2020-06-12T18:49:45.946651-04:00>>
```