### PR TITLE
Return correct response to emulated attribute writes

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -310,7 +310,7 @@ async def test_siren_send_attribute(zigpy_device_from_quirk, quirk):
         tuya_cluster.endpoint, "request", side_effect=async_success
     ) as m1:
 
-        (status,) = await switch_cluster.command(0x0000)
+        _, status = await switch_cluster.command(0x0000)
         m1.assert_called_with(
             61184,
             1,
@@ -318,11 +318,9 @@ async def test_siren_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == [
-            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
-        ]
+        assert status == foundation.Status.SUCCESS
 
-        (status,) = await switch_cluster.command(0x0001)
+        _, status = await switch_cluster.command(0x0001)
         m1.assert_called_with(
             61184,
             2,
@@ -330,11 +328,9 @@ async def test_siren_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == [
-            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
-        ]
+        assert status == foundation.Status.SUCCESS
 
-        status = switch_cluster.command(0x0003)
+        _, status = await switch_cluster.command(0x0003)
         assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
 
 
@@ -470,7 +466,7 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
         # simulate a target temp update so that relative changes can work
         hdr, args = tuya_cluster.deserialize(ZCL_TUYA_VALVE_TARGET_TEMP)
         tuya_cluster.handle_message(hdr, args)
-        (status,) = await thermostat_cluster.command(0x0000, 0x00, 20)
+        _, status = await thermostat_cluster.command(0x0000, 0x00, 20)
         m1.assert_called_with(
             61184,
             5,
@@ -478,11 +474,9 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == [
-            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
-        ]
+        assert status == foundation.Status.SUCCESS
 
-        status = await thermostat_cluster.command(0x0002)
+        _, status = await thermostat_cluster.command(0x0002)
         assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
 
 
@@ -733,7 +727,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
         # simulate a target temp update so that relative changes can work
         hdr, args = tuya_cluster.deserialize(ZCL_TUYA_VALVE_TARGET_TEMP)
         tuya_cluster.handle_message(hdr, args)
-        (status,) = await thermostat_cluster.command(0x0000, 0x00, 20)
+        _, status = await thermostat_cluster.command(0x0000, 0x00, 20)
         m1.assert_called_with(
             61184,
             4,
@@ -741,9 +735,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == [
-            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
-        ]
+        assert status == foundation.Status.SUCCESS
 
         (status,) = await onoff_cluster.write_attributes(
             {
@@ -956,7 +948,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
         ]
 
-        (status,) = await onoff_cluster.command(0x0000)
+        _, status = await onoff_cluster.command(0x0000)
         m1.assert_called_with(
             61184,
             18,
@@ -964,11 +956,9 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == [
-            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
-        ]
+        assert status == foundation.Status.SUCCESS
 
-        (status,) = await onoff_cluster.command(0x0001)
+        _, status = await onoff_cluster.command(0x0001)
 
         m1.assert_called_with(
             61184,
@@ -977,11 +967,9 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == [
-            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
-        ]
+        assert status == foundation.Status.SUCCESS
 
-        (status,) = await onoff_cluster.command(0x0002)
+        _, status = await onoff_cluster.command(0x0002)
         m1.assert_called_with(
             61184,
             20,
@@ -989,19 +977,17 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == [
-            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
-        ]
+        assert status == foundation.Status.SUCCESS
 
         (status,) = await onoff_cluster.write_attributes({})
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
         ]
 
-        status = await thermostat_cluster.command(0x0002)
+        _, status = await thermostat_cluster.command(0x0002)
         assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
 
-        status = await onoff_cluster.command(0x0009)
+        _, status = await onoff_cluster.command(0x0009)
         assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
 
         origdatetime = datetime.datetime
@@ -1107,7 +1093,7 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
         # simulate a target temp update so that relative changes can work
         hdr, args = tuya_cluster.deserialize(ZCL_TUYA_EHEAT_TARGET_TEMP)
         tuya_cluster.handle_message(hdr, args)
-        (status,) = await thermostat_cluster.command(0x0000, 0x00, 20)
+        _, status = await thermostat_cluster.command(0x0000, 0x00, 20)
         m1.assert_called_with(
             61184,
             4,
@@ -1115,11 +1101,9 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == [
-            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
-        ]
+        assert status == foundation.Status.SUCCESS
 
-        status = await thermostat_cluster.command(0x0002)
+        _, status = await thermostat_cluster.command(0x0002)
         assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
 
 

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -243,7 +243,7 @@ async def test_tuya_send_attribute(zigpy_device_from_quirk, quirk):
         tuya_cluster.endpoint, "request", side_effect=async_success
     ) as m1:
 
-        status = await tuya_cluster.write_attributes({617: 179})
+        (status,) = await tuya_cluster.write_attributes({617: 179})
         m1.assert_called_with(
             61184,
             1,
@@ -251,7 +251,9 @@ async def test_tuya_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
 
 @pytest.mark.parametrize("quirk", (zhaquirks.tuya.siren.TuyaSiren,))
@@ -308,7 +310,7 @@ async def test_siren_send_attribute(zigpy_device_from_quirk, quirk):
         tuya_cluster.endpoint, "request", side_effect=async_success
     ) as m1:
 
-        status = await switch_cluster.command(0x0000)
+        (status,) = await switch_cluster.command(0x0000)
         m1.assert_called_with(
             61184,
             1,
@@ -316,9 +318,11 @@ async def test_siren_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await switch_cluster.command(0x0001)
+        (status,) = await switch_cluster.command(0x0001)
         m1.assert_called_with(
             61184,
             2,
@@ -326,7 +330,9 @@ async def test_siren_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
         status = switch_cluster.command(0x0003)
         assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
@@ -397,7 +403,7 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
         tuya_cluster.endpoint, "request", side_effect=async_success
     ) as m1:
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "occupied_heating_setpoint": 2500,
             }
@@ -409,9 +415,11 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "system_mode": 0x00,
             }
@@ -423,9 +431,11 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "system_mode": 0x04,
             }
@@ -437,9 +447,11 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "programing_oper_mode": 0x01,
             }
@@ -451,12 +463,14 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
         # simulate a target temp update so that relative changes can work
         hdr, args = tuya_cluster.deserialize(ZCL_TUYA_VALVE_TARGET_TEMP)
         tuya_cluster.handle_message(hdr, args)
-        status = await thermostat_cluster.command(0x0000, 0x00, 20)
+        (status,) = await thermostat_cluster.command(0x0000, 0x00, 20)
         m1.assert_called_with(
             61184,
             5,
@@ -464,7 +478,9 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
         status = await thermostat_cluster.command(0x0002)
         assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
@@ -666,7 +682,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
         tuya_cluster.endpoint, "request", side_effect=async_success
     ) as m1:
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "occupied_heating_setpoint": 2500,
             }
@@ -678,9 +694,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "operation_preset": 0x00,
             }
@@ -692,9 +710,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "operation_preset": 0x02,
             }
@@ -706,12 +726,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
         # simulate a target temp update so that relative changes can work
         hdr, args = tuya_cluster.deserialize(ZCL_TUYA_VALVE_TARGET_TEMP)
         tuya_cluster.handle_message(hdr, args)
-        status = await thermostat_cluster.command(0x0000, 0x00, 20)
+        (status,) = await thermostat_cluster.command(0x0000, 0x00, 20)
         m1.assert_called_with(
             61184,
             4,
@@ -719,9 +741,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await onoff_cluster.write_attributes(
+        (status,) = await onoff_cluster.write_attributes(
             {
                 "on_off": 0x00,
                 "window_detection_timeout_minutes": 0x02,
@@ -735,9 +759,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "occupancy": 0x00,
             }
@@ -749,9 +775,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "occupancy": 0x01,
                 "programing_oper_mode": 0x00,
@@ -764,9 +792,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "programing_oper_mode": 0x01,
             }
@@ -778,9 +808,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "programing_oper_mode": 0x04,
             }
@@ -792,9 +824,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "workday_schedule_1_temperature": 1700,
             }
@@ -806,9 +840,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "workday_schedule_1_minute": 45,
             }
