### PR TITLE
IKEA ROTATED from const.py

### DIFF
--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -10,7 +10,6 @@ from zhaquirks import DoublingPowerConfigurationCluster
 
 _LOGGER = logging.getLogger(__name__)
 IKEA = "IKEA of Sweden"
-ROTATED = "device_rotated"
 
 
 class LightLinkCluster(CustomCluster, LightLink):

--- a/zhaquirks/ikea/dimmer.py
+++ b/zhaquirks/ikea/dimmer.py
@@ -27,8 +27,9 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     RIGHT,
+    ROTATED,
 )
-from zhaquirks.ikea import IKEA, ROTATED, PowerConfiguration1CRXCluster
+from zhaquirks.ikea import IKEA, PowerConfiguration1CRXCluster
 
 
 class IkeaDimmer(CustomDevice):

--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -31,12 +31,13 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     RIGHT,
+    ROTATED,
     SHORT_PRESS,
     STOP,
     TRIPLE_PRESS,
     TURN_ON,
 )
-from zhaquirks.ikea import IKEA, ROTATED, PowerConfiguration1CRCluster
+from zhaquirks.ikea import IKEA, PowerConfiguration1CRCluster
 
 
 class IkeaSYMFONISK(CustomDevice):


### PR DESCRIPTION
Use ROTATED from const.py and deleting it in IKEA INIT and change the import for symfonisk.py so its using it from const.py.

Edit: I was forgetting that the retro dimer was using it 2 :-((