### PR TITLE
Adding double press for E1812

### DIFF
--- a/zhaquirks/ikea/shortcutbtn.py
+++ b/zhaquirks/ikea/shortcutbtn.py
@@ -20,10 +20,11 @@ from zhaquirks.const import (
     CLUSTER_ID,
     COMMAND,
     COMMAND_MOVE_ON_OFF,
+    COMMAND_OFF,
     COMMAND_ON,
     COMMAND_STOP,
     DEVICE_TYPE,
-    DIM_UP,
+    DOUBLE_PRESS,
     ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -100,13 +101,14 @@ class IkeaTradfriShortcutBtn(CustomDevice):
 
     device_automation_triggers = {
         (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 1},
-        (LONG_PRESS, DIM_UP): {
+        (DOUBLE_PRESS, TURN_ON): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 1},
+(LONG_PRESS, TURN_ON): {
             COMMAND: COMMAND_MOVE_ON_OFF,
             CLUSTER_ID: 8,
             ENDPOINT_ID: 1,
             ARGS: [0, 83],
         },
-        (LONG_RELEASE, DIM_UP): {
+        (LONG_RELEASE, TURN_ON): {
             COMMAND: COMMAND_STOP,
             CLUSTER_ID: 8,
             ENDPOINT_ID: 1,

--- a/zhaquirks/ikea/shortcutbtn.py
+++ b/zhaquirks/ikea/shortcutbtn.py
@@ -102,7 +102,7 @@ class IkeaTradfriShortcutBtn(CustomDevice):
     device_automation_triggers = {
         (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 1},
         (DOUBLE_PRESS, TURN_ON): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 1},
-(LONG_PRESS, TURN_ON): {
+        (LONG_PRESS, TURN_ON): {
             COMMAND: COMMAND_MOVE_ON_OFF,
             CLUSTER_ID: 8,
             ENDPOINT_ID: 1,

--- a/zhaquirks/ikea/shortcutbtn.py
+++ b/zhaquirks/ikea/shortcutbtn.py
@@ -24,6 +24,7 @@ from zhaquirks.const import (
     COMMAND_ON,
     COMMAND_STOP,
     DEVICE_TYPE,
+    DIM_UP,
     DOUBLE_PRESS,
     ENDPOINT_ID,
     ENDPOINTS,
@@ -102,13 +103,13 @@ class IkeaTradfriShortcutBtn(CustomDevice):
     device_automation_triggers = {
         (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 1},
         (DOUBLE_PRESS, TURN_ON): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 1},
-        (LONG_PRESS, TURN_ON): {
+        (LONG_PRESS, DIM_UP): {
             COMMAND: COMMAND_MOVE_ON_OFF,
             CLUSTER_ID: 8,
             ENDPOINT_ID: 1,
             ARGS: [0, 83],
         },
-        (LONG_RELEASE, TURN_ON): {
+        (LONG_RELEASE, DIM_UP): {
             COMMAND: COMMAND_STOP,
             CLUSTER_ID: 8,
             ENDPOINT_ID: 1,


### PR DESCRIPTION
Adding double press device automation for IKEA E1812 Shortcut button (New in 2.3.080 FW).
Also changing name on the functions so its writing the same button for all device automatons and not on button and dim up button. (renaming reverted)

Tested with updated E1812.