### PR TITLE
Use pre-commit as tox linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,53 @@ jobs:
           . venv/bin/activate
           pre-commit run --hook-stage manual isort --all-files --show-diff-on-failure
 
+  lint-codespell:
+    name: Check codespell
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        uses: actions/setup-python@v2.1.4
+        id: python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Restore base Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v2
+        with:
+          path: venv
+          key: >-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('setup.py') }}-${{
+            hashFiles('requirements_test_all.txt') }}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python virtual environment from cache"
+          exit 1
+      - name: Restore pre-commit environment from cache
+        id: cache-precommit
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.PRE_COMMIT_HOME }}
+          key: |
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Fail job if cache restore failed
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python virtual environment from cache"
+          exit 1
+      - name: Register codespell problem matcher
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/codespell.json"
+      - name: Run codespell
+        run: |
+          . venv/bin/activate
+          pre-commit run --hook-stage manual codespell --all-files --show-diff-on-failure
+
   pytest:
     runs-on: ubuntu-latest
     needs: prepare-base

--- a/.github/workflows/matchers/codespell.json
+++ b/.github/workflows/matchers/codespell.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "codespell",
+      "severity": "warning",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):\\s(.+)$",
+          "file": 1,
+          "line": 2,
+          "message": 3
+        }
+      ]
+    }
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,12 @@ repos:
     rev: 5.5.2
     hooks:
       - id: isort
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v1.17.1
+    hooks:
+      - id: codespell
+        args:
+          - --ignore-words-list=dout,hass
+          - --skip="./.*"
+          - --quiet-level=2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,15 @@ repos:
         args:
           - --safe
           - --quiet
+
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-docstrings==1.3.1
-          - pydocstyle==4.0.0
+          - flake8-docstrings==1.5.0
+          - pydocstyle==5.1.1
+
   - repo: https://github.com/PyCQA/isort
     rev: 5.5.2
     hooks:

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ class Plug(XiaomiCustomDevice):
 
 This quirk is for the US version of the Xiaomi plug. Xiaomi is notorious for not following the Zigbee specifications and most of their non Zigbee 3.0 devices need a quirk to function correctly. In this case we are correcting the `ElectricalMeasurement` cluster readings. Xiaomi decided to report the values for this cluster on the `AnalogInput` cluster instead. To fix this we will create a custom cluster to replace the `AnalogInput` and `ElectricalMeasurement` clusters. We will take the values that are reported on the `AnalogInput` cluster and publish them to the `ElectricalMeasurement` cluster. Doing this allows the device to work as if Xiaomi had implemented this in the first place. This is the act of translating that was mentioned in the Google Translate analogy above.
 
-First things first. All device definitions in quirks must extend `CustomDevice` or a derivative of it and all clusters that you define must extend `CustomCluster` or a derivative of it. If you want to send messages between `CustomCluster` definitions as we do here you need to create channels for the communication to flow through. We do this by adding instances of `Bus` on our `CustomDevice` implementation. `Bus` is a utility class used specifically for this purpose and adding it to the device implementation ensures that all clusters that you define will have access to the `Bus` so that they can communicate with eachother.
+First things first. All device definitions in quirks must extend `CustomDevice` or a derivative of it and all clusters that you define must extend `CustomCluster` or a derivative of it. If you want to send messages between `CustomCluster` definitions as we do here you need to create channels for the communication to flow through. We do this by adding instances of `Bus` on our `CustomDevice` implementation. `Bus` is a utility class used specifically for this purpose and adding it to the device implementation ensures that all clusters that you define will have access to the `Bus` so that they can communicate with each other.
 
 ```python
 class Plug(XiaomiCustomDevice):
@@ -271,7 +271,7 @@ Here are the custom cluster definitions:
 
 ```python
 class AnalogInputCluster(CustomCluster, AnalogInput):
-    """Analog input cluster, only used to relay power consumtion information to ElectricalMeasurementCluster."""
+    """Analog input cluster, only used to relay power consumption information to ElectricalMeasurementCluster."""
 
     cluster_id = AnalogInput.cluster_id
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -5,11 +5,9 @@
 asynctest==0.13.0
 codecov==2.1.10
 coveralls==2.2.0
