### PR TITLE
Adding Rotating Knob plus scene DA for DMS

### DIFF
--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -234,7 +234,6 @@ class TuyaSmartRemote004FDMS(CustomDevice):
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,  # Is needed for adding group then binding is not working.
-                    TuyaSmartRemoteOnOffCluster,
                     LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -243,6 +242,7 @@ class TuyaSmartRemote004FDMS(CustomDevice):
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
                     LevelControl.cluster_id,
                     Color.cluster_id,
                     LightLink.cluster_id,

--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 import asyncio
 import logging
 
-import zigpy
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomDevice
 import zigpy.types as t
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -32,9 +31,9 @@ from zhaquirks.const import (
     CLUSTER_ID,
     COMMAND,
     COMMAND_MOVE,
+    COMMAND_MOVE_SATURATION,
     COMMAND_OFF,
     COMMAND_ON,
-    COMMAND_MOVE_SATURATION,
     COMMAND_STEP,
     COMMAND_STOP,
     COMMAND_STOP_MOVE_STEP,
@@ -58,7 +57,6 @@ from zhaquirks.const import (
     ROTATED_FAST,
     ROTATED_SLOW,
     SHORT_PRESS,
-    STOP,
     TURN_OFF,
     TURN_ON,
 )
@@ -145,7 +143,7 @@ class TuyaSmartRemote004FROK(CustomDevice):
             ENDPOINT_ID: 1,
             CLUSTER_ID: 8,
             ARGS: [0, 13, 1],
-        },  # Trigered for both let and right in HA (HA bug).
+        },  # Triggered for both let and right in HA (HA bug).
         (ROTATED_SLOW, LEFT): {
             COMMAND: COMMAND_STEP,
             ENDPOINT_ID: 1,
@@ -195,7 +193,7 @@ class TuyaSmartRemote004FDMS(CustomDevice):
 
         attr_to_read = [4, 0, 1, 5, 7, 0xFFFE]
         await basic_cluster.read_attributes(attr_to_read)
-        _LOGGER.debug(f"Device class is casting Tuya Magic Spell")
+        _LOGGER.debug("Device class is casting Tuya Magic Spell")
 
     signature = {
         # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=0, *allocate_address=True, *complex_descriptor_available=False, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False, *is_valid=True, *logical_type=<LogicalType.EndDevice: 2>, *user_descriptor_available=False)",

--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -6,7 +6,6 @@ import logging
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
-import zigpy.types as t
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -60,7 +59,7 @@ from zhaquirks.const import (
     TURN_OFF,
     TURN_ON,
 )
-from zhaquirks.tuya import TuyaZBOnOffAttributeCluster, TuyaSmartRemoteOnOffCluster
+from zhaquirks.tuya import TuyaSmartRemoteOnOffCluster, TuyaZBOnOffAttributeCluster
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -1,7 +1,13 @@
-"""Tuya 4 Button Remote TS004F."""
+"""Tuya TS004F devices."""
+from __future__ import annotations
 
+import asyncio
+import logging
+
+import zigpy
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -13,37 +19,264 @@ from zigpy.zcl.clusters.general import (
     Scenes,
     Time,
 )
+from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
 from zhaquirks.const import (
     ARGS,
+    BUTTON,
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    BUTTON_4,
     CLUSTER_ID,
     COMMAND,
     COMMAND_MOVE,
     COMMAND_OFF,
     COMMAND_ON,
+    COMMAND_MOVE_SATURATION,
     COMMAND_STEP,
     COMMAND_STOP,
+    COMMAND_STOP_MOVE_STEP,
+    COMMAND_TOGGLE,
     DEVICE_TYPE,
     DIM_DOWN,
     DIM_UP,
+    DOUBLE_PRESS,
     ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
+    LEFT,
     LONG_PRESS,
     LONG_RELEASE,
     MODEL,
+    MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    RIGHT,
+    ROTATED,
+    ROTATED_FAST,
+    ROTATED_SLOW,
     SHORT_PRESS,
+    STOP,
     TURN_OFF,
     TURN_ON,
 )
-from zhaquirks.tuya import TuyaZBOnOffAttributeCluster
+from zhaquirks.tuya import TuyaZBOnOffAttributeCluster, TuyaSmartRemoteOnOffCluster
+
+_LOGGER = logging.getLogger(__name__)
 
 
-class Tuya4NewButtonTriggers:
-    """Tuya 4-button New version remote device triggers."""
+class TuyaSmartRemote004FROK(CustomDevice):
+    """Tuya Smart (rotating) Knob device."""
+
+    signature = {
+        # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=0, *allocate_address=True, *complex_descriptor_available=False, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False, *is_valid=True, *logical_type=<LogicalType.EndDevice: 2>, *user_descriptor_available=False)",
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=260, device_version=1, input_clusters=[0, 1, 3, 4, 6, 4096], output_clusters=[25, 10, 3, 4, 5, 6, 8, 4096])
+        MODELS_INFO: [("_TZ3000_4fjiwweb", "TS004F")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,  # Is needed for adding group then binding is not working.
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1, CLUSTER_ID: 6},
+        (LONG_RELEASE, BUTTON): {
+            COMMAND: COMMAND_STOP_MOVE_STEP,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 768,
+        },
+        (LONG_PRESS, BUTTON): {
+            COMMAND: COMMAND_MOVE_SATURATION,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 768,
+            ARGS: [1, 200],
+        },
+        (ROTATED_SLOW, RIGHT): {
+            COMMAND: COMMAND_STEP,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 8,
+            ARGS: [0, 13, 1],
+        },  # Trigered for both let and right in HA (HA bug).
+        (ROTATED_SLOW, LEFT): {
+            COMMAND: COMMAND_STEP,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 8,
+            ARGS: [1, 13, 1],
+        },
+        (ROTATED_FAST, RIGHT): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 37, 2],
+        },
+        (ROTATED_FAST, LEFT): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [1, 37, 2],
+        },
+        (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
+        (ROTATED, RIGHT): {
+            COMMAND: RIGHT,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 6,
+        },
+        (ROTATED, LEFT): {
+            COMMAND: LEFT,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 6,
+        },
+    }
+
+
+class TuyaSmartRemote004FDMS(CustomDevice):
+    """Tuya 4 btton dimmer switch / remote device."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize with task."""
+        super().__init__(*args, **kwargs)
+
+        self._init_plug_task = asyncio.create_task(self.spell())
+
+    async def spell(self) -> None:
+        """Initialize device so that all endpoints become available."""
+        basic_cluster = self.endpoints[1].in_clusters[0]
+
+        attr_to_read = [4, 0, 1, 5, 7, 0xFFFE]
+        await basic_cluster.read_attributes(attr_to_read)
+        _LOGGER.debug(f"Device class is casting Tuya Magic Spell")
+
+    signature = {
+        # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=0, *allocate_address=True, *complex_descriptor_available=False, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False, *is_valid=True, *logical_type=<LogicalType.EndDevice: 2>, *user_descriptor_available=False)",
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=260, device_version=1, input_clusters=[0, 1, 3, 4, 6, 4096], output_clusters=[25, 10, 3, 4, 5, 6, 8, 4096])
+        MODELS_INFO: [("_TZ3000_xabckq1v", "TS004F")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,  # Is needed for adding group then binding is not working.
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    TuyaSmartRemoteOnOffCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    TuyaSmartRemoteOnOffCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    TuyaSmartRemoteOnOffCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
 
     device_automation_triggers = {
         (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 1},
@@ -77,10 +310,22 @@ class Tuya4NewButtonTriggers:
             CLUSTER_ID: 8,
             ENDPOINT_ID: 1,
         },
+        (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
+        (SHORT_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: DOUBLE_PRESS},
+        (SHORT_PRESS, BUTTON_3): {ENDPOINT_ID: 3, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_3): {ENDPOINT_ID: 3, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_3): {ENDPOINT_ID: 3, COMMAND: DOUBLE_PRESS},
+        (SHORT_PRESS, BUTTON_4): {ENDPOINT_ID: 4, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_4): {ENDPOINT_ID: 4, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_4): {ENDPOINT_ID: 4, COMMAND: DOUBLE_PRESS},
     }
 
 
-class TuyaSmartRemote004F(CustomDevice, Tuya4NewButtonTriggers):
+class TuyaSmartRemote004F(CustomDevice):
     """Tuya 4-button New version remote device."""
 
     signature = {
@@ -109,9 +354,10 @@ class TuyaSmartRemote004F(CustomDevice, Tuya4NewButtonTriggers):
                     LevelControl.cluster_id,
                     LightLink.cluster_id,
                 ],
-            }
+            },
         },
     }
