### PR TITLE
Support for Aqara H1 wireless remote (single and double rocker version)

### DIFF
--- a/zhaquirks/xiaomi/aqara/remote_h1.py
+++ b/zhaquirks/xiaomi/aqara/remote_h1.py
@@ -1,3 +1,4 @@
+"""Aqara H1-series wireless remote"""
 import zigpy.types as t
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Identify, OnOff, PowerConfiguration

--- a/zhaquirks/xiaomi/aqara/remote_h1.py
+++ b/zhaquirks/xiaomi/aqara/remote_h1.py
@@ -1,0 +1,227 @@
+import zigpy.types as t
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import Basic, Identify, OnOff, PowerConfiguration
+from zhaquirks import PowerConfigurationCluster
+from zhaquirks.const import (
+    ALT_DOUBLE_PRESS,
+    ALT_SHORT_PRESS,
+    ARGS,
+    BUTTON,
+    COMMAND,
+    COMMAND_OFF,
+    COMMAND_TOGGLE,
+    DEVICE_TYPE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    LEFT,
+    LONG_PRESS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    RIGHT,
+    SHORT_PRESS,
+    TRIPLE_PRESS,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    XiaomiCustomDevice,
+    XiaomiAqaraE1Cluster,
+)
+from zhaquirks.xiaomi.aqara.opple_remote import (
+    MultistateInputCluster,
+    COMMAND_1_SINGLE,
+    COMMAND_1_DOUBLE,
+    COMMAND_1_TRIPLE,
+    COMMAND_1_HOLD,
+    COMMAND_2_SINGLE,
+    COMMAND_2_DOUBLE,
+    COMMAND_2_TRIPLE,
+    COMMAND_2_HOLD,
+    COMMAND_3_SINGLE,
+    COMMAND_3_DOUBLE,
+    COMMAND_3_TRIPLE,
+    COMMAND_3_HOLD,
+)
+
+BOTH_BUTTONS = "both_buttons"
+
+
+class AqaraRemoteManuSpecificCluster(XiaomiAqaraE1Cluster):
+    ep_attribute = "aqara_cluster"
+
+    # manufacture override code: 4447 (0x115f)
+    # to get/set these attributes, you might need to click the button 5 times
+    # quickly.
+    manufacturer_attributes = {
+        # operation_mode:
+        # 0 means "command" mode.
+        # 1 means "event" mode.
+        0x0009: ("operation_mode", t.uint8_t),
+        # click_mode:
+        # 1 means single click mode, which is low latency (50ms) but only sends
+        #   single click events.
+        # 2 means multiple click mode, which has a slightly higher latency but
+        #   supports single/double/triple click and long press.
+        # default value after factory reset: 1.
+        0x0125: ("click_mode", t.uint8_t),
+    }
+
+
+class PowerConfigurationClusterH1Remote(PowerConfigurationCluster):
+    # Aqara H1 wireless remote uses one CR2450 battery.
+    # Values are copied from zigbee-herdsman-converters.
+    MIN_VOLTS = 2.5
+    MAX_VOLTS = 3.0
+
+
+class RemoteH1SingleRocker(XiaomiCustomDevice):
+    """Aqara H1 Wireless Remote Single Rocker Version WRS-R01"""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.remote.b18ac1")],
+        ENDPOINTS: {
+            # SizePrefixedSimpleDescriptor(
+            #   endpoint=1, profile=260, device_type=259, device_version=1,
+            #   input_clusters=[0, 3, 1], output_clusters=[3, 6])
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            }
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                    PowerConfigurationClusterH1Remote,
+                    MultistateInputCluster,
+                    AqaraRemoteManuSpecificCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            }
+        }
+    }
+    device_automation_triggers = {
+        # triggers when operation_mode == event
+        # the button doesn't send an release event after hold
+        (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_1_SINGLE},
+        (DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_1_DOUBLE},
+        (TRIPLE_PRESS, BUTTON): {COMMAND: COMMAND_1_TRIPLE},
+        (LONG_PRESS, BUTTON): {COMMAND: COMMAND_1_HOLD},
+        # triggers when operation_mode == command
+        (ALT_SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1, ARGS: []},
+        (ALT_DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1, ARGS: []},
+    }
+
+
+class RemoteH1DoubleRocker(XiaomiCustomDevice):
+    """Aqara H1 Wireless Remote Double Rocker Version WRS-R02"""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.remote.b28ac1")],
+        ENDPOINTS: {
+            1: {
+                # SizePrefixedSimpleDescriptor(
+                #   endpoint=1, profile=260, device_type=259, device_version=1,
+                #   input_clusters=[0, 3, 1], output_clusters=[3, 6])
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+            3: {
+                # SizePrefixedSimpleDescriptor(
+                #   endpoint=3, profile=260, device_type=259, device_version=1,
+                #   input_clusters=[3], output_clusters=[6])
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [Identify.cluster_id],
+                OUTPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                    PowerConfigurationClusterH1Remote,
+                    MultistateInputCluster,
+                    AqaraRemoteManuSpecificCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    MultistateInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    MultistateInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+        }
+    }
+    device_automation_triggers = {
+        # triggers when operation_mode == event
+        # the button doesn't send an release event after hold
+        (SHORT_PRESS, LEFT): {COMMAND: COMMAND_1_SINGLE},
+        (DOUBLE_PRESS, LEFT): {COMMAND: COMMAND_1_DOUBLE},
+        (TRIPLE_PRESS, LEFT): {COMMAND: COMMAND_1_TRIPLE},
+        (LONG_PRESS, LEFT): {COMMAND: COMMAND_1_HOLD},
+        (SHORT_PRESS, RIGHT): {COMMAND: COMMAND_2_SINGLE},
+        (DOUBLE_PRESS, RIGHT): {COMMAND: COMMAND_2_DOUBLE},
+        (TRIPLE_PRESS, RIGHT): {COMMAND: COMMAND_2_TRIPLE},
+        (LONG_PRESS, RIGHT): {COMMAND: COMMAND_2_HOLD},
+        (SHORT_PRESS, BOTH_BUTTONS): {COMMAND: COMMAND_3_SINGLE},
+        (DOUBLE_PRESS, BOTH_BUTTONS): {COMMAND: COMMAND_3_DOUBLE},
+        (TRIPLE_PRESS, BOTH_BUTTONS): {COMMAND: COMMAND_3_TRIPLE},
+        (LONG_PRESS, BOTH_BUTTONS): {COMMAND: COMMAND_3_HOLD},
+        # triggers when operation_mode == command
+        # known issue: it seems impossible to know which button being pressed
+        # when operation_mode == command
+        (ALT_SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1, ARGS: []},
+    }

--- a/zhaquirks/xiaomi/aqara/remote_h1.py
+++ b/zhaquirks/xiaomi/aqara/remote_h1.py
@@ -139,8 +139,8 @@ class RemoteH1SingleRocker(XiaomiCustomDevice):
     }
 
 
