### PR TITLE
Add LST001 Light Strip, Expose PhilipsColorCluster and PhilipsLevelCo…

### DIFF
--- a/zhaquirks/philips/lst.py
+++ b/zhaquirks/philips/lst.py
@@ -95,7 +95,8 @@ class PhilipsLST001(CustomDevice):
             },
         }
     }
-    
+
+
 class PhilipsLST002(CustomDevice):
     """Philips LST002 device."""
 

--- a/zhaquirks/philips/lst.py
+++ b/zhaquirks/philips/lst.py
@@ -1,4 +1,4 @@
-"""Quirk for Phillips LST002."""
+"""Quirk for Phillips LST001 and LST002 Light Strips."""
 from zigpy.profiles import zll
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -22,9 +22,80 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.philips import PHILIPS, PhilipsOnOffCluster
+from zhaquirks.philips import (
+    PHILIPS,
+    PhilipsColorCluster,
+    PhilipsLevelControlCluster,
+    PhilipsOnOffCluster,
+)
 
 
+class PhilipsLST001(CustomDevice):
+    """Philips LST001 device."""
+
+    signature = {
+        MODELS_INFO: [(PHILIPS, "LST001")],
+        ENDPOINTS: {
+            11: {
+                # <SimpleDescriptor endpoint=11 profile=49246 device_type=512
+                # device_version=2
+                # input_clusters=[0, 3, 4, 5, 6, 8, 4096, 768, 64513]
+                # output_clusters=[25]
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.COLOR_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                    Color.cluster_id,
+                    64513,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+                # device_version=0
+                # input_clusters=[33]
+                # output_clusters=[33]
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            11: {
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.COLOR_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    PhilipsOnOffCluster,
+                    PhilipsLevelControlCluster,
+                    LightLink.cluster_id,
+                    PhilipsColorCluster,
+                    64513,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }
+    
 class PhilipsLST002(CustomDevice):
     """Philips LST002 device."""
 
@@ -75,9 +146,9 @@ class PhilipsLST002(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     PhilipsOnOffCluster,
-                    LevelControl.cluster_id,
+                    PhilipsLevelControlCluster,
                     LightLink.cluster_id,
-                    Color.cluster_id,
+                    PhilipsColorCluster,
                     64513,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],


### PR DESCRIPTION
…ntrolCluster for both LST00x

LST001 device signature:
```
{
  "node_descriptor": "NodeDescriptor(byte1=1, byte2=64, mac_capability_flags=142, manufacturer_code=4107, maximum_buffer_size=80, maximum_incoming_transfer_size=80, server_mask=0, maximum_outgoing_transfer_size=80, descriptor_capability_field=0)",
  "endpoints": {
    "11": {
      "profile_id": 49246,
      "device_type": "0x0210",
      "in_clusters": [
        "0x0000",
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006",
        "0x0008",
        "0x0300",
        "0x1000",
        "0xfc01"
      ],
      "out_clusters": [
        "0x0019"
      ]
    },
    "242": {
      "profile_id": 41440,
      "device_type": "0x0061",
      "in_clusters": [
        "0x0021"
      ],
      "out_clusters": [
        "0x0021"
      ]
    }
  },
  "manufacturer": "Philips",
  "model": "LST001",
  "class": "zhaquirks.philips.lst001.PhilipsLST001"
}
```