### PR TITLE
Migrate ts0601_switch to MCU classes

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -223,8 +223,8 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
         status = await switch_cluster.command(0x0000)
         m1.assert_called_with(
             61184,
-            1,
-            b"\x01\x01\x00\x00\x00\x01\x01\x00\x01\x00",
+            2,
+            b"\x01\x02\x00\x00\x01\x01\x01\x00\x01\x00",
             expect_reply=True,
             command_id=0,
         )
@@ -233,8 +233,8 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
         status = await switch_cluster.command(0x0001)
         m1.assert_called_with(
             61184,
-            2,
-            b"\x01\x02\x00\x00\x00\x01\x01\x00\x01\x01",
+            4,
+            b"\x01\x04\x00\x00\x03\x01\x01\x00\x01\x01",
             expect_reply=True,
             command_id=0,
         )

--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -79,7 +79,7 @@ async def test_write_attr(zigpy_device_from_quirk, quirk):
             61184,
             2,
             b"\x01\x02\x00\x00\x01\x03\x02\x00\x04\x00\x00\x00b",
-            expect_reply=True,
+            expect_reply=False,
             command_id=0,
         )
         assert status == [

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -63,7 +63,7 @@ async def test_tuya_methods(zigpy_device_from_quirk, quirk):
 
     tcd_1 = TuyaClusterData(endpoint_id=2, cluster_attr="minimum_level", attr_value=25)
 
-    tcd_switch1_on = TuyaClusterData(endpoint_id=1, cluster_attr="on_off", attr_value=1)
+    tcd_switch1_on = TuyaClusterData(endpoint_id=1, cluster_attr="on_off", attr_value=1, expect_reply=True)
 
     result_1 = tuya_cluster.from_cluster_data(tcd_1)
     assert result_1

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -63,7 +63,9 @@ async def test_tuya_methods(zigpy_device_from_quirk, quirk):
 
     tcd_1 = TuyaClusterData(endpoint_id=2, cluster_attr="minimum_level", attr_value=25)
 
-    tcd_switch1_on = TuyaClusterData(endpoint_id=1, cluster_attr="on_off", attr_value=1, expect_reply=True)
+    tcd_switch1_on = TuyaClusterData(
+        endpoint_id=1, cluster_attr="on_off", attr_value=1, expect_reply=True
+    )
 
     result_1 = tuya_cluster.from_cluster_data(tcd_1)
     assert result_1

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -113,6 +113,8 @@ class TuyaAttributesCluster(TuyaLocalCluster):
                 endpoint_id=self.endpoint.endpoint_id,
                 cluster_attr=self.attributes[record.attrid][0],
                 attr_value=record.value.value,
+                expect_reply=False,
+                manufacturer=manufacturer
             )
             self.endpoint.device.command_bus.listener_event(
                 TUYA_MCU_COMMAND,
@@ -279,6 +281,8 @@ class TuyaOnOff(OnOff, TuyaLocalCluster):
                 endpoint_id=self.endpoint.endpoint_id,
                 cluster_attr="on_off",
                 attr_value=command_id,
+                expect_reply=expect_reply,
+                manufacturer=manufacturer
             )
             self.endpoint.device.command_bus.listener_event(
                 TUYA_MCU_COMMAND,
@@ -389,6 +393,8 @@ class TuyaLevelControl(LevelControl, TuyaLocalCluster):
                 endpoint_id=self.endpoint.endpoint_id,
                 cluster_attr="current_level",
                 attr_value=args[0],
+                expect_reply=expect_reply,
+                manufacturer=manufacturer
             )
             self.endpoint.device.command_bus.listener_event(
                 TUYA_MCU_COMMAND,

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -114,7 +114,7 @@ class TuyaAttributesCluster(TuyaLocalCluster):
                 cluster_attr=self.attributes[record.attrid][0],
                 attr_value=record.value.value,
                 expect_reply=False,
-                manufacturer=manufacturer
+                manufacturer=manufacturer,
             )
             self.endpoint.device.command_bus.listener_event(
                 TUYA_MCU_COMMAND,
@@ -282,7 +282,7 @@ class TuyaOnOff(OnOff, TuyaLocalCluster):
                 cluster_attr="on_off",
                 attr_value=command_id,
                 expect_reply=expect_reply,
-                manufacturer=manufacturer
+                manufacturer=manufacturer,
             )
             self.endpoint.device.command_bus.listener_event(
                 TUYA_MCU_COMMAND,
@@ -394,7 +394,7 @@ class TuyaLevelControl(LevelControl, TuyaLocalCluster):
                 cluster_attr="current_level",
                 attr_value=args[0],
                 expect_reply=expect_reply,
-                manufacturer=manufacturer
+                manufacturer=manufacturer,
             )
             self.endpoint.device.command_bus.listener_event(
                 TUYA_MCU_COMMAND,

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -13,6 +13,7 @@ from zhaquirks.tuya import (
     TUYA_MCU_VERSION_RSP,
     TUYA_SET_DATA,
     Data,
+    PowerOnState,
     TuyaCommand,
     TuyaData,
     TuyaLocalCluster,
@@ -73,6 +74,17 @@ class TuyaClusterData(t.Struct):
     endpoint_id: int
     cluster_attr: str
     attr_value: int  # Maybe also others types?
+    expect_reply: bool
+    manufacturer: str
+
+
+class MoesBacklight(t.enum8):
+    """MOES switch backlight mode enum."""
+
+    off = 0x00
+    light_when_on = 0x01
+    light_when_off = 0x02
+    freeze = 0x03
 
 
 class TuyaAttributesCluster(TuyaLocalCluster):
@@ -128,6 +140,7 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
                 # MCU version is 1 byte length
                 # is converted from HEX -> BIN -> XX.XX.XXXX -> DEC (x.y.z)
                 # example: 0x98 -> 10011000 -> 10.01.1000 -> 2.1.8
+                # https://developer.tuya.com/en/docs/iot-device-dev/firmware-version-description?id=K9zzuc5n2gff8#title-1-Zigbee%20firmware%20versions
                 major = self.version_raw >> 6
                 minor = (self.version_raw & 63) >> 4
                 release = self.version_raw & 15
@@ -203,11 +216,16 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
         self.debug("tuya_command: %s", tuya_command)
         if tuya_command:
             self.create_catching_task(
-                self.command(TUYA_SET_DATA, tuya_command, expect_reply=True)
+                self.command(
+                    TUYA_SET_DATA,
+                    tuya_command,
+                    expect_reply=cluster_data.expect_reply,
+                    manufacturer=cluster_data.manufacturer,
+                )
             )
         else:
             self.warning(
-                "MCU command not call for data %s",
+                "no MCU command for data %s",
                 cluster_data,
             )
 
@@ -309,12 +327,12 @@ class TuyaOnOffManufCluster(TuyaMCUCluster):
     }
 
 
-class SurfaceSwitchManufCluster(TuyaOnOffManufCluster):
+class MoesSwitchManufCluster(TuyaOnOffManufCluster):
     """On/Off Tuya cluster with extra device attributes."""
 
     attributes = {
-        0x8001: ("backlight_mode", t.enum8),
-        0x8002: ("power_on_state", t.enum8),
+        0x8001: ("backlight_mode", MoesBacklight),
+        0x8002: ("power_on_state", PowerOnState),
     }
 
     dp_to_attribute: Dict[
@@ -326,6 +344,7 @@ class SurfaceSwitchManufCluster(TuyaOnOffManufCluster):
                 TuyaMCUCluster.ep_attribute,
                 "power_on_state",
                 dp_type=TuyaDPType.ENUM,
+                converter=lambda x: PowerOnState(x),
             )
         }
     )
