### PR TITLE
Fixed the cover attribute for lumi.curtain.acn002 when using firmware 1427

### DIFF
--- a/zhaquirks/tuya/ts0044.py
+++ b/zhaquirks/tuya/ts0044.py
@@ -229,7 +229,7 @@ class TuyaSmartRemote0044TO(CustomDevice, Tuya4ButtonTriggers):
     }
 
 
-class TuyaSmartRemote0044TOPlus(CustomDevice, Tuya4ButtonTriggers):
+class TuyaSmartRemote0044TOPlusA(CustomDevice, Tuya4ButtonTriggers):
     """Tuya 4-button remote device with time on out cluster."""
 
     signature = {
@@ -318,6 +318,95 @@ class TuyaSmartRemote0044TOPlus(CustomDevice, Tuya4ButtonTriggers):
                     TuyaSmartRemoteOnOffCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+
+class TuyaSmartRemote0044TOPlusB(CustomDevice, Tuya4ButtonTriggers):
+    """Tuya 4-button remote device with time on out cluster."""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0, device_version=1, input_clusters=[0, 1, 6,], output_clusters=[10, 25]))
+        # SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=0, device_version=1, input_clusters=[1, 6, 57344], output_clusters=[])
+        # SizePrefixedSimpleDescriptor(endpoint=3, profile=260, device_type=0, device_version=1, input_clusters=[1, 6, 57344], output_clusters=[])
+        # SizePrefixedSimpleDescriptor(endpoint=4, profile=260, device_type=0, device_version=1, input_clusters=[1, 6, 57344], output_clusters=[])
+        MODEL: "TS0044",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                    TuyaZBE000Cluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                    TuyaZBE000Cluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                    TuyaZBE000Cluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster, TuyaZBE000Cluster],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster, TuyaZBE000Cluster],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster, TuyaZBE000Cluster],
             },
         },
     }

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -91,12 +91,12 @@ class WindowCoveringRollerE1(WindowCovering):
         self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None
     ):
         if command_id == UP_OPEN:
