### PR TITLE
Add device support for TS110E Model QS-Zigbee-D02-TRIAC-LN

### DIFF
--- a/zhaquirks/tuya/ts110e.py
+++ b/zhaquirks/tuya/ts110e.py
@@ -1,0 +1,142 @@
+"""Tuya Dimmer TS110E."""
+from zigpy.profiles import zha
+import zigpy.types as t
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    LevelControl,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+
+from zigpy.zcl import foundation
+from typing import Optional, Union
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+from zhaquirks.tuya import (
+    TuyaDimmerSwitch,
+    TuyaZBExternalSwitchTypeCluster,
+)
+
+class TuyaLevelPayload(t.Struct):
+    """Tuya Level payload."""
+
+    level: t.uint16_t
+    transtime: t.uint16_t
+
+TUYA_LEVEL_ATTRIBUTE = 0xF000
+TUYA_CUSTOM_LEVEL_COMMAND = 0x00F0
+
+class F000LevelControlCluster(LevelControl):
+    """LevelControlCluster that reports to attrid 0xF000."""
+
+    manufacturer_attributes = {TUYA_LEVEL_ATTRIBUTE: ("manufacturer_current_level", t.uint16_t),} 
+
+    manufacturer_server_commands = {
+        TUYA_CUSTOM_LEVEL_COMMAND: ("moveToLevelTuya", (TuyaLevelPayload,), False),
+    }
+
+    # 0xF000 reported values are 0-1000, convert to 0-255
+    def _update_attribute(self, attrid, value):
+        if attrid == TUYA_LEVEL_ATTRIBUTE:
+            value = (value * 255) // 1000
+            attrid = 0x0000
+
+        super()._update_attribute(attrid, value)
+
+    async def command(
+        self,
+        command_id: Union[foundation.Command, int, t.uint8_t],
+        *args,
+        manufacturer: Optional[Union[int, t.uint16_t]] = None,
+        expect_reply: bool = True,
+        tsn: Optional[Union[int, t.uint8_t]] = None,
+    ):
+        """Override the default Cluster command."""
+        self.debug(
+            "Sending Cluster Command. Cluster Command is %x, Arguments are %s",
+            command_id,
+            args,
+        )
+        # move_to_level, move, move_to_level_with_on_off
+        if command_id in (0x0000, 0x0001, 0x0004):
+            # convert dim values to 0-1000
+            brightness = (args[0] * 1000) // 255
+            return await super().command(
+                TUYA_CUSTOM_LEVEL_COMMAND, 
+                TuyaLevelPayload(level=brightness, transtime=0), 
+                manufacturer=manufacturer, 
+                expect_reply=expect_reply,
+                tsn=tsn
+            )
+
+        return super().command(command_id, *args, manufacturer, expect_reply, tsn)
+
+
+class DimmerSwitchWithNeutral1Gang(TuyaDimmerSwitch):
+    """Tuya Dimmer Switch Module With Neutral 1 Gang"""
+
+    signature = {
+        MODELS_INFO: [("_TZ3210_ngqk6jia", "TS110E")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=257
+            # input_clusters=[0, 4, 5, 6, 8, 57345]
+            # output_clusters=[10, 25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+                # input_clusters=[]
+                # output_clusters=[33]
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    F000LevelControlCluster,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }

--- a/zhaquirks/tuya/ts110e.py
+++ b/zhaquirks/tuya/ts110e.py
@@ -1,6 +1,9 @@
 """Tuya Dimmer TS110E."""
+from typing import Optional, Union
+
 from zigpy.profiles import zha
 import zigpy.types as t
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
@@ -12,9 +15,6 @@ from zigpy.zcl.clusters.general import (
     Time,
 )
 
-from zigpy.zcl import foundation
-from typing import Optional, Union
-
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -24,10 +24,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 
-from zhaquirks.tuya import (
-    TuyaDimmerSwitch,
-    TuyaZBExternalSwitchTypeCluster,
-)
+from zhaquirks.tuya import TuyaDimmerSwitch, TuyaZBExternalSwitchTypeCluster
 
 
 TUYA_LEVEL_ATTRIBUTE = 0xF000

--- a/zhaquirks/tuya/ts110e.py
+++ b/zhaquirks/tuya/ts110e.py
@@ -23,13 +23,11 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
 from zhaquirks.tuya import (
+    NoManufacturerCluster,
     TuyaDimmerSwitch,
     TuyaZBExternalSwitchTypeCluster,
-    NoManufacturerCluster,
 )
-
 
 TUYA_LEVEL_ATTRIBUTE = 0xF000
 TUYA_BULB_TYPE_ATTRIBUTE = 0xFC02
@@ -123,7 +121,7 @@ class F000LevelControlCluster(NoManufacturerCluster, LevelControl):
 
 
 class DimmerSwitchWithNeutral1Gang(TuyaDimmerSwitch):
-    """Tuya Dimmer Switch Module With Neutral 1 Gang"""
+    """Tuya Dimmer Switch Module With Neutral 1 Gang."""
 
     signature = {
         MODELS_INFO: [("_TZ3210_ngqk6jia", "TS110E")],

--- a/zhaquirks/tuya/ts110e.py
+++ b/zhaquirks/tuya/ts110e.py
@@ -29,19 +29,24 @@ from zhaquirks.tuya import (
     TuyaZBExternalSwitchTypeCluster,
 )
 
+
+TUYA_LEVEL_ATTRIBUTE = 0xF000
+TUYA_CUSTOM_LEVEL_COMMAND = 0x00F0
+
+
 class TuyaLevelPayload(t.Struct):
     """Tuya Level payload."""
 
     level: t.uint16_t
     transtime: t.uint16_t
 
-TUYA_LEVEL_ATTRIBUTE = 0xF000
-TUYA_CUSTOM_LEVEL_COMMAND = 0x00F0
 
 class F000LevelControlCluster(LevelControl):
     """LevelControlCluster that reports to attrid 0xF000."""
 
-    manufacturer_attributes = {TUYA_LEVEL_ATTRIBUTE: ("manufacturer_current_level", t.uint16_t),} 
+    manufacturer_attributes = {
+        TUYA_LEVEL_ATTRIBUTE: ("manufacturer_current_level", t.uint16_t),
+    }
 
     manufacturer_server_commands = {
         TUYA_CUSTOM_LEVEL_COMMAND: ("moveToLevelTuya", (TuyaLevelPayload,), False),
@@ -74,11 +79,11 @@ class F000LevelControlCluster(LevelControl):
             # convert dim values to 0-1000
             brightness = (args[0] * 1000) // 255
             return await super().command(
-                TUYA_CUSTOM_LEVEL_COMMAND, 
-                TuyaLevelPayload(level=brightness, transtime=0), 
-                manufacturer=manufacturer, 
+                TUYA_CUSTOM_LEVEL_COMMAND,
+                TuyaLevelPayload(level=brightness, transtime=0),
+                manufacturer=manufacturer,
                 expect_reply=expect_reply,
-                tsn=tsn
+                tsn=tsn,
             )
 
         return super().command(command_id, *args, manufacturer, expect_reply, tsn)

--- a/zhaquirks/tuya/ts110e.py
+++ b/zhaquirks/tuya/ts110e.py
@@ -1,6 +1,9 @@
 """Tuya Dimmer TS110E."""
+from typing import Optional, Union
+
 from zigpy.profiles import zha
 import zigpy.types as t
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
@@ -12,9 +15,6 @@ from zigpy.zcl.clusters.general import (
     Time,
 )
 
-from zigpy.zcl import foundation
-from typing import Optional, Union
-
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -23,12 +23,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-from zhaquirks.tuya import (
-    TuyaDimmerSwitch,
-    TuyaZBExternalSwitchTypeCluster,
-)
-
+from zhaquirks.tuya import TuyaDimmerSwitch, TuyaZBExternalSwitchTypeCluster
 
 TUYA_LEVEL_ATTRIBUTE = 0xF000
 TUYA_CUSTOM_LEVEL_COMMAND = 0x00F0
@@ -90,7 +85,7 @@ class F000LevelControlCluster(LevelControl):
 
 
 class DimmerSwitchWithNeutral1Gang(TuyaDimmerSwitch):
-    """Tuya Dimmer Switch Module With Neutral 1 Gang"""
+    """Tuya Dimmer Switch Module With Neutral 1 Gang."""
 
     signature = {
         MODELS_INFO: [("_TZ3210_ngqk6jia", "TS110E")],


### PR DESCRIPTION
This device uses a non-default set level command.

This device looks exactly the same as TS110F but seems to have different zigbee command IDs. This is TS110F on blakadder: https://zigbee.blakadder.com/Lonsonho_QS-Zigbee-D02-TRIAC-LN.html

Tested in local docker environment.
Thanks to @javicalle this was possible.
Fix #1415