### PR TITLE
Adding attribute for OnOff cluster TS0001X

### DIFF
--- a/zhaquirks/tuya/ts001x.py
+++ b/zhaquirks/tuya/ts001x.py
@@ -13,7 +13,7 @@ from zhaquirks.const import (
     PROFILE_ID,
     SKIP_CONFIGURATION,
 )
-from zhaquirks.tuya import TuyaSwitch
+from zhaquirks.tuya import TuyaSwitch, TuyaZBOnOffAttributeCluster
 
 
 class TuyaSingleNoNeutralSwitch(TuyaSwitch):
@@ -53,7 +53,7 @@ class TuyaSingleNoNeutralSwitch(TuyaSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    OnOff.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -115,7 +115,7 @@ class TuyaDoubleNoNeutralSwitch(TuyaSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    OnOff.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -125,7 +125,7 @@ class TuyaDoubleNoNeutralSwitch(TuyaSwitch):
                 INPUT_CLUSTERS: [
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    OnOff.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -201,7 +201,7 @@ class TuyaTripleNoNeutralSwitch(TuyaSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    OnOff.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -211,7 +211,7 @@ class TuyaTripleNoNeutralSwitch(TuyaSwitch):
                 INPUT_CLUSTERS: [
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    OnOff.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -221,7 +221,7 @@ class TuyaTripleNoNeutralSwitch(TuyaSwitch):
                 INPUT_CLUSTERS: [
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    OnOff.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
             },


### PR DESCRIPTION
Adding the tuya OnOff cluster for getting all the attributes implanted on it for all ts0001X devices.

Depends on https://github.com/zigpy/zha-device-handlers/pull/1105