### PR TITLE
Use the correct `stop` command in new IKEA E1812 quirk

### DIFF
--- a/zhaquirks/ikea/shortcutbtn.py
+++ b/zhaquirks/ikea/shortcutbtn.py
@@ -186,7 +186,7 @@ class IkeaTradfriShortcutBtn2(CustomDevice):
             ARGS: [0, 83],
         },
         (LONG_RELEASE, DIM_UP): {
-            COMMAND: COMMAND_STOP,
+            COMMAND: COMMAND_STOP_ON_OFF,
             CLUSTER_ID: 8,
             ENDPOINT_ID: 1,
         },


### PR DESCRIPTION
https://github.com/zigpy/zha-device-handlers/pull/1462 was merged with the wrong `stop` command, which would prevent the automation trigger from properly catching the release event.