### PR TITLE
Add LLC012 Bloom, Expose PhilipsLevelControlCluster and PhilipsColorC…

### DIFF
--- a/zhaquirks/philips/llcbloom.py
+++ b/zhaquirks/philips/llcbloom.py
@@ -1,4 +1,4 @@
-"""Quirk for Phillips Hue LivingColors Bloom."""
+"""Quirk for Phillips Hue LivingColors Bloom LLC011 and LLC012."""
 from zigpy.profiles import zll
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -22,14 +22,19 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.philips import PHILIPS, PhilipsOnOffCluster
+from zhaquirks.philips import (
+    PHILIPS,
+    PhilipsColorCluster,
+    PhilipsLevelControlCluster,
+    PhilipsOnOffCluster,
+)
 
 
-class PhilipsLLC011(CustomDevice):
-    """Philips LLC device."""
+class PhilipsLLCBloom(CustomDevice):
+    """Philips LLC Bloom device."""
 
     signature = {
-        MODELS_INFO: [(PHILIPS, "LLC011")],
+        MODELS_INFO: [(PHILIPS, "LLC011"), (PHILIPS, "LLC012")],
         ENDPOINTS: {
             11: {
                 # <SimpleDescriptor endpoint=11 profile=49246 device_type=512
@@ -75,9 +80,9 @@ class PhilipsLLC011(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     PhilipsOnOffCluster,
-                    LevelControl.cluster_id,
+                    PhilipsLevelControlCluster,
                     LightLink.cluster_id,
-                    Color.cluster_id,
+                    PhilipsColorCluster,
                     64513,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],


### PR DESCRIPTION
…luster

LLC012 device signature:
```
{
  "node_descriptor": "NodeDescriptor(byte1=1, byte2=64, mac_capability_flags=142, manufacturer_code=4107, maximum_buffer_size=80, maximum_incoming_transfer_size=80, server_mask=0, maximum_outgoing_transfer_size=80, descriptor_capability_field=0)",
  "endpoints": {
    "11": {
      "profile_id": 49246,
      "device_type": "0x0200",
      "in_clusters": [
        "0x0000",
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006",
        "0x0008",
        "0x0300",
        "0x1000",
        "0xfc01"
      ],
      "out_clusters": [
        "0x0019"
      ]
    },
    "242": {
      "profile_id": 41440,
      "device_type": "0x0061",
      "in_clusters": [
        "0x0021"
      ],
      "out_clusters": [
        "0x0021"
      ]
    }
  },
  "manufacturer": "Philips",
  "model": "LLC012",
  "class": "zhaquirks.philips.llcbloom.PhilipsLLCBloom"
}
```