### PR TITLE
Adding some more tuya TS0601 touch switches

### DIFF
--- a/zhaquirks/tuya/ts0601.py
+++ b/zhaquirks/tuya/ts0601.py
@@ -39,7 +39,7 @@ class TuyaSingleSwitch(TuyaSwitch):
             ("_TZ3000_uim07oem", "TS0601"),
             ("_TZE200_tz32mtza", "TS0601"),
         ],
-            ENDPOINTS: {
+        ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.SMART_PLUG,

--- a/zhaquirks/tuya/ts0601.py
+++ b/zhaquirks/tuya/ts0601.py
@@ -32,7 +32,12 @@ class TuyaSingleSwitch(TuyaSwitch):
         # input_clusters=[0x0000, 0x0004, 0x0005, 0xef00]
         # output_clusters=[0x000a, 0x0019]
         # <SimpleDescriptor endpoint=1 profile=260 device_type=51 device_version=1 input_clusters=[0, 4, 5, 61184] output_clusters=[10, 25]>
-        MODELS_INFO: [("_TZE200_oisqyl4o", "TS0601")],
+        MODELS_INFO: [
+            ("_TZE200_oisqyl4o", "TS0601"),
+            ("_TZE200_wunufsil", "TS0601"),
+            ("_TZE200_vhy3iakz", "TS0601"),
+            ("_TZ3000_uim07oem", "TS0601"),
+            ("_TZE200_tz32mtza", "TS0601"),
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/tuya/ts0601.py
+++ b/zhaquirks/tuya/ts0601.py
@@ -38,7 +38,8 @@ class TuyaSingleSwitch(TuyaSwitch):
             ("_TZE200_vhy3iakz", "TS0601"),
             ("_TZ3000_uim07oem", "TS0601"),
             ("_TZE200_tz32mtza", "TS0601"),
-        ENDPOINTS: {
+        ],
+            ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.SMART_PLUG,


### PR DESCRIPTION
Adding:
```
         MODELS_INFO: [
            ("_TZE200_oisqyl4o", "TS0601"),
            ("_TZE200_wunufsil", "TS0601"),
            ("_TZE200_vhy3iakz", "TS0601"),
            ("_TZ3000_uim07oem", "TS0601"),
            ("_TZE200_tz32mtza", "TS0601"),
```
The quirk is made  for only one gang switches and some of the new is multiple one.
The first gang is working OK but the 2 and higher is not working :-((

For the moment is better then not working at all but its needs little patching for working OK with all gangs.
Some users is trying getting the code fixed but i think its OK for first shut for getting the users getting little use of there devices.

Feel free reacting this PR if not liking the approach or helping fixing the code for supporting multiple gang devices.