### PR TITLE
Add command_bus to TuyaManufCluster

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -133,6 +133,80 @@ async def test_singleswitch_state_report(zigpy_device_from_quirk, quirk):
     assert switch_listener.attribute_updates[1][1] == OFF
 
 
+@pytest.mark.parametrize("quirk", (zhaquirks.tuya.ts0601_switch.TuyaDoubleSwitchTO,))
+async def test_doubleswitch_state_report(zigpy_device_from_quirk, quirk):
+    """Test tuya single switch."""
+
+    ZCL_TUYA_SWITCH_COMMAND_03 = b"\tQ\x03\x006\x01\x01\x00\x01\x01"
+    ZCL_TUYA_SWITCH_EP2_ON = b"\tQ\x02\x006\x02\x01\x00\x01\x01"
+    ZCL_TUYA_SWITCH_EP2_OFF = b"\tQ\x02\x006\x02\x01\x00\x01\x00"
+
+    switch_dev = zigpy_device_from_quirk(quirk)
+
+    switch1_cluster = switch_dev.endpoints[1].on_off
+    switch1_listener = ClusterListener(switch1_cluster)
+
+    switch2_cluster = switch_dev.endpoints[2].on_off
+    switch2_listener = ClusterListener(switch2_cluster)
+
+    tuya_cluster = switch_dev.endpoints[1].tuya_manufacturer
+
+    assert len(switch1_listener.cluster_commands) == 0
+    assert len(switch1_listener.attribute_updates) == 0
+    assert len(switch2_listener.cluster_commands) == 0
+    assert len(switch2_listener.attribute_updates) == 0
+
+    # events from channel 1 updates only EP 1
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_ON)
+    tuya_cluster.handle_message(hdr, args)
+    assert len(switch1_listener.attribute_updates) == 1
+    assert len(switch2_listener.attribute_updates) == 0
+    assert switch1_listener.attribute_updates[0][0] == 0x0000
+    assert switch1_listener.attribute_updates[0][1] == ON
+
+    # events from channel 2 updates only EP 2
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_EP2_ON)
+    tuya_cluster.handle_message(hdr, args)
+    assert len(switch1_listener.attribute_updates) == 1
+    assert len(switch2_listener.attribute_updates) == 1
+    assert switch2_listener.attribute_updates[0][0] == 0x0000
+    assert switch2_listener.attribute_updates[0][1] == ON
+
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_OFF)
+    tuya_cluster.handle_message(hdr, args)
+    assert len(switch1_listener.attribute_updates) == 2
+    assert len(switch2_listener.attribute_updates) == 1
+    assert switch1_listener.attribute_updates[1][0] == 0x0000
+    assert switch1_listener.attribute_updates[1][1] == OFF
+
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_EP2_OFF)
+    tuya_cluster.handle_message(hdr, args)
+    assert len(switch1_listener.attribute_updates) == 2
+    assert len(switch2_listener.attribute_updates) == 2
+    assert switch2_listener.attribute_updates[1][0] == 0x0000
+    assert switch2_listener.attribute_updates[1][1] == OFF
+
+    assert len(switch1_listener.cluster_commands) == 0
+    assert len(switch2_listener.cluster_commands) == 0
+
+    # command_id = 0x0003
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_COMMAND_03)
+    tuya_cluster.handle_message(hdr, args)
+    assert len(switch1_listener.cluster_commands) == 0
+    assert len(switch2_listener.cluster_commands) == 0
+    # no switch attribute updated (Unsupported command)
+    assert len(switch1_listener.attribute_updates) == 2
+    assert len(switch2_listener.attribute_updates) == 2
+
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SET_TIME_REQUEST)
+    tuya_cluster.handle_message(hdr, args)
+    assert len(switch1_listener.cluster_commands) == 0
+    assert len(switch2_listener.cluster_commands) == 0
+    # no switch attribute updated (TUYA_SET_TIME command)
+    assert len(switch1_listener.attribute_updates) == 2
+    assert len(switch2_listener.attribute_updates) == 2
+
+
 @pytest.mark.parametrize("quirk", (zhaquirks.tuya.ts0601_switch.TuyaSingleSwitchTI,))
 async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
     """Test tuya single switch."""

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -146,7 +146,7 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
         tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
     ) as m1:
 
-        status = switch_cluster.command(0x0000)
+        status = await switch_cluster.command(0x0000)
         m1.assert_called_with(
             61184,
             1,
@@ -156,7 +156,7 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
         )
         assert status == 0
 
-        status = switch_cluster.command(0x0001)
+        status = await switch_cluster.command(0x0001)
         m1.assert_called_with(
             61184,
             2,
@@ -166,7 +166,7 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
         )
         assert status == 0
 
-    status = switch_cluster.command(0x0002)
+    status = await switch_cluster.command(0x0002)
     assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
 
 

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -309,18 +309,13 @@ class TuyaManufCluster(CustomCluster):
         """Init."""
         super().__init__(*args, **kwargs)
         self.endpoint.device.command_bus = Bus()
-        self.endpoint.device.command_bus.add_listener(self) # listen MCU commands
+        self.endpoint.device.command_bus.add_listener(self)  # listen MCU commands
 
