### PR TITLE
Cleanup tests of pytest.mark.asyncio marks

### DIFF
--- a/tests/test_konke.py
+++ b/tests/test_konke.py
@@ -11,7 +11,6 @@ import zhaquirks.konke.motion
 from tests.common import ZCL_IAS_MOTION_COMMAND, ClusterListener
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "quirk", (zhaquirks.konke.motion.KonkeMotion, zhaquirks.konke.motion.KonkeMotionB)
 )

--- a/tests/test_orvibo.py
+++ b/tests/test_orvibo.py
@@ -11,7 +11,6 @@ import zhaquirks.orvibo.motion
 from tests.common import ZCL_IAS_MOTION_COMMAND, ClusterListener
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("quirk", (zhaquirks.orvibo.motion.SN10ZW,))
 async def test_konke_motion(zigpy_device_from_quirk, quirk):
     """Test Orvibo motion sensor."""

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -59,7 +59,6 @@ def test_basic_cluster_deserialize_wrong_len_2():
     assert deserialized[1]
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "quirk",
     (


### PR DESCRIPTION
Remove `pytest.mark.asyncio` test markings, since we do not longer depend on `pytest-asyncio`