+
     replacement = {
         ENDPOINTS: {
             1: {
@@ -134,6 +380,40 @@ class TuyaSmartRemote004F(CustomDevice, Tuya4NewButtonTriggers):
                     LevelControl.cluster_id,
                     LightLink.cluster_id,
                 ],
-            }
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 1},
+        (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 1},
+        (SHORT_PRESS, DIM_UP): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 51, 10],
+        },
+        (LONG_PRESS, DIM_UP): {
+            COMMAND: COMMAND_MOVE,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 51],
+        },
+        (SHORT_PRESS, DIM_DOWN): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [1, 51, 10],
+        },
+        (LONG_PRESS, DIM_DOWN): {
+            COMMAND: COMMAND_MOVE,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [1, 51],
+        },
+        (LONG_RELEASE, DIM_DOWN): {
+            COMMAND: COMMAND_STOP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
         },
     }

--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -234,6 +234,7 @@ class TuyaSmartRemote004FDMS(CustomDevice):
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,  # Is needed for adding group then binding is not working.
+                    TuyaSmartRemoteOnOffCluster,
                     LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -242,7 +243,6 @@ class TuyaSmartRemote004FDMS(CustomDevice):
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaSmartRemoteOnOffCluster,
                     LevelControl.cluster_id,
                     Color.cluster_id,
                     LightLink.cluster_id,


### PR DESCRIPTION
Adding the new Smart Rotating Knob with both command end event mode and device automatons that working but one is hitted of one HA bug that we cant fixing.
Adding Event mode (tuya scenes) after 10 mounts of user requests and all possible device automatons for it.

Implanting sending "tuya magic" from the device class that working every time the device is doing  on new joining do the 3 new endpoints is being initiated OK.