### PR TITLE
Added support for Philips LCE002 (Color E14 Bluetooth model)

### DIFF
--- a/zhaquirks/philips/zhaextendedcolorlight.py
+++ b/zhaquirks/philips/zhaextendedcolorlight.py
@@ -34,7 +34,12 @@ class ZHAExtendedColorLight(CustomDevice):
     """Philips ZigBee HomeAutomation extended color bulb device."""
 
     signature = {
-        MODELS_INFO: [(PHILIPS, "LCA001"), (PHILIPS, "LCA003"), (PHILIPS, "LCB001")],
+        MODELS_INFO: [
+            (PHILIPS, "LCA001"),
+            (PHILIPS, "LCA003"),
+            (PHILIPS, "LCB001"),
+            (PHILIPS, "LCE002"),
+        ],
         ENDPOINTS: {
             11: {
                 # <SimpleDescriptor endpoint=11 profile=260 device_type=269


### PR DESCRIPTION
Added support for Philips LCE002 (Color E14 Bluetooth model). (Tested)
(Amazon link: https://www.amazon.de/dp/B08HFPDJQJ/)