### PR TITLE
Add _TZ3000_8uaoilu9 for CT

### DIFF
--- a/zhaquirks/lidl/cct.py
+++ b/zhaquirks/lidl/cct.py
@@ -44,6 +44,7 @@ class CCTLight(CustomDevice):
             ("_TZ3000_rylaozuc", "TS0502A"),
             ("_TZ3000_el5kt5im", "TS0502A"),
             ("_TZ3000_oh7jddmx", "TS0502A"),
+            ("_TZ3000_8uaoilu9", "TS0502A"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Adding "_TZ3000_8uaoilu9" for getting CT only.
Fix #1203