### PR TITLE
Support default power on state for Hue Lily and Hue Calla

### DIFF
--- a/zhaquirks/philips/zllextendedcolorlight.py
+++ b/zhaquirks/philips/zllextendedcolorlight.py
@@ -49,6 +49,8 @@ class ZLLExtendedColorLight(CustomDevice):
             (PHILIPS, "LCT021"),
             (PHILIPS, "LCT024"),
             (PHILIPS, "LLC020"),
+            (PHILIPS, "LCF002"),
+            (PHILIPS, "LCS001"),
         ],
         ENDPOINTS: {
             11: {


### PR DESCRIPTION
Adds support for the PowerOnState for the Hue Lily (small spot) and Hue Calla (small light).