### PR TITLE
[RWL021 & RWL020] Add Multiple Click Support

### DIFF
--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -181,7 +181,7 @@ class PhilipsRemoteCluster(CustomCluster):
             # Override PRESS_TYPE
             event_args[PRESS_TYPE] = press_type
 
-            action = "{}_{}".format(button, press_type)
+            action = f"{button}_{press_type}"
             self.listener_event(ZHA_SEND_EVENT, action, event_args)
 
         # Derive Multiple Presses

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -165,8 +165,7 @@ class PhilipsRemoteCluster(CustomCluster):
 
         def send_press_event(click_count):
             _LOGGER.debug(
-                "PhilipsRemoteCluster - send_press_event click_count: [%s]",
-                click_count,
+                "PhilipsRemoteCluster - send_press_event click_count: [%s]", click_count
             )
             if click_count == 1:
                 press_type = "press"

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -114,7 +114,7 @@ class ButtonPressQueue:
         self._callback(self._click_counter)
 
     def press(self, callback):
-        """Processes a button press in the queue."""
+        """Process a button press."""
         self._callback = callback
         now_ms = time.time() * 1000
         if now_ms - self._ms_last_click > self._ms_threshold:

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -188,5 +188,5 @@ class PhilipsRemoteCluster(CustomCluster):
         if press_type == "press":
             self.button_press_queue.press(send_press_event)
         else:
-            action = "{}_{}".format(button, press_type)
+            action = f"{button}_{press_type}"
             self.listener_event(ZHA_SEND_EVENT, action, event_args)

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -99,7 +99,10 @@ class PhilipsBasicCluster(CustomCluster, Basic):
 
 
 class ButtonPressQueue:
+    """Philips button queue to derive multiple press events."""
+
     def __init__(self):
+        """Init."""
         self._ms_threshold = 500
         self._ms_last_click = 0
         self._click_counter = 1
@@ -111,6 +114,7 @@ class ButtonPressQueue:
         self._callback(self._click_counter)
 
     def press(self, callback):
+        """Processes a button press in the queue."""
         self._callback = callback
         now_ms = time.time() * 1000
         if now_ms - self._ms_last_click > self._ms_threshold:


### PR DESCRIPTION
Software implementation for multiple press support (Double / Triple / Quadruple / Quintuple) for the Philips Hue Dimmer Switch. (RWL021 & RWL020)

This capability uses a 500ms timeout (which is reset every time we press). Currently this is statically defined, as I'm not sure theres any way to change configuration on the ZHA side. Downside is that this adds a 500ms delay to any "press" `press_type`. However, in practice I didn't notice it.

Also possible to add a `click_count` as requested here: https://github.com/zigpy/zha-device-handlers/issues/401, but this should solve the "why" to that request, so it's likely not necessary.