### PR TITLE
Fixed factor/divider for _TZE200_b6wax7g0 temperature settings

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -261,6 +261,34 @@ class MoesManufCluster(TuyaManufClusterAttributes):
                 "battery_change", 5 if value else 100
             )
 
+# this is the class for the new moes TRV "_TZE200_b6wax7g0"
+class MoesManufClusterNew(MoesManufCluster):
+    DIRECT_MAPPED_ATTRS = {
+        MOES_TEMPERATURE_ATTR: ("local_temp", lambda value: value * 10),
+        MOES_TARGET_TEMP_ATTR: ("occupied_heating_setpoint", lambda value: value * 100), #jms
+        MOES_AWAY_TEMP_ATTR: ("unoccupied_heating_setpoint", lambda value: value * 100),
+        MOES_COMFORT_TEMP_ATTR: ("comfort_heating_setpoint", lambda value: value * 100),
+        MOES_ECO_TEMP_ATTR: ("eco_heating_setpoint", lambda value: value * 100),
+        MOES_TEMP_CALIBRATION_ATTR: (
+            "local_temperature_calibration",
+            lambda value: value * 10,
+        ),
+        MOES_MIN_TEMPERATURE_ATTR: (
+            "min_heat_setpoint_limit",
+            lambda value: value * 100,
+        ),
+        MOES_MAX_TEMPERATURE_ATTR: (
+            "max_heat_setpoint_limit",
+            lambda value: value * 100,
+        ),
+        MOES_VALVE_STATE_ATTR: ("valve_open_percentage", None),
+        MOES_AWAY_DAYS_ATTR: ("unoccupied_duration_days", None),
+        MOES_BOOST_TIME_ATTR: ("boost_duration_seconds", None),
+        MOES_MODE_ATTR: ("operation_preset", None),
+        MOES_WEEK_FORMAT_ATTR: ("work_days", None),
+        MOES_FORCE_VALVE_ATTR: ("valve_force_state", None),
+    }
+            
 
 class MoesThermostat(TuyaThermostatCluster):
     """Thermostat cluster for some thermostatic valves."""
@@ -612,6 +640,41 @@ class MoesThermostat(TuyaThermostatCluster):
                 self.attridx["weekend_schedule_6_temperature"], value[0] * 100
             )
 
+# this is the class for the new moes TRV "_TZE200_b6wax7g0"
+class MoesThermostatNew(MoesThermostat):
+    DIRECT_MAPPING_ATTRS = {
+        "occupied_heating_setpoint": (
+            MOES_TARGET_TEMP_ATTR,
+            lambda value: round(value / 100),  #jms
+        ),
+        "unoccupied_heating_setpoint": (
+            MOES_AWAY_TEMP_ATTR,
+            lambda value: round(value / 100),
+        ),
+        "comfort_heating_setpoint": (
+            MOES_COMFORT_TEMP_ATTR,
+            lambda value: round(value / 100),
+        ),
+        "eco_heating_setpoint": (MOES_ECO_TEMP_ATTR, lambda value: round(value / 100)),
+        "min_heat_setpoint_limit": (
+            MOES_MIN_TEMPERATURE_ATTR,
+            lambda value: round(value / 100),
+        ),
+        "max_heat_setpoint_limit": (
+            MOES_MAX_TEMPERATURE_ATTR,
+            lambda value: round(value / 100),
+        ),
+        "local_temperature_calibration": (
+            MOES_TEMP_CALIBRATION_ATTR,
+            lambda value: round(value / 10),
+        ),
+        "work_days": (MOES_WEEK_FORMAT_ATTR, None),
+        "operation_preset": (MOES_MODE_ATTR, None),
+        "boost_duration_seconds": (MOES_BOOST_TIME_ATTR, None),
+        "valve_force_state": (MOES_FORCE_VALVE_ATTR, None),
+        "unoccupied_duration_days": (MOES_AWAY_DAYS_ATTR, None),
+    }
+            
 
 class MoesUserInterface(TuyaUserInterfaceCluster):
     """HVAC User interface cluster for tuya electric heating thermostats."""
@@ -1017,6 +1080,56 @@ class MoesHY368_Type1(TuyaThermostat):
                     Scenes.cluster_id,
                     MoesManufCluster,
                     MoesThermostat,
+                    MoesUserInterface,
+                    MoesWindowDetection,
+                    TuyaPowerConfigurationCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            }
+        }
+    }
+
+# for Moes TRV _TZE200_b6wax7g0
+class MoesHY368_Type1new(TuyaThermostat):
+    """MoesHY368 Thermostatic radiator valve."""
+
+    def __init__(self, *args, **kwargs):
+        """Init device."""
+        self.window_detection_bus = Bus()
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        #  endpoint=1 profile=260 device_type=81 device_version=0 input_clusters=[0, 4, 5, 61184]
+        #  output_clusters=[10, 25]>
+        MODELS_INFO: [
+            ("_TZE200_b6wax7g0", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufClusterAttributes.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.THERMOSTAT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    MoesManufClusterNew,
+                    MoesThermostatNew,
                     MoesUserInterface,
                     MoesWindowDetection,
                     TuyaPowerConfigurationCluster,


### PR DESCRIPTION
For moeshouse ZTRV-BY-100-WH-DE thermostat radiator valve, the setpoint temperature was wrong by a factor of 10.
To correct this, I introduced 3 new classes for this device.
The main change are these 2 lines:
MOES_TARGET_TEMP_ATTR: ("occupied_heating_setpoint", lambda value: value * 100)
DIRECT_MAPPING_ATTRS = { "occupied_heating_setpoint": (MOES_TARGET_TEMP_ATTR, lambda value: round(value / 100),   ),
In the original code, the factor/divider was 10 which I changed to 100.
As a side effect, the temperature can only be set in steps of 1 degree and not in steps of 0.5 degrees. The reason for this is not clear. But it seems that in the cluster - which is an int value - the temperature is stored in degrees and not in centidegrees.