### PR TITLE
Fix XBee manufacturer and model

### DIFF
--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -336,5 +336,5 @@ class XBeeCommon(CustomDevice):
                 OUTPUT_CLUSTERS: [SerialDataCluster, EventRelayCluster],
             }
         },
-        "manufacturer": "XBee",
+        "manufacturer": "Digi",
     }

--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -332,10 +332,9 @@ class XBeeCommon(CustomDevice):
     replacement = {
         ENDPOINTS: {
             232: {
-                "manufacturer": "XBEE",
-                "model": "xbee.io",
                 INPUT_CLUSTERS: [DigitalIOCluster, SerialDataCluster],
                 OUTPUT_CLUSTERS: [SerialDataCluster, EventRelayCluster],
             }
-        }
+        },
+        "manufacturer": "XBee",
     }

--- a/zhaquirks/xbee/xbee3_io.py
+++ b/zhaquirks/xbee/xbee3_io.py
@@ -11,123 +11,109 @@ class XBee3Sensor(XBeeCommon):
 
     def __init__(self, application, ieee, nwk, replaces):
         """Initialize device-specific properties."""
+        self.replacement["model"] = "XBee3"
         self.replacement[ENDPOINTS].update(
             {
                 0xD0: {
-                    "manufacturer": "XBEE",
-                    "model": "AD0/DIO0/Commissioning",
+                    # AD0/DIO0/Commissioning
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD1: {
-                    "manufacturer": "XBEE",
-                    "model": "AD1/DIO1/SPI_nATTN",
+                    # AD1/DIO1/SPI_nATTN
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD2: {
-                    "manufacturer": "XBEE",
-                    "model": "AD2/DIO2/SPI_CLK",
+                    # AD2/DIO2/SPI_CLK
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD3: {
-                    "manufacturer": "XBEE",
-                    "model": "AD3/DIO3",
+                    # AD3/DIO3
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD4: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO4/SPI_MOSI",
+                    # DIO4/SPI_MOSI
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD5: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO5/Assoc",
+                    # DIO5/Assoc
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD6: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO6/RTS",
+                    # DIO6/RTS
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD7: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO7/CTS",
+                    # DIO7/CTS
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD8: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO8",
+                    # DIO8
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD9: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO9",
+                    # DIO9
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDA: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO10/PWM0",
+                    # DIO10/PWM0
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff, XBeePWM],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDB: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO11/PWM1",
+                    # DIO11/PWM1
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff, XBeePWM],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDC: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO12/SPI_MISO",
+                    # DIO12/SPI_MISO
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDD: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO13/DOUT",
+                    # DIO13/DOUT
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDE: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO14/DIN",
+                    # DIO14/DIN
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],

--- a/zhaquirks/xbee/xbee_io.py
+++ b/zhaquirks/xbee/xbee_io.py
@@ -11,123 +11,109 @@ class XBeeSensor(XBeeCommon):
 
     def __init__(self, application, ieee, nwk, replaces):
         """Initialize device-specific properties."""
+        self.replacement["model"] = "XBee2"
         self.replacement[ENDPOINTS].update(
             {
                 0xD0: {
-                    "manufacturer": "XBEE",
-                    "model": "AD0/DIO0/Commissioning",
+                    # AD0/DIO0/Commissioning
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD1: {
-                    "manufacturer": "XBEE",
-                    "model": "AD1/DIO1/SPI_nATTN",
+                    # AD1/DIO1/SPI_nATTN
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD2: {
-                    "manufacturer": "XBEE",
-                    "model": "AD2/DIO2/SPI_CLK",
+                    # AD2/DIO2/SPI_CLK
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD3: {
-                    "manufacturer": "XBEE",
-                    "model": "AD3/DIO3",
+                    # AD3/DIO3
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD4: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO4/SPI_MOSI",
+                    # DIO4/SPI_MOSI
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD5: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO5/Assoc",
+                    # DIO5/Assoc
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD6: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO6/RTS",
+                    # DIO6/RTS
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD7: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO7/CTS",
+                    # DIO7/CTS
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD8: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO8",
+                    # DIO8
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD9: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO9",
+                    # DIO9
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDA: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO10/PWM0",
+                    # DIO10/PWM0
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDB: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO11/PWM1",
+                    # DIO11/PWM1
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDC: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO12/SPI_MISO",
+                    # DIO12/SPI_MISO
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDD: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO13/DOUT",
+                    # DIO13/DOUT
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDE: {
-                    "manufacturer": "XBEE",
-                    "model": "DIO14/DIN",
+                    # DIO14/DIN
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],


### PR DESCRIPTION
1. Added model and manufacturer on device level for XBee
2. Removed model and manufacturer on endpoint level since I couldn't find where it is used.

This is required for home-assistant/core#41311 to actually work.