### PR TITLE
Add "Signify Netherlands B.V." as a manufacturer for ZHA Philips lights

### DIFF
--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -32,6 +32,7 @@ from ..const import (
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 PHILIPS = "Philips"
+SIGNIFY = "Signify Netherlands B.V."
 _LOGGER = logging.getLogger(__name__)
 
 HUE_REMOTE_DEVICE_TRIGGERS = {

--- a/zhaquirks/philips/zhadimmablelight.py
+++ b/zhaquirks/philips/zhadimmablelight.py
@@ -21,14 +21,19 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.philips import PHILIPS, PhilipsLevelControlCluster, PhilipsOnOffCluster
+from zhaquirks.philips import (
+    PHILIPS,
+    PhilipsLevelControlCluster,
+    PhilipsOnOffCluster,
+    SIGNIFY,
+)
 
 
 class ZHADimmableLight(CustomDevice):
     """Philips ZigBee HomeAutomation dimmable bulb device."""
 
     signature = {
-        MODELS_INFO: [(PHILIPS, "LWV001")],
+        MODELS_INFO: [(PHILIPS, "LWV001"), (SIGNIFY, "LWV001")],
         ENDPOINTS: {
             11: {
                 # <SimpleDescriptor endpoint=11 profile=260 device_type=528

--- a/zhaquirks/philips/zhadimmablelight.py
+++ b/zhaquirks/philips/zhadimmablelight.py
@@ -23,9 +23,9 @@ from zhaquirks.const import (
 )
 from zhaquirks.philips import (
     PHILIPS,
+    SIGNIFY,
     PhilipsLevelControlCluster,
     PhilipsOnOffCluster,
-    SIGNIFY,
 )
 
 

--- a/zhaquirks/philips/zhaextendedcolorlight.py
+++ b/zhaquirks/philips/zhaextendedcolorlight.py
@@ -27,6 +27,7 @@ from zhaquirks.philips import (
     PhilipsColorCluster,
     PhilipsLevelControlCluster,
     PhilipsOnOffCluster,
+    SIGNIFY,
 )
 
 
@@ -40,6 +41,11 @@ class ZHAExtendedColorLight(CustomDevice):
             (PHILIPS, "LCB001"),
             (PHILIPS, "LCE002"),
             (PHILIPS, "LCG002"),
+            (SIGNIFY, "LCA001"),
+            (SIGNIFY, "LCA003"),
+            (SIGNIFY, "LCB001"),
+            (SIGNIFY, "LCE002"),
+            (SIGNIFY, "LCG002"),
         ],
         ENDPOINTS: {
             11: {
@@ -116,6 +122,12 @@ class ZHAExtendedColorLight2(CustomDevice):
             (PHILIPS, "4090330P9_02"),
             (PHILIPS, "929002376001"),
             (PHILIPS, "929002375901"),
+            (SIGNIFY, "LCL001"),
+            (SIGNIFY, "LCT026"),
+            (SIGNIFY, "4090330P9_01"),
+            (SIGNIFY, "4090330P9_02"),
+            (SIGNIFY, "929002376001"),
+            (SIGNIFY, "929002375901"),
         ],
         ENDPOINTS: {
             11: {

--- a/zhaquirks/philips/zhaextendedcolorlight.py
+++ b/zhaquirks/philips/zhaextendedcolorlight.py
@@ -24,10 +24,10 @@ from zhaquirks.const import (
 )
 from zhaquirks.philips import (
     PHILIPS,
+    SIGNIFY,
     PhilipsColorCluster,
     PhilipsLevelControlCluster,
     PhilipsOnOffCluster,
-    SIGNIFY,
 )
 
 


### PR DESCRIPTION
The 1.7x.xx firmware that is being rolled out for Bluetooth capable lights (so Philips lights with the ZHA profile instead of the ZLL profile) changed the manufacturer name from "Philips" to "Signify Netherlands B.V.".

Tested and working using a "Lightstrip Plus" "LCL001".
Signature (with quirk applied due to these changes):
```
{
  "node_descriptor": "NodeDescriptor(byte1=1, byte2=64, mac_capability_flags=142, manufacturer_code=4107, maximum_buffer_size=82, maximum_incoming_transfer_size=128, server_mask=11264, maximum_outgoing_transfer_size=128, descriptor_capability_field=0)",
  "endpoints": {
    "11": {
      "profile_id": 260,
      "device_type": "0x010d",
      "in_clusters": [
        "0x0000",
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006",
        "0x0008",
        "0x0300",
        "0x1000",
        "0xfc01"
      ],
      "out_clusters": [
        "0x0019"
      ]
    },
    "242": {
      "profile_id": 41440,
      "device_type": "0x0061",
      "in_clusters": [],
      "out_clusters": [
        "0x0021"
      ]
    }
  },
  "manufacturer": "Signify Netherlands B.V.",
  "model": "LCL001",
  "class": "zhaquirks.philips.zhaextendedcolorlight.ZHAExtendedColorLight2"
}
```

Edit: https://github.com/zigpy/zha-device-handlers/pull/687 was rebased on the branch of this PR.
https://github.com/zigpy/zha-device-handlers/pull/687 should only be merged after this PR is merged.