### PR TITLE
Added Tuya TS0012, aka Smart Life DS-112.

### DIFF
--- a/zhaquirks/tuya/ts0012.py
+++ b/zhaquirks/tuya/ts0012.py
@@ -1,0 +1,97 @@
+"""Tuya 2 Button switch."""
+
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import Basic, Groups, OnOff, Ota, Scenes, PowerConfiguration, Time
+
+from . import TuyaSmartRemote, TuyaSmartRemoteOnOffCluster, TuyaManufacturerClusterOnOff, TuyaManufCluster, TuyaOnOff, TuyaSwitch
+from ..const import (
+    BUTTON_1,
+    BUTTON_2,
+    COMMAND,
+    DEVICE_TYPE,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+)
+
+
+class TuyaDoubleSwitch(TuyaSwitch):
+    """Tuya 2-button remote device."""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=100, device_version=0, input_clusters=[0, 4, 5, 6], output_clusters=[19]))
+        # SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=100, device_version=0, input_clusters=[4, 5, 6], output_clusters=[])
+        MODELS_INFO: [("_TYZB01_vzrytttn", "TS0012")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    Time.cluster_id,
+                    TuyaManufCluster.cluster_id,
+
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    Time.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                    Time.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufacturerClusterOnOff,
+                    TuyaOnOff,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                    Time.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufacturerClusterOnOff,
+                    TuyaOnOff,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: SHORT_PRESS},
+        (SHORT_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: SHORT_PRESS},
+    }

--- a/zhaquirks/tuya/ts0012.py
+++ b/zhaquirks/tuya/ts0012.py
@@ -10,6 +10,7 @@ from zigpy.zcl.clusters.general import (
     Scenes,
     Time,
 )
+
 from . import (
     TuyaManufacturerClusterOnOff,
     TuyaManufCluster,

--- a/zhaquirks/tuya/ts0012.py
+++ b/zhaquirks/tuya/ts0012.py
@@ -1,7 +1,15 @@
 """Tuya 2 Button switch."""
 
 from zigpy.profiles import zha
-from zigpy.zcl.clusters.general import Basic, Groups, OnOff, Ota, Scenes, PowerConfiguration, Time
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    OnOff,
+    Ota,
+    PowerConfiguration,
+    Scenes,
+    Time,
+)
 
 from . import (
     TuyaManufacturerClusterOnOff,
@@ -10,6 +18,7 @@ from . import (
     TuyaSmartRemoteOnOffCluster,
     TuyaSwitch,
 )
+
 from ..const import (
     BUTTON_1,
     BUTTON_2,

--- a/zhaquirks/tuya/ts0012.py
+++ b/zhaquirks/tuya/ts0012.py
@@ -3,7 +3,13 @@
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Groups, OnOff, Ota, Scenes, PowerConfiguration, Time
 
-from . import TuyaSmartRemote, TuyaSmartRemoteOnOffCluster, TuyaManufacturerClusterOnOff, TuyaManufCluster, TuyaOnOff, TuyaSwitch
+from . import (
+    TuyaManufacturerClusterOnOff,
+    TuyaManufCluster,
+    TuyaOnOff,
+    TuyaSmartRemoteOnOffCluster,
+    TuyaSwitch
+)
 from ..const import (
     BUTTON_1,
     BUTTON_2,
@@ -38,7 +44,6 @@ class TuyaDoubleSwitch(TuyaSwitch):
                     Scenes.cluster_id,
                     Time.cluster_id,
                     TuyaManufCluster.cluster_id,
-
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },

--- a/zhaquirks/tuya/ts0012.py
+++ b/zhaquirks/tuya/ts0012.py
@@ -8,7 +8,7 @@ from . import (
     TuyaManufCluster,
     TuyaOnOff,
     TuyaSmartRemoteOnOffCluster,
-    TuyaSwitch
+    TuyaSwitch,
 )
 from ..const import (
     BUTTON_1,

--- a/zhaquirks/tuya/ts0012.py
+++ b/zhaquirks/tuya/ts0012.py
@@ -10,7 +10,6 @@ from zigpy.zcl.clusters.general import (
     Scenes,
     Time,
 )
-
 from . import (
     TuyaManufacturerClusterOnOff,
     TuyaManufCluster,
@@ -18,7 +17,6 @@ from . import (
     TuyaSmartRemoteOnOffCluster,
     TuyaSwitch,
 )
-
 from ..const import (
     BUTTON_1,
     BUTTON_2,


### PR DESCRIPTION
I could not get the Smart Life DS-112 to be recognized as a switch. The status was transmitted, but I could not control the switch, I combined two examples of the Tuya folder (singleswitch.py and ts0043.py) and lo and behold, it is working now. If I have added to much cruft, please remove. 

This was the info I started of with:

{
  "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=512, server_mask=11264, maximum_outgoing_transfer_size=512, descriptor_capability_field=0)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": "0x0100",
      "in_clusters": [
        "0x0000",
        "0x0004",
        "0x0005",
        "0x0006"
      ],
      "out_clusters": [
        "0x0019"
      ]
    },
    "2": {
      "profile_id": 260,
      "device_type": "0x0100",
      "in_clusters": [
        "0x0004",
        "0x0005",
        "0x0006"
      ],
      "out_clusters": []
    }
  },
  "manufacturer": "_TYZB01_vzrytttn",
  "model": "TS0012",
  "class": "zigpy.device.Device"
}