### PR TITLE
Move TuyaZBMeteringCluster to init

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -12,7 +12,6 @@ from zigpy.zcl.clusters.general import LevelControl, OnOff, PowerConfiguration
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.clusters.smartenergy import Metering
 
-
 from zhaquirks import Bus, EventableCluster, LocalDataCluster
 from zhaquirks.const import DOUBLE_PRESS, LONG_PRESS, SHORT_PRESS, ZHA_SEND_EVENT
 

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -10,6 +10,8 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import LevelControl, OnOff, PowerConfiguration
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
+from zigpy.zcl.clusters.smartenergy import Metering
+
 
 from zhaquirks import Bus, EventableCluster, LocalDataCluster
 from zhaquirks.const import DOUBLE_PRESS, LONG_PRESS, SHORT_PRESS, ZHA_SEND_EVENT
@@ -744,6 +746,14 @@ class TuyaZBOnOffRestorePowerCluster(CustomCluster, OnOff):
 
     attributes = OnOff.attributes.copy()
     attributes.update({0x8002: ("power_on_state", TZBPowerOnState)})
+
+
+class TuyaZBMeteringCluster(CustomCluster, Metering):
+    """Divides the kWh for tuya."""
+
+    MULTIPLIER = 0x0301
+    DIVISOR = 0x0302
+    _CONSTANT_ATTRIBUTES = {MULTIPLIER: 1, DIVISOR: 100}
 
 
 # Tuya Window Cover Implementation

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -23,7 +23,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import TuyaZBOnOffRestorePowerCluster
+from zhaquirks.tuya import TuyaZBMeteringCluster, TuyaZBOnOffRestorePowerCluster
 
 
 class TuyaClusterE000(CustomCluster):
@@ -40,14 +40,6 @@ class TuyaClusterE001(CustomCluster):
     name = "Tuya Manufacturer Specific"
     cluster_id = 0xE001
     ep_attribute = "tuya_is_pita_1"
-
-
-class TuyaZBMetering(CustomCluster, Metering):
-    """Divides the KwH for tuya."""
-
-    MULTIPLIER = 0x0301
-    DIVISOR = 0x0302
-    _CONSTANT_ATTRIBUTES = {MULTIPLIER: 1, DIVISOR: 100}
 
 
 class TuyaZBElectricalMeasurement(CustomCluster, ElectricalMeasurement):
@@ -107,7 +99,7 @@ class Plug(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     TuyaZBOnOffRestorePowerCluster,
-                    TuyaZBMetering,
+                    TuyaZBMeteringCluster,
                     TuyaZBElectricalMeasurement,
                     TuyaClusterE000,
                     TuyaClusterE001,

--- a/zhaquirks/tuya/ts0121_plug.py
+++ b/zhaquirks/tuya/ts0121_plug.py
@@ -1,6 +1,6 @@
 """Tuya TS0121 plug."""
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Groups, OnOff, Ota, Scenes, Time
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
@@ -13,15 +13,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import TuyaZBOnOffRestorePowerCluster
-
-
-class TuyaMeteringCluster(CustomCluster, Metering):
-    """TuyaMeteringCluster divides the kWh for tuya."""
-
-    MULTIPLIER = 0x0301
-    DIVISOR = 0x0302
-    _CONSTANT_ATTRIBUTES = {MULTIPLIER: 1, DIVISOR: 100}
+from zhaquirks.tuya import TuyaZBMeteringCluster, TuyaZBOnOffRestorePowerCluster
 
 
 class Plug(CustomDevice):
@@ -59,7 +51,7 @@ class Plug(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     TuyaZBOnOffRestorePowerCluster,
-                    TuyaMeteringCluster,
+                    TuyaZBMeteringCluster,
                     ElectricalMeasurement.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],


### PR DESCRIPTION
Two small code improvements

- Move `TuyaZBMeteringCluster` to `__init__.py` to avoid duplicated code
- ~~rename  `zhaquirks/tuya/TS011F_plug.py → zhaquirks/tuya/ts011f_plug.py` to be consistent with other files (and this gave a pylint warning locally)~~ already done in #1070 