### PR TITLE
xbee: Remote AT command cluster

### DIFF
--- a/xbee.md
+++ b/xbee.md
@@ -114,19 +114,34 @@ If the command is unsuccessful, you will get an exception in the logs. If it is 
 
 You can check the AT-to-Command_ID mapping in Device info screen. Click on `Manage clusters`, then select XBeeRemoteATRequest cluster, and you would find the mapping in the `Cluster Commands` dropdown list.
 
-Example service:
+Here is an example for the temperature sensor of an XBee Pro, you can get its value with TP command:
 ```
-service: zha.issue_zigbee_cluster_command
-data:
-  ieee: 00:13:a2:00:41:98:23:f9
-  endpoint_id: 230
-  command: 0x43
-  command_type: server
-  cluster_type: out
-  cluster_id: 33
-```
+template:
+  - trigger:
+    - platform: event
+      event_type: zha_event
+      event_data:
+        device_ieee: 00:13:a2:00:41:98:23:f9
+        command: tp_command_response
+    sensor:
+      - name: "XBee Temperature"
+        state: '{{ trigger.event.data.args }}'
+        unit_of_measurement: "°C"
+        device_class: temperature
+        state_class: measurement
 
-An example response event:
-```
-<Event zha_event[L]: device_ieee=00:13:a2:00:41:98:23:f9, unique_id=00:13:a2:00:41:98:23:f9:232:0x0008, device_id=114baa056e224fbc86797c0053817eb1, endpoint_id=232, cluster_id=8, command=tp_command_response, args=28>
+automation:
+  - alias: Update XBee Temperature
+    trigger:
+      platform: time_pattern
+      minutes: "/5"
+    action:
+      service: zha.issue_zigbee_cluster_command
+      data:
+        ieee: 00:13:a2:00:41:98:23:f9
+        endpoint_id: 230
+        command: 0x43
+        command_type: server
+        cluster_type: out
+        cluster_id: 33
 ```

--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -81,6 +81,12 @@ class uint8_t(uint_t):
     _size = 1
 
 
+class int16_t(int_t):
+    """Signed int 16 bit type."""
+
+    _size = 2
+
+
 class uint16_t(uint_t):
     """Unsigned int 16 bit type."""
 
@@ -194,7 +200,7 @@ AT_COMMANDS = {
     "RP": uint8_t,
     "%V": uint16_t,  # read only
     "V+": uint16_t,
-    "TP": uint16_t,
+    "TP": int16_t,
     "M0": uint16_t,  # 0 - 0x3FF
     "M1": uint16_t,  # 0 - 0x3FF
     # Diagnostics commands


### PR DESCRIPTION
It is now possible to send almost all AT commands remotely directly from HA!
Note that some (most destructive) commands are disabled.