### PR TITLE
Fix MODELS_INFO typo for TH1300ZB and TH1400ZB

### DIFF
--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -118,7 +118,7 @@ class SinopeTH1400ZB(SinopeTechnologiesThermostat):
         # <SimpleDescriptor endpoint=1 profile=260 device_type=769 device_version=1
         # input_clusters=[0, 3, 4, 5, 513, 516, 1026, 1794, 2821, 65281]
         # output_clusters=[10, 65281, 25]>
-        MODELS_INFO: [(SINOPE, "TH11400ZB")],
+        MODELS_INFO: [(SINOPE, "TH1400ZB")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha_p.PROFILE_ID,
@@ -172,7 +172,7 @@ class SinopeTH1300ZB(SinopeTechnologiesThermostat):
         # <SimpleDescriptor endpoint=1 profile=260 device_type=769 device_version=1
         # input_clusters=[0, 3, 4, 5, 513, 516, 1026, 1794, 2820, 2821, 65281]
         # output_clusters=[10, 25, 65281]>
-        MODELS_INFO: [(SINOPE, "TH11300ZB")],
+        MODELS_INFO: [(SINOPE, "TH1300ZB")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha_p.PROFILE_ID,


### PR DESCRIPTION
I tested the TH1300ZB locally and before this change it was not getting the quirks applied while after the change it was. I was not able to test the TH1400ZB as I do not own one however assume the same issue applies.

The device signature for the TH1300ZB is:
2021-04-09 20:33:27 INFO (MainThread) [zigpy.endpoint] [0x96e2:1] Discovered endpoint information: SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=769, device_version=1, input_clusters=[0, 3, 4, 5, 513, 516, 1026, 1794, 2820, 2821, 65281], output_clusters=[10, 65281, 25])