### PR TITLE
Philips power on color temperature and brightness

### DIFF
--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -3,7 +3,8 @@ import logging
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, OnOff
+from zigpy.zcl.clusters.general import Basic, LevelControl, OnOff
+from zigpy.zcl.clusters.lighting import Color
 
 from ..const import (
     ARGS,
@@ -59,6 +60,20 @@ class PhilipsOnOffCluster(CustomCluster, OnOff):
 
     attributes = OnOff.attributes.copy()
     attributes.update({0x4003: ("power_on_state", PowerOnState)})
+
+
+class PhilipsLevelControlCluster(CustomCluster, LevelControl):
+    """Philips LevelControl cluster."""
+
+    attributes = LevelControl.attributes.copy()
+    attributes.update({0x4000: ("power_on_level", t.uint8_t)})
+
+
+class PhilipsColorCluster(CustomCluster, Color):
+    """Philips Color cluster."""
+
+    attributes = Color.attributes.copy()
+    attributes.update({0x4010: ("power_on_color_temperature", t.uint16_t)})
 
 
 class PhilipsBasicCluster(CustomCluster, Basic):

--- a/zhaquirks/philips/zhaextendedcolorlight.py
+++ b/zhaquirks/philips/zhaextendedcolorlight.py
@@ -23,7 +23,12 @@ from zhaquirks.const import (
     PROFILE_ID,
     MODELS_INFO,
 )
-from zhaquirks.philips import PHILIPS, PhilipsOnOffCluster
+from zhaquirks.philips import (
+    PHILIPS,
+    PhilipsColorCluster,
+    PhilipsLevelControlCluster,
+    PhilipsOnOffCluster,
+)
 
 
 class ZHAExtendedColorLight(CustomDevice):
@@ -77,10 +82,10 @@ class ZHAExtendedColorLight(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     PhilipsOnOffCluster,
-                    LevelControl.cluster_id,
+                    PhilipsLevelControlCluster,
                     LightLink.cluster_id,
                     64514,
-                    Color.cluster_id,
+                    PhilipsColorCluster,
                     64513,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
@@ -149,9 +154,9 @@ class ZHAExtendedColorLight2(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     PhilipsOnOffCluster,
-                    LevelControl.cluster_id,
+                    PhilipsLevelControlCluster,
                     LightLink.cluster_id,
-                    Color.cluster_id,
+                    PhilipsColorCluster,
                     64513,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],

--- a/zhaquirks/philips/zllextendedcolorlight.py
+++ b/zhaquirks/philips/zllextendedcolorlight.py
@@ -23,7 +23,12 @@ from zhaquirks.const import (
     PROFILE_ID,
     MODELS_INFO,
 )
-from zhaquirks.philips import PHILIPS, PhilipsOnOffCluster
+from zhaquirks.philips import (
+    PHILIPS,
+    PhilipsColorCluster,
+    PhilipsLevelControlCluster,
+    PhilipsOnOffCluster,
+)
 
 
 class ZLLExtendedColorLight(CustomDevice):
@@ -90,9 +95,9 @@ class ZLLExtendedColorLight(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     PhilipsOnOffCluster,
-                    LevelControl.cluster_id,
+                    PhilipsLevelControlCluster,
                     LightLink.cluster_id,
-                    Color.cluster_id,
+                    PhilipsColorCluster,
                     64513,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],


### PR DESCRIPTION
Add attributes for power on color temperature and power on brightness configuration.
Attribute numbers are taken from this comment: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1055#issuecomment-559993258
Tested on Philips LCT003 (`ZLLExtendedColorLight`). `ZHAExtendedColorLight` and `ZHAExtendedColorLight2` are not tested but they should be the same for what I know.
Apparently, to set the power on color itself one could use the Color (0x0300) cluster, current_x (0x0003) and current_y (0x0004) attributes with manufacturer code 0x100b (4107).