### PR TITLE
Quirk to fix IKEA CCT devices with ZLL device type and ZHA profile

### DIFF
--- a/zhaquirks/ikea/cctlightzha.py
+++ b/zhaquirks/ikea/cctlightzha.py
@@ -1,4 +1,4 @@
-"""Tradfri GU10 bulb Quirk."""
+"""Tradfri CCT light Quirk."""
 from zigpy.profiles import zha, zll
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -16,22 +16,33 @@ from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
 from . import IKEA
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
 
 
-class TradfriGU10Bulb(CustomDevice):
-    """TRADFRI GU10 WS 400lm."""
+class CCTLightZHA(CustomDevice):
+    """TRADFRI CCT lights with ZHA profile but ZLL device type."""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=544
         # device_version=2
         # input_clusters=[0, 3, 4, 5, 6, 8, 768, 2821, 4096]
         # output_clusters=[5, 25, 32, 4096]>
-        "models_info": [(IKEA, "TRADFRI bulb GU10 WS 400lm")],
-        "endpoints": {
+        MODELS_INFO: [
+            (IKEA, "TRADFRI bulb GU10 WS 400lm"),
+            (IKEA, "FLOALT panel WS 30x90"),
+        ],
+        ENDPOINTS: {
             1: {
-                "profile_id": zha.PROFILE_ID,
-                "device_type": zll.DeviceType.COLOR_TEMPERATURE_LIGHT,
-                "input_clusters": [
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
@@ -42,7 +53,7 @@ class TradfriGU10Bulb(CustomDevice):
                     Diagnostic.cluster_id,
                     LightLink.cluster_id,
                 ],
-                "output_clusters": [
+                OUTPUT_CLUSTERS: [
                     Scenes.cluster_id,
                     Ota.cluster_id,
                     PollControl.cluster_id,
@@ -50,15 +61,14 @@ class TradfriGU10Bulb(CustomDevice):
                 ],
             },
         },
-        "manufacturer": IKEA,
     }
 
     replacement = {
-        "endpoints": {
+        ENDPOINTS: {
             1: {
-                "profile_id": zha.PROFILE_ID,
-                "device_type": zha.DeviceType.COLOR_TEMPERATURE_LIGHT,
-                "input_clusters": [
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
@@ -69,7 +79,7 @@ class TradfriGU10Bulb(CustomDevice):
                     Diagnostic.cluster_id,
                     LightLink.cluster_id,
                 ],
-                "output_clusters": [
+                OUTPUT_CLUSTERS: [
                     Scenes.cluster_id,
                     Ota.cluster_id,
                     PollControl.cluster_id,


### PR DESCRIPTION
Basically renames the ``TradfriGU10Bulb`` quirk to ``CCTLightZHA`` (I thought that ``CCTZHALight`` would be a little too unreadable and CCTLight alone doesn't provide enough information on what the quirk is doing. I can change the name though). Also adds the IKEA ``FLOALT panel WS 30x90``.
Signature of the FLOALT panels: https://paste.ubuntu.com/p/S4C4jVHPxY/

Tested and confirmed working by ``Iyaka#8414`` on Discord.
