### PR TITLE
Add Lixee ZLinky_TIC manufacturer specific cluster

### DIFF
--- a/zhaquirks/lixee/__init__.py
+++ b/zhaquirks/lixee/__init__.py
@@ -1,3 +1,5 @@
 """Module for LiXee devices quirks."""
 
 LIXEE = "LiXee"
+
+ZLINKY_MANUFACTURER_CLUSTER_ID = 0xFF66

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -24,19 +24,93 @@ class ZLinkyTICManufacturerCluster(CustomCluster, ManufacturerSpecificCluster):
     cluster_id = ZLINKY_MANUFACTURER_CLUSTER_ID
     name = "ZLinky_TIC Manufacturer specific"
     ep_attribute = "zlinky_manufacturer_specific"
+
+    # The attribute comments below are in French to match the reference documentation,
+    # see https://github.com/fairecasoimeme/Zlinky_TIC/tree/v9.0#synth%C3%A8se-d%C3%A9veloppeur
+    # and https://github.com/fairecasoimeme/Zlinky_TIC/blob/v9.0/ZLinky/Source/LixeeCluster.h
     attributes = {
-        0x0000: ("histo_optarif_or_standard_ngtf", t.LimitedCharString(16)),
-        0x0001: ("histo_demain", t.LimitedCharString(4)),
-        0x0002: ("histo_hhphc", t.uint8_t),
-        0x0003: ("histo_ppot", t.uint8_t),
-        0x0004: ("histo_pejp", t.uint8_t),
-        0x0005: ("histo_adps", t.uint16_t),
-        0x0006: ("histo_adir1", t.uint16_t),
-        0x0007: ("histo_adir2", t.uint16_t),
-        0x0008: ("histo_adir3", t.uint16_t),
-        0x0200: ("standard_ltarf", t.LimitedCharString(16)),
-        0x0201: ("standard_ntarf", t.uint8_t),
-        0x0202: ("standard_date", t.LimitedCharString(10)),
+        # Historical mode: OPTARIF "Option tarifaire" / String 4 car
+        # Standard mode: NGTF "Nom du calendrier tarifaire fournisseur" / String 16 car
+        0x0000: ("histo_optarif_or_standard_ngtf", t.LimitedCharString(16), True),
+        # Historical mode: DEMAIN "Couleur du lendemain" / String 4 car
+        0x0001: ("histo_demain", t.LimitedCharString(4), True),
+        # Historical mode: HHPHC "Horaire Heure Pleines Heures Creuses" / Uint8 1 car
+        0x0002: ("histo_hhphc", t.uint8_t, True),
+        # Historical mode: PPOT "Présence des potentiels" (Triphasé) / Uint8 2 car
+        0x0003: ("histo_ppot", t.uint8_t, True),
+        # Historical mode: PEJP "Préavis début EJP(30min)" / Uint8 2 car
+        0x0004: ("histo_pejp", t.uint8_t, True),
+        # Historical mode: ADPS "Avertissement de Dépassement De Puissance Souscrite" / Uint16 3 car
+        0x0005: ("histo_adps", t.uint16_t, True),
+        # Historical mode: ADIR1 "Avertissement de Dépassement D'intensité phase 1" / Uint16 3 car
+        0x0006: ("histo_adir1", t.uint16_t, True),
+        # Historical mode: ADIR2 "Avertissement de Dépassement D'intensité phase 2" / Uint16 3 car
+        0x0007: ("histo_adir2", t.uint16_t, True),
+        # Historical mode: ADIR3 "Avertissement de Dépassement D'intensité phase 3" / Uint16 3 car
+        0x0008: ("histo_adir3", t.uint16_t, True),
+        # Historical and Standard mode: "Linky acquisition time (From V7)"" / Uint8 1 car
+        0x0100: ("linky_acquisition_time", t.uint8_t, True),
+        # Standard mode: LTARF "Libellé tarif fournisseur en cours" / String 16 car
+        0x0200: ("standard_ltarf", t.LimitedCharString(16), True),
+        # Standard mode: NTARF "Numéro de l’index tarifaire en cours" / Uint8 2 car
+        0x0201: ("standard_ntarf", t.uint8_t, True),
+        # Standard mode: DATE "Date et heure courant" / String 10 car
+        0x0202: ("standard_date", t.LimitedCharString(10), True),
+        # Standard mode: EASD01 "Energie active soutirée Distributeur, index 01" / Uint32 9 car
+        0x0203: ("standard_easd01", t.uint32_t, True),
+        # Standard mode: EASD02 "Energie active soutirée Distributeur, index 02" / Uint32 9 car
+        0x0204: ("standard_easd02", t.uint32_t, True),
+        # Standard mode: EASD03 "Energie active soutirée Distributeur, index 03" / Uint32 9 car
+        0x0205: ("standard_easd03", t.uint32_t, True),
+        # Standard mode: EASD04 "Energie active soutirée Distributeur, index 04" / Uint32 9 car
+        0x0206: ("standard_easd04", t.uint32_t, True),
+        # Standard mode: SINSTI "Puissance app. Instantanée injectée" (Production) / Uint16 5 car
+        0x0207: ("standard_sinsti", t.uint16_t, True),
+        # Standard mode: SMAXIN "Puissance app max. injectée n" (Production) / Uint16 5 car
+        0x0208: ("standard_smaxin", t.uint16_t, True),
+        # Standard mode: SMAXIN-1 "Puissance app max. injectée n-1" (Production) / Uint16 5 car
+        0x0209: ("standard_smaxin_1", t.uint16_t, True),
+        # Standard mode: CCAIN "Point n de la courbe de charge active injectée" (Production) / Uint16 5 car
+        0x0210: ("standard_ccain", t.uint16_t, True),
+        # Standard mode: CCAIN-1 "Point n-1 de la courbe de charge active injectée" (Production) / Uint16 5 car
+        0x0211: ("standard_ccain_1", t.uint16_t, True),
+        # Standard mode: SMAXN-1 "Puissance app. max. soutirée n-1" (Monophasé) / Uint16 5 car
+        # Standard mode: SMAXN1-1 "Puissance app. max. soutirée n-1 ph.1" (Triphasé) / Uint16 5 car
+        0x0212: ("standard_smaxn1_1", t.uint16_t, True),
+        # Standard mode: SMAXN2-1 "Puissance app. max. soutirée n-1 ph. 2" (Triphasé) / Uint16 5 car
+        0x0213: ("standard_smaxn2_1", t.uint16_t, True),
+        # Standard mode: SMAXN3-1 "Puissance app. max. soutirée n-1 ph. 3" (Triphasé) / Uint16 5 car
+        0x0214: ("standard_smaxn3_1", t.uint16_t, True),
+        # Standard mode: MSG1 "Message court" / String 32 car
+        0x0215: ("standard_msg1", t.LimitedCharString(32), True),
+        # Standard mode: MSG2 "Message ultra court" / String 16 car
+        0x0216: ("standard_msg2", t.LimitedCharString(16), True),
+        # Standard mode: STGE "Registre de Statuts" / String 8 car
+        0x0217: ("standard_stge", t.LimitedCharString(8), True),
+        # Standard mode: DPM1 "Début Pointe Mobile 1" / Uint8 2 car
+        0x0218: ("standard_dpm1", t.uint8_t, True),
+        # Standard mode: FPM1 "Fin Pointe Mobile 1" / Uint8 2 car
+        0x0219: ("standard_fpm1", t.uint8_t, True),
+        # Standard mode: DPM2 "Début Pointe Mobile 2" / Uint8 2 car
+        0x0220: ("standard_dpm2", t.uint8_t, True),
+        # Standard mode: FPM2 "Fin Pointe Mobile 2" / Uint8 2 car
+        0x0221: ("standard_fpm2", t.uint8_t, True),
+        # Standard mode: DPM3 "Début Pointe Mobile 3" / Uint8 2 car
+        0x0222: ("standard_dpm3", t.uint8_t, True),
+        # Standard mode: FPM3 "Fin Pointe Mobile 3" / Uint8 2 car
+        0x0223: ("standard_fpm3", t.uint8_t, True),
+        # Standard mode: RELAIS "RELAIS" / Uint16 3 car
+        0x0224: ("standard_relais", t.uint8_t, True),
+        # Standard mode: NJOURF "Numéro du jour en cours calendrier fournisseur" / Uint8 2 car
+        0x0225: ("standard_njourf", t.uint8_t, True),
+        # Standard mode: NJOURF+1 "Numéro du prochain jour calendrier fournisseur" / Uint8 2 car
+        0x0226: ("standard_njourf_1", t.uint8_t, True),
+        # Standard mode: PJOURF+1 "Profil du prochain jour calendrier fournisseur" / String 98 car
+        0x0227: ("standard_pjourf_1", t.LimitedCharString(98), True),
+        # Standard mode: PPOINTE1 "Profil du prochain jour de pointe" / String 98 car
+        0x0228: ("standard_ppointe1", t.LimitedCharString(98), True),
+        # Historical and Standard mode: - "Linky Mode (From V4)" / Uint8 1 car
+        0x0300: ("linky_mode", t.uint8_t, True),
     }
 
 

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -14,9 +14,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.lixee import LIXEE
-
-ZLINKY_MANUFACTURER_CLUSTER_ID = 0xFF66
+from zhaquirks.lixee import LIXEE, ZLINKY_MANUFACTURER_CLUSTER_ID
 
 
 class ZLinkyTICManufacturerCluster(CustomCluster):
