### PR TITLE
add D5X84YU to Danfoss quirk

### DIFF
--- a/zhaquirks/danfoss/__init__.py
+++ b/zhaquirks/danfoss/__init__.py
@@ -1,2 +1,3 @@
 """Module for Sinope quirks implementations."""
 DANFOSS = "Danfoss"
+D5X84YU = "D5X84YU"

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -25,10 +25,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.danfoss import (
-    D5X84YU,
-    DANFOSS,
-)
+from zhaquirks.danfoss import D5X84YU, DANFOSS
 
 
 class DanfossThermostatCluster(CustomCluster, Thermostat):

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -26,8 +26,8 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.danfoss import (
-    DANFOSS,
     D5X84YU,
+    DANFOSS,
 )
 
 
@@ -113,7 +113,7 @@ class DanfossThermostat(CustomDevice):
         # <SimpleDescriptor endpoint=1 profile=260 device_type=769
         # device_version=0 input_clusters=[0, 1, 3, 10,32, 513, 516, 1026, 2821]
         # output_clusters=[0, 25]>
-        MODELS_INFO: [(DANFOSS, "eTRV0100"),(D5X84YU, "eT093WRO")],
+        MODELS_INFO: [(DANFOSS, "eTRV0100"), (D5X84YU, "eT093WRO")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha_p.PROFILE_ID,

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -25,7 +25,10 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.danfoss import DANFOSS
+from zhaquirks.danfoss import (
+    DANFOSS,
+    D5X84YU,
+)
 
 
 class DanfossThermostatCluster(CustomCluster, Thermostat):
@@ -110,7 +113,7 @@ class DanfossThermostat(CustomDevice):
         # <SimpleDescriptor endpoint=1 profile=260 device_type=769
         # device_version=0 input_clusters=[0, 1, 3, 10,32, 513, 516, 1026, 2821]
         # output_clusters=[0, 25]>
-        MODELS_INFO: [(DANFOSS, "eTRV0100")],
+        MODELS_INFO: [(DANFOSS, "eTRV0100"),(D5X84YU, "eT093WRO")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha_p.PROFILE_ID,


### PR DESCRIPTION
Bought two of the Danfoss thermostats under the oem named Popp . 
Without the updated quirks no updates could be triggered from HA.
After the changes updateing from HA works flawless (at least the last day).
The already working way thermostat -> HA still works.

Popp Danfoss was also already mentioned in #1005 

First try more than open for input. Ty.