### PR TITLE
feat(tuya): Quirk for tuya-based 1-channel switch

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -20,3 +20,4 @@
 - [Piotr Majkrzak](https://github.com/majkrzak)
 - [Gleb Sinyavskiy](https://github.com/zhulik)
 - [Michael Thingnes](https://github.com/thimic)
+- [Piotr Mis](https://github.com/piomis)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ If you are looking to make your first code contribution to this project then we 
 - [YRD210](https://www.yalehome.com/Yale/Yale%20US/Real%20Living/installation%20instructions/Yale%20DB%20PUSH%20Quickstart%2018JUL11_Rev%20B.pdf): Yale YRD210 Deadbolt
 - [YRL220](https://www.yalehome.com/Yale/Yale%20US/Real%20Living/installation%20instructions/Yale%20%20DB%20Touch%20Instructions%2023AUG11_Rev%20B.pdf): Yale YRL220 Lock
 
+### Tuya-based
+- [TS0601 switch](https://zigbee.blakadder.com/Lerlink_X701A.html): Tuya-based 1-gang switches with neutral (e.g. Lerlink, Lonsonho)
+
 # Configuration:
 
 1. Update Home Assistant to 0.85.1 or a later version.

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -2,9 +2,7 @@
 
 import asyncio
 from unittest import mock
-from asynctest import CoroutineMock
 
-from .conftest import MockApp
 import pytest
 
 from zhaquirks.const import OFF, ON, ZONE_STATE
@@ -20,7 +18,6 @@ ZCL_TUYA_SWITCH_OFF = b"\tQ\x02\x006\x01\x01\x00\x01\x00"
 
 
 @pytest.mark.parametrize("quirk", (zhaquirks.tuya.motion.TuyaMotion,))
-@pytest.mark.asyncio
 async def test_motion(zigpy_device_from_quirk, quirk):
     """Test tuya motion sensor."""
 
@@ -49,7 +46,6 @@ async def test_motion(zigpy_device_from_quirk, quirk):
 
 
 @pytest.mark.parametrize("quirk", (zhaquirks.tuya.singleswitch.TuyaSingleSwitch,))
-@pytest.mark.asyncio
 async def test_singleswitch_state_report(zigpy_device_from_quirk, quirk):
     """Test tuya single switch."""
 
@@ -74,7 +70,6 @@ async def test_singleswitch_state_report(zigpy_device_from_quirk, quirk):
 
 
 @pytest.mark.parametrize("quirk", (zhaquirks.tuya.singleswitch.TuyaSingleSwitch,))
-@pytest.mark.asyncio
 async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
     """Test tuya single switch."""
 
@@ -84,32 +79,28 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
     tuya_cluster = switch_dev.endpoints[1].tuya_manufacturer
 
     with mock.patch.object(
-        tuya_cluster.endpoint.device, "request", return_value=foundation.Status.SUCCESS
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
     ) as m1:
 
-        status = await switch_cluster.command(0x0000)
+        status = switch_cluster.command(0x0000)
         m1.assert_called_with(
-            260,
             61184,
-            1,
-            1,
             1,
             b"\x01\x01\x00\x00\x00\x01\x01\x00\x01\x00",
             expect_reply=True,
+            command_id=0,
         )
         assert status == 0
 
-        status = await switch_cluster.command(0x0001)
+        status = switch_cluster.command(0x0001)
         m1.assert_called_with(
-            260,
             61184,
-            1,
-            1,
             2,
             b"\x01\x02\x00\x00\x00\x01\x01\x00\x01\x01",
             expect_reply=True,
+            command_id=0,
         )
         assert status == 0
 
-    status = await switch_cluster.command(0x0002)
+    status = switch_cluster.command(0x0002)
     assert status == foundation.Status.UNSUP_CLUSTER_COMMAND

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -2,18 +2,25 @@
 
 import asyncio
 from unittest import mock
+from asynctest import CoroutineMock
 
+from .conftest import MockApp
 import pytest
 
 from zhaquirks.const import OFF, ON, ZONE_STATE
+
 import zhaquirks.tuya.motion
+from zigpy.zcl import foundation
 
 from tests.common import ClusterListener
 
 ZCL_TUYA_MOTION = b"\tL\x01\x00\x05\x03\x04\x00\x01\x02"
+ZCL_TUYA_SWITCH_ON = b"\tQ\x02\x006\x01\x01\x00\x01\x01"
+ZCL_TUYA_SWITCH_OFF = b"\tQ\x02\x006\x01\x01\x00\x01\x00"
 
 
 @pytest.mark.parametrize("quirk", (zhaquirks.tuya.motion.TuyaMotion,))
+@pytest.mark.asyncio
 async def test_motion(zigpy_device_from_quirk, quirk):
     """Test tuya motion sensor."""
 
@@ -39,3 +46,70 @@ async def test_motion(zigpy_device_from_quirk, quirk):
     assert len(motion_listener.cluster_commands) == 2
     assert motion_listener.cluster_commands[1][1] == ZONE_STATE
     assert motion_listener.cluster_commands[1][2][0] == OFF
+
+
+@pytest.mark.parametrize("quirk", (zhaquirks.tuya.singleswitch.TuyaSingleSwitch,))
+@pytest.mark.asyncio
+async def test_singleswitch_state_report(zigpy_device_from_quirk, quirk):
+    """Test tuya single switch."""
+
+    switch_dev = zigpy_device_from_quirk(quirk)
+
+    switch_cluster = switch_dev.endpoints[1].on_off
+    switch_listener = ClusterListener(switch_cluster)
+
+    tuya_cluster = switch_dev.endpoints[1].tuya_manufacturer
+
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_ON)
+    tuya_cluster.handle_message(hdr, args)
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_OFF)
+    tuya_cluster.handle_message(hdr, args)
+
+    assert len(switch_listener.cluster_commands) == 0
+    assert len(switch_listener.attribute_updates) == 2
+    assert switch_listener.attribute_updates[0][0] == 0x0000
+    assert switch_listener.attribute_updates[0][1] == ON
+    assert switch_listener.attribute_updates[1][0] == 0x0000
+    assert switch_listener.attribute_updates[1][1] == OFF
+
+
+@pytest.mark.parametrize("quirk", (zhaquirks.tuya.singleswitch.TuyaSingleSwitch,))
+@pytest.mark.asyncio
+async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
+    """Test tuya single switch."""
+
+    switch_dev = zigpy_device_from_quirk(quirk)
+
+    switch_cluster = switch_dev.endpoints[1].on_off
+    tuya_cluster = switch_dev.endpoints[1].tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint.device, "request", return_value=foundation.Status.SUCCESS
+    ) as m1:
+
+        status = await switch_cluster.command(0x0000)
+        m1.assert_called_with(
+            260,
+            61184,
+            1,
+            1,
+            1,
+            b"\x01\x01\x00\x00\x00\x01\x01\x00\x01\x00",
+            expect_reply=True,
+        )
+        assert status == 0
+
+        status = await switch_cluster.command(0x0001)
+        m1.assert_called_with(
+            260,
+            61184,
+            1,
+            1,
+            2,
+            b"\x01\x02\x00\x00\x00\x01\x01\x00\x01\x01",
+            expect_reply=True,
+        )
+        assert status == 0
+
+    status = await switch_cluster.command(0x0002)
+    assert status == foundation.Status.UNSUP_CLUSTER_COMMAND

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1,9 +1,34 @@
 """Tuya devices."""
+import logging
 
-from zigpy.quirks import CustomCluster
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import OnOff
+from zigpy.zcl import foundation
 import zigpy.types as t
 
+from .. import Bus
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
+
 TUYA_CLUSTER_ID = 0xEF00
+TUYA_SET_DATA = 0x0000
+TUYA_GET_DATA = 0x0001
+TUYA_SET_DATA_RESPONSE = 0x0002
+
+SWITCH_EVENT = "switch_event"
+ATTR_ON_OFF = 0x0000
+TUYA_CMD_BASE = 0x0100
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class Data(t.List, item_type=t.uint8_t):
@@ -33,3 +58,61 @@ class TuyaManufCluster(CustomCluster):
         0x0002: ("set_data_response", (Command,), True),
     }
 
+
+class TuyaOnOff(CustomCluster, OnOff):
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.switch_bus.add_listener(self)
+
+    def switch_event(self, channel, state):
+        """Switch event."""
+        _LOGGER.debug(
+            "%s - Received switch event message, channel: %d, state: %d",
+            self.endpoint.device.ieee,
+            channel,
+            state,
+        )
+        self._update_attribute(ATTR_ON_OFF, state)
+
+    async def command(self, command, *args, manufacturer=None, expect_reply=None):
+        """Override the default Cluster command."""
+
+        if command == 0x0000 or command == 0x0001:
+            cmd_payload = TuyaManufCluster.Command()
+            cmd_payload.status = 0
+            cmd_payload.tsn = 0
+            cmd_payload.command_id = TUYA_CMD_BASE + self.endpoint.endpoint_id
+            cmd_payload.function = 0
+            cmd_payload.data = [1, command]
+            return await self.endpoint.tuya_manufacturer.command(
+                TUYA_SET_DATA, cmd_payload, expect_reply=True
+            )
+        else:
+            return foundation.Status.UNSUP_CLUSTER_COMMAND
+
+
+class TuyaManufacturerClusterOnOff(TuyaManufCluster):
+    """Manufacturer Specific Cluster of the Motion device."""
+
+    def handle_cluster_request(
+        self, tsn: int, command_id: int, args: Tuple[TuyaManufCluster.Command]
+    ) -> None:
+        """Handle cluster request."""
+
+        tuya_payload = args[0]
+        if command_id == 0x0002 or command_id == 0x0001:
+            self.endpoint.device.switch_bus.listener_event(
+                SWITCH_EVENT,
+                tuya_payload.command_id - TUYA_CMD_BASE,
+                tuya_payload.data[1],
+            )
+
+
+class TuyaSwitch(CustomDevice):
+    """Tuya switch device."""
+
+    def __init__(self, *args, **kwargs):
+        """Init device."""
+        self.switch_bus = Bus()
+        super().__init__(*args, **kwargs)

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1,11 +1,7 @@
 """Tuya devices."""
 import logging
 
-from typing import (
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Optional, Tuple, Union
 
 from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy.zcl.clusters.general import OnOff

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1,89 +1,35 @@
-"""Module for Tuya based devices."""
+"""Tuya devices."""
 
-import logging
-
-import zigpy.types as t
 from zigpy.quirks import CustomCluster
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import OnOff
+import zigpy.types as t
 
-TUYA = "Tuya"
-ATTR_ON_OFF = 0x0000
-MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xEF00  # Decimal: 61184
-_LOGGER = logging.getLogger(__name__)
+TUYA_CLUSTER_ID = 0xEF00
 
-class TuyaSwitchCluster(CustomCluster,OnOff):
-    """Tuya Switch Cluster."""
 
-    cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID
-    ep_attribute = "on_off"
-    name = "Tuya Switch"
-    attributes = OnOff.attributes.copy()
+class Data(t.List, item_type=t.uint8_t):
+    """list of uint8_t."""
 
-    manufacturer_server_commands = {
-        0x0000: (
-            "write_state",
-            (
-                foundation.Status,
-                t.uint8_t,   # transactionId
-                t.uint16_t,  # attribute
-                t.uint8_t,   # always 0
-                t.uint8_t,   # length of data
-                t.Bool       # data
-            ),
-            False,
-        ),
-        0x0001: (
-            "read_state",
-            (
-                foundation.Status,
-                t.uint8_t,   # transactionId
-                t.uint16_t,  # attribute
-                t.uint8_t,   # always 0
-                t.uint8_t,   # length of data
-                t.Bool,      # data
-            ),
-            False,
-        )
-    }
+
+class TuyaManufCluster(CustomCluster):
+    """Tuya manufacturer specific cluster."""
+
+    name = "Tuya Manufacturer Specicific"
+    cluster_id = TUYA_CLUSTER_ID
+    ep_attribute = "tuya_manufacturer"
+
+    class Command(t.Struct):
+        """Tuya manufacturer cluster command."""
+
+        status: t.uint8_t
+        tsn: t.uint8_t
+        command_id: t.uint16_t
+        function: t.uint8_t
+        data: Data
+
+    manufacturer_server_commands = {0x0000: ("set_data", (Command,), False)}
 
     manufacturer_client_commands = {
-        0x0001: (
-            "read_state_rsp",
-            (
-                foundation.Status,
-                t.uint8_t,   # transactionId
-                t.uint16_t,  # attribute
-                t.uint8_t,   # always 0
-                t.uint8_t,   # length of data
-                t.Bool,      # data
-            ),
-            False,
-        ),
-        0x0002: (
-            "state_change_ntfy",
-            (
-                foundation.Status,
-                t.uint8_t,   # transactionId
-                t.uint16_t,  # attribute
-                t.uint8_t,   # always 0
-                t.uint8_t,   # length of data
-                t.Bool,      # data
-            ),
-            False,
-        ),
+        0x0001: ("get_data", (Command,), True),
+        0x0002: ("set_data_response", (Command,), True),
     }
-
-    def handle_cluster_request(self, tsn, command_id, args):
-        """Handle the cluster command."""
-        _LOGGER.debug(
-            "TuyaSwitchCluster - handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
-            tsn,
-            command_id,
-            args,
-        )
-
-        if( command_id == 0x0002):
-            _LOGGER.debug("Endpoint ID: %d", self._endpoint.endpoint_id)
-            super()._update_attribute(ATTR_ON_OFF, args[5])
 

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -2,7 +2,6 @@
 import logging
 
 from typing import (
-    Coroutine,
     Optional,
     Tuple,
     Union,

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1,34 +1,89 @@
-"""Tuya devices."""
+"""Module for Tuya based devices."""
 
-from zigpy.quirks import CustomCluster
+import logging
+
 import zigpy.types as t
+from zigpy.quirks import CustomCluster
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import OnOff
 
-TUYA_CLUSTER_ID = 0xEF00
+TUYA = "Tuya"
+ATTR_ON_OFF = 0x0000
+MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xEF00  # Decimal: 61184
+_LOGGER = logging.getLogger(__name__)
 
+class TuyaSwitchCluster(CustomCluster,OnOff):
+    """Tuya Switch Cluster."""
 
-class Data(t.List, item_type=t.uint8_t):
-    """list of uint8_t."""
+    cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID
+    ep_attribute = "on_off"
+    name = "Tuya Switch"
+    attributes = OnOff.attributes.copy()
 
-
-class TuyaManufCluster(CustomCluster):
-    """Tuya manufacturer specific cluster."""
-
-    name = "Tuya Manufacturer Specicific"
-    cluster_id = TUYA_CLUSTER_ID
-    ep_attribute = "tuya_manufacturer"
-
-    class Command(t.Struct):
-        """Tuya manufacturer cluster command."""
-
-        status: t.uint8_t
-        tsn: t.uint8_t
-        command_id: t.uint16_t
-        function: t.uint8_t
-        data: Data
-
-    manufacturer_server_commands = {0x0000: ("set_data", (Command,), False)}
+    manufacturer_server_commands = {
+        0x0000: (
+            "write_state",
+            (
+                foundation.Status,
+                t.uint8_t,   # transactionId
+                t.uint16_t,  # attribute
+                t.uint8_t,   # always 0
+                t.uint8_t,   # length of data
+                t.Bool       # data
+            ),
+            False,
+        ),
+        0x0001: (
+            "read_state",
+            (
+                foundation.Status,
+                t.uint8_t,   # transactionId
+                t.uint16_t,  # attribute
+                t.uint8_t,   # always 0
+                t.uint8_t,   # length of data
+                t.Bool,      # data
+            ),
+            False,
+        )
+    }
 
     manufacturer_client_commands = {
-        0x0001: ("get_data", (Command,), True),
-        0x0002: ("set_data_response", (Command,), True),
+        0x0001: (
+            "read_state_rsp",
+            (
+                foundation.Status,
+                t.uint8_t,   # transactionId
+                t.uint16_t,  # attribute
+                t.uint8_t,   # always 0
+                t.uint8_t,   # length of data
+                t.Bool,      # data
+            ),
+            False,
+        ),
+        0x0002: (
+            "state_change_ntfy",
+            (
+                foundation.Status,
+                t.uint8_t,   # transactionId
+                t.uint16_t,  # attribute
+                t.uint8_t,   # always 0
+                t.uint8_t,   # length of data
+                t.Bool,      # data
+            ),
+            False,
+        ),
     }
+
+    def handle_cluster_request(self, tsn, command_id, args):
+        """Handle the cluster command."""
+        _LOGGER.debug(
+            "TuyaSwitchCluster - handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
+            tsn,
+            command_id,
+            args,
+        )
+
+        if( command_id == 0x0002):
+            _LOGGER.debug("Endpoint ID: %d", self._endpoint.endpoint_id)
+            super()._update_attribute(ATTR_ON_OFF, args[5])
+

--- a/zhaquirks/tuya/singleswitch.py
+++ b/zhaquirks/tuya/singleswitch.py
@@ -1,6 +1,6 @@
 """Tuya based button sensor."""
 from zigpy.profiles import zha
-from zigpy.zcl.clusters.general import Basic, Groups, Scenes, Time, Ota, OnOff
+from zigpy.zcl.clusters.general import Basic, Groups, Scenes, Time, Ota
 from ..const import (
     DEVICE_TYPE,
     ENDPOINTS,

--- a/zhaquirks/tuya/singleswitch.py
+++ b/zhaquirks/tuya/singleswitch.py
@@ -1,38 +1,18 @@
 """Tuya based button sensor."""
-import logging
-
 from zigpy.profiles import zha
-from zigpy.zcl.clusters.general import Basic, Groups, Scenes, Time, Ota
-from ..tuya import TuyaManufCluster
-
-from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import Basic, Groups, Scenes, Time, Ota, OnOff
 from ..const import (
-    ARGS,
-    ATTRIBUTE_ID,
-    ATTRIBUTE_NAME,
-    CLUSTER_ID,
-    COMMAND,
-    COMMAND_ATTRIBUTE_UPDATED,
-    COMMAND_TRIPLE,
     DEVICE_TYPE,
-    DOUBLE_PRESS,
-    ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    SHORT_PRESS,
-    SKIP_CONFIGURATION,
-    TRIPLE_PRESS,
-    UNKNOWN,
-    VALUE,
 )
+from ..tuya import TuyaManufCluster, TuyaManufacturerClusterOnOff, TuyaOnOff, TuyaSwitch
 
-_LOGGER = logging.getLogger(__name__)
 
-
-class TuyaSingleSwitch(CustomDevice):
+class TuyaSingleSwitch(TuyaSwitch):
     """Tuya single channel switch device."""
 
     signature = {
@@ -42,6 +22,7 @@ class TuyaSingleSwitch(CustomDevice):
         # device_version=1
         # input_clusters=[0x0000,0x0004, 0x0005,0x000a, 0xef00]
         # output_clusters=[0x0019]
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=81 device_version=1 input_clusters=[0, 4, 5, 10, 61184] output_clusters=[25]>
         MODELS_INFO: [("_TZE200_7tdtqgwv", "TS0601")],
         ENDPOINTS: {
             1: {
@@ -52,7 +33,8 @@ class TuyaSingleSwitch(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     Time.cluster_id,
-                    TuyaManufCluster.cluster_id],
+                    TuyaManufCluster.cluster_id,
+                ],
                 OUTPUT_CLUSTERS: [
                     Ota.cluster_id,
                 ],
@@ -67,7 +49,10 @@ class TuyaSingleSwitch(CustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Time.cluster_id,
-                    TuyaManufCluster,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufacturerClusterOnOff,
+                    TuyaOnOff,
                 ],
                 OUTPUT_CLUSTERS: [
                     Ota.cluster_id,
@@ -75,4 +60,3 @@ class TuyaSingleSwitch(CustomDevice):
             }
         },
     }
-

--- a/zhaquirks/tuya/singleswitch.py
+++ b/zhaquirks/tuya/singleswitch.py
@@ -35,9 +35,7 @@ class TuyaSingleSwitch(TuyaSwitch):
                     Time.cluster_id,
                     TuyaManufCluster.cluster_id,
                 ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
             }
         },
     }
@@ -54,9 +52,7 @@ class TuyaSingleSwitch(TuyaSwitch):
                     TuyaManufacturerClusterOnOff,
                     TuyaOnOff,
                 ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
             }
-        },
+        }
     }

