### PR TITLE
Adding "_TYST11_czk78ptr", "zk78ptr"

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -964,6 +964,7 @@ class SiterwellGS361_Type1(TuyaThermostat):
             ("_TYST11_ps5v5jor", "s5v5jor"),
             ("_TYST11_owwdxjbx", "wwdxjbx"),
             ("_TYST11_8daqwrsj", "daqwrsj"),
+            ("_TYST11_czk78ptr", "zk78ptr"),
         ],
         ENDPOINTS: {
             1: {
@@ -1008,6 +1009,7 @@ class SiterwellGS361_Type2(TuyaThermostat):
             ("_TZE200_ps5v5jor", "TS0601"),
             ("_TZE200_owwdxjbx", "TS0601"),
             ("_TZE200_8daqwrsj", "TS0601"),
+            ("_TZE200_czk78ptr", "TS0601"),
         ],
         ENDPOINTS: {
             1: {
@@ -1059,6 +1061,7 @@ class MoesHY368_Type1(TuyaThermostat):
             ("_TZE200_ckud7u2l", "TS0601"),
             ("_TZE200_ywdxldoj", "TS0601"),
             ("_TZE200_cwnjrr72", "TS0601"),
+            ("_TZE200_2atgpdho", "TS0601"),
         ],
         ENDPOINTS: {
             1: {
@@ -1157,7 +1160,7 @@ class MoesHY368_Type2(TuyaThermostat):
             ("_TYST11_ckud7u2l", "kud7u2l"),
             ("_TYST11_ywdxldoj", "wdxldoj"),
             ("_TYST11_cwnjrr72", "wnjrr72"),
-            ("_TYST11_b6wax7g0", "6wax7g0"),
+            ("_TYST11_2atgpdho", "atgpdho"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Adding "_TZE200_czk78ptr", "TS0601", "_TYST11_czk78ptr", "zk78ptr", "_TZE200_2atgpdho", "TS0601" and ("_TYST11_2atgpdho", "atgpdho")
I also deleting the ("_TYST11_b6wax7g0", "6wax7g0") then its look Beca Smart is not making one with the old Zigbee module.
The "2atgpdho" versions also need getting presets in ZHA in one other PR for working OK.

Fixes #1178
Fixes #1180