### PR TITLE
Support new version of Aqara Opple 4 button remote

### DIFF
--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -779,6 +779,87 @@ class RemoteB486OPCN01V2(XiaomiCustomDevice):
     device_automation_triggers = RemoteB486OPCN01.device_automation_triggers
 
 
+class RemoteB486OPCN01V3(XiaomiCustomDevice):
+    """Aqara Opple 4 button remote device."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
+        # device_version=1
+        # input_clusters=[0, 3, 1]
+        # output_clusters=[3, 6, 8, 768]>
+        MODELS_INFO: [(LUMI, "lumi.remote.b486opcn01")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    PowerConfigurationCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                ],
+            },
+            2: {},
+            3: {},
+            4: {},
+            5: {},
+            6: {},
+        },
+    }
+
+    replacement = {
+        NODE_DESCRIPTOR: NodeDescriptor(
+            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
+        ),
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                    PowerConfigurationCluster,
+                    OppleCluster,
+                    MultistateInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [MultistateInputCluster],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [MultistateInputCluster],
+                OUTPUT_CLUSTERS: [],
+            },
+            5: {},
+            6: {},
+        },
+    }
+
+    device_automation_triggers = RemoteB486OPCN01.device_automation_triggers
+
+
 class RemoteB686OPCN01V2(XiaomiCustomDevice):
     """Aqara Opple 6 button remote device."""
 


### PR DESCRIPTION
Add support for a new variant of the Aqara Opple 4 button remote:

```
lumi.remote.b486opcn01
von LUMI
Zigbee info
IEEE: 04:cf:8c:df:3c:75:c3:70
Nwk: 0x19cd
Device Type: EndDevice
LQI: 255
RSSI: -25
Zuletzt gesehen: 2021-01-03T22:24:58
Energiequelle: Mains
```

Signature:

```
{
  "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=132, manufacturer_code=4447, maximum_buffer_size=127, maximum_incoming_transfer_size=100, server_mask=11264, maximum_outgoing_transfer_size=100, descriptor_capability_field=0)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": "0x0105",
      "in_clusters": [
        "0x0000",
        "0x0001",
        "0x0003"
      ],
      "out_clusters": [
        "0x0003",
        "0x0006",
        "0x0008",
        "0x0300"
      ]
    },
    "2": {
      "profile_id": null,
      "device_type": "",
      "in_clusters": [],
      "out_clusters": []
    },
    "3": {
      "profile_id": null,
      "device_type": "",
      "in_clusters": [],
      "out_clusters": []
    },
    "4": {
      "profile_id": null,
      "device_type": "",
      "in_clusters": [],
      "out_clusters": []
    },
    "5": {
      "profile_id": null,
      "device_type": "",
      "in_clusters": [],
      "out_clusters": []
    },
    "6": {
      "profile_id": null,
      "device_type": "",
      "in_clusters": [],
      "out_clusters": []
    }
  },
  "manufacturer": "LUMI",
  "model": "lumi.remote.b486opcn01",
  "class":  "zigpy.device.Device"
}