### PR TITLE
Add Lonsonhome QS-Zigbee-C01

### DIFF
--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -1,0 +1,110 @@
+"""Device handler for loratap TS130F smart curtain switch. """
+import logging
+from typing import List, Optional, Union
+
+from zigpy.zcl import foundation
+from zigpy.profiles import zha
+import zigpy.types as t
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Scenes,
+    Time,
+    OnOff,
+    Ota,
+)
+
+from ..const import (
+    CLOSE,
+    COMMAND,
+    COMMAND_STOP,
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OPEN,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+ATTR_CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
+CMD_GO_TO_LIFT_PERCENTAGE = 0x0005
+
+class TuyaWithBacklightOnOffCluster(CustomCluster):
+    """TuyaSmartCurtainOnOffCluster: fire events corresponding to press type."""
+
+    cluster_id = OnOff.cluster_id
+
+    LIGHT_MODE_1 = {0x8001: 0}
+    LIGHT_MODE_2 = {0x8001: 1}
+    LIGHT_MODE_3 = {0x8001: 2}
+
+    attributes = {0x8001: ("backlight_mode", t.enum8)}
+
+class TuyaCoveringCluster(CustomCluster, WindowCovering):
+    """TuyaSmartCurtainWindowCoveringCluster: Allow to setup Window covering tuya devices. """
+
+    attributes = WindowCovering.attributes.copy()
+    attributes.update({0xF000: ("tuya_moving_state", t.enum8)})
+    attributes.update({0xF001: ("calibration", t.enum8)})
+    attributes.update({0xF002: ("motor_reversal", t.enum8)})
+
+    def _update_attribute(self, attrid, value):
+        if attrid == ATTR_CURRENT_POSITION_LIFT_PERCENTAGE:
+            # Invert the percentage value (cf https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3757)
+            value = 100 - value
+        super()._update_attribute(attrid, value)
+
+    async def command(self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None):
+        """Override default command to invert percent lift value"""
+        if command_id == CMD_GO_TO_LIFT_PERCENTAGE:
+            percent = args[0]
+            # Invert the percentage value (cf https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3757)
+            percent = 100 - percent
+            v = (percent,)
+            return await super().command(command_id, *v)
+        return await super().command(command_id, *args, manufacturer=manufacturer, expect_reply=expect_reply, tsn=tsn)
+
+class TuyaTS130F(CustomDevice):
+    """Tuya smart curtain roller shutter."""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0x0202, device_version=1, input_clusters=[0, 4, 5, 6, 10, 0x0102], output_clusters=[25]))
+        MODELS_INFO: [("_TZ3000_8kzqqzu4", "TS130F")],
+
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    Time.cluster_id,
+                    OnOff.cluster_id,
+                    WindowCovering.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    Time.cluster_id,
+                    TuyaWithBacklightOnOffCluster,
+                    TuyaCoveringCluster,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }
+

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -1,16 +1,9 @@
 """Device handler for loratap TS130F smart curtain switch."""
 from zigpy.profiles import zha
