### PR TITLE
Adding new tuya / Moes TRV

### DIFF
--- a/zhaquirks/tuya/valve.py
+++ b/zhaquirks/tuya/valve.py
@@ -891,6 +891,7 @@ class MoesHY368_Type2(TuyaThermostat):
             ("_TYST11_ckud7u2l", "kud7u2l"),
             ("_TYST11_ywdxldoj", "wdxldoj"),
             ("_TYST11_cwnjrr72", "wnjrr72"),
+            ("_TYST11_b6wax7g0", "6wax7g0"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Adding the second type of the _TYST11 tuy /Moes TRV.
PR is made for adding them in ZHA for getting the extended functions Moes TRV is having.

Not  tested by my or some user but #931 is some gave testing the first version but im not 110% that all is working but i think its better then no quirk for the device.