### PR TITLE
Adding new ts0042 model

### DIFF
--- a/zhaquirks/tuya/ts0042.py
+++ b/zhaquirks/tuya/ts0042.py
@@ -167,7 +167,7 @@ class TuyaSmartRemote0042TOPlusA(CustomDevice):
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                     OnOff.cluster_id,
-                    TuyaZBE000Cluster,
+                    TuyaZBE000Cluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },

--- a/zhaquirks/tuya/ts0042.py
+++ b/zhaquirks/tuya/ts0042.py
@@ -19,7 +19,7 @@ from zhaquirks.const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
-from zhaquirks.tuya import TuyaSmartRemoteOnOffCluster
+from zhaquirks.tuya import TuyaSmartRemoteOnOffCluster, TuyaZBE000Cluster,
 
 
 class TuyaSmartRemote0042TI(CustomDevice):
@@ -167,7 +167,7 @@ class TuyaSmartRemote0042TOPlusA(CustomDevice):
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                     OnOff.cluster_id,
-                    0xE000,  # Unknown
+                    TuyaZBE000Cluster,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
@@ -208,6 +208,7 @@ class TuyaSmartRemote0042TOPlusA(CustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
+                    TuyaZBE000Cluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,

--- a/zhaquirks/tuya/ts0042.py
+++ b/zhaquirks/tuya/ts0042.py
@@ -148,3 +148,87 @@ class TuyaSmartRemote0042TO(CustomDevice):
         (LONG_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: LONG_PRESS},
         (DOUBLE_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: DOUBLE_PRESS},
     }
+
+
+class TuyaSmartRemote0042TOPlusA(CustomDevice):
+    """Tuya 2-button remote device with time on out cluster."""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0, device_version=1, input_clusters=[0, 1, 6, 57344], output_clusters=[10, 25]))
+        # SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
+        # SizePrefixedSimpleDescriptor(endpoint=3, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
+        # SizePrefixedSimpleDescriptor(endpoint=4, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
+        MODEL: "TS0042",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                    0xE000,  # Unknown
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
+        (SHORT_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: DOUBLE_PRESS},
+    }

--- a/zhaquirks/tuya/ts0042.py
+++ b/zhaquirks/tuya/ts0042.py
@@ -19,7 +19,7 @@ from zhaquirks.const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
-from zhaquirks.tuya import TuyaSmartRemoteOnOffCluster, TuyaZBE000Cluster,
+from zhaquirks.tuya import TuyaSmartRemoteOnOffCluster, TuyaZBE000Cluster
 
 
 class TuyaSmartRemote0042TI(CustomDevice):


### PR DESCRIPTION
Adding one new model with **4 endpoints** as the ts0044 but is only using the 2 first (hard and software recycling on high level from tuya then using the same for all switches and only changing the device ID !!).
Putting back the device type and moving OnOff to out and deleting power config from all EP but keeping it on EP1 so battery reporting is working better.

Fixes: https://github.com/zigpy/zha-device-handlers/issues/1375

The old is untouched but need being updated in the same way.