### PR TITLE
Refactor Konke Button "press" events

### DIFF
--- a/tests/test_konke.py
+++ b/tests/test_konke.py
@@ -5,7 +5,16 @@ from unittest import mock
 
 import pytest
 
-from zhaquirks.const import OFF, ON, ZONE_STATE
+from zhaquirks.const import (
+    COMMAND_DOUBLE,
+    COMMAND_HOLD,
+    COMMAND_ID,
+    COMMAND_SINGLE,
+    OFF,
+    ON,
+    PRESS_TYPE,
+    ZONE_STATE,
+)
 import zhaquirks.konke.motion
 
 from tests.common import ZCL_IAS_MOTION_COMMAND, ClusterListener
@@ -52,3 +61,46 @@ async def test_konke_motion(zigpy_device_from_quirk, quirk):
     assert len(occupancy_listener.attribute_updates) == 2
     assert occupancy_listener.attribute_updates[1][0] == 0x0000
     assert occupancy_listener.attribute_updates[1][1] == 0
+
+
+@pytest.mark.parametrize(
+    "quirk",
+    (
+        zhaquirks.konke.button.KonkeButtonRemote1,
+        zhaquirks.konke.button.KonkeButtonRemote2,
+    ),
+)
+async def test_konke_button(zigpy_device_from_quirk, quirk):
+    """Test Konke button remotes."""
+
+    device = zigpy_device_from_quirk(quirk)
+    cluster = device.endpoints[1].custom_on_off
+
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    # single press
+    message = b"\x08W\n\x00\x00\x10\x80"
+    device.handle_message(260, cluster.cluster_id, 1, 1, message)
+    assert listener.zha_send_event.call_count == 1
+    assert listener.zha_send_event.call_args_list[0][0][0] == COMMAND_SINGLE
+    assert listener.zha_send_event.call_args_list[0][0][1][PRESS_TYPE] == COMMAND_SINGLE
+    assert listener.zha_send_event.call_args_list[0][0][1][COMMAND_ID] == 0x80
+
+    # double press
+    listener.reset_mock()
+    message = b"\x08X\n\x00\x00\x10\x81"
+    device.handle_message(260, cluster.cluster_id, 1, 1, message)
+    assert listener.zha_send_event.call_count == 1
+    assert listener.zha_send_event.call_args_list[0][0][0] == COMMAND_DOUBLE
+    assert listener.zha_send_event.call_args_list[0][0][1][PRESS_TYPE] == COMMAND_DOUBLE
+    assert listener.zha_send_event.call_args_list[0][0][1][COMMAND_ID] == 0x81
+
+    # long press
+    listener.reset_mock()
+    message = b"\x08Y\n\x00\x00\x10\x82"
+    device.handle_message(260, cluster.cluster_id, 1, 1, message)
+    assert listener.zha_send_event.call_count == 1
+    assert listener.zha_send_event.call_args_list[0][0][0] == COMMAND_HOLD
+    assert listener.zha_send_event.call_args_list[0][0][1][PRESS_TYPE] == COMMAND_HOLD
+    assert listener.zha_send_event.call_args_list[0][0][1][COMMAND_ID] == 0x82

--- a/zhaquirks/konke/__init__.py
+++ b/zhaquirks/konke/__init__.py
@@ -1,14 +1,10 @@
 """Konke sensors."""
 
+import zigpy.types as t
 from zigpy.zcl.clusters.general import OnOff
+import zigpy.zcl.foundation
 
