### PR TITLE
Refactor Xiaomi PowerConfiguration cluster

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -276,3 +276,22 @@ async def test_mija_battery(zigpy_device_from_quirk, voltage, bpr):
     )
     power_cluster = device.endpoints[1].power
     assert power_cluster["battery_percentage_remaining"] == bpr
+
+
+@pytest.mark.parametrize(
+    "quirk, batt_size",
+    (
+        (zhaquirks.xiaomi.aqara.vibration_aq1.VibrationAQ1, 0x0A),
+        (zhaquirks.xiaomi.mija.motion.Motion, 0x09),
+        (zhaquirks.xiaomi.mija.sensor_switch.MijaButton, 0x0A),
+        (zhaquirks.xiaomi.mija.sensor_magnet.Magnet, 0x0B),
+    ),
+)
+async def test_xiaomi_batt_size(zigpy_device_from_quirk, quirk, batt_size):
+    """Test xiaomi battery size overrides."""
+
+    device = zigpy_device_from_quirk(quirk)
+    cluster = device.endpoints[1].power
+    succ, fail = await cluster.read_attributes(("battery_size", "battery_quantity"))
+    assert succ["battery_quantity"] == 1
+    assert succ["battery_size"] == batt_size

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -262,3 +262,20 @@ async def test_xiaomi_battery(zigpy_device_from_quirk, voltage, bpr):
     )
     power_cluster = device.endpoints[1].power
     assert power_cluster["battery_percentage_remaining"] == bpr
+
+
+@pytest.mark.parametrize("voltage, bpr", ((3000, 200), (2800, 0), (2600, 0)))
+async def test_mija_battery(zigpy_device_from_quirk, voltage, bpr):
+    """Test xiaomi batter voltage to % battery left."""
+    data_1 = b'\x1c_\x11I\n\x02\xffB"\x01!'
+    data_2 = (
+        b"\x03(\r\x04!\xa8\x13\x05!\xcb\x00\x06$\x01\x00\x00\x00\x00\x08!\x04\x02\n!"
+        b"\x00\x00d\x10\x00"
+    )
+
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.mija.motion.Motion)
+    device.handle_message(
+        0x260, 0x0000, 1, 1, data_1 + t.uint16_t(voltage).serialize() + data_2
+    )
+    power_cluster = device.endpoints[1].power
+    assert power_cluster["battery_percentage_remaining"] == bpr

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -267,11 +267,8 @@ async def test_xiaomi_battery(zigpy_device_from_quirk, voltage, bpr):
 @pytest.mark.parametrize("voltage, bpr", ((3000, 200), (2800, 0), (2600, 0)))
 async def test_mija_battery(zigpy_device_from_quirk, voltage, bpr):
     """Test xiaomi batter voltage to % battery left."""
-    data_1 = b'\x1c_\x11I\n\x02\xffB"\x01!'
-    data_2 = (
-        b"\x03(\r\x04!\xa8\x13\x05!\xcb\x00\x06$\x01\x00\x00\x00\x00\x08!\x04\x02\n!"
-        b"\x00\x00d\x10\x00"
-    )
+    data_1 = b"\x1c4\x12\x02\n\x02\xffL\x06\x00\x10\x01!"
+    data_2 = b"!\xa8\x01$\x00\x00\x00\x00\x00!n\x00 P"
 
     device = zigpy_device_from_quirk(zhaquirks.xiaomi.mija.motion.Motion)
     device.handle_message(

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -305,7 +305,7 @@ class XiaomiPowerConfiguration(PowerConfigurationCluster, LocalDataCluster):
 
     def battery_reported(self, voltage_mv: int) -> None:
         """Battery reported."""
-        self._update_attribute(self.BATTERY_VOLTAGE_ATTR, int(voltage_mv / 100))
+        self._update_attribute(self.BATTERY_VOLTAGE_ATTR, round(voltage_mv / 100))
 
 
 class OccupancyCluster(OccupancyWithReset):

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -42,6 +42,8 @@ BATTERY_LEVEL = "battery_level"
 BATTERY_PERCENTAGE_REMAINING = 0x0021
 BATTERY_REPORTED = "battery_reported"
 BATTERY_SIZE = "battery_size"
+BATTERY_SIZE_ATTR = 0x0031
+BATTERY_QUANTITY_ATTR = 0x0033
 BATTERY_VOLTAGE_MV = "battery_voltage_mV"
 HUMIDITY_MEASUREMENT = "humidity_measurement"
 HUMIDITY_REPORTED = "humidity_reported"
@@ -177,8 +179,7 @@ class BasicCluster(CustomCluster, Basic):
         )
         if BATTERY_VOLTAGE_MV in attributes:
             self.endpoint.device.battery_bus.listener_event(
-                BATTERY_REPORTED,
-                attributes[BATTERY_VOLTAGE_MV],
+                BATTERY_REPORTED, attributes[BATTERY_VOLTAGE_MV]
             )
 
         if TEMPERATURE_MEASUREMENT in attributes:
@@ -290,8 +291,6 @@ class BinaryOutputInterlock(CustomCluster, BinaryOutput):
 class XiaomiPowerConfiguration(PowerConfigurationCluster, LocalDataCluster):
     """Xiaomi power configuration cluster implementation."""
 
-    BATTERY_SIZE_ATTR = 0x0031
-    BATTERY_QUANTITY_ATTR = 0x0033
     MAX_VOLTS = 3.0
     MIN_VOLTS = 2.8
 
@@ -299,13 +298,10 @@ class XiaomiPowerConfiguration(PowerConfigurationCluster, LocalDataCluster):
         """Init."""
         super().__init__(*args, **kwargs)
         self.endpoint.device.battery_bus.add_listener(self)
-        if hasattr(self.endpoint.device, BATTERY_SIZE):
-            self._update_attribute(
-                self.BATTERY_SIZE_ATTR, self.endpoint.device.battery_size
-            )
-        else:
-            self._update_attribute(self.BATTERY_SIZE_ATTR, 0xFF)
-        self._update_attribute(self.BATTERY_QUANTITY_ATTR, 1)
+        self._CONSTANT_ATTRIBUTES = {
+            BATTERY_QUANTITY_ATTR: 1,
+            BATTERY_SIZE_ATTR: getattr(self.endpoint.device, BATTERY_SIZE, 0xFF),
+        }
 
     def battery_reported(self, voltage_mv: int) -> None:
         """Battery reported."""

