### PR TITLE
Update Aqara quirks for various Zigbee 3.0 devices

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(
     keywords="zha quirks homeassistant hass",
     packages=find_packages(exclude=["tests"]),
     python_requires=">=3",
-    install_requires=["zigpy>=0.32.0"],
+    install_requires=["zigpy>=0.42.0"],
     tests_require=["pytest"],
 )

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -64,7 +64,6 @@ VOLTAGE = "voltage"
 PRESSURE_MEASUREMENT = "pressure_measurement"
 PRESSURE_REPORTED = "pressure_reported"
 STATE = "state"
-TEMPERATURE = "temperature"
 TEMPERATURE_MEASUREMENT = "temperature_measurement"
 TEMPERATURE_REPORTED = "temperature_reported"
 POWER_REPORTED = "power_reported"
@@ -273,7 +272,7 @@ class XiaomiCluster(CustomCluster):
         attributes = {}
         attribute_names = {
             1: BATTERY_VOLTAGE_MV,
-            3: TEMPERATURE,
+            3: TEMPERATURE_MEASUREMENT,
             4: XIAOMI_ATTR_4,
             5: XIAOMI_ATTR_5,
             6: XIAOMI_ATTR_6,

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -55,6 +55,7 @@ BATTERY_VOLTAGE_MV = "battery_voltage_mV"
 HUMIDITY_MEASUREMENT = "humidity_measurement"
 HUMIDITY_REPORTED = "humidity_reported"
 LUMI = "LUMI"
+MODEL = 5
 MOTION_TYPE = 0x000D
 OCCUPANCY_STATE = 0
 PATH = "path"
@@ -212,7 +213,7 @@ class XiaomiCluster(CustomCluster):
             attributes = self._parse_mija_attributes(value)
         else:
             super()._update_attribute(attrid, value)
-            if attrid == 0x0005:
+            if attrid == MODEL:
                 # 0x0005 = model attribute.
                 # Xiaomi sensors send the model attribute when their reset button is
                 # pressed quickly."""

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -55,7 +55,6 @@ BATTERY_VOLTAGE_MV = "battery_voltage_mV"
 HUMIDITY_MEASUREMENT = "humidity_measurement"
 HUMIDITY_REPORTED = "humidity_reported"
 LUMI = "LUMI"
-MODEL = 5
 MOTION_TYPE = 0x000D
 OCCUPANCY_STATE = 0
 PATH = "path"
@@ -207,10 +206,7 @@ class XiaomiCluster(CustomCluster):
         if attrid in (XIAOMI_AQARA_ATTRIBUTE, XIAOMI_AQARA_ATTRIBUTE_E1):
             attributes = self._parse_aqara_attributes(value)
             super()._update_attribute(attrid, value)
-            if (
-                MODEL in self._attr_cache
-                and self._attr_cache[MODEL] == "lumi.sensor_switch.aq2"
-            ):
+            if self.endpoint.device.model == "lumi.sensor_switch.aq2":
                 if value == b"\x04!\xa8C\n!\x00\x00":
                     self.listener_event(ZHA_SEND_EVENT, COMMAND_TRIPLE, [])
         elif attrid == XIAOMI_MIJA_ATTRIBUTE:
@@ -284,7 +280,7 @@ class XiaomiCluster(CustomCluster):
             10: PATH,
         }
 
-        if MODEL in self._attr_cache and self._attr_cache[MODEL] in [
+        if self.endpoint.device.model in [
             "lumi.sensor_ht",
             "lumi.sens",
             "lumi.weather",
@@ -298,15 +294,12 @@ class XiaomiCluster(CustomCluster):
                     102: PRESSURE_MEASUREMENT,
                 }
             )