-from .. import (
-    CustomCluster,
-    CustomDevice,
-    LocalDataCluster,
-    MotionWithReset,
-    OccupancyOnEvent,
-)
+from .. import CustomCluster, LocalDataCluster, MotionWithReset, OccupancyOnEvent
 from ..const import (
     COMMAND_DOUBLE,
     COMMAND_HOLD,
@@ -40,9 +36,7 @@ class KonkeOnOffCluster(CustomCluster, OnOff):
     PRESS_TYPES = {0x0080: COMMAND_SINGLE, 0x0081: COMMAND_DOUBLE, 0x0082: COMMAND_HOLD}
     cluster_id = 6
     ep_attribute = "custom_on_off"
-    attributes = {}
-    server_commands = {}
-    client_commands = {}
+    manufacturer_attributes = {0x0000: (PRESS_TYPE, t.uint8_t)}
 
     def handle_cluster_general_request(self, header, args):
         """Handle the cluster command."""
@@ -52,31 +46,33 @@ class KonkeOnOffCluster(CustomCluster, OnOff):
             args,
         )
 
-        cmd = header.command_id
+        if header.command_id != zigpy.zcl.foundation.Command.Report_Attributes:
+            return
+
+        attr = args[0][0]
+        if attr.attrid != 0x0000:
+            return
+
+        value = attr.value.value
         event_args = {
-            PRESS_TYPE: self.PRESS_TYPES.get(cmd, cmd),
-            COMMAND_ID: cmd,
+            PRESS_TYPE: self.PRESS_TYPES.get(value, value),
+            COMMAND_ID: value,
         }
         self.listener_event(ZHA_SEND_EVENT, event_args[PRESS_TYPE], event_args)
 
-
-class KonkeButtonRemote(CustomDevice):
-    """Konke 1-button remote device."""
-
-    def handle_message(self, profile, cluster, src_ep, dst_ep, message):
-        """Handle a device message."""
-        if (
-            profile == 260
-            and cluster == 6
-            and len(message) == 7
-            and message[0] == 0x08
-            and message[2] == 0x0A
-        ):
-            # use the 7th byte as command_id
-            new_message = bytearray(4)
-            new_message[0] = message[0]
-            new_message[1] = message[1]
-            new_message[2] = message[6]
-            new_message[3] = 0
-            message = type(message)(new_message)
-            super().handle_message(profile, cluster, src_ep, dst_ep, message)
+    def deserialize(self, data):
+        """Deserialize fix for Konke butchered Bool ZCL type."""
+        try:
+            return super().deserialize(data)
+        except ValueError:
+            hdr, data = zigpy.zcl.foundation.ZCLHeader.deserialize(data)
+            if (
+                hdr.frame_control.is_cluster
+                or hdr.command_id != zigpy.zcl.foundation.Command.Report_Attributes
+            ):
+                raise
+            attr_id, data = t.uint16_t.deserialize(data)
+            attr = zigpy.zcl.foundation.Attribute(
+                attr_id, zigpy.zcl.foundation.TypeValue(t.uint8_t, data[1])
+            )
+            return hdr, [[attr]]

--- a/zhaquirks/konke/button.py
+++ b/zhaquirks/konke/button.py
@@ -2,6 +2,7 @@
 import logging
 
 from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -11,7 +12,7 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from . import KONKE, KonkeButtonRemote, KonkeOnOffCluster
+from . import KONKE, KonkeOnOffCluster
 from .. import PowerConfigurationCluster
 from ..const import (
     COMMAND,
@@ -34,7 +35,7 @@ KONKE_CLUSTER_ID = 0xFCC0
 _LOGGER = logging.getLogger(__name__)
 
 
-class KonkeButtonRemote1(KonkeButtonRemote):
+class KonkeButtonRemote1(CustomDevice):
     """Konke 1-button remote device."""
 
     signature = {
@@ -85,7 +86,7 @@ class KonkeButtonRemote1(KonkeButtonRemote):
     }
 
 
-class KonkeButtonRemote2(KonkeButtonRemote):
+class KonkeButtonRemote2(CustomDevice):
     """Konke 1-button remote device 2nd variant."""
 
     signature = {


### PR DESCRIPTION
Refactor Konke Button "press" events so it does not rely on raw data manipulation at the "device" level.
This is to make it compatible with https://github.com/zigpy/zigpy/pull/591