### PR TITLE
Add newer firmware Frient Heat Alarm

### DIFF
--- a/zhaquirks/develco/heat_alarm.py
+++ b/zhaquirks/develco/heat_alarm.py
@@ -23,7 +23,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.develco import DEVELCO, DevelcoIasZone, DevelcoPowerConfiguration
+from zhaquirks.develco import DEVELCO, FRIENT, DevelcoIasZone, DevelcoPowerConfiguration
 
 MANUFACTURER = 0x1015
 
@@ -40,7 +40,7 @@ class HESZB120(CustomDevice):
         # input_clusters=[0, 1, 3, 15, 32, 1280, 1282] output_clusters=[10, 25]>
         # <SimpleDescriptor endpoint=38 profile=260 device_type=770 device_version=0
         # input_clusters=[0, 3, 1026] output_clusters=[3]>
-        MODELS_INFO: [(DEVELCO, "HESZB-120")],
+        MODELS_INFO: [(DEVELCO, "HESZB-120"), (FRIENT, "HESZB-120")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: 49353,
@@ -94,6 +94,99 @@ class HESZB120(CustomDevice):
             35: {
                 PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
                 DEVICE_TYPE: zigpy.profiles.zha.DeviceType.IAS_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DevelcoPowerConfiguration,
+                    Identify.cluster_id,
+                    BinaryInput.cluster_id,
+                    PollControl.cluster_id,
+                    DevelcoIasZone,
+                    IasWd.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            38: {
+                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
+                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.TEMPERATURE_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id],
+            },
+        },
+    }
+
+
+class HESZB120F(CustomDevice):
+    """Frient A/S  Heat Alarm."""
+
+    manufacturer_id_override = MANUFACTURER
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=49353 device_type=1 device_version=1
+        # input_clusters=[3, 5, 6] output_clusters=[]>
+        # <SimpleDescriptor endpoint=35 profile=260 device_type=1026 device_version=0
+        # input_clusters=[0, 1, 3, 15, 32, 1280, 1282] output_clusters=[10, 25]>
+        # <SimpleDescriptor endpoint=38 profile=260 device_type=770 device_version=0
+        # input_clusters=[0, 3, 1026] output_clusters=[3]>
+        MODELS_INFO: [
+            (FRIENT, "HESZB-120"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: 49353,
+                DEVICE_TYPE: 1,
+                INPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            35: {
+                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
+                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    BinaryInput.cluster_id,
+                    PollControl.cluster_id,
+                    IasZone.cluster_id,
+                    IasWd.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            38: {
+                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
+                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.TEMPERATURE_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: 49353,
+                DEVICE_TYPE: 1,
+                INPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            35: {
+                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
+                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.IAS_ZONE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     DevelcoPowerConfiguration,


### PR DESCRIPTION
Add a quirk for the newer firmware of Frient Heat Alarm HESZB-120

Date code: `2021-01-22 11:47`
Firmware: `0x00030419`
Signature:
```
{
  "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.NONE: 0>, manufacturer_code=4117, maximum_buffer_size=80, maximum_incoming_transfer_size=80, server_mask=0, maximum_outgoing_transfer_size=80, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=False, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
  "endpoints": {
    "1": {
      "profile_id": 49353,
      "device_type": "0x0001",
      "in_clusters": [
        "0x0003",
        "0x0005",
        "0x0006"
      ],
      "out_clusters": []
    },
    "35": {
      "profile_id": 260,
      "device_type": "0x0402",
      "in_clusters": [
        "0x0000",
        "0x0001",
        "0x0003",
        "0x000f",
        "0x0020",
        "0x0500",
        "0x0502"
      ],
      "out_clusters": [
        "0x000a",
        "0x0019"
      ]
    },
    "38": {
      "profile_id": 260,
      "device_type": "0x0302",
      "in_clusters": [
        "0x0000",
        "0x0003",
        "0x0402"
      ],
      "out_clusters": [
        "0x0003"
      ]
    }
  },
  "manufacturer": "frient A/S",
  "model": "HESZB-120",
  "class": "zigpy.device.Device"
}
```
