### PR TITLE
Add manufacturer specific "interlock" attribute for lumi.relay.c2acn01 device

### DIFF
--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -8,7 +8,13 @@ from zigpy import types as t
 import zigpy.device
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
-from zigpy.zcl.clusters.general import AnalogInput, Basic, OnOff, PowerConfiguration
+from zigpy.zcl.clusters.general import (
+    AnalogInput,
+    Basic,
+    BinaryOutput,
+    OnOff,
+    PowerConfiguration,
+)
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.measurement import (
     IlluminanceMeasurement,
@@ -292,6 +298,12 @@ class BasicCluster(CustomCluster, Basic):
         max_voltage = 3000
         percent = (voltage - min_voltage) / (max_voltage - min_voltage) * 200
         return min(200, percent)
+
+
+class BinaryOutputInterlock(CustomCluster, BinaryOutput):
+    """Xiaomi binaryoutput cluster with added interlock attribute."""
+
+    manufacturer_attributes = {0xFF06: ("interlock", t.Bool)}
 
 
 class PowerConfigurationCluster(LocalDataCluster, PowerConfiguration):

--- a/zhaquirks/xiaomi/aqara/relay_c2acn01.py
+++ b/zhaquirks/xiaomi/aqara/relay_c2acn01.py
@@ -21,6 +21,7 @@ from .. import (
     LUMI,
     AnalogInputCluster,
     BasicCluster,
+    BinaryOutputInterlock,
     ElectricalMeasurementCluster,
     XiaomiCustomDevice,
 )
@@ -104,7 +105,7 @@ class Relay(XiaomiCustomDevice):
                     Identify.cluster_id,
                     OnOff.cluster_id,
                     Scenes.cluster_id,
-                    BinaryOutput.cluster_id,
+                    BinaryOutputInterlock,
                     Time.cluster_id,
                     ElectricalMeasurementCluster,
                     AnalogInputCluster,
@@ -116,7 +117,7 @@ class Relay(XiaomiCustomDevice):
                 DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
                     OnOff.cluster_id,
-                    BinaryOutput.cluster_id,
+                    BinaryOutputInterlock,
                     Groups.cluster_id,
                     Scenes.cluster_id,
                 ],


### PR DESCRIPTION
Add manufacturer specific "interlock" attribute for lumi.relay.c2acn01 device.
Fixes #639 