-        elif MODEL in self._attr_cache and self._attr_cache[MODEL] in [
+        elif self.endpoint.device.model in [
             "lumi.plug.maus01",
             "lumi.relay.c2acn01",
         ]:
             attribute_names.update({149: CONSUMPTION, 150: VOLTAGE, 152: POWER})
-        elif (
-            MODEL in self._attr_cache
-            and self._attr_cache[MODEL] == "lumi.sensor_motion.aq2"
-        ):
+        elif self.endpoint.device.model == "lumi.sensor_motion.aq2":
             attribute_names.update({11: ILLUMINANCE_MEASUREMENT})
 
         result = {}

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -67,6 +67,7 @@ PRESSURE_REPORTED = "pressure_reported"
 STATE = "state"
 TEMPERATURE = "temperature"
 TEMPERATURE_MEASUREMENT = "temperature_measurement"
+TVOC_MEASUREMENT = "tvoc_measurement"
 TEMPERATURE_REPORTED = "temperature_reported"
 POWER_REPORTED = "power_reported"
 CONSUMPTION_REPORTED = "consumption_reported"
@@ -268,6 +269,10 @@ class XiaomiCluster(CustomCluster):
             self.endpoint.device.illuminance_bus.listener_event(
                 ILLUMINANCE_REPORTED, attributes[ILLUMINANCE_MEASUREMENT]
             )
+        if TVOC_MEASUREMENT in attributes:
+            self.endpoint.voc_level.update_attribute(
+                0x0000, attributes[TVOC_MEASUREMENT]
+            )
 
     def _parse_aqara_attributes(self, value):
         """Parse non standard attributes."""
@@ -285,6 +290,7 @@ class XiaomiCluster(CustomCluster):
             "lumi.sensor_ht",
             "lumi.sens",
             "lumi.weather",
+            "lumi.airmonitor.acn01",
         ]:
             # Temperature sensors send temperature/humidity/pressure updates trough this
             # cluster instead of the respective clusters
