### PR TITLE
Decoupled mode for xiaomi.aqara.CtrlNeutral

### DIFF
--- a/zhaquirks/xiaomi/aqara/ctrl_neutral.py
+++ b/zhaquirks/xiaomi/aqara/ctrl_neutral.py
@@ -25,8 +25,8 @@ from .. import (
     XiaomiPowerConfiguration,
 )
 from ...const import (
-    DEVICE_TYPE,
     COMMAND_CLICK,
+    DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
@@ -58,16 +58,14 @@ _LOGGER = logging.getLogger(__name__)
 class CtrlNeutral(XiaomiCustomDevice):
     """Aqara single and double key switch device."""
 
-
     class BasicClusterDecoupled(BasicCluster):
         """Adds attributes for decoupled mode"""
         def __init__(self, *args, **kwargs):
             """Init."""
             self.attributes = BasicCluster.attributes.copy()
-            self.attributes.update({ 0xFF22: ("decoupled_mode_left", t.uint8_t)})
-            self.attributes.update({ 0xFF23: ("decoupled_mode_right", t.uint8_t)})
+            self.attributes.update({0xFF22: ("decoupled_mode_left", t.uint8_t)})
+            self.attributes.update({0xFF23: ("decoupled_mode_right", t.uint8_t)})
             super().__init__(*args, **kwargs)
-
 
     class CustomOnOffCluster(OnOffCluster):
         """Fire ZHA events for on off cluster."""
@@ -89,7 +87,6 @@ class CtrlNeutral(XiaomiCustomDevice):
                 }
                 self.listener_event(ZHA_SEND_EVENT, COMMAND_CLICK, event_args)
             super()._update_attribute(attrid, self._current_state)
