### PR TITLE
Update A19TunableWhite max mireds and color capabilities

### DIFF
--- a/zhaquirks/osram/a19twhite.py
+++ b/zhaquirks/osram/a19twhite.py
@@ -16,11 +16,15 @@ from zigpy.zcl.clusters.lighting import Color
 from . import OsramLightCluster
 from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
 
+
 class OsramColorCluster(CustomCluster, Color):
+    """Osram A19 tunable white device."""
+    
     _CONSTANT_ATTRIBUTES = {
-         0x400a: 16,
-         0x400C: 370,
+        0x400a: 16,
+        0x400C: 370,
     }
+
 
 class A19TunableWhite(CustomDevice):
     """Osram A19 tunable white device."""

--- a/zhaquirks/osram/a19twhite.py
+++ b/zhaquirks/osram/a19twhite.py
@@ -1,6 +1,6 @@
 """Osram A19 tunable white device."""
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
+from zigpy.quirks import CustomDevice, CustomCluster
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -16,6 +16,11 @@ from zigpy.zcl.clusters.lighting import Color
 from . import OsramLightCluster
 from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
 
+class OsramColorCluster(CustomCluster, Color):
+    _CONSTANT_ATTRIBUTES = {
+         0x400a: 16,
+         0x400C: 370,
+    }
 
 class A19TunableWhite(CustomDevice):
     """Osram A19 tunable white device."""
@@ -56,7 +61,7 @@ class A19TunableWhite(CustomDevice):
                     Scenes.cluster_id,
                     OnOff.cluster_id,
                     LevelControl.cluster_id,
-                    Color.cluster_id,
+                    OsramColorCluster,
                     ElectricalMeasurement.cluster_id,
                     OsramLightCluster,
                 ],

--- a/zhaquirks/osram/a19twhite.py
+++ b/zhaquirks/osram/a19twhite.py
@@ -19,7 +19,7 @@ from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PRO
 
 class OsramColorCluster(CustomCluster, Color):
     """Osram A19 tunable white device."""
-    
+
     _CONSTANT_ATTRIBUTES = {
         0x400a: 16,
         0x400C: 370,

--- a/zhaquirks/osram/a19twhite.py
+++ b/zhaquirks/osram/a19twhite.py
@@ -20,10 +20,7 @@ from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PRO
 class OsramColorCluster(CustomCluster, Color):
     """Osram A19 tunable white device."""
 
-    _CONSTANT_ATTRIBUTES = {
-        0x400a: 16,
-        0x400C: 370,
-    }
+    _CONSTANT_ATTRIBUTES = {0x400A: 16, 0x400C: 370}
 
 
 class A19TunableWhite(CustomDevice):


### PR DESCRIPTION
Override max mireds default 500 with device max mireds of 370.
Remove RGB color controls.