-            (res,) = await self.endpoint.analog_output.write_attributes(
-                {"present_value": 100}
+            (res,) = await self.endpoint.multistate_output.write_attributes(
+                {"present_value": 1}
             )
             return res[0].status
         elif command_id == DOWN_CLOSE:
-            (res,) = await self.endpoint.analog_output.write_attributes(
+            (res,) = await self.endpoint.multistate_output.write_attributes(
                 {"present_value": 0}
             )
             return res[0].status
@@ -106,15 +106,23 @@ class WindowCoveringRollerE1(WindowCovering):
             )
             return res[0].status
         elif command_id == STOP:
-            attrid = self.endpoint.analog_output.attridx["present_value"]
-            value, _ = await self.endpoint.analog_output.read_attributes(
-                (attrid,), manufacturer=manufacturer
-            )
-
-            (res,) = await self.endpoint.analog_output.write_attributes(
-                {"present_value": value[attrid]}
+            (res,) = await self.endpoint.multistate_output.write_attributes(
+                {"present_value": 2}
             )
             return res[0].status
+
+
+class MultistateOutputRollerE1(MultistateOutput):
+
+    cluster_id = MultistateOutput.cluster_id
+
+    manufacturer_attributes = {
+        0x0055: ("present_value", t.uint16_t),
+    }
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
 
 
 class PowerConfigurationRollerE1(PowerConfiguration, LocalDataCluster):
@@ -200,7 +208,7 @@ class RollerE1AQ(XiaomiCustomDevice):
                     Groups.cluster_id,
                     Identify.cluster_id,
                     XiaomiAqaraRollerE1,
-                    MultistateOutput.cluster_id,
+                    MultistateOutputRollerE1,
                     Scenes.cluster_id,
                     WindowCoveringRollerE1,
                     PowerConfigurationRollerE1,

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -90,7 +90,7 @@ class WindowCoveringRollerE1(WindowCovering):
     async def command(
         self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None
     ):
-        """Overwrite the commands to make it work for both firmware 1425 and 1427. We either overwrite analog_output's current_value or multistate_output's current value to make the roller work"""
+        """Overwrite the commands to make it work for both firmware 1425 and 1427. We either overwrite analog_output's current_value or multistate_output's current value to make the roller work."""
         if command_id == UP_OPEN:
             (res,) = await self.endpoint.multistate_output.write_attributes(
                 {"present_value": 1}
@@ -114,7 +114,7 @@ class WindowCoveringRollerE1(WindowCovering):
 
 
 class MultistateOutputRollerE1(MultistateOutput):
-    """Multistate Output cluster which overwrites present_value because else it gives errors of wrong datatype when using it in the commands"""
+    """Multistate Output cluster which overwrites present_value because else it gives errors of wrong datatype when using it in the commands."""
 
     cluster_id = MultistateOutput.cluster_id
 

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -90,6 +90,7 @@ class WindowCoveringRollerE1(WindowCovering):
     async def command(
         self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None
     ):
+        """Overwrite the commands to make it work for both firmware 1425 and 1427. We either overwrite analog_output's current_value or multistate_output's current value to make the roller work"""
         if command_id == UP_OPEN:
             (res,) = await self.endpoint.multistate_output.write_attributes(
                 {"present_value": 1}
@@ -113,6 +114,7 @@ class WindowCoveringRollerE1(WindowCovering):
 
 
 class MultistateOutputRollerE1(MultistateOutput):
+    """Multistate Output cluster which overwrites present_value because else it gives errors of wrong datatype when using it in the commands"""
 
     cluster_id = MultistateOutput.cluster_id
 

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -1,15 +1,5 @@
 """Aqara Roller Shade Driver E1 device."""
 
-from zhaquirks import Bus, LocalDataCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-from zhaquirks.xiaomi import LUMI, BasicCluster, XiaomiCluster, XiaomiCustomDevice
 from zigpy import types as t
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.closures import WindowCovering
@@ -29,6 +19,17 @@ from zigpy.zcl.clusters.general import (
     Time,
 )
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
+
+from zhaquirks import Bus, LocalDataCluster
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import LUMI, BasicCluster, XiaomiCluster, XiaomiCustomDevice
 
 PRESENT_VALUE = 0x0055
 CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -52,7 +52,7 @@ class XiaomiAqaraRollerE1(XiaomiCluster, ManufacturerSpecificCluster):
     }
 
 
-class AnalogOutputRollerE1(LocalDataCluster, AnalogOutput):
+class AnalogOutputRollerE1(CustomCluster, AnalogOutput):
     """Analog output cluster, only used to relay current_value to WindowCovering."""
 
     cluster_id = AnalogOutput.cluster_id

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -1,8 +1,17 @@
 """Aqara Roller Shade Driver E1 device."""
 
+from zhaquirks import Bus, LocalDataCluster
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import LUMI, BasicCluster, XiaomiCluster, XiaomiCustomDevice
 from zigpy import types as t
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import (
     Alarms,
@@ -21,20 +30,12 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 
-from zhaquirks import Bus, LocalDataCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-from zhaquirks.xiaomi import LUMI, BasicCluster, XiaomiCluster, XiaomiCustomDevice
-
 PRESENT_VALUE = 0x0055
 CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
 GO_TO_LIFT_PERCENTAGE = 0x0005
+DOWN_CLOSE = 0x0001
+UP_OPEN = 0x0000
+STOP = 0x0002
 
 
 class XiaomiAqaraRollerE1(XiaomiCluster, ManufacturerSpecificCluster):
@@ -52,7 +53,7 @@ class XiaomiAqaraRollerE1(XiaomiCluster, ManufacturerSpecificCluster):
     }
 
 
-class AnalogOutputRollerE1(CustomCluster, AnalogOutput):
+class AnalogOutputRollerE1(AnalogOutput):
     """Analog output cluster, only used to relay current_value to WindowCovering."""
 
     cluster_id = AnalogOutput.cluster_id
@@ -61,45 +62,59 @@ class AnalogOutputRollerE1(CustomCluster, AnalogOutput):
         """Init."""
         super().__init__(*args, **kwargs)
 
+        self._update_attribute(0x0041, float(0x064))  # max_present_value
+        self._update_attribute(0x0045, 0.0)  # min_present_value
+        self._update_attribute(0x0051, 0)  # out_of_service
+        self._update_attribute(0x006A, 1.0)  # resolution
+        self._update_attribute(0x006F, 0x00)  # status_flags
+
     def _update_attribute(self, attrid, value):
+
         super()._update_attribute(attrid, value)
-        if attrid is not None and attrid == PRESENT_VALUE:
-            self.endpoint.device.roller_bus.listener_event(
-                "current_position_lift_percentage", value
+
+        if attrid == PRESENT_VALUE:
+            self.endpoint.window_covering._update_attribute(
+                CURRENT_POSITION_LIFT_PERCENTAGE, (100 - value)
             )
 
 
-class WindowCoveringRollerE1(CustomCluster, WindowCovering):
-    """Window covering cluster to receive reports that are sent to the AnalogOutput cluster."""
+class WindowCoveringRollerE1(WindowCovering):
+    """Window covering cluster to receive commands that are sent to the AnalogOutput's present_value to move the motor."""
 
     cluster_id = WindowCovering.cluster_id
 
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
-        self.endpoint.device.roller_bus.add_listener(self)
-
-    def current_position_lift_percentage(self, value):
-        """Update current_position_lift_percentage and invert value."""
-        value = 100 - value
-        self._update_attribute(CURRENT_POSITION_LIFT_PERCENTAGE, value)
 
     async def command(
         self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None
     ):
-        """Override default command to invert percent lift value."""
-        if command_id == GO_TO_LIFT_PERCENTAGE:
-            percent = args[0]
-            percent = 100 - percent
-            v = (percent,)
-            return await super().command(command_id, *v)
-        return await super().command(
-            command_id,
-            *args,
-            manufacturer=manufacturer,
-            expect_reply=expect_reply,
-            tsn=tsn
-        )
+        if command_id == UP_OPEN:
+            (res,) = await self.endpoint.analog_output.write_attributes(
+                {"present_value": 100}
+            )
+            return [command_id, res[0].status]
+        elif command_id == DOWN_CLOSE:
+            (res,) = await self.endpoint.analog_output.write_attributes(
+                {"present_value": 0}
+            )
+            return [command_id, res[0].status]
+        elif command_id == GO_TO_LIFT_PERCENTAGE:
+            (res,) = await self.endpoint.analog_output.write_attributes(
+                {"present_value": (100 - args[0])}
+            )
+            return [command_id, res[0].status]
+        elif command_id == STOP:
+            attrid = self.endpoint.analog_output.attridx["present_value"]
+            value, _ = await self.endpoint.analog_output.read_attributes(
+                (attrid,), manufacturer=manufacturer
+            )
+
+            (res,) = await self.endpoint.analog_output.write_attributes(
+                {"present_value": value[attrid]}
+            )
+            return [command_id, res[0].status]
 
 
 class PowerConfigurationRollerE1(PowerConfiguration, LocalDataCluster):
@@ -127,7 +142,6 @@ class RollerE1AQ(XiaomiCustomDevice):
 
     def __init__(self, *args, **kwargs):
         """Init."""
-        self.roller_bus = Bus()
         self.power_bus_percentage = Bus()
         super().__init__(*args, **kwargs)
 

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -39,7 +39,7 @@ STOP = 0x0002
 
 
 class XiaomiAqaraRollerE1(XiaomiCluster, ManufacturerSpecificCluster):
-    """Xiaomi mfg cluster implementation specific for E1 Roller ."""
+    """Xiaomi mfg cluster implementation specific for E1 Roller."""
 
     cluster_id = 0xFCC0
 

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -94,17 +94,17 @@ class WindowCoveringRollerE1(WindowCovering):
             (res,) = await self.endpoint.analog_output.write_attributes(
                 {"present_value": 100}
             )
-            return [command_id, res[0].status]
+            return res[0].status
         elif command_id == DOWN_CLOSE:
             (res,) = await self.endpoint.analog_output.write_attributes(
                 {"present_value": 0}
             )
-            return [command_id, res[0].status]
+            return res[0].status
         elif command_id == GO_TO_LIFT_PERCENTAGE:
             (res,) = await self.endpoint.analog_output.write_attributes(
                 {"present_value": (100 - args[0])}
             )
-            return [command_id, res[0].status]
+            return res[0].status
         elif command_id == STOP:
             attrid = self.endpoint.analog_output.attridx["present_value"]
             value, _ = await self.endpoint.analog_output.read_attributes(
@@ -114,7 +114,7 @@ class WindowCoveringRollerE1(WindowCovering):
             (res,) = await self.endpoint.analog_output.write_attributes(
                 {"present_value": value[attrid]}
             )
-            return [command_id, res[0].status]
+            return res[0].status
 
 
 class PowerConfigurationRollerE1(PowerConfiguration, LocalDataCluster):


### PR DESCRIPTION
As discussed in https://github.com/zigpy/zha-device-handlers/issues/1181 the previous lumi.curtain.acn002 quirk only worked for firmware 1425. This PR focusses on both firmware 1425 and 1427 to make the cover attribute work. Also in the process made the analogOutput attribute work properly and made small tweaks.

Background:
The commands in 1427 always report success but no action is done. This PR catched the commands and writes to MultistateOutput and also AnalogOutput to make the curtains go up, down, stop or go to certain percentage.

