### PR TITLE
'New' approach for Tuya MCU Cluster

### DIFF
--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -1,0 +1,256 @@
+"""Tests for Tuya quirks."""
+
+from unittest import mock
+
+import pytest
+from zigpy.zcl import foundation
+
+import zhaquirks
+
+from tests.common import ClusterListener
+
+zhaquirks.setup()
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.tuya.ts0601_dimmer.TuyaDoubleSwitchDimmer,)
+)
+async def test_command(zigpy_device_from_quirk, quirk):
+    """Test write cluster attributes."""
+
+    dimmer_dev = zigpy_device_from_quirk(quirk)
+    tuya_cluster = dimmer_dev.endpoints[1].tuya_manufacturer
+    dimmer1_cluster = dimmer_dev.endpoints[1].level
+    switch2_cluster = dimmer_dev.endpoints[2].on_off
+    tuya_listener = ClusterListener(tuya_cluster)
+    # switch2_listener = ClusterListener(switch2_cluster)
+
+    assert len(tuya_listener.cluster_commands) == 0
+    assert len(tuya_listener.attribute_updates) == 0
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as m1:
+        status = await switch2_cluster.command(0x0001)
+
+        m1.assert_called_with(
+            61184,
+            2,
+            b"\x01\x02\x00\x00\x01\x07\x01\x00\x01\x01",
+            expect_reply=True,
+            command_id=0,
+        )
+        assert status == foundation.Status.SUCCESS
+
+        status = await dimmer1_cluster.command(0x0000, 225)
+
+        m1.assert_called_with(
+            61184,
+            4,
+            b"\x01\x04\x00\x00\x03\x02\x02\x00\x04\x00\x00\x03r",
+            expect_reply=True,
+            command_id=0,
+        )
+        assert status == foundation.Status.SUCCESS
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.tuya.ts0601_dimmer.TuyaDoubleSwitchDimmer,)
+)
+async def test_write_attr(zigpy_device_from_quirk, quirk):
+    """Test write cluster attributes."""
+
+    dimmer_dev = zigpy_device_from_quirk(quirk)
+    tuya_cluster = dimmer_dev.endpoints[1].tuya_manufacturer
+    dimmer1_cluster = dimmer_dev.endpoints[1].level
+
+    async def async_success(*args, **kwargs):
+        return foundation.Status.SUCCESS
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", side_effect=async_success
+    ) as m1:
+
+        (status,) = await dimmer1_cluster.write_attributes(
+            {
+                "minimum_level": 25,
+            }
+        )
+        m1.assert_called_with(
+            61184,
+            2,
+            b"\x01\x02\x00\x00\x01\x03\x02\x00\x04\x00\x00\x00b",
+            expect_reply=True,
+            command_id=0,
+        )
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
+
+    # # write_attributes doesn't update the attribute's values and
+    # # delegates it to the device response message
+    # succ, fail = await dimmer1_cluster.read_attributes(("minimum_level",))
+    # assert succ["minimum_level"] == 25
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.tuya.ts0601_dimmer.TuyaDoubleSwitchDimmer,)
+)
+async def test_dim_values(zigpy_device_from_quirk, quirk):
+    """Test dimming values."""
+
+    dimmer_dev = zigpy_device_from_quirk(quirk)
+
+    dimmer2_cluster = dimmer_dev.endpoints[2].level
+    dimmer2_listener = ClusterListener(dimmer2_cluster)
+
+    tuya_cluster = dimmer_dev.endpoints[1].tuya_manufacturer
+
+    assert len(dimmer2_listener.cluster_commands) == 0
+    assert len(dimmer2_listener.attribute_updates) == 0
+
+    # payload=553
+    hdr, args = tuya_cluster.deserialize(
+        b"\tV\x02\x01y\x08\x02\x00\x04\x00\x00\x02\x29"
+    )
+    tuya_cluster.handle_message(hdr, args)
+    assert len(dimmer2_listener.attribute_updates) == 1
+    assert dimmer2_listener.attribute_updates[0][0] == 0x0000
+    assert dimmer2_listener.attribute_updates[0][1] == 141
+
+    succ, fail = await dimmer2_cluster.read_attributes(("current_level",))
+    assert succ["current_level"] == 141
+
+    # payload=700
+    hdr, args = tuya_cluster.deserialize(
+        b"\tV\x02\x01y\x08\x02\x00\x04\x00\x00\x02\xbc"
+    )
+    tuya_cluster.handle_message(hdr, args)
+    succ, fail = await dimmer2_cluster.read_attributes(("current_level",))
+    assert succ["current_level"] == 178
+
+    # payload=982
+    hdr, args = tuya_cluster.deserialize(
+        b"\tV\x02\x01y\x08\x02\x00\x04\x00\x00\x03\xd6"
+    )
+    tuya_cluster.handle_message(hdr, args)
+    succ, fail = await dimmer2_cluster.read_attributes(("current_level",))
+    assert succ["current_level"] == 250
+
+    # payload=657
+    hdr, args = tuya_cluster.deserialize(
+        b"\tV\x02\x01y\x08\x02\x00\x04\x00\x00\x02\x91"
+    )
+    tuya_cluster.handle_message(hdr, args)
+    succ, fail = await dimmer2_cluster.read_attributes(("current_level",))
+    assert succ["current_level"] == 167
+
+    # payload=400
+    hdr, args = tuya_cluster.deserialize(
+        b"\tV\x02\x01y\x08\x02\x00\x04\x00\x00\x01\x90"
+    )
+    tuya_cluster.handle_message(hdr, args)
+    succ, fail = await dimmer2_cluster.read_attributes(("current_level",))
+    assert succ["current_level"] == 102
+
+    # payload=149
+    hdr, args = tuya_cluster.deserialize(
+        b"\tV\x02\x01y\x08\x02\x00\x04\x00\x00\x00\x95"
+    )
+    tuya_cluster.handle_message(hdr, args)
+    succ, fail = await dimmer2_cluster.read_attributes(("current_level",))
+    assert succ["current_level"] == 37
+
+    # payload=339
+    hdr, args = tuya_cluster.deserialize(
+        b"\tV\x02\x01y\x08\x02\x00\x04\x00\x00\x01\x53"
+    )
+    tuya_cluster.handle_message(hdr, args)
+    succ, fail = await dimmer2_cluster.read_attributes(("current_level",))
+    assert succ["current_level"] == 86
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.tuya.ts0601_dimmer.TuyaDoubleSwitchDimmer,)
+)
+async def test_doubledimmer_state_report(zigpy_device_from_quirk, quirk):
+    """Test tuya double switch."""
+
+    # TUYA_EP2_SWITCH_ON = b"\tG\x02\x01o\x07\x01\x00\x01\x01"
+    # TUYA_EP2_SWITCH_OFF = b"\tH\x02\x01p\x07\x01\x00\x01\x00"
+
+    TUYA_EP2_DIMM_1 = b"\tV\x02\x01y\x08\x02\x00\x04\x00\x00\x02\xc5"
+    TUYA_EP2_DIMM_2 = b"\tW\x02\x01z\x08\x02\x00\x04\x00\x00\x02\x9e"
+
+    dimmer_dev = zigpy_device_from_quirk(quirk)
+
+    dimmer1_cluster = dimmer_dev.endpoints[1].level
+    dimmer1_listener = ClusterListener(dimmer1_cluster)
+
+    dimmer2_cluster = dimmer_dev.endpoints[2].level
+    dimmer2_listener = ClusterListener(dimmer2_cluster)
+
+    tuya_cluster = dimmer_dev.endpoints[1].tuya_manufacturer
+
+    assert len(dimmer1_listener.cluster_commands) == 0
+    assert len(dimmer1_listener.attribute_updates) == 0
+    assert len(dimmer2_listener.cluster_commands) == 0
+    assert len(dimmer2_listener.attribute_updates) == 0
+
+    # events from channel 2 updates only EP 2
+    hdr, args = tuya_cluster.deserialize(TUYA_EP2_DIMM_1)
+    tuya_cluster.handle_message(hdr, args)
+    assert len(dimmer1_listener.attribute_updates) == 0
+    assert len(dimmer2_listener.attribute_updates) == 1
+    assert dimmer2_listener.attribute_updates[0][0] == 0x0000
+    assert dimmer2_listener.attribute_updates[0][1] == 180
+
+    # events from channel 1 updates only EP 1
+    hdr, args = tuya_cluster.deserialize(TUYA_EP2_DIMM_2)
+    tuya_cluster.handle_message(hdr, args)
+    assert len(dimmer1_listener.attribute_updates) == 0
+    assert len(dimmer2_listener.attribute_updates) == 2
+    assert dimmer2_listener.attribute_updates[1][0] == 0x0000
+    assert dimmer2_listener.attribute_updates[1][1] == 170
+
+    # # events from channel 2 updates only EP 2
+    # hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_EP2_ON)
+    # tuya_cluster.handle_message(hdr, args)
+    # assert len(dimmer1_listener.attribute_updates) == 1
+    # assert len(dimmer2_listener.attribute_updates) == 1
+    # assert dimmer2_listener.attribute_updates[0][0] == 0x0000
+    # assert dimmer2_listener.attribute_updates[0][1] == ON
+
+    # hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_OFF)
+    # tuya_cluster.handle_message(hdr, args)
+    # assert len(dimmer1_listener.attribute_updates) == 2
+    # assert len(dimmer2_listener.attribute_updates) == 1
+    # assert dimmer1_listener.attribute_updates[1][0] == 0x0000
+    # assert dimmer1_listener.attribute_updates[1][1] == OFF
+
+    # hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_EP2_OFF)
+    # tuya_cluster.handle_message(hdr, args)
+    # assert len(dimmer1_listener.attribute_updates) == 2
+    # assert len(dimmer2_listener.attribute_updates) == 2
+    # assert dimmer2_listener.attribute_updates[1][0] == 0x0000
+    # assert dimmer2_listener.attribute_updates[1][1] == OFF
+
+    # assert len(dimmer1_listener.cluster_commands) == 0
+    # assert len(dimmer2_listener.cluster_commands) == 0
+
+    # # command_id = 0x0003
+    # hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_COMMAND_03)
+    # tuya_cluster.handle_message(hdr, args)
+    # assert len(dimmer1_listener.cluster_commands) == 0
+    # assert len(dimmer2_listener.cluster_commands) == 0
+    # # no switch attribute updated (Unsupported command)
+    # assert len(dimmer1_listener.attribute_updates) == 2
+    # assert len(dimmer2_listener.attribute_updates) == 2
+
+    # hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SET_TIME_REQUEST)
+    # tuya_cluster.handle_message(hdr, args)
+    # assert len(dimmer1_listener.cluster_commands) == 0
+    # assert len(dimmer2_listener.cluster_commands) == 0
+    # # no switch attribute updated (TUYA_SET_TIME command)
+    # assert len(dimmer1_listener.attribute_updates) == 2
+    # assert len(dimmer2_listener.attribute_updates) == 2

