### PR TITLE
Xiaomi quick initialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
+            hashFiles('setup.py') }}-${{
             hashFiles('requirements_test_all.txt') }}
           restore-keys: |
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version }}-
@@ -70,6 +71,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
+            hashFiles('setup.py') }}-${{
             hashFiles('requirements_test_all.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -111,6 +113,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
+            hashFiles('setup.py') }}-${{
             hashFiles('requirements_test_all.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -154,6 +157,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
+            hashFiles('setup.py') }}-${{
             hashFiles('requirements_test_all.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -200,6 +204,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
+            hashFiles('setup.py') }}-${{
             hashFiles('requirements_test_all.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -247,6 +252,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
+            hashFiles('setup.py') }}-${{
             hashFiles('requirements_test_all.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -308,6 +314,7 @@ jobs:
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
+            hashFiles('setup.py') }}-${{
             hashFiles('requirements_test_all.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -4,7 +4,7 @@
 # new version
 asynctest==0.13.0
 codecov==2.1.10
-coveralls==2.1.2
+coveralls==2.2.0
 flake8-docstrings==1.5.0
 mock-open==1.4.0
 mypy==0.790

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(
     keywords="zha quirks homeassistant hass",
     packages=find_packages(exclude=["*.tests"]),
     python_requires=">=3",
-    install_requires=["zigpy>=0.22.1"],
+    install_requires=["zigpy>=0.28.0"],
     tests_require=["pytest"],
 )

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(
     keywords="zha quirks homeassistant hass",
     packages=find_packages(exclude=["*.tests"]),
     python_requires=">=3",
-    install_requires=["zigpy>=0.28.0"],
+    install_requires=["zigpy>=0.28.1"],
     tests_require=["pytest"],
 )

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -21,6 +21,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.xiaomi import XIAOMI_NODE_DESC
 
 ALL_QUIRK_CLASSES = [
     quirk
@@ -61,6 +62,7 @@ def test_dev_from_signature_incomplete_sig(raw_device):
     class BadSigNoModel(zhaquirks.QuickInitDevice):
         signature = {
             MODELS_INFO: [("manufacturer_1", "model_1")],
+            NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
             ENDPOINTS: {
                 3: {
                     PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
@@ -95,6 +97,7 @@ def test_dev_from_signature_incomplete_sig(raw_device):
         signature = {
             MANUFACTURER: "manufacturer",
             MODEL: "model",
+            NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
             ENDPOINTS: {3: {**ep_sig_complete}},
         }
 
@@ -122,6 +125,7 @@ def test_dev_from_signature_incomplete_sig(raw_device):
             },
             MANUFACTURER: "manufacturer_3",
             MODEL: "model_3",
+            NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         },
         {
             ENDPOINTS: {
@@ -140,6 +144,26 @@ def test_dev_from_signature_incomplete_sig(raw_device):
             },
             MANUFACTURER: "manufacturer_4",
             MODEL: "model_4",
+            NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
+        },
+        {
+            ENDPOINTS: {
+                2: {
+                    PROFILE_ID: 33,
+                    DEVICE_TYPE: 44,
+                    INPUT_CLUSTERS: [0, 0x0201, 0x0402],
+                    OUTPUT_CLUSTERS: [0x0019, 0x0401],
+                },
+                5: {
+                    PROFILE_ID: 55,
+                    DEVICE_TYPE: 66,
+                    INPUT_CLUSTERS: [0, 6, 8],
+                    OUTPUT_CLUSTERS: [0x0019, 0x0500],
+                },
+            },
+            MODELS_INFO: (("LUMI", "model_4"),),
+            MODEL: "model_4",
+            NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         },
         {
             ENDPOINTS: {
@@ -166,6 +190,7 @@ def test_dev_from_signature_incomplete_sig(raw_device):
             },
             MANUFACTURER: "manufacturer 5",
             MODEL: "model 5",
+            NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         },
     ),
 )
@@ -177,7 +202,10 @@ def test_dev_from_signature(raw_device, quirk_signature):
 
     device = QuirkDevice.from_signature(raw_device)
     assert device.status == zigpy.device.Status.ENDPOINTS_INIT
-    assert device.manufacturer == quirk_signature[MANUFACTURER]
+    if MANUFACTURER in quirk_signature:
+        assert device.manufacturer == quirk_signature[MANUFACTURER]
+    else:
+        assert device.manufacturer == "LUMI"
     assert device.model == quirk_signature[MODEL]
 
     ep_signature = quirk_signature[ENDPOINTS]

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -1,10 +1,25 @@
 """General quirk tests."""
 
+from unittest import mock
+
 import pytest
+import zigpy.device
+import zigpy.endpoint
+import zigpy.profiles
 import zigpy.quirks as zq
+import zigpy.types
 
 import zhaquirks  # noqa: F401, E402
-from zhaquirks.const import ENDPOINTS
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MANUFACTURER,
+    MODEL,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
 
 ALL_QUIRK_CLASSES = (
     quirk
@@ -22,3 +37,157 @@ def test_quirk_replacements(quirk):
     assert quirk.replacement
 
     assert quirk.replacement[ENDPOINTS]
+
+
+@pytest.fixture
+def raw_device():
+    """Raw device."""
+    app = mock.MagicMock()
+    ieee = zigpy.types.EUI64.convert("11:22:33:44:55:66:77:88")
+    nwk = 0x1234
+    return zigpy.device.Device(app, ieee, nwk)
+
+
+def test_dev_from_signature_incomplete_sig(raw_device):
+    """Test device initialization from quirk's based on incomplete signature."""
+
+    class BadSigNoSignature(zhaquirks.QuickInitDevice):
+        pass
+
+    with pytest.raises(AssertionError):
+        BadSigNoSignature.from_signature(raw_device, model="test_model")
+
+    class BadSigNoModel(zhaquirks.QuickInitDevice):
+        signature = {
+            MODELS_INFO: [("manufacturer_1", "model_1")],
+            ENDPOINTS: {
+                3: {
+                    PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
+                    DEVICE_TYPE: zigpy.profiles.zha.DeviceType.LEVEL_CONTROL_SWITCH,
+                    INPUT_CLUSTERS: [1, 6],
+                    OUTPUT_CLUSTERS: [0x19],
+                }
+            },
+        }
+
+    with pytest.raises(KeyError):
+        BadSigNoModel.from_signature(raw_device)
+
+    # require model in method, if none is present in signature
+    BadSigNoModel.from_signature(raw_device, model="model_model")
+
+    # require manufacturer, if no signature[MODELS_INFO]
+    BadSigNoModel.signature.pop(MODELS_INFO)
+    with pytest.raises(KeyError):
+        BadSigNoModel.from_signature(raw_device, model="model_model")
+    BadSigNoModel.signature[MANUFACTURER] = "some manufacturer"
+    BadSigNoModel.from_signature(raw_device, model="model_model")
+
+    ep_sig_complete = {
+        PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
+        DEVICE_TYPE: zigpy.profiles.zha.DeviceType.LEVEL_CONTROL_SWITCH,
+        INPUT_CLUSTERS: [1, 6],
+        OUTPUT_CLUSTERS: [0x19],
+    }
+
+    class BadSigIncompleteEp(zhaquirks.QuickInitDevice):
+        signature = {
+            MANUFACTURER: "manufacturer",
+            MODEL: "model",
+            ENDPOINTS: {3: {**ep_sig_complete}},
+        }
+
+    BadSigIncompleteEp.from_signature(raw_device)
+
+    for missing_item in ep_sig_complete:
+        incomplete_ep = {**ep_sig_complete}
+        incomplete_ep.pop(missing_item)
+        BadSigIncompleteEp.signature[ENDPOINTS][3] = incomplete_ep
+        with pytest.raises(KeyError):
+            BadSigIncompleteEp.from_signature(raw_device)
+
+
+@pytest.mark.parametrize(
+    "quirk_signature",
+    (
+        {
+            ENDPOINTS: {
+                1: {
+                    PROFILE_ID: 11,
+                    DEVICE_TYPE: 22,
+                    INPUT_CLUSTERS: [0, 1, 4],
+                    OUTPUT_CLUSTERS: [0, 6, 8, 768],
+                }
+            },
+            MANUFACTURER: "manufacturer_3",
+            MODEL: "model_3",
+        },
+        {
+            ENDPOINTS: {
+                2: {
+                    PROFILE_ID: 33,
+                    DEVICE_TYPE: 44,
+                    INPUT_CLUSTERS: [0, 0x0201, 0x0402],
+                    OUTPUT_CLUSTERS: [0x0019, 0x0401],
+                },
+                5: {
+                    PROFILE_ID: 55,
+                    DEVICE_TYPE: 66,
+                    INPUT_CLUSTERS: [0, 6, 8],
+                    OUTPUT_CLUSTERS: [0x0019, 0x0500],
+                },
+            },
+            MANUFACTURER: "manufacturer_4",
+            MODEL: "model_4",
+        },
+        {
+            ENDPOINTS: {
+                1: {
+                    "profile_id": 260,
+                    "device_type": 0x0100,
+                    INPUT_CLUSTERS: [
+                        0x0000,
+                        0x0003,
+                        0x0004,
+                        0x0005,
+                        0x0006,
+                        0x0702,
+                        0x0B05,
+                    ],
+                    OUTPUT_CLUSTERS: [0x000A, 0x0019],
+                },
+                2: {
+                    "profile_id": 260,
+                    "device_type": 0x0103,
+                    INPUT_CLUSTERS: [0x0000, 0x0003, 0x0B05],
+                    OUTPUT_CLUSTERS: [0x0003, 0x0006],
+                },
+            },
+            MANUFACTURER: "manufacturer 5",
+            MODEL: "model 5",
+        },
+    ),
+)
+def test_dev_from_signature(raw_device, quirk_signature):
+    """Test device initialization from quirk's based on signature."""
+
+    class QuirkDevice(zhaquirks.QuickInitDevice):
+        signature = quirk_signature
+
+    device = QuirkDevice.from_signature(raw_device)
+    assert device.status == zigpy.device.Status.ENDPOINTS_INIT
+    assert device.manufacturer == quirk_signature[MANUFACTURER]
+    assert device.model == quirk_signature[MODEL]
+
+    ep_signature = quirk_signature[ENDPOINTS]
+    assert len(device.endpoints) == len(ep_signature) + 1  # ZDO endpoint
+    for ep_id, ep_data in ep_signature.items():
+        assert ep_id in device.endpoints
+        ep = device.endpoints[ep_id]
+        assert ep.status == zigpy.endpoint.Status.ZDO_INIT
+        assert ep.profile_id == ep_data[PROFILE_ID]
+        assert ep.device_type == ep_data[DEVICE_TYPE]
+        assert [cluster_id for cluster_id in ep.in_clusters] == ep_data[INPUT_CLUSTERS]
+        assert [cluster_id for cluster_id in ep.out_clusters] == ep_data[
+            OUTPUT_CLUSTERS
+        ]

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -17,16 +17,17 @@ from zhaquirks.const import (
     MANUFACTURER,
     MODEL,
     MODELS_INFO,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
 
-ALL_QUIRK_CLASSES = (
+ALL_QUIRK_CLASSES = [
     quirk
     for manufacturer in zq._DEVICE_REGISTRY._registry.values()
     for model in manufacturer.values()
     for quirk in model
-)
+]
 
 
 @pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)
@@ -191,3 +192,21 @@ def test_dev_from_signature(raw_device, quirk_signature):
         assert [cluster_id for cluster_id in ep.out_clusters] == ep_data[
             OUTPUT_CLUSTERS
         ]
+
+
+@pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)
+def test_quirk_quickinit(quirk):
+    """Make sure signature in QuickInit Devices have all required attributes."""
+
+    if not issubclass(quirk, zhaquirks.QuickInitDevice):
+        return
+
+    assert quirk.signature.get(MODELS_INFO) or quirk.signature[MANUFACTURER]
+    assert quirk.signature[NODE_DESCRIPTOR]
+    assert quirk.signature[ENDPOINTS]
+    for ep_id, ep_data in quirk.signature[ENDPOINTS].items():
+        assert ep_id
+        assert PROFILE_ID in ep_data
+        assert DEVICE_TYPE in ep_data
+        assert isinstance(ep_data[INPUT_CLUSTERS], list)
+        assert isinstance(ep_data[OUTPUT_CLUSTERS], list)

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -23,12 +23,13 @@ from zhaquirks.const import (
 )
 from zhaquirks.xiaomi import XIAOMI_NODE_DESC
 
-ALL_QUIRK_CLASSES = [
-    quirk
-    for manufacturer in zq._DEVICE_REGISTRY._registry.values()
-    for model in manufacturer.values()
-    for quirk in model
-]
+ALL_QUIRK_CLASSES = []
+for manufacturer in zq._DEVICE_REGISTRY._registry.values():
+    for model_quirk_list in manufacturer.values():
+        for quirk in model_quirk_list:
+            if quirk in ALL_QUIRK_CLASSES:
+                continue
+            ALL_QUIRK_CLASSES.append(quirk)
 
 
 @pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -121,8 +121,8 @@ def raw_device():
 @pytest.mark.parametrize(
     "ep_id, cluster, message",
     (
-        (0, 0, b"\x18\x00\n\x05\x00B\x11lumi.sensor_smoke\x01\x00 \x01"),
-        (0, 1, b"\x18\x00\n\x05\x00B\x11lumi.sensor_smoke\x01\x00 \x01"),
+        (0, 0, b"\x18\x00\n\x05\x00B\x11lumi.sensor_sm0ke\x01\x00 \x01"),
+        (0, 1, b"\x18\x00\n\x05\x00B\x11lumi.sensor_sm0ke\x01\x00 \x01"),
     ),
 )
 def test_xiaomi_quick_init_wrong_ep(raw_device, ep_id, cluster, message):
@@ -143,21 +143,21 @@ def test_xiaomi_quick_init_wrong_ep(raw_device, ep_id, cluster, message):
     (
         (
             0,
-            b"\x19\x00\n\x05\x00B\x11lumi.sensor_smoke\x01\x00 \x01",
+            b"\x19\x00\n\x05\x00B\x11lumi.sensor_sm0ke\x01\x00 \x01",
         ),  # cluster command
-        (1, b"\x18\x00\n\x05\x00B\x11lumi.sensor_smoke\x01\x00 \x01"),  # wrong cluster
+        (1, b"\x18\x00\n\x05\x00B\x11lumi.sensor_sm0ke\x01\x00 \x01"),  # wrong cluster
         (
             0,
-            b"\x18\x00\x01\x05\x00B\x11lumi.sensor_smoke\x01\x00 \x01",
+            b"\x18\x00\x01\x05\x00B\x11lumi.sensor_sm0ke\x01\x00 \x01",
         ),  # wrong command
         (
             0,
-            b"\x18\x00\xFF\x05\x00B\x11lumi.sensor_smoke\x01\x00 \x01",
+            b"\x18\x00\xFF\x05\x00B\x11lumi.sensor_sm0ke\x01\x00 \x01",
         ),  # unknown command
-        (0, b"\x18\x00\n\x04\x00B\x11lumi.sensor_smoke\x01\x00 \x01"),  # wrong attr id
-        (0, b"\x18\x00\n\x05\x00B\x11lumi.sensor_smoke\x01\x00 "),  # data under run
+        (0, b"\x18\x00\n\x04\x00B\x11lumi.sensor_sm0ke\x01\x00 \x01"),  # wrong attr id
+        (0, b"\x18\x00\n\x05\x00B\x11lumi.sensor_sm0ke\x01\x00 "),  # data under run
         (0, b"\x18\x00\n\x05\x00B\x00\x01\x00 \x01"),  # no model
-        (0, b"\x18\x00\n\x05\x00B\x11lumi.sensor_smoke\x01\x00 \x01"),  # no quirk
+        (0, b"\x18\x00\n\x05\x00B\x11lumi.sensor_sm0ke\x01\x00 \x01"),  # no quirk
     ),
 )
 def test_xiaomi_quick_init_wrong_cluster_or_message(raw_device, cluster, message):
@@ -197,7 +197,7 @@ def test_xiaomi_quick_init_wrong_signature(raw_device):
 
     class WrongSignature(XiaomiQuickInitDevice):
         signature = {
-            MODEL: "lumi.sensor_smoke",
+            MODEL: "lumi.sensor_sm0ke",
         }
 
     assert (
@@ -207,7 +207,7 @@ def test_xiaomi_quick_init_wrong_signature(raw_device):
             0,
             1,
             1,
-            b"\x18\x00\n\x05\x00B\x11lumi.sensor_smoke\x01\x00 \x01",
+            b"\x18\x00\n\x05\x00B\x11lumi.sensor_sm0ke\x01\x00 \x01",
         )
         is None
     )
@@ -230,7 +230,7 @@ def test_xiaomi_quick_init(raw_device):
                 }
             },
             MANUFACTURER: LUMI,
-            MODEL: "lumi.sensor_smoke",
+            MODEL: "lumi.sensor_sm0ke",
         }
 
     assert (
@@ -240,7 +240,7 @@ def test_xiaomi_quick_init(raw_device):
             0,
             1,
             1,
-            b"\x18\x00\n\x05\x00B\x11lumi.sensor_smoke\x01\x00 \x01",
+            b"\x18\x00\n\x05\x00B\x11lumi.sensor_sm0ke\x01\x00 \x01",
         )
         is True
     )

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -315,7 +315,7 @@ class OccupancyWithReset(_Occupancy):
 class QuickInitDevice(CustomDevice):
     """Devices with quick initialization from quirk signature."""
 
-    signature: Optional[Dict[str, Any]] = {}
+    signature: Optional[Dict[str, Any]] = None
 
     @classmethod
     def from_signature(

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -3,8 +3,11 @@ import asyncio
 import importlib
 import logging
 import pkgutil
+from typing import Any, Dict, Optional
 
-from zigpy.quirks import CustomCluster
+import zigpy.device
+import zigpy.endpoint
+from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy.util import ListenableMixin
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import PowerConfiguration
@@ -17,9 +20,17 @@ from .const import (
     ATTRIBUTE_NAME,
     CLUSTER_COMMAND,
     COMMAND_ATTRIBUTE_UPDATED,
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MANUFACTURER,
+    MODEL,
+    MODELS_INFO,
     MOTION_EVENT,
     OFF,
     ON,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
     UNKNOWN,
     VALUE,
     ZHA_SEND_EVENT,
@@ -299,6 +310,50 @@ class OccupancyWithReset(_Occupancy):
                 self._timer_handle.cancel()
             self.endpoint.device.motion_bus.listener_event(MOTION_EVENT)
             self._timer_handle = self._loop.call_later(self.reset_s, self._turn_off)
+
+
+class QuickInitDevice(CustomDevice):
+    """Devices with quick initialization from quirk signature."""
+
+    signature: Optional[Dict[str, Any]] = {}
+
+    @classmethod
+    def from_signature(
+        cls, device: zigpy.device.Device, model: Optional[str] = None
+    ) -> zigpy.device.Device:
+        """Update device accordingly to quirk signature."""
+
+        assert isinstance(cls.signature, dict)
+        if model is None:
+            model = cls.signature[MODEL]
+        manufacturer = cls.signature.get(MANUFACTURER)
+        if manufacturer is None:
+            manufacturer = cls.signature[MODELS_INFO][0][0]
+
+        endpoints = cls.signature[ENDPOINTS]
+        for ep_id, ep_data in endpoints.items():
+            endpoint = device.add_endpoint(ep_id)
+            endpoint.profile_id = ep_data[PROFILE_ID]
+            endpoint.device_type = ep_data[DEVICE_TYPE]
+            for cluster_id in ep_data[INPUT_CLUSTERS]:
+                cluster = endpoint.add_input_cluster(cluster_id)
+                if cluster.ep_attribute == "basic":
+                    manuf_attr_id = cluster.attridx[MANUFACTURER]
+                    cluster._update_attribute(  # pylint: disable=W0212
+                        manuf_attr_id, manufacturer
+                    )
+                    cluster._update_attribute(  # pylint: disable=W0212
+                        cluster.attridx[MODEL], model
+                    )
+            for cluster_id in ep_data[OUTPUT_CLUSTERS]:
+                endpoint.add_output_cluster(cluster_id)
+            endpoint.status = zigpy.endpoint.Status.ZDO_INIT
+
+        device.status = zigpy.device.Status.ENDPOINTS_INIT
+        device.manufacturer = manufacturer
+        device.model = model
+
+        return device
 
 
 NAME = __name__

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -27,6 +27,7 @@ from .const import (
     MODEL,
     MODELS_INFO,
     MOTION_EVENT,
+    NODE_DESCRIPTOR,
     OFF,
     ON,
     OUTPUT_CLUSTERS,
@@ -329,6 +330,8 @@ class QuickInitDevice(CustomDevice):
         manufacturer = cls.signature.get(MANUFACTURER)
         if manufacturer is None:
             manufacturer = cls.signature[MODELS_INFO][0][0]
+
+        device.node_desc = cls.signature[NODE_DESCRIPTOR]
 
         endpoints = cls.signature[ENDPOINTS]
         for ep_id, ep_data in endpoints.items():

--- a/zhaquirks/const.py
+++ b/zhaquirks/const.py
@@ -1,4 +1,17 @@
 """Common constants for zhaquirks."""
+from zigpy.quirks import (
+    SIG_ENDPOINTS,
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    SIG_MANUFACTURER,
+    SIG_MODEL,
+    SIG_MODELS_INFO,
+    SIG_NODE_DESC,
+    SIG_SKIP_CONFIG,
+)
+
 ARGS = "args"
 ATTR_ID = "attr_id"
 ATTRIBUTE_ID = "attribute_id"
@@ -44,28 +57,30 @@ COMMAND_TILT = "Tilt"
 COMMAND_TOGGLE = "toggle"
 COMMAND_TRIPLE = "triple"
 DESCRIPTION = "description"
-DEVICE_TYPE = "device_type"
+DEVICE_TYPE = SIG_EP_TYPE
 DIM_DOWN = "dim_down"
 DIM_UP = "dim_up"
 DOUBLE_PRESS = "remote_button_double_press"
 ALT_DOUBLE_PRESS = "remote_button_alt_double_press"
 ENDPOINT_ID = "endpoint_id"
-ENDPOINTS = "endpoints"
-INPUT_CLUSTERS = "input_clusters"
+ENDPOINTS = SIG_ENDPOINTS
+INPUT_CLUSTERS = SIG_EP_INPUT
 LEFT = "left"
 LONG_PRESS = "remote_button_long_press"
 LONG_RELEASE = "remote_button_long_release"
 ALT_LONG_PRESS = "remote_button_alt_long_press"
 ALT_LONG_RELEASE = "remote_button_alt_long_release"
-MODELS_INFO = "models_info"
+MANUFACTURER = SIG_MANUFACTURER
+MODEL = SIG_MODEL
+MODELS_INFO = SIG_MODELS_INFO
 MOTION_EVENT = "motion_event"
-NODE_DESCRIPTOR = "node_desc"
+NODE_DESCRIPTOR = SIG_NODE_DESC
 OFF = 0
 ON = 1
 OPEN = "open"
-OUTPUT_CLUSTERS = "output_clusters"
+OUTPUT_CLUSTERS = SIG_EP_OUTPUT
 PRESS_TYPE = "press_type"
-PROFILE_ID = "profile_id"
+PROFILE_ID = SIG_EP_PROFILE
 QUADRUPLE_PRESS = "remote_button_quadruple_press"
 QUINTUPLE_PRESS = "remote_button_quintuple_press"
 RELATIVE_DEGREES = "relative_degrees"
@@ -73,7 +88,7 @@ RIGHT = "right"
 SHAKEN = "device_shaken"
 SHORT_PRESS = "remote_button_short_press"
 ALT_SHORT_PRESS = "remote_button_alt_short_press"
-SKIP_CONFIGURATION = "skip_configuration"
+SKIP_CONFIGURATION = SIG_SKIP_CONFIG
 SHORT_RELEASE = "remote_button_short_release"
 TRIPLE_PRESS = "remote_button_triple_press"
 TURN_OFF = "turn_off"

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -535,7 +535,7 @@ def handle_quick_init(
     if not model:
         return
 
-    for quirk in zigpy.quirks.get_model_quirks(model):
+    for quirk in zigpy.quirks.get_model_quirks(model) or []:
         if issubclass(quirk, XiaomiQuickInitDevice):
             break
     else:

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -504,7 +504,7 @@ def handle_quick_init(
 
     hdr, data = foundation.ZCLHeader.deserialize(message)
     sender.debug(
-        """Received ZCL message while uninitialized on %s endpoint, cluster 0x%04x """
+        """Received ZCL while uninitialized on endpoint id %s, cluster 0x%04x """
         """id, hdr: %s, payload: %s""",
         src_ep,
         cluster,

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -535,17 +535,18 @@ def handle_quick_init(
     if not model:
         return
 
-    for quirk in zigpy.quirks.get_model_quirks(model) or []:
+    for quirk in zigpy.quirks.get_model_quirks(model):
         if issubclass(quirk, XiaomiQuickInitDevice):
+            sender.debug("Found '%s' quirk for '%s' model", quirk.__name__, model)
+            try:
+                sender = quirk.from_signature(sender, model)
+            except (AssertionError, KeyError) as ex:
+                _LOGGER.debug(
+                    "Found quirk for quick init, but failed to init: %s", str(ex)
+                )
+                continue
             break
     else:
-        return
-
-    sender.debug("Found '%s' quirk for '%s' model", quirk.__name__, model)
-    try:
-        sender = quirk.from_signature(sender, model)
-    except (AssertionError, KeyError) as ex:
-        _LOGGER.debug("Found quirk for quick init, but failed to init: %s", str(ex))
         return
 
     sender.cancel_initialization()

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -5,6 +5,7 @@ import math
 from typing import Optional, Union
 
 from zigpy import types as t
+import zigpy.device
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy.zcl.clusters.general import AnalogInput, Basic, OnOff, PowerConfiguration
@@ -16,8 +17,10 @@ from zigpy.zcl.clusters.measurement import (
     TemperatureMeasurement,
 )
 import zigpy.zcl.foundation as foundation
+import zigpy.zdo
+from zigpy.zdo.types import NodeDescriptor
 
-from .. import Bus, LocalDataCluster, MotionOnEvent, OccupancyWithReset
+from .. import Bus, LocalDataCluster, MotionOnEvent, OccupancyWithReset, QuickInitDevice
 from ..const import (
     ATTRIBUTE_ID,
     ATTRIBUTE_NAME,
@@ -60,7 +63,19 @@ XIAOMI_ATTR_4 = "X-attrib-4"
 XIAOMI_ATTR_5 = "X-attrib-5"
 XIAOMI_ATTR_6 = "X-attrib-6"
 XIAOMI_MIJA_ATTRIBUTE = 0xFF02
+XIAOMI_NODE_DESC = NodeDescriptor(
+    byte1=2,
+    byte2=64,
+    mac_capability_flags=128,
+    manufacturer_code=4151,
+    maximum_buffer_size=127,
+    maximum_incoming_transfer_size=100,
+    server_mask=0,
+    maximum_outgoing_transfer_size=100,
+    descriptor_capability_field=0,
+)
 ZONE_TYPE = 0x0001
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,6 +89,10 @@ class XiaomiCustomDevice(CustomDevice):
         if not hasattr(self, BATTERY_SIZE):
             self.battery_size = 10
         super().__init__(*args, **kwargs)
+
+
+class XiaomiQuickInitDevice(XiaomiCustomDevice, QuickInitDevice):
+    """Xiaomi devices eligible for QuickInit."""
 
 
 class BasicCluster(CustomCluster, Basic):
@@ -469,3 +488,72 @@ class OnOffCluster(OnOff, CustomCluster):
             bytes([src_ep, tsn, command_id]),
             expect_reply=expect_reply,
         )
+
+
+def handle_quick_init(
+    sender: zigpy.device.Device,
+    profile: int,
+    cluster: int,
+    src_ep: int,
+    dst_ep: int,
+    message: bytes,
+) -> Optional[bool]:
+    """Handle message from an uninitialized device which could be a xiaomi."""
+    if src_ep == 0:
+        return
+
+    hdr, data = foundation.ZCLHeader.deserialize(message)
+    sender.debug(
+        """Received ZCL message while uninitialized on %s endpoint, cluster 0x%04x """
+        """id, hdr: %s, payload: %s""",
+        src_ep,
+        cluster,
+        hdr,
+        data,
+    )
+    if hdr.frame_control.is_cluster:
+        return
+
+    try:
+        schema = foundation.COMMANDS[hdr.command_id][0]
+        args, data = t.deserialize(data, schema)
+    except (KeyError, ValueError):
+        sender.debug("Failed to deserialize ZCL global command")
+        return
+
+    sender.debug("Uninitialized device command '%s' args: %s", hdr.command_id, args)
+    if hdr.command_id != foundation.Command.Report_Attributes or cluster != 0:
+        return
+
+    for attr_rec in args[0]:
+        if attr_rec.attrid == 5:
+            break
+    else:
+        return
+
+    model = attr_rec.value.value
+    if not model:
+        return
+
+    for quirk in zigpy.quirks.get_model_quirks(model):
+        if issubclass(quirk, XiaomiQuickInitDevice):
+            break
+    else:
+        return
+
+    sender.debug("Found '%s' quirk for '%s' model", quirk.__name__, model)
+    try:
+        sender = quirk.from_signature(sender, model)
+    except (AssertionError, KeyError) as ex:
+        _LOGGER.debug("Found quirk for quick init, but failed to init: %s", str(ex))
+        return
+
+    sender.cancel_initialization()
+    sender.application.device_initialized(sender)
+    sender.info(
+        "Was quickly initialized from '%s.%s' quirk", quirk.__module__, quirk.__name__
+    )
+    return True
+
+
+zigpy.quirks.register_uninitialized_device_message_handler(handle_quick_init)

--- a/zhaquirks/xiaomi/aqara/cube.py
+++ b/zhaquirks/xiaomi/aqara/cube.py
@@ -11,7 +11,13 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import LUMI, BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    PowerConfigurationCluster,
+    XiaomiQuickInitDevice,
+)
 from ... import CustomCluster
 from ...const import (
     ARGS,
@@ -20,6 +26,7 @@ from ...const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SHAKEN,
@@ -146,7 +153,7 @@ def extend_dict(dictionary, value, ranges):
 extend_dict(MOVEMENT_TYPE, FLIP, range(FLIP_BEGIN, FLIP_END))
 
 
-class Cube(XiaomiCustomDevice):
+class Cube(XiaomiQuickInitDevice):
     """Aqara magic cube device."""
 
     def __init__(self, *args, **kwargs):
@@ -275,6 +282,7 @@ class Cube(XiaomiCustomDevice):
 
     replacement = {
         SKIP_CONFIGURATION: True,
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,

--- a/zhaquirks/xiaomi/aqara/cube.py
+++ b/zhaquirks/xiaomi/aqara/cube.py
@@ -228,6 +228,7 @@ class Cube(XiaomiQuickInitDevice):
         #  input_clusters=[0, 3, 25, 18]
         #  output_clusters=[0, 4, 3, 5, 25, 18]>
         MODELS_INFO: [(LUMI, "lumi.sensor_cube")],
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -282,7 +283,6 @@ class Cube(XiaomiQuickInitDevice):
 
     replacement = {
         SKIP_CONFIGURATION: True,
-        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,

--- a/zhaquirks/xiaomi/aqara/magnet_aq2.py
+++ b/zhaquirks/xiaomi/aqara/magnet_aq2.py
@@ -4,12 +4,19 @@ import logging
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Groups, Identify, OnOff
 
-from .. import LUMI, BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    PowerConfigurationCluster,
+    XiaomiQuickInitDevice,
+)
 from ...const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
@@ -21,7 +28,7 @@ XIAOMI_CLUSTER_ID = 0xFFFF
 _LOGGER = logging.getLogger(__name__)
 
 
-class MagnetAQ2(XiaomiCustomDevice):
+class MagnetAQ2(XiaomiQuickInitDevice):
     """Xiaomi contact sensor device."""
 
     def __init__(self, *args, **kwargs):
@@ -55,6 +62,7 @@ class MagnetAQ2(XiaomiCustomDevice):
     }
     replacement = {
         SKIP_CONFIGURATION: True,
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 INPUT_CLUSTERS: [

--- a/zhaquirks/xiaomi/aqara/magnet_aq2.py
+++ b/zhaquirks/xiaomi/aqara/magnet_aq2.py
@@ -42,6 +42,7 @@ class MagnetAQ2(XiaomiQuickInitDevice):
         #  input_clusters=[0, 3, 65535, 6]
         #  output_clusters=[0, 4, 65535]>
         MODELS_INFO: [(LUMI, "lumi.sensor_magnet.aq2")],
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -62,7 +63,6 @@ class MagnetAQ2(XiaomiQuickInitDevice):
     }
     replacement = {
         SKIP_CONFIGURATION: True,
-        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 INPUT_CLUSTERS: [

--- a/zhaquirks/xiaomi/aqara/motion_aq2.py
+++ b/zhaquirks/xiaomi/aqara/motion_aq2.py
@@ -7,12 +7,13 @@ from zigpy.zcl.clusters.security import IasZone
 
 from .. import (
     LUMI,
+    XIAOMI_NODE_DESC,
     BasicCluster,
     IlluminanceMeasurementCluster,
     MotionCluster,
     OccupancyCluster,
     PowerConfigurationCluster,
-    XiaomiCustomDevice,
+    XiaomiQuickInitDevice,
 )
 from ... import Bus
 from ...const import (
@@ -20,6 +21,7 @@ from ...const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
@@ -28,7 +30,7 @@ from ...const import (
 XIAOMI_CLUSTER_ID = 0xFFFF
 
 
-class MotionAQ2(XiaomiCustomDevice):
+class MotionAQ2(XiaomiQuickInitDevice):
     """Custom device representing aqara body sensors."""
 
     def __init__(self, *args, **kwargs):
@@ -64,6 +66,7 @@ class MotionAQ2(XiaomiCustomDevice):
 
     replacement = {
         SKIP_CONFIGURATION: True,
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 INPUT_CLUSTERS: [

--- a/zhaquirks/xiaomi/aqara/motion_aq2.py
+++ b/zhaquirks/xiaomi/aqara/motion_aq2.py
@@ -46,6 +46,7 @@ class MotionAQ2(XiaomiQuickInitDevice):
         #  input_clusters=[0, 65535, 1030, 1024, 1280, 1, 3]
         #  output_clusters=[0, 25]>
         MODELS_INFO: [(LUMI, "lumi.sensor_motion.aq2")],
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -66,7 +67,6 @@ class MotionAQ2(XiaomiQuickInitDevice):
 
     replacement = {
         SKIP_CONFIGURATION: True,
-        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 INPUT_CLUSTERS: [

--- a/zhaquirks/xiaomi/aqara/remote_b186acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b186acn01.py
@@ -13,7 +13,13 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import LUMI, BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    PowerConfigurationCluster,
+    XiaomiQuickInitDevice,
+)
 from ... import CustomCluster
 from ...const import (
     ATTR_ID,
@@ -24,6 +30,7 @@ from ...const import (
     INPUT_CLUSTERS,
     LONG_PRESS,
     MODELS_INFO,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PRESS_TYPE,
     PROFILE_ID,
@@ -46,7 +53,7 @@ XIAOMI_DEVICE_TYPE3 = 0x5F03
 _LOGGER = logging.getLogger(__name__)
 
 
-class RemoteB186ACN01(XiaomiCustomDevice):
+class RemoteB186ACN01(XiaomiQuickInitDevice):
     """Aqara single key switch device."""
 
     class MultistateInputCluster(CustomCluster, MultistateInput):
@@ -141,6 +148,7 @@ class RemoteB186ACN01(XiaomiCustomDevice):
 
     replacement = {
         SKIP_CONFIGURATION: True,
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,

--- a/zhaquirks/xiaomi/aqara/remote_b186acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b186acn01.py
@@ -89,6 +89,7 @@ class RemoteB186ACN01(XiaomiQuickInitDevice):
             (LUMI, "lumi.remote.b186acn02"),
             (LUMI, "lumi.sensor_86sw1"),
         ],
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -148,7 +149,6 @@ class RemoteB186ACN01(XiaomiQuickInitDevice):
 
     replacement = {
         SKIP_CONFIGURATION: True,
-        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -16,7 +16,13 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.security import IasZone
 
-from .. import LUMI, BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    PowerConfigurationCluster,
+    XiaomiQuickInitDevice,
+)
 from ... import Bus, LocalDataCluster
 from ...const import (
     CLUSTER_COMMAND,
@@ -29,6 +35,7 @@ from ...const import (
     INPUT_CLUSTERS,
     MODELS_INFO,
     MOTION_EVENT,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
@@ -58,7 +65,7 @@ MEASUREMENT_TYPE = {
 _LOGGER = logging.getLogger(__name__)
 
 
-class VibrationAQ1(XiaomiCustomDevice):
+class VibrationAQ1(XiaomiQuickInitDevice):
     """Xiaomi aqara smart motion sensor device."""
 
     manufacturer_id_override = 0x115F
@@ -188,6 +195,7 @@ class VibrationAQ1(XiaomiCustomDevice):
 
     replacement = {
         SKIP_CONFIGURATION: True,
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 DEVICE_TYPE: zha.DeviceType.DOOR_LOCK,

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -160,6 +160,7 @@ class VibrationAQ1(XiaomiQuickInitDevice):
 
     signature = {
         MODELS_INFO: [(LUMI, "lumi.vibration.aq1")],
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -195,7 +196,6 @@ class VibrationAQ1(XiaomiQuickInitDevice):
 
     replacement = {
         SKIP_CONFIGURATION: True,
-        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 DEVICE_TYPE: zha.DeviceType.DOOR_LOCK,

--- a/zhaquirks/xiaomi/aqara/weather.py
+++ b/zhaquirks/xiaomi/aqara/weather.py
@@ -7,12 +7,13 @@ from zigpy.zcl.clusters.measurement import PressureMeasurement
 
 from .. import (
     LUMI,
+    XIAOMI_NODE_DESC,
     BasicCluster,
     PowerConfigurationCluster,
     PressureMeasurementCluster,
     RelativeHumidityCluster,
     TemperatureMeasurementCluster,
-    XiaomiCustomDevice,
+    XiaomiQuickInitDevice,
 )
 from ... import Bus
 from ...const import (
@@ -20,6 +21,7 @@ from ...const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
@@ -31,7 +33,7 @@ XIAOMI_CLUSTER_ID = 0xFFFF
 _LOGGER = logging.getLogger(__name__)
 
 
-class Weather(XiaomiCustomDevice):
+class Weather(XiaomiQuickInitDevice):
     """Xiaomi weather sensor device."""
 
     def __init__(self, *args, **kwargs):
@@ -70,6 +72,7 @@ class Weather(XiaomiCustomDevice):
 
     replacement = {
         SKIP_CONFIGURATION: True,
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 INPUT_CLUSTERS: [

--- a/zhaquirks/xiaomi/aqara/weather.py
+++ b/zhaquirks/xiaomi/aqara/weather.py
@@ -49,6 +49,7 @@ class Weather(XiaomiQuickInitDevice):
         #  input_clusters=[0, 3, 65535, 1026, 1027, 1029]
         #  output_clusters=[0, 4, 65535]>
         MODELS_INFO: [(LUMI, "lumi.weather")],
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -72,7 +73,6 @@ class Weather(XiaomiQuickInitDevice):
 
     replacement = {
         SKIP_CONFIGURATION: True,
-        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 INPUT_CLUSTERS: [
@@ -103,6 +103,7 @@ class Weather2(Weather):
         #  input_clusters=[0, 3, 65535, 1026, 1027, 1029]
         #  output_clusters=[0, 4, 65535]>
         MODELS_INFO: [(LUMI, "lumi.weather")],
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/xiaomi/aqara/wleak_aq1.py
+++ b/zhaquirks/xiaomi/aqara/wleak_aq1.py
@@ -45,6 +45,7 @@ class LeakAQ1(XiaomiQuickInitDevice):
         #  input_clusters=[0, 3, 1]
         #  output_clusters=[25]>
         MODELS_INFO: [(LUMI, "lumi.sensor_wleak.aq1")],
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -60,7 +61,6 @@ class LeakAQ1(XiaomiQuickInitDevice):
     }
     replacement = {
         SKIP_CONFIGURATION: True,
-        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 INPUT_CLUSTERS: [

--- a/zhaquirks/xiaomi/aqara/wleak_aq1.py
+++ b/zhaquirks/xiaomi/aqara/wleak_aq1.py
@@ -4,12 +4,19 @@ from zigpy.quirks import CustomCluster
 from zigpy.zcl.clusters.general import Identify, Ota
 from zigpy.zcl.clusters.security import IasZone
 
-from .. import LUMI, BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    PowerConfigurationCluster,
+    XiaomiQuickInitDevice,
+)
 from ...const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
@@ -29,7 +36,7 @@ class CustomIasZone(CustomCluster, IasZone):
             super()._update_attribute(attrid, value)
 
 
-class LeakAQ1(XiaomiCustomDevice):
+class LeakAQ1(XiaomiQuickInitDevice):
     """Xiaomi aqara leak sensor device."""
 
     signature = {
@@ -53,6 +60,7 @@ class LeakAQ1(XiaomiCustomDevice):
     }
     replacement = {
         SKIP_CONFIGURATION: True,
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 INPUT_CLUSTERS: [

--- a/zhaquirks/xiaomi/mija/motion.py
+++ b/zhaquirks/xiaomi/mija/motion.py
@@ -14,11 +14,12 @@ from zigpy.zcl.clusters.general import (
 
 from .. import (
     LUMI,
+    XIAOMI_NODE_DESC,
     BasicCluster,
     MotionCluster,
     OccupancyCluster,
     PowerConfigurationCluster,
-    XiaomiCustomDevice,
+    XiaomiQuickInitDevice,
 )
 from ... import Bus
 from ...const import (
@@ -26,6 +27,7 @@ from ...const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
@@ -35,7 +37,7 @@ XIAOMI_CLUSTER_ID = 0xFFFF
 _LOGGER = logging.getLogger(__name__)
 
 
-class Motion(XiaomiCustomDevice):
+class Motion(XiaomiQuickInitDevice):
     """Custom device representing mija body sensors."""
 
     def __init__(self, *args, **kwargs):
@@ -50,6 +52,7 @@ class Motion(XiaomiCustomDevice):
         #  input_clusters=[0, 65535, 3, 25]
         #  output_clusters=[0, 3, 4, 5, 6, 8, 25]>
         MODELS_INFO: [(LUMI, "lumi.sensor_motion")],
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/xiaomi/mija/sensor_magnet.py
+++ b/zhaquirks/xiaomi/mija/sensor_magnet.py
@@ -11,12 +11,19 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import LUMI, BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    PowerConfigurationCluster,
+    XiaomiQuickInitDevice,
+)
 from ...const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
@@ -28,7 +35,7 @@ XIAOMI_CLUSTER_ID = 0xFFFF
 _LOGGER = logging.getLogger(__name__)
 
 
-class Magnet(XiaomiCustomDevice):
+class Magnet(XiaomiQuickInitDevice):
     """Xiaomi mija contact sensor device."""
 
     def __init__(self, *args, **kwargs):
@@ -42,6 +49,7 @@ class Magnet(XiaomiCustomDevice):
         #  input_clusters=[0, 3, 65535, 25]
         #  output_clusters=[0, 4, 3, 6, 8, 5, 25]>
         MODELS_INFO: [(LUMI, "lumi.sensor_magnet")],
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/xiaomi/mija/smoke.py
+++ b/zhaquirks/xiaomi/mija/smoke.py
@@ -25,12 +25,20 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.security import IasZone
 
-from .. import BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    PowerConfigurationCluster,
+    XiaomiQuickInitDevice,
+)
 from ... import CustomCluster
 from ...const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
+    MODELS_INFO,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
@@ -50,7 +58,7 @@ class XiaomiSmokeIASCluster(CustomCluster, IasZone):
     }
 
 
-class MijiaHoneywellSmokeDetectorSensor(XiaomiCustomDevice):
+class MijiaHoneywellSmokeDetectorSensor(XiaomiQuickInitDevice):
     """MijiaHoneywellSmokeDetectorSensor custom device."""
 
     def __init__(self, *args, **kwargs):
@@ -63,6 +71,8 @@ class MijiaHoneywellSmokeDetectorSensor(XiaomiCustomDevice):
         #  device_version=
         #  input_clusters=[0, 1, 3, 12, 18, 1280]
         #  output_clusters=[25]>
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
+        MODELS_INFO: ((LUMI, "lumi.sensor_smoke"),),
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -77,7 +87,7 @@ class MijiaHoneywellSmokeDetectorSensor(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             }
-        }
+        },
     }
 
     replacement = {


### PR DESCRIPTION
Based on original idea of https://github.com/zigpy/zha-device-handlers/pull/550 and https://github.com/zigpy/zigpy/pull/531 add direct initialization of some xiaomi devices and keeps xiaomi specific initialization in `zha-device-handlers`

To add any other xiaomi device, the signature must contain:
- `models_info` or `manufacturer`
- `node_desc`
- each endpoint signature must contain
  - `profile_id`
  - `device_type`
  - `input_clusters`
  - `output_clusters` 

It was tested with the all devices that were updated in this PR
