### PR TITLE
add plug LIDL Silvercrest HG06337 / SAPZ 1 A1 (Tuya TS011F)

### DIFF
--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -92,6 +92,64 @@ class Plug(CustomDevice):
     }
 
 
+class Plug_1AC(CustomDevice):
+    """Tuya plug without metering with restore power state support."""
+
+    signature = {
+        MODEL: "TS011F",
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=11 profile=260 device_type=266
+            # device_version=1
+            # input_clusters=[0, 3, 4, 5, 6]
+            # output_clusters=[10, 25]>
+            11: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # device_version=0
+            # input_clusters=[]
+            # output_clusters=[33]>
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            11: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+
 class Plug_3AC_4USB(CustomDevice):
     """Tuya 3 outlet + 4 USB with restore power state support."""
 


### PR DESCRIPTION
ability to change the behavior of the led on the plug and the power on state on the plug LIDL Silvercrest HG06337 / SAPZ 1 A1 (based on Tuya TS011F)

for information jeedom format parameters associated
```
"config" : [
  {"endpoint":11,"cluster":6,"attribute":32769,"name":"Light mode","type":"select","values":[
    {"value":0,"name":"Led disabled"},
    {"value":1,"name":"Led enabled"},
    {"value":2,"name":"Led enabled but inverted"}
  ]},
  {"endpoint":11,"cluster":6,"attribute":32770,"name":"Power on state","type":"select","values":[
    {"value":0,"name":"Off"},
    {"value":1,"name":"On"},
    {"value":2,"name":"Last state"}
  ]}
],
```