### PR TITLE
Fix return values for `command` overrides

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,22 @@ error_summary = True
 install_types = True
 non_interactive = True
 
+disable_error_code =
+    arg-type,
+    assignment,
+    attr-defined,
+    call-arg,
+    dict-item,
+    index,
+    misc,
+    no-any-return,
+    no-untyped-call,
+    no-untyped-def,
+    override,
+    return-value,
+    union-attr,
+    var-annotated
+
 [pydocstyle]
 ignore =
     D202,

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -236,7 +236,7 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
         tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
     ) as m1:
 
-        status = await switch_cluster.command(0x0000)
+        rsp = await switch_cluster.command(0x0000)
         m1.assert_called_with(
             61184,
             2,
@@ -244,9 +244,9 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             command_id=0,
         )
-        assert status == 0
+        assert rsp.status == 0
 
-        status = await switch_cluster.command(0x0001)
+        rsp = await switch_cluster.command(0x0001)
         m1.assert_called_with(
             61184,
             4,
@@ -254,10 +254,10 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             command_id=0,
         )
-        assert status == 0
+        assert rsp.status == 0
 
-    status = await switch_cluster.command(0x0002)
-    assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
+    rsp = await switch_cluster.command(0x0002)
+    assert rsp.status == foundation.Status.UNSUP_CLUSTER_COMMAND
 
 
 def test_ts0121_signature(assert_signature_matches_quirk):

--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -30,7 +30,7 @@ async def test_command(zigpy_device_from_quirk, quirk):
     with mock.patch.object(
         tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
     ) as m1:
-        status = await switch2_cluster.command(0x0001)
+        rsp = await switch2_cluster.command(0x0001)
 
         m1.assert_called_with(
             61184,
@@ -39,9 +39,9 @@ async def test_command(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             command_id=0,
         )
-        assert status == foundation.Status.SUCCESS
+        assert rsp.status == foundation.Status.SUCCESS
 
-        status = await dimmer1_cluster.command(0x0000, 225)
+        rsp = await dimmer1_cluster.command(0x0000, 225)
 
         m1.assert_called_with(
             61184,
@@ -50,7 +50,7 @@ async def test_command(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             command_id=0,
         )
-        assert status == foundation.Status.SUCCESS
+        assert rsp.status == foundation.Status.SUCCESS
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -85,17 +85,17 @@ async def test_tuya_methods(zigpy_device_from_quirk, quirk):
         m1.assert_not_called()
 
     result_3 = await dimmer2_cluster.command(0x0006)
-    assert result_3 == foundation.Status.UNSUP_CLUSTER_COMMAND
+    assert result_3.status == foundation.Status.UNSUP_CLUSTER_COMMAND
 
     with mock.patch.object(tuya_cluster, "tuya_mcu_command") as m1:
-        status = await switch1_cluster.command(0x0001)
+        rsp = await switch1_cluster.command(0x0001)
 
         m1.assert_called_once_with(tcd_switch1_on)
-        assert status == foundation.Status.SUCCESS
+        assert rsp.status == foundation.Status.SUCCESS
 
-        status = await switch1_cluster.command(0x0004)
+        rsp = await switch1_cluster.command(0x0004)
         m1.assert_called_once_with(tcd_switch1_on)  # no extra calls
-        assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
+        assert rsp.status == foundation.Status.UNSUP_CLUSTER_COMMAND
 
 
 async def test_tuya_mcu_classes():

--- a/zhaquirks/kof/kof_mr101z.py
+++ b/zhaquirks/kof/kof_mr101z.py
@@ -39,7 +39,7 @@ class NoReplyMixin:
         if expect_reply is None:
             expect_reply = command not in self.void_input_commands
 
-        return super().command(
+        return super(NoReplyMixin, self).command(
             command, *args, manufacturer=manufacturer, expect_reply=expect_reply
         )
 

--- a/zhaquirks/kof/kof_mr101z.py
+++ b/zhaquirks/kof/kof_mr101z.py
@@ -39,7 +39,7 @@ class NoReplyMixin:
         if expect_reply is None:
             expect_reply = command not in self.void_input_commands
 
-        return super(NoReplyMixin, self).command(
+        return super().command(
             command, *args, manufacturer=manufacturer, expect_reply=expect_reply
         )
 

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -670,11 +670,17 @@ class TuyaThermostatCluster(LocalDataCluster, Thermostat):
         """Implement thermostat commands."""
 
         if command_id != 0x0000:
-            return [command_id, foundation.Status.UNSUP_CLUSTER_COMMAND]
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(
+                command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND
+            )
 
         mode, offset = args
         if mode not in (self.SetpointMode.Heat, self.SetpointMode.Both):
-            return [command_id, foundation.Status.INVALID_VALUE]
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.INVALID_VALUE)
 
         attrid = self.attributes_by_name["occupied_heating_setpoint"].id
 
@@ -689,7 +695,9 @@ class TuyaThermostatCluster(LocalDataCluster, Thermostat):
             {"occupied_heating_setpoint": current + offset * 10},
             manufacturer=manufacturer,
         )
-        return [command_id, res[0].status]
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=command_id, status=res[0].status)
 
 
 class TuyaUserInterfaceCluster(LocalDataCluster, UserInterface):

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -294,10 +294,14 @@ class TuyaOnOff(OnOff, TuyaLocalCluster):
                 TUYA_MCU_COMMAND,
                 cluster_data,
             )