@@ -292,7 +298,9 @@ class XiaomiCluster(CustomCluster):
                 {
                     100: TEMPERATURE_MEASUREMENT,
                     101: HUMIDITY_MEASUREMENT,
-                    102: PRESSURE_MEASUREMENT,
+                    102: TVOC_MEASUREMENT
+                    if self.endpoint.device.model == "lumi.airmonitor.acn01"
+                    else PRESSURE_MEASUREMENT,
                 }
             )
         elif self.endpoint.device.model in [

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -350,8 +350,6 @@ class XiaomiCluster(CustomCluster):
 class BasicCluster(XiaomiCluster, Basic):
     """Xiaomi basic cluster implementation."""
 
-    cluster_id = Basic.cluster_id
-
 
 class XiaomiAqaraE1Cluster(XiaomiCluster, ManufacturerSpecificCluster):
     """Xiaomi mfg cluster implementation."""

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -65,6 +65,7 @@ VOLTAGE = "voltage"
 PRESSURE_MEASUREMENT = "pressure_measurement"
 PRESSURE_REPORTED = "pressure_reported"
 STATE = "state"
+TEMPERATURE = "temperature"
 TEMPERATURE_MEASUREMENT = "temperature_measurement"
 TEMPERATURE_REPORTED = "temperature_reported"
 POWER_REPORTED = "power_reported"
@@ -273,7 +274,7 @@ class XiaomiCluster(CustomCluster):
         attributes = {}
         attribute_names = {
             1: BATTERY_VOLTAGE_MV,
-            3: TEMPERATURE_MEASUREMENT,
+            3: TEMPERATURE,
             4: XIAOMI_ATTR_4,
             5: XIAOMI_ATTR_5,
             6: XIAOMI_ATTR_6,

--- a/zhaquirks/xiaomi/aqara/magnet_acn001.py
+++ b/zhaquirks/xiaomi/aqara/magnet_acn001.py
@@ -1,0 +1,71 @@
+"""Xiaomi aqara E1 contact sensor device."""
+import logging
+
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import Identify, Ota
+from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    XiaomiAqaraE1Cluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
+)
+
+XIAOMI_CLUSTER_ID = 0xFCC0
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MagnetE1(XiaomiCustomDevice):
+    """Xiaomi contact sensor device."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.battery_size = 11
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
+        #  device_version=1
+        #  input_clusters=[0, 1, 3, 1280, 64704]
+        #  output_clusters=[3, 19]>
+        MODELS_INFO: [(LUMI, "lumi.magnet.acn001")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    BasicCluster.cluster_id,
+                    XiaomiPowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                    XIAOMI_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
+            }
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    XiaomiPowerConfiguration,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                    XiaomiAqaraE1Cluster,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
+            }
+        },
+    }

--- a/zhaquirks/xiaomi/aqara/motion_agl02.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl02.py
@@ -1,9 +1,9 @@
-"""Xiaomi aqara E1 contact sensor device."""
-
+"""Xiaomi aqara T1 motion sensor device."""
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Identify, Ota
-from zigpy.zcl.clusters.security import IasZone
+from zigpy.zcl.clusters.measurement import OccupancySensing
 
+from zhaquirks import Bus
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -15,6 +15,9 @@ from zhaquirks.const import (
 from zhaquirks.xiaomi import (
     LUMI,
     BasicCluster,
+    IlluminanceMeasurementCluster,
+    MotionCluster,
+    OccupancyCluster,
     XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
     XiaomiPowerConfiguration,
@@ -23,30 +26,42 @@ from zhaquirks.xiaomi import (
 XIAOMI_CLUSTER_ID = 0xFCC0
 
 
-class MagnetE1(XiaomiCustomDevice):
+class XiaomiManufacturerCluster(XiaomiAqaraE1Cluster):
+    """Xiaomi manufacturer cluster."""
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == 274:
+            value = value - 65536
+            self.endpoint.illuminance.illuminance_reported(value)
+            self.endpoint.occupancy.update_attribute(0, 1)
+
+
+class MotionT1(XiaomiCustomDevice):
     """Xiaomi contact sensor device."""
 
     def __init__(self, *args, **kwargs):
         """Init."""
         self.battery_size = 11
+        self.motion_bus = Bus()
+        self.illuminance_bus = Bus()
         super().__init__(*args, **kwargs)
 
     signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=263
         #  device_version=1
-        #  input_clusters=[0, 1, 3, 1280, 64704]
+        #  input_clusters=[0, 1, 3, 1030]
         #  output_clusters=[3, 19]>
-        MODELS_INFO: [(LUMI, "lumi.magnet.acn001")],
+        MODELS_INFO: [(LUMI, "lumi.motion.agl02")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
                 INPUT_CLUSTERS: [
                     BasicCluster.cluster_id,
                     XiaomiPowerConfiguration.cluster_id,
                     Identify.cluster_id,
-                    IasZone.cluster_id,
-                    XIAOMI_CLUSTER_ID,
+                    OccupancySensing.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
             }
@@ -59,8 +74,10 @@ class MagnetE1(XiaomiCustomDevice):
                     BasicCluster,
                     XiaomiPowerConfiguration,
                     Identify.cluster_id,
-                    IasZone.cluster_id,
-                    XiaomiAqaraE1Cluster,
+                    OccupancyCluster,
+                    MotionCluster,
+                    IlluminanceMeasurementCluster,
+                    XiaomiManufacturerCluster,
                 ],
                 OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
             }


### PR DESCRIPTION
This PR adds battery support to the Aqara E1 contact sensor. The device appears to follow the ZCL spec for all clusters and the Xiaomi custom report appears to be sent on cluster `0xFCC0` via attribute `0x00F7`. The basic cluster implementation was refactored to accommodate this. 

These devices (Aqara E1 devices) require that we respond w/ a certain manufacturer id when they join the network. Z2M has produced new firmwares to make this work w/ TI coordinators. I have been able to get these to work by making a small change to bellows to set the manufacturer code to what these devices expect at network startup. We are still evaluating the best path forward to support these. 

This PR also adds support for the Aqara T1 motion sensor so that it continues to function after the changes to enable the E1 contact sensor. 

This PR also updates the TVOC quirk so that it gets the Xiaomi heartbeat data and updates the appropriate clusters.