### PR TITLE
Added Philips Hue LWA007 to ZHADimmableLight quirk

### DIFF
--- a/zhaquirks/philips/zhadimmablelight.py
+++ b/zhaquirks/philips/zhadimmablelight.py
@@ -36,6 +36,7 @@ class ZHADimmableLight(CustomDevice):
         MODELS_INFO: [
             (PHILIPS, "LWA004"),
             (PHILIPS, "LWA005"),
+            (PHILIPS, "LWA007"),
             (PHILIPS, "LWO001"),
             (PHILIPS, "LWO003"),
             (PHILIPS, "LWV001"),


### PR DESCRIPTION
Signature: https://paste.ubuntu.com/p/gCfwbCrqxW/ (provided by Walt_H on Discord)

It's very likely that LWA002, LWA003, LWA008, LWA009, LWA010 and LWA011 also have the same signature (they are all Hue White bulbs and the same signature is also shared by the Hue White Filament bulbs).
Should these be added perhaps?