--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -23,7 +23,6 @@ async def test_command(zigpy_device_from_quirk, quirk):
     dimmer1_cluster = dimmer_dev.endpoints[1].level
     switch2_cluster = dimmer_dev.endpoints[2].on_off
     tuya_listener = ClusterListener(tuya_cluster)
-    # switch2_listener = ClusterListener(switch2_cluster)
 
     assert len(tuya_listener.cluster_commands) == 0
     assert len(tuya_listener.attribute_updates) == 0
@@ -87,7 +86,7 @@ async def test_write_attr(zigpy_device_from_quirk, quirk):
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
         ]
 
-    # # write_attributes doesn't update the attribute's values and
+    # # write_attributes doesn't update the cluster's attribute value and
     # # delegates it to the device response message
     # succ, fail = await dimmer1_cluster.read_attributes(("minimum_level",))
     # assert succ["minimum_level"] == 25
@@ -176,9 +175,6 @@ async def test_dim_values(zigpy_device_from_quirk, quirk):
 async def test_doubledimmer_state_report(zigpy_device_from_quirk, quirk):
     """Test tuya double switch."""
 
-    # TUYA_EP2_SWITCH_ON = b"\tG\x02\x01o\x07\x01\x00\x01\x01"
-    # TUYA_EP2_SWITCH_OFF = b"\tH\x02\x01p\x07\x01\x00\x01\x00"
-
     TUYA_EP2_DIMM_1 = b"\tV\x02\x01y\x08\x02\x00\x04\x00\x00\x02\xc5"
     TUYA_EP2_DIMM_2 = b"\tW\x02\x01z\x08\x02\x00\x04\x00\x00\x02\x9e"
 
@@ -212,45 +208,3 @@ async def test_doubledimmer_state_report(zigpy_device_from_quirk, quirk):
     assert len(dimmer2_listener.attribute_updates) == 2
     assert dimmer2_listener.attribute_updates[1][0] == 0x0000
     assert dimmer2_listener.attribute_updates[1][1] == 170
