### PR TITLE
Added quirk for iluminize universal controller: remove color wheel

### DIFF
--- a/zhaquirks/iluminize/__init__.py
+++ b/zhaquirks/iluminize/__init__.py
@@ -1,0 +1,3 @@
+"""Module for iluminize devices"""
+
+ILUMINIZE = "iluminize"

--- a/zhaquirks/iluminize/__init__.py
+++ b/zhaquirks/iluminize/__init__.py
@@ -1,3 +1,3 @@
-"""Module for iluminize devices"""
+"""Module for iluminize devices."""
 
 ILUMINIZE = "iluminize"

--- a/zhaquirks/iluminize/cct.py
+++ b/zhaquirks/iluminize/cct.py
@@ -1,0 +1,101 @@
+"""Quirk for iluminize CCT actor."""
+from zigpy.profiles import zll
+from zigpy.quirks import CustomDevice, CustomCluster
+from zigpy.zcl.clusters.general import (
+    OnOff,
+    Basic,
+    Identify,
+    LevelControl,
+    Scenes,
+    Groups,
+    Ota,
+    GreenPowerProxy,
+)
+from zigpy.zcl.clusters.homeautomation import Diagnostic
+
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from zhaquirks.const import (
+    ENDPOINTS,
+    OUTPUT_CLUSTERS,
+    INPUT_CLUSTERS,
+    DEVICE_TYPE,
+    PROFILE_ID,
+    MODELS_INFO,
+)
+from zhaquirks.iluminize import ILUMINIZE
+
+
+class IluminizeCCTColorCluster(CustomCluster, Color):
+    """iluminize CCT Lighting custom cluster."""
+
+    # Remove RGB color wheel for CCT Lighting: only expose color temperature
+    _CONSTANT_ATTRIBUTES = {0x400A: 16}
+
+
+class CCTLight(CustomDevice):
+    """iluminize ZigBee LightLink CCT Lighting device."""
+
+    signature = {
+        MODELS_INFO: [(ILUMINIZE, "CCT Lighting")],
+        ENDPOINTS: {
+            1: {
+                # <SimpleDescriptor endpoint=1 profile=49246 device_type=544
+                # device_version=1
+                # input_clusters=[0, 3, 4, 5, 6, 8, 768, 2821, 4096]
+                # output_clusters=[25]
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    Diagnostic.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                # <SimpleDescriptor endpoint=242 profile=41440 device_type=102
+                # device_version=0
+                # input_clusters=[33]
+                # output_clusters=[33]
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 102,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    IluminizeCCTColorCluster,
+                    Diagnostic.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 102,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }

--- a/zhaquirks/iluminize/dim.py
+++ b/zhaquirks/iluminize/dim.py
@@ -1,0 +1,101 @@
+"""Quirk for iluminize DIM actor."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice, CustomCluster
+from zigpy.zcl.clusters.general import (
+    OnOff,
+    Basic,
+    Identify,
+    LevelControl,
+    Scenes,
+    Groups,
+    Ota,
+    GreenPowerProxy,
+)
+from zigpy.zcl.clusters.homeautomation import Diagnostic
+
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from zhaquirks.const import (
+    ENDPOINTS,
+    OUTPUT_CLUSTERS,
+    INPUT_CLUSTERS,
+    DEVICE_TYPE,
+    PROFILE_ID,
+    MODELS_INFO,
+)
+from zhaquirks.iluminize import ILUMINIZE
+
+
+class IluminizeDIMColorCluster(CustomCluster, Color):
+    """iluminize DIM Lighting custom cluster."""
+
+    # Remove RGB color wheel for DIM Lighting
+    _CONSTANT_ATTRIBUTES = {0x400A: 0}
+
+
+class DIMLight(CustomDevice):
+    """iluminize ZigBee LightLink DIM Lighting device."""
+
+    signature = {
+        MODELS_INFO: [(ILUMINIZE, "DIM Lighting")],
+        ENDPOINTS: {
+            1: {
+                # <SimpleDescriptor endpoint=1 profile=260 device_type=257
+                # device_version=1
+                # input_clusters=[0, 3, 4, 5, 6, 8, 768, 2821, 4096]
+                # output_clusters=[25]
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    Diagnostic.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                # <SimpleDescriptor endpoint=242 profile=41440 device_type=102
+                # device_version=0
+                # input_clusters=[33]
+                # output_clusters=[33]
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 102,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    IluminizeDIMColorCluster,
+                    Diagnostic.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 102,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }


### PR DESCRIPTION
This adds a quirk for iluminize universal actor/controller (https://www.amazon.de/dp/B07XF1B8YN/).
Without this quirk, the device still showed the color wheel for the DIM and CCT mode. (After each mode change, the device needs to be repaired and then shows up with a different model.
The color wheel is removed by correctly replacing 0x400A (color_capabilities) in the color cluster with either nothing (for DIM mode, so only the brightness slider shows up in Hass) or with 2^4: 16 (for CCT mode, so only the CCT slider shows up in Hass).