### PR TITLE
[BREAKING CHANGE] Phillips Hue remote manufacturer specific cluster handling

### DIFF
--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -61,11 +61,11 @@ class PhilipsOnOffCluster(CustomCluster, OnOff):
     attributes.update({0x4003: ("power_on_state", PowerOnState)})
 
 
-class PhillipsBasicCluster(CustomCluster, Basic):
-    """Phillips Basic cluster."""
+class PhilipsBasicCluster(CustomCluster, Basic):
+    """Philips Basic cluster."""
 
     attributes = Basic.attributes.copy()
-    attributes.update({0x0031: ("phillips", t.bitmap16)})
+    attributes.update({0x0031: ("philips", t.bitmap16)})
 
     attr_config = {0x0031: 0x000B}
 
@@ -76,12 +76,12 @@ class PhillipsBasicCluster(CustomCluster, Basic):
         return result
 
 
-class PhillipsRemoteCluster(CustomCluster):
-    """Phillips remote cluster."""
+class PhilipsRemoteCluster(CustomCluster):
+    """Philips remote cluster."""
 
     cluster_id = 64512
-    name = "PhillipsRemoteCluster"
-    ep_attribute = "phillips_remote_cluster"
+    name = "PhilipsRemoteCluster"
+    ep_attribute = "philips_remote_cluster"
     attributes = {}
     server_commands = {}
     client_commands = {
@@ -97,7 +97,7 @@ class PhillipsRemoteCluster(CustomCluster):
     def handle_cluster_request(self, tsn, command_id, args):
         """Handle the cluster command."""
         _LOGGER.debug(
-            "PhillipsRemoteCluster - handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
+            "PhilipsRemoteCluster - handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
             tsn,
             command_id,
             args,

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -1,9 +1,15 @@
 """Module for Philips quirks implementations."""
-from zigpy.quirks import CustomCluster
-from zigpy.zcl.clusters.general import OnOff
-import zigpy.types as t
+import logging
 
+from zigpy.quirks import CustomCluster
+import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic, OnOff
+
+from ..const import ARGS, BUTTON, COMMAND_ID, PRESS_TYPE, ZHA_SEND_EVENT
+
+DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 PHILIPS = "Philips"
+_LOGGER = logging.getLogger(__name__)
 
 
 class PowerOnState(t.enum8):
@@ -19,3 +25,57 @@ class PhilipsOnOffCluster(CustomCluster, OnOff):
 
     attributes = OnOff.attributes.copy()
     attributes.update({0x4003: ("power_on_state", PowerOnState)})
+
+
+class PhillipsBasicCluster(CustomCluster, Basic):
+    """Phillips Basic cluster."""
+
+    attributes = Basic.attributes.copy()
+    attributes.update({0x0031: ("phillips", t.bitmap16)})
+
+    attr_config = {0x0031: 0x000B}
+
+    async def bind(self):
+        """Bind cluster."""
+        result = await super().bind()
+        await self.write_attributes(self.attr_config, manufacturer=0x100B)
+        return result
+
+
+class PhillipsRemoteCluster(CustomCluster):
+    """Phillips remote cluster."""
+
+    cluster_id = 64512
+    name = "PhillipsRemoteCluster"
+    ep_attribute = "phillips_remote_cluster"
+    attributes = {}
+    server_commands = {}
+    client_commands = {
+        0x0000: (
+            "notification",
+            (t.uint8_t, t.uint24_t, t.uint8_t, t.uint8_t, t.uint8_t, t.uint8_t),
+            False,
+        )
+    }
+    BUTTONS = {1: "on", 2: "up", 3: "down", 4: "off"}
+    PRESS_TYPES = {0: "press", 1: "hold", 2: "short_release", 3: "long_release"}
+
+    def handle_cluster_request(self, tsn, command_id, args):
+        """Handle the cluster command."""
+        _LOGGER.debug(
+            "PhillipsRemoteCluster - handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
+            tsn,
+            command_id,
+            args,
+        )
+        button = self.BUTTONS.get(args[0], args[0])
+        press_type = self.PRESS_TYPES.get(args[2], args[2])
+
+        event_args = {
+            BUTTON: button,
+            PRESS_TYPE: press_type,
+            COMMAND_ID: command_id,
+            ARGS: args,
+        }
+        action = "{}_{}".format(button, press_type)
+        self.listener_event(ZHA_SEND_EVENT, action, event_args)

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -5,11 +5,45 @@ from zigpy.quirks import CustomCluster
 import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic, OnOff
 
-from ..const import ARGS, BUTTON, COMMAND_ID, PRESS_TYPE, ZHA_SEND_EVENT
+from ..const import (
+    ARGS,
+    BUTTON,
+    COMMAND,
+    COMMAND_ID,
+    DIM_DOWN,
+    DIM_UP,
+    LONG_PRESS,
+    LONG_RELEASE,
+    PRESS_TYPE,
+    SHORT_PRESS,
+    SHORT_RELEASE,
+    TURN_OFF,
+    TURN_ON,
+    ZHA_SEND_EVENT,
+)
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 PHILIPS = "Philips"
 _LOGGER = logging.getLogger(__name__)
+
+HUE_REMOTE_DEVICE_TRIGGERS = {
+    (SHORT_PRESS, TURN_ON): {COMMAND: "on_press"},
+    (SHORT_PRESS, TURN_OFF): {COMMAND: "off_press"},
+    (SHORT_PRESS, DIM_UP): {COMMAND: "up_press"},
+    (SHORT_PRESS, DIM_DOWN): {COMMAND: "down_press"},
+    (LONG_PRESS, TURN_ON): {COMMAND: "on_hold"},
+    (LONG_PRESS, TURN_OFF): {COMMAND: "off_hold"},
+    (LONG_PRESS, DIM_UP): {COMMAND: "up_hold"},
+    (LONG_PRESS, DIM_DOWN): {COMMAND: "down_hold"},
+    (SHORT_RELEASE, TURN_ON): {COMMAND: "on_short_release"},
+    (SHORT_RELEASE, TURN_OFF): {COMMAND: "off_short_release"},
+    (SHORT_RELEASE, DIM_UP): {COMMAND: "up_short_release"},
+    (SHORT_RELEASE, DIM_DOWN): {COMMAND: "down_short_release"},
+    (LONG_RELEASE, TURN_ON): {COMMAND: "on_long_release"},
+    (LONG_RELEASE, TURN_OFF): {COMMAND: "off_long_release"},
+    (LONG_RELEASE, DIM_UP): {COMMAND: "up_long_release"},
+    (LONG_RELEASE, DIM_DOWN): {COMMAND: "down_long_release"},
+}
 
 
 class PowerOnState(t.enum8):

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -16,6 +16,8 @@ from zigpy.zcl.clusters.general import (
 
 from ..const import (
     ARGS,
+    COMMAND_ID,
+    BUTTON,
     CLUSTER_ID,
     COMMAND,
     COMMAND_OFF_WITH_EFFECT,
@@ -29,10 +31,12 @@ from ..const import (
     INPUT_CLUSTERS,
     LONG_PRESS,
     OUTPUT_CLUSTERS,
+    PRESS_TYPE,
     PROFILE_ID,
     SHORT_PRESS,
     TURN_OFF,
     TURN_ON,
+    ZHA_SEND_EVENT,
 )
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
@@ -69,14 +73,28 @@ class PhillipsCluster(CustomCluster):
             False,
         )
     }
-
-    def _update_attribute(self, attrid, value):
-        super()._update_attribute(attrid, value)
-        _LOGGER.info("Received attribute %s - value: [%s]", attrid, value)
+    BUTTONS = {1: "on", 2: "up", 3: "down", 4: "off"}
+    PRESS_TYPES = {0: "press", 1: "hold", 2: "short_release", 3: "long_release"}
 
     def handle_cluster_request(self, tsn, command_id, args):
         """Handle the cluster command."""
-        _LOGGER.info("Received attribute %s - value: [%s]", command_id, args)
+        _LOGGER.info(
+            "handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
+            tsn,
+            command_id,
+            args,
+        )
+        button = self.BUTTONS.get(args[0], args[0])
+        press_type = self.PRESS_TYPES.get(args[2], args[2])
+
+        event_args = {
+            BUTTON: button,
+            PRESS_TYPE: press_type,
+            COMMAND_ID: command_id,
+            ARGS: args,
+        }
+        action = "{}_{}".format(button, press_type)
+        self.listener_event(ZHA_SEND_EVENT, action, event_args)
 
 
 class PhilipsRWL020(CustomDevice):

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -13,27 +13,8 @@ from zigpy.zcl.clusters.general import (
     PowerConfiguration,
 )
 
-from . import PhillipsBasicCluster, PhillipsRemoteCluster
-from ..const import (
-    ARGS,
-    CLUSTER_ID,
-    COMMAND,
-    COMMAND_OFF_WITH_EFFECT,
-    COMMAND_ON,
-    COMMAND_STEP,
-    DEVICE_TYPE,
-    DIM_DOWN,
-    DIM_UP,
-    ENDPOINT_ID,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    LONG_PRESS,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-    SHORT_PRESS,
-    TURN_OFF,
-    TURN_ON,
-)
+from . import HUE_REMOTE_DEVICE_TRIGGERS, PhillipsBasicCluster, PhillipsRemoteCluster
+from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 
@@ -103,31 +84,4 @@ class PhilipsRWL020(CustomDevice):
         }
     }
 