-
-    # # events from channel 2 updates only EP 2
-    # hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_EP2_ON)
-    # tuya_cluster.handle_message(hdr, args)
-    # assert len(dimmer1_listener.attribute_updates) == 1
-    # assert len(dimmer2_listener.attribute_updates) == 1
-    # assert dimmer2_listener.attribute_updates[0][0] == 0x0000
-    # assert dimmer2_listener.attribute_updates[0][1] == ON
-
-    # hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_OFF)
-    # tuya_cluster.handle_message(hdr, args)
-    # assert len(dimmer1_listener.attribute_updates) == 2
-    # assert len(dimmer2_listener.attribute_updates) == 1
-    # assert dimmer1_listener.attribute_updates[1][0] == 0x0000
-    # assert dimmer1_listener.attribute_updates[1][1] == OFF
-
-    # hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_EP2_OFF)
-    # tuya_cluster.handle_message(hdr, args)
-    # assert len(dimmer1_listener.attribute_updates) == 2
-    # assert len(dimmer2_listener.attribute_updates) == 2
-    # assert dimmer2_listener.attribute_updates[1][0] == 0x0000
-    # assert dimmer2_listener.attribute_updates[1][1] == OFF
-
-    # assert len(dimmer1_listener.cluster_commands) == 0
-    # assert len(dimmer2_listener.cluster_commands) == 0
-
-    # # command_id = 0x0003
-    # hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_COMMAND_03)
-    # tuya_cluster.handle_message(hdr, args)
-    # assert len(dimmer1_listener.cluster_commands) == 0
-    # assert len(dimmer2_listener.cluster_commands) == 0
-    # # no switch attribute updated (Unsupported command)
-    # assert len(dimmer1_listener.attribute_updates) == 2
-    # assert len(dimmer2_listener.attribute_updates) == 2
-
-    # hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SET_TIME_REQUEST)
-    # tuya_cluster.handle_message(hdr, args)
-    # assert len(dimmer1_listener.cluster_commands) == 0
-    # assert len(dimmer2_listener.cluster_commands) == 0
-    # # no switch attribute updated (TUYA_SET_TIME command)
-    # assert len(dimmer1_listener.attribute_updates) == 2
-    # assert len(dimmer2_listener.attribute_updates) == 2

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -1,0 +1,71 @@
+"""Tests for Tuya quirks."""
+
+import pytest
+
+import zhaquirks
+import zigpy.types as t
+
+from zhaquirks.tuya import TUYA_MCU_VERSION_RSP
+
+from zhaquirks.tuya.mcu import ATTR_MCU_VERSION, TuyaDPType, TuyaMCUCluster
+
+from tests.common import ClusterListener
+
+zhaquirks.setup()
+
+# ZCL_TUYA_VERSION_RSP = b"\tp\x17\x00\x03\x82"
+ZCL_TUYA_VERSION_RSP = b'\x09\x06\x11\x01\x6D\x82'
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.tuya.ts0601_dimmer.TuyaDoubleSwitchDimmer,)
+)
+async def test_tuya_version(zigpy_device_from_quirk, quirk):
+    """Test TUYA_MCU_VERSION_RSP messages"""
+
+    tuya_device = zigpy_device_from_quirk(quirk)
+
+    tuya_cluster = tuya_device.endpoints[1].tuya_manufacturer
+    cluster_listener = ClusterListener(tuya_cluster)
+
+    assert len(cluster_listener.attribute_updates) == 0
+
+    # simulate a TUYA_MCU_VERSION_RSP message
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_VERSION_RSP)
+    assert hdr.command_id == TUYA_MCU_VERSION_RSP
+
+    tuya_cluster.handle_message(hdr, args)
+    assert len(cluster_listener.attribute_updates) == 1
+    assert cluster_listener.attribute_updates[0][0] == ATTR_MCU_VERSION
+    assert cluster_listener.attribute_updates[0][1] == '2.0.2'
+
+    # read 'mcu_version' from cluster's attributes
+    succ, fail = await tuya_cluster.read_attributes(("mcu_version",))
+    assert succ["mcu_version"] == '2.0.2'
+
+
+async def test_tuya_mcu_classes():
+    """Test tuya conversion from Data to ztype and reverse."""
+
+    # Test TuyaDPType class
+    assert len(TuyaDPType) == 6
+    assert TuyaDPType.BOOL.ztype == t.Bool
+    assert TuyaDPType.get_from_ztype(t.uint32_t) == TuyaDPType.VALUE
+    # no ztype for TuyaDPType.RAW
+    assert not TuyaDPType.RAW.ztype
+    assert TuyaDPType(3) == TuyaDPType.STRING
+
+    # Test TuyaMCUCluster.MCUVersion class
+    mcu_version = TuyaMCUCluster.MCUVersion.deserialize(b"\x00\x03\x82")[0]
+    assert mcu_version
+    assert mcu_version.tsn == 3
+    assert mcu_version.version_raw == 130
+    assert mcu_version.version == '2.0.2'
+    mcu_version = TuyaMCUCluster.MCUVersion.deserialize(b"\x00\x04\x01")[0]
+    assert mcu_version
+    assert mcu_version.version_raw == 1
+    assert mcu_version.version == '0.0.1'
+    mcu_version = TuyaMCUCluster.MCUVersion.deserialize(b"\x00\x05\xFF")[0]
+    assert mcu_version
+    assert mcu_version.version_raw == 255
+    assert mcu_version.version == '3.3.15'

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -19,7 +19,6 @@ from tests.common import ClusterListener
 
 zhaquirks.setup()
 
-# ZCL_TUYA_VERSION_RSP = b"\tp\x17\x00\x03\x82"
 ZCL_TUYA_VERSION_RSP = b"\x09\x06\x11\x01\x6D\x82"
 
 

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -48,7 +48,6 @@ async def test_tuya_mcu_classes():
     # Test TuyaDPType class
     assert len(TuyaDPType) == 6
     assert TuyaDPType.BOOL.ztype == t.Bool
-    assert TuyaDPType.get_from_ztype(t.uint32_t) == TuyaDPType.VALUE
     # no ztype for TuyaDPType.RAW
     assert not TuyaDPType.RAW.ztype
     assert TuyaDPType(3) == TuyaDPType.STRING

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -1,12 +1,10 @@
 """Tests for Tuya quirks."""
 
 import pytest
-
-import zhaquirks
 import zigpy.types as t
 
+import zhaquirks
 from zhaquirks.tuya import TUYA_MCU_VERSION_RSP
-
 from zhaquirks.tuya.mcu import ATTR_MCU_VERSION, TuyaDPType, TuyaMCUCluster
 
 from tests.common import ClusterListener
