### PR TITLE
That is ("_TZE200_b6wax7g0", "TS0601") "Moes TRV BRT-100" Thermostat. It is not compatible with the Tuya !!! Update valve.py

### DIFF
--- a/zhaquirks/tuya/valve.py
+++ b/zhaquirks/tuya/valve.py
@@ -976,7 +976,6 @@ class MoesHY368_Type1(TuyaThermostat):
             ("_TZE200_ckud7u2l", "TS0601"),
             ("_TZE200_ywdxldoj", "TS0601"),
             ("_TZE200_cwnjrr72", "TS0601"),
-            ("_TZE200_b6wax7g0", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
     These are Tuya thermostats:
            ("_TZE200_ckud7u2l", "TS0601"),
            ("_TZE200_ywdxldoj", "TS0601"),
            ("_TZE200_cwnjrr72", "TS0601"),


**And that is  ("_TZE200_b6wax7g0", "TS0601")  "Moes TRV BRT-100" Thermostat. 
It is not compatible with the Tuya !!! 
It has completely different functions!!!**