### PR TITLE
Update Tuya model info for Lonsonho 1 and 3 button switches

### DIFF
--- a/zhaquirks/tuya/ts0041.py
+++ b/zhaquirks/tuya/ts0041.py
@@ -25,7 +25,7 @@ class TuyaSmartRemote0041(TuyaSmartRemote):
 
     signature = {
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0, device_version=1, input_clusters=[0, 10, 1, 6], output_clusters=[25]))
-        MODELS_INFO: [("_TZ3000_xkwalgne", "TS0041")],
+        MODELS_INFO: [("_TZ3000_xkwalgne", "TS0041"), ("_TZ3000_peszejy7", "TS0041")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/tuya/ts0043.py
+++ b/zhaquirks/tuya/ts0043.py
@@ -29,7 +29,7 @@ class TuyaSmartRemote0043(TuyaSmartRemote):
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0, device_version=1, input_clusters=[0, 10, 1, 6], output_clusters=[25]))
         # SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
         # SizePrefixedSimpleDescriptor(endpoint=3, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
-        MODELS_INFO: [("_TZ3000_bi6lpsew", "TS0043")],
+        MODELS_INFO: [("_TZ3000_bi6lpsew", "TS0043"), ("_TZ3000_a7ouggvs", "TS0043")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
Bought the 1, 2 and 3 button switches from Lonsonho (Tuya). The 2 variant works fine, but my other switches got different signatures as provided in this PR. 

Switches are bought at Aliexpress (https://aliexpress.com/item/4001095272467.html)

---

**_TZ3000_peszejy7, TS0041**

<img width="582" alt="Screenshot 2020-12-16 at 19 07 23" src="https://user-images.githubusercontent.com/2136273/102388361-ef462b00-3fd1-11eb-8259-752ada507038.png">

**_TZ3000_a7ouggvs, TS0043**

<img width="587" alt="Screenshot 2020-12-16 at 19 06 36" src="https://user-images.githubusercontent.com/2136273/102388278-d3428980-3fd1-11eb-9dc6-2d217472e755.png">