@@ -14,14 +12,14 @@ from tests.common import ClusterListener
 zhaquirks.setup()
 
 # ZCL_TUYA_VERSION_RSP = b"\tp\x17\x00\x03\x82"
-ZCL_TUYA_VERSION_RSP = b'\x09\x06\x11\x01\x6D\x82'
+ZCL_TUYA_VERSION_RSP = b"\x09\x06\x11\x01\x6D\x82"
 
 
 @pytest.mark.parametrize(
     "quirk", (zhaquirks.tuya.ts0601_dimmer.TuyaDoubleSwitchDimmer,)
 )
 async def test_tuya_version(zigpy_device_from_quirk, quirk):
-    """Test TUYA_MCU_VERSION_RSP messages"""
+    """Test TUYA_MCU_VERSION_RSP messages."""
 
     tuya_device = zigpy_device_from_quirk(quirk)
 
@@ -37,11 +35,11 @@ async def test_tuya_version(zigpy_device_from_quirk, quirk):
     tuya_cluster.handle_message(hdr, args)
     assert len(cluster_listener.attribute_updates) == 1
     assert cluster_listener.attribute_updates[0][0] == ATTR_MCU_VERSION
-    assert cluster_listener.attribute_updates[0][1] == '2.0.2'
+    assert cluster_listener.attribute_updates[0][1] == "2.0.2"
 
     # read 'mcu_version' from cluster's attributes
     succ, fail = await tuya_cluster.read_attributes(("mcu_version",))
-    assert succ["mcu_version"] == '2.0.2'
+    assert succ["mcu_version"] == "2.0.2"
 
 
 async def test_tuya_mcu_classes():
@@ -60,12 +58,12 @@ async def test_tuya_mcu_classes():
     assert mcu_version
     assert mcu_version.tsn == 3
     assert mcu_version.version_raw == 130
-    assert mcu_version.version == '2.0.2'
+    assert mcu_version.version == "2.0.2"
     mcu_version = TuyaMCUCluster.MCUVersion.deserialize(b"\x00\x04\x01")[0]
     assert mcu_version
     assert mcu_version.version_raw == 1
-    assert mcu_version.version == '0.0.1'
+    assert mcu_version.version == "0.0.1"
     mcu_version = TuyaMCUCluster.MCUVersion.deserialize(b"\x00\x05\xFF")[0]
     assert mcu_version
     assert mcu_version.version_raw == 255
-    assert mcu_version.version == '3.3.15'
+    assert mcu_version.version == "3.3.15"

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -22,6 +22,7 @@ from zhaquirks.tuya import (
 # New manufacturer attributes
 ATTR_MCU_VERSION = 0xEF00
 
+
 class TuyaDPType(t.enum8):
     """Tuya DataPoint Type."""
 

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -48,7 +48,7 @@ class TuyaMCUCluster(TuyaNewManufCluster):
     def get_dp_from_cluster(
         self, endpoint_id: int, attribute_name: str
     ) -> Optional[int]:
-        """Search for the DP in dp_to_attribute"""
+        """Search for the DP in dp_to_attribute."""
 
         for dp, dp_mapping in self.dp_to_attribute.items():
             if (attribute_name == dp_mapping.attribute_name) and (

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -184,7 +184,7 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
             self.debug("raw: %s", cmd_payload.data.raw)
             return cmd_payload
         else:
-            self.info(
+            self.warning(
                 "No cluster_dp found for %s, %s",
                 data.endpoint_id,
                 data.cluster_attr,
@@ -326,7 +326,6 @@ class SurfaceSwitchManufCluster(TuyaOnOffManufCluster):
                 TuyaMCUCluster.ep_attribute,
                 "power_on_state",
                 dp_type=TuyaDPType.ENUM,
-                # lambda x: PowerOnState(x),
             )
         }
     )
@@ -336,7 +335,6 @@ class SurfaceSwitchManufCluster(TuyaOnOffManufCluster):
                 TuyaMCUCluster.ep_attribute,
                 "backlight_mode",
                 dp_type=TuyaDPType.ENUM,
-                # lambda x: BackLight(x),
             ),
         }
     )

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -31,12 +31,16 @@ class TuyaDPType(t.enum8):
     BITMAP = 0x05, None
 
     def __new__(cls, value, ztype):
+        """Overload instance to store the ztype."""
+
         member = t.enum8.__new__(cls, value)
         member.ztype = ztype
         return member
 
     @classmethod
     def get_from_ztype(cls, ztype):
+        """Search for the TuyaDPType with a compatible ztype."""
+
         for dpt in TuyaDPType:
             if dpt.ztype and issubclass(ztype, dpt.ztype):
                 return dpt

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -1,5 +1,6 @@
 """Tuya MCU comunications."""
-from typing import Dict, Optional, Union
+import dataclasses
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import zigpy.types as t
 from zigpy.zcl import foundation
@@ -12,7 +13,6 @@ from zhaquirks.tuya import (
     TUYA_MCU_VERSION_RSP,
     TUYA_SET_DATA,
     Data,
-    DPToAttributeMapping,
     TuyaCommand,
     TuyaData,
     TuyaLocalCluster,
@@ -40,14 +40,39 @@ class TuyaDPType(t.enum8):
         member.ztype = ztype
         return member
 
-    @classmethod
-    def get_from_ztype(cls, ztype):
-        """Search for the TuyaDPType with a compatible ztype."""
 
-        for dpt in TuyaDPType:
-            if dpt.ztype and issubclass(ztype, dpt.ztype):
-                return dpt
-        return None
+@dataclasses.dataclass
+class DPToAttributeMapping:
+    """Container for datapoint to cluster attribute update mapping."""
+
+    ep_attribute: str
+    attribute_name: str
+    dp_type: TuyaDPType
+    converter: Optional[
+        Callable[
+            [
+                Any,
+            ],
+            Any,
+        ]
+    ] = None
+    dp_converter: Optional[
+        Callable[
+            [
+                Any,
+            ],
+            Any,
+        ]
+    ] = None
+    endpoint_id: Optional[int] = None
+
+
+class TuyaClusterData(t.Struct):
+    """Tuya cluster data."""
+
+    endpoint_id: int
+    cluster_attr: str
+    attr_value: int  # Maybe also others types?
 
 
 class TuyaAttributesCluster(TuyaLocalCluster):
@@ -72,26 +97,14 @@ class TuyaAttributesCluster(TuyaLocalCluster):
 
             self.debug("write_attributes --> record: %s", record)
 
-            cmd_payload = TuyaCommand()
-            cmd_payload.status = 0
-            cmd_payload.tsn = self.endpoint.device.application.get_sequence()
-
-            ztype = self.attributes[record.attrid][1]
-            dp_type = TuyaDPType.get_from_ztype(ztype)
-            val = Data.from_value(ztype(record.value.value))
-
-            cmd_payload.data = TuyaData()
-            cmd_payload.data.dp_type = dp_type
-            cmd_payload.data.function = 0
-            cmd_payload.data.raw = t.LVBytes.deserialize(val)[0]
-
-            self.debug("write_attributes --> payload: %s", cmd_payload)
-
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_attr=self.attributes[record.attrid][0],
+                attr_value=record.value.value,
+            )
             self.endpoint.device.command_bus.listener_event(
                 TUYA_MCU_COMMAND,
-                cmd_payload,
-                self.endpoint.endpoint_id,
-                self.attributes[record.attrid][0],
+                cluster_data,
             )
 
         return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
