### PR TITLE
Implementations for `NO_MANUFACTURER_ID` dimmers

### DIFF
--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -397,6 +397,20 @@ class TuyaLevelControl(LevelControl, TuyaLocalCluster):
             command_id,
             args,
         )
+        # (move_to_level_with_on_off --> send the on_off command first)
+        if command_id  ==  0x0004:
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_attr="on_off",
+                attr_value=args[1],
+                expect_reply=expect_reply,
+                manufacturer=manufacturer,
+            )
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cluster_data,
+            )
+
         # (move_to_level, move, move_to_level_with_on_off)
         if command_id in (0x0000, 0x0001, 0x0004):
             cluster_data = TuyaClusterData(
@@ -489,6 +503,34 @@ class TuyaLevelControlManufCluster(TuyaMCUCluster):
             dp_type=TuyaDPType.ENUM,
             endpoint_id=2,
         ),
+        15: DPToAttributeMapping(
+            TuyaOnOff.ep_attribute,
+            "on_off",
+            dp_type=TuyaDPType.BOOL,
+            endpoint_id=3,
+        ),
+        16: DPToAttributeMapping(
+            TuyaLevelControl.ep_attribute,
+            "current_level",
+            dp_type=TuyaDPType.VALUE,
+            converter=lambda x: (x * 255) // 1000,
+            dp_converter=lambda x: (x * 1000) // 255,
+            endpoint_id=3,
+        ),
+        17: DPToAttributeMapping(
+            TuyaLevelControl.ep_attribute,
+            "minimum_level",
+            dp_type=TuyaDPType.VALUE,
+            converter=lambda x: (x * 255) // 1000,
+            dp_converter=lambda x: (x * 1000) // 255,
+            endpoint_id=3,
+        ),
+        18: DPToAttributeMapping(
+            TuyaLevelControl.ep_attribute,
+            "bulb_type",
+            dp_type=TuyaDPType.ENUM,
+            endpoint_id=3,
+        ),
     }
 
     data_point_handlers = {
@@ -500,4 +542,8 @@ class TuyaLevelControlManufCluster(TuyaMCUCluster):
         8: "_dp_2_attr_update",
         9: "_dp_2_attr_update",
         10: "_dp_2_attr_update",
+        15: "_dp_2_attr_update",
+        16: "_dp_2_attr_update",
+        17: "_dp_2_attr_update",
+        18: "_dp_2_attr_update",
     }

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -398,7 +398,7 @@ class TuyaLevelControl(LevelControl, TuyaLocalCluster):
             args,
         )
         # (move_to_level_with_on_off --> send the on_off command first)
-        if command_id  ==  0x0004:
+        if command_id == 0x0004:
             cluster_data = TuyaClusterData(
                 endpoint_id=self.endpoint.endpoint_id,
                 cluster_attr="on_off",

--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -5,15 +5,7 @@ from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import (
-    Basic,
-    GreenPowerProxy,
-    Groups,
-    LevelControl,
-    Ota,
-    Scenes,
-    Time,
-)
+from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Groups, Ota, Scenes, Time
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -23,18 +15,11 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import (
-    TuyaDimmerSwitch,
-    TuyaLevelControl,
-    TuyaManufacturerClusterOnOff,
-    TuyaManufacturerLevelControl,
-    TuyaManufCluster,
-    TuyaOnOff,
-)
+from zhaquirks.tuya import TuyaDimmerSwitch
 from zhaquirks.tuya.mcu import (
     TuyaInWallLevelControl,
     TuyaLevelControlManufCluster,
-    TuyaOnOff as TuyaOnOffMCU,
+    TuyaOnOff,
 )
 
 
@@ -60,7 +45,7 @@ class NoManufacturerCluster(CustomCluster):
         )
 
 
-class TuyaOnOffNM(NoManufacturerCluster, TuyaOnOffMCU):
+class TuyaOnOffNM(NoManufacturerCluster, TuyaOnOff):
     """Tuya OnOff cluster with NoManufacturerID."""
 
     pass
