### PR TITLE
Add 2 more CN-Hysen TRVs

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1062,6 +1062,8 @@ class MoesHY368_Type1(TuyaThermostat):
             ("_TZE200_ywdxldoj", "TS0601"),
             ("_TZE200_cwnjrr72", "TS0601"),
             ("_TZE200_2atgpdho", "TS0601"),
+            ("_TZE200_pvvbommb", "TS0601"),
+            ("_TZE200_4eeyebrt", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Add 2 more CN-Hysen TRVs "_TZE200_pvvbommb" and "_TZE200_4eeyebrt".
Both is needing updated presets in ZHA for working OK.

Fixes #1199

PR for adding presets in ZHA https://github.com/home-assistant/core/pull/61002 that  must being merged for getting the device working OK in ZHA.