### PR TITLE
Small cleanups in several classes

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -62,7 +62,7 @@ async def test_motion(zigpy_device_from_quirk, quirk):
         tuya_cluster.handle_message(hdr, args)
 
     assert len(motion_listener.cluster_commands) == 1
-    assert len(motion_listener.attribute_updates) == 0
+    assert len(motion_listener.attribute_updates) == 1
     assert motion_listener.cluster_commands[0][1] == ZONE_STATE
     assert motion_listener.cluster_commands[0][2][0] == ON
 

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -86,7 +86,7 @@ async def test_konke_motion(zigpy_device_from_quirk, quirk):
         occupancy_cluster.handle_message(hdr, args)
 
     assert len(motion_listener.cluster_commands) == 1
-    assert len(motion_listener.attribute_updates) == 0
+    assert len(motion_listener.attribute_updates) == 1
     assert motion_listener.cluster_commands[0][1] == ZONE_STATE
     assert motion_listener.cluster_commands[0][2][0] == ON
 

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -260,6 +260,7 @@ class MotionOnEvent(_Motion):
     def motion_event(self):
         """Motion event."""
         super().listener_event(CLUSTER_COMMAND, 254, ZONE_STATE, [ON, 0, 0, 0])
+        self._update_attribute(ZONE_STATE, ON)
 
         _LOGGER.debug("%s - Received motion event message", self.endpoint.device.ieee)
 

--- a/zhaquirks/const.py
+++ b/zhaquirks/const.py
@@ -97,3 +97,4 @@ UNKNOWN = "Unknown"
 VALUE = "value"
 ZHA_SEND_EVENT = "zha_send_event"
 ZONE_STATE = 0
+ZONE_TYPE = 0x0001

--- a/zhaquirks/smartthings/moisturev4.py
+++ b/zhaquirks/smartthings/moisturev4.py
@@ -15,20 +15,14 @@ from ..const import (
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    ZONE_TYPE,
 )
 
 
 class CustomIasZone(CustomCluster, IasZone):
     """Custom IasZone cluster."""
 
-    MOISTURE_TYPE = 0x002A
-    ZONE_TYPE = 0x0001
-
-    def _update_attribute(self, attrid, value):
-        if attrid == self.ZONE_TYPE:
-            super()._update_attribute(attrid, self.MOISTURE_TYPE)
-        else:
-            super()._update_attribute(attrid, value)
+    _CONSTANT_ATTRIBUTES = {ZONE_TYPE: IasZone.ZoneType.Water_Sensor}
 
 
 class SmartThingsMoistureV4(CustomDevice):

--- a/zhaquirks/smartthings/pgc313.py
+++ b/zhaquirks/smartthings/pgc313.py
@@ -2,6 +2,7 @@
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Ota
+from zigpy.zcl.clusters.security import IasZone
 
 from . import SMART_THINGS, SmartThingsIasZone
 from ..const import (
@@ -11,6 +12,7 @@ from ..const import (
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    ZONE_TYPE,
 )
 
 SMARTSENSE_MULTI_DEVICE_TYPE = 0x0139  # decimal = 313
@@ -19,9 +21,7 @@ SMARTSENSE_MULTI_DEVICE_TYPE = 0x0139  # decimal = 313
 class IasZoneContactSwitchCluster(SmartThingsIasZone):
     """Custom IasZone cluster."""
 
-    ZONE_TYPE = 0x0001
-    CONTACT_SWITCH_TYPE = 0x0015
-    _CONSTANT_ATTRIBUTES = {ZONE_TYPE: CONTACT_SWITCH_TYPE}
+    _CONSTANT_ATTRIBUTES = {ZONE_TYPE: IasZone.ZoneType.Contact_Switch}
 
 
 class SmartthingsSmartSenseMultiSensor(CustomDevice):

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -340,7 +340,7 @@ class MotionCluster(LocalDataCluster, MotionOnEvent):
     """Motion cluster."""
 
     _CONSTANT_ATTRIBUTES = {ZONE_TYPE: MOTION_TYPE}
-    reset_s: int = 120
+    reset_s: int = 70
 
 
 class TemperatureMeasurementCluster(CustomCluster, TemperatureMeasurement):

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -84,7 +84,6 @@ class VibrationAQ1(XiaomiQuickInitDevice):
         """Multistate input cluster."""
 
         cluster_id = DoorLock.cluster_id
-        manufacturer_attributes = {0x0000: ("lock_state", types.uint8_t)}
 
         def __init__(self, *args, **kwargs):
             """Init."""
@@ -118,10 +117,6 @@ class VibrationAQ1(XiaomiQuickInitDevice):
                     "vibration_strength",
                     {"strength": strength},
                 )
-
-            # show something in the sensor in HA
-            if STATUS_TYPE_ATTR in self._current_state:
-                super()._update_attribute(0, self._current_state[STATUS_TYPE_ATTR])
 
     class MotionCluster(LocalDataCluster, MotionOnEvent):
         """Aqara Vibration Sensor."""

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -1,5 +1,4 @@
 """Xiaomi aqara smart motion sensor device."""