--- a/zhaquirks/xiaomi/aqara/ctrl_ln.py
+++ b/zhaquirks/xiaomi/aqara/ctrl_ln.py
@@ -21,8 +21,8 @@ from .. import (
     AnalogInputCluster,
     BasicCluster,
     OnOffCluster,
-    PowerConfigurationCluster,
     XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 from ...const import (
     DEVICE_TYPE,
@@ -51,7 +51,7 @@ class CtrlLn(XiaomiCustomDevice):
                 DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    XiaomiPowerConfiguration.cluster_id,
                     DeviceTemperature.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
@@ -109,7 +109,7 @@ class CtrlLn(XiaomiCustomDevice):
                 DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     DeviceTemperature.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,

--- a/zhaquirks/xiaomi/aqara/ctrl_neutral.py
+++ b/zhaquirks/xiaomi/aqara/ctrl_neutral.py
@@ -20,8 +20,8 @@ from .. import (
     LUMI,
     BasicCluster,
     OnOffCluster,
-    PowerConfigurationCluster,
     XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 from ...const import (
     DEVICE_TYPE,
@@ -71,7 +71,7 @@ class CtrlNeutral(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    XiaomiPowerConfiguration.cluster_id,
                     DeviceTemperature.cluster_id,
                     Ota.cluster_id,
                     Time.cluster_id,
@@ -159,7 +159,7 @@ class CtrlNeutral(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    XiaomiPowerConfiguration.cluster_id,
                     DeviceTemperature.cluster_id,
                     Ota.cluster_id,
                     Time.cluster_id,

--- a/zhaquirks/xiaomi/aqara/cube.py
+++ b/zhaquirks/xiaomi/aqara/cube.py
@@ -15,7 +15,7 @@ from .. import (
     LUMI,
     XIAOMI_NODE_DESC,
     BasicCluster,
-    PowerConfigurationCluster,
+    XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
 )
 from ... import CustomCluster
@@ -288,7 +288,7 @@ class Cube(XiaomiQuickInitDevice):
                 DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     Ota.cluster_id,
                 ],

--- a/zhaquirks/xiaomi/aqara/cube_aqgl01.py
+++ b/zhaquirks/xiaomi/aqara/cube_aqgl01.py
@@ -11,7 +11,7 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import LUMI, BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import LUMI, BasicCluster, XiaomiCustomDevice, XiaomiPowerConfiguration
 from ... import CustomCluster
 from ...const import (
     ARGS,
@@ -280,7 +280,7 @@ class CubeAQGL01(XiaomiCustomDevice):
                 DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     Ota.cluster_id,
                 ],

--- a/zhaquirks/xiaomi/aqara/magnet_aq2.py
+++ b/zhaquirks/xiaomi/aqara/magnet_aq2.py
@@ -8,7 +8,7 @@ from .. import (
     LUMI,
     XIAOMI_NODE_DESC,
     BasicCluster,
-    PowerConfigurationCluster,
+    XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
 )
 from ...const import (
@@ -68,7 +68,7 @@ class MagnetAQ2(XiaomiQuickInitDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     XIAOMI_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [

--- a/zhaquirks/xiaomi/aqara/motion_aq2.py
+++ b/zhaquirks/xiaomi/aqara/motion_aq2.py
@@ -12,7 +12,7 @@ from .. import (
     IlluminanceMeasurementCluster,
     MotionCluster,
     OccupancyCluster,
-    PowerConfigurationCluster,
+    XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
 )
 from ... import Bus
@@ -71,7 +71,7 @@ class MotionAQ2(XiaomiQuickInitDevice):
             1: {
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     IlluminanceMeasurementCluster,
                     OccupancyCluster,

--- a/zhaquirks/xiaomi/aqara/motion_aq2b.py
+++ b/zhaquirks/xiaomi/aqara/motion_aq2b.py
@@ -10,8 +10,8 @@ from .. import (
     IlluminanceMeasurementCluster,
     MotionCluster,
     OccupancyCluster,
-    PowerConfigurationCluster,
     XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 from ... import Bus
 from ...const import (
@@ -64,7 +64,7 @@ class MotionAQ2(XiaomiCustomDevice):
             1: {
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     IlluminanceMeasurementCluster,
                     OccupancyCluster,
                     MotionCluster,

--- a/zhaquirks/xiaomi/aqara/remote_b186acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b186acn01.py
@@ -17,7 +17,7 @@ from .. import (
     LUMI,
     XIAOMI_NODE_DESC,
     BasicCluster,
-    PowerConfigurationCluster,
+    XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
 )
 from ... import CustomCluster
@@ -154,7 +154,7 @@ class RemoteB186ACN01(XiaomiQuickInitDevice):
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     Ota.cluster_id,
                     XIAOMI_CLUSTER_ID,

--- a/zhaquirks/xiaomi/aqara/remote_b286acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b286acn01.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import LUMI, BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import LUMI, BasicCluster, XiaomiCustomDevice, XiaomiPowerConfiguration
 from ... import CustomCluster
 from ...const import (
     ATTR_ID,
@@ -161,7 +161,7 @@ class RemoteB286ACN01(XiaomiCustomDevice):
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     Ota.cluster_id,
                     XIAOMI_CLUSTER_ID,

--- a/zhaquirks/xiaomi/aqara/sensor_swit.py
+++ b/zhaquirks/xiaomi/aqara/sensor_swit.py
@@ -4,7 +4,7 @@ import logging
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, MultistateInput, OnOff
 
-from .. import LUMI, BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import LUMI, BasicCluster, XiaomiCustomDevice, XiaomiPowerConfiguration
 from ... import CustomCluster
 from ...const import (
     COMMAND,
@@ -86,7 +86,7 @@ class SwitchAQ3V2(XiaomiCustomDevice):
                 DEVICE_TYPE: BUTTON_DEVICE_TYPE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    XiaomiPowerConfiguration.cluster_id,
                     OnOff.cluster_id,
                     MultistateInput.cluster_id,
                 ],
@@ -101,7 +101,7 @@ class SwitchAQ3V2(XiaomiCustomDevice):
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     MultistateInputCluster,
                 ],
                 OUTPUT_CLUSTERS: [Basic.cluster_id, OnOff.cluster_id],

--- a/zhaquirks/xiaomi/aqara/sensor_switch_aq3.py
+++ b/zhaquirks/xiaomi/aqara/sensor_switch_aq3.py
@@ -4,7 +4,7 @@ import logging
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Identify, MultistateInput, OnOff
 
-from .. import LUMI, BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import LUMI, BasicCluster, XiaomiCustomDevice, XiaomiPowerConfiguration
 from ... import CustomCluster
 from ...const import (
     COMMAND,
@@ -90,7 +90,7 @@ class SwitchAQ3(XiaomiCustomDevice):
                 DEVICE_TYPE: BUTTON_DEVICE_TYPE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    XiaomiPowerConfiguration.cluster_id,
                     OnOff.cluster_id,
                     MultistateInput.cluster_id,
                 ],
@@ -105,7 +105,7 @@ class SwitchAQ3(XiaomiCustomDevice):
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     MultistateInputCluster,
                 ],
                 OUTPUT_CLUSTERS: [Basic.cluster_id, OnOff.cluster_id],
@@ -151,7 +151,7 @@ class SwitchAQ3B(XiaomiCustomDevice):
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     MultistateInputCluster,
                 ],
                 OUTPUT_CLUSTERS: [Basic.cluster_id],

--- a/zhaquirks/xiaomi/aqara/switch_aq2.py
+++ b/zhaquirks/xiaomi/aqara/switch_aq2.py
@@ -8,7 +8,7 @@ from .. import (
     LUMI,
     XIAOMI_NODE_DESC,
     BasicCluster,
-    PowerConfigurationCluster,
+    XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
 )
 from ...const import (
@@ -74,7 +74,7 @@ class SwitchAQ2(XiaomiQuickInitDevice):
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     XIAOMI_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -19,7 +19,7 @@ from .. import (
     LUMI,
     XIAOMI_NODE_DESC,
     BasicCluster,
-    PowerConfigurationCluster,
+    XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
 )
 from ... import Bus, LocalDataCluster, MotionOnEvent
@@ -171,7 +171,7 @@ class VibrationAQ1(XiaomiQuickInitDevice):
                 DEVICE_TYPE: zha.DeviceType.DOOR_LOCK,
                 INPUT_CLUSTERS: [
                     VibrationBasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     MotionCluster,
                     Ota.cluster_id,

--- a/zhaquirks/xiaomi/aqara/weather.py
+++ b/zhaquirks/xiaomi/aqara/weather.py
@@ -9,10 +9,10 @@ from .. import (
     LUMI,
     XIAOMI_NODE_DESC,
     BasicCluster,
-    PowerConfigurationCluster,
     PressureMeasurementCluster,
     RelativeHumidityCluster,
     TemperatureMeasurementCluster,
+    XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
 )
 from ... import Bus
@@ -77,7 +77,7 @@ class Weather(XiaomiQuickInitDevice):
             1: {
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     TemperatureMeasurementCluster,
                     PressureMeasurementCluster,

--- a/zhaquirks/xiaomi/aqara/wleak_aq1.py
+++ b/zhaquirks/xiaomi/aqara/wleak_aq1.py
@@ -8,7 +8,7 @@ from .. import (
     LUMI,
     XIAOMI_NODE_DESC,
     BasicCluster,
-    PowerConfigurationCluster,
+    XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
 )
 from ...const import (
@@ -47,7 +47,7 @@ class LeakAQ1(XiaomiQuickInitDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    XiaomiPowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             }
@@ -60,7 +60,7 @@ class LeakAQ1(XiaomiQuickInitDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     CustomIasZone,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],

--- a/zhaquirks/xiaomi/mija/motion.py
+++ b/zhaquirks/xiaomi/mija/motion.py
@@ -18,7 +18,7 @@ from .. import (
     BasicCluster,
     MotionCluster,
     OccupancyCluster,
-    PowerConfigurationCluster,
+    XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
 )
 from ... import Bus
@@ -84,7 +84,7 @@ class Motion(XiaomiQuickInitDevice):
                 DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     OccupancyCluster,
                     MotionCluster,

--- a/zhaquirks/xiaomi/mija/sensor_ht.py
+++ b/zhaquirks/xiaomi/mija/sensor_ht.py
@@ -14,10 +14,10 @@ from zigpy.zcl.clusters.general import (
 from .. import (
     LUMI,
     BasicCluster,
-    PowerConfigurationCluster,
     RelativeHumidityCluster,
     TemperatureMeasurementCluster,
     XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 from ... import Bus
 from ...const import (
@@ -114,7 +114,7 @@ class Weather(XiaomiCustomDevice):
                 DEVICE_TYPE: TEMPERATURE_HUMIDITY_DEVICE_TYPE2,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     TemperatureMeasurementCluster,
                     RelativeHumidityCluster,

--- a/zhaquirks/xiaomi/mija/sensor_magnet.py
+++ b/zhaquirks/xiaomi/mija/sensor_magnet.py
@@ -15,7 +15,7 @@ from .. import (
     LUMI,
     XIAOMI_NODE_DESC,
     BasicCluster,
-    PowerConfigurationCluster,
+    XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
 )
 from ...const import (
@@ -81,7 +81,7 @@ class Magnet(XiaomiQuickInitDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     XIAOMI_CLUSTER_ID,
                     Ota.cluster_id,
                 ],

--- a/zhaquirks/xiaomi/mija/sensor_switch.py
+++ b/zhaquirks/xiaomi/mija/sensor_switch.py
@@ -12,7 +12,7 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import LUMI, BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice
+from .. import LUMI, BasicCluster, XiaomiCustomDevice, XiaomiPowerConfiguration
 from ... import CustomCluster
 from ...const import (
     ARGS,
@@ -137,7 +137,7 @@ class MijaButton(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Identify.cluster_id,
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                 ],
                 OUTPUT_CLUSTERS: [
                     BasicCluster,

--- a/zhaquirks/xiaomi/mija/smoke.py
+++ b/zhaquirks/xiaomi/mija/smoke.py
@@ -29,7 +29,7 @@ from .. import (
     LUMI,
     XIAOMI_NODE_DESC,
     BasicCluster,
-    PowerConfigurationCluster,
+    XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
 )
 from ... import CustomCluster
@@ -98,7 +98,7 @@ class MijiaHoneywellSmokeDetectorSensor(XiaomiQuickInitDevice):
             1: {
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     AnalogInput.cluster_id,
                     MultistateInput.cluster_id,


### PR DESCRIPTION
Use common code base for Xiaomi PowerConfiguration cluster to calculate battery % remaining attribute based on voltage. 
Fixes negative battery % if voltage goes below 2.8V

Fixes #676