@@ -144,38 +157,72 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
         self.endpoint.device.command_bus = Bus()
         self.endpoint.device.command_bus.add_listener(self)
 
-    def tuya_mcu_command(
-        self, command: TuyaCommand, endpoint_id: int, attribute_name: str
-    ):
-        """Tuya MCU command listener. Only manufacturer endpoint must listen to MCU commands."""
+    def from_cluster_data(self, data: TuyaClusterData) -> Optional[TuyaCommand]:
+        """Convert from cluster data to a tuya data payload."""
 
-        self.debug("tuya_mcu_command: %s", command)
-        cluster_dp = self.get_dp_from_cluster(endpoint_id, attribute_name)
-        if cluster_dp:
-            command.dp = cluster_dp
-
-            self.create_catching_task(
-                self.command(TUYA_SET_DATA, command, expect_reply=True)
-            )
+        dp, mapping = self.get_dp_mapping(data.endpoint_id, data.cluster_attr)
+        self.debug("from_cluster_data: %s, %s", dp, mapping)
+        if dp:
+            cmd_payload = TuyaCommand()
+            cmd_payload.status = 0
+            cmd_payload.tsn = self.endpoint.device.application.get_sequence()
+            cmd_payload.dp = dp
+            cmd_payload.data = TuyaData()
+            datapoint_type = mapping.dp_type
+            cmd_payload.data.dp_type = datapoint_type
+            cmd_payload.data.function = 0
+            val = data.attr_value
+            if mapping.dp_converter:
+                val = mapping.dp_converter(val)
+                self.debug("converted: %s", val)
+            if datapoint_type.ztype:
+                val = datapoint_type.ztype(val)
+                self.debug("ztype: %s", val)
+            val = Data.from_value(val)
+            self.debug("from_value: %s", val)
+            cmd_payload.data.raw = t.LVBytes.deserialize(val)[0]
+            self.debug("raw: %s", cmd_payload.data.raw)
+            return cmd_payload
         else:
             self.info(
                 "No cluster_dp found for %s, %s",
-                endpoint_id,
-                attribute_name,
+                data.endpoint_id,
+                data.cluster_attr,
+            )
+            return None
+
+    def tuya_mcu_command(self, cluster_data: TuyaClusterData):
+        """Tuya MCU command listener. Only manufacturer endpoint must listen to MCU commands."""
+
+        self.debug(
+            "tuya_mcu_command: cluster_data=%s",
+            cluster_data,
+        )
+
+        tuya_command = self.from_cluster_data(cluster_data)
+        self.debug("tuya_command: %s", tuya_command)
+        if tuya_command:
+            self.create_catching_task(
+                self.command(TUYA_SET_DATA, tuya_command, expect_reply=True)
+            )
+        else:
+            self.warning(
+                "MCU command not call for data %s",
+                cluster_data,
             )
 
-    def get_dp_from_cluster(
+    def get_dp_mapping(
         self, endpoint_id: int, attribute_name: str
-    ) -> Optional[int]:
+    ) -> Optional[Tuple[int, DPToAttributeMapping]]:
         """Search for the DP in dp_to_attribute."""
 
         for dp, dp_mapping in self.dp_to_attribute.items():
             if (attribute_name == dp_mapping.attribute_name) and (
                 endpoint_id in [dp_mapping.endpoint_id, self.endpoint.endpoint_id]
             ):
-                self.debug("get_dp_from_cluster --> found DP: %s", dp)
-                return dp
-        return None
+                self.debug("get_dp_mapping --> found DP: %s", dp)
+                return [dp, dp_mapping]
+        return [None, None]
 
     def handle_mcu_version_response(self, payload: MCUVersion) -> foundation.Status:
         """Handle MCU version response."""
@@ -210,21 +257,14 @@ class TuyaOnOff(OnOff, TuyaLocalCluster):
 
         # (off, on)
         if command_id in (0x0000, 0x0001):
-            cmd_payload = TuyaCommand()
-            cmd_payload.status = 0
-            # cmd_payload.tsn = tsn if tsn else self.endpoint.device.application.get_sequence()
-            cmd_payload.tsn = 0
-            cmd_payload.data = TuyaData()
-            cmd_payload.data.dp_type = TuyaDPType.BOOL
-            cmd_payload.data.function = 0
-            val = Data.from_value(TuyaDPType.BOOL.ztype(command_id))
-            cmd_payload.data.raw = t.LVBytes.deserialize(val)[0]
-
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_attr="on_off",
+                attr_value=command_id,
+            )
             self.endpoint.device.command_bus.listener_event(
                 TUYA_MCU_COMMAND,
-                cmd_payload,
-                self.endpoint.endpoint_id,
-                "on_off",
+                cluster_data,
             )
             return foundation.Status.SUCCESS
 
@@ -239,20 +279,24 @@ class TuyaOnOffManufCluster(TuyaMCUCluster):
         1: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
+            dp_type=TuyaDPType.BOOL,
         ),
         2: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
+            dp_type=TuyaDPType.BOOL,
             endpoint_id=2,
         ),
         3: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
+            dp_type=TuyaDPType.BOOL,
             endpoint_id=3,
         ),
         4: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
+            dp_type=TuyaDPType.BOOL,
             endpoint_id=4,
         ),
     }
@@ -281,6 +325,7 @@ class SurfaceSwitchManufCluster(TuyaOnOffManufCluster):
             14: DPToAttributeMapping(
                 TuyaMCUCluster.ep_attribute,
                 "power_on_state",
+                dp_type=TuyaDPType.ENUM,
                 # lambda x: PowerOnState(x),
             )
         }
@@ -290,6 +335,7 @@ class SurfaceSwitchManufCluster(TuyaOnOffManufCluster):
             15: DPToAttributeMapping(
                 TuyaMCUCluster.ep_attribute,
                 "backlight_mode",
+                dp_type=TuyaDPType.ENUM,
                 # lambda x: BackLight(x),
             ),
         }
