### PR TITLE
Fixed bug 1319 by inverting and swapping open/close commands for _TZE200_fzo2pocs blind

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -103,7 +103,7 @@ ATTR_COVER_INVERTED = 0x8002
 # For most tuya devices 0 = Up/Open, 1 = Stop, 2 = Down/Close
 TUYA_COVER_COMMAND = {
     "_TZE200_zah67ekd": {0x0000: 0x0000, 0x0001: 0x0002, 0x0002: 0x0001},
-    "_TZE200_fzo2pocs": {0x0000: 0x0000, 0x0001: 0x0002, 0x0002: 0x0001},
+    "_TZE200_fzo2pocs": {0x0000: 0x0002, 0x0001: 0x0000, 0x0002: 0x0001},
     "_TZE200_xuzcvlku": {0x0000: 0x0000, 0x0001: 0x0002, 0x0002: 0x0001},
     "_TZE200_rddyvrci": {0x0000: 0x0002, 0x0001: 0x0001, 0x0002: 0x0000},
     "_TZE200_3i3exuay": {0x0000: 0x0000, 0x0001: 0x0002, 0x0002: 0x0001},
@@ -127,6 +127,7 @@ TUYA_COVER_COMMAND = {
 # Use manufacturerName to identify device!
 # Don't invert _TZE200_cowvfni3: https://github.com/Koenkk/zigbee2mqtt/issues/6043
 TUYA_COVER_INVERTED_BY_DEFAULT = [
+    "_TZE200_fzo2pocs",
     "_TZE200_wmcdj3aq",
     "_TZE200_nogaemzt",
     "_TZE200_xuzcvlku",


### PR DESCRIPTION
When adding to ZHA these blinds needed to be inverted and the up and down commands were inverted.
This fix swaps the commands so that open will open the blind and close will close the blind.

Fixes issue https://github.com/zigpy/zha-device-handlers/issues/1319