-import asyncio
 import logging
 
 from zigpy.profiles import zha
@@ -23,9 +22,8 @@ from .. import (
     PowerConfigurationCluster,
     XiaomiQuickInitDevice,
 )
-from ... import Bus, LocalDataCluster
+from ... import Bus, LocalDataCluster, MotionOnEvent
 from ...const import (
-    CLUSTER_COMMAND,
     CLUSTER_ID,
     COMMAND,
     COMMAND_TILT,
@@ -41,6 +39,7 @@ from ...const import (
     SKIP_CONFIGURATION,
     UNKNOWN,
     ZHA_SEND_EVENT,
+    ZONE_TYPE,
 )
 
 ACCELEROMETER_ATTR = 0x0508  # decimal = 1288
@@ -110,50 +109,29 @@ class VibrationAQ1(XiaomiQuickInitDevice):
                     self._current_state[STATUS_TYPE_ATTR],
                     {"degrees": value},
                 )
+            elif attrid == RECENT_ACTIVITY_LEVEL_ATTR:
+                # these seem to be sent every minute when vibration is active
+                strength = value >> 8
+                strength = ((strength & 0xFF) << 8) | ((strength >> 8) & 0xFF)
+                self.endpoint.device.motion_bus.listener_event(
+                    SEND_EVENT,
+                    "vibration_strength",
+                    {"strength": strength},
+                )
 
             # show something in the sensor in HA
             if STATUS_TYPE_ATTR in self._current_state:
                 super()._update_attribute(0, self._current_state[STATUS_TYPE_ATTR])
 
-    class MotionCluster(LocalDataCluster, IasZone):
-        """Motion cluster."""
+    class MotionCluster(LocalDataCluster, MotionOnEvent):
+        """Aqara Vibration Sensor."""
 
-        cluster_id = IasZone.cluster_id
-        OFF = 0
-        ON = 1
-        VIBRATION_TYPE = 0x002D
-        ZONE_STATE = 0x0000
-        ZONE_STATUS = 0x0002
-        ZONE_TYPE = 0x0001
-
-        def __init__(self, *args, **kwargs):
-            """Init."""
-            super().__init__(*args, **kwargs)
-            self._timer_handle = None
-            self.endpoint.device.motion_bus.add_listener(self)
-            self._update_attribute(self.ZONE_STATE, self.OFF)
-            self._update_attribute(self.ZONE_TYPE, self.VIBRATION_TYPE)
-            self._update_attribute(self.ZONE_STATUS, self.OFF)
-
-        def motion_event(self):
-            """Motion event."""
-            super().listener_event(CLUSTER_COMMAND, None, self.ZONE_STATE, [self.ON])
-            super().listener_event(CLUSTER_COMMAND, None, self.ZONE_STATUS, [self.ON])
-
-            if self._timer_handle:
-                self._timer_handle.cancel()
-
-            loop = asyncio.get_event_loop()
-            self._timer_handle = loop.call_later(75, self._turn_off)
+        _CONSTANT_ATTRIBUTES = {ZONE_TYPE: IasZone.ZoneType.Vibration_Movement_Sensor}
+        reset_s = 70
 
         def send_event(self, event, *args):
             """Send event."""
             self.listener_event(ZHA_SEND_EVENT, event, args)
-
-        def _turn_off(self):
-            self._timer_handle = None
-            super().listener_event(CLUSTER_COMMAND, None, self.ZONE_STATE, [self.OFF])
-            super().listener_event(CLUSTER_COMMAND, None, self.ZONE_STATUS, [self.OFF])
 
     signature = {
         MODELS_INFO: [(LUMI, "lumi.vibration.aq1")],

--- a/zhaquirks/xiaomi/aqara/wleak_aq1.py
+++ b/zhaquirks/xiaomi/aqara/wleak_aq1.py
@@ -20,20 +20,14 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+    ZONE_TYPE,
 )
 
 
 class CustomIasZone(CustomCluster, IasZone):
     """Custom IasZone cluster."""
 
-    MOISTURE_TYPE = 0x002A
-    ZONE_TYPE = 0x0001
-
-    def _update_attribute(self, attrid, value):
-        if attrid == self.ZONE_TYPE:
-            super()._update_attribute(attrid, self.MOISTURE_TYPE)
-        else:
-            super()._update_attribute(attrid, value)
+    _CONSTANT_ATTRIBUTES = {ZONE_TYPE: IasZone.ZoneType.Water_Sensor}
 
 
 class LeakAQ1(XiaomiQuickInitDevice):


### PR DESCRIPTION
This PR:

- cleans up IASZone implementations that use constant attributes to set zone type
- changes the Xiaomi motion cool down to 70 seconds
- cleans up the Aqara vibration sensor motion class
- changes the Aqara vibration sensor cool down to 70 seconds
- adds an event to publish the reported vibration strength

~~I still have to test the motion cool down after the device vacates test mode...~~ I can confirm that the device does in fact trigger about every 60s like this says:  https://community.smartthings.com/t/xiaomi-motion-sensor-aqara-how-to-test/170752/11

Fixes: #646
Fixes: #523