-            return foundation.Status.SUCCESS
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
 
         self.warning("Unsupported command_id: %s", command_id)
-        return foundation.Status.UNSUP_CLUSTER_COMMAND
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
 
 
 class TuyaOnOffManufCluster(TuyaMCUCluster):
@@ -406,10 +410,14 @@ class TuyaLevelControl(LevelControl, TuyaLocalCluster):
                 TUYA_MCU_COMMAND,
                 cluster_data,
             )
-            return foundation.Status.SUCCESS
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
 
         self.warning("Unsupported command_id: %s", command_id)
-        return foundation.Status.UNSUP_CLUSTER_COMMAND
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
 
 
 class TuyaInWallLevelControl(TuyaAttributesCluster, TuyaLevelControl):

--- a/zhaquirks/tuya/ts0601_siren.py
+++ b/zhaquirks/tuya/ts0601_siren.py
@@ -150,9 +150,13 @@ class TuyaSirenOnOff(LocalDataCluster, OnOff):
             (res,) = await self.endpoint.tuya_manufacturer.write_attributes(
                 {TUYA_ALARM_ATTR: command_id}, manufacturer=manufacturer
             )
-            return [command_id, res[0].status]
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
 
-        return [command_id, foundation.Status.UNSUP_CLUSTER_COMMAND]
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
 
 
 class TuyaTemperatureMeasurement(LocalDataCluster, TemperatureMeasurement):
@@ -270,7 +274,9 @@ class TuyaMCUSiren(OnOff, TuyaAttributesCluster):
     async def write_attributes(self, attributes, manufacturer=None):
         """Overwrite to force manufacturer code."""
 
-        return await super().write_attributes(attributes, manufacturer="")
+        return await super().write_attributes(
+            attributes, manufacturer=foundation.ZCLHeader.NO_MANUFACTURER_ID
+        )
 
     async def command(
         self,
@@ -289,16 +295,20 @@ class TuyaMCUSiren(OnOff, TuyaAttributesCluster):
                 cluster_attr="on_off",
                 attr_value=command_id,
                 expect_reply=expect_reply,
-                manufacturer="",
+                manufacturer=foundation.ZCLHeader.NO_MANUFACTURER_ID,
             )
             self.endpoint.device.command_bus.listener_event(
                 TUYA_MCU_COMMAND,
                 cluster_data,
             )
-            return foundation.Status.SUCCESS
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
 
         self.warning("Unsupported command_id: %s", command_id)
-        return foundation.Status.UNSUP_CLUSTER_COMMAND
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
 
 
 class NeoSirenManufCluster(TuyaMCUCluster):

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -885,16 +885,22 @@ class MoesWindowDetection(LocalDataCluster, OnOff):
                 try:
                     value = success[attrid]
                 except KeyError:
