### PR TITLE
Fix RWLFirstGen quirk not applying to old RWL021 dimmers

### DIFF
--- a/zhaquirks/philips/rwlfirstgen.py
+++ b/zhaquirks/philips/rwlfirstgen.py
@@ -109,15 +109,20 @@ class PhilipsRWLFirstGen(CustomDevice):
     device_automation_triggers = HUE_REMOTE_DEVICE_TRIGGERS
 
 
-class PhilipsRWL020(CustomDevice):
-    """Philips RWL020 device."""
+class PhilipsRWLFirstGen2(CustomDevice):
+    """Philips older RWL020 and RWL021 devices."""
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=49246 device_type=2080
         #  device_version=2
         #  input_clusters=[0]
         #  output_clusters=[0, 3, 4, 6, 8]>
-        MODELS_INFO: [(PHILIPS, "RWL020"), (SIGNIFY, "RWL020")],
+        MODELS_INFO: [
+            (PHILIPS, "RWL020"),
+            (SIGNIFY, "RWL020"),
+            (PHILIPS, "RWL021"),
+            (SIGNIFY, "RWL021"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zll.PROFILE_ID,


### PR DESCRIPTION
Basically like https://github.com/zigpy/zha-device-handlers/pull/837 just for the EU-dimmers (RWL021).
It seems like some really old (non updated) RWL021 dimmers also have a different device type.
This can cause older RWL021 dimmers to not show the device automation triggers. This PR fixes this.

Fix https://github.com/zigpy/zha-device-handlers/issues/878

Ready to merge.
**Tested** and **working**.

---
Testing instructions:

Download this file: https://raw.githubusercontent.com/TheJulianJES/zha-device-handlers/rwl021_fix/zhaquirks/philips/rwlfirstgen.py
(Make sure you're on Home Assistant 2021.5.x or later)

Add https://www.home-assistant.io/integrations/zha/#custom_quirks_path to your ZHA config, create the folder, create a philips folder in the custom quirks folder, then drop the file in there, restart Home Assistant and hope for the best.

I think something like this should work:
```
zha:
  custom_quirks_path: /config/custom_quirks
```
Then create the custom_quirks folder in your config folder. (Then the philips folder in that one, then drop the downloaded file in the philips folder).