### PR TITLE
Adding the type 1 of new SiterwellGS361 TRV II

### DIFF
--- a/zhaquirks/tuya/valve.py
+++ b/zhaquirks/tuya/valve.py
@@ -755,6 +755,7 @@ class SiterwellGS361_Type1(TuyaThermostat):
             ("_TYST11_kfvq6avy", "fvq6avy"),
             ("_TYST11_zivfvd7h", "ivfvd7h"),
             ("_TYST11_hhrtiq0x", "hrtiq0x"),
+            ("_TYST11_ps5v5jor", "s5v5jor"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Type 2 is added in #1000 but the type 1 was not added so i putting it in so the user have it working out of the box then its shoeing up.
("_TYST11_ps5v5jor", "s5v5jor"),

Rebase was not working so i was doing on new and deleting the first one.

Thanks David now many user is getting there device working in ZHA :-)))