### PR TITLE
Add support for LIDL RGB+CCT bulbs

### DIFF
--- a/zhaquirks/lidl/rgbcct.py
+++ b/zhaquirks/lidl/rgbcct.py
@@ -1,0 +1,98 @@
+"""Quirk for LIDL RGB+CCT bulb."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class LidlRGBCCTColorCluster(CustomCluster, Color):
+    """Lidl RGB+CCT Lighting custom cluster."""
+
+    # Set correct capabilities to ct, xy, hs
+    # LIDL bulbs do not correctly report this attribute (comes back as None in Home Assistant)
+    _CONSTANT_ATTRIBUTES = {0x400A: 0b11001}
+
+
+class RGBCCTLight(CustomDevice):
+    """Lidl RGB+CCT Lighting device."""
+
+    signature = {
+        MODELS_INFO: [("_TZ3000_dbou1ap4", "TS0505A")],
+        ENDPOINTS: {
+            1: {
+                # <SimpleDescriptor endpoint=1 profile=269 device_type=268
+                # device_version=1
+                # input_clusters=[0, 3, 4, 5, 6, 8, 768, 4096]
+                # output_clusters=[10, 25]
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.EXTENDED_COLOR_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+                # device_version=0
+                # input_clusters=[]
+                # output_clusters=[33]
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.EXTENDED_COLOR_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LidlRGBCCTColorCluster,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }


### PR DESCRIPTION
Adds support for LIDL/whitelabel Tuya RGB+CCT LED bulbs. I don't have all 3 different models so I can only add one model number for now unless someone has the exact manufacturer names with the weird generated hash at the end. The bulbs don't report color_capabilities correctly, like their CCT-only bretheren, so it's hardcoded to ColorTemperature+XY+HueSaturation based on the attributes that work on the bulb.