### PR TITLE
fixes yale YRD220/240 TSDB only displaying half the battery

### DIFF
--- a/zhaquirks/yale/yrd220240.py
+++ b/zhaquirks/yale/yrd220240.py
@@ -1,6 +1,6 @@
-"""Device handler for Yale Real Living.
+"""Device handler for Yale Real Living YRD220/240 TSDB.
 
-Based on Yale Real Living YRD210 code.
+Based on Yale Real Living YRD210 PB DB code.
 """
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice

--- a/zhaquirks/yale/yrd220240.py
+++ b/zhaquirks/yale/yrd220240.py
@@ -1,0 +1,63 @@
+"""Device handler for Yale Real Living.
+
+Based on Yale Real Living YRD210 code.
+"""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.closures import DoorLock
+from zigpy.zcl.clusters.general import Alarms, Basic, Ota, PollControl, Time
+
+from .. import DoublingPowerConfigurationCluster
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class YaleRealLiving(CustomDevice):
+    """Custom device representing Yale Real Living devices."""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=10
+        #  device_version=0
+        #  input_clusters=[0, 1, 9, 10, 32, 257]
+        #  output_clusters=[10, 25]>
+        MODELS_INFO: [("Yale", "YRD220/240 TSDB")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DOOR_LOCK,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DoublingPowerConfigurationCluster.cluster_id,
+                    Alarms.cluster_id,
+                    Time.cluster_id,
+                    PollControl.cluster_id,
+                    DoorLock.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DOOR_LOCK,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DoublingPowerConfigurationCluster,
+                    Alarms.cluster_id,
+                    Time.cluster_id,
+                    PollControl.cluster_id,
+                    DoorLock.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [DoorLock.cluster_id, Ota.cluster_id],
+            }
+        }
+    }


### PR DESCRIPTION
This quirk aims to fix the problem of Yale Real Living YRD 220/240 TSDB only displaying half of the available battery percentage.

```
{
  "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=43690, maximum_buffer_size=82, maximum_incoming_transfer_size=255, server_mask=0, maximum_outgoing_transfer_size=255, descriptor_capability_field=0)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": "0x000a",
      "in_clusters": [
        "0x0000",
        "0x0001",
        "0x0009",
        "0x000a",
        "0x0020",
        "0x0101"
      ],
      "out_clusters": [
        "0x000a",
        "0x0019"
      ]
    }
  },
  "manufacturer": "Yale",
  "model": "YRD220/240 TSDB",
  "class": "zigpy.device.Device"
}
```

Currently, without a quirk, the battery percentage displayed only starts from 50%, as shown in the attached screenshot.
![image](https://user-images.githubusercontent.com/12470297/105503226-70ec4f80-5d1a-11eb-923e-23d5fb8c8440.png)
