### PR TITLE
Add alternative quirk for IKEA E1812 button

### DIFF
--- a/zhaquirks/ikea/shortcutbtn.py
+++ b/zhaquirks/ikea/shortcutbtn.py
@@ -115,3 +115,78 @@ class IkeaTradfriShortcutBtn(CustomDevice):
             ENDPOINT_ID: 1,
         },
     }
+
+class IkeaTradfriShortcutBtn2(CustomDevice):
+    """Custom device representing IKEA of Sweden TRADFRI shortcut button with IKEA cluster."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=2080
+        # device_version=1
+        # input_clusters=[0, 1, 3, 9, 32, 4096, 64636]
+        # output_clusters=[3, 4, 6, 8, 25, 4096]>
+        MODELS_INFO: [(IKEA, "TRADFRI SHORTCUT Button")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Alarms.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                    0xfc7c, # IKEA Cluster
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration1CRCluster,
+                    Identify.cluster_id,
+                    Alarms.cluster_id,
+                    PollControl.cluster_id,
+                    LightLinkCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 1},
+        (DOUBLE_PRESS, TURN_ON): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 1},
+        (LONG_PRESS, DIM_UP): {
+            COMMAND: COMMAND_MOVE_ON_OFF,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 83],
+        },
+        (LONG_RELEASE, DIM_UP): {
+            COMMAND: COMMAND_STOP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+        },
+    }

--- a/zhaquirks/ikea/shortcutbtn.py
+++ b/zhaquirks/ikea/shortcutbtn.py
@@ -116,6 +116,7 @@ class IkeaTradfriShortcutBtn(CustomDevice):
         },
     }
 
+
 class IkeaTradfriShortcutBtn2(CustomDevice):
     """Custom device representing IKEA of Sweden TRADFRI shortcut button with IKEA cluster."""
 
@@ -136,7 +137,7 @@ class IkeaTradfriShortcutBtn2(CustomDevice):
                     Alarms.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,
-                    0xfc7c, # IKEA Cluster
+                    0xFC7C,  # IKEA Cluster
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,


### PR DESCRIPTION
Some IKEA Tradfri shortcut buttons (E1812) expose the 0xFC7C manufacturer-specific input cluster but lack the WindowCovering cluster. This leads to the IkeaTradfriShortcutBtn quirk not being applied. This PR adds an alternative quirk that can be used with these buttons.

Closes #1204 