### PR TITLE
Philio 4in1 PST03A motion, opening, temperature and illuminance sensor

### DIFF
--- a/zhaquirks/philio/__init__.py
+++ b/zhaquirks/philio/__init__.py
@@ -1,0 +1,10 @@
+"""Module for Philio quirks implementations."""
+
+from .. import MotionWithReset
+
+PHILIO = "Philio"
+
+class MotionCluster(MotionWithReset):
+    """Motion cluster."""
+
+    reset_s: int = 20

--- a/zhaquirks/philio/__init__.py
+++ b/zhaquirks/philio/__init__.py
@@ -4,7 +4,8 @@ from .. import MotionWithReset
 
 PHILIO = "Philio"
 
+
 class MotionCluster(MotionWithReset):
     """Motion cluster."""
 
-    reset_s: int = 20
+    reset_s: int = 30

--- a/zhaquirks/philio/pst03a.py
+++ b/zhaquirks/philio/pst03a.py
@@ -1,0 +1,93 @@
+"""Device handler for Philio PST03A-v2.2.5."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    PowerConfiguration,
+    Alarms,
+    OnOff,
+    BinaryInput,
+    Ota,
+    PollControl,
+)
+from zigpy.zcl.clusters.measurement import (
+    TemperatureMeasurement, 
+    IlluminanceMeasurement, 
+    OccupancySensing,
+)
+from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks import PowerConfigurationCluster
+
+from . import PHILIO, MotionCluster
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS, 
+    MANUFACTURER,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class PST03A(CustomDevice):
+    """Custom device representing PST03A 4in1 motion/opening/temperature/illuminance sensors."""
+
+    signature = {
+        MODELS_INFO: [("", "PST03A-v2.2.5")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Alarms.cluster_id,
+                    OccupancySensing.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [OnOff.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Alarms.cluster_id,
+                    BinaryInput.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Alarms.cluster_id,
+                    MotionCluster,
+                    TemperatureMeasurement.cluster_id,
+                    IlluminanceMeasurement.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Alarms.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            }
+        },
+        MANUFACTURER: PHILIO,
+    }

--- a/zhaquirks/philio/pst03a.py
+++ b/zhaquirks/philio/pst03a.py
@@ -10,14 +10,11 @@ from zigpy.zcl.clusters.general import (
     Ota,
 )
 from zigpy.zcl.clusters.measurement import (
-    TemperatureMeasurement, 
-    IlluminanceMeasurement, 
+    TemperatureMeasurement,
+    IlluminanceMeasurement,
     OccupancySensing,
 )
 from zigpy.zcl.clusters.security import IasZone
-
-from zhaquirks import PowerConfigurationCluster
-
 from . import PHILIO, MotionCluster
 from ..const import (
     DEVICE_TYPE,

--- a/zhaquirks/philio/pst03a.py
+++ b/zhaquirks/philio/pst03a.py
@@ -8,7 +8,6 @@ from zigpy.zcl.clusters.general import (
     OnOff,
     BinaryInput,
     Ota,
-    PollControl,
 )
 from zigpy.zcl.clusters.measurement import (
     TemperatureMeasurement, 
@@ -23,11 +22,11 @@ from . import PHILIO, MotionCluster
 from ..const import (
     DEVICE_TYPE,
     ENDPOINTS,
-    INPUT_CLUSTERS, 
-    MANUFACTURER,
+    INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    SKIP_CONFIGURATION,
 )
 
 
@@ -35,6 +34,7 @@ class PST03A(CustomDevice):
     """Custom device representing PST03A 4in1 motion/opening/temperature/illuminance sensors."""
 
     signature = {
+        SKIP_CONFIGURATION: True,
         MODELS_INFO: [("", "PST03A-v2.2.5")],
         ENDPOINTS: {
             1: {
@@ -65,6 +65,7 @@ class PST03A(CustomDevice):
     }
 
     replacement = {
+        MODELS_INFO: [(PHILIO, "PST03A-v2.2.5")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -89,5 +90,4 @@ class PST03A(CustomDevice):
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             }
         },
-        MANUFACTURER: PHILIO,
     }

--- a/zhaquirks/philio/pst03a.py
+++ b/zhaquirks/philio/pst03a.py
@@ -20,6 +20,7 @@ from ..const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
+    MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
@@ -31,6 +32,7 @@ class PST03A(CustomDevice):
 
     signature = {
         SKIP_CONFIGURATION: True,
+        MODELS_INFO: [("", "PST03A-v2.2.5")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -60,6 +62,7 @@ class PST03A(CustomDevice):
     }
 
     replacement = {
+        MODELS_INFO: [(PHILIO, "PST03A-v2.2.5")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/philio/pst03a.py
+++ b/zhaquirks/philio/pst03a.py
@@ -20,7 +20,6 @@ from ..const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
-    MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
@@ -32,7 +31,6 @@ class PST03A(CustomDevice):
 
     signature = {
         SKIP_CONFIGURATION: True,
-        MODELS_INFO: [("", "PST03A-v2.2.5")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -62,7 +60,6 @@ class PST03A(CustomDevice):
     }
 
     replacement = {
-        MODELS_INFO: [(PHILIO, "PST03A-v2.2.5")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
This PR adds support for the Philio 4in1 PST03A motion, opening, temperature and illuminance sensor : https://www.zwavetaiwan.com.tw/pst03
![PST03A](https://user-images.githubusercontent.com/4821565/107588216-89f26d00-6c03-11eb-8d28-c4773a1364b9.jpg)

Known as Evology in France
