### PR TITLE
Refactor "manufacturer specific" attributes and commands declaration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(
     keywords="zha quirks homeassistant hass",
     packages=find_packages(exclude=["*.tests"]),
     python_requires=">=3",
-    install_requires=["zigpy>=0.20.0"],
+    install_requires=["zigpy>=0.22.0"],
     tests_require=["pytest"],
 )

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -41,7 +41,7 @@ class LocalDataCluster(CustomCluster):
         """Prevent unbind."""
         return (foundation.Status.SUCCESS,)
 
-    async def _configure_reporting(self, *args, **kwargs):
+    async def _configure_reporting(self, *args, **kwargs):  # pylint: disable=W0221
         """Prevent remote configure reporting."""
         return foundation.ConfigureReportingResponse.deserialize(b"\x00")[0]
 

--- a/zhaquirks/centralite/3310S.py
+++ b/zhaquirks/centralite/3310S.py
@@ -26,12 +26,10 @@ class SmartthingsRelativeHumidityCluster(CustomCluster):
     cluster_id = SMRT_THINGS_REL_HUM_CLSTR
     name = "Smartthings Relative Humidity Measurement"
     ep_attribute = "humidity"
-    attributes = {
+    manufacturer_attributes = {
         # Relative Humidity Measurement Information
         0x0000: ("measured_value", t.int16s)
     }
-    server_commands = {}
-    client_commands = {}
 
 
 class CentraLite3310S(CustomDevice):

--- a/zhaquirks/centralite/__init__.py
+++ b/zhaquirks/centralite/__init__.py
@@ -14,7 +14,7 @@ class CentraLiteAccelCluster(CustomCluster):
     cluster_id = 0xFC02
     name = "CentraLite Accelerometer"
     ep_attribute = "accelerometer"
-    attributes = {
+    manufacturer_attributes = {
         0x0000: ("motion_threshold_multiplier", t.uint8_t),
         0x0002: ("motion_threshold", t.uint16_t),
         0x0010: ("acceleration", t.bitmap8),  # acceleration detected
@@ -22,6 +22,3 @@ class CentraLiteAccelCluster(CustomCluster):
         0x0013: ("y_axis", t.int16s),
         0x0014: ("z_axis", t.int16s),
     }
-
-    client_commands = {}
-    server_commands = {}

--- a/zhaquirks/eurotronic/__init__.py
+++ b/zhaquirks/eurotronic/__init__.py
@@ -42,16 +42,13 @@ _LOGGER = logging.getLogger(__name__)
 class ThermostatCluster(CustomCluster, Thermostat):
     """Thermostat cluster."""
 
-    cluster_id = Thermostat.cluster_id
-
-    attributes = {
+    manufacturer_attributes = {
         TRV_MODE_ATTR: ("trv_mode", types.enum8),
         SET_VALVE_POS_ATTR: ("set_valve_position", types.uint8_t),
         ERRORS_ATTR: ("errors", types.uint8_t),
         CURRENT_TEMP_SETPOINT_ATTR: ("current_temperature_setpoint", types.int16s),
         HOST_FLAGS_ATTR: ("host_flags", types.uint24_t),
     }
-    attributes.update(Thermostat.attributes)
 
     def _update_attribute(self, attrid, value):
         _LOGGER.debug("update attribute %04x to %s... ", attrid, value)

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -37,14 +37,8 @@ class LightLinkCluster(CustomCluster, LightLink):
 class ScenesCluster(CustomCluster, Scenes):
     """Ikea Scenes cluster."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.server_commands = Scenes.attributes.copy()
-        self.server_commands.update(
-            {
-                0x0007: ("press", (t.int16s, t.int8s, t.int8s), False),
-                0x0008: ("hold", (t.int16s, t.int8s), False),
-                0x0009: ("release", (t.int16s,), False),
-            }
-        )
+    manufacturer_server_commands = {
+        0x0007: ("press", (t.int16s, t.int8s, t.int8s), False),
+        0x0008: ("hold", (t.int16s, t.int8s), False),
+        0x0009: ("release", (t.int16s,), False),
+    }

--- a/zhaquirks/ledvance/__init__.py
+++ b/zhaquirks/ledvance/__init__.py
@@ -7,9 +7,7 @@ LEDVANCE = "LEDVANCE"
 class LedvanceLightCluster(CustomCluster):
     """LedvanceLightCluster."""
 
-    attributes = {}
-    client_commands = {}
     cluster_id = 0xFC01
     ep_attribute = "ledvance_light"
     name = "LedvanceLight"
-    server_commands = {0x0001: ("save_defaults", (), False)}
+    manufacturer_server_commands = {0x0001: ("save_defaults", (), False)}

--- a/zhaquirks/legrand/dimmer.py
+++ b/zhaquirks/legrand/dimmer.py
@@ -33,13 +33,11 @@ class LegrandCluster(CustomCluster, ManufacturerSpecificCluster):
     cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID
     name = "LegrandCluster"
     ep_attribute = "legrand_cluster"
-    attributes = {
+    manufacturer_attributes = {
         0x0000: ("dimmer", t.data16),
         0x0001: ("led_dark", t.Bool),
         0x0002: ("led_on", t.Bool),
     }
-    server_commands = {}
-    client_commands = {}
 
 
 class DimmerWithoutNeutral(CustomDevice):

--- a/zhaquirks/osram/__init__.py
+++ b/zhaquirks/osram/__init__.py
@@ -7,9 +7,7 @@ OSRAM = "OSRAM"
 class OsramLightCluster(CustomCluster):
     """OsramLightCluster."""
 
-    attributes = {}
-    client_commands = {}
     cluster_id = 0xFC0F
     ep_attribute = "osram_light"
     name = "OsramLight"
-    server_commands = {0x0001: ("save_defaults", (), False)}
+    manufacturer_server_commands = {0x0001: ("save_defaults", (), False)}

--- a/zhaquirks/osram/lightifyx4.py
+++ b/zhaquirks/osram/lightifyx4.py
@@ -55,7 +55,7 @@ class OsramButtonCluster(CustomCluster):
     cluster_id = OSRAM_CLUSTER
     name = "OsramCluster"
     ep_attribute = "osram_cluster"
-    attributes = {
+    manufacturer_attributes = {
         0x000A: ("osram_1", t.uint8_t),
         0x000B: ("osram_2", t.uint8_t),
         0x000C: ("osram_3", t.uint16_t),
@@ -71,8 +71,6 @@ class OsramButtonCluster(CustomCluster):
         0x002E: ("osram_13", t.uint16_t),
         0x002F: ("osram_14", t.uint16_t),
     }
-    server_commands = {}
-    client_commands = {}
     attr_config = {
         0x000A: 0x01,
         0x000B: 0x00,

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -57,15 +57,13 @@ class PowerOnState(t.enum8):
 class PhilipsOnOffCluster(CustomCluster, OnOff):
     """Philips OnOff cluster."""
 
-    attributes = OnOff.attributes.copy()
-    attributes.update({0x4003: ("power_on_state", PowerOnState)})
+    manufacturer_attributes = {0x4003: ("power_on_state", PowerOnState)}
 
 
 class PhilipsBasicCluster(CustomCluster, Basic):
     """Philips Basic cluster."""
 
-    attributes = Basic.attributes.copy()
-    attributes.update({0x0031: ("philips", t.bitmap16)})
+    manufacturer_attributes = {0x0031: ("philips", t.bitmap16)}
 
     attr_config = {0x0031: 0x000B}
 
@@ -82,9 +80,7 @@ class PhilipsRemoteCluster(CustomCluster):
     cluster_id = 64512
     name = "PhilipsRemoteCluster"
     ep_attribute = "philips_remote_cluster"
-    attributes = {}
-    server_commands = {}
-    client_commands = {
+    manufacturer_client_commands = {
         0x0000: (
             "notification",
             (t.uint8_t, t.uint24_t, t.uint8_t, t.uint8_t, t.uint8_t, t.uint8_t),

--- a/zhaquirks/philips/sml002.py
+++ b/zhaquirks/philips/sml002.py
@@ -33,9 +33,10 @@ from ..const import (
 class OccupancyCluster(CustomCluster, OccupancySensing):
     """philips occupancy cluster."""
 
-    attributes = OccupancySensing.attributes.copy()
-    attributes.update({0x0030: ("sensitivity", t.uint8_t)})
-    attributes.update({0x0031: ("sensitivity_max", t.uint8_t)})
+    manufacturer_attributes = {
+        0x0030: ("sensitivity", t.uint8_t),
+        0x0031: ("sensitivity_max", t.uint8_t),
+    }
 
 
 class PhilipsSML002(CustomDevice):

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -52,8 +52,7 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
 class SinopeTechnologiesThermostatCluster(CustomCluster, Thermostat):
     """SinopeTechnologiesThermostatCluster custom cluster."""
 
-    attributes = Thermostat.attributes.copy()
-    attributes[0x0400] = ("set_occupancy", t.enum8)
+    manufacturer_attributes = {0x0400: ("set_occupancy", t.enum8)}
 
 
 class SinopeTechnologiesThermostat(CustomDevice):

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -41,12 +41,10 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
     cluster_id = SINOPE_MANUFACTURER_CLUSTER_ID
     name = "Sinopé Technologies Manufacturer specific"
     ep_attribute = "sinope_manufacturer_specific"
-    attributes = {
+    manufacturer_attributes = {
         0x0010: ("outdoor_temp", t.int16s),
         0x0020: ("secs_since_2k", t.uint32_t),
     }
-    client_commands = {}
-    server_commands = {}
 
 
 class SinopeTechnologiesThermostatCluster(CustomCluster, Thermostat):

--- a/zhaquirks/smartthings/__init__.py
+++ b/zhaquirks/smartthings/__init__.py
@@ -14,7 +14,7 @@ class SmartThingsAccelCluster(CustomCluster):
     cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID
     name = "Smartthings Accelerometer"
     ep_attribute = "accelerometer"
-    attributes = {
+    manufacturer_attributes = {
         0x0000: ("motion_threshold_multiplier", t.uint8_t),
         0x0002: ("motion_threshold", t.uint16_t),
         0x0010: ("acceleration", t.bitmap8),  # acceleration detected
@@ -23,22 +23,20 @@ class SmartThingsAccelCluster(CustomCluster):
         0x0014: ("z_axis", t.int16s),
     }
 
-    client_commands = {}
-    server_commands = {}
-
 
 class SmartThingsIasZone(CustomCluster, IasZone):
     """IasZone cluster patched to support SmartThings spec violations."""
 
-    client_commands = IasZone.client_commands.copy()
-    client_commands[0x0000] = (
-        "status_change_notification",
-        (
-            IasZone.ZoneStatus,
-            t.bitmap8,
-            # SmartThings never sends these two
-            t.Optional(t.uint8_t),
-            t.Optional(t.uint16_t),
-        ),
-        False,
-    )
+    manufacturer_client_commands = {
+        0x0000: (
+            "status_change_notification",
+            (
+                IasZone.ZoneStatus,
+                t.bitmap8,
+                # SmartThings never sends these two
+                t.Optional(t.uint8_t),
+                t.Optional(t.uint16_t),
+            ),
+            False,
+        )
+    }

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -59,13 +59,13 @@ class EmulatedIasZone(LocalDataCluster, IasZone):
 class WAXMANApplianceEventAlerts(CustomCluster, ApplianceEventAlerts):
     """WAXMAN specific ApplianceEventAlert cluster."""
 
+    manufacturer_client_commands = {
+        WAXMAN_CMDID: ("alerts_notification", (t.uint8_t, t.bitmap24), False)
+    }
+
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
-        self.client_commands = super().client_commands.copy()
-        self.client_commands.update(
-            {WAXMAN_CMDID: ("alerts_notification", (t.uint8_t, t.bitmap24), False)}
-        )
         self.endpoint.device.app_cluster = self
 
     def handle_cluster_request(self, tsn, command_id, args):

--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -142,7 +142,7 @@ class OppleCluster(CustomCluster):
 
     ep_attribute = "opple_cluster"
     cluster_id = OPPLE_CLUSTER_ID
-    attributes = {0x0009: ("mode", types.uint8_t)}
+    manufacturer_attributes = {0x0009: ("mode", types.uint8_t)}
     attr_config = {0x0009: 0x01}
 
     def __init__(self, *args, **kwargs):

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -61,6 +61,8 @@ _LOGGER = logging.getLogger(__name__)
 class VibrationAQ1(XiaomiCustomDevice):
     """Xiaomi aqara smart motion sensor device."""
 
+    manufacturer_id_override = 0x115F
+
     def __init__(self, *args, **kwargs):
         """Init."""
         self.motion_bus = Bus()

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -70,15 +70,13 @@ class VibrationAQ1(XiaomiCustomDevice):
         """Vibration cluster."""
 
         cluster_id = BasicCluster.cluster_id
-        attributes = Basic.attributes.copy()
-        attributes.update({0xFF0D: ("sensitivity", types.uint8_t)})
+        manufacturer_attributes = {0xFF0D: ("sensitivity", types.uint8_t)}
 
     class MultistateInputCluster(CustomCluster, MultistateInput):
         """Multistate input cluster."""
 
         cluster_id = DoorLock.cluster_id
-        attributes = MultistateInput.attributes.copy()
-        attributes.update({0x0000: ("lock_state", types.uint8_t)})
+        manufacturer_attributes = {0x0000: ("lock_state", types.uint8_t)}
 
         def __init__(self, *args, **kwargs):
             """Init."""

--- a/zhaquirks/xiaomi/mija/smoke.py
+++ b/zhaquirks/xiaomi/mija/smoke.py
@@ -44,11 +44,10 @@ _LOGGER = logging.getLogger(__name__)
 class XiaomiSmokeIASCluster(CustomCluster, IasZone):
     """Xiaomi smoke IAS cluster implementation."""
 
-    cluster_id = IasZone.cluster_id
-    attributes = IasZone.attributes.copy()
-    attributes.update(
-        {0xFFF1: ("set_options", t.uint32_t), 0xFFF0: ("get_status", t.uint32_t)}
-    )
+    manufacturer_attributes = {
+        0xFFF1: ("set_options", t.uint32_t),
+        0xFFF0: ("get_status", t.uint32_t),
+    }
 
 
 class MijiaHoneywellSmokeDetectorSensor(XiaomiCustomDevice):


### PR DESCRIPTION
Sync with https://github.com/zigpy/zigpy/pull/429 changes. Refactor manufacturer specific attribute, client and server commands.

Allow Zigpy Device class to override manufacturer code, normally supplied by the node_descriptor.
Implement the following new attributes for the CustomCluster class:

`manufacturer_attributes` -- a dict of manufacturer specific attributes, in addition to ZCL standard attributes
`manufacturer_client_commands` -- a dict of manufacturer specific commands, in addition to ZCL standard client commands
`manufacturer_server_commands` -- a dict of manufacturer specific commands, in addition to ZCL standard server commands

`CustomDevice` allow definition of the `manufacturer_id_override: Optional[int]` and this manufacturer code would be used automatically for operations related to any manufacturer specific commands or cluster. If not specified, then `manufacturer_id` from the node descriptor is being used.

Requesting manufacturer specific commands or attributes would automatically provide manufacturer_id for the ZCL frame, unless overridden by the manufacturer parameter for the request.

e.g. for quirks now you can just do:
```
class ThermostatCluster(CustomCluster, Thermostat):
    """Thermostat cluster."""

    manufacturer_attributes = {
        TRV_MODE_ATTR: ("trv_mode", types.enum8),
        SET_VALVE_POS_ATTR: ("set_valve_position", types.uint8_t),
        ERRORS_ATTR: ("errors", types.uint8_t),
        CURRENT_TEMP_SETPOINT_ATTR: ("current_temperature_setpoint", types.int16s),
        HOST_FLAGS_ATTR: ("host_flags", types.uint24_t),
    }
```
And this would extend standard ZCL attributes with new manufacturer specific attributes for this cluster