### PR TITLE
Support for WXKG07LM

### DIFF
--- a/zhaquirks/xiaomi/aqara/remote_b286acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b286acn01.py
@@ -92,7 +92,11 @@ class RemoteB286ACN01(XiaomiCustomDevice):
         # device_version=1
         # input_clusters=[0, 3, 25, 65535, 18]
         # output_clusters=[0, 4, 3, 5, 25, 65535, 18]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b286acn01"), (LUMI, "lumi.sensor_86sw2")],
+        MODELS_INFO: [
+            (LUMI, "lumi.remote.b286acn01"),
+            (LUMI, "lumi.remote.b286acn02"),
+            (LUMI, "lumi.sensor_86sw2"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
Add support for the Xiaomi Aqara D1 double key wireless wall switch.

It is detected as a "lumi.remote.b286acn02" when paired to Home Assistant.

I tested all actions (left/right/both single, double and long press) and they all map correctly.