### PR TITLE
Add quirk for ZLinky_TIC

### DIFF
--- a/zhaquirks/lixee/__init__.py
+++ b/zhaquirks/lixee/__init__.py
@@ -1,0 +1,3 @@
+"""Module for LiXee devices quirks."""
+
+LIXEE = "LiXee"

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -1,0 +1,78 @@
+"""Quirk for ZLinky_TIC."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Identify, Ota
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement, MeterIdentification
+from zigpy.zcl.clusters.smartenergy import Metering
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.lixee import LIXEE
+
+
+class ZLinkyTICMetering(CustomCluster, Metering):
+    """ZLinky_TIC custom metring cluster."""
+
+    # ZLinky_TIC reports current_summ_delivered in Wh
+    # Home Assistant expects kWh (1kWh = 1000 Wh)
+    MULTIPLIER = 0x0301
+    DIVISOR = 0x0302
+    _CONSTANT_ATTRIBUTES = {MULTIPLIER: 1, DIVISOR: 1000}
+
+
+class ZLinkyTIC(CustomDevice):
+    """ZLinky_TIC from LiXee."""
+
+    signature = {
+        MODELS_INFO: [(LIXEE, "ZLinky_TIC")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.METER_INTERFACE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Metering.cluster_id,
+                    MeterIdentification.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    0xFF66,  # Manufacturer Specific
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.METER_INTERFACE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    ZLinkyTICMetering,
+                    MeterIdentification.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    0xFF66,  # Manufacturer Specific
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }


### PR DESCRIPTION
Zlinky_TIC is a zigbee module reporting electrical measurement and metering for the french smart electric meter Linky. ZLinky reports the attribute `current_summ_delivered` in Wh when Home Assistant expects kWh. This quirks correct this.

More info on ZLinky_TIC [here](https://github.com/fairecasoimeme/Zlinky_TIC) (in french :fr:)

This PR should fix this issue : https://github.com/zigpy/zha-device-handlers/issues/1146