### PR TITLE
Add some ts0601_motion devices (with Tuya MCU Cluster approach)

### DIFF
--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -89,6 +89,7 @@ class NeoMotionManufCluster(TuyaNewManufCluster):
     manufacturer_attributes = {
         0xEF01: ("battery_level", NeoBatteryLevel),  # ramdom attribute ID
         0x0004: ("tamper", t.uint8_t),  # same ID as IasZone.ZoneStatus.Tamper
+        0xEF0D: ("dp_113", t.enum8),  # ramdom attribute ID
     }
 
     dp_to_attribute: Dict[int, DPToAttributeMapping] = {
@@ -108,11 +109,16 @@ class NeoMotionManufCluster(TuyaNewManufCluster):
         104: DPToAttributeMapping(
             TuyaTemperatureMeasurement.ep_attribute,
             "measured_value",
-            lambda x: x / 10,
+            lambda x: x * 10,
         ),
         105: DPToAttributeMapping(
             TuyaRelativeHumidity.ep_attribute,
             "measured_value",
+            lambda x: x * 100,
+        ),
+        113: DPToAttributeMapping(
+            TuyaNewManufCluster.ep_attribute,
+            "dp_113",
         ),
     }
 
@@ -122,6 +128,7 @@ class NeoMotionManufCluster(TuyaNewManufCluster):
         103: "_dp_2_attr_update",
         104: "_dp_2_attr_update",
         105: "_dp_2_attr_update",
+        113: "_dp_2_attr_update",
     }
 
 

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -44,28 +44,31 @@ ZONE_TYPE = 0x0001
 
 
 class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
-    """Tuya occupancy measurement."""
+    """Tuya local OccupancySensing cluster."""
 
     pass
 
 
 class TuyaAnalogInput(AnalogInput, TuyaLocalCluster):
-    """Tuya AnalogInput measurement."""
+    """Tuya local AnalogInput cluster."""
 
     pass
 
 
 class TuyaIlluminanceMeasurement(IlluminanceMeasurement, TuyaLocalCluster):
+    """Tuya local IlluminanceMeasurement cluster."""
 
     pass
 
 
 class TuyaTemperatureMeasurement(TemperatureMeasurement, TuyaLocalCluster):
+    """Tuya local TemperatureMeasurement cluster."""
 
     pass
 
 
 class TuyaRelativeHumidity(RelativeHumidity, TuyaLocalCluster):
+    """Tuya local RelativeHumidity cluster."""
 
     pass
 

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -41,6 +41,7 @@ from zhaquirks.tuya import (
     TuyaManufCluster,
     TuyaNewManufCluster,
 )
+from zhaquirks.tuya.mcu import TuyaMCUCluster
 
 ZONE_TYPE = 0x0001
 
@@ -121,11 +122,11 @@ class NeoMotionManufCluster(TuyaNewManufCluster):
     }
 
 
-class MmwRadarManufCluster(TuyaNewManufCluster):
+class MmwRadarManufCluster(TuyaMCUCluster):
     """Neo manufacturer cluster."""
 
     # # Possible DPs and values
-    # DP=1 presence_state: presence
+    # presence_state: presence
     # target distance: 1.61m
     # illuminance: 250lux
     # sensitivity: 9
@@ -137,8 +138,6 @@ class MmwRadarManufCluster(TuyaNewManufCluster):
     # presence_brightness: no control
     # no_one_brightness: no control
     # current_brightness: off
