### PR TITLE
Add another Lidl CCT-only lamp

### DIFF
--- a/zhaquirks/lidl/cct.py
+++ b/zhaquirks/lidl/cct.py
@@ -43,6 +43,7 @@ class CCTLight(CustomDevice):
             ("_TZ3000_9evm3otq", "TS0502A"),
             ("_TZ3000_rylaozuc", "TS0502A"),
             ("_TZ3000_el5kt5im", "TS0502A"),
+            ("_TZ3000_oh7jddmx", "TS0502A"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Tested it in my install, works flawlessly.

fixes #890