### PR TITLE
Add support for BTicino L441C/N4411C/NT4411C.

### DIFF
--- a/zhaquirks/legrand/dimmer.py
+++ b/zhaquirks/legrand/dimmer.py
@@ -130,3 +130,42 @@ class DimmerWithoutNeutral2(DimmerWithoutNeutral):
             },
         },
     }
+
+
+class DimmerWithNeutral(DimmerWithoutNeutral):
+    """Dimmer switch with neutral."""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=256
+        # device_version=1
+        # input_clusters=[0, 3, 4, 8, 6, 5, 15, 64513]
+        # output_clusters=[0, 25, 64513]>
+        MODELS_INFO: [(f" {LEGRAND}", " Dimmer switch with neutral")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Scenes.cluster_id,
+                    BinaryInput.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 0x0066,
+                INPUT_CLUSTERS: [0x0021],
+                OUTPUT_CLUSTERS: [0x0021],
+            },
+        },
+    }


### PR DESCRIPTION
Hi,
I've added support for the manufacturer specific cluster found in BTicino (a Legrand subsidiary) dimmer switch with neutral (models L441C/N4411C/NT4411C).
Most of the work was already done for another Legrand dimmer, so I only had to subclass that implementation and change the signature.