### PR TITLE
Add Philips Hue Filament (default power on state) support

### DIFF
--- a/zhaquirks/philips/zhadimmablelight.py
+++ b/zhaquirks/philips/zhadimmablelight.py
@@ -33,7 +33,12 @@ class ZHADimmableLight(CustomDevice):
     """Philips ZigBee HomeAutomation dimmable bulb device."""
 
     signature = {
-        MODELS_INFO: [(PHILIPS, "LWV001"), (SIGNIFY, "LWV001")],
+        MODELS_INFO: [
+            (PHILIPS, "LWO001"),
+            (PHILIPS, "LWV001"),
+            (SIGNIFY, "LWO001"),
+            (PHILIPS, "LWV001"),
+        ],
         ENDPOINTS: {
             11: {
                 # <SimpleDescriptor endpoint=11 profile=260 device_type=528

--- a/zhaquirks/philips/zhadimmablelight.py
+++ b/zhaquirks/philips/zhadimmablelight.py
@@ -34,10 +34,16 @@ class ZHADimmableLight(CustomDevice):
 
     signature = {
         MODELS_INFO: [
+            (PHILIPS, "LWA004"),
+            (PHILIPS, "LWA005"),
             (PHILIPS, "LWO001"),
+            (PHILIPS, "LWO003"),
             (PHILIPS, "LWV001"),
+            (SIGNIFY, "LWA004"),
+            (SIGNIFY, "LWA005"),
             (SIGNIFY, "LWO001"),
-            (PHILIPS, "LWV001"),
+            (SIGNIFY, "LWO003"),
+            (SIGNIFY, "LWV001"),
         ],
         ENDPOINTS: {
             11: {

--- a/zhaquirks/philips/zhaextendedcolorlight.py
+++ b/zhaquirks/philips/zhaextendedcolorlight.py
@@ -28,6 +28,7 @@ from zhaquirks.philips import (
     PhilipsColorCluster,
     PhilipsLevelControlCluster,
     PhilipsOnOffCluster,
+    SIGNIFY,
 )
 
 

--- a/zhaquirks/philips/zhaextendedcolorlight.py
+++ b/zhaquirks/philips/zhaextendedcolorlight.py
@@ -28,7 +28,6 @@ from zhaquirks.philips import (
     PhilipsColorCluster,
     PhilipsLevelControlCluster,
     PhilipsOnOffCluster,
-    SIGNIFY,
 )
 
 


### PR DESCRIPTION
Edit: Now, https://github.com/zigpy/zha-device-handlers/pull/728 needs to be merged before this as some "Giant filament" bulbs seem to come with firmware where the manufacturer name is Signify [...] instead of Philips.

Adds support for all Hue filament bulbs.
Two models (LWO001 and LWV001) are tested. The rest is very likely to have the same signature.

(Other non-filament Hue White bulbs will probably also have this signature, but they are not part of this PR)