### PR TITLE
Switch all relative imports to absolute imports

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -17,7 +17,7 @@ from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zdo import types as zdotypes
 
-from .const import (
+from zhaquirks.const import (
     ATTRIBUTE_ID,
     ATTRIBUTE_NAME,
     CLUSTER_COMMAND,

--- a/zhaquirks/bosch/isw_zdl1_wp11g.py
+++ b/zhaquirks/bosch/isw_zdl1_wp11g.py
@@ -7,9 +7,8 @@ from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-
-from . import BOSCH
-from ..const import (
+from zhaquirks.bosch import BOSCH
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,

--- a/zhaquirks/bosch/motion.py
+++ b/zhaquirks/bosch/motion.py
@@ -7,9 +7,8 @@ from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-
-from . import BOSCH
-from ..const import (
+from zhaquirks.bosch import BOSCH
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,

--- a/zhaquirks/centralite/ias.py
+++ b/zhaquirks/centralite/ias.py
@@ -6,9 +6,8 @@ from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-
-from . import CENTRALITE
-from ..const import (
+from zhaquirks.centralite import CENTRALITE
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,

--- a/zhaquirks/centralite/motion.py
+++ b/zhaquirks/centralite/motion.py
@@ -6,9 +6,8 @@ from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-
-from . import CENTRALITE
-from ..const import (
+from zhaquirks.centralite import CENTRALITE
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -17,8 +17,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 
-from . import DANFOSS
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -26,6 +25,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.danfoss import DANFOSS
 
 
 class DanfossThermostatCluster(CustomCluster, Thermostat):

--- a/zhaquirks/develco/__init__.py
+++ b/zhaquirks/develco/__init__.py
@@ -1,5 +1,5 @@
 """Quirks for Develco Products A/S."""
-from .. import PowerConfigurationCluster
+from zhaquirks import PowerConfigurationCluster
 
 DEVELCO = "Develco Products A/S"
 

--- a/zhaquirks/develco/open_close.py
+++ b/zhaquirks/develco/open_close.py
@@ -16,8 +16,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
-from . import DEVELCO, DevelcoPowerConfiguration
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -25,6 +24,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.develco import DEVELCO, DevelcoPowerConfiguration
 
 
 class DevelcoIASZone(CustomCluster, IasZone):

--- a/zhaquirks/echostar/bell.py
+++ b/zhaquirks/echostar/bell.py
@@ -11,7 +11,7 @@ from zigpy.zcl.clusters.general import (
     PowerConfiguration,
 )
 
-from ..const import (
+from zhaquirks.const import (
     BUTTON_1,
     BUTTON_2,
     CLUSTER_ID,

--- a/zhaquirks/edpwithus/redy_plug.py
+++ b/zhaquirks/edpwithus/redy_plug.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.smartenergy import Metering
 
-from . import MeteringCluster
+from zhaquirks.edpwithus import MeteringCluster
 
 
 class EdpWithUsSmartPlug(CustomDevice):

--- a/zhaquirks/eurotronic/spzb0001.py
+++ b/zhaquirks/eurotronic/spzb0001.py
@@ -20,8 +20,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-from . import EUROTRONIC, ThermostatCluster
+from zhaquirks.eurotronic import EUROTRONIC, ThermostatCluster
 
 
 class SPZB0001(CustomDevice):

--- a/zhaquirks/heiman/smoke.py
+++ b/zhaquirks/heiman/smoke.py
@@ -6,8 +6,7 @@ from zigpy.zcl.clusters.general import Alarms, Basic, Identify, Ota, PowerConfig
 from zigpy.zcl.clusters.security import IasWd, IasZone
 import zigpy.zdo.types
 
-from . import HEIMAN
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -16,6 +15,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.heiman import HEIMAN
 
 
 class HeimanSmokYDLV10(CustomDevice):

--- a/zhaquirks/hivehome/__init__.py
+++ b/zhaquirks/hivehome/__init__.py
@@ -1,6 +1,6 @@
 """Hive Home."""
 
-from .. import MotionWithReset
+from zhaquirks import MotionWithReset
 
 HIVEHOME = "HiveHome.com"
 

--- a/zhaquirks/hivehome/mot003V0.py
+++ b/zhaquirks/hivehome/mot003V0.py
@@ -21,8 +21,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-from . import HIVEHOME, MotionCluster
+from zhaquirks.hivehome import HIVEHOME, MotionCluster
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/zhaquirks/hivehome/mot003V6.py
+++ b/zhaquirks/hivehome/mot003V6.py
@@ -24,8 +24,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-from . import HIVEHOME, MotionCluster
+from zhaquirks.hivehome import HIVEHOME, MotionCluster
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/zhaquirks/ikea/blinds.py
+++ b/zhaquirks/ikea/blinds.py
@@ -13,9 +13,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA
-from .. import DoublingPowerConfigurationCluster
-from ..const import (
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -23,6 +22,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.ikea import IKEA
 
 IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
 

--- a/zhaquirks/ikea/cctlightzha.py
+++ b/zhaquirks/ikea/cctlightzha.py
@@ -15,8 +15,7 @@ from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -24,6 +23,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.ikea import IKEA
 
 
 class CCTLightZHA(CustomDevice):

--- a/zhaquirks/ikea/dimmer.py
+++ b/zhaquirks/ikea/dimmer.py
@@ -13,9 +13,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA, ROTATED
-from .. import DoublingPowerConfigurationCluster
-from ..const import (
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
     ARGS,
     CLUSTER_ID,
     COMMAND,
@@ -30,6 +29,7 @@ from ..const import (
     PROFILE_ID,
     RIGHT,
 )
+from zhaquirks.ikea import IKEA, ROTATED
 
 
 class IkeaDimmer(CustomDevice):

--- a/zhaquirks/ikea/fivebtnremote.py
+++ b/zhaquirks/ikea/fivebtnremote.py
@@ -14,9 +14,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA, LightLinkCluster, ScenesCluster
-from .. import DoublingPowerConfigurationCluster
-from ..const import (
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
     ARGS,
     CLUSTER_ID,
     COMMAND,
@@ -43,6 +42,7 @@ from ..const import (
     SHORT_PRESS,
     TURN_ON,
 )
+from zhaquirks.ikea import IKEA, LightLinkCluster, ScenesCluster
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 

--- a/zhaquirks/ikea/fivebtnremotezha.py
+++ b/zhaquirks/ikea/fivebtnremotezha.py
@@ -15,9 +15,8 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA, LightLinkCluster, ScenesCluster
-from .. import DoublingPowerConfigurationCluster
-from ..const import (
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
     ARGS,
     CLUSTER_ID,
     COMMAND,
@@ -44,6 +43,7 @@ from ..const import (
     SHORT_PRESS,
     TURN_ON,
 )
+from zhaquirks.ikea import IKEA, LightLinkCluster, ScenesCluster
 
 IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
 

--- a/zhaquirks/ikea/motion.py
+++ b/zhaquirks/ikea/motion.py
@@ -12,9 +12,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA, LightLinkCluster
-from .. import DoublingPowerConfigurationCluster
-from ..const import (
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -22,6 +21,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.ikea import IKEA, LightLinkCluster
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 

--- a/zhaquirks/ikea/motionzha.py
+++ b/zhaquirks/ikea/motionzha.py
@@ -14,9 +14,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA, LightLinkCluster
-from .. import DoublingPowerConfigurationCluster
-from ..const import (
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -24,6 +23,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.ikea import IKEA, LightLinkCluster
 
 IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821

--- a/zhaquirks/ikea/opencloseremote.py
+++ b/zhaquirks/ikea/opencloseremote.py
@@ -19,9 +19,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA
-from .. import DoublingPowerConfigurationCluster
-from ..const import (
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
     ARGS,
     CLOSE,
     COMMAND,
@@ -37,6 +36,7 @@ from ..const import (
     SHORT_PRESS,
     ZHA_SEND_EVENT,
 )
+from zhaquirks.ikea import IKEA
 
 COMMAND_CLOSE = "down_close"
 COMMAND_STOP_OPENING = "stop_opening"

--- a/zhaquirks/ikea/shortcutbtn.py
+++ b/zhaquirks/ikea/shortcutbtn.py
@@ -15,9 +15,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA, LightLinkCluster
-from .. import DoublingPowerConfigurationCluster
-from ..const import (
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
     ARGS,
     CLUSTER_ID,
     COMMAND,
@@ -37,6 +36,7 @@ from ..const import (
     SHORT_PRESS,
     TURN_ON,
 )
+from zhaquirks.ikea import IKEA, LightLinkCluster
 
 
 class IkeaTradfriShortcutBtn(CustomDevice):

--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -13,9 +13,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA, ROTATED
-from .. import DoublingPowerConfigurationCluster
-from ..const import (
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
     ARGS,
     CLUSTER_ID,
     COMMAND,
@@ -36,6 +35,7 @@ from ..const import (
     TRIPLE_PRESS,
     TURN_ON,
 )
+from zhaquirks.ikea import IKEA, ROTATED
 
 
 class IkeaSYMFONISK(CustomDevice):

--- a/zhaquirks/ikea/tradfriplug.py
+++ b/zhaquirks/ikea/tradfriplug.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA
+from zhaquirks.ikea import IKEA
 
 IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
 

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -15,9 +15,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import IKEA, LightLinkCluster
-from .. import DoublingPowerConfigurationCluster
-from ..const import (
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
     ARGS,
     CLUSTER_ID,
     COMMAND,
@@ -41,6 +40,7 @@ from ..const import (
     TURN_OFF,
     TURN_ON,
 )
+from zhaquirks.ikea import IKEA, LightLinkCluster
 
 IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
 

--- a/zhaquirks/imagic/gs1117s.py
+++ b/zhaquirks/imagic/gs1117s.py
@@ -13,9 +13,7 @@ from zigpy.zcl.clusters.measurement import RelativeHumidity, TemperatureMeasurem
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-
-from . import IMAGIC
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -23,6 +21,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.imagic import IMAGIC
 
 MANUFACTURER_SPECIFIC_PROFILE_ID = 0xFC01
 MANUFACTURER_SPECIFIC_PROFILE_ID2 = 0xFC02

--- a/zhaquirks/imagic/im1116s.py
+++ b/zhaquirks/imagic/im1116s.py
@@ -6,9 +6,7 @@ from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-
-from . import IMAGIC
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -16,6 +14,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.imagic import IMAGIC
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFC01  # decimal = 64513

--- a/zhaquirks/innr/rs228t.py
+++ b/zhaquirks/innr/rs228t.py
@@ -15,7 +15,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,

--- a/zhaquirks/keenhome/sv02612mp13.py
+++ b/zhaquirks/keenhome/sv02612mp13.py
@@ -13,8 +13,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.measurement import PressureMeasurement, TemperatureMeasurement
 
-from .. import DoublingPowerConfigurationCluster
-from ..const import (
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,

--- a/zhaquirks/keenhome/weather.py
+++ b/zhaquirks/keenhome/weather.py
@@ -17,7 +17,7 @@ from zigpy.zcl.clusters.measurement import (
     TemperatureMeasurement,
 )
 
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -25,7 +25,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from ..xiaomi import LUMI
+from zhaquirks.xiaomi import LUMI
 
 
 class PressureMeasurementCluster(CustomCluster, PressureMeasurement):

--- a/zhaquirks/konke/__init__.py
+++ b/zhaquirks/konke/__init__.py
@@ -5,8 +5,8 @@ import zigpy.types as t
 from zigpy.zcl.clusters.general import OnOff
 import zigpy.zcl.foundation
 
-from .. import CustomCluster, LocalDataCluster, MotionWithReset, OccupancyOnEvent
-from ..const import (
+from zhaquirks import CustomCluster, LocalDataCluster, MotionWithReset, OccupancyOnEvent
+from zhaquirks.const import (
     COMMAND_DOUBLE,
     COMMAND_HOLD,
     COMMAND_ID,

--- a/zhaquirks/konke/button.py
+++ b/zhaquirks/konke/button.py
@@ -12,9 +12,8 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from . import KONKE, KonkeOnOffCluster
-from .. import PowerConfigurationCluster
-from ..const import (
+from zhaquirks import PowerConfigurationCluster
+from zhaquirks.const import (
     COMMAND,
     COMMAND_DOUBLE,
     COMMAND_HOLD,
@@ -29,6 +28,7 @@ from ..const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
+from zhaquirks.konke import KONKE, KonkeOnOffCluster
 
 KONKE_CLUSTER_ID = 0xFCC0
 

--- a/zhaquirks/konke/magnet.py
+++ b/zhaquirks/konke/magnet.py
@@ -5,9 +5,8 @@ from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
 from zigpy.zcl.clusters.security import IasZone
 
-from . import KONKE
-from .. import PowerConfigurationCluster
-from ..const import (
+from zhaquirks import PowerConfigurationCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -15,6 +14,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.konke import KONKE
 
 KONKE_CLUSTER_ID = 0xFCC0
 

--- a/zhaquirks/konke/motion.py
+++ b/zhaquirks/konke/motion.py
@@ -5,9 +5,8 @@ from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
 from zigpy.zcl.clusters.security import IasZone
 
-from . import KONKE, MotionCluster, OccupancyCluster
-from .. import Bus, PowerConfigurationCluster
-from ..const import (
+from zhaquirks import Bus, PowerConfigurationCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -15,6 +14,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.konke import KONKE, MotionCluster, OccupancyCluster
 
 KONKE_CLUSTER_ID = 0xFCC0
 

--- a/zhaquirks/konke/temp.py
+++ b/zhaquirks/konke/temp.py
@@ -5,9 +5,8 @@ from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
 from zigpy.zcl.clusters.measurement import RelativeHumidity, TemperatureMeasurement
 
-from . import KONKE
-from .. import PowerConfigurationCluster
-from ..const import (
+from zhaquirks import PowerConfigurationCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -15,6 +14,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.konke import KONKE
 
 
 class KonkeTempHumidity(CustomDevice):

--- a/zhaquirks/lds/cctswitch.py
+++ b/zhaquirks/lds/cctswitch.py
@@ -13,8 +13,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import MANUFACTURER, LightLinkCluster
-from ..const import (
+from zhaquirks.const import (
     ARGS,
     CLUSTER_ID,
     COMMAND,
@@ -37,6 +36,7 @@ from ..const import (
     SHORT_PRESS,
     TURN_ON,
 )
+from zhaquirks.lds import MANUFACTURER, LightLinkCluster
 
 
 class CCTSwitch(CustomDevice):

--- a/zhaquirks/ledvance/a19rgbw.py
+++ b/zhaquirks/ledvance/a19rgbw.py
@@ -13,8 +13,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.lighting import Color
 
-from . import LEDVANCE, LedvanceLightCluster
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -22,6 +21,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.ledvance import LEDVANCE, LedvanceLightCluster
 
 
 class LedvanceA19RGBW(CustomDevice):

--- a/zhaquirks/ledvance/flexrgbw.py
+++ b/zhaquirks/ledvance/flexrgbw.py
@@ -13,8 +13,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.lighting import Color
 
-from . import LEDVANCE, LedvanceLightCluster
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -22,6 +21,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.ledvance import LEDVANCE, LedvanceLightCluster
 
 
 class FlexRGBW(CustomDevice):

--- a/zhaquirks/legrand/dimmer.py
+++ b/zhaquirks/legrand/dimmer.py
@@ -14,8 +14,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 
-from . import LEGRAND
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -23,6 +22,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.legrand import LEGRAND
 
 MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFC01  # decimal = 64513
 

--- a/zhaquirks/lutron/lzl4bwhl01remote.py
+++ b/zhaquirks/lutron/lzl4bwhl01remote.py
@@ -12,8 +12,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lightlink import LightLink
 
 from zhaquirks import GroupBoundCluster
-
-from ..const import (
+from zhaquirks.const import (
     ARGS,
     CLUSTER_ID,
     COMMAND,

--- a/zhaquirks/netvox/z308e3ed.py
+++ b/zhaquirks/netvox/z308e3ed.py
@@ -5,8 +5,13 @@ from zigpy.zcl.clusters.general import Basic, Commissioning, Identify, PollContr
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-
-from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 

--- a/zhaquirks/orvibo/__init__.py
+++ b/zhaquirks/orvibo/__init__.py
@@ -1,6 +1,6 @@
 """Module for ORVIBO quirks implementations."""
 
-from .. import LocalDataCluster, MotionWithReset, OccupancyOnEvent
+from zhaquirks import LocalDataCluster, MotionWithReset, OccupancyOnEvent
 
 ORVIBO = "欧瑞博"
 ORVIBO_LATIN = "ORVIBO"

--- a/zhaquirks/orvibo/dimmer.py
+++ b/zhaquirks/orvibo/dimmer.py
@@ -5,8 +5,7 @@ from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Groups, LevelControl, OnOff, Scenes
 from zigpy.zcl.clusters.lighting import Color
 
-from . import ORVIBO
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -14,6 +13,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.orvibo import ORVIBO
 
 
 class T10D1ZW(CustomDevice):

--- a/zhaquirks/orvibo/motion.py
+++ b/zhaquirks/orvibo/motion.py
@@ -14,9 +14,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.security import IasZone
 
-from . import ORVIBO_LATIN, MotionCluster, OccupancyCluster
-from .. import Bus, PowerConfigurationCluster
-from ..const import (
+from zhaquirks import Bus, PowerConfigurationCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -24,6 +23,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.orvibo import ORVIBO_LATIN, MotionCluster, OccupancyCluster
 
 ORVIBO_CLUSTER_ID = 0xFFFF
 

--- a/zhaquirks/osram/a19rgbw.py
+++ b/zhaquirks/osram/a19rgbw.py
@@ -12,8 +12,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lighting import Color
 
-from . import OSRAM, OsramLightCluster
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -21,6 +20,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.osram import OSRAM, OsramLightCluster
 
 
 class LIGHTIFYA19RGBW(CustomDevice):

--- a/zhaquirks/osram/flexrgbw.py
+++ b/zhaquirks/osram/flexrgbw.py
@@ -12,8 +12,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lighting import Color
 
-from . import OSRAM, OsramLightCluster
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -21,6 +20,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.osram import OSRAM, OsramLightCluster
 
 
 class FlexRGBW(CustomDevice):

--- a/zhaquirks/osram/gardenpolesrgbw.py
+++ b/zhaquirks/osram/gardenpolesrgbw.py
@@ -13,8 +13,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import OSRAM, OsramLightCluster
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -22,6 +21,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.osram import OSRAM, OsramLightCluster
 
 
 class GardenpoleRGBW(CustomDevice):

--- a/zhaquirks/osram/lightifyx4.py
+++ b/zhaquirks/osram/lightifyx4.py
@@ -19,8 +19,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import OSRAM
-from ..const import (
+from zhaquirks.const import (
     BUTTON_1,
     BUTTON_2,
     BUTTON_3,
@@ -40,6 +39,7 @@ from ..const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
+from zhaquirks.osram import OSRAM
 
 OSRAM_DEVICE = 0x0810  # 2064 base 10
 OSRAM_CLUSTER = 0xFD00  # 64768 base 10

--- a/zhaquirks/osram/osramplug.py
+++ b/zhaquirks/osram/osramplug.py
@@ -5,8 +5,7 @@ from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scen
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import OSRAM, OsramLightCluster
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -14,6 +13,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.osram import OSRAM, OsramLightCluster
 
 
 class OsramPlug(CustomDevice):

--- a/zhaquirks/osram/smartplusac05347.py
+++ b/zhaquirks/osram/smartplusac05347.py
@@ -13,8 +13,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import OSRAM, OsramLightCluster
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -22,6 +21,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.osram import OSRAM, OsramLightCluster
 
 
 class SmartplusAC05347(CustomDevice):

--- a/zhaquirks/osram/switchmini.py
+++ b/zhaquirks/osram/switchmini.py
@@ -15,8 +15,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import OSRAM
-from ..const import (
+from zhaquirks.const import (
     BUTTON_1,
     BUTTON_2,
     BUTTON_3,
@@ -38,6 +37,7 @@ from ..const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
+from zhaquirks.osram import OSRAM
 
 OSRAM_CLUSTER = 0xFD00
 

--- a/zhaquirks/osram/tunablewhite.py
+++ b/zhaquirks/osram/tunablewhite.py
@@ -13,8 +13,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.lighting import Color
 
-from . import OSRAM, OsramLightCluster
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -22,6 +21,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.osram import OSRAM, OsramLightCluster
 
 
 class OsramColorCluster(CustomCluster, Color):

--- a/zhaquirks/philio/__init__.py
+++ b/zhaquirks/philio/__init__.py
@@ -1,6 +1,6 @@
 """Module for Philio quirks implementations."""
 
-from .. import MotionWithReset
+from zhaquirks import MotionWithReset
 
 PHILIO = "Philio"
 

--- a/zhaquirks/philio/pst03a.py
+++ b/zhaquirks/philio/pst03a.py
@@ -16,8 +16,7 @@ from zigpy.zcl.clusters.measurement import (
 )
 from zigpy.zcl.clusters.security import IasZone
 
-from . import PHILIO, MotionCluster
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -27,6 +26,7 @@ from ..const import (
     PROFILE_ID,
     SKIP_CONFIGURATION,
 )
+from zhaquirks.philio import PHILIO, MotionCluster
 
 
 class Pst03a(CustomDevice):

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -11,7 +11,7 @@ from zigpy.zcl.clusters.general import Basic, LevelControl, OnOff
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.measurement import OccupancySensing
 
-from ..const import (
+from zhaquirks.const import (
     ARGS,
     BUTTON,
     COMMAND,

--- a/zhaquirks/philips/motion.py
+++ b/zhaquirks/philips/motion.py
@@ -18,8 +18,7 @@ from zigpy.zcl.clusters.measurement import (
     TemperatureMeasurement,
 )
 
-from . import PHILIPS, OccupancyCluster
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -27,6 +26,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.philips import PHILIPS, OccupancyCluster
 
 
 class PhilipsMotion(CustomDevice):

--- a/zhaquirks/philips/rom001.py
+++ b/zhaquirks/philips/rom001.py
@@ -13,8 +13,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import PHILIPS, SIGNIFY, PhilipsBasicCluster, PhilipsRemoteCluster
-from ..const import (
+from zhaquirks.const import (
     COMMAND,
     DEVICE_TYPE,
     DOUBLE_PRESS,
@@ -31,6 +30,12 @@ from ..const import (
     SHORT_RELEASE,
     TRIPLE_PRESS,
     TURN_ON,
+)
+from zhaquirks.philips import (
+    PHILIPS,
+    SIGNIFY,
+    PhilipsBasicCluster,
+    PhilipsRemoteCluster,
 )
 
 DEVICE_SPECIFIC_UNKNOWN = 64512

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -13,20 +13,20 @@ from zigpy.zcl.clusters.general import (
     PowerConfiguration,
 )
 
-from . import (
-    HUE_REMOTE_DEVICE_TRIGGERS,
-    PHILIPS,
-    SIGNIFY,
-    PhilipsBasicCluster,
-    PhilipsRemoteCluster,
-)
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+)
+from zhaquirks.philips import (
+    HUE_REMOTE_DEVICE_TRIGGERS,
+    PHILIPS,
+    SIGNIFY,
+    PhilipsBasicCluster,
+    PhilipsRemoteCluster,
 )
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821

--- a/zhaquirks/philips/rwl021.py
+++ b/zhaquirks/philips/rwl021.py
@@ -14,20 +14,20 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from . import (
-    HUE_REMOTE_DEVICE_TRIGGERS,
-    PHILIPS,
-    SIGNIFY,
-    PhilipsBasicCluster,
-    PhilipsRemoteCluster,
-)
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+)
+from zhaquirks.philips import (
+    HUE_REMOTE_DEVICE_TRIGGERS,
+    PHILIPS,
+    SIGNIFY,
+    PhilipsBasicCluster,
+    PhilipsRemoteCluster,
 )
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821

--- a/zhaquirks/philips/rwl022.py
+++ b/zhaquirks/philips/rwl022.py
@@ -13,19 +13,19 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from . import (
-    HUE_REMOTE_DEVICE_TRIGGERS,
-    SIGNIFY,
-    PhilipsBasicCluster,
-    PhilipsRemoteCluster,
-)
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+)
+from zhaquirks.philips import (
+    HUE_REMOTE_DEVICE_TRIGGERS,
+    SIGNIFY,
+    PhilipsBasicCluster,
+    PhilipsRemoteCluster,
 )
 
 DEVICE_SPECIFIC_UNKNOWN = 64512

--- a/zhaquirks/plaid/soil.py
+++ b/zhaquirks/plaid/soil.py
@@ -5,9 +5,8 @@ from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.measurement import RelativeHumidity, TemperatureMeasurement
 
-from . import PLAID_SYSTEMS
-from .. import PowerConfigurationCluster
-from ..const import (
+from zhaquirks import PowerConfigurationCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -15,6 +14,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.plaid import PLAID_SYSTEMS
 
 
 class PowerConfigurationClusterMains(PowerConfigurationCluster):

--- a/zhaquirks/salus/sp600.py
+++ b/zhaquirks/salus/sp600.py
@@ -13,8 +13,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
-from . import COMPUTIME
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -22,6 +21,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.salus import COMPUTIME
 
 MODEL = "SP600"
 

--- a/zhaquirks/samjin/__init__.py
+++ b/zhaquirks/samjin/__init__.py
@@ -7,7 +7,7 @@ from zigpy.types import Addressing
 from zigpy.zcl import foundation
 import zigpy.zcl.clusters.security
 
-from ..const import ARGS, COMMAND_ID, PRESS_TYPE, ZHA_SEND_EVENT
+from zhaquirks.const import ARGS, COMMAND_ID, PRESS_TYPE, ZHA_SEND_EVENT
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/zhaquirks/samjin/button.py
+++ b/zhaquirks/samjin/button.py
@@ -13,8 +13,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
-from . import SAMJIN, SamjinIASCluster
-from ..const import (
+from zhaquirks.const import (
     BUTTON,
     COMMAND,
     COMMAND_BUTTON_DOUBLE,
@@ -30,6 +29,7 @@ from ..const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
+from zhaquirks.samjin import SAMJIN, SamjinIASCluster
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/zhaquirks/samjin/button2.py
+++ b/zhaquirks/samjin/button2.py
@@ -13,8 +13,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
-from . import SAMJIN, SamjinIASCluster
-from ..const import (
+from zhaquirks.const import (
     BUTTON,
     COMMAND,
     COMMAND_BUTTON_DOUBLE,
@@ -30,6 +29,7 @@ from ..const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
+from zhaquirks.samjin import SAMJIN, SamjinIASCluster
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/zhaquirks/samjin/multi2.py
+++ b/zhaquirks/samjin/multi2.py
@@ -10,8 +10,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
-from . import SAMJIN
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -19,7 +18,8 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from ..smartthings import SmartThingsAccelCluster
+from zhaquirks.samjin import SAMJIN
+from zhaquirks.smartthings import SmartThingsAccelCluster
 
 DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
 

--- a/zhaquirks/sengled/e1e_g7f.py
+++ b/zhaquirks/sengled/e1e_g7f.py
@@ -15,8 +15,8 @@ from zigpy.zcl.clusters.general import (
     PowerConfiguration,
 )
 
-from .. import Bus
-from ..const import (
+from zhaquirks import Bus
+from zhaquirks.const import (
     ARGS,
     COMMAND,
     COMMAND_OFF,

--- a/zhaquirks/sercomm/szwtd02n.py
+++ b/zhaquirks/sercomm/szwtd02n.py
@@ -15,8 +15,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-from . import SERCOMM
+from zhaquirks.sercomm import SERCOMM
 
 
 class SercommPowerConfiguration(PowerConfigurationCluster):

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -19,8 +19,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.smartenergy import Metering
 
-from . import SINOPE
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -28,6 +27,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.sinope import SINOPE
 
 SINOPE_MANUFACTURER_CLUSTER_ID = 0xFF01
 

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -21,8 +21,7 @@ from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
-from . import SINOPE
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -30,6 +29,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.sinope import SINOPE
 
 SINOPE_MANUFACTURER_CLUSTER_ID = 0xFF01
 

--- a/zhaquirks/smartthings/moisturev4.py
+++ b/zhaquirks/smartthings/moisturev4.py
@@ -6,9 +6,7 @@ from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-
-from . import SMART_THINGS
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -17,6 +15,7 @@ from ..const import (
     PROFILE_ID,
     ZONE_TYPE,
 )
+from zhaquirks.smartthings import SMART_THINGS
 
 
 class CustomIasZone(CustomCluster, IasZone):

--- a/zhaquirks/smartthings/motion.py
+++ b/zhaquirks/smartthings/motion.py
@@ -6,9 +6,7 @@ from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-
-from . import SMART_THINGS
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -16,6 +14,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.smartthings import SMART_THINGS
 
 
 class SmartThingsMotion(CustomDevice):

--- a/zhaquirks/smartthings/multi.py
+++ b/zhaquirks/smartthings/multi.py
@@ -12,7 +12,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
-from . import SmartThingsAccelCluster
+from zhaquirks.smartthings import SmartThingsAccelCluster
 
 
 class SmartthingsMultiPurposeSensor(CustomDevice):

--- a/zhaquirks/smartthings/multiv4.py
+++ b/zhaquirks/smartthings/multiv4.py
@@ -6,10 +6,8 @@ from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-
-from . import SMART_THINGS
-from ..centralite import CentraLiteAccelCluster
-from ..const import (
+from zhaquirks.centralite import CentraLiteAccelCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -17,6 +15,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.smartthings import SMART_THINGS
 
 
 class SmartThingsMultiV4(CustomDevice):

--- a/zhaquirks/smartthings/pgc313.py
+++ b/zhaquirks/smartthings/pgc313.py
@@ -4,8 +4,7 @@ from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Ota
 from zigpy.zcl.clusters.security import IasZone
 
-from . import SMART_THINGS, SmartThingsIasZone
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -14,6 +13,7 @@ from ..const import (
     PROFILE_ID,
     ZONE_TYPE,
 )
+from zhaquirks.smartthings import SMART_THINGS, SmartThingsIasZone
 
 SMARTSENSE_MULTI_DEVICE_TYPE = 0x0139  # decimal = 313
 

--- a/zhaquirks/smartthings/pgc314.py
+++ b/zhaquirks/smartthings/pgc314.py
@@ -3,8 +3,7 @@ from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Ota
 
-from . import SMART_THINGS, SmartThingsIasZone
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -12,6 +11,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.smartthings import SMART_THINGS, SmartThingsIasZone
 
 SMARTSENSE_MOTION_DEVICE_TYPE = 0x013A  # decimal = 314
 

--- a/zhaquirks/smartthings/tag_v4.py
+++ b/zhaquirks/smartthings/tag_v4.py
@@ -6,8 +6,13 @@ from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, BinaryInput, Identify, Ota, PollControl
 
 from zhaquirks import Bus, LocalDataCluster, PowerConfigurationCluster
-
-from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/zhaquirks/terncy/__init__.py
+++ b/zhaquirks/terncy/__init__.py
@@ -11,8 +11,8 @@ from zigpy.zcl.clusters.measurement import (
     TemperatureMeasurement,
 )
 
-from .. import OCCUPANCY_EVENT, LocalDataCluster, OccupancyOnEvent, _Motion
-from ..const import (
+from zhaquirks import OCCUPANCY_EVENT, LocalDataCluster, OccupancyOnEvent, _Motion
+from zhaquirks.const import (
     BUTTON,
     CLUSTER_COMMAND,
     COMMAND,

--- a/zhaquirks/terncy/pp01.py
+++ b/zhaquirks/terncy/pp01.py
@@ -14,9 +14,16 @@ from zigpy.zcl.clusters.measurement import (
     TemperatureMeasurement,
 )
 
-from zhaquirks import DoublingPowerConfigurationCluster
-
-from . import (
+from zhaquirks import Bus, DoublingPowerConfigurationCluster
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.terncy import (
     BUTTON_TRIGGERS,
     IlluminanceMeasurementCluster,
     MotionClusterLeft,
@@ -24,15 +31,6 @@ from . import (
     OccupancyCluster,
     TemperatureMeasurementCluster,
     TerncyRawCluster,
-)
-from .. import Bus
-from ..const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
 )
 
 TERNCY_AWARENESS_DEVICE_TYPE = 0x01F0

--- a/zhaquirks/terncy/sd01.py
+++ b/zhaquirks/terncy/sd01.py
@@ -11,9 +11,7 @@ from zigpy.zcl.clusters.general import (
 )
 
 from zhaquirks import DoublingPowerConfigurationCluster
-
-from . import BUTTON_TRIGGERS, KNOB_TRIGGERS, TerncyRawCluster
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -21,6 +19,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.terncy import BUTTON_TRIGGERS, KNOB_TRIGGERS, TerncyRawCluster
 
 TERNCY_KNOB_DEVICE_TYPE = 0x01F2
 

--- a/zhaquirks/thirdreality/switch.py
+++ b/zhaquirks/thirdreality/switch.py
@@ -3,6 +3,7 @@ from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes
 
+from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -11,9 +12,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-from . import THIRD_REALITY
-from .. import PowerConfigurationCluster
+from zhaquirks.thirdreality import THIRD_REALITY
 
 
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):

--- a/zhaquirks/trust/__init__.py
+++ b/zhaquirks/trust/__init__.py
@@ -1,5 +1,5 @@
 """Trust."""
-from .. import MotionWithReset
+from zhaquirks import MotionWithReset
 
 TRUST = "Trust"
 

--- a/zhaquirks/trust/zpir8000.py
+++ b/zhaquirks/trust/zpir8000.py
@@ -12,8 +12,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-from . import MotionCluster
+from zhaquirks.trust import MotionCluster
 
 MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFFFF
 

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -10,8 +10,8 @@ from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import OnOff, PowerConfiguration
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 
-from .. import Bus, EventableCluster, LocalDataCluster
-from ..const import DOUBLE_PRESS, LONG_PRESS, SHORT_PRESS, ZHA_SEND_EVENT
+from zhaquirks import Bus, EventableCluster, LocalDataCluster
+from zhaquirks.const import DOUBLE_PRESS, LONG_PRESS, SHORT_PRESS, ZHA_SEND_EVENT
 
 TUYA_CLUSTER_ID = 0xEF00
 TUYA_SET_DATA = 0x0000

--- a/zhaquirks/tuya/electric_heating.py
+++ b/zhaquirks/tuya/electric_heating.py
@@ -5,19 +5,19 @@ from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic, Groups, Ota, Scenes, Time
 
-from . import (
-    TuyaManufClusterAttributes,
-    TuyaThermostat,
-    TuyaThermostatCluster,
-    TuyaUserInterfaceCluster,
-)
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+)
+from zhaquirks.tuya import (
+    TuyaManufClusterAttributes,
+    TuyaThermostat,
+    TuyaThermostatCluster,
+    TuyaUserInterfaceCluster,
 )
 
 # info from https://github.com/zigpy/zha-device-handlers/pull/538#issuecomment-723334124

--- a/zhaquirks/tuya/motion.py
+++ b/zhaquirks/tuya/motion.py
@@ -9,9 +9,8 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Identify, Ota
 from zigpy.zcl.clusters.security import IasZone
 
-from . import TuyaManufCluster
-from .. import Bus, LocalDataCluster, MotionOnEvent
-from ..const import (
+from zhaquirks import Bus, LocalDataCluster, MotionOnEvent
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -20,6 +19,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.tuya import TuyaManufCluster
 
 ZONE_TYPE = 0x0001
 

--- a/zhaquirks/tuya/plug.py
+++ b/zhaquirks/tuya/plug.py
@@ -6,7 +6,7 @@ from zigpy.zcl.clusters.general import Basic, Groups, OnOff, Ota, Scenes, Time
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,

--- a/zhaquirks/tuya/singleswitch.py
+++ b/zhaquirks/tuya/singleswitch.py
@@ -2,7 +2,7 @@
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Groups, Ota, Scenes, Time
 
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -10,7 +10,12 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from ..tuya import TuyaManufacturerClusterOnOff, TuyaManufCluster, TuyaOnOff, TuyaSwitch
+from zhaquirks.tuya import (
+    TuyaManufacturerClusterOnOff,
+    TuyaManufCluster,
+    TuyaOnOff,
+    TuyaSwitch,
+)
 
 
 class TuyaSingleSwitch(TuyaSwitch):

--- a/zhaquirks/tuya/siren.py
+++ b/zhaquirks/tuya/siren.py
@@ -9,9 +9,8 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
 from zigpy.zcl.clusters.measurement import RelativeHumidity, TemperatureMeasurement
 
-from . import TuyaManufCluster, TuyaManufClusterAttributes
-from .. import Bus, LocalDataCluster
-from ..const import (
+from zhaquirks import Bus, LocalDataCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -19,6 +18,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.tuya import TuyaManufCluster, TuyaManufClusterAttributes
 
 TUYA_ALARM_ATTR = 0x0168  # [0]/[1] Alarm!
 TUYA_TEMP_ALARM_ATTR = 0x0171  # [0]/[1] Disable/Enable alarm by temperature

--- a/zhaquirks/tuya/thermostat_88teujp.py
+++ b/zhaquirks/tuya/thermostat_88teujp.py
@@ -15,15 +15,19 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.hvac import Thermostat
 
-from . import TuyaManufClusterAttributes, TuyaThermostat, TuyaThermostatCluster
-from .. import LocalDataCluster
-from ..const import (
+from zhaquirks import LocalDataCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+)
+from zhaquirks.tuya import (
+    TuyaManufClusterAttributes,
+    TuyaThermostat,
+    TuyaThermostatCluster,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/zhaquirks/tuya/ts0041.py
+++ b/zhaquirks/tuya/ts0041.py
@@ -4,8 +4,7 @@ from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota, PowerConfiguration, Time
 
-from . import TuyaSmartRemoteOnOffCluster
-from ..const import (
+from zhaquirks.const import (
     BUTTON_1,
     COMMAND,
     DEVICE_TYPE,
@@ -19,6 +18,7 @@ from ..const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
+from zhaquirks.tuya import TuyaSmartRemoteOnOffCluster
 
 
 class TuyaSmartRemote0041(CustomDevice):

--- a/zhaquirks/tuya/ts0041_zemismart.py
+++ b/zhaquirks/tuya/ts0041_zemismart.py
@@ -4,8 +4,7 @@ from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota, PowerConfiguration, Time
 
-from . import TuyaSmartRemoteOnOffCluster
-from ..const import (
+from zhaquirks.const import (
     BUTTON_1,
     COMMAND,
     DEVICE_TYPE,
@@ -19,6 +18,7 @@ from ..const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
+from zhaquirks.tuya import TuyaSmartRemoteOnOffCluster
 
 
 class TuyaZemismartSmartRemote0041(CustomDevice):

--- a/zhaquirks/tuya/ts0042.py
+++ b/zhaquirks/tuya/ts0042.py
@@ -4,8 +4,7 @@ from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota, PowerConfiguration, Time
 
-from . import TuyaSmartRemoteOnOffCluster
-from ..const import (
+from zhaquirks.const import (
     BUTTON_1,
     BUTTON_2,
     COMMAND,
@@ -20,6 +19,7 @@ from ..const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
+from zhaquirks.tuya import TuyaSmartRemoteOnOffCluster
 
 
 class TuyaSmartRemote0042(CustomDevice):

--- a/zhaquirks/tuya/ts0043.py
+++ b/zhaquirks/tuya/ts0043.py
@@ -4,8 +4,7 @@ from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota, PowerConfiguration, Time
 
-from . import TuyaSmartRemoteOnOffCluster
-from ..const import (
+from zhaquirks.const import (
     BUTTON_1,
     BUTTON_2,
     BUTTON_3,
@@ -21,6 +20,7 @@ from ..const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
+from zhaquirks.tuya import TuyaSmartRemoteOnOffCluster
 
 
 class TuyaSmartRemote0043(CustomDevice):

--- a/zhaquirks/tuya/ts0044.py
+++ b/zhaquirks/tuya/ts0044.py
@@ -4,8 +4,7 @@ from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota, PowerConfiguration, Time
 
-from . import TuyaSmartRemoteOnOffCluster
-from ..const import (
+from zhaquirks.const import (
     BUTTON_1,
     BUTTON_2,
     BUTTON_3,
@@ -22,6 +21,7 @@ from ..const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
+from zhaquirks.tuya import TuyaSmartRemoteOnOffCluster
 
 
 class Tuya4ButtonTriggers:

--- a/zhaquirks/tuya/ts0501b.py
+++ b/zhaquirks/tuya/ts0501b.py
@@ -15,7 +15,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,

--- a/zhaquirks/tuya/ts0601.py
+++ b/zhaquirks/tuya/ts0601.py
@@ -2,7 +2,7 @@
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Groups, Ota, Scenes, Time
 
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -10,7 +10,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from ..tuya import (
+from zhaquirks.tuya import (
     TuyaManufacturerClusterOnOff,
     TuyaManufacturerWindowCover,
     TuyaManufCluster,

--- a/zhaquirks/tuya/valve.py
+++ b/zhaquirks/tuya/valve.py
@@ -8,21 +8,21 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
 from zigpy.zcl.clusters.hvac import Thermostat
 
-from . import (
-    TuyaManufClusterAttributes,
-    TuyaPowerConfigurationCluster,
-    TuyaThermostat,
-    TuyaThermostatCluster,
-    TuyaUserInterfaceCluster,
-)
-from .. import Bus, LocalDataCluster
-from ..const import (
+from zhaquirks import Bus, LocalDataCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+)
+from zhaquirks.tuya import (
+    TuyaManufClusterAttributes,
+    TuyaPowerConfigurationCluster,
+    TuyaThermostat,
+    TuyaThermostatCluster,
+    TuyaUserInterfaceCluster,
 )
 
 # info from https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/converters/common.js#L113

--- a/zhaquirks/visonic/mct340e.py
+++ b/zhaquirks/visonic/mct340e.py
@@ -8,8 +8,7 @@ from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -17,9 +17,8 @@ from zigpy.zcl.clusters.homeautomation import ApplianceEventAlerts
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
-from . import WAXMAN
-from .. import Bus, LocalDataCluster
-from ..const import (
+from zhaquirks import Bus, LocalDataCluster
+from zhaquirks.const import (
     CLUSTER_COMMAND,
     DEVICE_TYPE,
     ENDPOINTS,
@@ -28,6 +27,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.waxman import WAXMAN
 
 MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFC02  # decimal = 64514
 MOISTURE_TYPE = 0x002A

--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -30,8 +30,8 @@ from zigpy.zcl.clusters.general import (
     OnOff,
 )
 
-from .. import EventableCluster, LocalDataCluster
-from ..const import ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS
+from zhaquirks import EventableCluster, LocalDataCluster
+from zhaquirks.const import ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/zhaquirks/xbee/xbee3_io.py
+++ b/zhaquirks/xbee/xbee3_io.py
@@ -2,8 +2,20 @@
 
 from zigpy.profiles import zha
 
-from . import XBEE_PROFILE_ID, XBeeAnalogInput, XBeeCommon, XBeeOnOff, XBeePWM
-from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xbee import (
+    XBEE_PROFILE_ID,
+    XBeeAnalogInput,
+    XBeeCommon,
+    XBeeOnOff,
+    XBeePWM,
+)
 
 
 class XBee3Sensor(XBeeCommon):

--- a/zhaquirks/xbee/xbee_io.py
+++ b/zhaquirks/xbee/xbee_io.py
@@ -2,8 +2,14 @@
 
 from zigpy.profiles import zha
 
-from . import XBEE_PROFILE_ID, XBeeAnalogInput, XBeeCommon, XBeeOnOff
-from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xbee import XBEE_PROFILE_ID, XBeeAnalogInput, XBeeCommon, XBeeOnOff
 
 
 class XBeeSensor(XBeeCommon):

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -26,8 +26,14 @@ import zigpy.zcl.foundation as foundation
 import zigpy.zdo
 from zigpy.zdo.types import NodeDescriptor
 
-from .. import Bus, LocalDataCluster, MotionOnEvent, OccupancyWithReset, QuickInitDevice
-from ..const import (
+from zhaquirks import (
+    Bus,
+    LocalDataCluster,
+    MotionOnEvent,
+    OccupancyWithReset,
+    QuickInitDevice,
+)
+from zhaquirks.const import (
     ATTRIBUTE_ID,
     ATTRIBUTE_NAME,
     COMMAND_ATTRIBUTE_UPDATED,

--- a/zhaquirks/xiaomi/aqara/ctrl_ln.py
+++ b/zhaquirks/xiaomi/aqara/ctrl_ln.py
@@ -15,16 +15,7 @@ from zigpy.zcl.clusters.general import (
 )
 
 from zhaquirks import Bus
-
-from .. import (
-    LUMI,
-    AnalogInputCluster,
-    BasicCluster,
-    OnOffCluster,
-    XiaomiCustomDevice,
-    XiaomiPowerConfiguration,
-)
-from ...const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -32,6 +23,14 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    AnalogInputCluster,
+    BasicCluster,
+    OnOffCluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 
 

--- a/zhaquirks/xiaomi/aqara/ctrl_neutral.py
+++ b/zhaquirks/xiaomi/aqara/ctrl_neutral.py
@@ -17,15 +17,8 @@ from zigpy.zcl.clusters.general import (
     Time,
 )
 
-from .. import (
-    LUMI,
-    BasicCluster,
-    OnOffCluster,
-    XiaomiCustomDevice,
-    XiaomiPowerConfiguration,
-)
-from ... import EventableCluster
-from ...const import (
+from zhaquirks import EventableCluster
+from zhaquirks.const import (
     ARGS,
     ATTRIBUTE_ID,
     ATTRIBUTE_NAME,
@@ -45,6 +38,13 @@ from ...const import (
     PROFILE_ID,
     SKIP_CONFIGURATION,
     VALUE,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    OnOffCluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 
 ATTRIBUTE_ON_OFF = "on_off"

--- a/zhaquirks/xiaomi/aqara/cube.py
+++ b/zhaquirks/xiaomi/aqara/cube.py
@@ -11,15 +11,8 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import (
-    LUMI,
-    XIAOMI_NODE_DESC,
-    BasicCluster,
-    XiaomiPowerConfiguration,
-    XiaomiQuickInitDevice,
-)
-from ... import CustomCluster
-from ...const import (
+from zhaquirks import CustomCluster
+from zhaquirks.const import (
     ARGS,
     COMMAND,
     DEVICE_TYPE,
@@ -34,6 +27,13 @@ from ...const import (
     TURN_ON,
     VALUE,
     ZHA_SEND_EVENT,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    XiaomiPowerConfiguration,
+    XiaomiQuickInitDevice,
 )
 
 ACTIVATED_FACE = "activated_face"

--- a/zhaquirks/xiaomi/aqara/cube_aqgl01.py
+++ b/zhaquirks/xiaomi/aqara/cube_aqgl01.py
@@ -11,9 +11,8 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import LUMI, BasicCluster, XiaomiCustomDevice, XiaomiPowerConfiguration
-from ... import CustomCluster
-from ...const import (
+from zhaquirks import CustomCluster
+from zhaquirks.const import (
     ARGS,
     COMMAND,
     DEVICE_TYPE,
@@ -27,6 +26,12 @@ from ...const import (
     TURN_ON,
     VALUE,
     ZHA_SEND_EVENT,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 
 ACTIVATED_FACE = "activated_face"

--- a/zhaquirks/xiaomi/aqara/illumination.py
+++ b/zhaquirks/xiaomi/aqara/illumination.py
@@ -6,9 +6,8 @@ from zigpy.zcl.clusters.general import Basic, Identify
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement
 from zigpy.zdo.types import NodeDescriptor
 
-from .. import LUMI, BasicCluster, XiaomiCustomDevice
-from ... import PowerConfigurationCluster
-from ...const import (
+from zhaquirks import PowerConfigurationCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -17,6 +16,7 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.xiaomi import LUMI, BasicCluster, XiaomiCustomDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/zhaquirks/xiaomi/aqara/light_aqcn2.py
+++ b/zhaquirks/xiaomi/aqara/light_aqcn2.py
@@ -23,9 +23,8 @@ from zigpy.zcl.clusters.measurement import (
     TemperatureMeasurement,
 )
 
-from .. import LUMI, BasicCluster, XiaomiCustomDevice
-from ... import CustomCluster
-from ...const import (
+from zhaquirks import CustomCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -33,6 +32,7 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.xiaomi import LUMI, BasicCluster, XiaomiCustomDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/zhaquirks/xiaomi/aqara/magnet_aq2.py
+++ b/zhaquirks/xiaomi/aqara/magnet_aq2.py
@@ -4,14 +4,7 @@ import logging
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Groups, Identify, OnOff
 
-from .. import (
-    LUMI,
-    XIAOMI_NODE_DESC,
-    BasicCluster,
-    XiaomiPowerConfiguration,
-    XiaomiQuickInitDevice,
-)
-from ...const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -20,6 +13,13 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    XiaomiPowerConfiguration,
+    XiaomiQuickInitDevice,
 )
 
 OPEN_CLOSE_DEVICE_TYPE = 0x5F01

--- a/zhaquirks/xiaomi/aqara/motion_aq2.py
+++ b/zhaquirks/xiaomi/aqara/motion_aq2.py
@@ -5,18 +5,8 @@ from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
 
-from .. import (
-    LUMI,
-    XIAOMI_NODE_DESC,
-    BasicCluster,
-    IlluminanceMeasurementCluster,
-    MotionCluster,
-    OccupancyCluster,
-    XiaomiPowerConfiguration,
-    XiaomiQuickInitDevice,
-)
-from ... import Bus
-from ...const import (
+from zhaquirks import Bus
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -25,6 +15,16 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    IlluminanceMeasurementCluster,
+    MotionCluster,
+    OccupancyCluster,
+    XiaomiPowerConfiguration,
+    XiaomiQuickInitDevice,
 )
 
 XIAOMI_CLUSTER_ID = 0xFFFF

--- a/zhaquirks/xiaomi/aqara/motion_aq2b.py
+++ b/zhaquirks/xiaomi/aqara/motion_aq2b.py
@@ -4,17 +4,8 @@ from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Ota
 from zigpy.zcl.clusters.measurement import OccupancySensing
 
-from .. import (
-    LUMI,
-    BasicCluster,
-    IlluminanceMeasurementCluster,
-    MotionCluster,
-    OccupancyCluster,
-    XiaomiCustomDevice,
-    XiaomiPowerConfiguration,
-)
-from ... import Bus
-from ...const import (
+from zhaquirks import Bus
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -22,6 +13,15 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    IlluminanceMeasurementCluster,
+    MotionCluster,
+    OccupancyCluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 
 XIAOMI_CLUSTER_ID = 0xFFFF

--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -13,11 +13,8 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zdo.types import NodeDescriptor
 
-from zhaquirks import CustomCluster
-
-from .. import LUMI, BasicCluster, XiaomiCustomDevice
-from ... import PowerConfigurationCluster
-from ...const import (
+from zhaquirks import CustomCluster, PowerConfigurationCluster
+from zhaquirks.const import (
     ALT_DOUBLE_PRESS,
     ALT_LONG_PRESS,
     ALT_SHORT_PRESS,
@@ -54,6 +51,7 @@ from ...const import (
     VALUE,
     ZHA_SEND_EVENT,
 )
+from zhaquirks.xiaomi import LUMI, BasicCluster, XiaomiCustomDevice
 
 PRESS_TYPES = {0: "long press", 1: "single", 2: "double", 3: "triple", 255: "release"}
 STATUS_TYPE_ATTR = 0x0055  # decimal = 85

--- a/zhaquirks/xiaomi/aqara/plug_maus01.py
+++ b/zhaquirks/xiaomi/aqara/plug_maus01.py
@@ -18,15 +18,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 
-from .. import (
-    LUMI,
-    AnalogInputCluster,
-    BasicCluster,
-    ElectricalMeasurementCluster,
-    XiaomiCustomDevice,
-)
-from ... import Bus
-from ...const import (
+from zhaquirks import Bus
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -34,6 +27,13 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    AnalogInputCluster,
+    BasicCluster,
+    ElectricalMeasurementCluster,
+    XiaomiCustomDevice,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/zhaquirks/xiaomi/aqara/plug_mmeu01.py
+++ b/zhaquirks/xiaomi/aqara/plug_mmeu01.py
@@ -18,15 +18,8 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
-from .. import (
-    LUMI,
-    AnalogInputCluster,
-    BasicCluster,
-    ElectricalMeasurementCluster,
-    XiaomiCustomDevice,
-)
-from ... import Bus
-from ...const import (
+from zhaquirks import Bus
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -34,6 +27,13 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    AnalogInputCluster,
+    BasicCluster,
+    ElectricalMeasurementCluster,
+    XiaomiCustomDevice,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/zhaquirks/xiaomi/aqara/relay_c2acn01.py
+++ b/zhaquirks/xiaomi/aqara/relay_c2acn01.py
@@ -17,16 +17,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 
-from .. import (
-    LUMI,
-    AnalogInputCluster,
-    BasicCluster,
-    BinaryOutputInterlock,
-    ElectricalMeasurementCluster,
-    XiaomiCustomDevice,
-)
-from ... import Bus
-from ...const import (
+from zhaquirks import Bus
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -34,6 +26,14 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    AnalogInputCluster,
+    BasicCluster,
+    BinaryOutputInterlock,
+    ElectricalMeasurementCluster,
+    XiaomiCustomDevice,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/zhaquirks/xiaomi/aqara/remote_b186acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b186acn01.py
@@ -13,15 +13,8 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import (
-    LUMI,
-    XIAOMI_NODE_DESC,
-    BasicCluster,
-    XiaomiPowerConfiguration,
-    XiaomiQuickInitDevice,
-)
-from ... import CustomCluster
-from ...const import (
+from zhaquirks import CustomCluster
+from zhaquirks.const import (
     ATTR_ID,
     COMMAND,
     DEVICE_TYPE,
@@ -38,6 +31,13 @@ from ...const import (
     SKIP_CONFIGURATION,
     VALUE,
     ZHA_SEND_EVENT,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    XiaomiPowerConfiguration,
+    XiaomiQuickInitDevice,
 )
 
 DOUBLE = "double"

--- a/zhaquirks/xiaomi/aqara/remote_b286acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b286acn01.py
@@ -13,9 +13,8 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import LUMI, BasicCluster, XiaomiCustomDevice, XiaomiPowerConfiguration
-from ... import CustomCluster
-from ...const import (
+from zhaquirks import CustomCluster
+from zhaquirks.const import (
     ATTR_ID,
     BUTTON,
     BUTTON_1,
@@ -35,6 +34,12 @@ from ...const import (
     SKIP_CONFIGURATION,
     VALUE,
     ZHA_SEND_EVENT,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 
 BOTH_BUTTONS = "both_buttons"

--- a/zhaquirks/xiaomi/aqara/sensor_swit.py
+++ b/zhaquirks/xiaomi/aqara/sensor_swit.py
@@ -4,9 +4,8 @@ import logging
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, MultistateInput, OnOff
 
-from .. import LUMI, BasicCluster, XiaomiCustomDevice, XiaomiPowerConfiguration
-from ... import CustomCluster
-from ...const import (
+from zhaquirks import CustomCluster
+from zhaquirks.const import (
     COMMAND,
     COMMAND_DOUBLE,
     COMMAND_HOLD,
@@ -27,6 +26,12 @@ from ...const import (
     SKIP_CONFIGURATION,
     VALUE,
     ZHA_SEND_EVENT,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 
 BUTTON_DEVICE_TYPE = 0x5F01

--- a/zhaquirks/xiaomi/aqara/sensor_switch_aq3.py
+++ b/zhaquirks/xiaomi/aqara/sensor_switch_aq3.py
@@ -4,9 +4,8 @@ import logging
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Identify, MultistateInput, OnOff
 
-from .. import LUMI, BasicCluster, XiaomiCustomDevice, XiaomiPowerConfiguration
-from ... import CustomCluster
-from ...const import (
+from zhaquirks import CustomCluster
+from zhaquirks.const import (
     COMMAND,
     COMMAND_DOUBLE,
     COMMAND_HOLD,
@@ -27,6 +26,12 @@ from ...const import (
     SKIP_CONFIGURATION,
     VALUE,
     ZHA_SEND_EVENT,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 
 B1ACN01_HOLD = 0

--- a/zhaquirks/xiaomi/aqara/switch_aq2.py
+++ b/zhaquirks/xiaomi/aqara/switch_aq2.py
@@ -4,14 +4,7 @@ import logging
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Groups, OnOff
 
-from .. import (
-    LUMI,
-    XIAOMI_NODE_DESC,
-    BasicCluster,
-    XiaomiPowerConfiguration,
-    XiaomiQuickInitDevice,
-)
-from ...const import (
+from zhaquirks.const import (
     ARGS,
     ATTRIBUTE_ID,
     ATTRIBUTE_NAME,
@@ -34,6 +27,13 @@ from ...const import (
     TRIPLE_PRESS,
     UNKNOWN,
     VALUE,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    XiaomiPowerConfiguration,
+    XiaomiQuickInitDevice,
 )
 
 BUTTON_DEVICE_TYPE = 0x5F01

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -15,15 +15,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.security import IasZone
 
-from .. import (
-    LUMI,
-    XIAOMI_NODE_DESC,
-    BasicCluster,
-    XiaomiPowerConfiguration,
-    XiaomiQuickInitDevice,
-)
-from ... import Bus, LocalDataCluster, MotionOnEvent
-from ...const import (
+from zhaquirks import Bus, LocalDataCluster, MotionOnEvent
+from zhaquirks.const import (
     CLUSTER_ID,
     COMMAND,
     COMMAND_TILT,
@@ -40,6 +33,13 @@ from ...const import (
     UNKNOWN,
     ZHA_SEND_EVENT,
     ZONE_TYPE,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    XiaomiPowerConfiguration,
+    XiaomiQuickInitDevice,
 )
 
 ACCELEROMETER_ATTR = 0x0508  # decimal = 1288

--- a/zhaquirks/xiaomi/aqara/weather.py
+++ b/zhaquirks/xiaomi/aqara/weather.py
@@ -5,18 +5,8 @@ from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Groups, Identify
 from zigpy.zcl.clusters.measurement import PressureMeasurement
 
-from .. import (
-    LUMI,
-    XIAOMI_NODE_DESC,
-    BasicCluster,
-    PressureMeasurementCluster,
-    RelativeHumidityCluster,
-    TemperatureMeasurementCluster,
-    XiaomiPowerConfiguration,
-    XiaomiQuickInitDevice,
-)
-from ... import Bus
-from ...const import (
+from zhaquirks import Bus
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -25,6 +15,16 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    PressureMeasurementCluster,
+    RelativeHumidityCluster,
+    TemperatureMeasurementCluster,
+    XiaomiPowerConfiguration,
+    XiaomiQuickInitDevice,
 )
 
 TEMPERATURE_HUMIDITY_DEVICE_TYPE = 0x5F01

--- a/zhaquirks/xiaomi/aqara/wleak_aq1.py
+++ b/zhaquirks/xiaomi/aqara/wleak_aq1.py
@@ -4,14 +4,7 @@ from zigpy.quirks import CustomCluster
 from zigpy.zcl.clusters.general import Identify, Ota
 from zigpy.zcl.clusters.security import IasZone
 
-from .. import (
-    LUMI,
-    XIAOMI_NODE_DESC,
-    BasicCluster,
-    XiaomiPowerConfiguration,
-    XiaomiQuickInitDevice,
-)
-from ...const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -21,6 +14,13 @@ from ...const import (
     PROFILE_ID,
     SKIP_CONFIGURATION,
     ZONE_TYPE,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    XiaomiPowerConfiguration,
+    XiaomiQuickInitDevice,
 )
 
 

--- a/zhaquirks/xiaomi/mija/motion.py
+++ b/zhaquirks/xiaomi/mija/motion.py
@@ -12,17 +12,8 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import (
-    LUMI,
-    XIAOMI_NODE_DESC,
-    BasicCluster,
-    MotionCluster,
-    OccupancyCluster,
-    XiaomiPowerConfiguration,
-    XiaomiQuickInitDevice,
-)
-from ... import Bus
-from ...const import (
+from zhaquirks import Bus
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -31,6 +22,15 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    MotionCluster,
+    OccupancyCluster,
+    XiaomiPowerConfiguration,
+    XiaomiQuickInitDevice,
 )
 
 XIAOMI_CLUSTER_ID = 0xFFFF

--- a/zhaquirks/xiaomi/mija/sensor_ht.py
+++ b/zhaquirks/xiaomi/mija/sensor_ht.py
@@ -11,16 +11,8 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import (
-    LUMI,
-    BasicCluster,
-    RelativeHumidityCluster,
-    TemperatureMeasurementCluster,
-    XiaomiCustomDevice,
-    XiaomiPowerConfiguration,
-)
-from ... import Bus
-from ...const import (
+from zhaquirks import Bus
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -28,6 +20,14 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    RelativeHumidityCluster,
+    TemperatureMeasurementCluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 
 TEMPERATURE_HUMIDITY_DEVICE_TYPE = 0x5F01

--- a/zhaquirks/xiaomi/mija/sensor_magnet.py
+++ b/zhaquirks/xiaomi/mija/sensor_magnet.py
@@ -11,14 +11,7 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import (
-    LUMI,
-    XIAOMI_NODE_DESC,
-    BasicCluster,
-    XiaomiPowerConfiguration,
-    XiaomiQuickInitDevice,
-)
-from ...const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -27,6 +20,13 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    XiaomiPowerConfiguration,
+    XiaomiQuickInitDevice,
 )
 
 OPEN_CLOSE_DEVICE_TYPE = 0x5F01

--- a/zhaquirks/xiaomi/mija/sensor_switch.py
+++ b/zhaquirks/xiaomi/mija/sensor_switch.py
@@ -12,15 +12,8 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from .. import (
-    LUMI,
-    XIAOMI_NODE_DESC,
-    BasicCluster,
-    XiaomiPowerConfiguration,
-    XiaomiQuickInitDevice,
-)
-from ... import CustomCluster
-from ...const import (
+from zhaquirks import CustomCluster
+from zhaquirks.const import (
     ARGS,
     CLICK_TYPE,
     COMMAND,
@@ -45,6 +38,13 @@ from ...const import (
     TRIPLE_PRESS,
     UNKNOWN,
     ZHA_SEND_EVENT,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    XiaomiPowerConfiguration,
+    XiaomiQuickInitDevice,
 )
 
 XIAOMI_CLUSTER_ID = 0xFFFF

--- a/zhaquirks/xiaomi/mija/smoke.py
+++ b/zhaquirks/xiaomi/mija/smoke.py
@@ -25,15 +25,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.security import IasZone
 
-from .. import (
-    LUMI,
-    XIAOMI_NODE_DESC,
-    BasicCluster,
-    XiaomiPowerConfiguration,
-    XiaomiQuickInitDevice,
-)
-from ... import CustomCluster
-from ...const import (
+from zhaquirks import CustomCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -42,6 +35,13 @@ from ...const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    XIAOMI_NODE_DESC,
+    BasicCluster,
+    XiaomiPowerConfiguration,
+    XiaomiQuickInitDevice,
 )
 
 IAS_ZONE = 0x0402

--- a/zhaquirks/yale/realliving.py
+++ b/zhaquirks/yale/realliving.py
@@ -4,8 +4,8 @@ from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.closures import DoorLock
 from zigpy.zcl.clusters.general import Alarms, Basic, Identify, Ota, PollControl, Time
 
-from .. import DoublingPowerConfigurationCluster
-from ..const import (
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,

--- a/zhaquirks/zen/__init__.py
+++ b/zhaquirks/zen/__init__.py
@@ -1,6 +1,6 @@
 """Module for Zen Within quirks implementations."""
 
-from .. import PowerConfigurationCluster
+from zhaquirks import PowerConfigurationCluster
 
 ZEN = "Zen Within"
 

--- a/zhaquirks/zen/thermostat.py
+++ b/zhaquirks/zen/thermostat.py
@@ -4,8 +4,7 @@ import zigpy.profiles.zha as zha_p
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters import general, homeautomation, hvac
 
-from . import ZEN, ZenPowerConfiguration
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -13,6 +12,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.zen import ZEN, ZenPowerConfiguration
 
 
 class ZenThermostat(CustomDevice):

--- a/zhaquirks/zhongxing/__init__.py
+++ b/zhaquirks/zhongxing/__init__.py
@@ -1,6 +1,6 @@
 """Module for ZHONGXING (knockoff Orvibo) quirks implementations."""
 
-from .. import LocalDataCluster, MotionWithReset, OccupancyOnEvent
+from zhaquirks import LocalDataCluster, MotionWithReset, OccupancyOnEvent
 
 ZHONGXING = "中性"
 ZHONGXING_LATIN = "ZHONGXING"

--- a/zhaquirks/zhongxing/motion.py
+++ b/zhaquirks/zhongxing/motion.py
@@ -14,9 +14,8 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.security import IasZone
 
-from . import ZHONGXING, MotionCluster
-from .. import Bus, PowerConfigurationCluster
-from ..const import (
+from zhaquirks import Bus, PowerConfigurationCluster
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -24,6 +23,7 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.zhongxing import ZHONGXING, MotionCluster
 
 
 class SN10ZW(CustomDevice):


### PR DESCRIPTION
To streamline quirk development and make it easier for new users, I've replaced all relative imports in all quirk submodules with absolute imports. I've also added a rudimentary unit test to enforce this as I couldn't find a way to have pylint or flake8 do this automatically.

The new process (in theory) will just be:

1. Configure HA to load custom quirks:
   ```YAML
   zha:
     custom_quirks_path: /config/custom_zha_quirks/
   ```
2. Copy/paste or download an existing quirk module and save it as `/config/custom_zha_quirks/new_quirk.py`. Relative imports are now gone so this will work even for deeply nested modules like `zhaquirks.xiaomi.aqara.*`.
3. Edit the quirk (e.g. by mounting the `/config/` folder over SMB) and restart HA. Existing quirks can be tweaked because custom quirks always take priority. New quirks can be tested without messing with Docker.