@@ -66,7 +64,7 @@ class ZLinkyTIC(CustomDevice):
                     Metering.cluster_id,
                     MeterIdentification.cluster_id,
                     ElectricalMeasurement.cluster_id,
-                    ZLINKY_MANUFACTURER_CLUSTER_ID,
+                    ZLinkyTICManufacturerCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -4,6 +4,7 @@ from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Identify, Ota
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement, MeterIdentification
+from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.const import (
@@ -17,13 +18,13 @@ from zhaquirks.const import (
 from zhaquirks.lixee import LIXEE, ZLINKY_MANUFACTURER_CLUSTER_ID
 
 
-class ZLinkyTICManufacturerCluster(CustomCluster):
+class ZLinkyTICManufacturerCluster(CustomCluster, ManufacturerSpecificCluster):
     """ZLinkyTICManufacturerCluster manufacturer cluster."""
 
     cluster_id = ZLINKY_MANUFACTURER_CLUSTER_ID
     name = "ZLinky_TIC Manufacturer specific"
-    ep_attribute = "zlinky_cluster"
-    manufacturer_attributes = {
+    ep_attribute = "zlinky_manufacturer_specific"
+    attributes = {
         0x0000: ("histo_optarif_or_standard_ngtf", t.LimitedCharString(16)),
         0x0001: ("histo_demain", t.LimitedCharString(4)),
         0x0002: ("histo_hhphc", t.uint8_t),

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -1,6 +1,7 @@
 """Quirk for ZLinky_TIC."""
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Identify, Ota
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement, MeterIdentification
 from zigpy.zcl.clusters.smartenergy import Metering
@@ -14,6 +15,19 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.lixee import LIXEE
+
+ZLINKY_MANUFACTURER_CLUSTER_ID = 0xFF66
+
+
+class ZLinkyTICManufacturerCluster(CustomCluster):
+    """ZLinkyTICManufacturerCluster manufacturer cluster."""
+
+    cluster_id = ZLINKY_MANUFACTURER_CLUSTER_ID
+    name = "ZLinky_TIC Manufacturer specific"
+    ep_attribute = "zlinky_cluster"
+    manufacturer_attributes = {
+        0x0000: ("optarif_or_ngtf", t.LimitedCharString(16)),
+    }
 
 
 class ZLinkyTICMetering(CustomCluster, Metering):
@@ -41,7 +55,7 @@ class ZLinkyTIC(CustomDevice):
                     Metering.cluster_id,
                     MeterIdentification.cluster_id,
                     ElectricalMeasurement.cluster_id,
-                    0xFF66,  # Manufacturer Specific
+                    ZLINKY_MANUFACTURER_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -64,7 +78,7 @@ class ZLinkyTIC(CustomDevice):
                     ZLinkyTICMetering,
                     MeterIdentification.cluster_id,
                     ElectricalMeasurement.cluster_id,
-                    0xFF66,  # Manufacturer Specific
+                    ZLinkyTICManufacturerCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -31,84 +31,84 @@ class ZLinkyTICManufacturerCluster(CustomCluster, ManufacturerSpecificCluster):
     attributes = {
         # Historical mode: OPTARIF "Option tarifaire" / String 4 car
         # Standard mode: NGTF "Nom du calendrier tarifaire fournisseur" / String 16 car
-        0x0000: ("histo_optarif_or_standard_ngtf", t.LimitedCharString(16), True),
+        0x0000: ("hist_optarif_or_std_ngtf", t.LimitedCharString(16), True),
         # Historical mode: DEMAIN "Couleur du lendemain" / String 4 car
-        0x0001: ("histo_demain", t.LimitedCharString(4), True),
+        0x0001: ("hist_demain", t.LimitedCharString(4), True),
         # Historical mode: HHPHC "Horaire Heure Pleines Heures Creuses" / Uint8 1 car
-        0x0002: ("histo_hhphc", t.uint8_t, True),
+        0x0002: ("hist_hhphc", t.uint8_t, True),
         # Historical mode: PPOT "Présence des potentiels" (Triphasé) / Uint8 2 car
-        0x0003: ("histo_ppot", t.uint8_t, True),
+        0x0003: ("hist_ppot", t.uint8_t, True),
         # Historical mode: PEJP "Préavis début EJP(30min)" / Uint8 2 car
-        0x0004: ("histo_pejp", t.uint8_t, True),
+        0x0004: ("hist_pejp", t.uint8_t, True),
         # Historical mode: ADPS "Avertissement de Dépassement De Puissance Souscrite" / Uint16 3 car
-        0x0005: ("histo_adps", t.uint16_t, True),
+        0x0005: ("hist_adps", t.uint16_t, True),
         # Historical mode: ADIR1 "Avertissement de Dépassement D'intensité phase 1" / Uint16 3 car
-        0x0006: ("histo_adir1", t.uint16_t, True),
+        0x0006: ("hist_adir1", t.uint16_t, True),
         # Historical mode: ADIR2 "Avertissement de Dépassement D'intensité phase 2" / Uint16 3 car
-        0x0007: ("histo_adir2", t.uint16_t, True),
+        0x0007: ("hist_adir2", t.uint16_t, True),
         # Historical mode: ADIR3 "Avertissement de Dépassement D'intensité phase 3" / Uint16 3 car
-        0x0008: ("histo_adir3", t.uint16_t, True),
+        0x0008: ("hist_adir3", t.uint16_t, True),
         # Historical and Standard mode: "Linky acquisition time (From V7)"" / Uint8 1 car
         0x0100: ("linky_acquisition_time", t.uint8_t, True),
         # Standard mode: LTARF "Libellé tarif fournisseur en cours" / String 16 car
-        0x0200: ("standard_ltarf", t.LimitedCharString(16), True),
+        0x0200: ("std_ltarf", t.LimitedCharString(16), True),
         # Standard mode: NTARF "Numéro de l’index tarifaire en cours" / Uint8 2 car
-        0x0201: ("standard_ntarf", t.uint8_t, True),
+        0x0201: ("std_ntarf", t.uint8_t, True),
         # Standard mode: DATE "Date et heure courant" / String 10 car
-        0x0202: ("standard_date", t.LimitedCharString(10), True),
+        0x0202: ("std_date", t.LimitedCharString(10), True),
         # Standard mode: EASD01 "Energie active soutirée Distributeur, index 01" / Uint32 9 car
-        0x0203: ("standard_easd01", t.uint32_t, True),
+        0x0203: ("std_easd01", t.uint32_t, True),
         # Standard mode: EASD02 "Energie active soutirée Distributeur, index 02" / Uint32 9 car
-        0x0204: ("standard_easd02", t.uint32_t, True),
+        0x0204: ("std_easd02", t.uint32_t, True),
         # Standard mode: EASD03 "Energie active soutirée Distributeur, index 03" / Uint32 9 car
-        0x0205: ("standard_easd03", t.uint32_t, True),
+        0x0205: ("std_easd03", t.uint32_t, True),
         # Standard mode: EASD04 "Energie active soutirée Distributeur, index 04" / Uint32 9 car
-        0x0206: ("standard_easd04", t.uint32_t, True),
+        0x0206: ("std_easd04", t.uint32_t, True),
         # Standard mode: SINSTI "Puissance app. Instantanée injectée" (Production) / Uint16 5 car
-        0x0207: ("standard_sinsti", t.uint16_t, True),
+        0x0207: ("std_sinsti", t.uint16_t, True),
         # Standard mode: SMAXIN "Puissance app max. injectée n" (Production) / Uint16 5 car
-        0x0208: ("standard_smaxin", t.uint16_t, True),
+        0x0208: ("std_smaxin", t.uint16_t, True),
         # Standard mode: SMAXIN-1 "Puissance app max. injectée n-1" (Production) / Uint16 5 car
-        0x0209: ("standard_smaxin_1", t.uint16_t, True),
+        0x0209: ("std_smaxin_1", t.uint16_t, True),
         # Standard mode: CCAIN "Point n de la courbe de charge active injectée" (Production) / Uint16 5 car
-        0x0210: ("standard_ccain", t.uint16_t, True),
+        0x0210: ("std_ccain", t.uint16_t, True),
         # Standard mode: CCAIN-1 "Point n-1 de la courbe de charge active injectée" (Production) / Uint16 5 car
-        0x0211: ("standard_ccain_1", t.uint16_t, True),
+        0x0211: ("std_ccain_1", t.uint16_t, True),
         # Standard mode: SMAXN-1 "Puissance app. max. soutirée n-1" (Monophasé) / Uint16 5 car
         # Standard mode: SMAXN1-1 "Puissance app. max. soutirée n-1 ph.1" (Triphasé) / Uint16 5 car
-        0x0212: ("standard_smaxn1_1", t.uint16_t, True),
+        0x0212: ("std_smaxn1_1", t.uint16_t, True),
         # Standard mode: SMAXN2-1 "Puissance app. max. soutirée n-1 ph. 2" (Triphasé) / Uint16 5 car
-        0x0213: ("standard_smaxn2_1", t.uint16_t, True),
+        0x0213: ("std_smaxn2_1", t.uint16_t, True),
         # Standard mode: SMAXN3-1 "Puissance app. max. soutirée n-1 ph. 3" (Triphasé) / Uint16 5 car
-        0x0214: ("standard_smaxn3_1", t.uint16_t, True),
+        0x0214: ("std_smaxn3_1", t.uint16_t, True),
         # Standard mode: MSG1 "Message court" / String 32 car
-        0x0215: ("standard_msg1", t.LimitedCharString(32), True),
+        0x0215: ("std_msg1", t.LimitedCharString(32), True),
         # Standard mode: MSG2 "Message ultra court" / String 16 car
-        0x0216: ("standard_msg2", t.LimitedCharString(16), True),
+        0x0216: ("std_msg2", t.LimitedCharString(16), True),
         # Standard mode: STGE "Registre de Statuts" / String 8 car
-        0x0217: ("standard_stge", t.LimitedCharString(8), True),
+        0x0217: ("std_stge", t.LimitedCharString(8), True),
         # Standard mode: DPM1 "Début Pointe Mobile 1" / Uint8 2 car
-        0x0218: ("standard_dpm1", t.uint8_t, True),
+        0x0218: ("std_dpm1", t.uint8_t, True),
         # Standard mode: FPM1 "Fin Pointe Mobile 1" / Uint8 2 car
-        0x0219: ("standard_fpm1", t.uint8_t, True),
+        0x0219: ("std_fpm1", t.uint8_t, True),
         # Standard mode: DPM2 "Début Pointe Mobile 2" / Uint8 2 car
-        0x0220: ("standard_dpm2", t.uint8_t, True),
+        0x0220: ("std_dpm2", t.uint8_t, True),
         # Standard mode: FPM2 "Fin Pointe Mobile 2" / Uint8 2 car
-        0x0221: ("standard_fpm2", t.uint8_t, True),
+        0x0221: ("std_fpm2", t.uint8_t, True),
         # Standard mode: DPM3 "Début Pointe Mobile 3" / Uint8 2 car
-        0x0222: ("standard_dpm3", t.uint8_t, True),
+        0x0222: ("std_dpm3", t.uint8_t, True),
         # Standard mode: FPM3 "Fin Pointe Mobile 3" / Uint8 2 car
-        0x0223: ("standard_fpm3", t.uint8_t, True),
+        0x0223: ("std_fpm3", t.uint8_t, True),
         # Standard mode: RELAIS "RELAIS" / Uint16 3 car
-        0x0224: ("standard_relais", t.uint8_t, True),
+        0x0224: ("std_relais", t.uint8_t, True),
         # Standard mode: NJOURF "Numéro du jour en cours calendrier fournisseur" / Uint8 2 car
-        0x0225: ("standard_njourf", t.uint8_t, True),
+        0x0225: ("std_njourf", t.uint8_t, True),
         # Standard mode: NJOURF+1 "Numéro du prochain jour calendrier fournisseur" / Uint8 2 car
-        0x0226: ("standard_njourf_1", t.uint8_t, True),
+        0x0226: ("std_njourf_1", t.uint8_t, True),
         # Standard mode: PJOURF+1 "Profil du prochain jour calendrier fournisseur" / String 98 car
-        0x0227: ("standard_pjourf_1", t.LimitedCharString(98), True),
+        0x0227: ("std_pjourf_1", t.LimitedCharString(98), True),
         # Standard mode: PPOINTE1 "Profil du prochain jour de pointe" / String 98 car
-        0x0228: ("standard_ppointe1", t.LimitedCharString(98), True),
+        0x0228: ("std_ppointe1", t.LimitedCharString(98), True),
         # Historical and Standard mode: - "Linky Mode (From V4)" / Uint8 1 car
         0x0300: ("linky_mode", t.uint8_t, True),
     }

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -26,7 +26,18 @@ class ZLinkyTICManufacturerCluster(CustomCluster):
     name = "ZLinky_TIC Manufacturer specific"
     ep_attribute = "zlinky_cluster"
     manufacturer_attributes = {
-        0x0000: ("optarif_or_ngtf", t.LimitedCharString(16)),
+        0x0000: ("histo_optarif_or_standard_ngtf", t.LimitedCharString(16)),
+        0x0001: ("histo_demain", t.LimitedCharString(4)),
+        0x0002: ("histo_hhphc", t.uint8_t),
+        0x0003: ("histo_ppot", t.uint8_t),
+        0x0004: ("histo_pejp", t.uint8_t),
+        0x0005: ("histo_adps", t.uint16_t),
+        0x0006: ("histo_adir1", t.uint16_t),
+        0x0007: ("histo_adir2", t.uint16_t),
+        0x0008: ("histo_adir3", t.uint16_t),
+        0x0200: ("standard_ltarf", t.LimitedCharString(16)),
+        0x0201: ("standard_ntarf", t.uint8_t),
+        0x0202: ("standard_date", t.LimitedCharString(10)),
     }
 
 

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -31,84 +31,96 @@ class ZLinkyTICManufacturerCluster(CustomCluster, ManufacturerSpecificCluster):
     attributes = {
         # Historical mode: OPTARIF "Option tarifaire" / String 4 car
         # Standard mode: NGTF "Nom du calendrier tarifaire fournisseur" / String 16 car
-        0x0000: ("hist_optarif_or_std_ngtf", t.LimitedCharString(16), True),
+        0x0000: (
+            "hist_tariff_option_or_std_supplier_price_schedule_name",
+            t.LimitedCharString(16),
+            True,
+        ),
         # Historical mode: DEMAIN "Couleur du lendemain" / String 4 car
-        0x0001: ("hist_demain", t.LimitedCharString(4), True),
+        0x0001: ("hist_tomorrow_color", t.LimitedCharString(4), True),
         # Historical mode: HHPHC "Horaire Heure Pleines Heures Creuses" / Uint8 1 car
-        0x0002: ("hist_hhphc", t.uint8_t, True),
+        0x0002: ("hist_schedule_peak_hours_off_peak_hours", t.uint8_t, True),
         # Historical mode: PPOT "Présence des potentiels" (Triphasé) / Uint8 2 car
-        0x0003: ("hist_ppot", t.uint8_t, True),
+        0x0003: ("hist_potentials_presence", t.uint8_t, True),
         # Historical mode: PEJP "Préavis début EJP(30min)" / Uint8 2 car
-        0x0004: ("hist_pejp", t.uint8_t, True),
+        0x0004: ("hist_ejp_start_notice", t.uint8_t, True),
         # Historical mode: ADPS "Avertissement de Dépassement De Puissance Souscrite" / Uint16 3 car
-        0x0005: ("hist_adps", t.uint16_t, True),
+        0x0005: ("hist_subscribed_power_exceeding_warning", t.uint16_t, True),
         # Historical mode: ADIR1 "Avertissement de Dépassement D'intensité phase 1" / Uint16 3 car
-        0x0006: ("hist_adir1", t.uint16_t, True),
+        0x0006: ("hist_current_exceeding_warning_phase_1", t.uint16_t, True),
         # Historical mode: ADIR2 "Avertissement de Dépassement D'intensité phase 2" / Uint16 3 car
-        0x0007: ("hist_adir2", t.uint16_t, True),
+        0x0007: ("hist_current_exceeding_warning_phase_2", t.uint16_t, True),
         # Historical mode: ADIR3 "Avertissement de Dépassement D'intensité phase 3" / Uint16 3 car
-        0x0008: ("hist_adir3", t.uint16_t, True),
+        0x0008: ("hist_current_exceeding_warning_phase_3", t.uint16_t, True),
         # Historical and Standard mode: "Linky acquisition time (From V7)"" / Uint8 1 car
         0x0100: ("linky_acquisition_time", t.uint8_t, True),
         # Standard mode: LTARF "Libellé tarif fournisseur en cours" / String 16 car
-        0x0200: ("std_ltarf", t.LimitedCharString(16), True),
+        0x0200: (
+            "std_current_supplier_price_description",
+            t.LimitedCharString(16),
+            True,
+        ),
         # Standard mode: NTARF "Numéro de l’index tarifaire en cours" / Uint8 2 car
-        0x0201: ("std_ntarf", t.uint8_t, True),
+        0x0201: ("std_current_tariff_index_number", t.uint8_t, True),
         # Standard mode: DATE "Date et heure courant" / String 10 car
-        0x0202: ("std_date", t.LimitedCharString(10), True),
+        0x0202: ("std_current_date_and_time", t.LimitedCharString(10), True),
         # Standard mode: EASD01 "Energie active soutirée Distributeur, index 01" / Uint32 9 car
-        0x0203: ("std_easd01", t.uint32_t, True),
+        0x0203: ("std_active_energy_withdrawn_distributor_index_01", t.uint32_t, True),
         # Standard mode: EASD02 "Energie active soutirée Distributeur, index 02" / Uint32 9 car
-        0x0204: ("std_easd02", t.uint32_t, True),
+        0x0204: ("std_active_energy_withdrawn_distributor_index_02", t.uint32_t, True),
         # Standard mode: EASD03 "Energie active soutirée Distributeur, index 03" / Uint32 9 car
-        0x0205: ("std_easd03", t.uint32_t, True),
+        0x0205: ("std_active_energy_withdrawn_distributor_index_03", t.uint32_t, True),
         # Standard mode: EASD04 "Energie active soutirée Distributeur, index 04" / Uint32 9 car
-        0x0206: ("std_easd04", t.uint32_t, True),
+        0x0206: ("std_active_energy_withdrawn_distributor_index_04", t.uint32_t, True),
         # Standard mode: SINSTI "Puissance app. Instantanée injectée" (Production) / Uint16 5 car
-        0x0207: ("std_sinsti", t.uint16_t, True),
+        0x0207: ("std_apparent_power_injected_instantaneous", t.uint16_t, True),
         # Standard mode: SMAXIN "Puissance app max. injectée n" (Production) / Uint16 5 car
-        0x0208: ("std_smaxin", t.uint16_t, True),
+        0x0208: ("std_apparent_power_injected_max", t.uint16_t, True),
         # Standard mode: SMAXIN-1 "Puissance app max. injectée n-1" (Production) / Uint16 5 car
-        0x0209: ("std_smaxin_1", t.uint16_t, True),
+        0x0209: ("std_apparent_power_injected_max_1", t.uint16_t, True),
         # Standard mode: CCAIN "Point n de la courbe de charge active injectée" (Production) / Uint16 5 car
-        0x0210: ("std_ccain", t.uint16_t, True),
+        0x0210: ("std_injected_active_load_curve_point_n", t.uint16_t, True),
         # Standard mode: CCAIN-1 "Point n-1 de la courbe de charge active injectée" (Production) / Uint16 5 car
-        0x0211: ("std_ccain_1", t.uint16_t, True),
+        0x0211: ("std_injected_active_load_curve_point_n_1", t.uint16_t, True),
         # Standard mode: SMAXN-1 "Puissance app. max. soutirée n-1" (Monophasé) / Uint16 5 car
         # Standard mode: SMAXN1-1 "Puissance app. max. soutirée n-1 ph.1" (Triphasé) / Uint16 5 car
-        0x0212: ("std_smaxn1_1", t.uint16_t, True),
+        0x0212: ("std_apparent_power_withdrawn_max_phase_1_n_1", t.uint16_t, True),
         # Standard mode: SMAXN2-1 "Puissance app. max. soutirée n-1 ph. 2" (Triphasé) / Uint16 5 car
-        0x0213: ("std_smaxn2_1", t.uint16_t, True),
+        0x0213: ("std_apparent_power_withdrawn_max_phase_2_n_1", t.uint16_t, True),
         # Standard mode: SMAXN3-1 "Puissance app. max. soutirée n-1 ph. 3" (Triphasé) / Uint16 5 car
-        0x0214: ("std_smaxn3_1", t.uint16_t, True),
+        0x0214: ("std_apparent_power_withdrawn_max_phase_3_n_1", t.uint16_t, True),
         # Standard mode: MSG1 "Message court" / String 32 car
-        0x0215: ("std_msg1", t.LimitedCharString(32), True),
+        0x0215: ("std_message_short", t.LimitedCharString(32), True),
         # Standard mode: MSG2 "Message ultra court" / String 16 car
-        0x0216: ("std_msg2", t.LimitedCharString(16), True),
+        0x0216: ("std_message_ultra_short", t.LimitedCharString(16), True),
         # Standard mode: STGE "Registre de Statuts" / String 8 car
-        0x0217: ("std_stge", t.LimitedCharString(8), True),
+        0x0217: ("std_status_register", t.LimitedCharString(8), True),
         # Standard mode: DPM1 "Début Pointe Mobile 1" / Uint8 2 car
-        0x0218: ("std_dpm1", t.uint8_t, True),
+        0x0218: ("std_mobile_peak_start_1", t.uint8_t, True),
         # Standard mode: FPM1 "Fin Pointe Mobile 1" / Uint8 2 car
-        0x0219: ("std_fpm1", t.uint8_t, True),
+        0x0219: ("std_mobile_peak_end_1", t.uint8_t, True),
         # Standard mode: DPM2 "Début Pointe Mobile 2" / Uint8 2 car
-        0x0220: ("std_dpm2", t.uint8_t, True),
+        0x0220: ("std_mobile_peak_start_2", t.uint8_t, True),
         # Standard mode: FPM2 "Fin Pointe Mobile 2" / Uint8 2 car
-        0x0221: ("std_fpm2", t.uint8_t, True),
+        0x0221: ("std_mobile_peak_end_2", t.uint8_t, True),
         # Standard mode: DPM3 "Début Pointe Mobile 3" / Uint8 2 car
-        0x0222: ("std_dpm3", t.uint8_t, True),
+        0x0222: ("std_mobile_peak_start_3", t.uint8_t, True),
         # Standard mode: FPM3 "Fin Pointe Mobile 3" / Uint8 2 car
-        0x0223: ("std_fpm3", t.uint8_t, True),
+        0x0223: ("std_mobile_peak_end_3", t.uint8_t, True),
         # Standard mode: RELAIS "RELAIS" / Uint16 3 car
-        0x0224: ("std_relais", t.uint8_t, True),
+        0x0224: ("std_relay", t.uint8_t, True),
         # Standard mode: NJOURF "Numéro du jour en cours calendrier fournisseur" / Uint8 2 car
-        0x0225: ("std_njourf", t.uint8_t, True),
+        0x0225: ("std_supplier_calendar_current_day_number", t.uint8_t, True),
         # Standard mode: NJOURF+1 "Numéro du prochain jour calendrier fournisseur" / Uint8 2 car
-        0x0226: ("std_njourf_1", t.uint8_t, True),
+        0x0226: ("std_supplier_calendar_next_day_number", t.uint8_t, True),
         # Standard mode: PJOURF+1 "Profil du prochain jour calendrier fournisseur" / String 98 car
-        0x0227: ("std_pjourf_1", t.LimitedCharString(98), True),
+        0x0227: (
+            "std_supplier_calendar_next_day_profile",
+            t.LimitedCharString(98),
+            True,
+        ),
         # Standard mode: PPOINTE1 "Profil du prochain jour de pointe" / String 98 car
-        0x0228: ("std_ppointe1", t.LimitedCharString(98), True),
+        0x0228: ("std_next_peak_day_profile", t.LimitedCharString(98), True),
         # Historical and Standard mode: - "Linky Mode (From V4)" / Uint8 1 car
         0x0300: ("linky_mode", t.uint8_t, True),
     }


### PR DESCRIPTION
This PR adds support for the manufacturer specific cluster `0xFF66` of the Lixee ZLinky_TIC device.

Reference available at:
- https://github.com/fairecasoimeme/Zlinky_TIC
- https://github.com/fairecasoimeme/Zlinky_TIC/blob/master/ZLinky/Source/LixeeCluster.h#L74-L125

Submitted as draft as there's only one of many attribute for now.

Resolves #1146 