### PR TITLE
Add the 2nd signature of TS0601 _TZE200_zpzndjez

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -79,6 +79,7 @@ class TuyaZemismartSmartCover0601_3(TuyaWindowCover):
         # <SimpleDescriptor endpoint=1 profile=260 device_type=51 input_clusters=[0, 4, 5, 61184] output_clusters=[25]>
         MODELS_INFO: [
             ("_TZE200_fzo2pocs", "TS0601"),
+            ("_TZE200_zpzndjez", "TS0601"),
             ("_TZE200_iossyxra", "TS0601"),
         ],
         ENDPOINTS: {


### PR DESCRIPTION
Tested with five TS0601 _TZE200_zpzndjez curtain motors

Two of them use the endpoints signature defined in ```TuyaZemismartSmartCover0601```
Three have the same siganture as ```TuyaZemismartSmartCover0601_3```

Thus the model should be added to both.