@@ -321,23 +367,14 @@ class TuyaLevelControl(LevelControl, TuyaLocalCluster):
         )
         # (move_to_level, move, move_to_level_with_on_off)
         if command_id in (0x0000, 0x0001, 0x0004):
-            cmd_payload = TuyaCommand()
-            cmd_payload.status = 0
-            # cmd_payload.tsn = tsn if tsn else self.endpoint.device.application.get_sequence()
-            cmd_payload.tsn = 0
-            cmd_payload.data = TuyaData()
-            cmd_payload.data.dp_type = TuyaDPType.VALUE
-            cmd_payload.data.function = 0
-
-            brightness = (args[0] * 1000) // 255
-            val = Data.from_value(TuyaDPType.VALUE.ztype(brightness))
-            cmd_payload.data.raw = t.LVBytes.deserialize(val)[0]
-
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_attr="current_level",
+                attr_value=args[0],
+            )
             self.endpoint.device.command_bus.listener_event(
                 TUYA_MCU_COMMAND,
-                cmd_payload,
-                self.endpoint.endpoint_id,
-                "current_level",
+                cluster_data,
             )
             return foundation.Status.SUCCESS
 
@@ -348,9 +385,9 @@ class TuyaLevelControl(LevelControl, TuyaLocalCluster):
 class TuyaInWallLevelControl(TuyaAttributesCluster, TuyaLevelControl):
     """Tuya Level cluster for inwall dimmable device."""
 
-    # Not sure if these are 'inwall' specific attributes
+    # Not sure if these are 'inwall' specific attributes or common to dimmers
     manufacturer_attributes = {
-        0xEF01: ("minimum_level", t.uint8_t),
+        0xEF01: ("minimum_level", t.uint32_t),
         0xEF02: ("bulb_type", t.enum8),
     }
 
@@ -362,41 +399,53 @@ class TuyaLevelControlManufCluster(TuyaMCUCluster):
         1: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
+            dp_type=TuyaDPType.BOOL,
         ),
         2: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "current_level",
-            lambda x: (x * 255) // 1000,
+            dp_type=TuyaDPType.VALUE,
+            converter=lambda x: (x * 255) // 1000,
+            dp_converter=lambda x: (x * 1000) // 255,
         ),
         3: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "minimum_level",
-            lambda x: (x * 255) // 1000,
+            dp_type=TuyaDPType.VALUE,
+            converter=lambda x: (x * 255) // 1000,
+            dp_converter=lambda x: (x * 1000) // 255,
         ),
         4: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "bulb_type",
+            dp_type=TuyaDPType.ENUM,
         ),
         7: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
+            dp_type=TuyaDPType.BOOL,
             endpoint_id=2,
         ),
         8: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "current_level",
-            lambda x: (x * 255) // 1000,
+            dp_type=TuyaDPType.VALUE,
+            converter=lambda x: (x * 255) // 1000,
+            dp_converter=lambda x: (x * 1000) // 255,
             endpoint_id=2,
         ),
         9: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "minimum_level",
-            lambda x: (x * 255) // 1000,
+            dp_type=TuyaDPType.VALUE,
+            converter=lambda x: (x * 255) // 1000,
+            dp_converter=lambda x: (x * 1000) // 255,
             endpoint_id=2,
         ),
         10: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "bulb_type",
