### PR TITLE
Update of Tuya Wireless Scene Remote TS0044 for _TZ3000_dku2cfsc

### DIFF
--- a/zhaquirks/tuya/ts0044.py
+++ b/zhaquirks/tuya/ts0044.py
@@ -145,7 +145,7 @@ class ZemiSmartRemote0044(CustomDevice, Tuya4ButtonTriggers):
         # SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
         # SizePrefixedSimpleDescriptor(endpoint=3, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
         # SizePrefixedSimpleDescriptor(endpoint=4, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
-        MODELS_INFO: [("_TZ3000_vp6clf9d", "TS0044"), ("_TZ3000_abci1hiu", "TS0044")],
+        MODELS_INFO: [("_TZ3000_vp6clf9d", "TS0044"), ("_TZ3000_abci1hiu", "TS0044"), ("_TZ3000_dku2cfsc", "TS0044")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
My Scene Remote has an additional manufacturer string. I tested it locally, with this changes all works as expected.

Zigbee device signature before update:

```
{
  "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=0, *allocate_address=True, *complex_descriptor_available=False, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False, *is_valid=True, *logical_type=<LogicalType.EndDevice: 2>, *user_descriptor_available=False)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": "0x0000",
      "in_clusters": [
        "0x0000",
        "0x0001",
        "0x0006"
      ],
      "out_clusters": [
        "0x000a",
        "0x0019"
      ]
    },
    "2": {
      "profile_id": 260,
      "device_type": "0x0000",
      "in_clusters": [
        "0x0001",
        "0x0006"
      ],
      "out_clusters": []
    },
    "3": {
      "profile_id": 260,
      "device_type": "0x0000",
      "in_clusters": [
        "0x0001",
        "0x0006"
      ],
      "out_clusters": []
    },
    "4": {
      "profile_id": 260,
      "device_type": "0x0000",
      "in_clusters": [
        "0x0001",
        "0x0006"
      ],
      "out_clusters": []
    }
  },
  "manufacturer": "_TZ3000_dku2cfsc",
  "model": "TS0044",
  "class": "zigpy.device.Device"
}
```

Zigbee device signature after update:
```
{
  "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=0, *allocate_address=True, *complex_descriptor_available=False, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False, *is_valid=True, *logical_type=<LogicalType.EndDevice: 2>, *user_descriptor_available=False)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": "0x0006",
      "in_clusters": [
        "0x0000",
        "0x0001",
        "0x0006"
      ],
      "out_clusters": [
        "0x000a",
        "0x0019"
      ]
    },
    "2": {
      "profile_id": 260,
      "device_type": "0x0006",
      "in_clusters": [
        "0x0001",
        "0x0006"
      ],
      "out_clusters": []
    },
    "3": {
      "profile_id": 260,
      "device_type": "0x0006",
      "in_clusters": [
        "0x0001",
        "0x0006"
      ],
      "out_clusters": []
    },
    "4": {
      "profile_id": 260,
      "device_type": "0x0006",
      "in_clusters": [
        "0x0001",
        "0x0006"
      ],
      "out_clusters": []
    }
  },
  "manufacturer": "_TZ3000_dku2cfsc",
  "model": "TS0044",
  "class": "zhaquirks.tuya.ts0044.ZemiSmartRemote0044"
}
```