-                    return foundation.Status.FAILURE
+                    return foundation.GENERAL_COMMANDS[
+                        foundation.GeneralCommand.Default_Response
+                    ].schema(command_id=command_id, status=foundation.Status.FAILURE)
                 value = not value
 
             (res,) = await self.write_attributes(
                 {"on_off": value},
                 manufacturer=manufacturer,
             )
-            return [command_id, res[0].status]
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
 
-        return [command_id, foundation.Status.UNSUP_CLUSTER_COMMAND]
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
 
 
 ZONNSMART_MODE_ATTR = (
@@ -1262,16 +1268,22 @@ class ZONNSMARTHelperOnOff(LocalDataCluster, OnOff):
                 try:
                     value = success[attrid]
                 except KeyError:
-                    return foundation.Status.FAILURE
+                    return foundation.GENERAL_COMMANDS[
+                        foundation.GeneralCommand.Default_Response
+                    ].schema(command_id=command_id, status=foundation.Status.FAILURE)
                 value = not value
             _LOGGER.debug("CALLING WRITE FROM COMMAND")
             (res,) = await self.write_attributes(
                 {"on_off": value},
                 manufacturer=manufacturer,
             )
-            return [command_id, res[0].status]
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
 
-        return [command_id, foundation.Status.UNSUP_CLUSTER_COMMAND]
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
 
 
 class ZONNSMARTBoost(ZONNSMARTHelperOnOff):

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -47,8 +47,7 @@ class EmulatedIasZone(LocalDataCluster, IasZone):
 
     async def bind(self):
         """Bind cluster."""
-        result = await self.endpoint.device.app_cluster.bind()
-        return result
+        return await self.endpoint.device.app_cluster.bind()
 
     async def write_attributes(self, attributes, manufacturer=None):
         """Ignore write_attributes."""

--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -488,7 +488,11 @@ class XBeeRemoteATRequest(LocalDataCluster):
         self._endpoint.device.endpoints[232].out_clusters[
             LevelControl.cluster_id
         ].handle_cluster_request(hdr, value)
-        return 0, foundation.Status.SUCCESS
+
+        # XXX: Is command_id=0x00 correct?
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=0x00, status=foundation.Status.SUCCESS)
 
 
 class XBeeRemoteATResponse(LocalDataCluster):

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -120,7 +120,7 @@ class XiaomiCluster(CustomCluster):
 
     def _iter_parse_attr_report(
         self, data: bytes
-    ) -> Iterator[foundation.Attribute, bytes]:
+    ) -> Iterator[tuple[foundation.Attribute, bytes]]:
         """Yield all interpretations of the first attribute in an Xiaomi report."""
 
         # Peek at the attribute report

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -114,22 +114,30 @@ class WindowCoveringRollerE1(CustomCluster, WindowCovering):
             (res,) = await self.endpoint.multistate_output.write_attributes(
                 {"present_value": 1}
             )
-            return res[0].status
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
         if command_id == DOWN_CLOSE:
             (res,) = await self.endpoint.multistate_output.write_attributes(
                 {"present_value": 0}
             )
-            return res[0].status
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
         if command_id == GO_TO_LIFT_PERCENTAGE:
             (res,) = await self.endpoint.analog_output.write_attributes(
                 {"present_value": (100 - args[0])}
             )
-            return res[0].status
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
         if command_id == STOP:
             (res,) = await self.endpoint.multistate_output.write_attributes(
                 {"present_value": 2}
             )
-            return res[0].status
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
 
 
 class MultistateOutputRollerE1(CustomCluster, MultistateOutput):


### PR DESCRIPTION
Many quirks had invalid return values when overriding the cluster's `command` method. ZHA was recently updated to properly check this return value, which is causing runtime errors with quirks (mostly Tuya).

This change should fix the underlying problem. And also make MyPy pass by disabling all failing checks...

Related issue: https://github.com/home-assistant/core/issues/69498