### PR TITLE
TuyaManufClusterAttributes -> write_attributes: add DEBUG logging

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -443,7 +443,7 @@ class TuyaManufClusterAttributes(TuyaManufCluster):
                 self.cluster_id,
                 cmd_payload
             )
-            
+
             await super().command(
                 TUYA_SET_DATA,
                 cmd_payload,

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -436,6 +436,14 @@ class TuyaManufClusterAttributes(TuyaManufCluster):
             cmd_payload.function = 0
             cmd_payload.data = Data.from_value(record.value.value)
 
+            _LOGGER.debug(
+                "[0x%04x:%s:0x%04x] Sending command: %s",
+                self.endpoint.device.nwk,
+                self.endpoint.endpoint_id,
+                self.cluster_id,
+                cmd_payload
+            )
+            
             await super().command(
                 TUYA_SET_DATA,
                 cmd_payload,

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -441,7 +441,7 @@ class TuyaManufClusterAttributes(TuyaManufCluster):
                 self.endpoint.device.nwk,
                 self.endpoint.endpoint_id,
                 self.cluster_id,
-                cmd_payload
+                cmd_payload,
             )
 
             await super().command(


### PR DESCRIPTION
DEBUG logger helpful for implementing new Tuya TRV devices, sometimes attributes are directly updated omitting TuyaThermostatCluster.
It can help to debug code a little better.