### PR TITLE
Add alternative manufacturer for Aqara illumination sensor

### DIFF
--- a/zhaquirks/xiaomi/aqara/illumination.py
+++ b/zhaquirks/xiaomi/aqara/illumination.py
@@ -29,7 +29,7 @@ class Illumination(XiaomiCustomDevice):
         # device_version=1
         # input_clusters=[0, 1024, 3, 1]
         # output_clusters=[3]>
-        MODELS_INFO: [(LUMI, "lumi.sen_ill.mgl01")],
+        MODELS_INFO: [(LUMI, "lumi.sen_ill.mgl01"), ("XIAOMI", "lumi.sen_ill.mgl01")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
Apparently new Aqara Illumination sensors are using `"Xiaomi"` as manufacturer name. Add it to signature.
Fixes #703 
```
{
	"node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=132, manufacturer_code=4718, maximum_buffer_size=127, maximum_incoming_transfer_size=100, server_mask=11264, maximum_outgoing_transfer_size=100, descriptor_capability_field=0)",
	"endpoints": {
		"1": {
			"profile_id": 260,
			"device_type": "0x0106",
			"in_clusters": [
				"0x0000",
				"0x0001",
				"0x0003",
				"0x0400"
			],
			"out_clusters": [
				"0x0003"
			]
		}
	},
	"manufacturer": "XIAOMI",
	"model": "lumi.sen_ill.mgl01",
	"class": "zigpy.device.Device"
}
```
