### PR TITLE
Syncup with Zigpy regression fix in 0.28.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(
     keywords="zha quirks homeassistant hass",
     packages=find_packages(exclude=["tests"]),
     python_requires=">=3",
-    install_requires=["zigpy>=0.28.1"],
+    install_requires=["zigpy>=0.28.2"],
     tests_require=["pytest"],
 )

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -541,7 +541,7 @@ def handle_quick_init(
     if not model:
         return
 
-    for quirk in zigpy.quirks.get_model_quirks(model):
+    for quirk in zigpy.quirks.get_quirk_list(LUMI, model):
         if issubclass(quirk, XiaomiQuickInitDevice):
             sender.debug("Found '%s' quirk for '%s' model", quirk.__name__, model)
             try:


### PR DESCRIPTION
Update Xiaomi quick init devices with changes to `zigpy==0.28.2`.
Fixes issues described in https://github.com/zigpy/zha-device-handlers/pull/538#issuecomment-736793397 Related Zigpy PR https://github.com/zigpy/zigpy/pull/568