### PR TITLE
Fix Philips Hue Smart Button device automation triggers for custom clusters

### DIFF
--- a/zhaquirks/philips/rom001.py
+++ b/zhaquirks/philips/rom001.py
@@ -16,15 +16,19 @@ from zigpy.zcl.clusters.lightlink import LightLink
 from . import PhilipsBasicCluster, PhilipsRemoteCluster
 from ..const import (
     COMMAND,
-    COMMAND_OFF_WITH_EFFECT,
-    COMMAND_ON,
     DEVICE_TYPE,
+    DOUBLE_PRESS,
     ENDPOINTS,
     INPUT_CLUSTERS,
+    LONG_PRESS,
+    LONG_RELEASE,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    QUADRUPLE_PRESS,
+    QUINTUPLE_PRESS,
     SHORT_PRESS,
-    TURN_OFF,
+    SHORT_RELEASE,
+    TRIPLE_PRESS,
     TURN_ON,
 )
 
@@ -91,6 +95,12 @@ class PhilipsROM001(CustomDevice):
     }
 
     device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON},
-        (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF_WITH_EFFECT},
+        (SHORT_PRESS, TURN_ON): {COMMAND: "on_press"},
+        (LONG_PRESS, TURN_ON): {COMMAND: "on_hold"},
+        (DOUBLE_PRESS, TURN_ON): {COMMAND: "on_double_press"},
+        (TRIPLE_PRESS, TURN_ON): {COMMAND: "on_triple_press"},
+        (QUADRUPLE_PRESS, TURN_ON): {COMMAND: "on_quadruple_press"},
+        (QUINTUPLE_PRESS, TURN_ON): {COMMAND: "on_quintuple_press"},
+        (SHORT_RELEASE, TURN_ON): {COMMAND: "on_short_release"},
+        (LONG_RELEASE, TURN_ON): {COMMAND: "on_long_release"},
     }


### PR DESCRIPTION
Since https://github.com/zigpy/zha-device-handlers/pull/664 was merged, we now have additional ``zha_event``s.
This PR now makes use of them as device automation triggers.

This fixes https://github.com/home-assistant/core/issues/44170 as the ``on_hold`` event is now "exposed" in the Home Assistant GUI (as well as all other Philips emulated multi-click features).

The Hue Smart Buttons works by switching between sending the ``on`` and ``off_with_effect`` (this is because the button is meant to be a bound directly to a light. Here, pressing it once would toggle the light each time the button is pressed).
However, the PhilipsBasicCluster and PhilipsRemoteCluster (which were added to the Smart Button in https://github.com/zigpy/zha-device-handlers/pull/664 as well) are/were only meant for the 4 button Philips Dimmers which have separated off and on buttons.
As keeping the ``on`` and ``off_with_effect`` would cause confusion and break the emulated multi-clicking implementation, the ``off_with_effect`` has been removed. ``(SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON}`` is replaced by ``(SHORT_PRESS, TURN_ON): {COMMAND: "on_press"}``.
In most cases this will not break any automations, as (basically nobody uses the Smart Button atm and) the most used automation in Home Assistant (simply telling if the button was pressed) has two triggers: ``on`` and ``off``. Since ``off`` will be removed and ``on`` also called when the button is pressed a "second time", these automations will still work fine.
Only if a user is actually relying on having two distinct automations which are called in an alternative fashion, the user will need to create an input_boolean in Hass and switch with each click.

All in all, I think it makes more sense to implement it like this:
- because of https://github.com/zigpy/zha-device-handlers/pull/664 being merged and having a consistent implementation with the Hue Dimmer remotes creates a better user experience (in Hass GUI)
- and because a user expects a stateless button to not alternative between on and off


These changes have been tested and my automations also didn't break because of the reasons mentioned above (alternation of on/off as two triggers for the same automation is now only on)