### PR TITLE
Adding 2 new tuya TRVs

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1426,6 +1426,8 @@ class MoesHY368_Type1(TuyaThermostat):
             ("_TZE200_2atgpdho", "TS0601"),
             ("_TZE200_pvvbommb", "TS0601"),
             ("_TZE200_4eeyebrt", "TS0601"),
+            ("_TZE200_cpmgn2cf", "TS0601"),
+            ("_TZE200_9sfg7gm0", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Adding `_TZE200_cpmgn2cf` and `_TZE200_9sfg7gm0` that is new / updated version of the normal TH TRVs.

Fix #1439