### PR TITLE
Add model info to Osram A19TunableWhite quirk (Fixes #536)

### DIFF
--- a/zhaquirks/osram/a19twhite.py
+++ b/zhaquirks/osram/a19twhite.py
@@ -13,8 +13,15 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.lighting import Color
 
-from . import OsramLightCluster
-from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
+from . import OsramLightCluster, OSRAM
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    MODELS_INFO,
+)
 
 
 class OsramColorCluster(CustomCluster, Color):
@@ -30,6 +37,7 @@ class A19TunableWhite(CustomDevice):
         # <SimpleDescriptor endpoint=3 profile=260 device_type=258
         # device_version=2 input_clusters=[0, 3, 4, 5, 6, 8, 768, 64527]
         # output_clusters=[25]>
+        MODELS_INFO: [(OSRAM, "LIGHTIFY A19 Tunable White")],
         ENDPOINTS: {
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -47,7 +55,7 @@ class A19TunableWhite(CustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             }
-        }
+        },
     }
 
     replacement = {

--- a/zhaquirks/osram/tunablewhite.py
+++ b/zhaquirks/osram/tunablewhite.py
@@ -1,4 +1,4 @@
-"""Osram A19 tunable white device."""
+"""Osram tunable white device."""
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice, CustomCluster
 from zigpy.zcl.clusters.general import (
@@ -30,14 +30,17 @@ class OsramColorCluster(CustomCluster, Color):
     _CONSTANT_ATTRIBUTES = {0x400A: 16, 0x400C: 370}
 
 
-class A19TunableWhite(CustomDevice):
-    """Osram A19 tunable white device."""
+class OsramTunableWhite(CustomDevice):
+    """Osram tunable white device."""
 
     signature = {
         # <SimpleDescriptor endpoint=3 profile=260 device_type=258
         # device_version=2 input_clusters=[0, 3, 4, 5, 6, 8, 768, 64527]
         # output_clusters=[25]>
-        MODELS_INFO: [(OSRAM, "LIGHTIFY A19 Tunable White")],
+        MODELS_INFO: [
+            (OSRAM, "LIGHTIFY A19 Tunable White"),
+            (OSRAM, "LIGHTIFY RT Tunable White"),
+        ],
         ENDPOINTS: {
             3: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
Fixes #536 by also including MODELS_INFO for the Osram A19TunableWhite quirk (based on the device signature given here: https://github.com/zigpy/zha-device-handlers/issues/536#issuecomment-716198388)