### PR TITLE
Support older SmartThings sensors (multi and motion)

### DIFF
--- a/zhaquirks/smartthings/__init__.py
+++ b/zhaquirks/smartthings/__init__.py
@@ -28,7 +28,7 @@ class SmartThingsAccelCluster(CustomCluster):
 
 
 class SmartThingsIasZone(CustomCluster, IasZone):
-    """IasZone cluster patched to support SmartThings spec violations"""
+    """IasZone cluster patched to support SmartThings spec violations."""
 
     client_commands = IasZone.client_commands.copy()
     client_commands[0x0000] = (

--- a/zhaquirks/smartthings/__init__.py
+++ b/zhaquirks/smartthings/__init__.py
@@ -2,6 +2,7 @@
 
 import zigpy.types as t
 from zigpy.quirks import CustomCluster
+from zigpy.zcl.clusters.security import IasZone
 
 SMART_THINGS = "SmartThings"
 MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFC02  # decimal = 64514
@@ -24,3 +25,20 @@ class SmartThingsAccelCluster(CustomCluster):
 
     client_commands = {}
     server_commands = {}
+
+
+class SmartThingsIasZone(CustomCluster, IasZone):
+    """IasZone cluster patched to support SmartThings spec violations"""
+
+    client_commands = IasZone.client_commands.copy()
+    client_commands[0x0000] = (
+        "status_change_notification",
+        (
+            IasZone.ZoneStatus,
+            t.bitmap8,
+            # SmartThings never sends these two
+            t.Optional(t.uint8_t),
+            t.Optional(t.uint16_t),
+        ),
+        False,
+    )

--- a/zhaquirks/smartthings/pgc313.py
+++ b/zhaquirks/smartthings/pgc313.py
@@ -1,0 +1,58 @@
+"""SmartThings SmartSense Multi Sensor quirk."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import Basic, Ota
+from zigpy.zcl.clusters.security import IasZone
+
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from . import SMART_THINGS
+
+SMARTSENSE_MULTI_DEVICE_TYPE = 0x0139  # decimal = 313
+
+class IasZoneContactSwitchCluster(CustomCluster, IasZone):
+    """Custom IasZone cluster."""
+
+    ZONE_TYPE = 0x0001
+    CONTACT_SWITCH_TYPE = 0x0015
+    _CONSTANT_ATTRIBUTES = {ZONE_TYPE: CONTACT_SWITCH_TYPE}
+
+class SmartthingsSmartSenseMultiSensor(CustomDevice):
+    """Multipurpose sensor."""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=313
+        #  device_version=0 input_clusters=[0] output_clusters=[25]>
+        MODELS_INFO: [(SMART_THINGS, "PGC313")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: SMARTSENSE_MULTI_DEVICE_TYPE,
+                INPUT_CLUSTERS: [Basic.cluster_id,],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            #  <SimpleDescriptor endpoint=2 profile=64513 device_type=313
+            #  device_version=0 input_clusters=[] output_clusters=[]>
+            2: {
+                PROFILE_ID: 0xFC01,  # decimal = 64513
+                DEVICE_TYPE: SMARTSENSE_MULTI_DEVICE_TYPE,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [Basic.cluster_id, IasZoneContactSwitchCluster,],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            }
+        }
+    }

--- a/zhaquirks/smartthings/pgc313.py
+++ b/zhaquirks/smartthings/pgc313.py
@@ -1,8 +1,7 @@
 """SmartThings SmartSense Multi Sensor quirk."""
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Ota
-from zigpy.zcl.clusters.security import IasZone
 
 from ..const import (
     DEVICE_TYPE,
@@ -12,16 +11,18 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from . import SMART_THINGS
+from . import SMART_THINGS, SmartThingsIasZone
 
 SMARTSENSE_MULTI_DEVICE_TYPE = 0x0139  # decimal = 313
 
-class IasZoneContactSwitchCluster(CustomCluster, IasZone):
+
+class IasZoneContactSwitchCluster(SmartThingsIasZone):
     """Custom IasZone cluster."""
 
     ZONE_TYPE = 0x0001
     CONTACT_SWITCH_TYPE = 0x0015
     _CONSTANT_ATTRIBUTES = {ZONE_TYPE: CONTACT_SWITCH_TYPE}
+
 
 class SmartthingsSmartSenseMultiSensor(CustomDevice):
     """Multipurpose sensor."""

--- a/zhaquirks/smartthings/pgc313.py
+++ b/zhaquirks/smartthings/pgc313.py
@@ -35,7 +35,7 @@ class SmartthingsSmartSenseMultiSensor(CustomDevice):
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: SMARTSENSE_MULTI_DEVICE_TYPE,
-                INPUT_CLUSTERS: [Basic.cluster_id,],
+                INPUT_CLUSTERS: [Basic.cluster_id],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
             #  <SimpleDescriptor endpoint=2 profile=64513 device_type=313
@@ -52,7 +52,7 @@ class SmartthingsSmartSenseMultiSensor(CustomDevice):
     replacement = {
         ENDPOINTS: {
             1: {
-                INPUT_CLUSTERS: [Basic.cluster_id, IasZoneContactSwitchCluster,],
+                INPUT_CLUSTERS: [Basic.cluster_id, IasZoneContactSwitchCluster],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             }
         }

--- a/zhaquirks/smartthings/pgc314.py
+++ b/zhaquirks/smartthings/pgc314.py
@@ -1,0 +1,59 @@
+"""SmartThings SmartSense Motion quirk."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import Basic, Ota
+
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from . import SMART_THINGS, SmartThingsIasZone
+
+SMARTSENSE_MOTION_DEVICE_TYPE = 0x013A  # decimal = 314
+
+
+class IasZoneMotionCluster(SmartThingsIasZone):
+    """Custom IasZone cluster."""
+
+    ZONE_TYPE = 0x0001
+    MOTION_TYPE = 0x000D
+    _CONSTANT_ATTRIBUTES = {ZONE_TYPE: MOTION_TYPE}
+
+
+class SmartthingsSmartSenseMotionSensor(CustomDevice):
+    """SmartSense Motion Sensor."""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=314
+        #  device_version=0 input_clusters=[0] output_clusters=[25]>
+        MODELS_INFO: [(SMART_THINGS, "PGC314")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: SMARTSENSE_MOTION_DEVICE_TYPE,
+                INPUT_CLUSTERS: [Basic.cluster_id,],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            #  <SimpleDescriptor endpoint=2 profile=64513 device_type=314
+            #  device_version=0 input_clusters=[] output_clusters=[]>
+            2: {
+                PROFILE_ID: 0xFC01,  # decimal = 64513
+                DEVICE_TYPE: SMARTSENSE_MOTION_DEVICE_TYPE,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [Basic.cluster_id, IasZoneMotionCluster,],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            }
+        }
+    }

