### PR TITLE
Implemented additional time sync case for TuYa devices.

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -234,6 +234,7 @@ class TuyaManufCluster(CustomCluster):
     cluster_id = TUYA_CLUSTER_ID
     ep_attribute = "tuya_manufacturer"
     set_time_offset = 0
+    set_time_local_offset = None
 
     class Command(t.Struct):
         """Tuya manufacturer cluster command."""
@@ -255,6 +256,7 @@ class TuyaManufCluster(CustomCluster):
             Zigbee payload is very similar to the UART payload which is described here: https://developer.tuya.com/en/docs/iot/device-development/access-mode-mcu/zigbee-general-solution/tuya-zigbee-module-uart-communication-protocol/tuya-zigbee-module-uart-communication-protocol?id=K9ear5khsqoty#title-10-Time%20synchronization
 
             Some devices need the timestamp in seconds from 1/1/1970 and others in seconds from 1/1/2000.
+            Also, there is devices which uses both timestamps variants (probably bug). Use set_time_local_offset var in this cases.
 
             NOTE: You need to wait for time request before setting it. You can't set time without request."""
 
@@ -305,7 +307,10 @@ class TuyaManufCluster(CustomCluster):
         )
         local_timestamp = int(
             (
-                datetime.datetime.now() - datetime.datetime(self.set_time_offset, 1, 1)
+                datetime.datetime.now()
+                - datetime.datetime(
+                    self.set_time_local_offset or self.set_time_offset, 1, 1
+                )
             ).total_seconds()
         )
         payload.extend(utc_timestamp.to_bytes(4, "big", signed=False))


### PR DESCRIPTION
Haozee HY08WE thermostat (_TZE200_znzs7yaw) needs two different timestamps in one payload (timestamp in seconds from _**1/1/2000**_ for UTC time and timestamp in seconds from _**1/1/1970**_ for local time).
Thats seems like a bug, but device works with TuYa hub without problems.

[Z2M reference]( https://github.com/Koenkk/zigbee-herdsman-converters/blob/a83dd5338a20d35a3b59d54164cc371bcd8d2622/converters/fromZigbee.js#L2515-L2533):
```
    hy_set_time_request: {
        cluster: 'manuSpecificTuya',
        type: ['commandSetTimeRequest'],
        convert: async (model, msg, publish, options, meta) => {
            const OneJanuary2000 = new Date('January 01, 2000 00:00:00 UTC+00:00').getTime();
            const currentTime = new Date().getTime();
            const utcTime = Math.round((currentTime - OneJanuary2000) / 1000);
            const localTime = Math.round(currentTime / 1000) - (new Date()).getTimezoneOffset() * 60;
            const endpoint = msg.device.getEndpoint(1);
            const payload = {
                payloadSize: 8,
                payload: [
                    ...tuya.convertDecimalValueTo4ByteHexArray(utcTime),
                    ...tuya.convertDecimalValueTo4ByteHexArray(localTime),
                ],
            };
            await endpoint.command('manuSpecificTuya', 'setTime', payload, {});
        },
    },
```