### PR TITLE
Adding missing Saswell SEA801

### DIFF
--- a/zhaquirks/tuya/thermostat_88teujp.py
+++ b/zhaquirks/tuya/thermostat_88teujp.py
@@ -162,7 +162,12 @@ class Thermostat_TYST11_c88teujp(TuyaThermostat):
         # device_version=0
         # input_clusters=[0, 3]
         # output_clusters=[3, 25]>
-        MODELS_INFO: [("_TYST11_c88teujp", "88teujp")],
+        MODELS_INFO: [
+            ("_TYST11_c88teujp", "88teujp"),
+            ("_TYST11_KGbxAXL2", "GbxAXL2"),
+            ("_TYST11_zuhszj9s", "uhszj9s"),
+            ("_TYST11_yw7cahqs", "w7cahqs"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
Adding:
Saswell	SEA801	_TYST11_KGbxAXL2	GbxAXL2
HiHome	WZB-TRVL	_TYST11_zuhszj9s	uhszj9s
Hama	00176592	_TYST11_yw7cahqs	w7cahqs

All ID is verified from Z2M