-    def tuya_mcu_command(
-        self,
-        command: Command
-    ):
+    def tuya_mcu_command(self, command: Command):
         """Tuya MCU command listener. Only endpoint:1 must listen to MCU commands."""
 
         self.create_catching_task(
-            self.command(
-                TUYA_SET_DATA, command, expect_reply=True
-            )
+            self.command(TUYA_SET_DATA, command, expect_reply=True)
         )
 
     def handle_cluster_request(

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -37,6 +37,7 @@ TUYA_LEVEL_COMMAND = 514
 
 COVER_EVENT = "cover_event"
 LEVEL_EVENT = "level_event"
+TUYA_MCU_COMMAND = "tuya_mcu_command"
 
 # ---------------------------------------------------------
 # Value for dp_type
@@ -304,6 +305,24 @@ class TuyaManufCluster(CustomCluster):
         0x0024: ("set_time_request", (t.data16,), True),
     }
 
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.command_bus = Bus()
+        self.endpoint.device.command_bus.add_listener(self) # listen MCU commands
+
+    def tuya_mcu_command(
+        self,
+        command: Command
+    ):
+        """Tuya MCU command listener. Only endpoint:1 must listen to MCU commands."""
+
+        self.create_catching_task(
+            self.command(
+                TUYA_SET_DATA, command, expect_reply=True
+            )
+        )
+
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
@@ -446,9 +465,11 @@ class TuyaOnOff(CustomCluster, OnOff):
             channel,
             state,
         )
-        self._update_attribute(ATTR_ON_OFF, state)
+        # update status only if event == endpoint
+        if self.endpoint.endpoint_id == channel:
+            self._update_attribute(ATTR_ON_OFF, state)
 
-    def command(
+    async def command(
         self,
         command_id: Union[foundation.Command, int, t.uint8_t],
         *args,
@@ -466,9 +487,11 @@ class TuyaOnOff(CustomCluster, OnOff):
             cmd_payload.function = 0
             cmd_payload.data = [1, command_id]
 
-            return self.endpoint.tuya_manufacturer.command(
-                TUYA_SET_DATA, cmd_payload, expect_reply=True
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cmd_payload,
             )
+            return foundation.Status.SUCCESS
 
         return foundation.Status.UNSUP_CLUSTER_COMMAND
 
@@ -487,17 +510,23 @@ class TuyaManufacturerClusterOnOff(TuyaManufCluster):
     ) -> None:
         """Handle cluster request."""
 
-        # Send default response because the MCU expects it
-        if not hdr.frame_control.disable_default_response:
-            self.send_default_rsp(hdr, status=foundation.Status.SUCCESS)
-
-        tuya_payload = args[0]
         if hdr.command_id in (0x0002, 0x0001):
+            # Send default response because the MCU expects it
+            if not hdr.frame_control.disable_default_response:
+                self.send_default_rsp(hdr, status=foundation.Status.SUCCESS)
+
+            tuya_payload = args[0]
             self.endpoint.device.switch_bus.listener_event(
                 SWITCH_EVENT,
                 tuya_payload.command_id - TUYA_CMD_BASE,
                 tuya_payload.data[1],
             )
+        elif hdr.command_id == TUYA_SET_TIME:
+            """Time event call super"""
+            _LOGGER.debug("TUYA_SET_TIME --> hdr: %s, args: %s", hdr, args)
+            super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+        else:
+            _LOGGER.warning("Unsupported command: %s", hdr)
 
 
 class TuyaSwitch(CustomDevice):

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -477,6 +477,7 @@ class TuyaOnOff(CustomCluster, OnOff):
         if command_id in (0x0000, 0x0001):
             cmd_payload = TuyaManufCluster.Command()
             cmd_payload.status = 0
+            # cmd_payload.tsn = tsn if tsn else self.endpoint.device.application.get_sequence()
             cmd_payload.tsn = 0
             cmd_payload.command_id = TUYA_CMD_BASE + self.endpoint.endpoint_id
             cmd_payload.function = 0

--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -113,3 +113,57 @@ class TuyaSingleSwitchTO(TuyaSwitch):
             }
         }
     }
+
+
+class TuyaDoubleSwitchTO(TuyaSwitch):
+    """Tuya double channel switch time on out cluster device."""
+
+    signature = {
+        # "node_descriptor": "<NodeDescriptor byte1=1 byte2=64 mac_capability_flags=142 manufacturer_code=4098
+        #                       maximum_buffer_size=82 maximum_incoming_transfer_size=82 server_mask=11264
+        #                       maximum_outgoing_transfer_size=82 descriptor_capability_field=0>",
+        # device_version=1
+        # input_clusters=[0x0000, 0x0004, 0x0005, 0xef00]
+        # output_clusters=[0x000a, 0x0019]
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=51 device_version=1 input_clusters=[0, 4, 5, 61184] output_clusters=[10, 25]>
+        MODELS_INFO: [
+            ("_TZE200_g1ib5ldv", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufacturerClusterOnOff,
+                    TuyaOnOff,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOff,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        }
+    }


### PR DESCRIPTION
This PR adds a new `command_bus` to TuyaManufCluster.
This new bus would listen to MCU commands from other endpoints and talk to MCU.

There are some points to review:
* [x] Tests are failing. Trying to fix it
* [ ] Not sure about naming. MCU or DP commands?
* [x] `TuyaOnOff.command()` changed to `async`
This is one of those changes that you make to make it work, but that you just don't understand. I am concerned about the impact of this change (I am not fluent in Python)

The next thing will be to upload a quirk that makes use of this approach to show its use.

I have thinked about duplicate the `TuyaManufCluster` implementation and create a new subclass, but I understand that the purpose of the `TuyaManufCluster` class is precisely to send the MCU commands so I think it is the right place to implement the functionality.

IMHO the listener approach should replace the use of `self.endpoint.tuya_manufacturer.command ()` but before modifying all the implementations I prefer to validate it with a few uses (ClusterOnOff) and if it does not generate incidents, migrate to the rest of uses (WindowCover , LevelControl, Motion, ...). 
Or maybe it can be applied in those cases that require it (multi switch type). 

(Fixes: #1038 )