-class RemoteH1DoubleRocker(XiaomiCustomDevice):
-    """Aqara H1 Wireless Remote Double Rocker Version WRS-R02."""
+class RemoteH1DoubleRocker1(XiaomiCustomDevice):
+    """Aqara H1 Wireless Remote Double Rocker Version WRS-R02, variant 1."""
 
     signature = {
         MODELS_INFO: [(LUMI, "lumi.remote.b28ac1")],
@@ -193,9 +193,13 @@ class RemoteH1DoubleRocker(XiaomiCustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
+                    Identify.cluster_id,
                     MultistateInputCluster,
                 ],
-                OUTPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
             },
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -231,3 +235,57 @@ class RemoteH1DoubleRocker(XiaomiCustomDevice):
         # when operation_mode == command
         (ALT_SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1, ARGS: []},
     }
+
+
+class RemoteH1DoubleRocker2(XiaomiCustomDevice):
+    """Aqara H1 Wireless Remote Double Rocker Version WRS-R02, variant 2."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.remote.b28ac1")],
+        ENDPOINTS: {
+            1: {
+                # "1": {
+                #   "profile_id": 260, "device_type": "0x0103",
+                #   "in_clusters": [ "0x0000", "0x0001", "0x0003" ],
+                #   "out_clusters": [ "0x0003", "0x0006" ] }
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+            2: {
+                # "2": {
+                #   "profile_id": 260, "device_type": "0x0103",
+                #   "in_clusters": [ "0x0003" ],
+                #   "out_clusters": [ "0x0003", "0x0006" ] }
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+            3: {
+                # "3": {
+                #   "profile_id": 260, "device_type": "0x0103",
+                #   "in_clusters": [ "0x0003" ],
+                #   "out_clusters": [ "0x0006" ] }
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [Identify.cluster_id],
+                OUTPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+        },
+    }
+    replacement = RemoteH1DoubleRocker1.replacement
+    device_automation_triggers = RemoteH1DoubleRocker1.device_automation_triggers

--- a/zhaquirks/xiaomi/aqara/remote_h1.py
+++ b/zhaquirks/xiaomi/aqara/remote_h1.py
@@ -1,6 +1,6 @@
-"""Aqara H1-series wireless remote"""
-import zigpy.types as t
+"""Aqara H1-series wireless remote."""
 from zigpy.profiles import zha
+import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic, Identify, OnOff, PowerConfiguration
 from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
@@ -28,29 +28,31 @@ from zhaquirks.const import (
 from zhaquirks.xiaomi import (
     LUMI,
     BasicCluster,
-    XiaomiCustomDevice,
     XiaomiAqaraE1Cluster,
+    XiaomiCustomDevice,
 )
 from zhaquirks.xiaomi.aqara.opple_remote import (
-    MultistateInputCluster,
-    COMMAND_1_SINGLE,
     COMMAND_1_DOUBLE,
-    COMMAND_1_TRIPLE,
     COMMAND_1_HOLD,
-    COMMAND_2_SINGLE,
+    COMMAND_1_SINGLE,
+    COMMAND_1_TRIPLE,
     COMMAND_2_DOUBLE,
-    COMMAND_2_TRIPLE,
     COMMAND_2_HOLD,
-    COMMAND_3_SINGLE,
+    COMMAND_2_SINGLE,
+    COMMAND_2_TRIPLE,
     COMMAND_3_DOUBLE,
-    COMMAND_3_TRIPLE,
     COMMAND_3_HOLD,
+    COMMAND_3_SINGLE,
+    COMMAND_3_TRIPLE,
+    MultistateInputCluster,
 )
 
 BOTH_BUTTONS = "both_buttons"
 
 
 class AqaraRemoteManuSpecificCluster(XiaomiAqaraE1Cluster):
+    """Aqara manufacturer specific settings."""
+
     ep_attribute = "aqara_cluster"
 
     # manufacture override code: 4447 (0x115f)
@@ -72,6 +74,8 @@ class AqaraRemoteManuSpecificCluster(XiaomiAqaraE1Cluster):
 
 
 class PowerConfigurationClusterH1Remote(PowerConfigurationCluster):
+    """Reports battery level."""
+
     # Aqara H1 wireless remote uses one CR2450 battery.
     # Values are copied from zigbee-herdsman-converters.
     MIN_VOLTS = 2.5
@@ -79,7 +83,7 @@ class PowerConfigurationClusterH1Remote(PowerConfigurationCluster):
 
 
 class RemoteH1SingleRocker(XiaomiCustomDevice):
-    """Aqara H1 Wireless Remote Single Rocker Version WRS-R01"""
+    """Aqara H1 Wireless Remote Single Rocker Version WRS-R01."""
 
     signature = {
         MODELS_INFO: [(LUMI, "lumi.remote.b18ac1")],
@@ -135,7 +139,7 @@ class RemoteH1SingleRocker(XiaomiCustomDevice):
 
 
 class RemoteH1DoubleRocker(XiaomiCustomDevice):
-    """Aqara H1 Wireless Remote Double Rocker Version WRS-R02"""
+    """Aqara H1 Wireless Remote Double Rocker Version WRS-R02."""
 
     signature = {
         MODELS_INFO: [(LUMI, "lumi.remote.b28ac1")],

--- a/zhaquirks/xiaomi/aqara/remote_h1.py
+++ b/zhaquirks/xiaomi/aqara/remote_h1.py
@@ -2,6 +2,7 @@
 from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic, Identify, OnOff, PowerConfiguration
+
 from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
     ALT_DOUBLE_PRESS,


### PR DESCRIPTION
This PR adds support for Aqara H1 Wireless Remote (WRS-R01 and [WRS-R02](https://zigbee.blakadder.com/Aqara_WRS-R02.html)).

Kudos to:
* @kirovilya For his [PR](https://github.com/Koenkk/zigbee-herdsman-converters/pull/2621) in zigbee-herdsman-converter.
* @cray19003 @mmatecki @griphos For help in writing/testing this quirk in https://github.com/zigpy/zha-device-handlers/issues/940

---

## Instructions for Aqara H1 remote owners:

Aqara H1 Remote has many modes, you need to set it to the proper mode to get the desired behavior:

1. Home Assistant ➡️ Configuration ➡️ Devices & Services ➡️ (Find your H1 Remote device) ➡️ Manage Clusters ➡️ Select `AqaraRemoteManuSpecificCluster (Endpoint id: 1, Id: 0xfcc0, Type: in)` ➡️ See "Cluster Attributes"
2. For `operation_mode (id: 0x0009)`: Fill your desired value, set "Manufacturer Code Override" to 4447, press "Set Zigbee Attribute". You may need to press H1 remote five times quickly to wake it up.
   * Value `0` means "command" mode. In the "command" mode, the remote will send commands like "toggle" or "off". You can bind the device with a light (it works like ikea tradfri remotes). Pro: when you bind to a specific light, the button works even when home assistant is down. Con: (1) Limited customization. (2) no known way to differentiate the left/right button in this mode.
   * Value `1` means "event" mode. In the "event" mode, the remote will send generic click events to HA, and HA is responsible for the automation. When HA is down, the automation is down. But it allows more customization. I'm using this mode.
3. For `click_mode (id: 0x0125)`, set it similarly. You may need to press H1 remote five times quickly to wake it up.
   * value `1` means single click mode. This mode has lower delay but only reports single click events. If you click twice you'll receive two "single click" events. This is the default mode after factory reset.
   * value `2` means multiple click mode. This mode has a slightly higher delay but detects single/double/triple click and long press. I'm using this mode.
4. FYI here's the behavior of my aqara h1 single button remote under different settings.
   * `click_mode=1 and operation_mode=0`
     * single click: sends `toggle` zha_event
   * `click_mode=2 and operation_mode=0`
     * single click: `toggle` zha_event
     * double click: `off` zha_event
   * `click_mode=1 and operation_mode=1`
     * single click: `1_single` zha_event
   * `click_mode=2 and operation_mode=1`
     * single click: `1_single` zha_event
     * double click: `1_double` zha_event
     * triple click: `1_triple` zha_event
     * long press: `1_hold` zha_event

When you press the button, a `zha_event` will be triggered, which can be used in automation. The device trigger might help your automation as well
![demo of device trigger setting](https://user-images.githubusercontent.com/4636537/147708714-d4ecc340-6217-41e7-98c6-a8593cbdd310.png)