-    device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON},
-        (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF_WITH_EFFECT},
-        (SHORT_PRESS, DIM_UP): {
-            COMMAND: COMMAND_STEP,
-            CLUSTER_ID: 8,
-            ENDPOINT_ID: 1,
-            ARGS: [0, 30, 9],
-        },
-        (LONG_PRESS, DIM_UP): {
-            COMMAND: COMMAND_STEP,
-            CLUSTER_ID: 8,
-            ENDPOINT_ID: 1,
-            ARGS: [0, 56, 9],
-        },
-        (SHORT_PRESS, DIM_DOWN): {
-            COMMAND: COMMAND_STEP,
-            CLUSTER_ID: 8,
-            ENDPOINT_ID: 1,
-            ARGS: [1, 30, 9],
-        },
-        (LONG_PRESS, DIM_DOWN): {
-            COMMAND: COMMAND_STEP,
-            CLUSTER_ID: 8,
-            ENDPOINT_ID: 1,
-            ARGS: [1, 56, 9],
-        },
-    }
+    device_automation_triggers = HUE_REMOTE_DEVICE_TRIGGERS

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -1,5 +1,4 @@
 """Phillips RWL020 device."""
-import logging
 
 from zigpy.profiles import zha, zll
 from zigpy.quirks import CustomDevice
