### PR TITLE
Fix button n°2 for Xiamo Aqara Opple remote 6

### DIFF
--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -1072,7 +1072,7 @@ class RemoteB686OPCN01V4(XiaomiCustomDevice):
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],
+                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
                 OUTPUT_CLUSTERS: [OnOff.cluster_id, Identify.cluster_id],
             },
             3: {


### PR DESCRIPTION
Fix detection of button n°2 for Xiamo Aqara Opple Remote 6 V4.
This can also apply to other version but I don't have the device to check if it's working.