### PR TITLE
Added another IKEA FLOALT panel to CCT ZHA light quirk

### DIFF
--- a/zhaquirks/ikea/cctlightzha.py
+++ b/zhaquirks/ikea/cctlightzha.py
@@ -37,6 +37,7 @@ class CCTLightZHA(CustomDevice):
         MODELS_INFO: [
             (IKEA, "TRADFRI bulb GU10 WS 400lm"),
             (IKEA, "FLOALT panel WS 30x90"),
+            (IKEA, "FLOALT panel WS 60x60"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Same as https://github.com/zigpy/zha-device-handlers/pull/793 but with a different device.
Signature: https://paste.ubuntu.com/p/c7dvvvgypb/