### PR TITLE
Corrected BUG: Elko Smart Super Thermostat - local variable 'night_lowering' referenced before assignment

### DIFF
--- a/zhaquirks/elko/smart_super_thermostat.py
+++ b/zhaquirks/elko/smart_super_thermostat.py
@@ -95,6 +95,7 @@ class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
         """Override writes to thermostat attributes."""
         if "system_mode" in attributes:
             val = attributes.get("system_mode")
+            night_lowering = 0
             if val == Thermostat.SystemMode.Off:
                 device_on = 0
             elif val == Thermostat.SystemMode.Auto:
@@ -102,7 +103,6 @@ class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
                 night_lowering = 1
             elif val == Thermostat.SystemMode.Heat:
                 device_on = 1
-                night_lowering = 0
             attributes["device_on"] = device_on
             attributes["night_lowering"] = night_lowering
 


### PR DESCRIPTION
https://github.com/zigpy/zha-device-handlers/issues/1085