### PR TITLE
add plug LIDL Silvercrest HG06337 / SAPZ 1 A1 (Tuya TS011F)

### DIFF
--- a/zhaquirks/lidl/__init__.py
+++ b/zhaquirks/lidl/__init__.py
@@ -1,1 +1,38 @@
 """Module for LIDL devices."""
+
+from zigpy.quirks import CustomCluster
+import zigpy.types as t
+from zigpy.zcl.clusters.general import OnOff
+
+
+# Tuya Zigbee OnOff Cluster Attribute Implementation
+class SwitchBackLight(t.enum8):
+    """Tuya switch back light mode enum."""
+
+    Mode_0 = 0x00
+    Mode_1 = 0x01
+    Mode_2 = 0x02
+
+
+class SwitchMode(t.enum8):
+    """Tuya switch mode enum."""
+
+    Command = 0x00
+    Event = 0x01
+
+
+class PowerOnState(t.enum8):
+    """Tuya power on state enum."""
+
+    Off = 0x00
+    On = 0x01
+    LastState = 0x02
+
+
+class TuyaZBOnOffAttributeCluster(CustomCluster, OnOff):
+    """Tuya Zigbee On Off cluster with extra attributes."""
+
+    attributes = OnOff.attributes.copy()
+    attributes.update({0x8001: ("backlight_mode", SwitchBackLight)})
+    attributes.update({0x8002: ("power_on_state", PowerOnState)})
+    attributes.update({0x8004: ("switch_mode", SwitchMode)})

--- a/zhaquirks/lidl/ts011f_plug.py
+++ b/zhaquirks/lidl/ts011f_plug.py
@@ -1,0 +1,87 @@
+"""Quirk for LIDL TS011F plug."""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+#    MODEL,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+from zhaquirks.lidl import (
+    TuyaZBOnOffAttributeCluster,
+)
+
+
+class Plug(CustomDevice):
+    """Tuya plug with restore power state support."""
+
+    signature = {
+        #MODEL: "TS011F",
+        MODELS_INFO: [("_TZ3000_wamqdr3f", "TS011F")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=11 profile=260 device_type=266
+            # device_version=1
+            # input_clusters=[0, 3, 4, 5, 6]
+            # output_clusters=[10, 25]>
+            11: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # device_version=0
+            # input_clusters=[]
+            # output_clusters=[33]>
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            11: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }

--- a/zhaquirks/lidl/ts011f_plug.py
+++ b/zhaquirks/lidl/ts011f_plug.py
@@ -17,7 +17,6 @@ from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
-    # MODEL,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
@@ -32,7 +31,6 @@ class Plug(CustomDevice):
     """Tuya plug with restore power state support."""
 
     signature = {
-        # MODEL: "TS011F",
         MODELS_INFO: [("_TZ3000_wamqdr3f", "TS011F")],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=11 profile=260 device_type=266

--- a/zhaquirks/lidl/ts011f_plug.py
+++ b/zhaquirks/lidl/ts011f_plug.py
@@ -22,9 +22,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 
-from zhaquirks.lidl import (
-    TuyaZBOnOffAttributeCluster,
-)
+from zhaquirks.lidl import TuyaZBOnOffAttributeCluster
 
 
 class Plug(CustomDevice):

--- a/zhaquirks/lidl/ts011f_plug.py
+++ b/zhaquirks/lidl/ts011f_plug.py
@@ -17,7 +17,7 @@ from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
-#    MODEL,
+    # MODEL,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
@@ -32,7 +32,7 @@ class Plug(CustomDevice):
     """Tuya plug with restore power state support."""
 
     signature = {
-        #MODEL: "TS011F",
+        # MODEL: "TS011F",
         MODELS_INFO: [("_TZ3000_wamqdr3f", "TS011F")],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=11 profile=260 device_type=266


### PR DESCRIPTION
ability to change the behavior of the led on the plug and the power on state on the plug LIDL Silvercrest HG06337 / SAPZ 1 A1 (based on Tuya TS011F)

for information jeedom format parameters associated
```
"config" : [
  {"endpoint":11,"cluster":6,"attribute":32769,"name":"Light mode","type":"select","values":[
    {"value":0,"name":"Led disabled"},
    {"value":1,"name":"Led enabled"},
    {"value":2,"name":"Led enabled but inverted"}
  ]},
  {"endpoint":11,"cluster":6,"attribute":32770,"name":"Power on state","type":"select","values":[
    {"value":0,"name":"Off"},
    {"value":1,"name":"On"},
    {"value":2,"name":"Last state"}
  ]}
],
```