### PR TITLE
Added support for Müller Licht tint remote.

### DIFF
--- a/zhaquirks/mli/__init__.py
+++ b/zhaquirks/mli/__init__.py
@@ -1,0 +1,1 @@
+"""Mueller Licht International."""

--- a/zhaquirks/mli/tint.py
+++ b/zhaquirks/mli/tint.py
@@ -3,19 +3,18 @@ import logging
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
-import zigpy.types as t
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
-    Identify,
     Groups,
-    OnOff,
+    Identify,
     LevelControl,
+    OnOff,
     Ota,
     Scenes,
 )
-from zigpy.zcl.clusters.lightlink import LightLink
 from zigpy.zcl.clusters.lighting import Color
-from zigpy.zcl import foundation
+from zigpy.zcl.clusters.lightlink import LightLink
 
 from zhaquirks import Bus, LocalDataCluster
 from zhaquirks.const import (
@@ -33,7 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class TintRemoteScenesCluster(LocalDataCluster, Scenes):
-    """Tint remote cluster"""
+    """Tint remote cluster."""
 
     cluster_id = Scenes.cluster_id
 
@@ -44,11 +43,12 @@ class TintRemoteScenesCluster(LocalDataCluster, Scenes):
         self.endpoint.device.scene_bus.add_listener(self)
 
     def change_scene(self, value):
+        """Change scene attribute to new value."""
         self._update_attribute(self.attridx["current_scene"], value)
 
 
 class TintRemoteBasicCluster(CustomCluster, Basic):
-    """Tint remote cluster"""
+    """Tint remote cluster."""
 
     cluster_id = Basic.cluster_id
 
@@ -57,6 +57,7 @@ class TintRemoteBasicCluster(CustomCluster, Basic):
         super().__init__(*args, **kwargs)
 
     def handle_cluster_general_request(self, hdr, args, *, dst_addressing=None):
+        """Send write_attributes value to TintRemoteSceneCluster."""
         if hdr.command_id != foundation.Command.Write_Attributes:
             return
 
@@ -69,7 +70,7 @@ class TintRemoteBasicCluster(CustomCluster, Basic):
 
 
 class TintRemote(CustomDevice):
-    """Tint remote quirk"""
+    """Tint remote quirk."""
 
     def __init__(self, *args, **kwargs):
         """Init."""

--- a/zhaquirks/mli/tint.py
+++ b/zhaquirks/mli/tint.py
@@ -1,0 +1,129 @@
+"""Tint remote."""
+import logging
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Identify,
+    Groups,
+    OnOff,
+    LevelControl,
+    Ota,
+    Scenes,
+)
+from zigpy.zcl.clusters.lightlink import LightLink
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl import foundation
+
+from zhaquirks import Bus, LocalDataCluster
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+TINT_SCENE_ATTR = 0x4005
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TintRemoteScenesCluster(LocalDataCluster, Scenes):
+    """Tint remote cluster"""
+
+    cluster_id = Scenes.cluster_id
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+
+        self.endpoint.device.scene_bus.add_listener(self)
+
+    def change_scene(self, value):
+        self._update_attribute(self.attridx["current_scene"], value)
+
+
+class TintRemoteBasicCluster(CustomCluster, Basic):
+    """Tint remote cluster"""
+
+    cluster_id = Basic.cluster_id
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+
+    def handle_cluster_general_request(self, hdr, args, *, dst_addressing=None):
+        if hdr.command_id != foundation.Command.Write_Attributes:
+            return
+
+        attr = args[0][0]
+        if attr.attrid != TINT_SCENE_ATTR:
+            return
+
+        value = attr.value.value
+        self.endpoint.device.scene_bus.listener_event("change_scene", value)
+
+
+class TintRemote(CustomDevice):
+    """Tint remote quirk"""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.scene_bus = Bus()
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        # endpoint=1 profile=260 device_type=2048 device_version=1 input_clusters=[0, 3, 4096]
+        # output_clusters=[0, 3, 4, 5, 8, 25, 768, 4096]
+        MODELS_INFO: [("MLI", "ZBT-Remote-ALL-RGBW")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,  # 0
+                    Identify.cluster_id,  # 3
+                    LightLink.cluster_id,  # 4096
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,  # 0
+                    Identify.cluster_id,  # 3
+                    Groups.cluster_id,  # 4
+                    OnOff.cluster_id,  # 6
+                    LevelControl.cluster_id,  # 8
+                    Ota.cluster_id,  # 25
+                    Color.cluster_id,  # 768
+                    LightLink.cluster_id,  # 4096
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    TintRemoteBasicCluster,  # 0
+                    Identify.cluster_id,  # 3
+                    LightLink.cluster_id,  # 4096
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,  # 0
+                    Identify.cluster_id,  # 3
+                    Groups.cluster_id,  # 4
+                    TintRemoteScenesCluster,  # 5
+                    OnOff.cluster_id,  # 6
+                    LevelControl.cluster_id,  # 8
+                    Ota.cluster_id,  # 25
+                    Color.cluster_id,  # 768
+                    LightLink.cluster_id,  # 4096
+                ],
+            },
+        },
+    }


### PR DESCRIPTION
This adds support for the six scene buttons found on [MLIs "ZBT-Remote-ALL-RGBW"](https://zigbee.blakadder.com/Muller_Licht_404011.html).

The remote normally issues a write_attributes command if one of those buttons is pressed. The quirk translates this to an update on a scene cluster.