### PR TITLE
Test device signature fixture and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,119 @@ If you look at another example for the same device:
 
 You can see a pattern that illustrates how to match a more complex event. In this case the step command is used for the dim up and dim down buttons so we need to match more of the event data to uniquely match the event.
 
+## Testing using unit tests
+
+The tests use the [pytest](https://docs.pytest.org/en/latest/) framework.
+
+### Getting started
+
+To get set up, you need install the test dependencies:
+
+```bash
+pip install -r requirements_test_all.txt
+```
+
+### Running the tests
+
+See the [pytest documentation](https://docs.pytest.org/en/latest/) for details about how to run
+the tests. For example, to run all the `test_tuya.py` tests:
+
+```bash
+$ pytest --disable-warnings tests/test_tuya.py
+Test session starts (platform: linux, Python 3.9.2, pytest 6.2.5, pytest-sugar 0.9.4)
+
+collecting ...
+ tests/test_tuya.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                                                                                         100% ██████████
+
+Results (3.58s):
+      41 passed
+```
+
+### Writing tests
+
+To add a new test, start by adding a new function to one of the existing test files. You
+can follow the instructions in the [Getting started](https://docs.pytest.org/en/latest/getting-started.html)
+section of the pytest documentation.
+
+### Using fixtures to set things up
+
+In order to write a test, you will need to access an instance of a quirk to run the tests against. Pytest
+provides a useful feature called Fixtures that allow you to write and use the setup code necessary in one
+place, similar to how we use libraries to provide common functions to other code.
+
+You can read more about fixtures [here](https://docs.pytest.org/en/latest/how-to/fixtures.html#how-to-fixtures).
+
+You can find the common fixtures in files named `conftest.py`. Pytest will list them for you as follows:
+
+```bash
+$ pytest --fxitures
+[...]
+--- fixtures defined from tests.conftest ---
+MockAppController
+    App controller mock.
+
+ieee_mock
+    Return a static ieee.
+
+zigpy_device_mock
+    Zigpy device mock.
+
+zigpy_device_from_quirk
+    Create zigpy device from Quirks signature.
+
+[...]
+--- fixtures defined from tests.test_tuya_clusters ---
+TuyaCluster
+    Mock of the new Tuya manufacturer cluster.
+```
+
+Some fixtures such as `app_controller_mock` will provide an object instance that you can
+use directly. Others, such as `zigpy_device_mock` will return a function, which you can
+call to create a customised object during your own setup.
+
+### Testing the quirk signature matching
+
+The fixture `assert_signature_matches_quirk` provides a function that can be
+used to check that a particular device signature matches the corresponding quirk.
+By capturing the signature and adding a few lines to the test file, this means that
+you can verify that your device will be matched against the quirk without needing to
+go through the paring process directly.
+
+You need to capture the device signature and save it. If you have previously started the
+pairing process in Home assistant, you can find the signature under 'Zigbee Device Signature'
+on the device page.
+
+Now you can create a test that checks the signature as follows:
+
+```python
+def test_ts0121_signature(assert_signature_matches_quirk):
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+            "profile_id": 260,
+            "device_type": "0x0051",
+            "in_clusters": [
+                "0x0000",
+                "0x0004",
+                "0x0005",
+                "0x0006",
+                "0x0702",
+                "0x0b04"
+            ],
+            "out_clusters": [
+                "0x000a",
+                "0x0019"
+            ]
+            }
+        },
+        "manufacturer": "_TZ3000_g5xawfcq",
+        "model": "TS0121",
+        "class": "zhaquirks.tuya.ts0121_plug.Plug"
+    }
+    assert_signature_matches_quirk(zhaquirks.tuya.ts0121_plug.Plug, signature)
+```
+
 # Testing new releases
 
 Testing a new release of the zha-quirks package before it is released in Home Assistant.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ from asynctest import CoroutineMock
 import pytest
 import zigpy.application
 import zigpy.device
-import zigpy.types
 import zigpy.quirks
+import zigpy.types
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -120,7 +120,7 @@ def zigpy_device_from_quirk(MockAppController, ieee_mock):
 
 @pytest.fixture
 def assert_signature_matches_quirk():
-    """Return a function that can be used to check if a given quirk matches a signature"""
+    """Return a function that can be used to check if a given quirk matches a signature."""
 
     def _check(quirk, signature):
         # Check device signature as copied from Zigbee device signature window for the device

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import zigpy.application
 import zigpy.device
 import zigpy.types
+import zigpy.quirks
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -115,3 +116,47 @@ def zigpy_device_from_quirk(MockAppController, ieee_mock):
         return device
 
     return _dev
+
+
+@pytest.fixture
+def assert_signature_matches_quirk():
+    """Return a function that can be used to check if a given quirk matches a signature"""
+
+    def _check(quirk, signature):
+        # Check device signature as copied from Zigbee device signature window for the device
+        class FakeDevEndpoint:
+            def __init__(self, endpoint):
+                self.endpoint = endpoint
+
+            def __getattr__(self, key):
+                if key == "device_type":
+                    return int(self.endpoint[key], 16)
+                elif key in ("in_clusters", "out_clusters"):
+                    return [int(cluster_id, 16) for cluster_id in self.endpoint[key]]
+                else:
+                    return self.endpoint[key]
+
+        class FakeDevice:
+            nwk = 0
+
+            def __init__(self, signature):
+                self.endpoints = {
+                    int(id): FakeDevEndpoint(ep)
+                    for id, ep in signature["endpoints"].items()
+                }
+                for attr in ("manufacturer", "model", "ieee"):
+                    setattr(self, attr, signature.get(attr))
+
+            def __getitem__(self, key):
+                # Return item from signature, or None if not given
+                return self.endpoints.get(key)
+
+            def __getattr__(self, key):
+                # Return item from signature, or None if not given
+                return self.endpoints.get(key)
+
+        test_dev = FakeDevice(signature)
+        device = zigpy.quirks.get_device(test_dev)
+        assert isinstance(device, quirk)
+
+    return _check

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -260,6 +260,34 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
     assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
 
 
+def test_ts0121_signature(assert_signature_matches_quirk):
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+            "profile_id": 260,
+            "device_type": "0x0051",
+            "in_clusters": [
+                "0x0000",
+                "0x0004",
+                "0x0005",
+                "0x0006",
+                "0x0702",
+                "0x0b04"
+            ],
+            "out_clusters": [
+                "0x000a",
+                "0x0019"
+            ]
+            }
+        },
+        "manufacturer": "_TZ3000_g5xawfcq",
+        "model": "TS0121",
+        "class": "zhaquirks.tuya.ts0121_plug.Plug"
+    }
+    assert_signature_matches_quirk(zhaquirks.tuya.ts0121_plug.Plug, signature)
+
+
 async def test_tuya_data_conversion():
     """Test tuya conversion from Data to ztype and reverse."""
     assert Data([4, 0, 0, 1, 39]).to_value(t.uint32_t) == 295

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -261,29 +261,27 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
 
 
 def test_ts0121_signature(assert_signature_matches_quirk):
+    """Test TS0121 remote signature is matched to its quirk."""
     signature = {
         "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
         "endpoints": {
             "1": {
-            "profile_id": 260,
-            "device_type": "0x0051",
-            "in_clusters": [
-                "0x0000",
-                "0x0004",
-                "0x0005",
-                "0x0006",
-                "0x0702",
-                "0x0b04"
-            ],
-            "out_clusters": [
-                "0x000a",
-                "0x0019"
-            ]
+                "profile_id": 260,
+                "device_type": "0x0051",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0004",
+                    "0x0005",
+                    "0x0006",
+                    "0x0702",
+                    "0x0b04",
+                ],
+                "out_clusters": ["0x000a", "0x0019"],
             }
         },
         "manufacturer": "_TZ3000_g5xawfcq",
         "model": "TS0121",
-        "class": "zhaquirks.tuya.ts0121_plug.Plug"
+        "class": "zhaquirks.tuya.ts0121_plug.Plug",
     }
     assert_signature_matches_quirk(zhaquirks.tuya.ts0121_plug.Plug, signature)
 


### PR DESCRIPTION
I have been working on support for some additional devices. As part of that, I wanted to be able to easily test if my device signatures would be matched without having to manually test them each time.

So I have created a test fixture that can be used to check if a given device signature will be matched to the given quirk. I wanted to use the real matching algorithm to do this to avoid differences in behaviour between the tests and real usage. In order to do this, I had mock out various parts related to devices.

I have added a test for a device which I have and is already implemented (TS0121 plug) to show how the tests work. I have also created a new section in the README about the tests. Hopefully this will encourage some of the developers implementing new devices to have a go at writing tests with their submissions.

I have some further tests for devices which I am working on but I will submit those together with their code: I wanted to separate the fixture out so that the discussion here can focus around the proposed fixture and documentation, without needing to discuss device implementations at the same time.

For the sample test, I wondered about using the `@pytest.mark.parametrize("quirk", [...])` style that a lot of tests in `test_tuya.py` seem to use, but decided against it so that people don't need to learn that concept before they start writing a test.