### PR TITLE
Add Siglis zigfred uno smart switch/relay/dimmer combination

### DIFF
--- a/zhaquirks/siglis/__init__.py
+++ b/zhaquirks/siglis/__init__.py
@@ -1,0 +1,1 @@
+"""Siglis device handlers."""

--- a/zhaquirks/siglis/zigfred.py
+++ b/zhaquirks/siglis/zigfred.py
@@ -124,7 +124,6 @@ class ZigfredUno(CustomDevice):
     }
 
     replacement = {
-        MODELS_INFO: [("Siglis", "zigfred uno")],
         ENDPOINTS: {
             5: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/siglis/zigfred.py
+++ b/zhaquirks/siglis/zigfred.py
@@ -1,0 +1,174 @@
+"""zigfred device handler."""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Scenes,
+)
+from zigpy.zcl.clusters.lighting import Color
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+# Siglis specific clusters
+ZIGFRED_CLUSTER_0345_ID = 0x0345
+
+# Siglis Cluster 0x0345 Implementation
+class Zigfred0345Cluster(CustomCluster):
+    """Siglis manufacturer specific cluster 837."""
+
+    name = "Siglis Manufacturer Specific"
+    cluster_id = ZIGFRED_CLUSTER_0345_ID
+
+
+class ZigfredUnoColorCluster(CustomCluster, Color):
+    """zigfred uno Color custom cluster."""
+
+    # Set correct capabilities to ct, xy, hs
+    # zigfred uno does not correctly report this attribute (comes back as None in Home Assistant)
+    _CONSTANT_ATTRIBUTES = {0x400A: 0b01000}
+
+
+class ZigfredUno(CustomDevice):
+    """zigfred uno device handler."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        MODELS_INFO: [("Siglis", "zigfred uno")],
+        ENDPOINTS: {
+            5: {
+                # Front Module LED
+                # SizePrefixedSimpleDescriptor(endpoint=5,
+                # profile=260, device_type=258,
+                # device_version=1,
+                # input_clusters=[0, 3, 4, 5, 6, 8, 768, 837],
+                # output_clusters=[])
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    Zigfred0345Cluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            6: {
+                # Relay
+                # SizePrefixedSimpleDescriptor(endpoint=6,
+                # profile=260, device_type=256,
+                # device_version=1,
+                # input_clusters=[0, 3, 4, 5, 6],
+                # output_clusters=[])
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            7: {
+                # Relay
+                # SizePrefixedSimpleDescriptor(endpoint=7,
+                # profile=260, device_type=257,
+                # device_version=1,
+                # input_clusters=[0, 3, 5, 4, 6, 8],
+                # output_clusters=[])
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                # SizePrefixedSimpleDescriptor(endpoint=242,
+                # profile=41440, device_type=97,
+                # device_version=0,
+                # input_clusters=[],
+                # output_clusters=[33])
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        MODELS_INFO: [("Siglis", "zigfred uno")],
+        ENDPOINTS: {
+            5: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    ZigfredUnoColorCluster,
+                    Zigfred0345Cluster,
+                ],
+                OUTPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+            6: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+            7: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }

--- a/zhaquirks/siglis/zigfred.py
+++ b/zhaquirks/siglis/zigfred.py
@@ -25,6 +25,7 @@ from zhaquirks.const import (
 # Siglis specific clusters
 ZIGFRED_CLUSTER_0345_ID = 0x0345
 
+
 # Siglis Cluster 0x0345 Implementation
 class Zigfred0345Cluster(CustomCluster):
     """Siglis manufacturer specific cluster 837."""


### PR DESCRIPTION
This adds Siglis zigfred uno smart switch/relay/dimmer combination.

Working out of the box:

- Relay control
- Dimmer control including brightness
- Front LED brightness and on/off

Requiring custom device handler:
- Front LED color: Color capability attribute currently return no bit set, meaning no color support. Overriding by setting ColorXY attribute makes selection of the color work, however it seems that reporting isn't working (color changes on the LED, but not in home assistant)
- No switch support yet

I do get frames from sourceEndpoint 5 (which has no output cluster though?) cluster 6 (On/Off). See the log in detail:

<details>

```
2022-01-17 10:09:50 DEBUG (MainThread) [bellows.ezsp.protocol] Application frame 98 (incomingSenderEui64Handler) received: b'bbcf88e61e36cef4'
2022-01-17 10:09:50 DEBUG (MainThread) [bellows.zigbee.application] Received incomingSenderEui64Handler frame with [f4:ce:36:1e:e6:88:cf:bb]
2022-01-17 10:09:50 DEBUG (MainThread) [bellows.ezsp.protocol] Application frame 69 (incomingMessageHandler) received: b'00040106000501000d0000df80bceeb3ffff03114200'
2022-01-17 10:09:50 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=6, sourceEndpoint=5, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_DESTINATION_EUI64|APS_OPTION_SOURCE_EUI64|APS_OPTION_ENABLE_ROUTE_DISCOVERY: 3328>, groupId=0, sequence=223), 128, -68, 0xb3ee, 255, 255, b'\x11B\x00']
2022-01-17 10:09:50 DEBUG (MainThread) [zigpy.zcl] [0xb3ee:5:0x0006] ZCL deserialize: <ZCLHeader frame_control=<FrameControl frame_type=CLUSTER_COMMAND manufacturer_specific=False is_reply=False disable_default_response=True> manufacturer=None tsn=66 command_id=0>
2022-01-17 10:09:50 DEBUG (MainThread) [zigpy.zcl] [0xb3ee:5:0x0006] ZCL request 0x0000: []
2022-01-17 10:09:50 DEBUG (MainThread) [zigpy.zcl] [0xb3ee:5:0x0006] No handler for cluster command 0
2022-01-17 10:09:50 DEBUG (MainThread) [homeassistant.components.zha.core.channels.base] [0xB3EE:5:0x0006]: received 'off' command with [] args on cluster_id '6' tsn '66'
2022-01-17 10:09:50 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=binary_sensor.siglis_zigfred_uno_bbcf88e6_on_off, old_state=<state binary_sensor.siglis_zigfred_uno_bbcf88e6_on_off=on; device_class=opening, friendly_name=Siglis zigfred uno bbcf88e6 on_off @ 2022-01-17T10:07:33.098772+00:00>, new_state=<state binary_sensor.siglis_zigfred_uno_bbcf88e6_on_off=off; device_class=opening, friendly_name=Siglis zigfred uno bbcf88e6 on_off @ 2022-01-17T10:09:50.303262+00:00>>
2022-01-17 10:09:50 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=light.siglis_zigfred_uno_bbcf88e6_level_light_color_on_off, old_state=<state light.siglis_zigfred_uno_bbcf88e6_level_light_color_on_off=on; supported_color_modes=['hs'], color_mode=hs, brightness=217, hs_color=(0.0, 100.0), rgb_color=(255, 0, 0), xy_color=(0.701, 0.299), off_brightness=None, friendly_name=Siglis zigfred uno bbcf88e6 level, light_color, on_off, supported_features=57 @ 2022-01-17T10:07:33.099024+00:00>, new_state=<state light.siglis_zigfred_uno_bbcf88e6_level_light_color_on_off=off; supported_color_modes=['hs'], off_brightness=None, friendly_name=Siglis zigfred uno bbcf88e6 level, light_color, on_off, supported_features=57 @ 2022-01-17T10:09:50.303388+00:00>>
2022-01-17 10:09:50 DEBUG (MainThread) [bellows.ezsp.protocol] Application frame 98 (incomingSenderEui64Handler) received: b'bbcf88e61e36cef4'
2022-01-17 10:09:50 DEBUG (MainThread) [bellows.zigbee.application] Received incomingSenderEui64Handler frame with [f4:ce:36:1e:e6:88:cf:bb]
2022-01-17 10:09:50 DEBUG (MainThread) [bellows.ezsp.protocol] Application frame 69 (incomingMessageHandler) received: b'00040106000501000d0000e0acc7eeb3ffff03114401'
2022-01-17 10:09:50 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=6, sourceEndpoint=5, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_DESTINATION_EUI64|APS_OPTION_SOURCE_EUI64|APS_OPTION_ENABLE_ROUTE_DISCOVERY: 3328>, groupId=0, sequence=224), 172, -57, 0xb3ee, 255, 255, b'\x11D\x01']
2022-01-17 10:09:50 DEBUG (MainThread) [zigpy.zcl] [0xb3ee:5:0x0006] ZCL deserialize: <ZCLHeader frame_control=<FrameControl frame_type=CLUSTER_COMMAND manufacturer_specific=False is_reply=False disable_default_response=True> manufacturer=None tsn=68 command_id=1>
2022-01-17 10:09:50 DEBUG (MainThread) [zigpy.zcl] [0xb3ee:5:0x0006] ZCL request 0x0001: []
2022-01-17 10:09:50 DEBUG (MainThread) [zigpy.zcl] [0xb3ee:5:0x0006] No handler for cluster command 1
2022-01-17 10:09:50 DEBUG (MainThread) [homeassistant.components.zha.core.channels.base] [0xB3EE:5:0x0006]: received 'on' command with [] args on cluster_id '6' tsn '68'
2022-01-17 10:09:50 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=binary_sensor.siglis_zigfred_uno_bbcf88e6_on_off, old_state=<state binary_sensor.siglis_zigfred_uno_bbcf88e6_on_off=off; device_class=opening, friendly_name=Siglis zigfred uno bbcf88e6 on_off @ 2022-01-17T10:09:50.303262+00:00>, new_state=<state binary_sensor.siglis_zigfred_uno_bbcf88e6_on_off=on; device_class=opening, friendly_name=Siglis zigfred uno bbcf88e6 on_off @ 2022-01-17T10:09:50.879962+00:00>>
2022-01-17 10:09:50 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=light.siglis_zigfred_uno_bbcf88e6_level_light_color_on_off, old_state=<state light.siglis_zigfred_uno_bbcf88e6_level_light_color_on_off=off; supported_color_modes=['hs'], off_brightness=None, friendly_name=Siglis zigfred uno bbcf88e6 level, light_color, on_off, supported_features=57 @ 2022-01-17T10:09:50.303388+00:00>, new_state=<state light.siglis_zigfred_uno_bbcf88e6_level_light_color_on_off=on; supported_color_modes=['hs'], color_mode=hs, brightness=217, hs_color=(0.0, 100.0), rgb_color=(255, 0, 0), xy_color=(0.701, 0.299), off_brightness=None, friendly_name=Siglis zigfred uno bbcf88e6 level, light_color, on_off, supported_features=57 @ 2022-01-17T10:09:50.880207+00:00>>
2022-01-17 10:09:51 DEBUG (MainThread) [bellows.ezsp.protocol] Application frame 98 (incomingSenderEui64Handler) received: b'bbcf88e61e36cef4'
2022-01-17 10:09:51 DEBUG (MainThread) [bellows.zigbee.application] Received incomingSenderEui64Handler frame with [f4:ce:36:1e:e6:88:cf:bb]
2022-01-17 10:09:51 DEBUG (MainThread) [bellows.ezsp.protocol] Application frame 69 (incomingMessageHandler) received: b'00040106000501000d0000e188beeeb3ffff03114500'
2022-01-17 10:09:51 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=6, sourceEndpoint=5, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_DESTINATION_EUI64|APS_OPTION_SOURCE_EUI64|APS_OPTION_ENABLE_ROUTE_DISCOVERY: 3328>, groupId=0, sequence=225), 136, -66, 0xb3ee, 255, 255, b'\x11E\x00']
2022-01-17 10:09:51 DEBUG (MainThread) [zigpy.zcl] [0xb3ee:5:0x0006] ZCL deserialize: <ZCLHeader frame_control=<FrameControl frame_type=CLUSTER_COMMAND manufacturer_specific=False is_reply=False disable_default_response=True> manufacturer=None tsn=69 command_id=0>
2022-01-17 10:09:51 DEBUG (MainThread) [zigpy.zcl] [0xb3ee:5:0x0006] ZCL request 0x0000: []
2022-01-17 10:09:51 DEBUG (MainThread) [zigpy.zcl] [0xb3ee:5:0x0006] No handler for cluster command 0
```

</details>


Support has been added to Zigbee2MQTT just recently, see [devices/siglis.js](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/devices/siglis.js).

Device descriptor as seen by ZHA (with quirk applied):

```json
{
  "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4764, maximum_buffer_size=108, maximum_incoming_transfer_size=1621, server_mask=11264, maximum_outgoing_transfer_size=1621, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
  "endpoints": {
    "5": {
      "profile_id": 260,
      "device_type": "0x0102",
      "in_clusters": [
        "0x0000",
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006",
        "0x0008",
        "0x0300",
        "0x0345"
      ],
      "out_clusters": [
        "0x0006"
      ]
    },
    "6": {
      "profile_id": 260,
      "device_type": "0x0100",
      "in_clusters": [
        "0x0000",
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006"
      ],
      "out_clusters": []
    },
    "7": {
      "profile_id": 260,
      "device_type": "0x0101",
      "in_clusters": [
        "0x0000",
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006",
        "0x0008"
      ],
      "out_clusters": []
    },
    "242": {
      "profile_id": 41440,
      "device_type": "0x0061",
      "in_clusters": [],
      "out_clusters": [
        "0x0021"
      ]
    }
  },
  "manufacturer": "Siglis",
  "model": "zigfred uno",
  "class": "zhaquirks.siglis.zigfred.ZigfredUno"
}
```