### PR TITLE
get button press events from Tuya/LIDL/SilverCrest doorbell TS0211

### DIFF
--- a/zhaquirks/tuya/ts0211.py
+++ b/zhaquirks/tuya/ts0211.py
@@ -1,0 +1,135 @@
+"""Tuya Doorbell."""
+
+from typing import Optional, Tuple, Union
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
+from zigpy.zcl.clusters.homeautomation import Diagnostic
+from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks.const import (
+    COMMAND_SINGLE,
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODEL,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    ZHA_SEND_EVENT,
+)
+
+
+class IasZoneDoorbellCluster(IasZone):
+    """Custom IasZone cluster for the doorbell."""
+
+    cluster_id = IasZone.cluster_id
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: Tuple[IasZone.ZoneStatus],
+        *,
+        dst_addressing: Optional[
+            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
+        ] = None,
+    ) -> None:
+        """Handle cluster request."""
+        # args looks like [<ZoneStatus.Alarm_1: 1>, <bitmap8.0: 0>, 0, 0]
+        # we are only interested in 3 bits of the ZoneStatus item
+
+        # with thanks to
+        # https://github.com/Koenkk/zigbee-herdsman-converters/blob/26553bfa9d747c1a8b6322090429c04cf612c3c1/converters/fromZigbee.js#L2193-L2206
+
+        arg = args[0]
+        if arg & IasZone.ZoneStatus.Alarm_1:
+            self.listener_event(ZHA_SEND_EVENT, COMMAND_SINGLE, [])
+
+        # the doorbell also sets (arg & IasZone.ZoneStatus.Tamper) and
+        # (arg & IasZone.ZoneStatus.Battery) but those should eventually
+        # be handled by a more generic IasZone handling
+
+
+class TuyaDoorbell0211(CustomDevice):
+    """Tuya doorbell."""
+
+    # {
+    #   "node_descriptor": "NodeDescriptor(
+    #      logical_type=<LogicalType.EndDevice: 2>,
+    #      complex_descriptor_available=0,
+    #      user_descriptor_available=0,
+    #      reserved=0,
+    #      aps_flags=0,
+    #      frequency_band=<FrequencyBand.Freq2400MHz: 8>,
+    #      mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>,
+    #      manufacturer_code=4619,
+    #      maximum_buffer_size=82,
+    #      maximum_incoming_transfer_size=82,
+    #      server_mask=11264,
+    #      maximum_outgoing_transfer_size=82,
+    #      descriptor_capability_field=<DescriptorCapability.NONE: 0>,
+    #      *allocate_address=True,
+    #      *is_alternate_pan_coordinator=False,
+    #      *is_coordinator=False,
+    #      *is_end_device=True,
+    #      *is_full_function_device=False,
+    #      *is_mains_powered=False,
+    #      *is_receiver_on_when_idle=False,
+    #      *is_router=False,
+    #      *is_security_capable=False)",
+    #   "endpoints": {
+    #     "1": {
+    #       "profile_id": 260,
+    #       "device_type": "0x0402",
+    #       "in_clusters": [
+    #         "0x0000",
+    #         "0x0001",
+    #         "0x0003",
+    #         "0x0500",
+    #         "0x0b05"
+    #       ],
+    #       "out_clusters": [
+    #         "0x0019"
+    #       ]
+    #     }
+    #   },
+    #   "manufacturer": "_TZ1800_ladpngdx",
+    #   "model": "TS0211",
+    #   "class": "zhaquirks.tuya.ts0211.TuyaDoorbell0211"
+    # }
+
+    signature = {
+        MODEL: "TS0211",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                    Diagnostic.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IasZoneDoorbellCluster,
+                    Diagnostic.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }


### PR DESCRIPTION
Fixes #1168.

This PR generates events (3, because the doorbell sends state 3 times in 5 seconds after a press) when the doorbell is pushed.

The event looks like this:

```
{
    "event_type": "zha_event",
    "data": {
        "device_ieee": "84:2e:14:ff:fe:f8:2a:08",
        "unique_id": "84:2e:14:ff:fe:f8:2a:08:1:0x0500",
        "device_id": "e3f05ce1cdd24bfe305af5c1ff166fec",
        "endpoint_id": 1,
        "cluster_id": 1280,
        "command": "single",
        "args": []
    },
    "origin": "LOCAL",
    "time_fired": "2022-03-04T19:41:28.219516+00:00",
    "context": {
        "id": "89f36ff0868b8763214b628f5af2bbf8",
        "parent_id": null,
        "user_id": null
    }
}
```

For previous ramblings I wrote while working on this, unfold below.

<details>
  <summary> Previous PR text</summary>
This is my first time working on ZHA and I have not figured everything out yet. I am also aware I have some unused imports, some debugging `print`s ~~and probably some other things black will be unhappy about~~. I'll clean all of that up.

For now, while this PR works (it generates a `zha_event` when I push the doorbell - in fact, it generates 3 of them over 6 seconds, which I guess makes some sense for a doorbell), I'd also like to expose the Tamper and Battery states correctly to Home Assistant. The states are currently logged, but I have not yet figured out how to cause related States to appear correctly in HA. Some hints about this would be very welcome!

Do I correctly get the impression that IasZone, generally (because this doorbell is not -that- deviated from the basic definition of IasZone) is not completely implemented in (Z)HA? #419 sounds that way.

Sorry to drop unfinished work on you - I suspect this is pretty close to workable, but I could really use a review.

Thanks!
</details>