### PR TITLE
Add support for lumi.switch.b1lacn02 and lumi.switch.b2lacn02 switches

### DIFF
--- a/zhaquirks/xiaomi/aqara/ctrl_neutral.py
+++ b/zhaquirks/xiaomi/aqara/ctrl_neutral.py
@@ -54,7 +54,12 @@ class CtrlNeutral(XiaomiCustomDevice):
     """Aqara single and double key switch device."""
 
     signature = {
-        MODELS_INFO: [(LUMI, "lumi.ctrl_neutral1"), (LUMI, "lumi.ctrl_neutral2")],
+        MODELS_INFO: [
+            (LUMI, "lumi.ctrl_neutral1"),
+            (LUMI, "lumi.ctrl_neutral2"),
+            (LUMI, "lumi.switch.b1lacn02"),
+            (LUMI, "lumi.switch.b2lacn02"),
+        ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=6
             # device_version=2


### PR DESCRIPTION
Adds support for the aqara d1 wall switch no neutral versions (1 & 2 gangs).

The discoverd endpoints (below for the 1 gang then the 2 gangs) match the ones for the older models lumi.ctrl_neutral1 and lumi.ctrl_neutral2

```
2020-09-17 10:45:27 INFO (MainThread) [zigpy.endpoint] [0x6292:1] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=6, device_version=2, input_clusters=[0, 3, 1, 2, 25, 10], output_clusters=[0, 10, 25])
2020-09-17 10:45:29 INFO (MainThread) [zigpy.endpoint] [0x6292:2] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=256, device_version=2, input_clusters=[16, 6, 4, 5], output_clusters=[])
2020-09-17 10:45:30 INFO (MainThread) [zigpy.endpoint] [0x6292:3] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=3, profile=260, device_type=256, device_version=2, input_clusters=[16, 6, 4, 5], output_clusters=[])
2020-09-17 10:45:31 INFO (MainThread) [zigpy.endpoint] [0x6292:4] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=4, profile=260, device_type=0, device_version=2, input_clusters=[18, 6], output_clusters=[])
2020-09-17 10:45:32 INFO (MainThread) [zigpy.endpoint] [0x6292:5] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=5, profile=260, device_type=0, device_version=2, input_clusters=[18, 6], output_clusters=[])
2020-09-17 10:45:33 INFO (MainThread) [zigpy.endpoint] [0x6292:6] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=6, profile=260, device_type=0, device_version=2, input_clusters=[18, 6], output_clusters=[])
2020-09-17 10:45:34 INFO (MainThread) [zigpy.endpoint] [0x6292:8] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=8, profile=260, device_type=83, device_version=2, input_clusters=[12], output_clusters=[])

2020-09-17 10:59:47 INFO (MainThread) [zigpy.endpoint] [0x5771:1] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=6, device_version=2, input_clusters=[0, 3, 1, 2, 25, 10], output_clusters=[0, 10, 25])
2020-09-17 10:59:49 INFO (MainThread) [zigpy.endpoint] [0x5771:2] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=256, device_version=2, input_clusters=[16, 6, 4, 5], output_clusters=[])
2020-09-17 10:59:50 INFO (MainThread) [zigpy.endpoint] [0x5771:3] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=3, profile=260, device_type=256, device_version=2, input_clusters=[16, 6, 4, 5], output_clusters=[])
2020-09-17 10:59:51 INFO (MainThread) [zigpy.endpoint] [0x5771:4] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=4, profile=260, device_type=0, device_version=2, input_clusters=[18, 6], output_clusters=[])
2020-09-17 10:59:52 INFO (MainThread) [zigpy.endpoint] [0x5771:5] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=5, profile=260, device_type=0, device_version=2, input_clusters=[18, 6], output_clusters=[])
2020-09-17 10:59:53 INFO (MainThread) [zigpy.endpoint] [0x5771:6] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=6, profile=260, device_type=0, device_version=2, input_clusters=[18, 6], output_clusters=[])
2020-09-17 10:59:55 INFO (MainThread) [zigpy.endpoint] [0x5771:8] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=8, profile=260, device_type=83, device_version=2, input_clusters=[12], output_clusters=[])

```