### PR TITLE
TS004x: send default response, so avoid repeated ZCL-frame from device

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -376,11 +376,25 @@ class TuyaSmartRemoteOnOffCluster(OnOff, EventableCluster):
 
     def handle_cluster_request(self, tsn, command_id, args):
         """Handle press_types command."""
+        ## normally if default response sent, TS004x wouldn't send such repeated zclframe (with same sequence number), 
+        ## but for stability reasons (e. g. the case the response doesn't arrive the device), we can simply ignore it
         if tsn == self.last_tsn:
             _LOGGER.debug("TS004X: ignoring duplicate frame")
             return
+        self.last_tsn = tsn; # save last sequence number
 
-        self.last_tsn = tsn
+        ## send default response (as soon as possible), so avoid repeated zclframe from device
+        _LOGGER.debug("TS004X: send default response")
+        self.create_catching_task(
+            self.general_command(
+                foundation.Command.Default_Response,
+                command_id,
+                foundation.Status.SUCCESS,
+                tsn=tsn,
+            )
+        )
+        
+        ## handle command
         super().handle_cluster_request(tsn, command_id, args)
         if command_id == 0xFD:
             press_type = args[0]

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -376,12 +376,13 @@ class TuyaSmartRemoteOnOffCluster(OnOff, EventableCluster):
 
     def handle_cluster_request(self, tsn, command_id, args):
         """Handle press_types command."""
-        ## normally if default response sent, TS004x wouldn't send such repeated zclframe (with same sequence number), 
+        ## normally if default response sent, TS004x wouldn't send such repeated zclframe (with same sequence number),
         ## but for stability reasons (e. g. the case the response doesn't arrive the device), we can simply ignore it
         if tsn == self.last_tsn:
             _LOGGER.debug("TS004X: ignoring duplicate frame")
             return
-        self.last_tsn = tsn; # save last sequence number
+        # save last sequence number
+        self.last_tsn = tsn
 
         ## send default response (as soon as possible), so avoid repeated zclframe from device
         _LOGGER.debug("TS004X: send default response")
@@ -393,7 +394,7 @@ class TuyaSmartRemoteOnOffCluster(OnOff, EventableCluster):
                 tsn=tsn,
             )
         )
-        
+
         ## handle command
         super().handle_cluster_request(tsn, command_id, args)
         if command_id == 0xFD:

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -376,15 +376,15 @@ class TuyaSmartRemoteOnOffCluster(OnOff, EventableCluster):
 
     def handle_cluster_request(self, tsn, command_id, args):
         """Handle press_types command."""
-        ## normally if default response sent, TS004x wouldn't send such repeated zclframe (with same sequence number),
-        ## but for stability reasons (e. g. the case the response doesn't arrive the device), we can simply ignore it
+        # normally if default response sent, TS004x wouldn't send such repeated zclframe (with same sequence number),
+        # but for stability reasons (e. g. the case the response doesn't arrive the device), we can simply ignore it
         if tsn == self.last_tsn:
             _LOGGER.debug("TS004X: ignoring duplicate frame")
             return
         # save last sequence number
         self.last_tsn = tsn
 
-        ## send default response (as soon as possible), so avoid repeated zclframe from device
+        # send default response (as soon as possible), so avoid repeated zclframe from device
         _LOGGER.debug("TS004X: send default response")
         self.create_catching_task(
             self.general_command(
@@ -395,7 +395,7 @@ class TuyaSmartRemoteOnOffCluster(OnOff, EventableCluster):
             )
         )
 
-        ## handle command
+        # handle command
         super().handle_cluster_request(tsn, command_id, args)
         if command_id == 0xFD:
             press_type = args[0]


### PR DESCRIPTION
A device may send a repeated ZCL frame (with the same sequence number) if it does not receive a default response to the sent command.
TS004x devices doing that 1 second after first frame. 
Following code was build to discard second frame with the same number, what is rather a workaround:
https://github.com/zigpy/zha-device-handlers/blob/65e54aaa3da32dbe1d8e12de5b0ae85f85d31fc8/zhaquirks/tuya/__init__.py#L379-L383

