### PR TITLE
Update issue templates to include proper formatting for device signature

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,5 +23,15 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
+**Device signature - this can be acquired by clicking on the "Zigbee Device Signature" button in the device settings**
+```
+Paste the device signature here
+```
+
+**Additional logs**
+```
+Paste any additional debug logs here
+```
+
 **Additional context**
-Add any other context about the problem here. Please include full debug logs as well as the device signature.
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,15 +23,32 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Device signature - this can be acquired by clicking on the "Zigbee Device Signature" button in the device settings**
+<details>
+<summary>Device signature - this can be acquired by clicking on the "Zigbee Device Signature" button in the device settings</summary>
+
 ```
-Paste the device signature here
+Paste the device signature here.
 ```
 
-**Additional logs**
+</details>
+
+<details>
+<summary>Diagnostic information - this can be acquired by clicking on the "Download Diagnostics" button in the device settings</summary>
+
 ```
-Paste any additional debug logs here
+Paste the diagnostic information here.
 ```
+
+</details>
+
+<details>
+<summary>Additional logs</summary>
+
+```
+Paste any additional debug logs here.
+```
+
+</details>
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/device-support-request.md
+++ b/.github/ISSUE_TEMPLATE/device-support-request.md
@@ -13,7 +13,15 @@ A clear and concise description of what the problem is. Ex. I'm always frustrate
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
-**Device signature - this can be acquired by removing the device from ZHA and pairing it again from the add devices screen. Be sure to add the entire content of the log panel after pairing the device to a code block below this line.**
+**Device signature - this can be acquired by clicking on the "Zigbee Device Signature" button in the device settings**
+```
+Paste the device signature here
+```
+
+**Additional logs**
+```
+Paste any additional debug logs here
+```
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/device-support-request.md
+++ b/.github/ISSUE_TEMPLATE/device-support-request.md
@@ -13,15 +13,32 @@ A clear and concise description of what the problem is. Ex. I'm always frustrate
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
-**Device signature - this can be acquired by clicking on the "Zigbee Device Signature" button in the device settings**
+<details>
+<summary>Device signature - this can be acquired by clicking on the "Zigbee Device Signature" button in the device settings</summary>
+
 ```
-Paste the device signature here
+Paste the device signature here.
 ```
 
-**Additional logs**
+</details>
+
+<details>
+<summary>Diagnostic information - this can be acquired by clicking on the "Download Diagnostics" button in the device settings</summary>
+
 ```
-Paste any additional debug logs here
+Paste the diagnostic information here.
 ```
+
+</details>
+
+<details>
+<summary>Additional logs</summary>
+
+```
+Paste any additional debug logs here.
+```
+
+</details>
 
 **Additional context**
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
These changes should avoid any confusion on whether removing and re-joining a device is required for just getting the device signature. It should also help with the proper formatting of the device signature.

(If further debug logs of a device working are required for a specific quirk, they can still be requested individually. I don't think it makes sense to include instructions to get debug logs in the issue template, as most simple quirks don't require these and grabbing them can be somewhat complicating for beginners. Just grabbing the device signature should be enough for a start.)

I'm open for changes of course.