### PR TITLE
Fixed small typo: contact/motion sensor mix-up in comment

### DIFF
--- a/zhaquirks/xiaomi/aqara/motion_agl02.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl02.py
@@ -38,7 +38,7 @@ class XiaomiManufacturerCluster(XiaomiAqaraE1Cluster):
 
 
 class MotionT1(XiaomiCustomDevice):
-    """Xiaomi contact sensor device."""
+    """Xiaomi motion sensor device."""
 
     def __init__(self, *args, **kwargs):
         """Init."""


### PR DESCRIPTION
I was looking through https://github.com/zigpy/zha-device-handlers/pull/1151 to figure out what exactly Xiaomi did this time and just noticed a very small typo in a comment.