### PR TITLE
Enable tox and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,15 @@ dist: xenial
 matrix:
   fast_finish: true
   include:
-    - python: "3.6.1"
+    - python: "3.7"
       env: TOXENV=lint
-    - python: "3.6.1"
+    - python: "3.7"
       env: TOXENV=pylint
+    - python: "3.7"
+      env: TOXENV=py37
+      sudo: true
+    - python: "3.8"
+      env: TOXENV=py38
 
 cache: pip
 install: pip install -U tox

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -19,6 +19,3 @@ pytest-sugar==0.9.2
 pytest-timeout==1.3.3
 pytest==5.1.2
 requests_mock==1.6.0
-
-zigpy-homeassistant==0.18.1
-homeassistant

--- a/script/check_format
+++ b/script/check_format
@@ -6,4 +6,5 @@ cd "$(dirname "$0")/.."
 black \
   --check \
   --fast \
+  --diff \
   zhaquirks tests script *.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ forced_separate = tests
 combine_as_imports = true
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_calls = true
@@ -52,3 +52,9 @@ warn_return_any = true
 warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
+
+[pydocstyle]
+ignore =
+    D202,
+    D203,
+    D213

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,60 @@
+"""Fixtures for all tests."""
+
+from asynctest import CoroutineMock
+import pytest
+import zigpy.application
+import zigpy.types
+
+
+class MockApp(zigpy.application.ControllerApplication):
+    """App Controller."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self._ieee = zigpy.types.EUI64(b"Zigbee78")
+        self._nwk = zigpy.types.NWK(0x0000)
+
+    async def probe(self, *args):
+        """Probe method."""
+        return True
+
+    async def shutdown(self):
+        """Mock shutdown."""
+
+    async def startup(self, *args):
+        """Mock startup."""
+
+    async def permit_ncp(self, *args):
+        """Mock permit ncp."""
+
+    mrequest = CoroutineMock()
+    request = CoroutineMock()
+
+
+@pytest.fixture(name="MockAppController")
+def app_controller_mock():
+    """App controller mock."""
+    config = {"device": {"path": "/dev/ttyUSB0"}, "database": None}
+    config = MockApp.SCHEMA(config)
+    app = MockApp(config)
+    return app
+
+
+@pytest.fixture
+def ieee_mock():
+    """Return a static ieee."""
+    return zigpy.types.EUI64([1, 2, 3, 4, 5, 6, 7, 8])
+
+
+@pytest.fixture
+def zigpy_device_mock(MockAppController, ieee_mock):
+    """Zigpy device mock."""
+
+    def _dev(ieee=None, nwk=zigpy.types.NWK(0x1234)):
+        if ieee is None:
+            ieee = ieee_mock
+        device = MockAppController.add_device(ieee, nwk)
+        return device
+
+    return _dev

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,18 @@
 
 from asynctest import CoroutineMock
 import pytest
+import zigpy.device
 import zigpy.application
 import zigpy.types
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
 
 
 class MockApp(zigpy.application.ControllerApplication):
@@ -55,6 +65,41 @@ def zigpy_device_mock(MockAppController, ieee_mock):
         if ieee is None:
             ieee = ieee_mock
         device = MockAppController.add_device(ieee, nwk)
+        return device
+
+    return _dev
+
+
+@pytest.fixture
+def zigpy_device_from_quirk(MockAppController, ieee_mock):
+    """Create zigpy device from Quirk's signature."""
+
+    def _dev(quirk, ieee=None, nwk=zigpy.types.NWK(0x1234)):
+        if ieee is None:
+            ieee = ieee_mock
+        models_info = quirk.signature.get(
+            MODELS_INFO, (("Mock Manufacturer", "Mock Model"),)
+        )
+        manufacturer, model = models_info[0]
+
+        raw_device = zigpy.device.Device(MockAppController, ieee, nwk)
+        raw_device.manufacturer = manufacturer
+        raw_device.model = model
+
+        endpoints = quirk.signature.get(ENDPOINTS, {})
+        for ep_id, ep_data in endpoints.items():
+            ep = raw_device.add_endpoint(ep_id)
+            ep.profile_id = ep_data.get(PROFILE_ID, 0x0260)
+            ep.device_type = ep_data.get(DEVICE_TYPE, 0xFEDB)
+            in_clusters = ep_data.get(INPUT_CLUSTERS, [])
+            for cluster_id in in_clusters:
+                ep.add_input_cluster(cluster_id)
+            out_clusters = ep_data.get(OUTPUT_CLUSTERS, [])
+            for cluster_id in out_clusters:
+                ep.add_output_cluster(cluster_id)
+        device = quirk(MockAppController, ieee, nwk, raw_device)
+        MockAppController.devices[ieee] = device
+
         return device
 
     return _dev

