### PR TITLE
Add Philips sml001 motion sensor quirk

### DIFF
--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -7,6 +7,7 @@ from zigpy.quirks import CustomCluster
 import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic, LevelControl, OnOff
 from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.measurement import OccupancySensing
 
 from ..const import (
     ARGS,
@@ -75,6 +76,15 @@ class PowerOnState(t.enum8):
     Off = 0x00
     On = 0x01
     LastState = 0xFF
+
+
+class OccupancyCluster(CustomCluster, OccupancySensing):
+    """Philips occupancy cluster."""
+
+    manufacturer_attributes = {
+        0x0030: ("sensitivity", t.uint8_t),
+        0x0031: ("sensitivity_max", t.uint8_t),
+    }
 
 
 class PhilipsOnOffCluster(CustomCluster, OnOff):

--- a/zhaquirks/philips/sml001.py
+++ b/zhaquirks/philips/sml001.py
@@ -1,7 +1,6 @@
 """Quirk for Philips SML001."""
 from zigpy.profiles import zha, zll
-from zigpy.quirks import CustomCluster, CustomDevice
-import zigpy.types as t
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -19,7 +18,7 @@ from zigpy.zcl.clusters.measurement import (
     TemperatureMeasurement,
 )
 
-from . import PHILIPS
+from . import PHILIPS, OccupancyCluster
 from ..const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -28,15 +27,6 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-
-class OccupancyCluster(CustomCluster, OccupancySensing):
-    """philips occupancy cluster."""
-
-    manufacturer_attributes = {
-        0x0030: ("sensitivity", t.uint8_t),
-        0x0031: ("sensitivity_max", t.uint8_t),
-    }
 
 
 class PhilipsSML001(CustomDevice):

--- a/zhaquirks/philips/sml001.py
+++ b/zhaquirks/philips/sml001.py
@@ -1,0 +1,116 @@
+"""Quirk for Philips SML001."""
+from zigpy.profiles import zha, zll
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    PowerConfiguration,
+    Scenes,
+)
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.measurement import (
+    IlluminanceMeasurement,
+    OccupancySensing,
+    TemperatureMeasurement,
+)
+
+from . import PHILIPS
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class OccupancyCluster(CustomCluster, OccupancySensing):
+    """philips occupancy cluster."""
+
+    manufacturer_attributes = {
+        0x0030: ("sensitivity", t.uint8_t),
+        0x0031: ("sensitivity_max", t.uint8_t),
+    }
+
+
+class PhilipsSML001(CustomDevice):
+    """philips SML001 device."""
+
+    signature = {
+        MODELS_INFO: [(PHILIPS, "SML001")],
+        ENDPOINTS: {
+            #  <SimpleDescriptor endpoint=1 profile=49246 device_type=0x0850
+            #  device_version=?
+            #  input_clusters=[0]
+            #  output_clusters=[0, 3, 4, 5, 6, 8, 300]>
+            1: {
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.ON_OFF_SENSOR,
+                INPUT_CLUSTERS: [Basic.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                ],
+            },
+            #  <SimpleDescriptor endpoint=2 profile=260 device_type=0x0107
+            #  device_version=?
+            #  input_clusters=[0, 1, 3, 400, 402, 406]
+            #  output_clusters=[19]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IlluminanceMeasurement.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    OccupancySensing.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.ON_OFF_SENSOR,
+                INPUT_CLUSTERS: [Basic.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IlluminanceMeasurement.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    OccupancyCluster,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        }
+    }

--- a/zhaquirks/philips/sml002.py
+++ b/zhaquirks/philips/sml002.py
@@ -1,7 +1,6 @@
 """Quirk for Philips SML002."""
 from zigpy.profiles import zha, zll
-from zigpy.quirks import CustomCluster, CustomDevice
-import zigpy.types as t
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -19,7 +18,7 @@ from zigpy.zcl.clusters.measurement import (
     TemperatureMeasurement,
 )
 
-from . import PHILIPS
+from . import PHILIPS, OccupancyCluster
 from ..const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -28,15 +27,6 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-
-class OccupancyCluster(CustomCluster, OccupancySensing):
-    """philips occupancy cluster."""
-
-    manufacturer_attributes = {
-        0x0030: ("sensitivity", t.uint8_t),
-        0x0031: ("sensitivity_max", t.uint8_t),
-    }
 
 
 class PhilipsSML002(CustomDevice):


### PR DESCRIPTION
Adds the sml001 motion sensor quirk, which exposes motion sensor sensitivity settings. Basically a copy of sml002 but with the correct endpoints for this device. SML001 is the indoor motion sensor.

```
{
  "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4107, maximum_buffer_size=89, maximum_incoming_transfer_size=63, server_mask=0, maximum_outgoing_transfer_size=63, descriptor_capability_field=0)",
  "endpoints": {
    "1": {
      "profile_id": 49246,
      "device_type": "0x0850",
      "in_clusters": [
        "0x0000"
      ],
      "out_clusters": [
        "0x0000",
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006",
        "0x0008",
        "0x0300"
      ]
    },
    "2": {
      "profile_id": 260,
      "device_type": "0x0107",
      "in_clusters": [
        "0x0000",
        "0x0001",
        "0x0003",
        "0x0400",
        "0x0402",
        "0x0406"
      ],
      "out_clusters": [
        "0x0019"
      ]
    }
  },
  "manufacturer": "Philips",
  "model": "SML001",
  "class": "zhaquirks.philips.sml001.PhilipsSML001"
}
```