+            dp_type=TuyaDPType.ENUM,
             endpoint_id=2,
         ),
     }

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -1,0 +1,253 @@
+"""Tuya MCU comunications."""
+import logging
+from typing import Dict, Optional, Union
+
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import LevelControl, OnOff
+
+from zhaquirks import Bus
+
+from zhaquirks.tuya import (
+    ATTR_ON_OFF,
+    DPToAttributeMapping,
+    TuyaCommand,
+    TuyaData,
+    TuyaDPType,
+    TuyaLocalCluster,
+    TuyaNewManufCluster,
+    TUYA_MCU_COMMAND,
+)
+
+
+class TuyaMCUCluster(TuyaNewManufCluster):
+    """Manufacturer specific cluster for sending Tuya MCU commands."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.command_bus = Bus()
+        self.endpoint.device.command_bus.add_listener(
+            self
+        )  # Cluster for endpoint: 1 (listen MCU commands)
+
+    def tuya_mcu_command(
+        self, command: TuyaCommand, endpoint_id: int, attribute_name: str
+    ):
+        """Tuya MCU command listener. Only endpoint:1 must listen to MCU commands."""
+
+        self.debug("tuya_mcu_command: %s", command)
+        cluster_dp = self.get_dp_from_cluster(endpoint_id, attribute_name)
+        if cluster_dp:
+            command.dp = cluster_dp
+
+            self.create_catching_task(
+                self.command(TUYA_SET_DATA, command, expect_reply=True)
+            )
+
+    def get_dp_from_cluster(self, endpoint_id: int, attribute_name: str) -> Optional[int]:
+        """Search for the DP in dp_to_attribute"""
+
+        for dp, dp_mapping in self.dp_to_attribute.items():
+            if (attribute_name == dp_mapping.attribute_name) and (
+                endpoint_id in [dp_mapping.endpoint_id, self.endpoint.endpoint_id]
+            ):
+                self.debug("get_dp_from_cluster --> found DP: %s", dp)
+                return dp
+        return None
+
+
+class TuyaAttributesCluster(TuyaMCUCluster, TuyaLocalCluster):
+    """Manufacturer specific cluster for Tuya converting attributes <-> commands."""
+
+    def read_attributes(
+        self, attributes, allow_cache=False, only_cache=False, manufacturer=None
+    ):
+        """Ignore remote reads as the "get_data" command doesn't seem to do anything."""
+
+        self.debug("read_attributes --> attrs: %s", attributes)
+        return super().read_attributes(
+            attributes, allow_cache=True, only_cache=True, manufacturer=manufacturer
+        )
+
+    async def write_attributes(self, attributes, manufacturer=None):
+        """Defer attributes writing to the set_data tuya command."""
+
+        records = self._write_attr_records(attributes)
+
+        for record in records:
+
+            self.debug("write_attributes --> record: %s", record)
+
+            cmd_payload = TuyaCommand()
+            cmd_payload.status = 0
+            cmd_payload.tsn = self.endpoint.device.application.get_sequence()
+            cmd_payload.data = TuyaData()
+            cmd_payload.data.dp_type = TuyaDPType.ENUM  ## TODO: get TuyaDPType from record.value.type
+            cmd_payload.data.function = 0
+            cmd_payload.data.raw = t.LVBytes.deserialize([1, record.value.value])[0]
+
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cmd_payload,
+                self.endpoint.endpoint_id,
+                self.attributes[record.attrid][0],  # get attribute_name from cluster attributes
+            )
+
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+
+
+class TuyaOnOff(OnOff, TuyaLocalCluster):
+    """Tuya MCU OnOff cluster."""
+
+    attributes = {
+        ATTR_ON_OFF: ("on_off", t.Bool),
+    }
+
+    async def command(
+        self,
+        command_id: Union[foundation.Command, int, t.uint8_t],
+        *args,
+        manufacturer: Optional[Union[int, t.uint16_t]] = None,
+        expect_reply: bool = True,
+        tsn: Optional[Union[int, t.uint8_t]] = None,
+    ):
+        """Override the default Cluster command."""
+
+        self.debug(
+            "Sending Tuya Cluster Command... Cluster Command is %x, Arguments are %s",
+            command_id,
+            args,
+        )
+
+        # (off, on)
+        if command_id in (0x0000, 0x0001):
+            cmd_payload = TuyaCommand()
+            cmd_payload.status = 0
+            # cmd_payload.tsn = tsn if tsn else self.endpoint.device.application.get_sequence()
+            cmd_payload.tsn = 0
+            cmd_payload.data = TuyaData()
+            cmd_payload.data.dp_type = TuyaDPType.BOOL
+            cmd_payload.data.function = 0
+            cmd_payload.data.raw = t.LVBytes.deserialize([1, command_id])[0]
+
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cmd_payload,
+                self.endpoint.endpoint_id,
+                "on_off",
+            )
+            return foundation.Status.SUCCESS
+
+        self.warning("ERROR: unsupported command_id: %s", command_id)
+        return foundation.Status.UNSUP_CLUSTER_COMMAND
+
+
+class TuyaOnOffManufCluster(TuyaMCUCluster):
+    """Tuya with On/Off data points."""
+
+    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+        1: DPToAttributeMapping(
+            TuyaOnOff.ep_attribute,
+            "on_off",
+        ),
+        2: DPToAttributeMapping(
+            TuyaOnOff.ep_attribute,
+            "on_off",
+            endpoint_id=2,
+        ),
+        3: DPToAttributeMapping(
+            TuyaOnOff.ep_attribute,
+            "on_off",
+            endpoint_id=3,
+        ),
+        4: DPToAttributeMapping(
+            TuyaOnOff.ep_attribute,
+            "on_off",
+            endpoint_id=4,
+        ),
+    }
+
+    data_point_handlers = {
+        1: "_dp_2_attr_update",
+        2: "_dp_2_attr_update",
+        3: "_dp_2_attr_update",
+        4: "_dp_2_attr_update",
+    }
+
+
+class TuyaLevelControl(LevelControl, TuyaLocalCluster):
+    """Tuya MCU Level cluster for dimmable device."""
+
+    attributes = {0x0000: ("current_level", t.uint8_t)}
+
+    async def command(
+        self,
+        command_id: Union[foundation.Command, int, t.uint8_t],
+        *args,
+        manufacturer: Optional[Union[int, t.uint16_t]] = None,
+        expect_reply: bool = True,
+        tsn: Optional[Union[int, t.uint8_t]] = None,
+    ):
+        """Override the default Cluster command."""
+        self.debug(
+            "Sending Tuya Cluster Command.. Cluster Command is %x, Arguments are %s",
+            command_id,
+            args,
+        )
+        # (move_to_level, move, move_to_level_with_on_off)
+        if command_id in (0x0000, 0x0001, 0x0004):
+            cmd_payload = TuyaCommand()
+            cmd_payload.status = 0
+            # cmd_payload.tsn = tsn if tsn else self.endpoint.device.application.get_sequence()
+            cmd_payload.tsn = 0
+            cmd_payload.data = TuyaData()
+            cmd_payload.data.dp_type = TuyaDPType.ENUM
+            cmd_payload.data.function = 0
+
+            brightness = (args[0] * 1000) // 255
+            val = Data.from_value(t.uint32_t(brightness))
+            cmd_payload.data.raw = t.LVBytes.deserialize(val)[0]
+
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cmd_payload,
+                self.endpoint.endpoint_id,
+                "current_level",
+            )
+            return foundation.Status.SUCCESS
+
+        self.warning("ERROR: unsupported command_id: %s", command_id)
+        return foundation.Status.UNSUP_CLUSTER_COMMAND
+
+
+class TuyaLevelControlManufCluster(TuyaMCUCluster):
+    """Tuya with Level Control data points."""
+
+    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+        1: DPToAttributeMapping(
+            TuyaOnOff.ep_attribute,
+            "on_off",
+        ),
+        2: DPToAttributeMapping(
+            TuyaLevelControl.ep_attribute,
+            "current_level",
+        ),
+        7: DPToAttributeMapping(
+            TuyaOnOff.ep_attribute,
+            "on_off",
+            endpoint_id=2,
+        ),
+        8: DPToAttributeMapping(
+            TuyaLevelControl.ep_attribute,
+            "current_level",
+            endpoint_id=2,
+        ),
+    }
+
+    data_point_handlers = {
+        1: "_dp_2_attr_update",
+        2: "_dp_2_attr_update",
+        7: "_dp_2_attr_update",
+        8: "_dp_2_attr_update",
+    }

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -1,5 +1,4 @@
 """Tuya MCU comunications."""
-import logging
 from typing import Dict, Optional, Union
 
 import zigpy.types as t
@@ -7,16 +6,17 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import LevelControl, OnOff
 
 from zhaquirks import Bus
-
 from zhaquirks.tuya import (
     ATTR_ON_OFF,
+    TUYA_MCU_COMMAND,
+    TUYA_SET_DATA,
+    Data,
     DPToAttributeMapping,
     TuyaCommand,
     TuyaData,
     TuyaDPType,
     TuyaLocalCluster,
     TuyaNewManufCluster,
-    TUYA_MCU_COMMAND,
 )
 
 
@@ -45,7 +45,9 @@ class TuyaMCUCluster(TuyaNewManufCluster):
                 self.command(TUYA_SET_DATA, command, expect_reply=True)
             )
 
-    def get_dp_from_cluster(self, endpoint_id: int, attribute_name: str) -> Optional[int]:
+    def get_dp_from_cluster(
+        self, endpoint_id: int, attribute_name: str
+    ) -> Optional[int]:
         """Search for the DP in dp_to_attribute"""
 
         for dp, dp_mapping in self.dp_to_attribute.items():
