### PR TITLE
Update valve.py

### DIFF
--- a/zhaquirks/tuya/valve.py
+++ b/zhaquirks/tuya/valve.py
@@ -843,6 +843,7 @@ class MoesHY368_Type1(TuyaThermostat):
         MODELS_INFO: [
             ("_TZE200_ckud7u2l", "TS0601"),
             ("_TZE200_ywdxldoj", "TS0601"),
+            ("_TZE200_cwnjrr72", "TS0601"),
         ],
         ENDPOINTS: {
             1: {
@@ -889,6 +890,7 @@ class MoesHY368_Type2(TuyaThermostat):
         MODELS_INFO: [
             ("_TYST11_ckud7u2l", "kud7u2l"),
             ("_TYST11_ywdxldoj", "wdxldoj"),
+            ("_TYST11_cwnjrr72", "wnjrr72"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Updating MoesHY368_Type1 and 2 with new Model ID _TZE200_cwnjrr72 with both Zigbee modules user in TRVs.
Issues: #819 Design and function is the same as  the "normal" YH368 then the user is having both models up and running in HA.