-flake8-docstrings==1.5.0
 mock-open==1.4.0
 mypy==0.790
 pre-commit==2.8.2
-pydocstyle==5.1.1
 pylint==2.6.0
 pytest-aiohttp==0.3.0
 pytest-cov==2.10.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,46 +1,32 @@
 [tox]
-envlist = py37, py38, lint, pylint
+envlist = py37, py38, lint, black
 skip_missing_interpreters = True
 
 [testenv]
-basepython = {env:PYTHON3_PATH:python3}
-commands =
-     pytest --timeout=9 --durations=10 -qq -o console_output_style=count -p no:sugar {posargs}
-deps =
-     -r{toxinidir}/requirements_test_all.txt
-
-[testenv:cov]
-commands =
-     pytest --timeout=9 --durations=10 -qq -o console_output_style=count -p no:sugar --cov --cov-report= {posargs}
-     {toxinidir}/script/check_dirty
+setenv = PYTHONPATH = {toxinidir}
+install_command = pip install {opts} {packages}
+commands = py.test --cov --cov-report= --timeout=9 --durations=10 -qq -p no:sugar {posargs}
 deps =
      -r{toxinidir}/requirements_test_all.txt
 
 [testenv:pylint]
 ignore_errors = True
-deps =
+deps = 
      -r{toxinidir}/requirements_test_all.txt
 commands =
      pylint {posargs} zhaquirks
 
 [testenv:lint]
-deps =
-     -r{toxinidir}/requirements_test_all.txt
+deps = pre-commit
 commands =
-    flake8 {posargs}
-    pydocstyle {posargs:zhaquirks tests}
-    {toxinidir}/script/check_format
+    pre-commit run --hook-stage manual flake8 --all-files
+    pre-commit run --hook-stage manual isort --all-files --show-diff-on-failure
 
-[flake8]
-exclude = .git, __pycache__, old, build, dist, .tox
-# To work with Black
-max-line-length = 88
-# E501: line too long
-# W503: Line break occurred before a binary operator
-# E203: Whitespace before ':'
-# D202 No blank lines allowed after function docstring
-ignore =
-    E501,
-    W503,
-    E203,
-    D202
+[testenv:black]
+deps = pre-commit
+setenv =
+    LC_ALL=C.UTF-8
+    LANG=C.UTF-8
+commands =
+    pre-commit run --hook-stage manual black --all-files --show-diff-on-failure
+

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps = pre-commit
 commands =
     pre-commit run --hook-stage manual flake8 --all-files
     pre-commit run --hook-stage manual isort --all-files --show-diff-on-failure
+    pre-commit run --hook-stage manual codespell --all-files --show-diff-on-failure
 
 [testenv:black]
 deps = pre-commit

--- a/xbee.md
+++ b/xbee.md
@@ -3,7 +3,7 @@
 Digital input/output pins are exposed as switches.
 
 To use this functionality must configure the xbee to send samples to the coordinator, `DH` and `DL` to the coordiator's address (0).
-The swich state will change depending on the state.
+The switch state will change depending on the state.
 
 There are two options of reporting the pin state: periodic sampling (`IR`) and on state change (`IC`).
 To configure reporting on state change please set the appropriate bit mask on `IC`, and to send perodic reports every x milliseconds please set `IR` to a value greater than zero.

--- a/zhaquirks/kof/kof_mr101z.py
+++ b/zhaquirks/kof/kof_mr101z.py
@@ -22,7 +22,7 @@ from zigpy.zcl.clusters.hvac import Fan
 class NoReplyMixin:
     """A simple mixin.
 
-    Allows a cluster to have configureable list of command
+    Allows a cluster to have configurable list of command
     ids that do not generate an explicit reply.
     """
 

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -204,7 +204,7 @@ class BasicCluster(CustomCluster, Basic):
             )
 
     def _parse_aqara_attributes(self, value):
-        """Parse non standard atrributes."""
+        """Parse non standard attributes."""
         attributes = {}
         attribute_names = {
             1: BATTERY_VOLTAGE_MV,


### PR DESCRIPTION
Use pre-commit as tox linter to keep all linter dependencies in one place.
Add codespell checks
Fix some spelling errors