-
-    # It may be necessary to implement multiple endpoints to host all the clusters
 
     manufacturer_attributes = {
         # ramdom attribute IDs
@@ -161,19 +160,19 @@ class MmwRadarManufCluster(TuyaNewManufCluster):
             "occupancy",
         ),
         2: DPToAttributeMapping(
-            TuyaNewManufCluster.ep_attribute,
+            TuyaMCUCluster.ep_attribute,
             "dp_2",
         ),
         3: DPToAttributeMapping(
-            TuyaNewManufCluster.ep_attribute,
+            TuyaMCUCluster.ep_attribute,
             "dp_3",
         ),
         4: DPToAttributeMapping(
-            TuyaNewManufCluster.ep_attribute,
+            TuyaMCUCluster.ep_attribute,
             "dp_4",
         ),
         6: DPToAttributeMapping(
-            TuyaNewManufCluster.ep_attribute,
+            TuyaMCUCluster.ep_attribute,
             "dp_6",
         ),
         9: DPToAttributeMapping(
@@ -182,15 +181,15 @@ class MmwRadarManufCluster(TuyaNewManufCluster):
             lambda x: x / 100,
         ),
         101: DPToAttributeMapping(
-            TuyaNewManufCluster.ep_attribute,
+            TuyaMCUCluster.ep_attribute,
             "dp_101",
         ),
         102: DPToAttributeMapping(
-            TuyaNewManufCluster.ep_attribute,
+            TuyaMCUCluster.ep_attribute,
             "dp_102",
         ),
         103: DPToAttributeMapping(
-            TuyaNewManufCluster.ep_attribute,
+            TuyaMCUCluster.ep_attribute,
             "dp_103",
         ),
         104: DPToAttributeMapping(
@@ -199,19 +198,19 @@ class MmwRadarManufCluster(TuyaNewManufCluster):
             lambda x: 10000 * math.log10(x) + 1,
         ),
         105: DPToAttributeMapping(
-            TuyaNewManufCluster.ep_attribute,
+            TuyaMCUCluster.ep_attribute,
             "dp_105",
         ),
         106: DPToAttributeMapping(
-            TuyaNewManufCluster.ep_attribute,
+            TuyaMCUCluster.ep_attribute,
             "dp_106",
         ),
         107: DPToAttributeMapping(
-            TuyaNewManufCluster.ep_attribute,
+            TuyaMCUCluster.ep_attribute,
             "dp_107",
         ),
         108: DPToAttributeMapping(
-            TuyaNewManufCluster.ep_attribute,
+            TuyaMCUCluster.ep_attribute,
             "dp_108",
         ),
     }

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -73,15 +73,22 @@ class TuyaRelativeHumidity(RelativeHumidity, TuyaLocalCluster):
     pass
 
 
+class NeoBatteryLevel(t.enum8):
+    """NEO battery level enum."""
+
+    BATTERY_FULL = 0x00
+    BATTERY_HIGH = 0x01
+    BATTERY_MEDIUM = 0x02
+    BATTERY_LOW = 0x03
+    USB_POWER = 0x04
+
+
 class NeoMotionManufCluster(TuyaNewManufCluster):
     """Tuya with Air quality data points."""
 
     manufacturer_attributes = {
-        0xEF01: (
-            "battery_level",
-            t.uint32_t,
-        ),  # ¿possible values= 0: full, 1: high, 2: med, 3: low, 4: usb?
-        0x0004: ("tamper", t.enum8),  # same ID as IasZone.ZoneStatus.Tamper
+        0xEF01: ("battery_level", NeoBatteryLevel),  # ramdom attribute ID
+        0x0004: ("tamper", t.uint8_t),  # same ID as IasZone.ZoneStatus.Tamper
     }
 
     dp_to_attribute: Dict[int, DPToAttributeMapping] = {


### PR DESCRIPTION
This PR will add support for some `ts0601_motion` devices.

The new devices will follow the new 'Tuya MCU Cluster' approach to update device attributes.

Fixes: #1236
Reported motion sensor 'NAS-PD07' manufactured by NEO.
Most of the code came from 'herdsman-converters'
Those DPs that have been possible are reported as a new cluster.
Those that I have not found a match for are reported as attributes of the MCU cluster.

Not sure about possible `tamper` values. Probably there are diferent values >0 with other meanings.

Fixes: #1312
Unknown sensor, from unknown manufacturer.
The functionality of most DPs is unknown. They are probably used to configure device settings.
The known DPs (`occupancy`, `illuminance`, `target_distance`) have been implemented according to the information provided by the manufacturer.
