### PR TITLE
Xbee pwm fix

### DIFF
--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -321,18 +321,12 @@ class XBeePWM(LocalDataCluster, AnalogOutput):
         elif "present_value" in attributes:
             attr_id = "present_value"
         if attr_id:
-            duty_cycle = int(round(float(attributes.pop(attr_id))))
+            duty_cycle = int(round(float(attributes[attr_id])))
             at_command = self._ep_id_2_pwm.get(self._endpoint.endpoint_id)
-            result = await self._endpoint.device.remote_at(at_command, duty_cycle)
-            if result != foundation.Status.SUCCESS:
-                return result
+            await self._endpoint.device.remote_at(at_command, duty_cycle)
 
             at_command = ENDPOINT_TO_AT.get(self._endpoint.endpoint_id)
-            result = await self._endpoint.device.remote_at(
-                at_command, PIN_ANALOG_OUTPUT
-            )
-            if result != foundation.Status.SUCCESS or not attributes:
-                return result
+            await self._endpoint.device.remote_at(at_command, PIN_ANALOG_OUTPUT)
 
         return await super().write_attributes(attributes, manufacturer)
 

--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -287,10 +287,9 @@ class XBeeOnOff(LocalDataCluster, OnOff):
             pin_cmd = DIO_PIN_LOW
         else:
             pin_cmd = DIO_PIN_HIGH
-        result = await self._endpoint.device.remote_at(pin_name, pin_cmd)
-        if result == foundation.Status.SUCCESS:
-            self._update_attribute(ATTR_ON_OFF, command_id)
-        return 0, result
+        await self._endpoint.device.remote_at(pin_name, pin_cmd)
+        self._update_attribute(ATTR_ON_OFF, command_id)
+        return 0, foundation.Status.SUCCESS
 
 
 class XBeeAnalogInput(LocalDataCluster, AnalogInput):


### PR DESCRIPTION
`remote_at` returns `None` on successful value set, and an exception on error. The current code assumes return of SUCCESS on success and other values on error, which is not correct. Fixing that.