### PR TITLE
Add quirks for Tuya multigang switches

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -135,7 +135,7 @@ async def test_singleswitch_state_report(zigpy_device_from_quirk, quirk):
 
 @pytest.mark.parametrize("quirk", (zhaquirks.tuya.ts0601_switch.TuyaDoubleSwitchTO,))
 async def test_doubleswitch_state_report(zigpy_device_from_quirk, quirk):
-    """Test tuya single switch."""
+    """Test tuya double switch."""
 
     ZCL_TUYA_SWITCH_COMMAND_03 = b"\tQ\x03\x006\x01\x01\x00\x01\x01"
     ZCL_TUYA_SWITCH_EP2_ON = b"\tQ\x02\x006\x02\x01\x00\x01\x01"

--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -76,12 +76,10 @@ class TuyaSingleSwitchTO(TuyaSwitch):
         # output_clusters=[0x000a, 0x0019]
         # <SimpleDescriptor endpoint=1 profile=260 device_type=51 device_version=1 input_clusters=[0, 4, 5, 61184] output_clusters=[10, 25]>
         MODELS_INFO: [
-            ("_TZE200_oisqyl4o", "TS0601"),
-            ("_TZE200_wunufsil", "TS0601"),
-            ("_TZE200_vhy3iakz", "TS0601"),
-            ("_TZ3000_uim07oem", "TS0601"),
-            ("_TZE200_tz32mtza", "TS0601"),
             ("_TZE200_amp6tsvy", "TS0601"),
+            ("_TZE200_oisqyl4o", "TS0601"),
+            ("_TZE200_vhy3iakz", "TS0601"),  # ¿1 or 4 gangs?
+            ("_TZ3000_uim07oem", "TS0601"),  # ¿1 or 4 gangs?
         ],
         ENDPOINTS: {
             1: {
@@ -128,6 +126,7 @@ class TuyaDoubleSwitchTO(TuyaSwitch):
         # <SimpleDescriptor endpoint=1 profile=260 device_type=51 device_version=1 input_clusters=[0, 4, 5, 61184] output_clusters=[10, 25]>
         MODELS_INFO: [
             ("_TZE200_g1ib5ldv", "TS0601"),
+            ("_TZE200_wunufsil", "TS0601"),
         ],
         ENDPOINTS: {
             1: {
@@ -158,6 +157,125 @@ class TuyaDoubleSwitchTO(TuyaSwitch):
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
             2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOff,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        }
+    }
+
+
+class TuyaTripleSwitchTO(TuyaSwitch):
+    """Tuya triple channel switch time on out cluster device."""
+
+    signature = {
+        MODELS_INFO: [
+            # ("_TZE200_kyfqmmyl", "TS0601"),  ## candidate reported in #716
+            ("_TZE200_tz32mtza", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufacturerClusterOnOff,
+                    TuyaOnOff,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOff,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOff,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        }
+    }
+
+
+class TuyaQuadrupleSwitchTO(TuyaSwitch):
+    """Tuya quadruple channel switch time on out cluster device."""
+
+    signature = {
+        MODELS_INFO: [
+            ("_TZE200_aqnazj70", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufacturerClusterOnOff,
+                    TuyaOnOff,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOff,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOff,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [


### PR DESCRIPTION
This PR add quirks for Tuya multigang switches.

It should correct the management of the On/Off cluster for the multiswitch devices that make use of the Tuya cluster (`0xEF00`) for command/status reporting.

The `MODELS_INFO` of those devices that have been reported or an issue has been reported have been added.
For those devices whose number of gangs is not clear, they have been defined as 1-gang devices until someone report correct info.

This could fix the following issues (only on/off switches):
fixes: #813
fixes: #824
fixes: #913
fixes: #972
fixes: #966
