### PR TITLE
PhilipsOnOffCluster support: LWB014 and LCT012 without cluster 64513

### DIFF
--- a/zhaquirks/philips/zlldimmablelight.py
+++ b/zhaquirks/philips/zlldimmablelight.py
@@ -1,4 +1,4 @@
-"""Quirk for Phillips LWB010."""
+"""Quirk for Phillips dimmable bulbs."""
 from zigpy.profiles import zll
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -25,11 +25,11 @@ from zhaquirks.const import (
 from zhaquirks.philips import PHILIPS, PhilipsOnOffCluster
 
 
-class PhilipsLBW010(CustomDevice):
-    """Philips LBW010 device."""
+class ZLLDimmableLight(CustomDevice):
+    """Philips ZigBee LightLink dimmable bulb device."""
 
     signature = {
-        MODELS_INFO: [(PHILIPS, "LWB010")],
+        MODELS_INFO: [(PHILIPS, "LWB010"), (PHILIPS, "LWB014")],
         ENDPOINTS: {
             11: {
                 # <SimpleDescriptor endpoint=11 profile=49246 device_type=528

--- a/zhaquirks/philips/zllextendedcolorlight.py
+++ b/zhaquirks/philips/zllextendedcolorlight.py
@@ -110,3 +110,68 @@ class ZLLExtendedColorLight(CustomDevice):
             },
         }
     }
+
+
+class ZLLExtendedColorLight2(CustomDevice):
+    """Philips ZigBee LightLink extended color bulb device without input cluster 64513."""
+
+    signature = {
+        MODELS_INFO: [(PHILIPS, "LCT012")],
+        ENDPOINTS: {
+            11: {
+                # <SimpleDescriptor endpoint=11 profile=49246 device_type=528
+                # device_version=2
+                # input_clusters=[0, 3, 4, 5, 6, 8, 4096, 768, 64513]
+                # output_clusters=[25]
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.EXTENDED_COLOR_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                    Color.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+                # device_version=0
+                # input_clusters=[33]
+                # output_clusters=[33]
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            11: {
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.EXTENDED_COLOR_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    PhilipsOnOffCluster,
+                    PhilipsLevelControlCluster,
+                    LightLink.cluster_id,
+                    PhilipsColorCluster,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }


### PR DESCRIPTION
Add ZLLExtendedColorLight2 for LCT012 without 64513 cluster (fixes #479)
Refactored Philips LWB010 quirk into ZLLDimmableLight and added LWB014 support (fixes #544)