### PR TITLE
Add quirk to support Moes ZigBee DIY RF433 Smart Curtain Switch Module.

### DIFF
--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -158,6 +158,50 @@ class TuyaZemismartTS130F(CustomDevice):
     }
 
 
+class TuyaMoesDiyRf433TS130F(CustomDevice):
+    """Moes Tuya ZigBee DIY RF433 Smart Curtain Switch Module."""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0x0202, device_version=1, input_clusters=[0x0000, 0x0004, 0x0005, 0x0006, 0x0102], output_clusters=[0x000a, 0x0019]))
+        MODEL: "TS130F",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    WindowCovering.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaWithBacklightOnOffCluster,
+                    TuyaCoveringCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
 class TuyaTS130FTO(CustomDevice):
     """Tuya smart curtain roller shutter Time Out."""
 

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -202,6 +202,7 @@ class TuyaMoesDiyRf433TS130F(CustomDevice):
         },
     }
 
+
 class TuyaTS130FTO(CustomDevice):
     """Tuya smart curtain roller shutter Time Out."""
 


### PR DESCRIPTION
This moes Smart Curtain Switch module is a WINDOW_COVERING_CONTROLLER instead of WINDOW_COVERING_DEVICE.
https://www.moeshouse.com/products/zigbee-diy-rf433-smart-curtain-switch-module-for-electric-motorized-roller-blinds-shutter-motor-2mqtt-available?pr_prod_strat=copurchase&pr_rec_pid=6551498686545&pr_ref_pid=6574316322897&pr_seq=uniform
![image](https://user-images.githubusercontent.com/36730900/141690305-f0b94ce4-5ca4-42a8-afe5-0b61f63ee586.png)
