### PR TITLE
Add Aqara lumi.sensor_switch.aq2 to quick initialize device list

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -250,7 +250,9 @@ def test_dev_from_signature(raw_device, quirk_signature):
         ]
 
 
-@pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)
+@pytest.mark.parametrize(
+    "quirk", (q for q in ALL_QUIRK_CLASSES if issubclass(q, zhaquirks.QuickInitDevice))
+)
 def test_quirk_quickinit(quirk):
     """Make sure signature in QuickInit Devices have all required attributes."""
 

--- a/zhaquirks/xiaomi/aqara/switch_aq2.py
+++ b/zhaquirks/xiaomi/aqara/switch_aq2.py
@@ -4,7 +4,13 @@ import logging
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Groups, OnOff
 
-from .. import LUMI, BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    PowerConfigurationCluster,
+    XiaomiQuickInitDevice,
+)
 from ...const import (
     ARGS,
     ATTRIBUTE_ID,
@@ -19,6 +25,7 @@ from ...const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     QUADRUPLE_PRESS,
@@ -36,7 +43,7 @@ XIAOMI_CLUSTER_ID = 0xFFFF
 _LOGGER = logging.getLogger(__name__)
 
 
-class SwitchAQ2(XiaomiCustomDevice):
+class SwitchAQ2(XiaomiQuickInitDevice):
     """Aqara button device."""
 
     signature = {
@@ -45,6 +52,7 @@ class SwitchAQ2(XiaomiCustomDevice):
         # input_clusters=[0, 6, 65535]
         # output_clusters=[0, 4, 65535]>
         MODELS_INFO: [(LUMI, "lumi.sensor_switch.aq2")],
+        NODE_DESCRIPTOR: XIAOMI_NODE_DESC,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
Add Aqara WXKG11LM, reporting itself as a `lumi.sensor_switch.aq2` to "quickly initialized" devices .