### PR TITLE
Added missing manufacturer_attributes

### DIFF
--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -51,6 +51,10 @@ class DanfossThermostatCluster(CustomCluster, Thermostat):
         0x404D: ("adaptation_run_status", t.bitmap8),
         0x404E: ("adaptation_run_settings", t.bitmap8),
         0xFFFD: ("cluster_revision", t.uint16_t),
+        0x404F: ("preheat_status", t.Bool),
+        0x4050: ("preheat_time", t.uint32_t),
+        0x4051: ("window_open_feature_on_off", t.Bool)
+        0xFFFD: ("cluster_revision", t.uint16_t)
     }
 
 

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -54,7 +54,6 @@ class DanfossThermostatCluster(CustomCluster, Thermostat):
         0x4050: ("preheat_time", t.uint32_t),
         0x4051: ("window_open_feature_on_off", t.Bool),
         0xFFFD: ("cluster_revision", t.uint16_t),
-
     }
 
 

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -50,11 +50,11 @@ class DanfossThermostatCluster(CustomCluster, Thermostat):
         0x404C: ("adaptation_run_control", t.enum8),
         0x404D: ("adaptation_run_status", t.bitmap8),
         0x404E: ("adaptation_run_settings", t.bitmap8),
-        0xFFFD: ("cluster_revision", t.uint16_t),
         0x404F: ("preheat_status", t.Bool),
         0x4050: ("preheat_time", t.uint32_t),
-        0x4051: ("window_open_feature_on_off", t.Bool)
-        0xFFFD: ("cluster_revision", t.uint16_t)
+        0x4051: ("window_open_feature_on_off", t.Bool),
+        0xFFFD: ("cluster_revision", t.uint16_t),
+
     }
 
 


### PR DESCRIPTION
I took the liberty to add missing manufacturer attributes for the DanfossThermostatCluster. These attributes most likely got added in the 1.08 firmware. Check this document for the full list of attributes [(Check here)](https://raw.githubusercontent.com/SimpleUserHA/DanfosseTRV/main/Danfoss%20Ally%20Radiator%20Thermostat%201.08%20Zigbee%20Cluster%20Specifications%2016122020.pdf)

There seem to be some additional command in the DiagnosticCluster (see last page), which I did not include due to the lack of knowledge how to specify the oclet string correctly.