-
 
     signature = {
         MODELS_INFO: [

--- a/zhaquirks/xiaomi/aqara/ctrl_neutral.py
+++ b/zhaquirks/xiaomi/aqara/ctrl_neutral.py
@@ -26,20 +26,13 @@ from .. import (
 )
 from ... import EventableCluster
 from ...const import (
-    COMMAND_CLICK,
     DEVICE_TYPE,
-    DOUBLE_PRESS,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
-    PRESS_TYPE,
     PROFILE_ID,
-    SHORT_PRESS,
-    SHORT_RELEASE,
     SKIP_CONFIGURATION,
-    VALUE,
-    ZHA_SEND_EVENT,
 )
 
 DOUBLE = "double"
@@ -75,59 +68,6 @@ class CtrlNeutral(XiaomiCustomDevice):
 
     class WallSwitchOnOffCluster(OnOff, EventableCluster):
         """WallSwitchOnOffCluster: fire events corresponding to press type."""
-
-        press_type = {
-            0x00: SHORT_PRESS,
-            0x01: SHORT_RELEASE,
-            0x02: DOUBLE_PRESS,
-        }
-        name = "WallSwitch_cluster"
-        ep_attribute = "WallSwitch_cluster"
-
-        def __init__(self, *args, **kwargs):
-            """Init."""
-            self.last_tsn = -1
-            super().__init__(*args, **kwargs)
-
-        manufacturer_server_commands = {
-            0xFD: ("press_type", (t.uint8_t,), False),
-        }
-
-        def handle_cluster_request(self, tsn, command_id, args):
-            """Handle press_types command."""
-            if tsn == self.last_tsn:
-                _LOGGER.debug("WallSwitch: ignoring duplicate frame")
-                return
-
-            self.last_tsn = tsn
-            _LOGGER.error("handle_cluster_request: %s, %s", command_id, args)
-            super().handle_cluster_request(tsn, command_id, args)
-            if command_id == 0xFD:
-                press_type = args[0]
-                self.listener_event(
-                    ZHA_SEND_EVENT, self.press_type.get(press_type, "unknown"), []
-                )
-
-    class CustomOnOffCluster(OnOffCluster):
-        """Fire ZHA events for on off cluster."""
-
-        cluster_id = OnOff.cluster_id
-
-        def __init__(self, *args, **kwargs):
-            """Init."""
-            self._current_state = {}
-            super().__init__(*args, **kwargs)
-
-        def _update_attribute(self, attrid, value):
-            _LOGGER.info("%s: %s", attrid, value)
-            if attrid == 0:
-                self._current_state = PRESS_TYPES.get(value)
-                event_args = {
-                    PRESS_TYPE: self._current_state,
-                    VALUE: value,
-                }
-                self.listener_event(ZHA_SEND_EVENT, COMMAND_CLICK, event_args)
-            super()._update_attribute(attrid, self._current_state)
 
     signature = {
         MODELS_INFO: [

--- a/zhaquirks/xiaomi/aqara/ctrl_neutral.py
+++ b/zhaquirks/xiaomi/aqara/ctrl_neutral.py
@@ -64,8 +64,8 @@ class CtrlNeutral(XiaomiCustomDevice):
         def __init__(self, *args, **kwargs):
             """Init."""
             self.attributes = BasicCluster.attributes.copy()
-            self.attributes.update({ 0xFF22: ("left_decoupled_mode", t.uint8_t)})
-            self.attributes.update({ 0xFF23: ("right_decoupled_mode", t.uint8_t)})
+            self.attributes.update({ 0xFF22: ("decoupled_mode_left", t.uint8_t)})
+            self.attributes.update({ 0xFF23: ("decoupled_mode_right", t.uint8_t)})
             super().__init__(*args, **kwargs)
 
 

--- a/zhaquirks/xiaomi/aqara/ctrl_neutral.py
+++ b/zhaquirks/xiaomi/aqara/ctrl_neutral.py
@@ -26,15 +26,28 @@ from .. import (
 )
 from ... import EventableCluster
 from ...const import (
+    ARGS,
+    ATTRIBUTE_ID,
+    ATTRIBUTE_NAME,
+    BUTTON,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_ATTRIBUTE_UPDATED,
+    COMMAND_DOUBLE,
+    COMMAND_HOLD,
+    COMMAND_RELEASE,
     DEVICE_TYPE,
+    ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+    VALUE,
 )
 
+ATTRIBUTE_ON_OFF = "on_off"
 DOUBLE = "double"
 HOLD = "long press"
 PRESS_TYPES = {0: "long press", 1: "single", 2: "double"}
@@ -66,8 +79,10 @@ class CtrlNeutral(XiaomiCustomDevice):
             0xFF23: ("decoupled_mode_right", t.uint8_t),
         }
 
-    class WallSwitchOnOffCluster(OnOff, EventableCluster):
+
+    class WallSwitchOnOffCluster(EventableCluster, OnOff):
         """WallSwitchOnOffCluster: fire events corresponding to press type."""
+
 
     signature = {
         MODELS_INFO: [
@@ -210,13 +225,26 @@ class CtrlNeutral(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
-            5: {
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
-                INPUT_CLUSTERS: [
-                    MultistateInput.cluster_id,
-                    WallSwitchOnOffCluster,
-                ],
-                OUTPUT_CLUSTERS: [],
-            },
+        },
+    }
+
+    device_automation_triggers = {
+        (COMMAND_HOLD, BUTTON): {
+            ENDPOINT_ID: 4,
+            CLUSTER_ID: 6,
+            COMMAND: COMMAND_ATTRIBUTE_UPDATED, 
+            ARGS: {ATTRIBUTE_ID: 0, ATTRIBUTE_NAME: ATTRIBUTE_ON_OFF, VALUE: 0},
+        },
+        (COMMAND_RELEASE, BUTTON): {
+            ENDPOINT_ID: 4,
+            CLUSTER_ID: 6,
+            COMMAND: COMMAND_ATTRIBUTE_UPDATED, 
+            ARGS: {ATTRIBUTE_ID: 0, ATTRIBUTE_NAME: ATTRIBUTE_ON_OFF, VALUE: 1},
+        },
+        (COMMAND_DOUBLE, BUTTON): {
+            ENDPOINT_ID: 4,
+            CLUSTER_ID: 6,
+            COMMAND: COMMAND_ATTRIBUTE_UPDATED, 
+            ARGS: {ATTRIBUTE_ID: 0, ATTRIBUTE_NAME: ATTRIBUTE_ON_OFF, VALUE: 2},
         },
     }

--- a/zhaquirks/xiaomi/aqara/ctrl_neutral.py
+++ b/zhaquirks/xiaomi/aqara/ctrl_neutral.py
@@ -79,10 +79,8 @@ class CtrlNeutral(XiaomiCustomDevice):
             0xFF23: ("decoupled_mode_right", t.uint8_t),
         }
 
-
     class WallSwitchOnOffCluster(EventableCluster, OnOff):
         """WallSwitchOnOffCluster: fire events corresponding to press type."""
-
 
     signature = {
         MODELS_INFO: [
@@ -232,19 +230,19 @@ class CtrlNeutral(XiaomiCustomDevice):
         (COMMAND_HOLD, BUTTON): {
             ENDPOINT_ID: 4,
             CLUSTER_ID: 6,
-            COMMAND: COMMAND_ATTRIBUTE_UPDATED, 
+            COMMAND: COMMAND_ATTRIBUTE_UPDATED,
             ARGS: {ATTRIBUTE_ID: 0, ATTRIBUTE_NAME: ATTRIBUTE_ON_OFF, VALUE: 0},
         },
         (COMMAND_RELEASE, BUTTON): {
             ENDPOINT_ID: 4,
             CLUSTER_ID: 6,
-            COMMAND: COMMAND_ATTRIBUTE_UPDATED, 
+            COMMAND: COMMAND_ATTRIBUTE_UPDATED,
             ARGS: {ATTRIBUTE_ID: 0, ATTRIBUTE_NAME: ATTRIBUTE_ON_OFF, VALUE: 1},
         },
         (COMMAND_DOUBLE, BUTTON): {
             ENDPOINT_ID: 4,
             CLUSTER_ID: 6,
-            COMMAND: COMMAND_ATTRIBUTE_UPDATED, 
+            COMMAND: COMMAND_ATTRIBUTE_UPDATED,
             ARGS: {ATTRIBUTE_ID: 0, ATTRIBUTE_NAME: ATTRIBUTE_ON_OFF, VALUE: 2},
         },
     }

--- a/zhaquirks/xiaomi/aqara/ctrl_neutral.py
+++ b/zhaquirks/xiaomi/aqara/ctrl_neutral.py
@@ -24,19 +24,19 @@ from .. import (
     XiaomiCustomDevice,
     XiaomiPowerConfiguration,
 )
-from ...const import (                                                         
-    DEVICE_TYPE,                                                               
-    COMMAND_CLICK,                                                             
-    ENDPOINTS,                                                                 
-    INPUT_CLUSTERS,                                                                
-    MODELS_INFO,                                                               
-    OUTPUT_CLUSTERS,                                                           
-    PRESS_TYPE,                                                                      
-    PROFILE_ID,                                                                
-    SKIP_CONFIGURATION,                                                        
-    VALUE,                                                                           
-    ZHA_SEND_EVENT,                                                            
-) 
+from ...const import (
+    DEVICE_TYPE,
+    COMMAND_CLICK,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PRESS_TYPE,
+    PROFILE_ID,
+    SKIP_CONFIGURATION,
+    VALUE,
+    ZHA_SEND_EVENT,
+)
 
 DOUBLE = "double"
 HOLD = "long press"
@@ -224,21 +224,21 @@ class CtrlNeutral(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
-            4: {                                                                   
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,                         
-                INPUT_CLUSTERS: [                                                  
-                    MultistateInput.cluster_id,                                        
-                    CustomOnOffCluster,                                        
-                ],                                                                 
-                OUTPUT_CLUSTERS: [],                                               
-            },  
-            5: {                                                                   
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,                         
-                INPUT_CLUSTERS: [                                                  
-                    MultistateInput.cluster_id,                                        
-                    CustomOnOffCluster,                                        
-                ],                                                                 
-                OUTPUT_CLUSTERS: [],                                               
-            },  
+            4: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MultistateInput.cluster_id,
+                    CustomOnOffCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            5: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MultistateInput.cluster_id,
+                    CustomOnOffCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
         },
     }


### PR DESCRIPTION
Some Aqara wall switches can work in decoupled mode, allowing the rocker to be independent from the relay.

The current implementation for these switches only exposes the relays, so for this change to be functional it is also necessary to implement the quirks of the buttons endpoints.

This PR implements the "decoupled mode" command and these quirks in `xiaomi.aqara.CtrlNeutral`.
This class supports devices: QBKG04LM/QBKG03LM/QBKG21LM/QBKG22LM.
Decoupled mode would be configurable from UI (thanks @albalaing):
![image](https://user-images.githubusercontent.com/31999997/104131764-d0d91280-5378-11eb-8f91-6a6bebee6b5f.png)

Value:
* 254 (decoupled)
* 18 (coupled)

Manufacturer code: 
* 4447 (important)


All the tests I am doing with the single rocker model (QBKG04LM). So I cannot guarantee the correct implementation for the 2 rockets models.
IMO is probably preferable to separate the implementations for 1 rocker model from the 2 rockers, but I think it will be best addressed in a second iteration when we have test data.


Some things to check:
- [ ] do not generate the HA entity
- [x] `double_click` event handling (related #719)
- [x] events format, more homogeneous with the rest of the events
- [x] implement `device_automation_triggers` (must have)
- [ ] check class nomenclature
- [ ] implement tests?

resolves #713 