@@ -37,7 +36,6 @@ from ..const import (
 )
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
-_LOGGER = logging.getLogger(__name__)
 
 
 class PhilipsRWL020(CustomDevice):

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -1,8 +1,8 @@
 """Phillips RWL020 device."""
 import logging
+
 from zigpy.profiles import zha, zll
-from zigpy.quirks import CustomCluster, CustomDevice
-import zigpy.types as t
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
     BinaryInput,
@@ -14,10 +14,9 @@ from zigpy.zcl.clusters.general import (
     PowerConfiguration,
 )
 
+from . import PhillipsBasicCluster, PhillipsRemoteCluster
 from ..const import (
     ARGS,
-    COMMAND_ID,
-    BUTTON,
     CLUSTER_ID,
     COMMAND,
     COMMAND_OFF_WITH_EFFECT,
@@ -31,70 +30,14 @@ from ..const import (
     INPUT_CLUSTERS,
     LONG_PRESS,
     OUTPUT_CLUSTERS,
-    PRESS_TYPE,
     PROFILE_ID,
     SHORT_PRESS,
     TURN_OFF,
     TURN_ON,
-    ZHA_SEND_EVENT,
 )
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 _LOGGER = logging.getLogger(__name__)
-
-
-class BasicCluster(CustomCluster, Basic):
-    """Phillips Basic cluster."""
-
-    attributes = Basic.attributes.copy()
-    attributes.update({0x0031: ("phillips", t.bitmap16)})
-
-    attr_config = {0x0031: 0x000B}
-
-    async def bind(self):
-        """Bind cluster."""
-        result = await super().bind()
-        await self.write_attributes(self.attr_config, manufacturer=0x100B)
-        return result
-
-
-class PhillipsCluster(CustomCluster):
-    """Phillips Basic cluster."""
-
-    cluster_id = 64512
-    name = "PhillipsCluster"
-    ep_attribute = "phillips_cluster"
-    attributes = {}
-    server_commands = {}
-    client_commands = {
-        0x0000: (
-            "notification",
-            (t.uint8_t, t.uint24_t, t.uint8_t, t.uint8_t, t.uint8_t, t.uint8_t),
-            False,
-        )
-    }
-    BUTTONS = {1: "on", 2: "up", 3: "down", 4: "off"}
-    PRESS_TYPES = {0: "press", 1: "hold", 2: "short_release", 3: "long_release"}
-
-    def handle_cluster_request(self, tsn, command_id, args):
-        """Handle the cluster command."""
-        _LOGGER.info(
-            "handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
-            tsn,
-            command_id,
-            args,
-        )
-        button = self.BUTTONS.get(args[0], args[0])
-        press_type = self.PRESS_TYPES.get(args[2], args[2])
-
-        event_args = {
-            BUTTON: button,
-            PRESS_TYPE: press_type,
-            COMMAND_ID: command_id,
-            ARGS: args,
-        }
-        action = "{}_{}".format(button, press_type)
-        self.listener_event(ZHA_SEND_EVENT, action, event_args)
 
 
 class PhilipsRWL020(CustomDevice):
@@ -151,11 +94,11 @@ class PhilipsRWL020(CustomDevice):
             },
             2: {
                 INPUT_CLUSTERS: [
-                    BasicCluster,
+                    PhillipsBasicCluster,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     BinaryInput.cluster_id,
-                    PhillipsCluster,
+                    PhillipsRemoteCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -1,4 +1,4 @@
-"""Phillips RWL020 device."""
+"""Philips RWL020 device."""
 
 from zigpy.profiles import zha, zll
 from zigpy.quirks import CustomDevice
@@ -13,14 +13,14 @@ from zigpy.zcl.clusters.general import (
     PowerConfiguration,
 )
 
-from . import HUE_REMOTE_DEVICE_TRIGGERS, PhillipsBasicCluster, PhillipsRemoteCluster
+from . import HUE_REMOTE_DEVICE_TRIGGERS, PhilipsBasicCluster, PhilipsRemoteCluster
 from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 
 
 class PhilipsRWL020(CustomDevice):
-    """Phillips RWL020 device."""
+    """Philips RWL020 device."""
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=49246 device_type=2080
@@ -73,11 +73,11 @@ class PhilipsRWL020(CustomDevice):
             },
             2: {
                 INPUT_CLUSTERS: [
-                    PhillipsBasicCluster,
+                    PhilipsBasicCluster,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     BinaryInput.cluster_id,
-                    PhillipsRemoteCluster,
+                    PhilipsRemoteCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },

--- a/zhaquirks/philips/rwl021.py
+++ b/zhaquirks/philips/rwl021.py
@@ -1,9 +1,7 @@
 """Phillips RWL021 device."""
-import logging
 
 from zigpy.profiles import zha, zll
-from zigpy.quirks import CustomCluster, CustomDevice
-import zigpy.types as t
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
     BinaryInput,
@@ -16,10 +14,9 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
+from . import PhillipsBasicCluster, PhillipsRemoteCluster
 from ..const import (
     ARGS,
-    COMMAND_ID,
-    BUTTON,
     CLUSTER_ID,
     COMMAND,
     COMMAND_OFF_WITH_EFFECT,
@@ -33,70 +30,13 @@ from ..const import (
     INPUT_CLUSTERS,
     LONG_PRESS,
     OUTPUT_CLUSTERS,
-    PRESS_TYPE,
     PROFILE_ID,
     SHORT_PRESS,
     TURN_OFF,
     TURN_ON,
-    ZHA_SEND_EVENT,
 )
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
-_LOGGER = logging.getLogger(__name__)
-
-
-class BasicCluster(CustomCluster, Basic):
-    """Phillips Basic cluster."""
-
-    attributes = Basic.attributes.copy()
-    attributes.update({0x0031: ("phillips", t.bitmap16)})
-
-    attr_config = {0x0031: 0x000B}
-
-    async def bind(self):
-        """Bind cluster."""
-        result = await super().bind()
-        await self.write_attributes(self.attr_config, manufacturer=0x100B)
-        return result
-
-
-class PhillipsCluster(CustomCluster):
-    """Phillips Basic cluster."""
-
-    cluster_id = 64512
-    name = "PhillipsCluster"
-    ep_attribute = "phillips_cluster"
-    attributes = {}
-    server_commands = {}
-    client_commands = {
-        0x0000: (
-            "notification",
-            (t.uint8_t, t.uint24_t, t.uint8_t, t.uint8_t, t.uint8_t, t.uint8_t),
-            False,
-        )
-    }
-    BUTTONS = {1: "on", 2: "up", 3: "down", 4: "off"}
-    PRESS_TYPES = {0: "press", 1: "hold", 2: "short_release", 3: "long_release"}
-
-    def handle_cluster_request(self, tsn, command_id, args):
-        """Handle the cluster command."""
-        _LOGGER.info(
-            "handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
-            tsn,
-            command_id,
-            args,
-        )
-        button = self.BUTTONS.get(args[0], args[0])
-        press_type = self.PRESS_TYPES.get(args[2], args[2])
-
-        event_args = {
-            BUTTON: button,
-            PRESS_TYPE: press_type,
-            COMMAND_ID: command_id,
-            ARGS: args,
-        }
-        action = "{}_{}".format(button, press_type)
-        self.listener_event(ZHA_SEND_EVENT, action, event_args)
 
 
 class PhilipsRWL021(CustomDevice):
@@ -155,11 +95,11 @@ class PhilipsRWL021(CustomDevice):
             },
             2: {
                 INPUT_CLUSTERS: [
-                    BasicCluster,
+                    PhillipsBasicCluster,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     BinaryInput.cluster_id,
-                    PhillipsCluster,
+                    PhillipsRemoteCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },

--- a/zhaquirks/philips/rwl021.py
+++ b/zhaquirks/philips/rwl021.py
@@ -1,4 +1,4 @@
-"""Phillips RWL021 device."""
+"""Philips RWL021 device."""
 
 from zigpy.profiles import zha, zll
 from zigpy.quirks import CustomDevice
@@ -14,14 +14,14 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from . import HUE_REMOTE_DEVICE_TRIGGERS, PhillipsBasicCluster, PhillipsRemoteCluster
+from . import HUE_REMOTE_DEVICE_TRIGGERS, PhilipsBasicCluster, PhilipsRemoteCluster
 from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 
 
 class PhilipsRWL021(CustomDevice):
-    """Phillips RWL021 device."""
+    """Philips RWL021 device."""
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=49246 device_type=2096
@@ -76,11 +76,11 @@ class PhilipsRWL021(CustomDevice):
             },
             2: {
                 INPUT_CLUSTERS: [
-                    PhillipsBasicCluster,
+                    PhilipsBasicCluster,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     BinaryInput.cluster_id,
-                    PhillipsRemoteCluster,
+                    PhilipsRemoteCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },

--- a/zhaquirks/philips/rwl021.py
+++ b/zhaquirks/philips/rwl021.py
@@ -1,5 +1,6 @@
 """Phillips RWL021 device."""
 import logging
+
 from zigpy.profiles import zha, zll
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
@@ -17,6 +18,8 @@ from zigpy.zcl.clusters.general import (
 
 from ..const import (
     ARGS,
+    COMMAND_ID,
+    BUTTON,
     CLUSTER_ID,
     COMMAND,
     COMMAND_OFF_WITH_EFFECT,
@@ -30,10 +33,12 @@ from ..const import (
     INPUT_CLUSTERS,
     LONG_PRESS,
     OUTPUT_CLUSTERS,
+    PRESS_TYPE,
     PROFILE_ID,
     SHORT_PRESS,
     TURN_OFF,
     TURN_ON,
+    ZHA_SEND_EVENT,
 )
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
@@ -70,14 +75,28 @@ class PhillipsCluster(CustomCluster):
             False,
         )
     }
-
-    def _update_attribute(self, attrid, value):
-        super()._update_attribute(attrid, value)
-        _LOGGER.info("Received attribute %s - value: [%s]", attrid, value)
+    BUTTONS = {1: "on", 2: "up", 3: "down", 4: "off"}
+    PRESS_TYPES = {0: "press", 1: "hold", 2: "short_release", 3: "long_release"}
 
     def handle_cluster_request(self, tsn, command_id, args):
         """Handle the cluster command."""
-        _LOGGER.info("Received attribute %s - value: [%s]", command_id, args)
+        _LOGGER.info(
+            "handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
+            tsn,
+            command_id,
+            args,
+        )
+        button = self.BUTTONS.get(args[0], args[0])
+        press_type = self.PRESS_TYPES.get(args[2], args[2])
+
+        event_args = {
+            BUTTON: button,
+            PRESS_TYPE: press_type,
+            COMMAND_ID: command_id,
+            ARGS: args,
+        }
+        action = "{}_{}".format(button, press_type)
+        self.listener_event(ZHA_SEND_EVENT, action, event_args)
 
 
 class PhilipsRWL021(CustomDevice):

--- a/zhaquirks/philips/rwl021.py
+++ b/zhaquirks/philips/rwl021.py
@@ -14,27 +14,8 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from . import PhillipsBasicCluster, PhillipsRemoteCluster
-from ..const import (
-    ARGS,
-    CLUSTER_ID,
-    COMMAND,
-    COMMAND_OFF_WITH_EFFECT,
-    COMMAND_ON,
-    COMMAND_STEP,
-    DEVICE_TYPE,
-    DIM_DOWN,
-    DIM_UP,
-    ENDPOINT_ID,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    LONG_PRESS,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-    SHORT_PRESS,
-    TURN_OFF,
-    TURN_ON,
-)
+from . import HUE_REMOTE_DEVICE_TRIGGERS, PhillipsBasicCluster, PhillipsRemoteCluster
+from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 
@@ -106,31 +87,4 @@ class PhilipsRWL021(CustomDevice):
         }
     }
 
-    device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON},
-        (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF_WITH_EFFECT},
-        (SHORT_PRESS, DIM_UP): {
-            COMMAND: COMMAND_STEP,
-            CLUSTER_ID: 8,
-            ENDPOINT_ID: 1,
-            ARGS: [0, 30, 9],
-        },
-        (LONG_PRESS, DIM_UP): {
-            COMMAND: COMMAND_STEP,
-            CLUSTER_ID: 8,
-            ENDPOINT_ID: 1,
-            ARGS: [0, 56, 9],
-        },
-        (SHORT_PRESS, DIM_DOWN): {
-            COMMAND: COMMAND_STEP,
-            CLUSTER_ID: 8,
-            ENDPOINT_ID: 1,
-            ARGS: [1, 30, 9],
-        },
-        (LONG_PRESS, DIM_DOWN): {
-            COMMAND: COMMAND_STEP,
-            CLUSTER_ID: 8,
-            ENDPOINT_ID: 1,
-            ARGS: [1, 56, 9],
-        },
-    }
+    device_automation_triggers = HUE_REMOTE_DEVICE_TRIGGERS

