### PR TITLE
Implement custom quirk loading

### DIFF
--- a/tests/test_ctrl_neutral1.py
+++ b/tests/test_ctrl_neutral1.py
@@ -1,7 +1,10 @@
 """Tests for xiaomi."""
 from unittest import mock
 
+import zhaquirks
 from zhaquirks.xiaomi.aqara.ctrl_neutral import CtrlNeutral
+
+zhaquirks.setup()
 
 # zigbee-herdsman:controller:endpoint Command 0x00158d00024be541/2 genOnOff.on({},
 #   {"timeout":6000,"manufacturerCode":null,"disableDefaultResponse":false})

--- a/tests/test_kof.py
+++ b/tests/test_kof.py
@@ -5,7 +5,10 @@ import zigpy.device
 import zigpy.endpoint
 import zigpy.quirks
 
+import zhaquirks
 import zhaquirks.kof.kof_mr101z
+
+zhaquirks.setup()
 
 
 def test_kof_no_reply():

--- a/tests/test_konke.py
+++ b/tests/test_konke.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 
+import zhaquirks
 from zhaquirks.const import (
     COMMAND_DOUBLE,
     COMMAND_HOLD,
@@ -18,6 +19,8 @@ from zhaquirks.const import (
 import zhaquirks.konke.motion
 
 from tests.common import ZCL_IAS_MOTION_COMMAND, ClusterListener
+
+zhaquirks.setup()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_orvibo.py
+++ b/tests/test_orvibo.py
@@ -5,10 +5,13 @@ from unittest import mock
 
 import pytest
 
+import zhaquirks
 from zhaquirks.const import OFF, ON, ZONE_STATE
 import zhaquirks.orvibo.motion
 
 from tests.common import ZCL_IAS_MOTION_COMMAND, ClusterListener
+
+zhaquirks.setup()
 
 
 @pytest.mark.parametrize("quirk", (zhaquirks.orvibo.motion.SN10ZW,))

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -10,6 +10,7 @@ from zigpy.quirks import CustomDevice, get_device
 import zigpy.types as t
 from zigpy.zcl import foundation
 
+import zhaquirks
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -30,6 +31,8 @@ import zhaquirks.tuya.ts0043
 import zhaquirks.tuya.valve
 
 from tests.common import ClusterListener
+
+zhaquirks.setup()
 
 ZCL_TUYA_SET_TIME_REQUEST = b"\tp\x24\x00\00"
 

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -6,6 +6,7 @@ import pytest
 import zigpy.device
 import zigpy.types as t
 
+import zhaquirks
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -32,6 +33,8 @@ import zhaquirks.xiaomi.aqara.motion_aq2b
 import zhaquirks.xiaomi.mija.motion
 
 from tests.common import ZCL_OCC_ATTR_RPT_OCC, ClusterListener
+
+zhaquirks.setup()
 
 
 def test_basic_cluster_deserialize_wrong_len():

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -395,7 +395,6 @@ def setup(config: Optional[Dict[str, Any]] = None) -> None:
 
     # Treat the custom quirk path (e.g. `/config/custom_quirks/`) itself as a module
     if config and config.get(CUSTOM_QUIRKS_PATH):
-        breakpoint()
         path = pathlib.Path(config[CUSTOM_QUIRKS_PATH])
 
         for importer, modname, ispkg in pkgutil.walk_packages(

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -396,13 +396,8 @@ def setup(config: Optional[Dict[str, Any]] = None) -> None:
     # Treat the custom quirk path (e.g. `/config/custom_quirks/`) itself as a module
     if config and config.get(CUSTOM_QUIRKS_PATH):
         path = pathlib.Path(config[CUSTOM_QUIRKS_PATH])
+        _LOGGER.debug("Loading custom quirks from %s", path)
 
-        for importer, modname, ispkg in pkgutil.walk_packages(
-            path=[str(path.parent)],
-            prefix=path.name + ".",
-        ):
+        for importer, modname, ispkg in pkgutil.walk_packages(path=[str(path)]):
             _LOGGER.debug("Loading custom quirks module %s", modname)
             importer.find_module(modname).load_module(modname)
-
-
-setup()

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -2,6 +2,7 @@
 import asyncio
 import importlib
 import logging
+import pathlib
 import pkgutil
 from typing import Any, Dict, List, Optional, Union
 
@@ -21,6 +22,7 @@ from .const import (
     ATTRIBUTE_NAME,
     CLUSTER_COMMAND,
     COMMAND_ATTRIBUTE_UPDATED,
+    CUSTOM_QUIRKS_PATH,
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -380,7 +382,28 @@ class QuickInitDevice(CustomDevice):
         return device
 
 
-NAME = __name__
-PATH = __path__
-for importer, modname, ispkg in pkgutil.walk_packages(path=PATH, prefix=NAME + "."):
-    importlib.import_module(modname)
+def setup(config: Optional[Dict[str, Any]] = None) -> None:
+    """Register all quirks with zigpy, including optional custom quirks."""
+
+    # Import all quirks in the `zhaquirks` package first
+    for importer, modname, ispkg in pkgutil.walk_packages(
+        path=__path__,
+        prefix=__name__ + ".",
+    ):
+        _LOGGER.debug("Loading quirks module %s", modname)
+        importlib.import_module(modname)
+
+    # Treat the custom quirk path (e.g. `/config/custom_quirks/`) itself as a module
+    if config and config.get(CUSTOM_QUIRKS_PATH):
+        breakpoint()
+        path = pathlib.Path(config[CUSTOM_QUIRKS_PATH])
+
+        for importer, modname, ispkg in pkgutil.walk_packages(
+            path=[str(path.parent)],
+            prefix=path.name + ".",
+        ):
+            _LOGGER.debug("Loading custom quirks module %s", modname)
+            importer.find_module(modname).load_module(modname)
+
+
+setup()

--- a/zhaquirks/const.py
+++ b/zhaquirks/const.py
@@ -56,6 +56,7 @@ COMMAND_STOP = "stop"
 COMMAND_TILT = "Tilt"
 COMMAND_TOGGLE = "toggle"
 COMMAND_TRIPLE = "triple"
+CUSTOM_QUIRKS_PATH = "custom_quirks_path"
 DESCRIPTION = "description"
 DEVICE_TYPE = SIG_EP_TYPE
 DIM_DOWN = "dim_down"


### PR DESCRIPTION
This change implements a folder for custom quirks that survive zha-device-handlers updates. For example:

```yaml
zha:
  zigpy_config:
    # maybe this would go a level higher?
    custom_quirks_path: /config/custom_zha_quirks/
```

Creating `/config/custom_zha_quirks/__init__.py` and quirk submodules will allow them to take priority over the built-in ones, allowing quirks to be subclassed, overridden, and maintained independently without having to patch the `zhaquirks` Python module directly.

One notable difference is that these custom quirks are not a part of the `zhaquirks` package. They will not be able to use relative imports, so while this will not work:

```Python
from . import BOSCH
from ..const import foo
```

This will:

```Python
from zhaquirks.bosch import BOSCH
from zhaquirks.const import foo
```

This won't change their functionality when merged into `zhaquirks` but does differ from the current coding style of using relative imports.

~~Right now the newly-defined `setup` function is called immediately after it is defined, maintaining backwards compatibility.~~ ZHA will have to be modified to call `zhaquirks.setup` with the relevant section of its configuration dictionary once this "shim" is removed. This will be a breaking change for any application relying on `import zhaquirks` mutating global state.

---

~~At the moment there are no unit tests included because I can't find any way to "properly" write any, beyond ensuring that `pkgutil.walk_packages` will be called. This is due to the metaclass-based quirk registration method currently used by zigpy and there being no way to un-register  and then re-register quirks without a bit of hackery.~~