Proposed PR provides an "ultimate" solution for this by sending of default response - so notifying device the frame was received, saves its battery (because prevents that device would send a repeated frame in 1 second again) and let device act faster by the next clicks (3 seconds before, few dozen milliseconds hereafter).
So I was seen 4 clicks (B1+B2+B3+B4) as command events in HA in fewer than 0.5 seconds, whereas previously all events need 12 seconds to arrive in HA (between first and last command event).

The discussion and some analysis about same issue in deconz can be found here - https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4227#issuecomment-764588677

Here are the logs before and after the patch has been applied:
<details><summary>log excerpt 1 (before patch) ...</summary>

```
01:16:59 [zigpy_deconz.api] Device state changed response: [<DeviceState.128|APSDE_DATA_REQUEST_SLOTS_AVAILABLE|APSDE_DATA_INDICATION|2: 170>, 0]
01:16:59 [zigpy_deconz.api] Command Command.aps_data_indication (1, 1)
01:16:59 [zigpy_deconz.api] APS data indication response: [30, <DeviceState.APSDE_DATA_REQUEST_SLOTS_AVAILABLE|2: 34>, <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x0000>, 1, <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x41ae>, 1, 260, 1, b'\x08\x14\n!\x00 \xb6', 0, 175, 71, 147, 202, 3, 0, -85]
01:16:59 [zigpy.zcl] [0x41ae:1:0x0001] ZCL deserialize: <ZCLHeader frame_control=<FrameControl frame_type=GLOBAL_COMMAND manufacturer_specific=False is_reply=False disable_default_response=False> manufacturer=None tsn=20 command_id=Command.Report_Attributes>
01:16:59 [zigpy.zcl] [0x41ae:1:0x0001] ZCL request 0x000a: [[Attribute(attrid=33, value=<TypeValue type=uint8_t, value=182>)]]
01:16:59 [zigpy.zcl] [0x41ae:1:0x0001] Attribute report received: battery_percentage_remaining=182
01:16:59 [zigpy_deconz.zigbee.application] Sending Zigbee request with tsn 20 under 1 request id, data: b'18140b0a00'
01:16:59 [zigpy_deconz.api] 'aps_data_indication' response from <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x41ae>, ep: 1, profile: 0x0104, cluster_id: 0x0001, data: b'08140a210020b6'
01:16:59 [zigpy_deconz.api] Command Command.aps_data_request (20, 1, 0, <DeconzAddressEndpoint address_mode=2 address=0x41AE endpoint=1>, 260, 1, 1, b'\x18\x14\x0b\n\x00', 2, 0)
01:16:59 [zigpy_deconz.api] APS data request response: [2, <DeviceState.APSDE_DATA_REQUEST_SLOTS_AVAILABLE|2: 34>, 1]
01:16:59 [zigpy_deconz.api] Device state changed response: [<DeviceState.128|APSDE_DATA_REQUEST_SLOTS_AVAILABLE|APSDE_DATA_CONFIRM|2: 166>, 0]
01:16:59 [zigpy_deconz.api] Command Command.aps_data_confirm (0,)
01:16:59 [zigpy_deconz.api] APS data confirm response for request with id 1: 00
01:16:59 [zigpy_deconz.api] Request id: 0x01 'aps_data_confirm' for <DeconzAddressEndpoint address_mode=ADDRESS_MODE.NWK address=0x41ae endpoint=1>, status: 0x00
01:17:00 [zigpy_deconz.api] Device state changed response: [<DeviceState.128|APSDE_DATA_REQUEST_SLOTS_AVAILABLE|APSDE_DATA_INDICATION|2: 170>, 0]
01:17:00 [zigpy_deconz.api] Command Command.aps_data_indication (1, 1)
01:17:00 [zigpy_deconz.api] APS data indication response: [27, <DeviceState.APSDE_DATA_REQUEST_SLOTS_AVAILABLE|2: 34>, <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x0000>, 1, <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x41ae>, 1, 260, 6, b'\x01\x15\xfd\x00', 0, 175, 79, 147, 202, 3, 0, -84]
01:17:00 [zigpy.zcl] [0x41ae:1:0x0006] ZCL deserialize: <ZCLHeader frame_control=<FrameControl frame_type=CLUSTER_COMMAND manufacturer_specific=False is_reply=False disable_default_response=False> manufacturer=None tsn=21 command_id=253>
01:17:00 [zigpy.zcl] [0x41ae:1:0x0006] ZCL request 0x00fd: [0]
# ---- from here it will be different ----
01:17:00 [zigpy_deconz.api] 'aps_data_indication' response from <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x41ae>, ep: 1, profile: 0x0104, cluster_id: 0x0006, data: b'0115fd00'
01:17:01 [zigpy_deconz.api] Device state changed response: [<DeviceState.128|APSDE_DATA_REQUEST_SLOTS_AVAILABLE|APSDE_DATA_INDICATION|2: 170>, 0]
01:17:01 [zigpy_deconz.api] Command Command.aps_data_indication (1, 1)
01:17:01 [zigpy_deconz.api] APS data indication response: [27, <DeviceState.APSDE_DATA_REQUEST_SLOTS_AVAILABLE|2: 34>, <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x0000>, 1, <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x41ae>, 1, 260, 6, b'\x01\x15\xfd\x00', 0, 175, 63, 147, 202, 3, 0, -86]
01:17:01 [zigpy.zcl] [0x41ae:1:0x0006] ZCL deserialize: <ZCLHeader frame_control=<FrameControl frame_type=CLUSTER_COMMAND manufacturer_specific=False is_reply=False disable_default_response=False> manufacturer=None tsn=21 command_id=253>
01:17:01 [zigpy.zcl] [0x41ae:1:0x0006] ZCL request 0x00fd: [0]
01:17:01 [zhaquirks.tuya] TS004X: ignoring duplicate frame
01:17:01 [zigpy_deconz.api] 'aps_data_indication' response from <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x41ae>, ep: 1, profile: 0x0104, cluster_id: 0x0006, data: b'0115fd00'
```
</details>

