### PR TITLE
Added current orientation to aqara vibration sensor

### DIFF
--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -1,10 +1,10 @@
 """Xiaomi aqara smart motion sensor device."""
 import logging
+import math
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster
 import zigpy.types as types
-import math
 from zigpy.zcl.clusters.closures import DoorLock
 from zigpy.zcl.clusters.general import (
     Basic,

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -117,24 +117,8 @@ class VibrationAQ1(XiaomiQuickInitDevice):
                 self.endpoint.device.motion_bus.listener_event(
                     SEND_EVENT,
                     "current_orientation",
-                    {"X": angleX, "Y": angleY, "Z": angleZ},
-                )  
-            elif attrid == ORIENTATION_ATTR:
-                x = value & 0xffff
-                y = value >> 16
-                z = value >> 32
-                X = 0.0 + x
-                Y = 0.0 + y
-                Z = 0.0 + z
-                angleX = round(math.atan(X / math.sqrt(Z * Z + Y * Y)) * 180 / math.pi)
-                angleY = round(math.atan(Y / math.sqrt(X * X + Z * Z)) * 180 / math.pi)
-                angleZ = round(math.atan(Z / math.sqrt(X * X + Y * Y)) * 180 / math.pi)
-
-                self.endpoint.device.motion_bus.listener_event(
-                    SEND_EVENT,
-                    "current_orientation",
-                    {"X": angleX, "Y": angleY, "Z": angleZ},
-                )         
+                    {"rawValueX": x, "rawValueY": y, "rawValueZ": z, "X": angleX, "Y": angleY, "Z": angleZ},
+                )          
             elif attrid == ROTATION_DEGREES_ATTR:
                 self.endpoint.device.motion_bus.listener_event(
                     SEND_EVENT,

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -44,7 +44,7 @@ from zhaquirks.xiaomi import (
 )
 
 DROP_VALUE = 3
-ORIENTATION_ATTR = 0x0508 # decimal = 1288
+ORIENTATION_ATTR = 0x0508  # decimal = 1288
 RECENT_ACTIVITY_LEVEL_ATTR = 0x0505  # decimal = 1285
 ROTATION_DEGREES_ATTR = 0x0503  # decimal = 1283
 SEND_EVENT = "send_event"
@@ -104,9 +104,9 @@ class VibrationAQ1(XiaomiQuickInitDevice):
                         SEND_EVENT, self._current_state[STATUS_TYPE_ATTR]
                     )
             elif attrid == ORIENTATION_ATTR:
-                x = value & 0xffff
-                y = (value >> 16) & 0xffff
-                z = (value >> 32) & 0xffff
+                x = value & 0xFFFF
+                y = (value >> 16) & 0xFFFF
+                z = (value >> 32) & 0xFFFF
                 X = 0.0 + x
                 Y = 0.0 + y
                 Z = 0.0 + z
@@ -117,14 +117,21 @@ class VibrationAQ1(XiaomiQuickInitDevice):
                 self.endpoint.device.motion_bus.listener_event(
                     SEND_EVENT,
                     "current_orientation",
-                    {"rawValueX": x, "rawValueY": y, "rawValueZ": z, "X": angleX, "Y": angleY, "Z": angleZ},
-                )          
+                    {
+                        "rawValueX": x,
+                        "rawValueY": y,
+                        "rawValueZ": z,
+                        "X": angleX,
+                        "Y": angleY,
+                        "Z": angleZ,
+                    },
+                )
             elif attrid == ROTATION_DEGREES_ATTR:
                 self.endpoint.device.motion_bus.listener_event(
                     SEND_EVENT,
                     self._current_state[STATUS_TYPE_ATTR],
                     {"degrees": value},
-                )  
+                )
             elif attrid == RECENT_ACTIVITY_LEVEL_ATTR:
                 # these seem to be sent every minute when vibration is active
                 strength = value >> 8


### PR DESCRIPTION
As reported in https://github.com/zigpy/zha-device-handlers/issues/1230.. The aqara vibration sensor does not show the current orientation after doing a rotation. The code is based on https://github.com/dresden-elektronik/deconz-rest-plugin/blob/master/devices/xiaomi/aq1_vibration_sensor.json and https://github.com/dresden-elektronik/deconz-rest-plugin/blob/master/devices/xiaomi/aq1_vibration_sensor_orientation.js.

I tested it using this method https://github.com/zigpy/zha-device-handlers#testing-quirks-in-development-in-docker-based-install and using nodered the new event showed up using zha_event. Example of output

```json
{
  "payload": {
    "event_type": "zha_event",
    "event": {
      "device_ieee": "00:15:8d:00:02:a5:7d:8f",
      "unique_id": "00:15:8d:00:02:a5:7d:8f:1:0x0500",
      "device_id": "a226eedbb4e375656c507de02530d4f1",
      "endpoint_id": 1,
      "cluster_id": 1280,
      "command": "current_orientation",
      "args": [
        {
          "rawValueX": 27,
          "rawValueY": 65520,
          "rawValueZ": 1166,
          "X": 0,
          "Y": 89,
          "Z": 1
        }
      ]
    },
    "origin": "LOCAL",
    "time_fired": "2021-12-27T09:57:38.030045+00:00",
    "context": {
      "id": "90dce445d31b118a7c38bb3111f54747",
      "parent_id": null,
      "user_id": null
    }
  },
  "topic": "zha_event",
  "event_type": "zha_event",
  "_msgid": "750c5e7d616c5134"
}
```