@@ -820,9 +856,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "workday_schedule_1_hour": 5,
             }
@@ -834,9 +872,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "weekend_schedule_1_temperature": 1700,
             }
@@ -848,9 +888,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "weekend_schedule_1_minute": 45,
             }
@@ -862,9 +904,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "weekend_schedule_1_hour": 5,
             }
@@ -876,9 +920,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "system_mode": 0x01,
             }
@@ -890,9 +936,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_ui_cluster.write_attributes(
+        (status,) = await thermostat_ui_cluster.write_attributes(
             {
                 "auto_lock": 0x00,
             }
@@ -904,9 +952,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await onoff_cluster.command(0x0000)
+        (status,) = await onoff_cluster.command(0x0000)
         m1.assert_called_with(
             61184,
             18,
@@ -914,9 +964,12 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await onoff_cluster.command(0x0001)
+        (status,) = await onoff_cluster.command(0x0001)
+
         m1.assert_called_with(
             61184,
             19,
@@ -924,9 +977,11 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await onoff_cluster.command(0x0002)
+        (status,) = await onoff_cluster.command(0x0002)
         m1.assert_called_with(
             61184,
             20,
@@ -934,10 +989,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await onoff_cluster.write_attributes({})
-        assert status == (foundation.Status.SUCCESS,)
+        (status,) = await onoff_cluster.write_attributes({})
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
         status = await thermostat_cluster.command(0x0002)
         assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
@@ -997,7 +1056,7 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
         tuya_cluster.endpoint, "request", side_effect=async_success
     ) as m1:
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "occupied_heating_setpoint": 2500,
             }
@@ -1009,9 +1068,11 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "system_mode": 0x00,
             }
@@ -1023,9 +1084,11 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
-        status = await thermostat_cluster.write_attributes(
+        (status,) = await thermostat_cluster.write_attributes(
             {
                 "system_mode": 0x04,
             }
@@ -1037,12 +1100,14 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
         # simulate a target temp update so that relative changes can work
         hdr, args = tuya_cluster.deserialize(ZCL_TUYA_EHEAT_TARGET_TEMP)
         tuya_cluster.handle_message(hdr, args)
-        status = await thermostat_cluster.command(0x0000, 0x00, 20)
+        (status,) = await thermostat_cluster.command(0x0000, 0x00, 20)
         m1.assert_called_with(
             61184,
             4,
@@ -1050,7 +1115,9 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             command_id=0,
         )
-        assert status == (foundation.Status.SUCCESS,)
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
 
         status = await thermostat_cluster.command(0x0002)
         assert status == foundation.Status.UNSUP_CLUSTER_COMMAND

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -389,7 +389,7 @@ class TuyaManufClusterAttributes(TuyaManufCluster):
                 tsn=cmd_payload.tsn,
             )
 
-        return (foundation.Status.SUCCESS,)
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
 
 class TuyaOnOff(CustomCluster, OnOff):
@@ -512,7 +512,7 @@ class TuyaThermostatCluster(LocalDataCluster, Thermostat):
         records = self._write_attr_records(attributes)
 
         if not records:
-            return (foundation.Status.SUCCESS,)
+            return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
         manufacturer_attrs = {}
         for record in records:
@@ -534,13 +534,20 @@ class TuyaThermostatCluster(LocalDataCluster, Thermostat):
             manufacturer_attrs.update(new_attrs)
 
         if not manufacturer_attrs:
-            return (foundation.Status.FAILURE,)
+            return [
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        foundation.Status.FAILURE, r.attrid
+                    )
+                    for r in records
+                ]
+            ]
 
         await self.endpoint.tuya_manufacturer.write_attributes(
             manufacturer_attrs, manufacturer=manufacturer
         )
 
-        return (foundation.Status.SUCCESS,)
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
     # pylint: disable=W0236
     async def command(
@@ -625,13 +632,20 @@ class TuyaUserInterfaceCluster(LocalDataCluster, UserInterface):
             manufacturer_attrs.update(new_attrs)
 
         if not manufacturer_attrs:
-            return (foundation.Status.FAILURE,)
+            return [
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        foundation.Status.FAILURE, r.attrid
+                    )
+                    for r in records
+                ]
+            ]
 
         await self.endpoint.tuya_manufacturer.write_attributes(
             manufacturer_attrs, manufacturer=manufacturer
         )
 
