### PR TITLE
Fix Aqara Opple Remote long press.

### DIFF
--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -53,7 +53,7 @@ from zhaquirks.const import (
 )
 from zhaquirks.xiaomi import LUMI, BasicCluster, XiaomiCustomDevice
 
-PRESS_TYPES = {0: "long press", 1: "single", 2: "double", 3: "triple", 255: "release"}
+PRESS_TYPES = {0: "hold", 1: "single", 2: "double", 3: "triple", 255: "release"}
 STATUS_TYPE_ATTR = 0x0055  # decimal = 85
 
 COMMAND_1_SINGLE = "1_single"


### PR DESCRIPTION
Broke in #280, command constants were changed from `long press` to `hold` but
change was not reflected in `PRESS_TYPES` mapping.