### PR TITLE
Added new Philips Hue dimmer (RWL022), added MODELS_INFO to others

### DIFF
--- a/zhaquirks/philips/rom001.py
+++ b/zhaquirks/philips/rom001.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import PHILIPS, PhilipsBasicCluster, PhilipsRemoteCluster, SIGNIFY
+from . import PHILIPS, SIGNIFY, PhilipsBasicCluster, PhilipsRemoteCluster
 from ..const import (
     COMMAND,
     DEVICE_TYPE,

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -13,8 +13,21 @@ from zigpy.zcl.clusters.general import (
     PowerConfiguration,
 )
 
-from . import HUE_REMOTE_DEVICE_TRIGGERS, PhilipsBasicCluster, PhilipsRemoteCluster
-from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
+from . import (
+    HUE_REMOTE_DEVICE_TRIGGERS,
+    PHILIPS,
+    PhilipsBasicCluster,
+    PhilipsRemoteCluster,
+    SIGNIFY,
+)
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 
@@ -27,6 +40,7 @@ class PhilipsRWL020(CustomDevice):
         #  device_version=2
         #  input_clusters=[0]
         #  output_clusters=[0, 3, 4, 6, 8]>
+        MODELS_INFO: [(PHILIPS, "RWL020"), (SIGNIFY, "RWL020")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zll.PROFILE_ID,
@@ -56,7 +70,7 @@ class PhilipsRWL020(CustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
-        }
+        },
     }
 
     replacement = {

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -16,9 +16,9 @@ from zigpy.zcl.clusters.general import (
 from . import (
     HUE_REMOTE_DEVICE_TRIGGERS,
     PHILIPS,
+    SIGNIFY,
     PhilipsBasicCluster,
     PhilipsRemoteCluster,
-    SIGNIFY,
 )
 from ..const import (
     DEVICE_TYPE,

--- a/zhaquirks/philips/rwl021.py
+++ b/zhaquirks/philips/rwl021.py
@@ -14,8 +14,21 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from . import HUE_REMOTE_DEVICE_TRIGGERS, PhilipsBasicCluster, PhilipsRemoteCluster
-from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
+from . import (
+    HUE_REMOTE_DEVICE_TRIGGERS,
+    PHILIPS,
+    PhilipsBasicCluster,
+    PhilipsRemoteCluster,
+    SIGNIFY,
+)
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 
@@ -28,6 +41,7 @@ class PhilipsRWL021(CustomDevice):
         #  device_version=2
         #  input_clusters=[0]
         #  output_clusters=[0, 3, 4, 6, 8, 5]>
+        MODELS_INFO: [(PHILIPS, "ROM001"), (SIGNIFY, "ROM001")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zll.PROFILE_ID,
@@ -58,7 +72,7 @@ class PhilipsRWL021(CustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
-        }
+        },
     }
 
     replacement = {

--- a/zhaquirks/philips/rwl021.py
+++ b/zhaquirks/philips/rwl021.py
@@ -17,9 +17,9 @@ from zigpy.zcl.clusters.general import (
 from . import (
     HUE_REMOTE_DEVICE_TRIGGERS,
     PHILIPS,
+    SIGNIFY,
     PhilipsBasicCluster,
     PhilipsRemoteCluster,
-    SIGNIFY,
 )
 from ..const import (
     DEVICE_TYPE,

--- a/zhaquirks/philips/rwl021.py
+++ b/zhaquirks/philips/rwl021.py
@@ -41,7 +41,7 @@ class PhilipsRWL021(CustomDevice):
         #  device_version=2
         #  input_clusters=[0]
         #  output_clusters=[0, 3, 4, 6, 8, 5]>
-        MODELS_INFO: [(PHILIPS, "ROM001"), (SIGNIFY, "ROM001")],
+        MODELS_INFO: [(PHILIPS, "RWL021"), (SIGNIFY, "RWL021")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zll.PROFILE_ID,

--- a/zhaquirks/philips/rwl022.py
+++ b/zhaquirks/philips/rwl022.py
@@ -1,4 +1,4 @@
-"""Philips ROM001 device."""
+"""Philips RWL022 device."""
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -13,38 +13,33 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import PHILIPS, PhilipsBasicCluster, PhilipsRemoteCluster, SIGNIFY
+from . import (
+    HUE_REMOTE_DEVICE_TRIGGERS,
+    PhilipsBasicCluster,
+    PhilipsRemoteCluster,
+    SIGNIFY,
+)
 from ..const import (
-    COMMAND,
     DEVICE_TYPE,
-    DOUBLE_PRESS,
     ENDPOINTS,
     INPUT_CLUSTERS,
-    LONG_PRESS,
-    LONG_RELEASE,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    QUADRUPLE_PRESS,
-    QUINTUPLE_PRESS,
-    SHORT_PRESS,
-    SHORT_RELEASE,
-    TRIPLE_PRESS,
-    TURN_ON,
 )
 
 DEVICE_SPECIFIC_UNKNOWN = 64512
 
 
-class PhilipsROM001(CustomDevice):
-    """Philips ROM001 device."""
+class PhilipsRWL022(CustomDevice):
+    """Philips RWL022 device."""
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=2096
         #  device_version=1
         #  input_clusters=[0, 1, 3, 64512, 4096]
         #  output_clusters=[25, 0, 3, 4, 6, 8, 5, 4096]>
-        MODELS_INFO: [(PHILIPS, "ROM001"), (SIGNIFY, "ROM001")],
+        MODELS_INFO: [(SIGNIFY, "RWL022")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -96,13 +91,4 @@ class PhilipsROM001(CustomDevice):
         }
     }
 
-    device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {COMMAND: "on_press"},
-        (LONG_PRESS, TURN_ON): {COMMAND: "on_hold"},
-        (DOUBLE_PRESS, TURN_ON): {COMMAND: "on_double_press"},
-        (TRIPLE_PRESS, TURN_ON): {COMMAND: "on_triple_press"},
-        (QUADRUPLE_PRESS, TURN_ON): {COMMAND: "on_quadruple_press"},
-        (QUINTUPLE_PRESS, TURN_ON): {COMMAND: "on_quintuple_press"},
-        (SHORT_RELEASE, TURN_ON): {COMMAND: "on_short_release"},
-        (LONG_RELEASE, TURN_ON): {COMMAND: "on_long_release"},
-    }
+    device_automation_triggers = HUE_REMOTE_DEVICE_TRIGGERS

--- a/zhaquirks/philips/rwl022.py
+++ b/zhaquirks/philips/rwl022.py
@@ -15,9 +15,9 @@ from zigpy.zcl.clusters.lightlink import LightLink
 
 from . import (
     HUE_REMOTE_DEVICE_TRIGGERS,
+    SIGNIFY,
     PhilipsBasicCluster,
     PhilipsRemoteCluster,
-    SIGNIFY,
 )
 from ..const import (
     DEVICE_TYPE,


### PR DESCRIPTION
The previous quirks for the Philips Hue remotes (US and EU dimmer switches as well as the Hue smart button) were missing ``MODELS_INFO``. The ROM001 (smart button) quirk always got applied to the RWL022 (new dimmer). Also added ``MODELS_INFO`` to the older dimmers for consistency. The new Hue dimmer only has Signify as manufacturer while the older dimmers and smart button currently still use "Philips" as their manufacturer. I've added both as they might be updated in the future (smart button more likely than older dimmers).

A quirk for the new Philips Hue dimmer (RWL022) is also added.
Note: The "OFF" event is sent by the ``PhilipsRemoteCluster`` here (when the 4th button is pressed -> "Hue" button -- OFF button on older dimmers): https://github.com/TheJulianJES/zha-device-handlers/blob/570da4a85d18f6b99b202a4a2eae1b7e20a5d035/zhaquirks/philips/__init__.py#L165-L179
If this needs to be changed, a separate PhilipsRemoteCluster would need to be created (just with ``BUTTONS`` where instead of ``4: "off"`` it is ``4: "hue"`` or ``4: "scene"`` or something like that). The problem then is that there's no real string to pass to the UI (for device automation triggers). Personally, I would just leave the Hue button to send the "OFF" event now. This can be corrected by a future PR but for now, it would fix the completely broken device automations (as the smart button quirk is applied).

These changes were tested with RWL021, RWL022 and ROM001 (so everything except the US-based dimmer) but it should work as the only differences to the RWL021 are the missing SCENES cluster, different device type and (important here): the model info.

Closes https://github.com/zigpy/zha-device-handlers/issues/821