### PR TITLE
Add Tuya based smoke detector (TS0601 _TZE200_aycxwiau)

### DIFF
--- a/zhaquirks/const.py
+++ b/zhaquirks/const.py
@@ -99,3 +99,4 @@ VALUE = "value"
 ZHA_SEND_EVENT = "zha_send_event"
 ZONE_STATE = 0
 ZONE_TYPE = 0x0001
+ZONE_STATUS = 0x0002

--- a/zhaquirks/tuya/ts0601_smoke.py
+++ b/zhaquirks/tuya/ts0601_smoke.py
@@ -1,0 +1,116 @@
+"""Smoke Sensor."""
+import logging
+
+import zigpy.profiles.zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic, Groups, Ota, Scenes, Time
+from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks import Bus
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    ZONE_STATUS,
+    ZONE_TYPE,
+)
+
+from . import TuyaManufCluster, TuyaManufClusterAttributes
+
+_LOGGER = logging.getLogger(__name__)
+
+TUYA_SMOKE_DETECTED_ATTR = 0x0401  # [0]/[1] [Detected]/[Clear]!
+
+
+class TuyaSmokeDetectorCluster(TuyaManufClusterAttributes):
+    """Manufacturer Specific Cluster of the TS0601 smoke detector."""
+
+    manufacturer_attributes = {
+        TUYA_SMOKE_DETECTED_ATTR: ("smoke_detected", t.uint8_t),
+    }
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == TUYA_SMOKE_DETECTED_ATTR:
+            if value == 0:
+                self.endpoint.device.ias_bus.listener_event(
+                    "update_zone_status", IasZone.ZoneStatus.Alarm_1
+                )
+            else:
+                self.endpoint.device.ias_bus.listener_event("update_zone_status", 0)
+        else:
+            _LOGGER.warning(
+                "[0x%04x:%s:0x%04x] unhandled attribute: 0x%04x",
+                self.endpoint.device.nwk,
+                self.endpoint.endpoint_id,
+                self.cluster_id,
+                attrid,
+            )
+
+
+class TuyaIasZone(CustomCluster, IasZone):
+    """IAS Zone."""
+
+    _CONSTANT_ATTRIBUTES = {ZONE_TYPE: IasZone.ZoneType.Fire_Sensor}
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.ias_bus.add_listener(self)
+
+    def update_zone_status(self, value):
+        """Update IAS status."""
+        super()._update_attribute(ZONE_STATUS, value)
+
+
+class TuyaSmokeDetector0601(CustomDevice):
+    """TS0601 _TZE200_aycxwiau quirk."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.ias_bus = Bus()
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        MODELS_INFO: [("_TZE200_aycxwiau", "TS0601")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
+                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
+                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaIasZone,
+                    TuyaSmokeDetectorCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }


### PR DESCRIPTION
Add support for Tuya based smoke detector. This one in particular can be found as Woox R7074 Smoke Alarm Kit ([https://wooxhome.com/woox-r7074-smoke-alarm-kit-p43](https://wooxhome.com/woox-r7074-smoke-alarm-kit-p43))

As a start all it can do is tell if smoke is detected or not. It is possible to detect state when a smoke detector test is triggered by the button on the device itself, but I did not implement that since it doesn't seem to have any impact in HA... It's also possible to trigger the test mode via Zigbee commands (doesn't seem to be supported by Zigbee IAS Zone).

Feedback is much appreciated. And if someone knows if it's possible to get battery level on these kinds of tuya devices I'd like to know that so I can add it.