--- a/zhaquirks/philips/rwl021.py
+++ b/zhaquirks/philips/rwl021.py
@@ -1,4 +1,5 @@
 """Phillips RWL021 device."""
+import logging
 from zigpy.profiles import zha, zll
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
@@ -36,13 +37,47 @@ from ..const import (
 )
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
+_LOGGER = logging.getLogger(__name__)
 
 
 class BasicCluster(CustomCluster, Basic):
-    """Centralite acceleration cluster."""
+    """Phillips Basic cluster."""
 
     attributes = Basic.attributes.copy()
     attributes.update({0x0031: ("phillips", t.bitmap16)})
+
+    attr_config = {0x0031: 0x000B}
+
+    async def bind(self):
+        """Bind cluster."""
+        result = await super().bind()
+        await self.write_attributes(self.attr_config, manufacturer=0x100B)
+        return result
+
+
+class PhillipsCluster(CustomCluster):
+    """Phillips Basic cluster."""
+
+    cluster_id = 64512
+    name = "PhillipsCluster"
+    ep_attribute = "phillips_cluster"
+    attributes = {}
+    server_commands = {}
+    client_commands = {
+        0x0000: (
+            "notification",
+            (t.uint8_t, t.uint24_t, t.uint8_t, t.uint8_t, t.uint8_t, t.uint8_t),
+            False,
+        )
+    }
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        _LOGGER.info("Received attribute %s - value: [%s]", attrid, value)
+
+    def handle_cluster_request(self, tsn, command_id, args):
+        """Handle the cluster command."""
+        _LOGGER.info("Received attribute %s - value: [%s]", command_id, args)
 
 
 class PhilipsRWL021(CustomDevice):
@@ -105,7 +140,7 @@ class PhilipsRWL021(CustomDevice):
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     BinaryInput.cluster_id,
-                    64512,
+                    PhillipsCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },


### PR DESCRIPTION
This PR adds support for 4 actions per button: press, hold, short release and long release. It needs https://github.com/home-assistant/core/pull/37172 in order to function. 

Fixes: #86 

Things still needed:

- [x] device trigger support
- [x] deduplicate code between remote versions