### PR TITLE
Add new MODELS_INFO for BlitzWolf Tuya plugs

### DIFF
--- a/zhaquirks/tuya/plug.py
+++ b/zhaquirks/tuya/plug.py
@@ -35,7 +35,10 @@ class Plug(CustomDevice):
     """Tuya plug with restore power state support."""
 
     signature = {
-        MODELS_INFO: [("_TZ3000_g5xawfcq", "TS0121")],
+        MODELS_INFO: [
+            ("_TZ3000_g5xawfcq", "TS0121"),
+            ("_TZ3000_3ooaz3ng", "TS0121"),
+        ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=81
             # device_version=1


### PR DESCRIPTION
It seems like there are several MODELS_INFO for BlitzWolf Tuya plugs.
Here added the one from my 16A EU Plug