--- a/tests/test_ctrl_neutral1.py
+++ b/tests/test_ctrl_neutral1.py
@@ -20,20 +20,14 @@ from zhaquirks.xiaomi.aqara.ctrl_neutral import CtrlNeutral
 # zigbee-herdsman:adapter:zStack:unpi:writer --> frame [254,13,36,1,31,255,2,1,6,0,16,0,30,3,1,7,0,198]
 
 
-def test_ctrl_neutral(zigpy_device_mock, MockAppController, ieee_mock):
+def test_ctrl_neutral(zigpy_device_from_quirk):
     """Test ctrl neutral 1 sends correct request."""
-    nwk = 1234
     data = b"\x01\x01\x01"
     cluster = 6
     src_ep = 1
     dst_ep = 2
 
-    rep = zigpy_device_mock(ieee_mock, nwk)
-    rep.add_endpoint(1)
-    rep.add_endpoint(2)
-    rep.add_endpoint(3)
-
-    dev = CtrlNeutral(MockAppController, ieee_mock, nwk, rep)
+    dev = zigpy_device_from_quirk(CtrlNeutral)
     dev.request = mock.MagicMock()
 
     dev[2].in_clusters[cluster].command(1)

--- a/tests/test_kof.py
+++ b/tests/test_kof.py
@@ -4,12 +4,15 @@ from unittest import mock
 import zigpy.device
 import zigpy.endpoint
 import zigpy.quirks
+import zhaquirks.kof.kof_mr101z
 
 
 def test_kof_no_reply():
     """Test KOF No reply."""
 
-    class TestCluster(zigpy.quirks.kof.NoReplyMixin, zigpy.quirks.CustomCluster):
+    class TestCluster(
+        zhaquirks.kof.kof_mr101z.NoReplyMixin, zigpy.quirks.CustomCluster
+    ):
         """Test Cluster Class."""
 
         cluster_id = 0x1234

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -14,7 +14,7 @@ def test_basic_cluster_deserialize_wrong_len():
     data += b"\x02\n!\x00\x00d\x10\x01"
 
     deserialized = cluster.deserialize(data)
-    assert deserialized[3]
+    assert deserialized[1]
 
 
 def test_basic_cluster_deserialize_wrong_len_2():
@@ -26,4 +26,4 @@ def test_basic_cluster_deserialize_wrong_len_2():
     data += b"\x00\x14\x00\x00\x08!\x04\x02\n!\x00\x00d\x10\x01"
 
     deserialized = cluster.deserialize(data)
-    assert deserialized[3]
+    assert deserialized[1]

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ skip_missing_interpreters = True
 basepython = {env:PYTHON3_PATH:python3}
 commands =
      pytest --timeout=9 --durations=10 -qq -o console_output_style=count -p no:sugar {posargs}
-     {toxinidir}/script/check_dirty
 deps =
      -r{toxinidir}/requirements_test_all.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, lint, pylint
+envlist = py37, py38, lint, pylint
 skip_missing_interpreters = True
 
 [testenv]

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -98,8 +98,7 @@ class EventableCluster(CustomCluster):
 
 
 class GroupBoundCluster(CustomCluster):