--- a/zhaquirks/tuya/singleswitch.py
+++ b/zhaquirks/tuya/singleswitch.py
@@ -1,0 +1,78 @@
+"""Tuya based button sensor."""
+import logging
+
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import Basic, Groups, Scenes, Time, Ota
+from ..tuya import TuyaSwitchCluster
+
+from zigpy.quirks import CustomDevice
+from ..const import (
+    ARGS,
+    ATTRIBUTE_ID,
+    ATTRIBUTE_NAME,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_ATTRIBUTE_UPDATED,
+    COMMAND_TRIPLE,
+    DEVICE_TYPE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+    SKIP_CONFIGURATION,
+    TRIPLE_PRESS,
+    UNKNOWN,
+    VALUE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SingleSwitch(CustomDevice):
+    """Tuya single channel switch device."""
+
+    signature = {
+        # "node_descriptor": "<NodeDescriptor byte1=1 byte2=64 mac_capability_flags=142 manufacturer_code=4098
+        #                       maximum_buffer_size=82 maximum_incoming_transfer_size=82 server_mask=11264
+        #                       maximum_outgoing_transfer_size=82 descriptor_capability_field=0>",
+        # device_version=1
+        # input_clusters=[0x0000,0x0004, 0x0005,0x000a, 0xef00]
+        # output_clusters=[0x0019]
+        MODELS_INFO: [("_TZE200_7tdtqgwv", "TS0601")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    Time.cluster_id,
+                    TuyaSwitchCluster.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Time.cluster_id,
+                    TuyaSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            }
+        },
+    }
+

