### PR TITLE
Add 5th version of Opple 6 button remote

### DIFF
--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -1103,3 +1103,94 @@ class RemoteB686OPCN01V4(XiaomiCustomDevice):
     }
 
     device_automation_triggers = RemoteB686OPCN01.device_automation_triggers
+
+
+class RemoteB686OPCN01V5(XiaomiCustomDevice):
+    """Aqara Opple 6 button remote device."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
+        # device_version=1
+        # input_clusters=[0, 3, 1]
+        # output_clusters=[3, 6, 8, 768]>
+        MODELS_INFO: [(LUMI, "lumi.remote.b686opcn01")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    PowerConfigurationCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                ],
+            },
+            2: {},
+            3: {},
+            4: {},
+            5: {},
+            6: {},
+        },
+    }
+
+    replacement = {
+        NODE_DESCRIPTOR: NodeDescriptor(
+            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
+        ),
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                    PowerConfigurationCluster,
+                    OppleCluster,
+                    MultistateInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [Identify.cluster_id],
+                OUTPUT_CLUSTERS: [OnOff.cluster_id, Identify.cluster_id],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
+                OUTPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
+                OUTPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+            5: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
+                OUTPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+            6: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
+                OUTPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+        },
+    }
+
+    device_automation_triggers = RemoteB686OPCN01.device_automation_triggers


### PR DESCRIPTION
Found an other signature for Opple 6 buttons

```
lumi.remote.b686opcn01
par LUMI
Zigbee info
IEEE: 04:cf:8c:df:3c:79:21:33
Nwk: 0x4e17
Device Type: EndDevice
LQI: 108
RSSI: Inconnu
Dernière vue: 2021-01-02T00:12:34
Source d'énergie: Mains
```

```
{
  "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=132, manufacturer_code=4447, maximum_buffer_size=127, maximum_incoming_transfer_size=100, server_mask=11264, maximum_outgoing_transfer_size=100, descriptor_capability_field=0)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": "0x0105",
      "in_clusters": [
        "0x0000",
        "0x0001",
        "0x0003"
      ],
      "out_clusters": [
        "0x0003",
        "0x0006",
        "0x0008",
        "0x0300"
      ]
    },
    "2": {
      "profile_id": null,
      "device_type": "",
      "in_clusters": [],
      "out_clusters": []
    },
    "3": {
      "profile_id": null,
      "device_type": "",
      "in_clusters": [],
      "out_clusters": []
    },
    "4": {
      "profile_id": null,
      "device_type": "",
      "in_clusters": [],
      "out_clusters": []
    },
    "5": {
      "profile_id": null,
      "device_type": "",
      "in_clusters": [],
      "out_clusters": []
    },
    "6": {
      "profile_id": null,
      "device_type": "",
      "in_clusters": [],
      "out_clusters": []
    }
  },
  "manufacturer": "LUMI",
  "model": "lumi.remote.b686opcn01",
  "class": "zigpy.device.Device"
}
```