### PR TITLE
Deleting  "_TZE200_c88teujp", "TS0601"

### DIFF
--- a/zhaquirks/tuya/valve.py
+++ b/zhaquirks/tuya/valve.py
@@ -792,7 +792,6 @@ class SiterwellGS361_Type2(TuyaThermostat):
         #  output_clusters=[10, 25]>
         MODELS_INFO: [
             ("_TZE200_kfvq6avy", "TS0601"),
-            ("_TZE200_c88teujp", "TS0601"),
             ("_TZE200_zivfvd7h", "TS0601"),
         ],
         ENDPOINTS: {


### PR DESCRIPTION
Deleting  "_TZE200_c88teujp", "TS0601" from Siterwell	TRV then its one Saswell	SEA802 that have being implanted in zhaquirks/tuya/thermostat_88teujp.py #576 
It was added wrongly in #710 and have making trouble.