### PR TITLE
Added another variation of TS0601 Tyua Air Sensor

### DIFF
--- a/zhaquirks/tuya/air/ts0601_air_quality.py
+++ b/zhaquirks/tuya/air/ts0601_air_quality.py
@@ -31,7 +31,11 @@ class TuyaCO2Sensor(CustomDevice):
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=81, device_version=1,
         # input_clusters=[0, 4, 5, 61184],
         # output_clusters=[25, 10])
-        MODELS_INFO: [("_TZE200_8ygsuhe1", "TS0601"), ("_TZE200_yvx5lh6k", "TS0601"), ("_TZE200_ryfmq5rl", "TS0601")],
+        MODELS_INFO: [
+            ("_TZE200_8ygsuhe1", "TS0601"), 
+            ("_TZE200_yvx5lh6k", "TS0601"), 
+            ("_TZE200_ryfmq5rl", "TS0601")
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/tuya/air/ts0601_air_quality.py
+++ b/zhaquirks/tuya/air/ts0601_air_quality.py
@@ -32,9 +32,9 @@ class TuyaCO2Sensor(CustomDevice):
         # input_clusters=[0, 4, 5, 61184],
         # output_clusters=[25, 10])
         MODELS_INFO: [
-            ("_TZE200_8ygsuhe1", "TS0601"), 
-            ("_TZE200_yvx5lh6k", "TS0601"), 
-            ("_TZE200_ryfmq5rl", "TS0601")
+            ("_TZE200_8ygsuhe1", "TS0601"),
+            ("_TZE200_yvx5lh6k", "TS0601"),
+            ("_TZE200_ryfmq5rl", "TS0601"),
         ],
         ENDPOINTS: {
             1: {

--- a/zhaquirks/tuya/air/ts0601_air_quality.py
+++ b/zhaquirks/tuya/air/ts0601_air_quality.py
@@ -31,7 +31,7 @@ class TuyaCO2Sensor(CustomDevice):
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=81, device_version=1,
         # input_clusters=[0, 4, 5, 61184],
         # output_clusters=[25, 10])
-        MODELS_INFO: [("_TZE200_8ygsuhe1", "TS0601"), ("_TZE200_yvx5lh6k", "TS0601")],
+        MODELS_INFO: [("_TZE200_8ygsuhe1", "TS0601"), ("_TZE200_yvx5lh6k", "TS0601"), ("_TZE200_ryfmq5rl", "TS0601")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
I just got my new TYUA Smart Air Box, which is exactly the same as the old one, but is not recognised. I found that it has a different model ID, which I added to the file.

It looks like they assign random IDs to their devices (to avoid using them without TYUA gateway?)

**Device signature:**
```
{
  "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": "0x0051",
      "in_clusters": [
        "0x0000",
        "0x0004",
        "0x0005",
        "0xef00"
      ],
      "out_clusters": [
        "0x000a",
        "0x0019"
      ]
    },
    "242": {
      "profile_id": 41440,
      "device_type": "0x0061",
      "in_clusters": [],
      "out_clusters": [
        "0x0021"
      ]
    }
  },
  "manufacturer": "_TZE200_ryfmq5rl",
  "model": "TS0601",
  "class": "zigpy.device.Device"
}
```