### PR TITLE
Added support for Moes 4-gang touch wall switch

### DIFF
--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -230,6 +230,7 @@ class TuyaQuadrupleSwitchTO(TuyaSwitch):
     signature = {
         MODELS_INFO: [
             ("_TZE200_aqnazj70", "TS0601"),
+            ("_TZE200_1ozguk6x", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Hi, I bought a [Moes 4-gang wall switch](https://www.amazon.com/dp/B08X3JM8C9?psc=1&ref=ppx_yo2_dt_b_product_details), but when I added it into HomeAssistant, there were no entities attached to the device. After googling I discovered this repo which contains "quirks", and it seems my wall switch has the same format as Tuya's 4-gang light switch...

I edited the quirk file locally (with Portainer) and added this device's model and it seems to work. After adding this line, then removing and re-adding the device, I now have 4 entities, one for each light, and I can turn them on and off successfully. It even updates HA's state correctly when turning the lights on/off at the wall.

Here's the device now working in Home Assistant, although the "Power Source" field still says "Battery or Unknown"...

<img width="764" alt="working" src="https://user-images.githubusercontent.com/2771104/147361529-140d77b4-3d73-421d-a98a-e406e9dcf997.png">