@@ -107,7 +92,7 @@ class TuyaSingleSwitchDimmer(TuyaDimmerSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufCluster.cluster_id,
+                    TuyaLevelControlManufCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             }
@@ -122,11 +107,9 @@ class TuyaSingleSwitchDimmer(TuyaDimmerSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    LevelControl.cluster_id,
-                    TuyaManufacturerClusterOnOff,
+                    TuyaLevelControlManufCluster,
                     TuyaOnOff,
-                    TuyaManufacturerLevelControl,
-                    TuyaLevelControl,
+                    TuyaInWallLevelControl,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             }
@@ -153,7 +136,7 @@ class TuyaDoubleSwitchDimmer(TuyaDimmerSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufCluster.cluster_id,
+                    TuyaLevelControlManufCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             }
@@ -169,7 +152,7 @@ class TuyaDoubleSwitchDimmer(TuyaDimmerSwitch):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     TuyaLevelControlManufCluster,
-                    TuyaOnOffMCU,
+                    TuyaOnOff,
                     TuyaInWallLevelControl,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
@@ -178,7 +161,7 @@ class TuyaDoubleSwitchDimmer(TuyaDimmerSwitch):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    TuyaOnOffMCU,
+                    TuyaOnOff,
                     TuyaInWallLevelControl,
                 ],
                 OUTPUT_CLUSTERS: [],
@@ -207,7 +190,7 @@ class TuyaSingleSwitchDimmerGP(TuyaDimmerSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufCluster.cluster_id,
+                    TuyaLevelControlManufCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
@@ -266,7 +249,7 @@ class TuyaDoubleSwitchDimmerGP(TuyaDimmerSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufCluster.cluster_id,
+                    TuyaLevelControlManufCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
@@ -334,7 +317,7 @@ class TuyaTripleSwitchDimmerGP(TuyaDimmerSwitch):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaManufCluster.cluster_id,
+                    TuyaLevelControlManufCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },

--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -1,6 +1,19 @@
 """Tuya based touch switch."""
+from typing import Optional, Union
+
 from zigpy.profiles import zha
-from zigpy.zcl.clusters.general import Basic, Groups, LevelControl, Ota, Scenes, Time
+from zigpy.quirks import CustomCluster
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    LevelControl,
+    Ota,
+    Scenes,
+    Time,
+)
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -23,6 +36,40 @@ from zhaquirks.tuya.mcu import (
     TuyaLevelControlManufCluster,
     TuyaOnOff as TuyaOnOffMCU,
 )
+
+
+class NoManufacturerCluster(CustomCluster):
+    """Forces the NO manufacturer id in command."""
+
+    async def command(
+        self,
+        command_id: Union[foundation.GeneralCommand, int, t.uint8_t],
+        *args,
+        manufacturer: Optional[Union[int, t.uint16_t]] = None,
+        expect_reply: bool = True,
+        tsn: Optional[Union[int, t.uint8_t]] = None,
+    ):
+        """Override the default Cluster command."""
+        self.debug("Setting the NO manufacturer id in command: %s", command_id)
+        return await super().command(
+            command_id,
+            *args,
+            manufacturer=foundation.ZCLHeader.NO_MANUFACTURER_ID,
+            expect_reply=expect_reply,
+            tsn=tsn,
+        )
+
+
+class TuyaInWallLevelControlNM(NoManufacturerCluster, TuyaInWallLevelControl):
+    """Tuya Level cluster for inwall dimmable device with NoManufacturerID."""
+
+    pass
+
+
+class TuyaOnOffNM(NoManufacturerCluster, TuyaOnOffMCU):
+    """Tuya OnOff cluster with NoManufacturerID."""
+
+    pass
 
 
 class TuyaSingleSwitchDimmer(TuyaDimmerSwitch):
@@ -135,6 +182,91 @@ class TuyaDoubleSwitchDimmer(TuyaDimmerSwitch):
                     TuyaInWallLevelControl,
                 ],
                 OUTPUT_CLUSTERS: [],
+            },
+        }
+    }
+
+
+class TuyaTripleSwitchDimmerGPP(TuyaDimmerSwitch):
+    """Tuya double channel dimmer device."""
+
+    signature = {
+        # "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0,
+        #                     reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>,
+        #                     mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>,
+        #                     manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752,
+        #                     maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>,
+        #                     *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False,
+        #                     *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True,
+        #                     *is_security_capable=False)",
+        # "endpoints": {
+        #     "1": {"profile_id": 260, "device_type": "0x0051", "in_clusters": ["0x0000","0x0004","0x0005","0xef00"],"out_clusters": ["0x000a","0x0019"]},
+        #     "242": {"profile_id": 41440,"device_type": "0x0061","in_clusters": [],"out_clusters": ["0x0021"]}
+        # },
+        # "manufacturer": "_TZE200_vm1gyrso",
+        # "model": "TS0601",
+        # "class": "zigpy.device.Device"
+        MODELS_INFO: [
+            ("_TZE200_vm1gyrso", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaLevelControlManufCluster,
+                    TuyaOnOffNM,
+                    TuyaInWallLevelControlNM,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOffNM,
+                    TuyaInWallLevelControlNM,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOffNM,
+                    TuyaInWallLevelControlNM,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
             },
         }
     }

