### PR TITLE
Extended ZONNSMART TRV functionality & added _TZE200_hue3yfsn

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -61,10 +61,18 @@ ZCL_TUYA_VALVE_CHILD_LOCK_ON = b"\t2\x01\x03\x04\x07\x01\x00\x01\x01"
 ZCL_TUYA_VALVE_AUTO_LOCK_ON = b"\t2\x01\x03\x04\x74\x01\x00\x01\x01"
 ZCL_TUYA_VALVE_BATTERY_LOW = b"\t2\x01\x03\x04\x6E\x01\x00\x01\x01"
 
-ZCL_TUYA_VALVE_ZONNSMART_TEMPERATURE = b"\tp\x01\x00\x02\x18\x02\x00\x04\x00\x00\x00\xd3"
-ZCL_TUYA_VALVE_ZONNSMART_TARGET_TEMP = b"\t3\x01\x03\x05\x10\x02\x00\x04\x00\x00\x00\xcd"
-ZCL_TUYA_VALVE_ZONNSMART_HOLIDAY_TEMP = b"\t3\x01\x03\x05\x20\x02\x00\x04\x00\x00\x00\xaa"
-ZCL_TUYA_VALVE_ZONNSMART_TEMP_OFFSET = b"\t3\x01\x03\x05\x1b\x02\x00\x04\x00\x00\x00\x0b"
+ZCL_TUYA_VALVE_ZONNSMART_TEMPERATURE = (
+    b"\tp\x01\x00\x02\x18\x02\x00\x04\x00\x00\x00\xd3"
+)
+ZCL_TUYA_VALVE_ZONNSMART_TARGET_TEMP = (
+    b"\t3\x01\x03\x05\x10\x02\x00\x04\x00\x00\x00\xcd"
+)
+ZCL_TUYA_VALVE_ZONNSMART_HOLIDAY_TEMP = (
+    b"\t3\x01\x03\x05\x20\x02\x00\x04\x00\x00\x00\xaa"
+)
+ZCL_TUYA_VALVE_ZONNSMART_TEMP_OFFSET = (
+    b"\t3\x01\x03\x05\x1b\x02\x00\x04\x00\x00\x00\x0b"
+)
 ZCL_TUYA_VALVE_ZONNSMART_MODE_MANUAL = b"\t2\x01\x03\x04\x02\x04\x00\x01\x01"
 ZCL_TUYA_VALVE_ZONNSMART_MODE_SCHEDULE = b"\t2\x01\x03\x04\x02\x04\x00\x01\x00"
 ZCL_TUYA_VALVE_ZONNSMART_HEAT_STOP = b"\t2\x01\x03\x04\x6b\x01\x00\x01\x00"
@@ -456,7 +464,7 @@ async def test_zonnsmart_state_report(zigpy_device_from_quirk, quirk):
     assert thermostat_listener.attribute_updates[8][1] == 1
     assert thermostat_listener.attribute_updates[9][0] == 0x4002
     assert thermostat_listener.attribute_updates[9][1] == 0
-    assert thermostat_listener.attribute_updates[10][0] == 0x001c  # HEAT ON
+    assert thermostat_listener.attribute_updates[10][0] == 0x001C  # HEAT ON
     assert thermostat_listener.attribute_updates[10][1] == 4
 
 

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -5,7 +5,17 @@ from typing import Optional, Union
 from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