@@ -83,7 +85,8 @@ class TuyaAttributesCluster(TuyaMCUCluster, TuyaLocalCluster):
             cmd_payload.status = 0
             cmd_payload.tsn = self.endpoint.device.application.get_sequence()
             cmd_payload.data = TuyaData()
-            cmd_payload.data.dp_type = TuyaDPType.ENUM  ## TODO: get TuyaDPType from record.value.type
+            # TODO: get TuyaDPType from record.value.type
+            cmd_payload.data.dp_type = TuyaDPType.ENUM
             cmd_payload.data.function = 0
             cmd_payload.data.raw = t.LVBytes.deserialize([1, record.value.value])[0]
 
@@ -91,7 +94,7 @@ class TuyaAttributesCluster(TuyaMCUCluster, TuyaLocalCluster):
                 TUYA_MCU_COMMAND,
                 cmd_payload,
                 self.endpoint.endpoint_id,
-                self.attributes[record.attrid][0],  # get attribute_name from cluster attributes
+                self.attributes[record.attrid][0],
             )
 
         return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -75,7 +75,7 @@ class TuyaMCUCluster(TuyaNewManufCluster):
 
     manufacturer_attributes = {
         # MCU version
-        0xEF01: {"mcu_version", t.uint48_t},
+        0xEF00: ("mcu_version", t.uint48_t),
     }
 
     manufacturer_client_commands = (

--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -19,7 +19,7 @@ from zhaquirks.tuya import (
     TuyaOnOff,
 )
 from zhaquirks.tuya.mcu import (
-    TuyaLevelControl as TuyaLevelControlMCU,
+    TuyaInWallLevelControl,
     TuyaLevelControlManufCluster,
     TuyaOnOff as TuyaOnOffMCU,
 )
@@ -123,7 +123,7 @@ class TuyaDoubleSwitchDimmer(TuyaDimmerSwitch):
                     Scenes.cluster_id,
                     TuyaLevelControlManufCluster,
                     TuyaOnOffMCU,
-                    TuyaLevelControlMCU,
+                    TuyaInWallLevelControl,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
@@ -132,7 +132,7 @@ class TuyaDoubleSwitchDimmer(TuyaDimmerSwitch):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
                     TuyaOnOffMCU,
-                    TuyaLevelControlMCU,
+                    TuyaInWallLevelControl,
                 ],
                 OUTPUT_CLUSTERS: [],
             },

--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -18,6 +18,11 @@ from zhaquirks.tuya import (
     TuyaManufCluster,
     TuyaOnOff,
 )
+from zhaquirks.tuya.mcu import (
+    TuyaLevelControl as TuyaLevelControlMCU,
+    TuyaLevelControlManufCluster,
+    TuyaOnOff as TuyaOnOffMCU,
+)
 
 
 class TuyaSingleSwitchDimmer(TuyaDimmerSwitch):
@@ -68,5 +73,68 @@ class TuyaSingleSwitchDimmer(TuyaDimmerSwitch):
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             }
+        }
+    }
+
+
+class TuyaDoubleSwitchDimmer(TuyaDimmerSwitch):
+    """Tuya double channel dimmer device."""
+
+    signature = {
+        # "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0,
+        #                     user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>,
+        #                     mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>,
+        #                     manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264,
+        #                     maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True,
+        #                     *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True,
+        #                     *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)
+        #   "endpoints": {
+        #       "1": { "profile_id": 260, "device_type": "0x0051", "in_clusters": [ "0x0000", "0x0004", "0x0005", "0xef00" ], "out_clusters": [ "0x000a", "0x0019" ] }
+        #   },
+        #  "manufacturer": "_TZE200_e3oitdyu",
+        #  "model": "TS0601",
+        #  "class": "zigpy.device.Device"
+        #  }
+        MODELS_INFO: [
+            ("_TZE200_e3oitdyu", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaLevelControlManufCluster,
+                    TuyaOnOffMCU,
+                    TuyaLevelControlMCU,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOffMCU,
+                    TuyaLevelControlMCU,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
         }
     }


### PR DESCRIPTION
Here I come with another approach for (all?) Tuya clusters that send commands through the MCU.
This approach tries to extend the `TuyaNewManufCluster` by also implementing Device --> MCU comunication, that is, sending commands to the DP.

I have taken the opportunity to segregate the MCU related implementations to a new folder. The idea would be for the rest of the classes to be migrated.

My starting point has been issue #1233 which allows me to release the new implementation without the risk of affecting operational devices.

I will try to explain the new implementation and the pros and cons that I have found.
- segregated classes that should help maintain functionality
- take advantage of the power of the `TuyaNewManufCluster` class. Its declarative model may not be intuitive but I think it has potential to be leveraged in more implementations. All the credit to its author (who is not me)
- maintains the use of a Bus to communicate `TUYA_MCU_COMMAND` events to the Tuya cluster. Its use has been discussed in #1153 but I haven't found a better solution
- new approaches to Tuya clusters (explained below)
- support for writing attributes (not implemented yet). It will allow modifying device attributes such as the `backlight_mode` or the `power_on_state`
- `TUYA_MCU_VERSION_RSP` message supported. New `mcu_version` attribute added to the `TuyaMCUCluster`. Reported version can be read in raw and `x.y.z` format.



The new approach to Tuya clusters makes use of the `TuyaCommad` classes instead of the `TuyaManufCluster.Command` classes. For my use cases they have been comfortable for me to transform the values.
Now the all clusters send a `TuyaClusterData` to the Bus (and not values). Each cluster knows how manage its values (is it a Bool, a String or an Enum?) And the `TuyaMCUCluster` will be only in charge of communicating with the MCU.


Some of the improvement points:
* [ ] `get_dp_from_cluster` method. Performs a reverse search to find the appropriate DP. Not the most elegant one.
* [x] ~~`cmd_payload = TuyaCommand()` flow. Static and repetitive. I thought I saw somewhere where it initializes on a line or two, but I'm not sure. Candidate to take it out to a helper class builder from the `TuyaDPType` and the value.~~
* [ ] response to sending commands and writing attributes is now decoupled from client (due to the use of the `command_bus`). This can mask errors and problems for the lack of response.
* [ ] Cluster attributes have been overwritten to leave only the ones that are actually handled by the MCU. It's probably wise to do the same for cluster commands.


The code has been tested locally with a `TuyaDoubleSwitch` device, but the device has not been included yet due to the risk of affecting multiple devices.
The included device implementation `TuyaDoubleSwitchDimmer` I have NOT been able to test it as I do not have a device, so the code will need to be validated before doing the merge.

(Fixes: #1033)