### PR TITLE
Support (old) IKEA Tradfri Wireless Dimmer ICTC-G-1

### DIFF
--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -32,7 +32,8 @@ class LightLinkCluster(CustomCluster, LightLink):
             )
             group_id = 0x0000
         status = await coordinator.add_to_group(
-            group_id, name="Default Lightlink Group",
+            group_id,
+            name="Default Lightlink Group",
         )
         return [status]
 

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -8,6 +8,7 @@ from zigpy.zcl.clusters.lightlink import LightLink
 
 _LOGGER = logging.getLogger(__name__)
 IKEA = "IKEA of Sweden"
+ROTATED = "device_rotated"
 
 
 class LightLinkCluster(CustomCluster, LightLink):
@@ -31,8 +32,7 @@ class LightLinkCluster(CustomCluster, LightLink):
             )
             group_id = 0x0000
         status = await coordinator.add_to_group(
-            group_id,
-            name="Default Lightlink Group",
+            group_id, name="Default Lightlink Group",
         )
         return [status]
 

--- a/zhaquirks/ikea/dimmer.py
+++ b/zhaquirks/ikea/dimmer.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA
+from . import IKEA, ROTATED
 from .. import DoublingPowerConfigurationCluster
 from ..const import (
     ARGS,
@@ -30,8 +30,6 @@ from ..const import (
     PROFILE_ID,
     RIGHT,
 )
-
-ROTATED = "device_rotated"
 
 
 class IkeaDimmer(CustomDevice):

--- a/zhaquirks/ikea/dimmer.py
+++ b/zhaquirks/ikea/dimmer.py
@@ -1,5 +1,5 @@
 """Device handler for IKEA of Sweden TRADFRI wireless dimmer ICTC-G-1."""
-from zigpy.profiles import zll
+from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -9,7 +9,7 @@ from zigpy.zcl.clusters.general import (
     OnOff,
     Ota,
     PowerConfiguration,
-    Alarms,
+    PollControl,
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
@@ -29,20 +29,20 @@ class IkeaDimmer(CustomDevice):
     """Custom device representing IKEA of Sweden TRADFRI wireless dimmer."""
 
     signature = {
-        # <SimpleDescriptor endpoint=1 profile=49246 device_type=2064
-        # device_version=2
-        # input_clusters=[0, 1, 3, 9, 2821, 4096]
-        # output_clusters=[3, 4, 6, 8, 25, 4096]>
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=2080
+        # device_version=1
+        # input_clusters=[0, 1, 3, 32, 4096]
+        # output_clusters=[3, 4, 6, 8, 25, 4096]
         MODELS_INFO: [(IKEA, "TRADFRI wireless dimmer")],
         ENDPOINTS: {
             1: {
-                PROFILE_ID: zll.PROFILE_ID,
-                DEVICE_TYPE: zll.DeviceType.COLOR_SCENE_CONTROLLER,
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
-                    Alarms.cluster_id,
+                    PollControl.cluster_id,
                     LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -60,13 +60,13 @@ class IkeaDimmer(CustomDevice):
     replacement = {
         ENDPOINTS: {
             1: {
-                PROFILE_ID: zll.PROFILE_ID,
-                DEVICE_TYPE: zll.DeviceType.COLOR_SCENE_CONTROLLER,
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     DoublingPowerConfigurationCluster,
                     Identify.cluster_id,
-                    Alarms.cluster_id,
+                    PollControl.cluster_id,
                     LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [

--- a/zhaquirks/ikea/dimmer.py
+++ b/zhaquirks/ikea/dimmer.py
@@ -8,8 +8,8 @@ from zigpy.zcl.clusters.general import (
     LevelControl,
     OnOff,
     Ota,
-    PowerConfiguration,
     PollControl,
+    PowerConfiguration,
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 

--- a/zhaquirks/ikea/dimmer.py
+++ b/zhaquirks/ikea/dimmer.py
@@ -1,0 +1,82 @@
+"""Device handler for IKEA of Sweden TRADFRI wireless dimmer ICTC-G-1."""
+from zigpy.profiles import zll
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    PowerConfiguration,
+    Alarms,
+)
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from . import IKEA
+from .. import DoublingPowerConfigurationCluster
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class IkeaDimmer(CustomDevice):
+    """Custom device representing IKEA of Sweden TRADFRI wireless dimmer."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=49246 device_type=2064
+        # device_version=2
+        # input_clusters=[0, 1, 3, 9, 2821, 4096]
+        # output_clusters=[3, 4, 6, 8, 25, 4096]>
+        MODELS_INFO: [(IKEA, "TRADFRI wireless dimmer")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Alarms.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DoublingPowerConfigurationCluster,
+                    Identify.cluster_id,
+                    Alarms.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        }
+    }

--- a/zhaquirks/ikea/dimmer.py
+++ b/zhaquirks/ikea/dimmer.py
@@ -16,13 +16,22 @@ from zigpy.zcl.clusters.lightlink import LightLink
 from . import IKEA
 from .. import DoublingPowerConfigurationCluster
 from ..const import (
+    ARGS,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_MOVE,
     DEVICE_TYPE,
+    ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
+    LEFT,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    RIGHT,
 )
+
+ROTATED = "device_rotated"
 
 
 class IkeaDimmer(CustomDevice):
@@ -80,3 +89,19 @@ class IkeaDimmer(CustomDevice):
             }
         }
     }
+
+
+device_automation_triggers = {
+    (ROTATED, RIGHT): {
+        COMMAND: COMMAND_MOVE,
+        CLUSTER_ID: 8,
+        ENDPOINT_ID: 1,
+        ARGS: [0, 195],
+    },
+    (ROTATED, LEFT): {
+        COMMAND: COMMAND_MOVE,
+        CLUSTER_ID: 8,
+        ENDPOINT_ID: 1,
+        ARGS: [1, 195],
+    },
+}

--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA
+from . import IKEA, ROTATED
 from .. import DoublingPowerConfigurationCluster
 from ..const import (
     ARGS,
@@ -36,8 +36,6 @@ from ..const import (
     TRIPLE_PRESS,
     TURN_ON,
 )
-
-ROTATED = "device_rotated"
 
 
 class IkeaSYMFONISK(CustomDevice):


### PR DESCRIPTION
Similar to the IKEA SYMFONISK "dimmer", but doesn't support clicks.
- adds doubling of the battery percentage: fixes https://github.com/zigpy/zha-device-handlers/issues/557, https://github.com/home-assistant/core/issues/42672
- also adds basic device automation triggers for moving the dial left and right

The support is for an IKEA wireless dimmer now with the updated ZB3 firmware. I didn't include the previous quirk for the ZLL firmware.
Based upon https://github.com/zigpy/zha-device-handlers/issues/557 and tested by @MattWestb 