### PR TITLE
Hue White Dimmable - Expose PhilipsLevelControlCluster

### DIFF
--- a/zhaquirks/philips/zlldimmablelight.py
+++ b/zhaquirks/philips/zlldimmablelight.py
@@ -22,8 +22,12 @@ from zhaquirks.const import (
     PROFILE_ID,
     MODELS_INFO,
 )
-from zhaquirks.philips import PHILIPS, PhilipsOnOffCluster
 
+from zhaquirks.philips import (
+    PHILIPS,
+    PhilipsLevelControlCluster,
+    PhilipsOnOffCluster
+)
 
 class ZLLDimmableLight(CustomDevice):
     """Philips ZigBee LightLink dimmable bulb device."""
@@ -73,7 +77,7 @@ class ZLLDimmableLight(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     PhilipsOnOffCluster,
-                    LevelControl.cluster_id,
+                    PhilipsLevelControlCluster,
                     LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],

--- a/zhaquirks/philips/zlldimmablelight.py
+++ b/zhaquirks/philips/zlldimmablelight.py
@@ -29,6 +29,7 @@ from zhaquirks.philips import (
     PhilipsOnOffCluster
 )
 
+
 class ZLLDimmableLight(CustomDevice):
     """Philips ZigBee LightLink dimmable bulb device."""
 

--- a/zhaquirks/philips/zlldimmablelight.py
+++ b/zhaquirks/philips/zlldimmablelight.py
@@ -23,11 +23,7 @@ from zhaquirks.const import (
     MODELS_INFO,
 )
 
-from zhaquirks.philips import (
-    PHILIPS,
-    PhilipsLevelControlCluster,
-    PhilipsOnOffCluster
-)
+from zhaquirks.philips import PHILIPS, PhilipsLevelControlCluster, PhilipsOnOffCluster
 
 
 class ZLLDimmableLight(CustomDevice):


### PR DESCRIPTION
In order for PhilipsOnOff power restore to work, you also need to be able to set Level Control cluster 0x0008, PowerOn Level attribute 0x4000 to value 255 (0xff).

I edited the quirk to add the Level Control cluster. When I read/get to attribute ox4000, it is set as 254 as default. This causes the bulb to restore to full brightness after power restore. If set as 255, it restores to previous brightness. 

Findings based on this https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1055#issuecomment-559993258