-    """
-    Cluster that can only bind to a group instead of direct to hub.
+    """Cluster that can only bind to a group instead of direct to hub.
 
     Binding this cluster results in binding to a group that the coordinator
     is a member of.

--- a/zhaquirks/kof/kof_mr101z.py
+++ b/zhaquirks/kof/kof_mr101z.py
@@ -1,5 +1,5 @@
 """
-This module handles quirks of the King of Fans MR101Z ceiling fan receiver.
+Module to handle quirks of the King of Fans MR101Z ceiling fan receiver.
 
 The King of Fans ceiling fan receiver does not generate default replies. This
 module overrides all server commands that do not have a mandatory reply to not

--- a/zhaquirks/kof/kof_mr101z.py
+++ b/zhaquirks/kof/kof_mr101z.py
@@ -1,5 +1,4 @@
-"""
-Module to handle quirks of the King of Fans MR101Z ceiling fan receiver.
+"""Module to handle quirks of the King of Fans MR101Z ceiling fan receiver.
 
 The King of Fans ceiling fan receiver does not generate default replies. This
 module overrides all server commands that do not have a mandatory reply to not
@@ -21,8 +20,7 @@ from zigpy.zcl.clusters.hvac import Fan
 
 
 class NoReplyMixin:
-    """
-    A simple mixin.
+    """A simple mixin.
 
     Allows a cluster to have configureable list of command
     ids that do not generate an explicit reply.
@@ -31,8 +29,7 @@ class NoReplyMixin:
     void_input_commands = []
 
     def command(self, command, *args, manufacturer=None, expect_reply=None):
-        """
-        Override the default Cluster command.
+        """Override the default Cluster command.
 
         expect_reply behavior is based on void_input_commands.
         Note that this method changes the default value of

--- a/zhaquirks/orvibo/motion.py
+++ b/zhaquirks/orvibo/motion.py
@@ -1,5 +1,4 @@
-"""
-ORVIBO motion sensors.
+"""ORVIBO motion sensors.
 
 Based on Konke motion sensor code.
 """

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -1,5 +1,5 @@
 """
-This module handles quirks of the  Sinopé Technologies light SW2500ZB and dimmer DM2500ZB.
+Module to handle quirks of the  Sinopé Technologies light SW2500ZB and dimmer DM2500ZB.
 
 Manufacturer specific cluster implements attributes to control displaying
 setting occupancy on/off.

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -1,5 +1,4 @@
-"""
-Module to handle quirks of the  Sinopé Technologies light SW2500ZB and dimmer DM2500ZB.
+"""Module to handle quirks of the  Sinopé Technologies light SW2500ZB and dimmer DM2500ZB.
 
 Manufacturer specific cluster implements attributes to control displaying
 setting occupancy on/off.

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -1,5 +1,4 @@
-"""
-Module to handle quirks of the  Sinopé Technologies thermostat.
+"""Module to handle quirks of the  Sinopé Technologies thermostat.
 
 manufacturer specific cluster implements attributes to control displaying
 of outdoor temperature, setting occupancy on/off and setting device time.

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -1,5 +1,5 @@
 """
-This module handles quirks of the  Sinopé Technologies thermostat.
+Module to handle quirks of the  Sinopé Technologies thermostat.
 
 manufacturer specific cluster implements attributes to control displaying
 of outdoor temperature, setting occupancy on/off and setting device time.

--- a/zhaquirks/zen/thermostat.py
+++ b/zhaquirks/zen/thermostat.py
@@ -1,4 +1,4 @@
-"""This module handles quirks of the  Zen Within thermostat."""
+"""Module to handle quirks of the  Zen Within thermostat."""
 
 import zigpy.profiles.zha as zha_p
 from zigpy.quirks import CustomDevice


### PR DESCRIPTION
Enable tox.
Drop py36.
Create fixtures to facilitate quirk tests.