### PR TITLE
adding ZONNSMART_TEMP_CALIBRATION_ATTR = 0x021b

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -826,7 +826,7 @@ ZONNSMART_CHILD_LOCK_ATTR = 0x0128  # [0] unlocked [1] child-locked
 ZONNSMART_WINDOW_DETECT_ATTR = 0x0108  # [0] inactive [1] active
 ZONNSMART_TARGET_TEMP_ATTR = 0x0210  # [0,0,0,210] target room temp (decidegree)
 ZONNSMART_TEMPERATURE_ATTR = 0x0218  # [0,0,0,200] current room temp (decidegree)
-ZONNSMART_TEMP_CALIBRATION_ATTR = 0x021b  # [0,0,0,0] calibration /10
+ZONNSMART_TEMP_CALIBRATION_ATTR = 0x021B  # [0,0,0,0] calibration /10
 ZONNSMART_BATTERY_ATTR = 0x0223  # [0,0,0,98] battery charge
 ZONNSMART_MODE_ATTR = (
     0x0402  # [0] Scheduled/auto [1] manual [2] Holiday [3] HolidayReady
@@ -856,7 +856,10 @@ class ZONNSMARTManufCluster(TuyaManufClusterAttributes):
 
     DIRECT_MAPPED_ATTRS = {
         ZONNSMART_TEMPERATURE_ATTR: ("local_temp", lambda value: value * 10),
-        ZONNSMART_TEMP_CALIBRATION_ATTR: ("local_temperature_calibration", lambda value: value * 10),
+        ZONNSMART_TEMP_CALIBRATION_ATTR: (
+            "local_temperature_calibration",
+            lambda value: value * 10,
+        ),
         ZONNSMART_TARGET_TEMP_ATTR: (
             "occupied_heating_setpoint",
             lambda value: value * 10,

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -826,6 +826,7 @@ ZONNSMART_CHILD_LOCK_ATTR = 0x0128  # [0] unlocked [1] child-locked
 ZONNSMART_WINDOW_DETECT_ATTR = 0x0108  # [0] inactive [1] active
 ZONNSMART_TARGET_TEMP_ATTR = 0x0210  # [0,0,0,210] target room temp (decidegree)
 ZONNSMART_TEMPERATURE_ATTR = 0x0218  # [0,0,0,200] current room temp (decidegree)
+ZONNSMART_TEMP_CALIBRATION_ATTR = 0x021b  # [0,0,0,0] calibration /10
 ZONNSMART_BATTERY_ATTR = 0x0223  # [0,0,0,98] battery charge
 ZONNSMART_MODE_ATTR = (
     0x0402  # [0] Scheduled/auto [1] manual [2] Holiday [3] HolidayReady
@@ -845,6 +846,7 @@ class ZONNSMARTManufCluster(TuyaManufClusterAttributes):
         ZONNSMART_WINDOW_DETECT_ATTR: ("window_detection", t.uint8_t),
         ZONNSMART_TARGET_TEMP_ATTR: ("target_temperature", t.uint32_t),
         ZONNSMART_TEMPERATURE_ATTR: ("temperature", t.uint32_t),
+        ZONNSMART_TEMP_CALIBRATION_ATTR: ("temperature_calibration", t.uint32_t),
         ZONNSMART_BATTERY_ATTR: ("battery", t.uint32_t),
         ZONNSMART_MODE_ATTR: ("mode", t.uint8_t),
         ZONNSMART_BOOST_TIME_ATTR: ("boost_duration_seconds", t.uint32_t),
@@ -854,6 +856,7 @@ class ZONNSMARTManufCluster(TuyaManufClusterAttributes):
 
     DIRECT_MAPPED_ATTRS = {
         ZONNSMART_TEMPERATURE_ATTR: ("local_temp", lambda value: value * 10),
+        ZONNSMART_TEMP_CALIBRATION_ATTR: ("local_temperature_calibration", lambda value: value * 10),
         ZONNSMART_TARGET_TEMP_ATTR: (
             "occupied_heating_setpoint",
             lambda value: value * 10,


### PR DESCRIPTION
This handle is temperature calibration sensor. 

TRVs like mine (_TZE200_husqqvux) and some others does not report correct temperature unless calibration sensor is changed.

Check discussion here:  https://community.home-assistant.io/t/moes-tv01-trv-temp-sensor-issues/356903

To update internal temperature sensor just send 0 (calibration to 0.0° on TRV display) to this handle and TRV will report correct temperature.