### PR TITLE
Tuya Air quality: ambiguous models info

### DIFF
--- a/zhaquirks/tuya/air/ts0601_air_quality.py
+++ b/zhaquirks/tuya/air/ts0601_air_quality.py
@@ -33,7 +33,6 @@ class TuyaCO2Sensor(CustomDevice):
         # output_clusters=[25, 10])
         MODELS_INFO: [
             ("_TZE200_8ygsuhe1", "TS0601"),
-            ("_TZE200_yvx5lh6k", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Resolves an ambiguity within Tuya Air Quality quirks when more > 1 class support the device TS0601/_TZE200_yvx5lh6k