### PR TITLE
Deleting left class from power on state

### DIFF
--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -72,14 +72,6 @@ HUE_REMOTE_DEVICE_TRIGGERS = {
 }
 
 
-class PowerOnState(t.enum8):
-    """Philips power on state enum."""
-
-    Off = 0x00
-    On = 0x01
-    LastState = 0xFF
-
-
 class OccupancyCluster(CustomCluster, OccupancySensing):
     """Philips occupancy cluster."""
 


### PR DESCRIPTION
The power on state is deleted (its implanted in the ZCL 7 part)  but the stat class was missed then it was made.