<details><summary>log excerpt 2 (after patch) ...</summary>

```
01:45:06 [zigpy_deconz.api] Device state changed response: [<DeviceState.128|APSDE_DATA_REQUEST_SLOTS_AVAILABLE|APSDE_DATA_INDICATION|2: 170>, 0]
01:45:06 [zigpy_deconz.api] Command Command.aps_data_indication (1, 1)
01:45:06 [zigpy_deconz.api] APS data indication response: [30, <DeviceState.APSDE_DATA_REQUEST_SLOTS_AVAILABLE|2: 34>, <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x0000>, 1, <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x41ae>, 1, 260, 1, b'\x08\x00\n!\x00 \xb6', 0, 175, 5, 242, 201, 3, 0, -93]
01:45:06 [zigpy.zcl] [0x41ae:1:0x0001] ZCL deserialize: <ZCLHeader frame_control=<FrameControl frame_type=GLOBAL_COMMAND manufacturer_specific=False is_reply=False disable_default_response=False> manufacturer=None tsn=0 command_id=Command.Report_Attributes>
01:45:06 [zigpy.zcl] [0x41ae:1:0x0001] ZCL request 0x000a: [[Attribute(attrid=33, value=<TypeValue type=uint8_t, value=182>)]]
01:45:06 [zigpy.zcl] [0x41ae:1:0x0001] Attribute report received: battery_percentage_remaining=182
01:45:06 [zigpy_deconz.zigbee.application] Sending Zigbee request with tsn 0 under 1 request id, data: b'18000b0a00'
01:45:06 [zigpy_deconz.api] 'aps_data_indication' response from <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x41ae>, ep: 1, profile: 0x0104, cluster_id: 0x0001, data: b'08000a210020b6'
01:45:06 [zigpy_deconz.api] Command Command.aps_data_request (20, 1, 0, <DeconzAddressEndpoint address_mode=2 address=0x41AE endpoint=1>, 260, 1, 1, b'\x18\x00\x0b\n\x00', 2, 0)
01:45:06 [zigpy_deconz.api] APS data request response: [2, <DeviceState.APSDE_DATA_REQUEST_SLOTS_AVAILABLE|2: 34>, 1]
01:45:06 [zigpy_deconz.api] Device state changed response: [<DeviceState.128|APSDE_DATA_REQUEST_SLOTS_AVAILABLE|APSDE_DATA_CONFIRM|2: 166>, 0]
01:45:06 [zigpy_deconz.api] Command Command.aps_data_confirm (0,)
01:45:06 [zigpy_deconz.api] APS data confirm response for request with id 1: 00
01:45:06 [zigpy_deconz.api] Request id: 0x01 'aps_data_confirm' for <DeconzAddressEndpoint address_mode=ADDRESS_MODE.NWK address=0x41ae endpoint=1>, status: 0x00
01:45:06 [zigpy_deconz.api] Device state changed response: [<DeviceState.128|APSDE_DATA_REQUEST_SLOTS_AVAILABLE|APSDE_DATA_INDICATION|2: 170>, 0]
01:45:06 [zigpy_deconz.api] Command Command.aps_data_indication (1, 1)
01:45:06 [zigpy_deconz.api] APS data indication response: [27, <DeviceState.APSDE_DATA_REQUEST_SLOTS_AVAILABLE|2: 34>, <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x0000>, 1, <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x41ae>, 1, 260, 6, b'\x01\x01\xfd\x00', 0, 175, 26, 242, 201, 3, 0, -89]
01:45:06 [zigpy.zcl] [0x41ae:1:0x0006] ZCL deserialize: <ZCLHeader frame_control=<FrameControl frame_type=CLUSTER_COMMAND manufacturer_specific=False is_reply=False disable_default_response=False> manufacturer=None tsn=1 command_id=253>
01:45:06 [zigpy.zcl] [0x41ae:1:0x0006] ZCL request 0x00fd: [0]
# ---- from here it will be different ----
01:45:06 [zhaquirks.tuya] TS004X: send default response
01:45:06 [zigpy_deconz.zigbee.application] Sending Zigbee request with tsn 1 under 2 request id, data: b'18010bfd00'
01:45:06 [zigpy_deconz.api] 'aps_data_indication' response from <DeconzAddress address_mode=ADDRESS_MODE.NWK address=0x41ae>, ep: 1, profile: 0x0104, cluster_id: 0x0006, data: b'0101fd00'
01:45:06 [zigpy_deconz.api] Command Command.aps_data_request (20, 2, 0, <DeconzAddressEndpoint address_mode=2 address=0x41AE endpoint=1>, 260, 6, 1, b'\x18\x01\x0b\xfd\x00', 2, 0)
01:45:06 [zigpy_deconz.api] APS data request response: [2, <DeviceState.APSDE_DATA_REQUEST_SLOTS_AVAILABLE|2: 34>, 2]
01:45:07 [zigpy_deconz.api] Device state changed response: [<DeviceState.128|APSDE_DATA_REQUEST_SLOTS_AVAILABLE|APSDE_DATA_CONFIRM|2: 166>, 0]
01:45:07 [zigpy_deconz.api] Command Command.aps_data_confirm (0,)
01:45:07 [zigpy_deconz.api] APS data confirm response for request with id 2: 00
01:45:07 [zigpy_deconz.api] Request id: 0x02 'aps_data_confirm' for <DeconzAddressEndpoint address_mode=ADDRESS_MODE.NWK address=0x41ae endpoint=1>, status: 0x00
```
</details>

There are also another similar issues about "false multiple presses", e. g. #712, so I think this can be made somewhere central as a general solution, for instance if `handle_cluster_request` would return a value (e. g. tuple `(foundation.Status.SUCCESS,)`), zigpy could send it as a default response to device.