### PR TITLE
Add setpoint command to imitate manual control of the thermostat

### DIFF
--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -63,11 +63,17 @@ class DanfossThermostatCluster(CustomCluster, Thermostat):
     async def write_attributes(self, attributes, manufacturer=None):
         """Send SETPOINT_COMMAND after setpoint change."""
 
-        write_res = await super().write_attributes(attributes, manufacturer=manufacturer)
+        write_res = await super().write_attributes(
+            attributes, manufacturer=manufacturer
+        )
 
         if "occupied_heating_setpoint" in attributes:
-            self.debug("sending setpoint command: %s", attributes["occupied_heating_setpoint"])
-            await self.setpoint_command(0x01, attributes["occupied_heating_setpoint"], manufacturer=manufacturer)
+            self.debug(
+                "sending setpoint command: %s", attributes["occupied_heating_setpoint"]
+            )
+            await self.setpoint_command(
+                0x01, attributes["occupied_heating_setpoint"], manufacturer=manufacturer
+            )
 
         return write_res
 

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -16,7 +16,6 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
-from zigpy.zcl import foundation
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -28,9 +27,6 @@ from zhaquirks.const import (
 )
 from zhaquirks.danfoss import DANFOSS
 
-COMMAND_SETPOINT_COMMAND = "setpoint_command"
-MANUFACTURER = 0x1246
-OCCUPIED_HEATING_SETPOINT_ATTR = 0x0012
 
 class DanfossThermostatCluster(CustomCluster, Thermostat):
     """Danfoss custom cluster."""
@@ -63,7 +59,6 @@ class DanfossThermostatCluster(CustomCluster, Thermostat):
         0x4051: ("window_open_feature_on_off", t.Bool),
         0xFFFD: ("cluster_revision", t.uint16_t),
     }
-
     
     async def write_attributes(self, attributes, manufacturer=None):
     """Send SETPOINT_COMMAND after setpoint change"""
@@ -75,6 +70,7 @@ class DanfossThermostatCluster(CustomCluster, Thermostat):
 
         return write_res
 
+    
 class DanfossUserInterfaceCluster(CustomCluster, UserInterface):
     """Danfoss custom cluster."""
 

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -66,6 +66,7 @@ class DanfossThermostatCluster(CustomCluster, Thermostat):
         write_res = await super().write_attributes(attributes, manufacturer=manufacturer)
 
         if "occupied_heating_setpoint" in attributes:
+            self.debug("sending setpoint command: %s", attributes ["occupied_heating_setpoint"])
             await self.setpoint_command(0x01, attributes["occupied_heating_setpoint"], manufacturer=manufacturer)
 
         return write_res

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -68,27 +68,12 @@ class DanfossThermostatCluster(CustomCluster, Thermostat):
     async def write_attributes(self, attributes, manufacturer=None):
     """Send SETPOINT_COMMAND after setpoint change"""
 
+        write_res = await super().write_attributes(attributes, manufacturer=manufacturer)
+
         if "occupied_heating_setpoint" in attributes:
-            setpoint = foundation.ReadAttributeRecord(
-                OCCUPIED_HEATING_SETPOINT_ATTR, foundation.Status.SUCCESS, foundation.TypeValue()
-            )
+            await self.setpoint_command(0x01, attributes["occupied_heating_setpoint"], manufacturer=manufacturer)
 
-            cmd_payload = super().Command()
-            cmd_payload.status = 0
-            cmd_payload.tsn = self.endpoint.device.application.get_sequence()
-            cmd_payload.command_id = 0x40
-            cmd_payload.function = 0
-            cmd_payload.data = [1, setpoint]
-
-            await super().command(
-                COMMAND_SETPOINT_COMMAND,
-                cmd_payload,
-                manufacturer=MANUFACTURER,
-                expect_reply=True,
-                tsn=cmd_payload.tsn,
-            )
-
-        return super().write_attributes(attributes, manufacturer)
+        return write_res
 
 class DanfossUserInterfaceCluster(CustomCluster, UserInterface):
     """Danfoss custom cluster."""

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -59,19 +59,19 @@ class DanfossThermostatCluster(CustomCluster, Thermostat):
         0x4051: ("window_open_feature_on_off", t.Bool),
         0xFFFD: ("cluster_revision", t.uint16_t),
     }
-    
+
     async def write_attributes(self, attributes, manufacturer=None):
-        """Send SETPOINT_COMMAND after setpoint change"""
+        """Send SETPOINT_COMMAND after setpoint change."""
 
         write_res = await super().write_attributes(attributes, manufacturer=manufacturer)
 
         if "occupied_heating_setpoint" in attributes:
-            self.debug("sending setpoint command: %s", attributes ["occupied_heating_setpoint"])
+            self.debug("sending setpoint command: %s", attributes["occupied_heating_setpoint"])
             await self.setpoint_command(0x01, attributes["occupied_heating_setpoint"], manufacturer=manufacturer)
 
         return write_res
 
-    
+
 class DanfossUserInterfaceCluster(CustomCluster, UserInterface):
     """Danfoss custom cluster."""
 

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -61,7 +61,7 @@ class DanfossThermostatCluster(CustomCluster, Thermostat):
     }
     
     async def write_attributes(self, attributes, manufacturer=None):
-    """Send SETPOINT_COMMAND after setpoint change"""
+        """Send SETPOINT_COMMAND after setpoint change"""
 
         write_res = await super().write_attributes(attributes, manufacturer=manufacturer)
 


### PR DESCRIPTION
This adds a manufacturer specific setpoint command which is issued if the setpoint changes (issued by Home Assistant / HA, regardless if changed by the user or automations or whatever) to imitate the reaction of the thermostat if a user manually controls the temperature by turning the wheel.

Without this change the internal PID of the thermostat does eract [very slowly](https://community.home-assistant.io/t/danfoss-ally-valve-slow-actuator-response-solved/254939) on temperature changes issued by HA.