### PR TITLE
Support for WXKG06LM

### DIFF
--- a/zhaquirks/xiaomi/aqara/remote_b186acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b186acn01.py
@@ -77,7 +77,11 @@ class RemoteB186ACN01(XiaomiCustomDevice):
         # device_version=1
         # input_clusters=[0, 3, 25, 65535, 18]
         # output_clusters=[0, 4, 3, 5, 25, 65535, 18]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b186acn01"), (LUMI, "lumi.sensor_86sw1")],
+        MODELS_INFO: [
+            (LUMI, "lumi.remote.b186acn01"),
+            (LUMI, "lumi.remote.b186acn02"),
+            (LUMI, "lumi.sensor_86sw1"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
Same as #419 but for the single key  Xiaomi Aqara D1 wireless switch.

Detected as lumi.remote.b186acn02, same clusters as lumi.remote.b186acn01 :

```
[0xe081:1] Discovered endpoint information: <Optional endpoint=1 profile=260 device_type=24321 device_version=1 input_clusters=[0, 3, 25, 65535, 18] output_clusters=[0, 4, 3, 5, 25, 65535, 18]>
[0xe081:2] Discovered endpoint information: <Optional endpoint=2 profile=260 device_type=24322 device_version=1 input_clusters=[3, 18] output_clusters=[4, 3, 5, 18]>
[0xe081:3] Discovered endpoint information: <Optional endpoint=3 profile=260 device_type=24323 device_version=1 input_clusters=[3, 12] output_clusters=[4, 3, 5, 12]>
```