### PR TITLE
Elko thermostat support

### DIFF
--- a/zhaquirks/elko/__init__.py
+++ b/zhaquirks/elko/__init__.py
@@ -1,24 +1,23 @@
 """Module for Elko quirks implementations."""
-import logging
 
-from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.quirks import CustomCluster, CustomDevice
-from zhaquirks import Bus, LocalDataCluster
+from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 
+from zhaquirks import Bus, LocalDataCluster
 
 ELKO = "ELKO"
 
 
 class ElkoThermostatCluster(CustomCluster, Thermostat):
-    """Thermostat cluster for Elko Thermostats"""
+    """Thermostat cluster for Elko Thermostats."""
 
     def __init__(self, *args, **kwargs):
-        """Init thermostat cluster"""
+        """Init thermostat cluster."""
         super().__init__(*args, **kwargs)
         self.endpoint.device.thermostat_bus.add_listener(self)
 
     def heating_active_change(self, value):
-        """State update from device"""
+        """State update from device."""
         if value == 0:
             mode = self.RunningMode.Off
             state = self.RunningState.Idle
@@ -31,15 +30,15 @@ class ElkoThermostatCluster(CustomCluster, Thermostat):
 
 
 class ElkoUserInterfaceCluster(LocalDataCluster, UserInterface):
-    """User interface cluster for Elko Thermostats"""
+    """User interface cluster for Elko Thermostats."""
 
     def __init__(self, *args, **kwargs):
-        """Init UI cluster"""
+        """Init UI cluster."""
         super().__init__(*args, **kwargs)
         self.endpoint.device.ui_bus.add_listener(self)
 
     def child_lock_change(self, mode):
-        """Enable/disable child lock"""
+        """Enable/disable child lock."""
         if mode:
             lockout = self.KeypadLockout.Level_1_lockout
         else:
@@ -49,10 +48,10 @@ class ElkoUserInterfaceCluster(LocalDataCluster, UserInterface):
 
 
 class ElkoThermostat(CustomDevice):
-    """Generic Elko Thermostat device"""
+    """Generic Elko Thermostat device."""
 
     def __init__(self, *args, **kwargs):
-        """Init device"""
+        """Init device."""
         self.thermostat_bus = Bus()
         self.ui_bus = Bus()
         super().__init__(*args, **kwargs)

--- a/zhaquirks/elko/__init__.py
+++ b/zhaquirks/elko/__init__.py
@@ -1,0 +1,59 @@
+"""Module for Elko quirks implementations."""
+import logging
+
+from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
+from zigpy.quirks import CustomCluster, CustomDevice
+from zhaquirks import Bus, LocalDataCluster
+
+
+ELKO = "ELKO"
+MANUFACTURER = 0x1002  # 4098
+
+
+class ElkoThermostatCluster(CustomCluster, Thermostat):
+    """Thermostat cluster for Elko Thermostats"""
+
+    def __init__(self, *args, **kwargs):
+        """Init thermostat cluster"""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.thermostat_bus.add_listener(self)
+
+    def heating_active_change(self, value):
+        """State update from device"""
+        if value == 0:
+            mode = self.RunningMode.Off
+            state = self.RunningState.Idle
+        else:
+            mode = self.RunningMode.Heat
+            state = self.RunningState.Heat_State_On
+
+        self._update_attribute(self.attridx["running_mode"], mode)
+        self._update_attribute(self.attridx["running_state"], state)
+
+
+class ElkoUserInterfaceCluster(LocalDataCluster, UserInterface):
+    """User interface cluster for Elko Thermostats"""
+
+    def __init__(self, *args, **kwargs):
+        """Init UI cluster"""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.ui_bus.add_listener(self)
+
+    def child_lock_change(self, mode):
+        """Enable/disable child lock"""
+        if mode:
+            lockout = self.KeypadLockout.Level_1_lockout
+        else:
+            lockout = self.KeypadLockout.No_lockout
+
+        self._update_attribute(self.attridx["keypad_lockout"], lockout)
+
+
+class ElkoThermostat(CustomDevice):
+    """Generic Elko Thermostat device"""
+
+    def __init__(self, *args, **kwargs):
+        """Init device"""
+        self.thermostat_bus = Bus()
+        self.ui_bus = Bus()
+        super().__init__(*args, **kwargs)

--- a/zhaquirks/elko/__init__.py
+++ b/zhaquirks/elko/__init__.py
@@ -7,7 +7,6 @@ from zhaquirks import Bus, LocalDataCluster
 
 
 ELKO = "ELKO"
-MANUFACTURER = 0x1002  # 4098
 
 
 class ElkoThermostatCluster(CustomCluster, Thermostat):

--- a/zhaquirks/elko/smart_super_thermostat.py
+++ b/zhaquirks/elko/smart_super_thermostat.py
@@ -1,17 +1,8 @@
-"""Module to handle quirks of the Elko Smart Super thermostat.
-
-"""
-import zigpy.types as t
+"""Module to handle quirks of the Elko Smart Super thermostat."""
 import zigpy.profiles.zha as zha_p
-
+import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, Ota, Scenes
 from zigpy.zcl.clusters.hvac import Thermostat
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Identify,
-    Groups,
-    Scenes,
-    Ota,
-)
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -83,6 +74,7 @@ class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
     }
 
     def __init__(self, *args, **kwargs):
