### PR TITLE
added power configuration to motion aq2b

### DIFF
--- a/zhaquirks/xiaomi/aqara/motion_aq2b.py
+++ b/zhaquirks/xiaomi/aqara/motion_aq2b.py
@@ -10,6 +10,7 @@ from .. import (
     IlluminanceMeasurementCluster,
     MotionCluster,
     OccupancyCluster,
+    PowerConfigurationCluster,
     XiaomiCustomDevice,
 )
 from ... import Bus
@@ -63,6 +64,7 @@ class MotionAQ2(XiaomiCustomDevice):
             1: {
                 INPUT_CLUSTERS: [
                     BasicCluster,
+                    PowerConfigurationCluster,
                     IlluminanceMeasurementCluster,
                     OccupancyCluster,
                     MotionCluster,


### PR DESCRIPTION
I guess power configuration was forgotten on alternative quirk for motion aq2.

I tested this on 5 devices i had which regsitered with this quirk and never reported battery. And with this simple modification now they all report there battery fluently and constitently

regards