### PR TITLE
Add quirk for Tuya wireless switch by Zemismart

### DIFF
--- a/zhaquirks/tuya/ts0041_zemismart.py
+++ b/zhaquirks/tuya/ts0041_zemismart.py
@@ -1,0 +1,61 @@
+"""Tuya 1 Button Remote."""
+
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import Basic, OnOff, Ota, PowerConfiguration, Time
+
+from . import TuyaSmartRemote, TuyaSmartRemoteOnOffCluster
+from ..const import (
+    BUTTON_1,
+    COMMAND,
+    DEVICE_TYPE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    LONG_PRESS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+)
+
+
+class TuyaZemismartSmartRemote0041(TuyaSmartRemote):
+    """Tuya Zemismart 1-button remote device."""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0, device_version=1, input_clusters=[0, 1, 6], output_clusters=[25, 10])
+        MODELS_INFO: [("_TZ3000_tk3s5tyg", "TS0041")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
+    }


### PR DESCRIPTION
This is very similar to https://github.com/zigpy/zha-device-handlers/pull/611 but these switches have a slightly different signature.
Adding a separate quirk for them.

Tested that button presses generate correct zha events in Home Assistant on single, double and long press.