+        """Init Elko thermostat."""
         super().__init__(*args, **kwargs)
         self.active_sensor = None
 
@@ -99,7 +91,7 @@ class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
         return super()._write_attributes(args, manufacturer=manufacturer)
 
     async def write_attributes(self, attributes, manufacturer=None):
-        """Override writes to thermostat attributes"""
+        """Override writes to thermostat attributes."""
         if "system_mode" in attributes:
             val = attributes.get("system_mode")
             if val == Thermostat.SystemMode.Off:
@@ -142,7 +134,7 @@ class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
 
 
 class ElkoSuperTRThermostat(ElkoThermostat):
-    """Elko thermostat custom device"""
+    """Elko thermostat custom device."""
 
     manufacturer_id_override = 0
 

--- a/zhaquirks/elko/smart_super_thermostat.py
+++ b/zhaquirks/elko/smart_super_thermostat.py
@@ -1,0 +1,137 @@
+"""Module to handle quirks of the Elko Smart Super thermostat.
+
+"""
+import logging
+
+import zigpy.types as t
+import zigpy.profiles.zha as zha_p
+
+from zigpy.zcl.clusters.hvac import Thermostat
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Identify,
+    Groups,
+    Scenes,
+    Ota,
+)
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.elko import (
+    ELKO,
+    ElkoThermostat,
+    ElkoThermostatCluster,
+    ElkoUserInterfaceCluster,
+)
+
+UNKNOWN_1 = 0x0401
+DISPLAY_TEXT = 0x0402
+ACTIVE_SENSOR = 0x0403
+UNKNOWN_2 = 0x0404
+REGULATOR_MODE = 0x0405
+DEVICE_ON = 0x0406
+UNKNOWN_3 = 0x0407
+POWER_CONSUMPTION = 0x0408
+FLOOR_SENSOR_TEMPERATURE = 0x0409
+UNKNOWN_4 = 0x0410
+NIGHT_LOWERING = 0x0411
+UNKNOWN_5 = 0x0412
+CHILD_LOCK = 0x0413
+PROTECTION_MAX_TEMP = 0x0414
+HEATING_ACTIVE = 0x0415
+UNKNOWN_7 = 0x0416
+UNKNOWN_8 = 0x0417
+UNKNOWN_9 = 0x0418
+UNKNOWN_A = 0x0419
+
+
+class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
+    """Elko custom thermostat cluster."""
+
+    class Sensor(t.enum8):
+        """Working modes of the thermostat."""
+
+        Air = 0x00
+        Floor = 0x01
+        Protection = 0x03
+
+    manufacturer_attributes = {
+        UNKNOWN_1: ("unknown_1", t.uint16_t),
+        DISPLAY_TEXT: ("display_text", t.CharacterString),
+        ACTIVE_SENSOR: ("active_sensor", Sensor),
+        UNKNOWN_2: ("unknown_2", t.uint8_t),
+        REGULATOR_MODE: ("regulator_mode", t.Bool),
+        DEVICE_ON: ("device_on", t.Bool),
+        UNKNOWN_3: ("unknown_3", t.LongOctetString),
+        POWER_CONSUMPTION: ("power_consumtion", t.uint16_t),
+        FLOOR_SENSOR_TEMPERATURE: ("floor_sensor_temperature", t.int16s),
+        UNKNOWN_4: ("unknown_4", t.uint16_t),
+        NIGHT_LOWERING: ("night_lowering", t.Bool),
+        UNKNOWN_5: ("unknown_5", t.Bool),
+        CHILD_LOCK: ("child_lock", t.Bool),
+        PROTECTION_MAX_TEMP: ("protection_max_temp", t.uint8_t),
+        HEATING_ACTIVE: ("heating_active", t.Bool),
+        UNKNOWN_7: ("unknown_7", t.LongOctetString),
+        UNKNOWN_8: ("unknown_8", t.int8s),
+        UNKNOWN_9: ("unknown_9", t.uint8_t),
+        UNKNOWN_A: ("unknown_a", t.uint8_t),
+    }
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == HEATING_ACTIVE:
+            self.endpoint.device.thermostat_bus.listener_event(
+                "heating_active_change", value
+            )
+        elif attrid == CHILD_LOCK:
+            self.endpoint.device.ui_bus.listener_event("child_lock_change", value)
+
+
+class ElkoSuperTRThermostat(ElkoThermostat):
+    """Elko thermostat custom device"""
+
+    signature = {
+        MODELS_INFO: [(ELKO, "Super TR")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha_p.PROFILE_ID,
+                DEVICE_TYPE: zha_p.DeviceType.THERMOSTAT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    Thermostat.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Ota.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    ElkoSuperTRThermostatCluster,
+                    ElkoUserInterfaceCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Ota.cluster_id,
+                ],
+            }
+        }
+    }


### PR DESCRIPTION
Basic support for Elko Super TR Thermostat.
The values and meaning for the custom attributes are copied from [Deconz Rest Plugin](https://github.com/dresden-elektronik/deconz-rest-plugin/blob/master/general.xml#L2034) and [Homey](https://github.com/prj84/com.elko/blob/Master/drivers/ESHSUPERTR/ST_Code/Elko%20Thermostat%20-%20Vendor%20Specific%20attributes.txt)

Tested with two thermostats and seem to be working fine.