### PR TITLE
Add more LIDL CCT only devices (fix #618)

### DIFF
--- a/zhaquirks/lidl/cct.py
+++ b/zhaquirks/lidl/cct.py
@@ -37,7 +37,12 @@ class CCTLight(CustomDevice):
     """Lidl CCT Lighting device."""
 
     signature = {
-        MODELS_INFO: [("_TZ3000_49qchf10", "TS0502A"), ("_TZ3000_oborybow", "TS0502A")],
+        MODELS_INFO: [
+            ("_TZ3000_49qchf10", "TS0502A"),
+            ("_TZ3000_oborybow", "TS0502A"),
+            ("_TZ3000_9evm3otq", "TS0502A"),
+            ("_TZ3000_rylaozuc", "TS0502A"),
+        ],
         ENDPOINTS: {
             1: {
                 # <SimpleDescriptor endpoint=1 profile=260 device_type=268


### PR DESCRIPTION
fixes: #618

Perhaps @gijsje and @docgalaxyblock can test this by downloading the "lidl" folder from here: https://github.com/TheJulianJES/zha-device-handlers/tree/lidl_cct/zhaquirks/lidl and moving it to their zha-quirks. (Instructions here for HassOS/Supervised: https://github.com/zigpy/zha-device-handlers#testing-quirks-in-development-in-docker-based-install)