--- a/zhaquirks/tuya/singleswitch.py
+++ b/zhaquirks/tuya/singleswitch.py
@@ -3,7 +3,7 @@ import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Groups, Scenes, Time, Ota
-from ..tuya import TuyaSwitchCluster
+from ..tuya import TuyaManufCluster
 
 from zigpy.quirks import CustomDevice
 from ..const import (
@@ -32,7 +32,7 @@ from ..const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-class SingleSwitch(CustomDevice):
+class TuyaSingleSwitch(CustomDevice):
     """Tuya single channel switch device."""
 
     signature = {
@@ -52,7 +52,7 @@ class SingleSwitch(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     Time.cluster_id,
-                    TuyaSwitchCluster.cluster_id],
+                    TuyaManufCluster.cluster_id],
                 OUTPUT_CLUSTERS: [
                     Ota.cluster_id,
                 ],
@@ -67,7 +67,7 @@ class SingleSwitch(CustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Time.cluster_id,
-                    TuyaSwitchCluster,
+                    TuyaManufCluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Ota.cluster_id,


### PR DESCRIPTION
Quirk for Tuya-based 1-gang switches with neutral (e.g. Lerlink, Lonsonho).
https://zigbee.blakadder.com/Lerlink_X701A.html

Manufacturer cluster should support also 2, 3-gang versions so more devices can be easily added in future (by adding proper manufacture name)

Credits to zigbee-herdsman-converters (https://github.com/Koenkk/zigbee-herdsman-converters)
