### PR TITLE
IKEA E1766 Removing OnOff Cluster

### DIFF
--- a/zhaquirks/ikea/opencloseremote.py
+++ b/zhaquirks/ikea/opencloseremote.py
@@ -131,7 +131,6 @@ class IkeaTradfriOpenCloseRemote(CustomDevice):
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
                     Groups.cluster_id,
-                    OnOff.cluster_id,
                     LevelControl.cluster_id,
                     Ota.cluster_id,
                     IkeaWindowCovering,


### PR DESCRIPTION
The E1766 Open / Close button do have one OnOff cluster like its having in the "E1743 mode" but the profile WINDOW_COVERING_CONTROLLER shall not having it so ZHA is making one OnOff sensor that is not working the the controller is not sending any commands on the OnOff cluster.
![OpenClose01](https://user-images.githubusercontent.com/49618193/142892339-451e8291-7195-4d59-8504-8faa4f0cb7df.PNG)
Also ZHA is also making automation trigger for the not working sensor.
By removing the OnOff Cluster the sensor is not being made and the false not working automation trigger is also not being made.