--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -93,7 +93,7 @@ class TuyaSingleSwitchDimmer(TuyaDimmerSwitch):
             ("_TZE200_swaamsoy", "TS0601"),
             ("_TZE200_0nauxa0p", "TS0601"),
             ("_TZE200_la2c2uo9", "TS0601"),
-            ("_TZE200_1agwnems", "TS0601"),  #TODO: validation pending?
+            ("_TZE200_1agwnems", "TS0601"),  # TODO: validation pending?
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0051

--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -60,26 +60,31 @@ class NoManufacturerCluster(CustomCluster):
         )
 
 
-class TuyaInWallLevelControlNM(NoManufacturerCluster, TuyaInWallLevelControl):
-    """Tuya Level cluster for inwall dimmable device with NoManufacturerID."""
-
-    pass
-
-
 class TuyaOnOffNM(NoManufacturerCluster, TuyaOnOffMCU):
     """Tuya OnOff cluster with NoManufacturerID."""
 
     pass
 
 
+class TuyaInWallLevelControlNM(NoManufacturerCluster, TuyaInWallLevelControl):
+    """Tuya Level cluster for inwall dimmable device with NoManufacturerID."""
+
+    pass
+
+
+# --- DEVICE SUMMARY ---
+# TuyaSingleSwitchDimmer: 0x00, 0x04, 0x05, 0xEF00; 0x000A, 0x0019
+# TuyaDoubleSwitchDimmer: 0x00, 0x04, 0x05, 0xEF00; 0x000A, 0x0019
+# - Dimmer with Green Power Proxy: Endpoint=242 profile=41440 device_type=0x0061, output_clusters: 0x0021 -
+# TuyaSingleSwitchDimmerGP: 0x00, 0x04, 0x05, 0xEF00; 0x000A, 0x0019
+# TuyaDoubleSwitchDimmerGP: 0x00, 0x04, 0x05, 0xEF00; 0x000A, 0x0019
+# TuyaTripleSwitchDimmerGP: 0x00, 0x04, 0x05, 0xEF00; 0x000A, 0x0019
+
+
 class TuyaSingleSwitchDimmer(TuyaDimmerSwitch):
     """Tuya touch switch device."""
 
     signature = {
-        # "node_descriptor": "<NodeDescriptor byte1=1, byte2=64, mac_capability_flags=142, manufacturer_code=4098,
-        # maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264,
-        # maximum_outgoing_transfer_size=82, descriptor_capability_field=0>",
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=51 device_version=1 input_clusters=[0, 4, 5, 61184] output_clusters=[10, 25]>
         MODELS_INFO: [
             ("_TZE200_dfxkcots", "TS0601"),
             ("_TZE200_whpb9yts", "TS0601"),
@@ -88,8 +93,13 @@ class TuyaSingleSwitchDimmer(TuyaDimmerSwitch):
             ("_TZE200_swaamsoy", "TS0601"),
             ("_TZE200_0nauxa0p", "TS0601"),
             ("_TZE200_la2c2uo9", "TS0601"),
+            ("_TZE200_1agwnems", "TS0601"),  #TODO: validation pending?
         ],
         ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0051
+            # device_version=1
+            # input_clusters=[0, 4, 5, 61184]
+            # output_clusters=[10, 25]>
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
@@ -128,24 +138,14 @@ class TuyaDoubleSwitchDimmer(TuyaDimmerSwitch):
     """Tuya double channel dimmer device."""
 
     signature = {
-        # "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0,
-        #                     user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>,
-        #                     mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>,
-        #                     manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264,
-        #                     maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True,
-        #                     *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True,
-        #                     *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)
-        #   "endpoints": {
-        #       "1": { "profile_id": 260, "device_type": "0x0051", "in_clusters": [ "0x0000", "0x0004", "0x0005", "0xef00" ], "out_clusters": [ "0x000a", "0x0019" ] }
-        #   },
-        #  "manufacturer": "_TZE200_e3oitdyu",
-        #  "model": "TS0601",
-        #  "class": "zigpy.device.Device"
-        #  }
         MODELS_INFO: [
             ("_TZE200_e3oitdyu", "TS0601"),
         ],
         ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0051
+            # device_version=1
+            # input_clusters=[0, 4, 5, 61184]
+            # output_clusters=[10, 25]>
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
@@ -187,29 +187,19 @@ class TuyaDoubleSwitchDimmer(TuyaDimmerSwitch):
     }
 
 
-class TuyaTripleSwitchDimmerGPP(TuyaDimmerSwitch):
-    """Tuya double channel dimmer device."""
+class TuyaSingleSwitchDimmerGP(TuyaDimmerSwitch):
+    """Tuya touch switch device."""
 
     signature = {
-        # "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0,
-        #                     reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>,
-        #                     mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>,
-        #                     manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752,
-        #                     maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>,
-        #                     *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False,
-        #                     *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True,
-        #                     *is_security_capable=False)",
-        # "endpoints": {
-        #     "1": {"profile_id": 260, "device_type": "0x0051", "in_clusters": ["0x0000","0x0004","0x0005","0xef00"],"out_clusters": ["0x000a","0x0019"]},
-        #     "242": {"profile_id": 41440,"device_type": "0x0061","in_clusters": [],"out_clusters": ["0x0021"]}
-        # },
-        # "manufacturer": "_TZE200_vm1gyrso",
-        # "model": "TS0601",
-        # "class": "zigpy.device.Device"
         MODELS_INFO: [
-            ("_TZE200_vm1gyrso", "TS0601"),
+            ("_TZE200_3p5ydos3", "TS0601"),
+            ("_TZE200_ip2akl4w", "TS0601"),
         ],
         ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0100
+            # device_version=1
+            # input_clusters=[0, 4, 5, 61184]
+            # output_clusters=[10, 25]>
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
@@ -221,6 +211,136 @@ class TuyaTripleSwitchDimmerGPP(TuyaDimmerSwitch):
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # input_clusters=[]
+            # output_clusters=[33]
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaLevelControlManufCluster,
+                    TuyaOnOffNM,
+                    TuyaInWallLevelControlNM,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }
+
+
+class TuyaDoubleSwitchDimmerGP(TuyaDimmerSwitch):
+    """Tuya double channel dimmer device."""
+
+    signature = {
+        MODELS_INFO: [
+            ("_TZE200_fjjbhx9d", "TS0601"),
+        ],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0100
+            # device_version=1
+            # input_clusters=[0, 4, 5, 61184]
+            # output_clusters=[10, 25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # input_clusters=[]
+            # output_clusters=[33]
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaLevelControlManufCluster,
+                    TuyaOnOffNM,
+                    TuyaInWallLevelControlNM,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOffNM,
+                    TuyaInWallLevelControlNM,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }
+
+
+class TuyaTripleSwitchDimmerGP(TuyaDimmerSwitch):
+    """Tuya triple channel dimmer device."""
+
+    signature = {
+        MODELS_INFO: [
+            ("_TZE200_vm1gyrso", "TS0601"),
+        ],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0100
+            # device_version=1
+            # input_clusters=[0, 4, 5, 61184]
+            # output_clusters=[10, 25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # input_clusters=[]
+            # output_clusters=[33]
             242: {
                 PROFILE_ID: 41440,
                 DEVICE_TYPE: 97,


### PR DESCRIPTION
This PR adds device definitions for dimmers that require send commands with the `NO_MANUFACTURER_ID` (or what is the same `manufacturer_specific=False`).

A few comments:
* `tuya/mcu/TuyaLevelControl` now handles `move_to_level_with_on_off` command, sending an `on_off` command before the `current_level` command.
* the `TuyaLevelControlManufCluster` handles DPs up to 3 gangs.
* the new `NoManufacturerCluster` will force the `NO_MANUFACTURER_ID` in commands. This is needed for recent dimmers
* at some point I wanted to migrate the remaining classes to the new implementation and I have done now. `TuyaSingleSwitchDimmer` devices will use the same implementation as the rest
* some definitions are using the `NoManufacturerCluster` implementation and others no. It can be important (or not) when adding new devices to the existing implementations

Related issues:
* Fixes: #730
* Fixes: #1011 
* Fixes: #1103
* Fixes: #1302
* Fixes: #1461
* Fixes: #1476

This PR is good to go in next minor version.
