### PR TITLE
Fix Philips power_on_state by not sending the manufacturer code

### DIFF
--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -57,7 +57,8 @@ class PowerOnState(t.enum8):
 class PhilipsOnOffCluster(CustomCluster, OnOff):
     """Philips OnOff cluster."""
 
-    manufacturer_attributes = {0x4003: ("power_on_state", PowerOnState)}
+    attributes = OnOff.attributes.copy()
+    attributes.update({0x4003: ("power_on_state", PowerOnState)})
 
 
 class PhilipsBasicCluster(CustomCluster, Basic):


### PR DESCRIPTION
Fix PhilipsOnOffCluster power_on_state by not sending the manufacturer code
Fixes #399, #461 

Credit @dmulcahey 

Values:
Off: 0x00
On: 0x01
LastState: 0xFF

Screenshots of it working:

Getting the current value of the attribute:
![image](https://user-images.githubusercontent.com/6409465/90960553-aad2d480-e4a2-11ea-8dde-018e68ed4a3e.png)

Setting a new value:
![image](https://user-images.githubusercontent.com/6409465/90960556-bb834a80-e4a2-11ea-8e1f-0df54b8dbe9f.png)

Getting the new value:
![image](https://user-images.githubusercontent.com/6409465/90960562-c1792b80-e4a2-11ea-8ae3-57fec35072a3.png)