+from zigpy.zcl.clusters.general import (
+    AnalogOutput,
+    Basic,
+    BinaryInput,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
 from zigpy.zcl.clusters.hvac import Thermostat
 
 from zhaquirks import Bus, LocalDataCluster
@@ -822,41 +832,74 @@ class MoesWindowDetection(LocalDataCluster, OnOff):
         return [command_id, foundation.Status.UNSUP_CLUSTER_COMMAND]
 
 
-ZONNSMART_CHILD_LOCK_ATTR = 0x0128  # [0] unlocked [1] child-locked
-ZONNSMART_WINDOW_DETECT_ATTR = 0x0108  # [0] inactive [1] active
+ZONNSMART_MODE_ATTR = (
+    0x0402  # [0] Scheduled/auto [1] manual [2] Holiday [3] HolidayTempShow
+)
+ZONNSMART_WINDOW_DETECT_ATTR = 0x0108  # window is opened [0] false [1] true
+ZONNSMART_FROST_PROTECT_ATTR = 0x010A  # [0] inactive [1] active
 ZONNSMART_TARGET_TEMP_ATTR = 0x0210  # [0,0,0,210] target room temp (decidegree)
 ZONNSMART_TEMPERATURE_ATTR = 0x0218  # [0,0,0,200] current room temp (decidegree)
-ZONNSMART_TEMP_CALIBRATION_ATTR = 0x021B  # [0,0,0,0] calibration /10
-ZONNSMART_BATTERY_ATTR = 0x0223  # [0,0,0,98] battery charge
-ZONNSMART_MODE_ATTR = (
-    0x0402  # [0] Scheduled/auto [1] manual [2] Holiday [3] HolidayReady
+ZONNSMART_TEMPERATURE_CALIBRATION_ATTR = 0x021B  # temperature calibration (decidegree)
+ZONNSMART_WEEK_FORMAT_ATTR = 0x041F  # # [0] 5+2 days [1] 6+1 days, [2] 7 days
+ZONNSMART_HOLIDAY_TEMP_ATTR = (
+    0x0220  # [0, 0, 0, 170] temp in holiday mode (decidegreee)
 )
-ZONNSMART_HEATING_STOPPING = 0x016B  # [0] inactive [1] active
-ZONNSMART_BOOST_TIME_ATTR = 0x0265  # BOOST mode operating time in (sec)
+ZONNSMART_BATTERY_ATTR = 0x0223  # [0,0,0,98] battery charge
 ZONNSMART_UPTIME_TIME_ATTR = (
     0x0024  # Seems to be the uptime attribute (sent hourly, increases) [0,200]
 )
+ZONNSMART_CHILD_LOCK_ATTR = 0x0128  # [0] unlocked [1] child-locked
+ZONNSMART_FAULT_DETECTION_ATTR = 0x052D  # [0] no fault [1] fault detected
+ZONNSMART_HOLIDAY_DATETIME_ATTR = 0x032E  # holiday mode datetime of begin and end
+ZONNSMART_BOOST_TIME_ATTR = 0x0265  # BOOST mode operating time in (sec) [0, 0, 1, 44]
+ZONNSMART_OPENED_WINDOW_TEMP = 0x0266  # [0, 0, 0, 210] opened window detected temp
+ZONNSMART_COMFORT_TEMP_ATTR = 0x0268  # [0, 0, 0, 210] comfort temp in auto (decidegree)
+ZONNSMART_ECO_TEMP_ATTR = 0x0269  # [0, 0, 0, 170] eco temp in auto (decidegree)
+ZONNSMART_HEATING_STOPPING_ATTR = 0x016B  # [0] inactive [1] active
+# In online mode TRV publishes all values, expires automatically after ca. 1 min
+# TRV uses different datatype for send and receive, we need both
+ZONNSMART_ONLINE_MODE_ENUM_ATTR = 0x0473  # device publises value as enum datatype
+ZONNSMART_ONLINE_MODE_BOOL_ATTR = 0x0173  # but expects to receive bool datatype
+
+ZONNSMART_MAX_TEMPERATURE_VAL = 3000
+ZONNSMART_MIN_TEMPERATURE_VAL = 500
+ZonnsmartManuClusterSelf = None
 
 
 class ZONNSMARTManufCluster(TuyaManufClusterAttributes):
     """Manufacturer Specific Cluster of some thermostatic valves."""
 
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        global ZonnsmartManuClusterSelf
+        ZonnsmartManuClusterSelf = self
+
     manufacturer_attributes = {
-        ZONNSMART_CHILD_LOCK_ATTR: ("child_lock", t.uint8_t),
+        ZONNSMART_MODE_ATTR: ("mode", t.uint8_t),
         ZONNSMART_WINDOW_DETECT_ATTR: ("window_detection", t.uint8_t),
+        ZONNSMART_FROST_PROTECT_ATTR: ("frost_protection", t.uint8_t),
         ZONNSMART_TARGET_TEMP_ATTR: ("target_temperature", t.uint32_t),
         ZONNSMART_TEMPERATURE_ATTR: ("temperature", t.uint32_t),
-        ZONNSMART_TEMP_CALIBRATION_ATTR: ("temperature_calibration", t.uint32_t),
+        ZONNSMART_TEMPERATURE_CALIBRATION_ATTR: ("temperature_calibration", t.int32s),
+        ZONNSMART_WEEK_FORMAT_ATTR: ("week_format", t.uint8_t),
+        ZONNSMART_HOLIDAY_TEMP_ATTR: ("holiday_temperature", t.uint32_t),
         ZONNSMART_BATTERY_ATTR: ("battery", t.uint32_t),
-        ZONNSMART_MODE_ATTR: ("mode", t.uint8_t),
-        ZONNSMART_BOOST_TIME_ATTR: ("boost_duration_seconds", t.uint32_t),
         ZONNSMART_UPTIME_TIME_ATTR: ("uptime", t.uint32_t),
-        ZONNSMART_HEATING_STOPPING: ("heating_stop", t.uint8_t),
+        ZONNSMART_CHILD_LOCK_ATTR: ("child_lock", t.uint8_t),
+        ZONNSMART_FAULT_DETECTION_ATTR: ("fault_detected", t.uint8_t),
+        ZONNSMART_BOOST_TIME_ATTR: ("boost_duration_seconds", t.uint32_t),
+        ZONNSMART_OPENED_WINDOW_TEMP: ("opened_window_temperature", t.uint32_t),
+        ZONNSMART_COMFORT_TEMP_ATTR: ("comfort_mode_temperature", t.uint32_t),
+        ZONNSMART_ECO_TEMP_ATTR: ("eco_mode_temperature", t.uint32_t),
+        ZONNSMART_HEATING_STOPPING_ATTR: ("heating_stop", t.uint8_t),
+        ZONNSMART_ONLINE_MODE_BOOL_ATTR: ("online_set", t.uint8_t),
+        ZONNSMART_ONLINE_MODE_ENUM_ATTR: ("online", t.uint8_t),
     }
 
     DIRECT_MAPPED_ATTRS = {
         ZONNSMART_TEMPERATURE_ATTR: ("local_temp", lambda value: value * 10),
-        ZONNSMART_TEMP_CALIBRATION_ATTR: (
+        ZONNSMART_TEMPERATURE_CALIBRATION_ATTR: (
             "local_temperature_calibration",
             lambda value: value * 10,
         ),
@@ -864,57 +907,109 @@ class ZONNSMARTManufCluster(TuyaManufClusterAttributes):
             "occupied_heating_setpoint",
             lambda value: value * 10,
         ),
-        ZONNSMART_BOOST_TIME_ATTR: ("boost_duration_seconds", None),
-        ZONNSMART_UPTIME_TIME_ATTR: ("uptime_duration_hours", None),
+        ZONNSMART_HOLIDAY_TEMP_ATTR: (
+            "unoccupied_heating_setpoint",
+            lambda value: value * 10,
+        ),
+        ZONNSMART_FAULT_DETECTION_ATTR: (
+            "alarm_mask",
+            lambda value: 0x02 if value else 0x00,
+        ),
     }
 
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
         if attrid in self.DIRECT_MAPPED_ATTRS:
+            pass
             self.endpoint.device.thermostat_bus.listener_event(
                 "temperature_change",
                 self.DIRECT_MAPPED_ATTRS[attrid][0],
                 value
                 if self.DIRECT_MAPPED_ATTRS[attrid][1] is None
-                else self.DIRECT_MAPPED_ATTRS[attrid][1](
-                    value
-                ),  # decidegree to centidegree
+                else self.DIRECT_MAPPED_ATTRS[attrid][1](value),
             )
-        elif attrid == ZONNSMART_MODE_ATTR:
-            self.endpoint.device.thermostat_bus.listener_event("mode_change", value)
-        elif attrid == ZONNSMART_HEATING_STOPPING:
+        elif attrid == ZONNSMART_WINDOW_DETECT_ATTR:
+            self.endpoint.device.window_detection_bus.listener_event("set_value", value)
+        elif attrid == ZONNSMART_OPENED_WINDOW_TEMP:
+            self.endpoint.device.window_temperature_bus.listener_event(
+                "set_value", value
+            )
+        elif attrid in (ZONNSMART_MODE_ATTR, ZONNSMART_FROST_PROTECT_ATTR):
             self.endpoint.device.thermostat_bus.listener_event(
-                "state_change", value == 0
+                "mode_change", attrid, value
+            )
+        elif attrid == ZONNSMART_HEATING_STOPPING_ATTR:
+            self.endpoint.device.thermostat_bus.listener_event(
+                "system_mode_change", value == 0
             )
         elif attrid == ZONNSMART_CHILD_LOCK_ATTR:
-            mode = 1 if value else 0
-            self.endpoint.device.ui_bus.listener_event("child_lock_change", mode)
+            self.endpoint.device.ui_bus.listener_event("child_lock_change", value)
+            self.endpoint.device.child_lock_bus.listener_event("set_change", value)
         elif attrid == ZONNSMART_BATTERY_ATTR:
             self.endpoint.device.battery_bus.listener_event("battery_change", value)
+        elif attrid == ZONNSMART_ONLINE_MODE_ENUM_ATTR:
+            self.endpoint.device.online_mode_bus.listener_event("set_change", value)
+        elif attrid == ZONNSMART_BOOST_TIME_ATTR:
+            self.endpoint.device.boost_bus.listener_event(
+                "set_change", 1 if value > 0 else 0
+            )
+
+        if attrid == ZONNSMART_TEMPERATURE_CALIBRATION_ATTR:
+            self.endpoint.device.temperature_calibration_bus.listener_event(
+                "set_value", value / 10
+            )
+        elif attrid in (ZONNSMART_TEMPERATURE_ATTR, ZONNSMART_TARGET_TEMP_ATTR):
+            self.endpoint.device.thermostat_bus.listener_event(
+                "state_temp_change", attrid, value
+            )
 
 
 class ZONNSMARTThermostat(TuyaThermostatCluster):
     """Thermostat cluster for some thermostatic valves."""
+
+    class Preset(t.enum8):
+        """Working modes of the thermostat."""
+
+        Schedule = 0x00
+        Manual = 0x01
+        Holiday = 0x02
+        HolidayTemp = 0x03
+        FrostProtect = 0x04
+
+    manufacturer_attributes = {
+        0x4002: ("operation_preset", Preset),
+    }
 
     DIRECT_MAPPING_ATTRS = {
         "occupied_heating_setpoint": (
             ZONNSMART_TARGET_TEMP_ATTR,
             lambda value: round(value / 10),
         ),
-        "operation_preset": (ZONNSMART_MODE_ATTR, None),
-        "boost_duration_seconds": (ZONNSMART_BOOST_TIME_ATTR, None),
     }
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.thermostat_bus.listener_event(
+            "temperature_change",
+            "min_heat_setpoint_limit",
+            ZONNSMART_MIN_TEMPERATURE_VAL,
+        )
+        self.endpoint.device.thermostat_bus.listener_event(
+            "temperature_change",
+            "max_heat_setpoint_limit",
+            ZONNSMART_MAX_TEMPERATURE_VAL,
+        )
 
     def map_attribute(self, attribute, value):
         """Map standardized attribute value to dict of manufacturer values."""
-
         if attribute in self.DIRECT_MAPPING_ATTRS:
             return {
                 self.DIRECT_MAPPING_ATTRS[attribute][0]: value
                 if self.DIRECT_MAPPING_ATTRS[attribute][1] is None
                 else self.DIRECT_MAPPING_ATTRS[attribute][1](value)
             }
-        if attribute in ("system_mode", "programing_oper_mode"):
+        elif attribute in ("system_mode", "programing_oper_mode"):
             if attribute == "system_mode":
                 system_mode = value
                 oper_mode = self._attr_cache.get(
@@ -927,7 +1022,7 @@ class ZONNSMARTThermostat(TuyaThermostatCluster):
                 )
                 oper_mode = value
             if system_mode == self.SystemMode.Off:
-                return {ZONNSMART_HEATING_STOPPING: 1}
+                return {ZONNSMART_HEATING_STOPPING_ATTR: 1}
             if system_mode == self.SystemMode.Heat:
                 if oper_mode == self.ProgrammingOperationMode.Schedule_programming_mode:
                     return {ZONNSMART_MODE_ATTR: 0}
@@ -936,24 +1031,285 @@ class ZONNSMARTThermostat(TuyaThermostatCluster):
                 self.error("Unsupported value for ProgrammingOperationMode")
             else:
                 self.error("Unsupported value for SystemMode")
+        elif attribute == "operation_preset":
+            if value == 0:
+                return {ZONNSMART_MODE_ATTR: 0}
+            elif value == 1:
+                return {ZONNSMART_MODE_ATTR: 1}
+            elif value == 3:
+                return {ZONNSMART_MODE_ATTR: 3}
+            elif value == 4:
+                return {ZONNSMART_FROST_PROTECT_ATTR: 1}
+            else:
+                self.error("Unsupported value for OperationPreset")
 
-    def mode_change(self, value):
+    def mode_change(self, attrid, value):
+        """Mode change."""
+        operation_preset = None
+
+        if attrid == ZONNSMART_MODE_ATTR:
+            prog_mode = None
+            if value == 0:
+                prog_mode = self.ProgrammingOperationMode.Schedule_programming_mode
+                operation_preset = self.Preset.Schedule
+            elif value == 1:
+                prog_mode = self.ProgrammingOperationMode.Simple
+                operation_preset = self.Preset.Manual
+            elif value == 2:
+                prog_mode = self.ProgrammingOperationMode.Simple
+                operation_preset = self.Preset.Holiday
+            elif value == 3:
+                prog_mode = self.ProgrammingOperationMode.Schedule_programming_mode
+                operation_preset = self.Preset.HolidayTemp
+            else:
+                self.error("Unsupported value for Mode")
+
+            if prog_mode is not None:
+                self._update_attribute(self.attridx["programing_oper_mode"], prog_mode)
+        elif attrid == ZONNSMART_FROST_PROTECT_ATTR:
+            if value == 1:
+                operation_preset = self.Preset.FrostProtect
+
+        if operation_preset is not None:
+            self._update_attribute(self.attridx["operation_preset"], operation_preset)
+
+    def system_mode_change(self, value):
         """System Mode change."""
-        if value == 0:
-            prog_mode = self.ProgrammingOperationMode.Schedule_programming_mode
-        elif value == 1:
-            prog_mode = self.ProgrammingOperationMode.Simple
-        else:
-            prog_mode = self.ProgrammingOperationMode.Simple
+        self._update_attribute(
+            self.attridx["system_mode"],
+            self.SystemMode.Heat if value else self.SystemMode.Off,
+        )
 
-        self._update_attribute(self.attridx["system_mode"], self.SystemMode.Heat)
-        self._update_attribute(self.attridx["programing_oper_mode"], prog_mode)
+    def state_temp_change(self, attrid, value):
+        """Set heating state based on current and set temperature."""
+        if attrid == ZONNSMART_TEMPERATURE_ATTR:
+            temp_current = value * 10
+            temp_set = self._attr_cache.get(self.attridx["occupied_heating_setpoint"])
+        elif attrid == ZONNSMART_TARGET_TEMP_ATTR:
+            temp_current = self._attr_cache.get(self.attridx["local_temp"])
+            temp_set = value * 10
+        else:
+            return
+
+        state = 0 if (int(temp_current) >= int(temp_set)) else 1
+        self.endpoint.device.thermostat_bus.listener_event("state_change", state)
 
 
 class ZONNSMARTUserInterface(TuyaUserInterfaceCluster):
     """HVAC User interface cluster for tuya electric heating thermostats."""
 
     _CHILD_LOCK_ATTR = ZONNSMART_CHILD_LOCK_ATTR
+
+
+class ZONNSMARTWindowDetection(LocalDataCluster, BinaryInput):
+    """Binary cluster for the window detection function of the heating thermostats."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.window_detection_bus.add_listener(self)
+        self._update_attribute(self.attridx["description"], "Open Window Detected")
+
+    def set_value(self, value):
+        """Set opened window value."""
+        self._update_attribute(self.attridx["present_value"], value)
+
+
+class ZONNSMARTHelperOnOff(LocalDataCluster, OnOff):
+    """Helper OnOff cluster for various functions controlled by switch."""
+
+    def set_change(self, value):
+        """Set new OnOff value."""
+        self._update_attribute(self.attridx["on_off"], value)
+
+    def get_attr_val_to_write(self, value):
+        """Return dict with attribute and value for thermostat."""
+        return None
+
+    async def write_attributes(self, attributes, manufacturer=None):
+        """Defer attributes writing to the set_data tuya command."""
+        records = self._write_attr_records(attributes)
+        if not records:
+            return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+
+        has_change = False
+        for record in records:
+            attr_name = self.attributes[record.attrid][0]
+            if attr_name == "on_off":
+                value = record.value.value
+                has_change = True
+
+        if has_change:
+            attr_val = self.get_attr_val_to_write(value)
+            if attr_val is not None:
+                # global self in case when different endpoint has to exist
+                return await ZonnsmartManuClusterSelf.endpoint.tuya_manufacturer.write_attributes(
+                    attr_val, manufacturer=manufacturer
+                )
+
+        return [
+            [
+                foundation.WriteAttributesStatusRecord(
+                    foundation.Status.FAILURE, r.attrid
+                )
+                for r in records
+            ]
+        ]
+
+    async def command(
+        self,
+        command_id: Union[foundation.Command, int, t.uint8_t],
+        *args,
+        manufacturer: Optional[Union[int, t.uint16_t]] = None,
+        expect_reply: bool = True,
+        tsn: Optional[Union[int, t.uint8_t]] = None,
+    ):
+        """Override the default Cluster command."""
+
+        if command_id in (0x0000, 0x0001, 0x0002):
+
+            if command_id == 0x0000:
+                value = False
+            elif command_id == 0x0001:
+                value = True
+            else:
+                attrid = self.attridx["on_off"]
+                success, _ = await self.read_attributes(
+                    (attrid,), manufacturer=manufacturer
+                )
+                try:
+                    value = success[attrid]
+                except KeyError:
+                    return foundation.Status.FAILURE
+                value = not value
+            _LOGGER.debug("CALLING WRITE FROM COMMAND")
+            (res,) = await self.write_attributes(
+                {"on_off": value},
+                manufacturer=manufacturer,
+            )
+            return [command_id, res[0].status]
+
+        return [command_id, foundation.Status.UNSUP_CLUSTER_COMMAND]
+
+
+class ZONNSMARTBoost(ZONNSMARTHelperOnOff):
+    """On/Off cluster for the boost function of the heating thermostats."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.boost_bus.add_listener(self)
+
+    def get_attr_val_to_write(self, value):
+        """Return dict with attribute and value for boot mode."""
+        return {ZONNSMART_BOOST_TIME_ATTR: 299 if value else 0}
+
+
+class ZONNSMARTChildLock(ZONNSMARTHelperOnOff):
+    """On/Off cluster for the child lock of the heating thermostats."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.child_lock_bus.add_listener(self)
+
+    def get_attr_val_to_write(self, value):
+        """Return dict with attribute and value for child lock."""
+        return {ZONNSMART_CHILD_LOCK_ATTR: value}
+
+
+class ZONNSMARTOnlineMode(ZONNSMARTHelperOnOff):
+    """On/Off cluster for the online mode of the heating thermostats."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.online_mode_bus.add_listener(self)
+
+    def get_attr_val_to_write(self, value):
+        """Return dict with attribute and value for online mode."""
+        return {ZONNSMART_ONLINE_MODE_BOOL_ATTR: value}
+
+
+class ZONNSMARTTemperatureOffset(LocalDataCluster, AnalogOutput):
+    """AnalogOutput cluster for setting temperature offset."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.temperature_calibration_bus.add_listener(self)
+        self._update_attribute(self.attridx["description"], "Temperature Offset")
+        self._update_attribute(self.attridx["max_present_value"], 5)
+        self._update_attribute(self.attridx["min_present_value"], -5)
+        self._update_attribute(self.attridx["resolution"], 0.1)
+        self._update_attribute(self.attridx["application_type"], 0x0009)
+        self._update_attribute(self.attridx["engineering_units"], 62)
+
+    def set_value(self, value):
+        """Set new temperature offset value."""
+        self._update_attribute(self.attridx["present_value"], value)
+
+    def get_value(self):
+        """Get current temperature offset value."""
+        return self._attr_cache.get(self.attridx["present_value"])
+
+    async def write_attributes(self, attributes, manufacturer=None):
+        """Modify value before passing it to the set_data tuya command."""
+        for attrid, value in attributes.items():
+            if isinstance(attrid, str):
+                attrid = self.attridx[attrid]
+            if attrid not in self.attributes:
+                self.error("%d is not a valid attribute id", attrid)
+                continue
+            self._update_attribute(attrid, value)
+
+            await self.endpoint.tuya_manufacturer.write_attributes(
+                {ZONNSMART_TEMPERATURE_CALIBRATION_ATTR: value * 10}, manufacturer=None
+            )
+        return ([foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],)
+
+
+class ZONNSMARTWindowOpenedTemp(LocalDataCluster, AnalogOutput):
+    """AnalogOutput cluster for temperature when opened window detected."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.window_temperature_bus.add_listener(self)
+        self._update_attribute(self.attridx["description"], "Opened Window Temperature")
+        self._update_attribute(
+            self.attridx["max_present_value"], ZONNSMART_MAX_TEMPERATURE_VAL / 100
+        )
+        self._update_attribute(
+            self.attridx["min_present_value"], ZONNSMART_MIN_TEMPERATURE_VAL / 100
+        )
+        self._update_attribute(self.attridx["resolution"], 0.5)
+        self._update_attribute(self.attridx["application_type"], 0 << 16)
+        self._update_attribute(self.attridx["engineering_units"], 62)
+
+    def set_value(self, value):
+        """Set temperature value when opened window detected."""
+        self._update_attribute(self.attridx["present_value"], value / 10)
+
+    def get_value(self):
+        """Get temperature value when opened window detected."""
+        return self._attr_cache.get(self.attridx["present_value"])
+
+    async def write_attributes(self, attributes, manufacturer=None):
+        """Modify value before passing it to the set_data tuya command."""
+        for attrid, value in attributes.items():
+            if isinstance(attrid, str):
+                attrid = self.attridx[attrid]
+            if attrid not in self.attributes:
+                self.error("%d is not a valid attribute id", attrid)
+                continue
+            self._update_attribute(attrid, value)
+
+            # different Endpoint for compatibility issue
+            await ZonnsmartManuClusterSelf.endpoint.tuya_manufacturer.write_attributes(
+                {ZONNSMART_OPENED_WINDOW_TEMP: value * 10}, manufacturer=None
+            )
+        return ([foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],)
 
 
 class SiterwellGS361_Type1(TuyaThermostat):
@@ -1203,6 +1559,16 @@ class MoesHY368_Type2(TuyaThermostat):
 class ZonnsmartTV01_ZG(TuyaThermostat):
     """ZONNSMART TV01-ZG Thermostatic radiator valve."""
 
+    def __init__(self, *args, **kwargs):
+        """Init device."""
+        self.boost_bus = Bus()
+        self.child_lock_bus = Bus()
+        self.online_mode_bus = Bus()
+        self.temperature_calibration_bus = Bus()
+        self.window_detection_bus = Bus()
+        self.window_temperature_bus = Bus()
+        super().__init__(*args, **kwargs)
+
     signature = {
         #  endpoint=1 profile=260 device_type=81 device_version=0 input_clusters=[0, 4, 5, 61184]
         #  output_clusters=[10, 25]>
@@ -1210,6 +1576,7 @@ class ZonnsmartTV01_ZG(TuyaThermostat):
             ("_TZE200_e9ba97vf", "TS0601"),
             ("_TZE200_husqqvux", "TS0601"),
             ("_TZE200_kly8gjlz", "TS0601"),
+            ("_TZE200_hue3yfsn", "TS0601"),  # TV02-ZG
         ],
         ENDPOINTS: {
             1: {
@@ -1235,12 +1602,32 @@ class ZonnsmartTV01_ZG(TuyaThermostat):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
+                    ZONNSMARTBoost,
                     ZONNSMARTManufCluster,
+                    ZONNSMARTTemperatureOffset,
                     ZONNSMARTThermostat,
                     ZONNSMARTUserInterface,
+                    ZONNSMARTWindowDetection,
                     TuyaPowerConfigurationCluster2AA,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            }
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COMBINED_INTERFACE,
+                INPUT_CLUSTERS: [
+                    ZONNSMARTChildLock,
+                    ZONNSMARTWindowOpenedTemp,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COMBINED_INTERFACE,
+                INPUT_CLUSTERS: [
+                    ZONNSMARTOnlineMode,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
         }
     }


### PR DESCRIPTION
After quite some time I've finally added _TZE200_hue3yfsn into ZONNSMART class, which is basically the same device in new design. Thanks to it I could extend the current ZONNSMART class with new functionalities like:
- modes
- temperature offset
- child lock
- boost mode
- online mode (for 1 minute device publishes all values including current temp)
- opened window sensor
- opened window temperature

Because I don't own the old TRV TV01-ZG _TZE200_e9ba97vf I couldn't tested the new features, but by reading manual on internet it should works.

Here is a picture from ha:

![Clipboard01](https://user-images.githubusercontent.com/38496829/154862161-1471063a-8328-42ce-aa84-1e9025b997ef.jpg)

This PR should close following issue #1027 