### PR TITLE
Power reading support for Elko Super RF thermostat

### DIFF
--- a/zhaquirks/elko/__init__.py
+++ b/zhaquirks/elko/__init__.py
@@ -2,6 +2,7 @@
 
 from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 
 from zhaquirks import Bus, LocalDataCluster
 
@@ -47,6 +48,21 @@ class ElkoUserInterfaceCluster(LocalDataCluster, UserInterface):
         self._update_attribute(self.attridx["keypad_lockout"], lockout)
 
 
+class ElkoElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
+    """Electrical measurement cluster for Elko Thermostats."""
+
+    cluster_id = ElectricalMeasurement.cluster_id
+    POWER_ID = 0x050B
+
+    def __init__(self, *args, **kwargs):
+        """Init electrical measurement cluster."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.power_bus.add_listener(self)
+
+    def power_reported(self, value):
+        """Report consumption."""
+        self._update_attribute(self.POWER_ID, value)
+
 class ElkoThermostat(CustomDevice):
     """Generic Elko Thermostat device."""
 
@@ -54,4 +70,5 @@ class ElkoThermostat(CustomDevice):
         """Init device."""
         self.thermostat_bus = Bus()
         self.ui_bus = Bus()
+        self.power_bus = Bus()
         super().__init__(*args, **kwargs)

--- a/zhaquirks/elko/__init__.py
+++ b/zhaquirks/elko/__init__.py
@@ -52,7 +52,7 @@ class ElkoElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
     """Electrical measurement cluster for Elko Thermostats."""
 
     cluster_id = ElectricalMeasurement.cluster_id
-    POWER_ID = 0x050B
+    ACTIVE_POWER_ID = 0x050B
 
     def __init__(self, *args, **kwargs):
         """Init electrical measurement cluster."""
@@ -61,7 +61,7 @@ class ElkoElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
 
     def power_reported(self, value):
         """Report consumption."""
-        self._update_attribute(self.POWER_ID, value)
+        self._update_attribute(self.ACTIVE_POWER_ID, value)
 
 class ElkoThermostat(CustomDevice):
     """Generic Elko Thermostat device."""

--- a/zhaquirks/elko/__init__.py
+++ b/zhaquirks/elko/__init__.py
@@ -63,6 +63,7 @@ class ElkoElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
         """Report consumption."""
         self._update_attribute(self.ACTIVE_POWER_ID, value)
 
+
 class ElkoThermostat(CustomDevice):
     """Generic Elko Thermostat device."""
 

--- a/zhaquirks/elko/__init__.py
+++ b/zhaquirks/elko/__init__.py
@@ -1,8 +1,8 @@
 """Module for Elko quirks implementations."""
 
 from zigpy.quirks import CustomCluster, CustomDevice
-from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 
 from zhaquirks import Bus, LocalDataCluster
 

--- a/zhaquirks/elko/smart_super_thermostat.py
+++ b/zhaquirks/elko/smart_super_thermostat.py
@@ -14,10 +14,10 @@ from zhaquirks.const import (
 )
 from zhaquirks.elko import (
     ELKO,
+    ElkoElectricalMeasurementCluster,
     ElkoThermostat,
     ElkoThermostatCluster,
     ElkoUserInterfaceCluster,
-    ElkoElectricalMeasurementCluster,
 )
 
 LOCAL_TEMP = 0x0000
@@ -132,7 +132,7 @@ class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
                 attrid = LOCAL_TEMP
         elif attrid == POWER_CONSUMPTION:
             if value is not None and value >= 0:
-                self.endpoint.device.power_bus.listener_event("power_reported", value);
+                self.endpoint.device.power_bus.listener_event("power_reported", value)
 
         super()._update_attribute(attrid, value)
 

--- a/zhaquirks/elko/smart_super_thermostat.py
+++ b/zhaquirks/elko/smart_super_thermostat.py
@@ -17,6 +17,7 @@ from zhaquirks.elko import (
     ElkoThermostat,
     ElkoThermostatCluster,
     ElkoUserInterfaceCluster,
+    ElkoElectricalMeasurementCluster,
 )
 
 LOCAL_TEMP = 0x0000
@@ -129,6 +130,9 @@ class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
                 and self.active_sensor == self.Sensor.FLOOR
             ):
                 attrid = LOCAL_TEMP
+        elif attrid == POWER_CONSUMPTION:
+            if value is not None and value >= 0:
+                self.endpoint.device.power_bus.listener_event("power_reported", value);
 
         super()._update_attribute(attrid, value)
 
@@ -169,6 +173,7 @@ class ElkoSuperTRThermostat(ElkoThermostat):
                     Scenes.cluster_id,
                     ElkoSuperTRThermostatCluster,
                     ElkoUserInterfaceCluster,
+                    ElkoElectricalMeasurementCluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,


### PR DESCRIPTION
Builds on the Elko Super RF quirk implemented by @lodegaard in #1036, and exposes the current power consumption/effect (in watts) of the thermostat. As far as I'm able to tell this is updated once every 10 minutes, with the first update coming 10 minutes after the heating initially starts. The value produced seems to be the average consumption over the preceding 10 minutes.

WIth this, I'm able to use the [integration sensor](https://www.home-assistant.io/integrations/integration/) to produce an effect value in kWh in Home Assistant so I can use the data from this sensor in my energy dashboard.

Note that I'm not 100% sure about this implementation yet - I'm still testing, but as far as I know there is no data coming in that sets the effect back to 0 when heating stops so I might have to add something for that. I'll run this in my local HA overnight to see what the data looks like tomorrow.