### PR TITLE
Add an additional CCT light to LIDL

### DIFF
--- a/zhaquirks/lidl/cct.py
+++ b/zhaquirks/lidl/cct.py
@@ -42,6 +42,7 @@ class CCTLight(CustomDevice):
             ("_TZ3000_oborybow", "TS0502A"),
             ("_TZ3000_9evm3otq", "TS0502A"),
             ("_TZ3000_rylaozuc", "TS0502A"),
+            ("_TZ3000_el5kt5im", "TS0502A"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
fixes: #808 
Makes the following lamp work:
https://www.lidl.de/de/livarno-lux-deckenspot-dreh-und-neigbare-spots-zigbee-smart-home/p354571
Assuming, that it is regularly registered with:
```
"profile_id": 260
"device_type": "0x010c"
```