### PR TITLE
LocalDataCluster support for _CONSTANT_ATTRIBUTES

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -64,7 +64,10 @@ class LocalDataCluster(CustomCluster):
             for attr in attributes
         ]
         for record in records:
-            record.value.value = self._attr_cache.get(record.attrid)
+            if record.attrid in self._CONSTANT_ATTRIBUTES:
+                record.value.value = self._CONSTANT_ATTRIBUTES[record.attrid]
+            else:
+                record.value.value = self._attr_cache.get(record.attrid)
             if record.value.value is not None:
                 record.status = foundation.Status.SUCCESS
         return (records,)

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -43,6 +43,8 @@ class Bus(ListenableMixin):
 class LocalDataCluster(CustomCluster):
     """Cluster meant to prevent remote calls."""
 
+    _CONSTANT_ATTRIBUTES = {}
+
     async def bind(self):
         """Prevent bind."""
         return (foundation.Status.SUCCESS,)

--- a/zhaquirks/orvibo/__init__.py
+++ b/zhaquirks/orvibo/__init__.py
@@ -1,12 +1,12 @@
 """Module for ORVIBO quirks implementations."""
 
-from .. import MotionWithReset, OccupancyOnEvent
+from .. import LocalDataCluster, MotionWithReset, OccupancyOnEvent
 
 ORVIBO = "欧瑞博"
 ORVIBO_LATIN = "ORVIBO"
 
 
-class OccupancyCluster(OccupancyOnEvent):
+class OccupancyCluster(LocalDataCluster, OccupancyOnEvent):
     """Occupancy cluster."""
 
 


### PR DESCRIPTION
Refactor `LocalDataCluster` CustomCluster to support `_CONSTANT_ATTRIBUTES` attributes.
eg:

```python
class MotionCluster(LocalDataCluster, MotionOnEvent):
    """Motion cluster."""

    _CONSTANT_ATTRIBUTES = {0x0001: MOTION_TYPE}
 ```

will create attribute id `0x0001` -- zone_type with a constant value.
