### PR TITLE
Fix multiplier and divisor for Tuya TS0121

### DIFF
--- a/zhaquirks/tuya/ts0121_plug.py
+++ b/zhaquirks/tuya/ts0121_plug.py
@@ -1,6 +1,6 @@
 """Tuya TS0121 plug."""
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
+from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy.zcl.clusters.general import Basic, Groups, OnOff, Ota, Scenes, Time
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
@@ -14,6 +14,14 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import TuyaZBOnOffRestorePowerCluster
+
+
+class TuyaMeteringCluster(CustomCluster, Metering):
+    """TuyaMeteringCluster divides the kWh for tuya."""
+    
+    MULTIPLIER = 0x0301
+    DIVISOR = 0x0302
+    _CONSTANT_ATTRIBUTES = {MULTIPLIER: 0.01, DIVISOR: 100}
 
 
 class Plug(CustomDevice):
@@ -51,7 +59,7 @@ class Plug(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     TuyaZBOnOffRestorePowerCluster,
-                    Metering.cluster_id,
+                    TuyaMeteringCluster,
                     ElectricalMeasurement.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],

--- a/zhaquirks/tuya/ts0121_plug.py
+++ b/zhaquirks/tuya/ts0121_plug.py
@@ -18,7 +18,7 @@ from zhaquirks.tuya import TuyaZBOnOffRestorePowerCluster
 
 class TuyaMeteringCluster(CustomCluster, Metering):
     """TuyaMeteringCluster divides the kWh for tuya."""
-    
+
     MULTIPLIER = 0x0301
     DIVISOR = 0x0302
     _CONSTANT_ATTRIBUTES = {MULTIPLIER: 1, DIVISOR: 100}

--- a/zhaquirks/tuya/ts0121_plug.py
+++ b/zhaquirks/tuya/ts0121_plug.py
@@ -21,7 +21,7 @@ class TuyaMeteringCluster(CustomCluster, Metering):
     
     MULTIPLIER = 0x0301
     DIVISOR = 0x0302
-    _CONSTANT_ATTRIBUTES = {MULTIPLIER: 0.01, DIVISOR: 100}
+    _CONSTANT_ATTRIBUTES = {MULTIPLIER: 1, DIVISOR: 100}
 
 
 class Plug(CustomDevice):


### PR DESCRIPTION
The device reports current_summ_delivered values in "10W" so we must multiply it by 0.01 or divide it by 100 to get kWh in HA.

See Issue #605 