-import zigpy.types as t
 from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
 from zigpy.zcl.clusters.closures import WindowCovering
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Scenes,
-    Time,
-    OnOff,
-    Ota,
-)
+from zigpy.zcl.clusters.general import Basic, Groups, OnOff, Ota, Scenes, Time
 
 from ..const import (
     DEVICE_TYPE,

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -25,6 +25,7 @@ from ..const import (
 ATTR_CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
 CMD_GO_TO_LIFT_PERCENTAGE = 0x0005
 
+
 class TuyaWithBacklightOnOffCluster(CustomCluster):
     """TuyaSmartCurtainOnOffCluster: fire events corresponding to press type."""
 
@@ -51,7 +52,9 @@ class TuyaCoveringCluster(CustomCluster, WindowCovering):
             value = 100 - value
         super()._update_attribute(attrid, value)
 
-    async def command(self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None):
+    async def command(
+        self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None
+    ):
         """Override default command to invert percent lift value"""
         if command_id == CMD_GO_TO_LIFT_PERCENTAGE:
             percent = args[0]
@@ -59,7 +62,13 @@ class TuyaCoveringCluster(CustomCluster, WindowCovering):
             percent = 100 - percent
             v = (percent,)
             return await super().command(command_id, *v)
-        return await super().command(command_id, *args, manufacturer=manufacturer, expect_reply=expect_reply, tsn=tsn)
+        return await super().command(
+            command_id,
+            *args,
+            manufacturer=manufacturer,
+            expect_reply=expect_reply,
+            tsn=tsn
+        )
 
 
 class TuyaTS130F(CustomDevice):

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -47,7 +47,7 @@ class TuyaCoveringCluster(CustomCluster, WindowCovering):
     async def command(
         self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None
     ):
-        """Override default command to invert percent lift value"""
+        """Override default command to invert percent lift value."""
         if command_id == CMD_GO_TO_LIFT_PERCENTAGE:
             percent = args[0]
             # Invert the percentage value (cf https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3757)
@@ -69,7 +69,6 @@ class TuyaTS130F(CustomDevice):
     signature = {
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0x0202, device_version=1, input_clusters=[0, 4, 5, 6, 10, 0x0102], output_clusters=[25]))
         MODELS_INFO: [("_TZ3000_8kzqqzu4", "TS130F")],
-
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -1,8 +1,4 @@
 """Device handler for loratap TS130F smart curtain switch. """
-import logging
-from typing import List, Optional, Union
-
-from zigpy.zcl import foundation
 from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -17,9 +13,6 @@ from zigpy.zcl.clusters.general import (
 )
 
 from ..const import (
-    CLOSE,
-    COMMAND,
-    COMMAND_STOP,
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -43,8 +36,9 @@ class TuyaWithBacklightOnOffCluster(CustomCluster):
 
     attributes = {0x8001: ("backlight_mode", t.enum8)}
 
+
 class TuyaCoveringCluster(CustomCluster, WindowCovering):
-    """TuyaSmartCurtainWindowCoveringCluster: Allow to setup Window covering tuya devices. """
+    """TuyaSmartCurtainWindowCoveringCluster: Allow to setup Window covering tuya devices."""
 
     attributes = WindowCovering.attributes.copy()
     attributes.update({0xF000: ("tuya_moving_state", t.enum8)})
@@ -66,6 +60,7 @@ class TuyaCoveringCluster(CustomCluster, WindowCovering):
             v = (percent,)
             return await super().command(command_id, *v)
         return await super().command(command_id, *args, manufacturer=manufacturer, expect_reply=expect_reply, tsn=tsn)
+
 
 class TuyaTS130F(CustomDevice):
     """Tuya smart curtain roller shutter."""
@@ -107,4 +102,3 @@ class TuyaTS130F(CustomDevice):
             },
         },
     }
-

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -1,4 +1,4 @@
-"""Device handler for loratap TS130F smart curtain switch. """
+"""Device handler for loratap TS130F smart curtain switch."""
 from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -17,7 +17,6 @@ from ..const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
-    OPEN,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -5,7 +5,7 @@ import zigpy.types as t
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import Basic, Groups, OnOff, Ota, Scenes, Time
 
-from ..const import (
+from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,


### PR DESCRIPTION
class QS-Zigbee-C01(CustomDevice):
    """Tuya smart curtain roller shutter."""

    signature = {
        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0x0202, device_version=1, input_clusters=[0, 4, 5, 0x0102], output_clusters=[10, 25]))
        MODELS_INFO: [("_TZ3000_vd43bbfq", "TS130F")],
        ENDPOINTS: {
            1: {
                PROFILE_ID: zha.PROFILE_ID,
                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
                INPUT_CLUSTERS: [
                    Basic.cluster_id,
                    Groups.cluster_id,
                    Scenes.cluster_id,
                    WindowCovering.cluster_id,
                ],
                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id,],
            },
        },
    }
    replacement = {
        ENDPOINTS: {
            1: {
                PROFILE_ID: zha.PROFILE_ID,
                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
                INPUT_CLUSTERS: [
                    Basic.cluster_id,
                    Groups.cluster_id,
                    Scenes.cluster_id,
                    TuyaCoveringCluster,					
                ],
                OUTPUT_CLUSTERS: [Time.cluster_id,Ota.cluster_id],
            },
        },
    }