### PR TITLE
IKEA 5 BTM Remote  V3

### DIFF
--- a/zhaquirks/ikea/fivebtnremotezha.py
+++ b/zhaquirks/ikea/fivebtnremotezha.py
@@ -52,7 +52,7 @@ from zhaquirks.ikea import (
 IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
 
 
-class IkeaTradfriRemote(CustomDevice):
+class IkeaTradfriRemote1(CustomDevice):
     """Custom device representing IKEA of Sweden TRADFRI remote control."""
 
     signature = {
@@ -218,6 +218,69 @@ class IkeaTradfriRemote2(IkeaTradfriRemote):
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     LightLinkCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    ScenesCluster,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        }
+    }
+
+    device_automation_triggers = IkeaTradfriRemote.device_automation_triggers.copy()
+
+
+class IkeaTradfriRemote3(CustomDevice):
+    """Custom device representing IKEA of Sweden TRADFRI remote control."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=2080
+        # device_version=1
+        # input_clusters=[0, 1, 3, 32, 4096, 64636]
+        # output_clusters=[3, 4, 5, 6, 8, 25, 4096]>
+        MODELS_INFO: [(IKEA, "TRADFRI remote control")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                    IKEA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    ScenesCluster,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration1CRCluster,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    LightLinkCluster,
+                    IKEA_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,

--- a/zhaquirks/ikea/fivebtnremotezha.py
+++ b/zhaquirks/ikea/fivebtnremotezha.py
@@ -295,4 +295,64 @@ class IkeaTradfriRemote3(IkeaTradfriRemote1):
         }
     }
 
-    device_automation_triggers = IkeaTradfriRemote1.device_automation_triggers.copy()
+    device_automation_triggers = {
+        (SHORT_PRESS, TURN_ON): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: 6,
+            ENDPOINT_ID: 1,
+        },
+        (LONG_PRESS, TURN_ON): {
+            COMMAND: COMMAND_RELEASE,
+            CLUSTER_ID: 5,
+            ENDPOINT_ID: 1,
+            ARGS: [],
+        },
+        (SHORT_PRESS, DIM_UP): {
+            COMMAND: COMMAND_STEP_ON_OFF,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 43, 5],
+        },
+        (LONG_PRESS, DIM_UP): {
+            COMMAND: COMMAND_MOVE_ON_OFF,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 84],
+        },
+        (SHORT_PRESS, DIM_DOWN): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [1, 43, 5],
+        },
+        (LONG_PRESS, DIM_DOWN): {
+            COMMAND: COMMAND_MOVE,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [1, 84],
+        },
+        (SHORT_PRESS, LEFT): {
+            COMMAND: COMMAND_PRESS,
+            CLUSTER_ID: 5,
+            ENDPOINT_ID: 1,
+            ARGS: [257, 13, 0],
+        },
+        (LONG_PRESS, LEFT): {
+            COMMAND: COMMAND_HOLD,
+            CLUSTER_ID: 5,
+            ENDPOINT_ID: 1,
+            ARGS: [3329, 0],
+        },
+        (SHORT_PRESS, RIGHT): {
+            COMMAND: COMMAND_PRESS,
+            CLUSTER_ID: 5,
+            ENDPOINT_ID: 1,
+            ARGS: [256, 13, 0],
+        },
+        (LONG_PRESS, RIGHT): {
+            COMMAND: COMMAND_HOLD,
+            CLUSTER_ID: 5,
+            ENDPOINT_ID: 1,
+            ARGS: [3328, 0],
+        },
+    }

--- a/zhaquirks/ikea/fivebtnremotezha.py
+++ b/zhaquirks/ikea/fivebtnremotezha.py
@@ -174,7 +174,7 @@ class IkeaTradfriRemote1(CustomDevice):
     }
 
 
-class IkeaTradfriRemote2(IkeaTradfriRemote):
+class IkeaTradfriRemote2(IkeaTradfriRemote1):
     """Custom device representing IKEA of Sweden TRADFRI 5 button remote control."""
 
     signature = {
@@ -232,10 +232,10 @@ class IkeaTradfriRemote2(IkeaTradfriRemote):
         }
     }
 
-    device_automation_triggers = IkeaTradfriRemote.device_automation_triggers.copy()
+    device_automation_triggers = IkeaTradfriRemote1.device_automation_triggers.copy()
 
 
-class IkeaTradfriRemote3(CustomDevice):
+class IkeaTradfriRemote3(IkeaTradfriRemote1):
     """Custom device representing IKEA of Sweden TRADFRI remote control."""
 
     signature = {
@@ -259,7 +259,7 @@ class IkeaTradfriRemote3(CustomDevice):
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
                     Groups.cluster_id,
-                    ScenesCluster,
+                    ScenesCluster.cluster_id,
                     OnOff.cluster_id,
                     LevelControl.cluster_id,
                     Ota.cluster_id,
@@ -295,4 +295,4 @@ class IkeaTradfriRemote3(CustomDevice):
         }
     }
 
-    device_automation_triggers = IkeaTradfriRemote.device_automation_triggers.copy()
+    device_automation_triggers = IkeaTradfriRemote1.device_automation_triggers.copy()


### PR DESCRIPTION
Adding version 3 of the 5 button remote for working with the new firmware 2.3.080 that have broken group binding but can binding to devices.
It must being one bug IKEA have made or they dont like the community using there products.

Device automatons looks OK also from the "IKEA scene cluster".

Also renamed the remote classes so can see witch is being loaded.
Updated firmware is using `TradfriRemote3` and "old production" is using `TradfriRemote1` so nuber 2 must being one older version that is not in use this days if the device is on current  firmware.

Fixes #1113