### PR TITLE
Adding  TRV _TZE200_hhrtiq0x

### DIFF
--- a/zhaquirks/tuya/valve.py
+++ b/zhaquirks/tuya/valve.py
@@ -754,7 +754,7 @@ class SiterwellGS361_Type1(TuyaThermostat):
             ("_TYST11_jeaxp72v", "eaxp72v"),
             ("_TYST11_kfvq6avy", "fvq6avy"),
             ("_TYST11_zivfvd7h", "ivfvd7h"),
-            ("_TZE200_hhrtiq0x", "hrtiq0x"),
+            ("_TYST11_hhrtiq0x", "hrtiq0x"),
         ],
         ENDPOINTS: {
             1: {

--- a/zhaquirks/tuya/valve.py
+++ b/zhaquirks/tuya/valve.py
@@ -754,6 +754,7 @@ class SiterwellGS361_Type1(TuyaThermostat):
             ("_TYST11_jeaxp72v", "eaxp72v"),
             ("_TYST11_kfvq6avy", "fvq6avy"),
             ("_TYST11_zivfvd7h", "ivfvd7h"),
+            ("_TZE200_hhrtiq0x", "hrtiq0x"),
         ],
         ENDPOINTS: {
             1: {
@@ -793,6 +794,7 @@ class SiterwellGS361_Type2(TuyaThermostat):
         MODELS_INFO: [
             ("_TZE200_kfvq6avy", "TS0601"),
             ("_TZE200_zivfvd7h", "TS0601"),
+            ("_TZE200_hhrtiq0x", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Adding both type 1 and 2 zigbee modules for the new  "_TZE200_hhrtiq0x" TRVs.
[Z2M #8333](https://github.com/Koenkk/zigbee2mqtt/issues/8333)