-        return (foundation.Status.SUCCESS,)
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
 
 class TuyaPowerConfigurationCluster(LocalDataCluster, PowerConfiguration):

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -561,11 +561,11 @@ class TuyaThermostatCluster(LocalDataCluster, Thermostat):
         """Implement thermostat commands."""
 
         if command_id != 0x0000:
-            return foundation.Status.UNSUP_CLUSTER_COMMAND
+            return [command_id, foundation.Status.UNSUP_CLUSTER_COMMAND]
 
         mode, offset = args
         if mode not in (self.SetpointMode.Heat, self.SetpointMode.Both):
-            return foundation.Status.INVALID_VALUE
+            return [command_id, foundation.Status.INVALID_VALUE]
 
         attrid = self.attridx["occupied_heating_setpoint"]
 
@@ -576,10 +576,11 @@ class TuyaThermostatCluster(LocalDataCluster, Thermostat):
             return foundation.Status.FAILURE
 
         # offset is given in decidegrees, see Zigbee cluster specification
-        return await self.write_attributes(
+        (res,) = await self.write_attributes(
             {"occupied_heating_setpoint": current + offset * 10},
             manufacturer=manufacturer,
         )
+        return [command_id, res[0].status]
 
 
 class TuyaUserInterfaceCluster(LocalDataCluster, UserInterface):

--- a/zhaquirks/tuya/siren.py
+++ b/zhaquirks/tuya/siren.py
@@ -84,7 +84,7 @@ class TuyaSirenOnOff(LocalDataCluster, OnOff):
         """Switch event."""
         self._update_attribute(self.ATTR_ID, state)
 
-    def command(
+    async def command(
         self,
         command_id: Union[foundation.Command, int, t.uint8_t],
         *args,
@@ -95,11 +95,12 @@ class TuyaSirenOnOff(LocalDataCluster, OnOff):
         """Override the default command and defer to the alarm attribute."""
 
         if command_id in (0x0000, 0x0001):
-            return self.endpoint.tuya_manufacturer.write_attributes(
+            (res,) = await self.endpoint.tuya_manufacturer.write_attributes(
                 {TUYA_ALARM_ATTR: command_id}, manufacturer=manufacturer
             )
+            return [command_id, res[0].status]
 
-        return foundation.Status.UNSUP_CLUSTER_COMMAND
+        return [command_id, foundation.Status.UNSUP_CLUSTER_COMMAND]
 
 
 class TuyaTemperatureMeasurement(LocalDataCluster, TemperatureMeasurement):

--- a/zhaquirks/tuya/valve.py
+++ b/zhaquirks/tuya/valve.py
@@ -743,12 +743,13 @@ class MoesWindowDetection(LocalDataCluster, OnOff):
                     return foundation.Status.FAILURE
                 value = not value
 
-            return await self.write_attributes(
+            (res,) = await self.write_attributes(
                 {"on_off": value},
                 manufacturer=manufacturer,
             )
+            return [command_id, res[0].status]
 
-        return foundation.Status.UNSUP_CLUSTER_COMMAND
+        return [command_id, foundation.Status.UNSUP_CLUSTER_COMMAND]
 
 
 ZONNSMART_CHILD_LOCK_ATTR = 0x0128  # [0] unlocked [1] child-locked

--- a/zhaquirks/tuya/valve.py
+++ b/zhaquirks/tuya/valve.py
@@ -664,7 +664,7 @@ class MoesWindowDetection(LocalDataCluster, OnOff):
         records = self._write_attr_records(attributes)
 
         if not records:
-            return (foundation.Status.SUCCESS,)
+            return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
         has_change = False
         data = t.data24()
@@ -707,7 +707,14 @@ class MoesWindowDetection(LocalDataCluster, OnOff):
                 {MOES_WINDOW_DETECT_ATTR: data}, manufacturer=manufacturer
             )
 
-        return (foundation.Status.FAILURE,)
+        return [
+            [
+                foundation.WriteAttributesStatusRecord(
+                    foundation.Status.FAILURE, r.attrid
+                )
+                for r in records
+            ]
+        ]
 
     async def command(
         self,


### PR DESCRIPTION
Return correctly formatted  response to emulated `write_attributes` commands. This wasn't a problem earlier, when ZHA was using plain patches, but if using quirks in tests it actually exposes the underlying problem and this starts failing Tuya specific tests if testing with the quirks.