### PR TITLE
Added another Aqara Opple 2 button remote B286OPCN01 quirk

### DIFF
--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -270,6 +270,92 @@ class RemoteB286OPCN01(XiaomiCustomDevice):
     }
 
 
+class RemoteB286OPCN01V2(XiaomiCustomDevice):
+    """Aqara Opple 2 button remote device."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
+        # device_version=1
+        # input_clusters=[0, 3, 1]
+        # output_clusters=[3, 6, 8, 768]>
+        MODELS_INFO: [(LUMI, "lumi.remote.b286opcn01")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    PowerConfigurationCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        NODE_DESCRIPTOR: NodeDescriptor(
+            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
+        ),
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                    PowerConfigurationCluster,
+                    OppleCluster,
+                    MultistateInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [MultistateInputCluster],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [MultistateInputCluster],
+                OUTPUT_CLUSTERS: [],
+            },
+            5: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [MultistateInputCluster],
+                OUTPUT_CLUSTERS: [],
+            },
+            6: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [MultistateInputCluster],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    device_automation_triggers = RemoteB286OPCN01.device_automation_triggers
+
+
 class RemoteB286OPCN01Alt(XiaomiCustomDevice):
     """Aqara Opple 2 button remote device (after alternate mode is enabled)."""
 
@@ -639,7 +725,7 @@ class RemoteB686OPCN01(XiaomiCustomDevice):
     }
 
 
-class RemoteB286OPCN01V2(XiaomiCustomDevice):
+class RemoteB286OPCN01V3(XiaomiCustomDevice):
     """Aqara Opple 2 button remote device."""
 
     signature = {


### PR DESCRIPTION
Also renamed ``RemoteB286OPCN01V2`` to ``RemoteB286OPCN01V3``, as the 6 button remote quirk V2 is basically like the new two button V2 quirk. This can be changed so the new quirk is V3 though. Changing the names makes more sense imo.

Tested and working.

Fixes https://github.com/zigpy/zha-device-handlers/issues/661