### PR TITLE
Add missing device automation triggers for alternative IKEA five button remote

### DIFF
--- a/zhaquirks/ikea/fivebtnremotezha.py
+++ b/zhaquirks/ikea/fivebtnremotezha.py
@@ -227,3 +227,5 @@ class IkeaTradfriRemote2(IkeaTradfriRemote):
             }
         }
     }
+
+    device_automation_triggers = IkeaTradfriRemote.device_automation_triggers.copy()


### PR DESCRIPTION
It looks like ``IkeaTradfriRemote2`` was missing ``device_automation_triggers``.
I don't think a ``copy()`` needs to be used on the dictionary but it's also used here: https://github.com/zigpy/zha-device-handlers/blob/5ef6918ce6dda4b8c13153bad8b8cfb63e57fd0a/zhaquirks/ikea/twobtnremote.py#L183