### PR TITLE
Add Philips LST004 to ZLLExtendedColorLight quirk

### DIFF
--- a/zhaquirks/philips/zllextendedcolorlight.py
+++ b/zhaquirks/philips/zllextendedcolorlight.py
@@ -50,6 +50,7 @@ class ZLLExtendedColorLight(CustomDevice):
             (PHILIPS, "LLC020"),
             (PHILIPS, "LCF002"),
             (PHILIPS, "LCS001"),
+            (PHILIPS, "LST004"),
         ],
         ENDPOINTS: {
             11: {


### PR DESCRIPTION
Hi,

This PR add support for philips LST004 Outdoor LightStrip

I added this to ZLLExtendedColorLight as it has the same clusters and replacements.
Correct me if i'm wrong, but i think PhilipsLST002 in lst.py should be removed and added to this quirk too, as it has the same clusters and replacements too.

Here is the original device informations  : 
 {
  "node_descriptor": "NodeDescriptor(byte1=1, byte2=64, mac_capability_flags=142, manufacturer_code=4107, maximum_buffer_size=71, maximum_incoming_transfer_size=45, server_mask=0, maximum_outgoing_transfer_size=45, descriptor_capability_field=0)",
  "endpoints": {
    "11": {
      "profile_id": 49246,
      "device_type": "0x0210",
      "in_clusters": [
        "0x0000",
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006",
        "0x0008",
        "0x0300",
        "0x1000",
        "0xfc01"
      ],
      "out_clusters": [
        "0x0019"
      ]
    },
    "242": {
      "profile_id": 41440,
      "device_type": "0x0061",
      "in_clusters": [
        "0x0021"
      ],
      "out_clusters": [
        "0x0021"
      ]
    }
  },
  "manufacturer": "Philips",
  "model": "LST004",
  "class": "zigpy.device.Device"
}