### PR TITLE
Legrand Dimmer switch w/o neutral for sw_build_id=0x0039 with and without Ballast cluster

### DIFF
--- a/zhaquirks/legrand/dimmer.py
+++ b/zhaquirks/legrand/dimmer.py
@@ -134,7 +134,7 @@ class DimmerWithoutNeutral2(DimmerWithoutNeutral):
     }
 
 class DimmerWithoutNeutral3(CustomDevice):
-    """Dimmer switch w/o neutral (at least for firmware 0x2e)."""
+    """Dimmer switch w/o neutral (at least for firmware 0x2e and above)."""
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=256
@@ -185,6 +185,10 @@ class DimmerWithoutNeutral3(CustomDevice):
                     LevelControl.cluster_id,
                     Scenes.cluster_id,
                     BinaryInput.cluster_id,
+                    # Some devices with firmware 0x39 have Ballast cluster,
+                    # but some of them don't. But in any case Ballast works,
+                    # if we add it here.
+                    Ballast.cluster_id, 
                     LegrandCluster,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -208,10 +212,7 @@ class DimmerWithoutNeutral3(CustomDevice):
 
 class DimmerWithoutNeutralAndBallast(CustomDevice):
     """Dimmer switch w/o neutral (at least for firmware 0x39)."""
-    #
-    # TODO: Some fw=0x39 devices have Ballast cluster, but some of them don't.
-    #       It seems that Ballast cluster is enabled through Manufacturer specific command
-    # 
+     
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=256
         # device_version=1

--- a/zhaquirks/legrand/dimmer.py
+++ b/zhaquirks/legrand/dimmer.py
@@ -5,6 +5,7 @@ import zigpy.types as t
 from zigpy.zcl.clusters.general import (
     Basic,
     BinaryInput,
+    GreenPowerProxy,
     Groups,
     Identify,
     LevelControl,
@@ -12,6 +13,7 @@ from zigpy.zcl.clusters.general import (
     Ota,
     Scenes,
 )
+from zigpy.zcl.clusters.lighting import Ballast
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 
 from zhaquirks.const import (
@@ -131,9 +133,8 @@ class DimmerWithoutNeutral2(DimmerWithoutNeutral):
         },
     }
 
-
-class DimmerWithoutNeutral3(DimmerWithoutNeutral):
-    """Dimmer switch w/o neutral (at least for firmware 0x2e3)."""
+class DimmerWithoutNeutral3(CustomDevice):
+    """Dimmer switch w/o neutral (at least for firmware 0x2e)."""
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=256
@@ -168,6 +169,117 @@ class DimmerWithoutNeutral3(DimmerWithoutNeutral):
                 DEVICE_TYPE: 0x0066,
                 INPUT_CLUSTERS: [0x0021],
                 OUTPUT_CLUSTERS: [0x0021],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Scenes.cluster_id,
+                    BinaryInput.cluster_id,
+                    LegrandCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    LegrandCluster,
+                    Ota.cluster_id,
+                    OnOff.cluster_id,
+                    Scenes.cluster_id
+                ],
+            },
+            # Green Power End Point
+            242: {
+                PROFILE_ID: 0xA1E0,
+                DEVICE_TYPE: 0x0066, #GP Combo Minimum
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+
+class DimmerWithoutNeutralAndBallast(CustomDevice):
+    """Dimmer switch w/o neutral (at least for firmware 0x39)."""
+    #
+    # TODO: Some fw=0x39 devices have Ballast cluster, but some of them don't.
+    #       It seems that Ballast cluster is enabled through Manufacturer specific command
+    # 
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=256
+        # device_version=1
+        # input_clusters=[0, 3, 4, 5, 6, 8, 15, 769, 64513]
+        # output_clusters=[0, 5, 6, 25, 64513]>
+        MODELS_INFO: [(f" {LEGRAND}", " Dimmer switch w/o neutral")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Scenes.cluster_id,
+                    BinaryInput.cluster_id,
+                    Ballast.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                    Ota.cluster_id,
+                    OnOff.cluster_id,
+                    Scenes.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 0x0066,
+                INPUT_CLUSTERS: [0x0021],
+                OUTPUT_CLUSTERS: [0x0021],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Scenes.cluster_id,
+                    BinaryInput.cluster_id,
+                    Ballast.cluster_id,
+                    LegrandCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    LegrandCluster,
+                    Ota.cluster_id,
+                    OnOff.cluster_id,
+                    Scenes.cluster_id
+                ],
+            },
+            # Green Power End Point
+            242: {
+                PROFILE_ID: 0xA1E0,
+                DEVICE_TYPE: 0x0066, #GP Combo Minimum
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
             },
         },
     }

--- a/zhaquirks/legrand/dimmer.py
+++ b/zhaquirks/legrand/dimmer.py
@@ -133,6 +133,7 @@ class DimmerWithoutNeutral2(DimmerWithoutNeutral):
         },
     }
 
+
 class DimmerWithoutNeutral3(CustomDevice):
     """Dimmer switch w/o neutral (at least for firmware 0x2e and above)."""
 
@@ -188,7 +189,7 @@ class DimmerWithoutNeutral3(CustomDevice):
                     # Some devices with firmware 0x39 have Ballast cluster,
                     # but some of them don't. But in any case Ballast works,
                     # if we add it here.
-                    Ballast.cluster_id, 
+                    Ballast.cluster_id,
                     LegrandCluster,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -196,13 +197,13 @@ class DimmerWithoutNeutral3(CustomDevice):
                     LegrandCluster,
                     Ota.cluster_id,
                     OnOff.cluster_id,
-                    Scenes.cluster_id
+                    Scenes.cluster_id,
                 ],
             },
             # Green Power End Point
             242: {
                 PROFILE_ID: 0xA1E0,
-                DEVICE_TYPE: 0x0066, #GP Combo Minimum
+                DEVICE_TYPE: 0x0066,  # GP Combo Minimum
                 INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
                 OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
             },
@@ -212,7 +213,7 @@ class DimmerWithoutNeutral3(CustomDevice):
 
 class DimmerWithoutNeutralAndBallast(CustomDevice):
     """Dimmer switch w/o neutral (at least for firmware 0x39)."""
-     
+
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=256
         # device_version=1
@@ -272,13 +273,13 @@ class DimmerWithoutNeutralAndBallast(CustomDevice):
                     LegrandCluster,
                     Ota.cluster_id,
                     OnOff.cluster_id,
-                    Scenes.cluster_id
+                    Scenes.cluster_id,
                 ],
             },
             # Green Power End Point
             242: {
                 PROFILE_ID: 0xA1E0,
-                DEVICE_TYPE: 0x0066, #GP Combo Minimum
+                DEVICE_TYPE: 0x0066,  # GP Combo Minimum
                 INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
                 OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
             },


### PR DESCRIPTION
Fixes #1127 