### PR TITLE
Use a "wildcard" Manufacturer for Tuya TS0042 and TS0043 quirks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(
     keywords="zha quirks homeassistant hass",
     packages=find_packages(exclude=["tests"]),
     python_requires=">=3",
-    install_requires=["zigpy>=0.28.2"],
+    install_requires=["zigpy>=0.31.0"],
     tests_require=["pytest"],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
+    MANUFACTURER,
+    MODEL,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
@@ -74,11 +76,17 @@ def zigpy_device_mock(MockAppController, ieee_mock):
 def zigpy_device_from_quirk(MockAppController, ieee_mock):
     """Create zigpy device from Quirk's signature."""
 
-    def _dev(quirk, ieee=None, nwk=zigpy.types.NWK(0x1234)):
+    def _dev(quirk, ieee=None, nwk=zigpy.types.NWK(0x1234), apply_quirk=True):
         if ieee is None:
             ieee = ieee_mock
         models_info = quirk.signature.get(
-            MODELS_INFO, (("Mock Manufacturer", "Mock Model"),)
+            MODELS_INFO,
+            (
+                (
+                    quirk.signature.get(MANUFACTURER, "Mock Manufacturer"),
+                    quirk.signature.get(MODEL, "Mock Model"),
+                ),
+            ),
         )
         manufacturer, model = models_info[0]
 
@@ -97,6 +105,10 @@ def zigpy_device_from_quirk(MockAppController, ieee_mock):
             out_clusters = ep_data.get(OUTPUT_CLUSTERS, [])
             for cluster_id in out_clusters:
                 ep.add_output_cluster(cluster_id)
+
+        if not apply_quirk:
+            return raw_device
+
         device = quirk(MockAppController, ieee, nwk, raw_device)
         MockAppController.devices[ieee] = device
 

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -25,6 +25,7 @@ import zhaquirks.tuya.electric_heating
 import zhaquirks.tuya.motion
 import zhaquirks.tuya.siren
 import zhaquirks.tuya.ts0042
+import zhaquirks.tuya.ts0043
 import zhaquirks.tuya.valve
 
 from tests.common import ClusterListener
@@ -540,6 +541,11 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
         (zhaquirks.tuya.ts0042.BenexmartRemote0042, "_TZ3000_adkvzooy"),
         (zhaquirks.tuya.ts0042.BenexmartRemote0042, "_TZ3400_keyjhapk"),
         (zhaquirks.tuya.ts0042.BenexmartRemote0042, "another random manufacturer"),
+        (zhaquirks.tuya.ts0043.TuyaSmartRemote0043, "_TZ3000_bi6lpsew"),
+        (zhaquirks.tuya.ts0043.TuyaSmartRemote0043, "_TZ3000_a7ouggvs"),
+        (zhaquirks.tuya.ts0043.TuyaSmartRemote0043, "another random manufacturer"),
+        (zhaquirks.tuya.ts0043.BenexmartRemote0043, "_TZ3000_qzjcsmar"),
+        (zhaquirks.tuya.ts0043.BenexmartRemote0043, "another random manufacturer"),
     ),
 )
 async def test_tuya_wildcard_manufacturer(zigpy_device_from_quirk, quirk, manufacturer):

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
+from zigpy.quirks import CustomDevice, get_device
 import zigpy.types as t
 from zigpy.zcl import foundation
 
@@ -24,6 +24,7 @@ from zhaquirks.tuya import Data, TuyaManufClusterAttributes
 import zhaquirks.tuya.electric_heating
 import zhaquirks.tuya.motion
 import zhaquirks.tuya.siren
+import zhaquirks.tuya.ts0042
 import zhaquirks.tuya.valve
 
 from tests.common import ClusterListener
@@ -528,3 +529,24 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
 
         status = await thermostat_cluster.command(0x0002)
         assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
+
+
+@pytest.mark.parametrize(
+    "quirk, manufacturer",
+    (
+        (zhaquirks.tuya.ts0042.TuyaSmartRemote0042, "_TZ3000_owgcnkrh"),
+        (zhaquirks.tuya.ts0042.TuyaSmartRemote0042, "_TZ3400_keyjhapk"),
+        (zhaquirks.tuya.ts0042.TuyaSmartRemote0042, "_some_random_manuf"),
+        (zhaquirks.tuya.ts0042.BenexmartRemote0042, "_TZ3000_adkvzooy"),
+        (zhaquirks.tuya.ts0042.BenexmartRemote0042, "_TZ3400_keyjhapk"),
+        (zhaquirks.tuya.ts0042.BenexmartRemote0042, "another random manufacturer"),
+    ),
+)
+async def test_tuya_wildcard_manufacturer(zigpy_device_from_quirk, quirk, manufacturer):
+    """Test thermostatic valve outgoing commands."""
+
+    zigpy_dev = zigpy_device_from_quirk(quirk, apply_quirk=False)
+    zigpy_dev.manufacturer = manufacturer
+
+    quirked_dev = get_device(zigpy_dev)
+    assert isinstance(quirked_dev, quirk)

--- a/zhaquirks/tuya/ts0042.py
+++ b/zhaquirks/tuya/ts0042.py
@@ -15,7 +15,7 @@ from ..const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     LONG_PRESS,
-    MODELS_INFO,
+    MODEL,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SHORT_PRESS,
@@ -28,7 +28,7 @@ class TuyaSmartRemote0042(CustomDevice):
     signature = {
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0, device_version=1, input_clusters=[0, 10, 1, 6], output_clusters=[25]))
         # SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
-        MODELS_INFO: [("_TZ3000_owgcnkrh", "TS0042")],
+        MODEL: "TS0042",
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -93,10 +93,7 @@ class BenexmartRemote0042(CustomDevice):
     signature = {
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0, device_version=1, input_clusters=[0, 1, 6], output_clusters=[10, 25]))
         # SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
-        MODELS_INFO: [
-            ("_TZ3000_adkvzooy", "TS0042"),
-            ("_TZ3400_keyjhapk", "TS0042"),
-        ],
+        MODEL: "TS0042",
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/tuya/ts0043.py
+++ b/zhaquirks/tuya/ts0043.py
@@ -16,7 +16,7 @@ from ..const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     LONG_PRESS,
-    MODELS_INFO,
+    MODEL,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SHORT_PRESS,
@@ -30,7 +30,7 @@ class TuyaSmartRemote0043(CustomDevice):
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0, device_version=1, input_clusters=[0, 10, 1, 6], output_clusters=[25]))
         # SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
         # SizePrefixedSimpleDescriptor(endpoint=3, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
-        MODELS_INFO: [("_TZ3000_bi6lpsew", "TS0043"), ("_TZ3000_a7ouggvs", "TS0043")],
+        MODEL: "TS0043",
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -117,7 +117,7 @@ class BenexmartRemote0043(CustomDevice):
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0, device_version=1, input_clusters=[0, 1, 6], output_clusters=[10, 25]))
         # SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
         # SizePrefixedSimpleDescriptor(endpoint=3, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
-        MODELS_INFO: [("_TZ3000_qzjcsmar", "TS0043")],
+        MODEL: "TS0043",
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
This PR requires new `zigpy>=0.31.0` version and uses a wildcard quirk, matching only on the model and endpoint signature.
