### PR TITLE
Update README.md to change phrase the supported hardware phrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you are looking to make your first code contribution to this project then we 
 - https://github.com/firstcontributions/first-contributions/blob/master/README.md
 - https://github.com/firstcontributions/first-contributions/blob/master/github-desktop-tutorial.md
 
-# Currently Supported Devices:
+# Zigbee devices not following specifications which there already are quirks for:
 
 ### CentraLite
 - [Contact Sensor](http://a.co/g9eWPAQ): CentraLite 3300-S


### PR DESCRIPTION
Small change in update README.md to change phrase the supported hardware phrase.

Read many comments in Home Assistant community where users ask which devices are supported by ZHA and this list of "supported hardware" in the ZHA Device Handlers README.md seems to confuse people more than the fact there is no list of devices that ZHA supports.