--- a/zhaquirks/smartthings/pgc314.py
+++ b/zhaquirks/smartthings/pgc314.py
@@ -35,7 +35,7 @@ class SmartthingsSmartSenseMotionSensor(CustomDevice):
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: SMARTSENSE_MOTION_DEVICE_TYPE,
-                INPUT_CLUSTERS: [Basic.cluster_id,],
+                INPUT_CLUSTERS: [Basic.cluster_id],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
             #  <SimpleDescriptor endpoint=2 profile=64513 device_type=314
@@ -52,7 +52,7 @@ class SmartthingsSmartSenseMotionSensor(CustomDevice):
     replacement = {
         ENDPOINTS: {
             1: {
-                INPUT_CLUSTERS: [Basic.cluster_id, IasZoneMotionCluster,],
+                INPUT_CLUSTERS: [Basic.cluster_id, IasZoneMotionCluster],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             }
         }


### PR DESCRIPTION
These devices fail to report the correct endpoints and, to top it off, send malformed IAS Zone commands. They've come up a least a few times over the years:

https://github.com/home-assistant/core/issues/31493
https://community.home-assistant.io/t/support-for-smartthings-multisensor-2013/130195
https://community.home-assistant.io/t/anyone-able-to-get-a-smartthings-smartsense-multi-2013-to-work/169032
https://community.home-assistant.io/t/zha-tried-to-add-smartthings-open-close-sensor/45249
https://community.home-assistant.io/t/zha-zigbee-tested-devices-please-add-your-device-results/17718/337
