### PR TITLE
Add power on state for BlitzWolf Tuya plugs

### DIFF
--- a/zhaquirks/tuya/plug.py
+++ b/zhaquirks/tuya/plug.py
@@ -1,0 +1,75 @@
+"""Tuya plug."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic, Groups, OnOff, Ota, Scenes, Time
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.smartenergy import Metering
+
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class PowerOnState(t.enum8):
+    """Tuya power on state enum."""
+
+    Off = 0x00
+    On = 0x01
+    LastState = 0x02
+
+
+class OnOffRestorePowerCluster(CustomCluster, OnOff):
+    """Tuya on off cluster with restore state."""
+
+    attributes = OnOff.attributes.copy()
+    attributes.update({0x8002: ("power_on_state", PowerOnState)})
+
+
+class Plug(CustomDevice):
+    """Tuya plug with restore power state support."""
+
+    signature = {
+        MODELS_INFO: [("_TZ3000_g5xawfcq", "TS0121")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=81
+            # device_version=1
+            # input_clusters=[0, 4, 5, 6, 9, 1794, 2820]
+            # output_clusters=[10, 25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffRestorePowerCluster,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+        },
+    }


### PR DESCRIPTION
See https://github.com/zigpy/zha-device-handlers/issues/605#issuecomment-762335346

This is tested and working.

This adds the option to change the default power on state for the BlitzWolf Tuya plugs.
I don't know of any other Tuya plugs that also support this. That's one of the reasons I didn't move ``OnOffRestorePowerCluster`` and ``PowerOnState`` in the ``__init__.py`` file in the Tuya directory.
The second reason is that it doesn't look like this plugs needs any Tuya-specific handling (and there is already a ``TuyaManufacturerClusterOnOff`` in ``tuya\__init.py__``.
I can move (and rename?) the ``PowerOnState`` and ``OnOffRestorePowerCluster`` if that would be better.

Also, ``manufacturer_attributes`` cannot be used in the ``OnOffRestorePowerCluster``.