### PR TITLE
Fix for MEOS TRV Time setting

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -132,7 +132,7 @@ class TuyaManufCluster(CustomCluster):
     manufacturer_client_commands = {
         0x0001: ("get_data", (Command,), True),
         0x0002: ("set_data_response", (Command,), True),
-        0x0024: ("set_time_request", (t.NoData,), True),
+        0x0024: ("set_time_request", (t.data16,), True),
     }
 
     def handle_cluster_request(

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -132,7 +132,7 @@ class TuyaManufCluster(CustomCluster):
     manufacturer_client_commands = {
         0x0001: ("get_data", (Command,), True),
         0x0002: ("set_data_response", (Command,), True),
-        0x0024: ("set_time_request", (TuyaTimePayload,), True),
+        0x0024: ("set_time_request", (t.NoData,), True),
     }
 
     def handle_cluster_request(


### PR DESCRIPTION
From https://github.com/zigpy/zha-device-handlers/issues/831#issuecomment-811776478
User have reported that its working changing the time request and the TRV is getting the right time then its pulling the coordinator for it.
I dont know if its doing more bad things but for the moment its only the MOES TRV that is using the time setting (i think its made different for other models but is for the moment not used / implanted in  other then the MOES TRV).