### PR TITLE
Adding one more TS0044 version

### DIFF
--- a/zhaquirks/tuya/ts0044.py
+++ b/zhaquirks/tuya/ts0044.py
@@ -349,7 +349,7 @@ class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
                 INPUT_CLUSTERS: [
                     PowerConfiguration.cluster_id,
                     OnOff.cluster_id,
-                    0xE000,  # Unknown
+                    TuyaZBE000Cluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -359,7 +359,7 @@ class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
                 INPUT_CLUSTERS: [
                     PowerConfiguration.cluster_id,
                     OnOff.cluster_id,
-                    0xE000,  # Unknown
+                    TuyaZBE000Cluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -369,7 +369,7 @@ class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
                 INPUT_CLUSTERS: [
                     PowerConfiguration.cluster_id,
                     OnOff.cluster_id,
-                    0xE000,  # Unknown
+                    TuyaZBE000Cluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -394,19 +394,19 @@ class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster],
+                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster, TuyaZBE000Cluster],
             },
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster],
+                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster, TuyaZBE000Cluster],
             },
             4: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster],
+                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster, TuyaZBE000Cluster],
             },
         },
     }

--- a/zhaquirks/tuya/ts0044.py
+++ b/zhaquirks/tuya/ts0044.py
@@ -322,8 +322,8 @@ class TuyaSmartRemote0044TOPlusA(CustomDevice, Tuya4ButtonTriggers):
         },
     }
 
-    
-    class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
+
+class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
     """Tuya 4-button remote device with time on out cluster."""
 
     signature = {

--- a/zhaquirks/tuya/ts0044.py
+++ b/zhaquirks/tuya/ts0044.py
@@ -229,7 +229,7 @@ class TuyaSmartRemote0044TO(CustomDevice, Tuya4ButtonTriggers):
     }
 
 
-class TuyaSmartRemote0044TOPlus(CustomDevice, Tuya4ButtonTriggers):
+class TuyaSmartRemote0044TOPlusA(CustomDevice, Tuya4ButtonTriggers):
     """Tuya 4-button remote device with time on out cluster."""
 
     signature = {
@@ -318,6 +318,91 @@ class TuyaSmartRemote0044TOPlus(CustomDevice, Tuya4ButtonTriggers):
                     TuyaSmartRemoteOnOffCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    
+    class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
+    """Tuya 4-button remote device with time on out cluster."""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0, device_version=1, input_clusters=[0, 1, 6,], output_clusters=[10, 25]))
+        # SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=0, device_version=1, input_clusters=[1, 6, 57344], output_clusters=[])
+        # SizePrefixedSimpleDescriptor(endpoint=3, profile=260, device_type=0, device_version=1, input_clusters=[1, 6, 57344], output_clusters=[])
+        # SizePrefixedSimpleDescriptor(endpoint=4, profile=260, device_type=0, device_version=1, input_clusters=[1, 6, 57344], output_clusters=[])
+        MODEL: "TS0044",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                    0xe000,  # Unknown
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                    0xe000,  # Unknown
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                    0xe000,  # Unknown
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id, TuyaSmartRemoteOnOffCluster],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster],
             },
         },
     }

--- a/zhaquirks/tuya/ts0044.py
+++ b/zhaquirks/tuya/ts0044.py
@@ -349,7 +349,7 @@ class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
                 INPUT_CLUSTERS: [
                     PowerConfiguration.cluster_id,
                     OnOff.cluster_id,
-                    0xe000,  # Unknown
+                    0xE000,  # Unknown
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -359,7 +359,7 @@ class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
                 INPUT_CLUSTERS: [
                     PowerConfiguration.cluster_id,
                     OnOff.cluster_id,
-                    0xe000,  # Unknown
+                    0xE000,  # Unknown
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -369,7 +369,7 @@ class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
                 INPUT_CLUSTERS: [
                     PowerConfiguration.cluster_id,
                     OnOff.cluster_id,
-                    0xe000,  # Unknown
+                    0xE000,  # Unknown
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -390,7 +390,11 @@ class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                ],
             },
             3: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/tuya/ts0044.py
+++ b/zhaquirks/tuya/ts0044.py
@@ -384,17 +384,17 @@ class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                 ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id, TuyaSmartRemoteOnOffCluster],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
-                INPUT_CLUSTERS: [],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,
                     Ota.cluster_id,
                     TuyaSmartRemoteOnOffCluster,
                 ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster],
             },
             3: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
One more TS0044 cluster version. Have moving the OnOff cluster to out in replace and deleting the power-config on EP 2-3 then it was not reporting battery OK with all 4 active.
So no no working switches on the device card and working battery reporting.

Fixes: #1373