### PR TITLE
Fix `manufacturer` type for `TuyaClusterData`

### DIFF
--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -125,3 +125,15 @@ async def test_tuya_mcu_classes():
     mcu_version = TuyaMCUCluster.MCUVersion()
     assert mcu_version
     assert not mcu_version.version
+
+    # test TuyaClusterData.manufacturer values
+    t_c_d = TuyaClusterData(manufacturer=foundation.ZCLHeader.NO_MANUFACTURER_ID)
+    assert t_c_d.manufacturer == -1
+    t_c_d = TuyaClusterData(manufacturer=4619)
+    assert t_c_d.manufacturer == 4619
+    t_c_d = TuyaClusterData(manufacturer="4098")
+    assert t_c_d.manufacturer == 4098
+    with pytest.raises(ValueError):
+        TuyaClusterData(manufacturer='xiaomi')
+    with pytest.raises(ValueError):
+        TuyaClusterData(manufacturer=b"")

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -134,6 +134,6 @@ async def test_tuya_mcu_classes():
     t_c_d = TuyaClusterData(manufacturer="4098")
     assert t_c_d.manufacturer == 4098
     with pytest.raises(ValueError):
-        TuyaClusterData(manufacturer='xiaomi')
+        TuyaClusterData(manufacturer="xiaomi")
     with pytest.raises(ValueError):
         TuyaClusterData(manufacturer=b"")

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -75,7 +75,7 @@ class TuyaClusterData(t.Struct):
     cluster_attr: str
     attr_value: int  # Maybe also others types?
     expect_reply: bool
-    manufacturer: str
+    manufacturer: int
 
 
 class MoesBacklight(t.enum8):


### PR DESCRIPTION
Fix for the `TuyaClusterData` the `manufacturer` type.