### PR TITLE
Add support for zhongxing (knock-off orvibo) motion sensor

### DIFF
--- a/zhaquirks/zhongxing/__init__.py
+++ b/zhaquirks/zhongxing/__init__.py
@@ -1,0 +1,17 @@
+"""Module for ZHONGXING (knockoff Orvibo) quirks implementations."""
+
+from .. import LocalDataCluster, MotionWithReset, OccupancyOnEvent
+
+ZHONGXING = "中性"
+ZHONGXING_LATIN = "ZHONGXING"
+
+
+class OccupancyCluster(LocalDataCluster, OccupancyOnEvent):
+    """Occupancy cluster."""
+
+
+class MotionCluster(MotionWithReset):
+    """Motion cluster."""
+
+    reset_s: int = 30
+    send_occupancy_event: bool = True

--- a/zhaquirks/zhongxing/motion.py
+++ b/zhaquirks/zhongxing/motion.py
@@ -1,0 +1,78 @@
+"""Knockoff ORVIBO motion sensors.
+Aka. ZHONGXING
+
+Based on Orvibo motion sensor code.
+"""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    PowerConfiguration,
+    Scenes,
+)
+from zigpy.zcl.clusters.security import IasZone
+
+from . import ZHONGXING, ZHONGXING_LATIN, MotionCluster, OccupancyCluster
+from .. import Bus, PowerConfigurationCluster
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+class SN10ZW(CustomDevice):
+    """SN10ZW motion sensor."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.occupancy_bus = Bus()
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
+        #  device_version=1
+        #  input_clusters=[0, 1, 3, 1280]
+        #  output_clusters=[3]>
+        MODELS_INFO: [(ZHONGXING, "700ae5aab3414ec09c1872efe7b8755a")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfigurationCluster,
+                    Identify.cluster_id,
+                    MotionCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                ],
+            }
+        }
+    }

--- a/zhaquirks/zhongxing/motion.py
+++ b/zhaquirks/zhongxing/motion.py
@@ -23,6 +23,7 @@ from ..const import (
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    SKIP_CONFIGURATION,
 )
 
 

--- a/zhaquirks/zhongxing/motion.py
+++ b/zhaquirks/zhongxing/motion.py
@@ -76,5 +76,5 @@ class SN10ZW(CustomDevice):
                     Scenes.cluster_id,
                 ],
             }
-        }
+        },
     }

--- a/zhaquirks/zhongxing/motion.py
+++ b/zhaquirks/zhongxing/motion.py
@@ -58,6 +58,7 @@ class SN10ZW(CustomDevice):
     }
 
     replacement = {
+        SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
                 INPUT_CLUSTERS: [

--- a/zhaquirks/zhongxing/motion.py
+++ b/zhaquirks/zhongxing/motion.py
@@ -1,7 +1,6 @@
 """Knockoff ORVIBO motion sensors.
-Aka. ZHONGXING
 
-Based on Orvibo motion sensor code.
+Aka. ZHONGXING. Based on Orvibo motion sensor code.
 """
 
 from zigpy.profiles import zha

--- a/zhaquirks/zhongxing/motion.py
+++ b/zhaquirks/zhongxing/motion.py
@@ -76,5 +76,5 @@ class SN10ZW(CustomDevice):
                     Scenes.cluster_id,
                 ],
             }
-        },
+        }
     }

--- a/zhaquirks/zhongxing/motion.py
+++ b/zhaquirks/zhongxing/motion.py
@@ -23,7 +23,6 @@ from ..const import (
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    SKIP_CONFIGURATION,
 )
 
 
@@ -59,7 +58,6 @@ class SN10ZW(CustomDevice):
     }
 
     replacement = {
-        SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
                 INPUT_CLUSTERS: [

--- a/zhaquirks/zhongxing/motion.py
+++ b/zhaquirks/zhongxing/motion.py
@@ -36,7 +36,7 @@ class SN10ZW(CustomDevice):
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        #  device_version=1
+        #  device_version=0
         #  input_clusters=[0, 1, 3, 1280]
         #  output_clusters=[3]>
         MODELS_INFO: [(ZHONGXING, "700ae5aab3414ec09c1872efe7b8755a")],

--- a/zhaquirks/zhongxing/motion.py
+++ b/zhaquirks/zhongxing/motion.py
@@ -15,7 +15,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.security import IasZone
 
-from . import ZHONGXING, ZHONGXING_LATIN, MotionCluster, OccupancyCluster
+from . import ZHONGXING, MotionCluster
 from .. import Bus, PowerConfigurationCluster
 from ..const import (
     DEVICE_TYPE,
@@ -25,6 +25,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+
 
 class SN10ZW(CustomDevice):
     """SN10ZW motion sensor."""


### PR DESCRIPTION
Hello

This quirk adds support for Zhongxing (中性, transliteration: Unisex) Motion Sensor which closely resembles the Orvibo SN10ZW. 

They are sometimes found on Taobao for about $3 a piece.

I've bought 8 of them thinking they are similar to the Orvibo SN10ZW, but realised they didn't work after receiving them. Hence I am opening this PR to add support for them.
Zigbee info:
`IEEE: 00:12:4b:00:0c:c5:b2:ee
Nwk: 0xa2ef
Device Type: EndDevice
LQI: 128
RSSI: Unknown
Last Seen: 2021-01-04T19:59:57
Power Source: Battery or Unknown
Quirk: zhaquirks.zhongxing.motion.SN10ZW`

Device signature:
`{
  "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=0, maximum_buffer_size=80, maximum_incoming_transfer_size=160, server_mask=0, maximum_outgoing_transfer_size=160, descriptor_capability_field=0)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": "0x0402",
      "in_clusters": [
        "0x0000",
        "0x0001",
        "0x0003",
        "0x0500"
      ],
      "out_clusters": [
        "0x0000",
        "0x0001",
        "0x0003",
        "0x0004",
        "0x0005"
      ]
    }
  },
  "manufacturer": "中性",
  "model": "700ae5aab3414ec09c1872efe7b8755a",
  "class": "zhaquirks.zhongxing.motion.SN10ZW"
}`

Tested with my Home Assistant Instance:
![image](https://user-images.githubusercontent.com/12470297/103518686-54ea5080-4ec8-11eb-9c00-c9662a1a1822.png)
