### PR TITLE
Philio (known as Evology for Leroy Merlin) PST03A quirk

### DIFF
--- a/zhaquirks/philio/__init__.py
+++ b/zhaquirks/philio/__init__.py
@@ -1,0 +1,10 @@
+"""Module for Philio quirks implementations."""
+
+from .. import MotionWithReset
+
+PHILIO = "Philio"
+
+class MotionCluster(MotionWithReset):
+    """Motion cluster."""
+
+    reset_s: int = 20

--- a/zhaquirks/philio/pst03a.py
+++ b/zhaquirks/philio/pst03a.py
@@ -1,0 +1,93 @@
+"""Device handler for Philio PST03A-v2.2.5."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    PowerConfiguration,
+    Alarms,
+    OnOff,
+    BinaryInput,
+    Ota,
+    PollControl,
+)
+from zigpy.zcl.clusters.measurement import (
+    TemperatureMeasurement, 
+    IlluminanceMeasurement, 
+    OccupancySensing,
+)
+from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks import PowerConfigurationCluster
+
+from . import PHILIO, MotionCluster
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS, 
+    MANUFACTURER,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class PST03A(CustomDevice):
+    """Custom device representing PST03A 4in1 motion/opening/temperature/illuminance sensors."""
+
+    signature = {
+        MODELS_INFO: [("", "PST03A-v2.2.5")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Alarms.cluster_id,
+                    OccupancySensing.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [OnOff.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Alarms.cluster_id,
+                    BinaryInput.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Alarms.cluster_id,
+                    MotionCluster,
+                    TemperatureMeasurement.cluster_id,
+                    IlluminanceMeasurement.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Alarms.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            }
+        },
+        MANUFACTURER: PHILIO,
+    }

--- a/zhaquirks/philio/pst03a.py
+++ b/zhaquirks/philio/pst03a.py
@@ -8,7 +8,6 @@ from zigpy.zcl.clusters.general import (
     OnOff,
     BinaryInput,
     Ota,
-    PollControl,
 )
 from zigpy.zcl.clusters.measurement import (
     TemperatureMeasurement, 
@@ -23,11 +22,11 @@ from . import PHILIO, MotionCluster
 from ..const import (
     DEVICE_TYPE,
     ENDPOINTS,
-    INPUT_CLUSTERS, 
-    MANUFACTURER,
+    INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    SKIP_CONFIGURATION,
 )
 
 
@@ -35,6 +34,7 @@ class PST03A(CustomDevice):
     """Custom device representing PST03A 4in1 motion/opening/temperature/illuminance sensors."""
 
     signature = {
+        SKIP_CONFIGURATION: True,
         MODELS_INFO: [("", "PST03A-v2.2.5")],
         ENDPOINTS: {
             1: {
@@ -65,6 +65,7 @@ class PST03A(CustomDevice):
     }
 
     replacement = {
+        MODELS_INFO: [(PHILIO, "PST03A-v2.2.5")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -89,5 +90,4 @@ class PST03A(CustomDevice):
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             }
         },
-        MANUFACTURER: PHILIO,
     }


### PR DESCRIPTION
Support for Philio PST03A 4in1 sensor https://www.zwavetaiwan.com.tw/pst03 :

![PST03A](https://user-images.githubusercontent.com/4821565/107577659-fca71c80-6bf2-11eb-83e7-ee8fc397cc6a.jpg)
![image](https://user-images.githubusercontent.com/4821565/107577770-22342600-6bf3-11eb-8cbb-885b0a384fd5.png)

This device is sold by Leroy Merlin/Boulanger/Darty under trademark Evology in France and proposed as a device for the Enki box : https://www.leroymerlin.fr/v3/p/produits/detecteur-connecte-multi-fonctions-ouverture-et-mouvement-evology-e1501334365