@@ -335,6 +354,7 @@ class SurfaceSwitchManufCluster(TuyaOnOffManufCluster):
                 TuyaMCUCluster.ep_attribute,
                 "backlight_mode",
                 dp_type=TuyaDPType.ENUM,
+                converter=lambda x: MoesBacklight(x),
             ),
         }
     )

--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -11,11 +11,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import TuyaSwitch
-from zhaquirks.tuya.mcu import (
-    MoesSwitchManufCluster,
-    TuyaOnOffManufCluster,
-    TuyaOnOff,
-)
+from zhaquirks.tuya.mcu import MoesSwitchManufCluster, TuyaOnOff, TuyaOnOffManufCluster
 
 
 class TuyaSingleSwitchTI(TuyaSwitch):

--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -10,11 +10,11 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import (
-    TuyaManufacturerClusterOnOff,
-    TuyaManufCluster,
+from zhaquirks.tuya import TuyaSwitch
+from zhaquirks.tuya.mcu import (
+    MoesSwitchManufCluster,
+    TuyaOnOffManufCluster,
     TuyaOnOff,
-    TuyaSwitch,
 )
 
 
@@ -39,7 +39,7 @@ class TuyaSingleSwitchTI(TuyaSwitch):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     Time.cluster_id,
-                    TuyaManufCluster.cluster_id,
+                    TuyaOnOffManufCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             }
@@ -55,7 +55,7 @@ class TuyaSingleSwitchTI(TuyaSwitch):
                     Time.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufacturerClusterOnOff,
+                    MoesSwitchManufCluster,
                     TuyaOnOff,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
@@ -90,7 +90,7 @@ class TuyaSingleSwitchTO(TuyaSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufCluster.cluster_id,
+                    TuyaOnOffManufCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             }
@@ -105,7 +105,7 @@ class TuyaSingleSwitchTO(TuyaSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufacturerClusterOnOff,
+                    MoesSwitchManufCluster,
                     TuyaOnOff,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
@@ -137,7 +137,7 @@ class TuyaDoubleSwitchTO(TuyaSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufCluster.cluster_id,
+                    TuyaOnOffManufCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             }
@@ -152,7 +152,7 @@ class TuyaDoubleSwitchTO(TuyaSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufacturerClusterOnOff,
+                    MoesSwitchManufCluster,
                     TuyaOnOff,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
@@ -185,7 +185,7 @@ class TuyaTripleSwitchTO(TuyaSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufCluster.cluster_id,
+                    TuyaOnOffManufCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             }
@@ -200,7 +200,7 @@ class TuyaTripleSwitchTO(TuyaSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufacturerClusterOnOff,
+                    MoesSwitchManufCluster,
                     TuyaOnOff,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
@@ -241,7 +241,7 @@ class TuyaQuadrupleSwitchTO(TuyaSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufCluster.cluster_id,
+                    TuyaOnOffManufCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             }
@@ -256,7 +256,7 @@ class TuyaQuadrupleSwitchTO(TuyaSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufacturerClusterOnOff,
+                    MoesSwitchManufCluster,
                     TuyaOnOff,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],


### PR DESCRIPTION
The first of the devices that I intend to migrate to the new MCU classes.

Also I have defined the ENUMs with the possible values of the `backlight_mode` and `power_on_state` attributes.
I have assumed that all switch devices have the characteristics of Moes devices. Most of the `MODELS_INFO` correspond to Moes devices, but it has not been an exhaustive check nor can I guarantee that all Moes behave the same.

A change in device behavior is not expected.