### PR TITLE
Tests: avoid traceback seen in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import zigpy.application
 import zigpy.device
 import zigpy.types
+import zigpy.zcl.foundation as foundation
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -41,7 +42,7 @@ class MockApp(zigpy.application.ControllerApplication):
         """Mock permit ncp."""
 
     mrequest = CoroutineMock()
-    request = CoroutineMock()
+    request = CoroutineMock(return_value=(foundation.Status.SUCCESS, None))
 
 
 @pytest.fixture(name="MockAppController")


### PR DESCRIPTION
This patch prevents the error log message generated when a quirk under test sends a reply back to the framework. The error message was not causing tests to fail but was confusing when looking at test logs for failing tests, which contained these errors:

 ERROR    zigpy.zcl:util.py:293 [0x1234:1:0xef00] Traceback (most recent call last):
  File "zigpy/device.py", line 265, in request
    result, msg = await self._application.request(
 ValueError: not enough values to unpack (expected 2, got 0)

I initially assumed that this error message was telling me where the problems in my tests were, but was in fact always there.

The fix ensures that a sent request to the mock app returns a valid return tuple instead of a mock, which cannot be unpacked and causes the traceback.


Example invocation before the patch (using `--log-cli-level` to show the log message):

```shell
$ pytest --disable-warnings --log-cli-level=error -k test_siren_state
[...]
----------------------------------------------------------------------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------------------------------------------------------------------
ERROR    zigpy.zcl:util.py:293 [0x1234:1:0xef00] Traceback (most recent call last):
  File "zigpy/device.py", line 265, in request
    result, msg = await self._application.request(
ValueError: not enough values to unpack (expected 2, got 0)

ERROR    zigpy.zcl:util.py:293 [0x1234:1:0xef00] Traceback (most recent call last):
  File "zigpy/device.py", line 265, in request
    result, msg = await self._application.request(
ValueError: not enough values to unpack (expected 2, got 0)

ERROR    zigpy.zcl:util.py:293 [0x1234:1:0xef00] Traceback (most recent call last):
  File "zigpy/device.py", line 265, in request
    result, msg = await self._application.request(
ValueError: not enough values to unpack (expected 2, got 0)

ERROR    zigpy.zcl:util.py:293 [0x1234:1:0xef00] Traceback (most recent call last):
  File "zigpy/device.py", line 265, in request
    result, msg = await self._application.request(
ValueError: not enough values to unpack (expected 2, got 0)


 tests/test_tuya.py::test_siren_state_report[TuyaSiren] ✓                                                                                                                                                                                                                                                             100% ██████████

Results (0.54s):
       1 passed
    1007 deselected
```

The same command after applying the patch:

```shell
(venv) ➜  zha-device-handlers git:(ts0043-add-variant) ✗ pytest --disable-warnings --log-cli-level=error -k test_siren_state
[...]
 tests/test_tuya.py::test_siren_state_report[TuyaSiren] ✓                                                                                                                                                                                                                                                             100% ██████████

Results (0.59s):
       1 passed
    1007 deselected
```