### PR TITLE
Verify quirks subclassing ZCL clusters extend them

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -62,6 +62,8 @@ for manufacturer in zq._DEVICE_REGISTRY._registry.values():
 
 del quirk, model_quirk_list, manufacturer
 
+ALL_ZIGPY_CLUSTERS = frozenset(zcl.clusters.CLUSTERS_BY_NAME.values())
+
 
 SIGNATURE_ALLOWED = {
     ENDPOINTS,
@@ -658,3 +660,36 @@ def test_quirk_device_automation_triggers_unique(quirk):
                 [f" * {event} <- {trigger}" for trigger, event in triggers_and_events]
             )
             fail_func(f"Triggers are not unique for {quirk}:\n{triggers_text}")
+
+
+@pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)
+def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
+    """Verify no quirks subclass a ZCL cluster but delete its attributes list."""
+
+    for ep_id, ep_data in quirk.replacement[ENDPOINTS].items():
+        for cluster in ep_data.get(INPUT_CLUSTERS, []) + ep_data.get(
+            OUTPUT_CLUSTERS, []
+        ):
+            if isinstance(cluster, int) or not issubclass(cluster, zcl.Cluster):
+                continue
+            elif cluster in ALL_ZIGPY_CLUSTERS:
+                continue
+
+            assert issubclass(cluster, zigpy.quirks.CustomCluster)
+
+            base_clusters = set(cluster.__mro__) & ALL_ZIGPY_CLUSTERS
+
+            # Completely custom cluster
+            if len(base_clusters) == 0:
+                continue
+            elif len(base_clusters) > 1:
+                pytest.fail(f"Cluster has more than one zigpy base class: {cluster}")
+
+            base_cluster = list(base_clusters)[0]
+
+            # Ensure the attribute IDs are extended
+            if not set(base_cluster.attributes) <= set(cluster.attributes):
+                pytest.fail(
+                    f"Cluster deletes parent class's attributes"
+                    f" instead of extending them: {cluster}"
+                )

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -662,7 +662,18 @@ def test_quirk_device_automation_triggers_unique(quirk):
             fail_func(f"Triggers are not unique for {quirk}:\n{triggers_text}")
 
 
-@pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)
+@pytest.mark.parametrize(
+    "quirk",
+    [
+        quirk_cls
+        for quirk_cls in ALL_QUIRK_CLASSES
+        if quirk_cls
+        not in (
+            zhaquirks.xbee.xbee_io.XBeeSensor,
+            zhaquirks.xbee.xbee3_io.XBee3Sensor,
+        )
+    ],
+)
 def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
     """Verify no quirks subclass a ZCL cluster but delete its attributes list."""
 
@@ -690,6 +701,6 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
             # Ensure the attribute IDs are extended
             if not set(base_cluster.attributes) <= set(cluster.attributes):
                 pytest.fail(
-                    f"Cluster deletes parent class's attributes"
-                    f" instead of extending them: {cluster}"
+                    f"Cluster {cluster} deletes parent class's attributes instead of"
+                    f" extending them: {base_cluster}"
                 )

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -10,7 +10,6 @@ from zigpy.zcl.clusters.general import LevelControl, OnOff
 
 from zhaquirks import Bus, DoublingPowerConfigurationCluster
 from zhaquirks.tuya import (
-    ATTR_ON_OFF,
     TUYA_MCU_COMMAND,
     TUYA_MCU_VERSION_RSP,
     TUYA_SET_DATA,
@@ -270,10 +269,6 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
 class TuyaOnOff(OnOff, TuyaLocalCluster):
     """Tuya MCU OnOff cluster."""
 
-    attributes = {
-        ATTR_ON_OFF: ("on_off", t.Bool),
-    }
-
     async def command(
         self,
         command_id: Union[foundation.GeneralCommand, int, t.uint8_t],
@@ -315,8 +310,6 @@ class TuyaOnOff(OnOff, TuyaLocalCluster):
 
 class TuyaOnOffNM(NoManufacturerCluster, TuyaOnOff):
     """Tuya OnOff cluster with NoManufacturerID."""
-
-    pass
 
 
 class TuyaOnOffManufCluster(TuyaMCUCluster):
@@ -373,10 +366,13 @@ class TuyaOnOffManufCluster(TuyaMCUCluster):
 class MoesSwitchManufCluster(TuyaOnOffManufCluster):
     """On/Off Tuya cluster with extra device attributes."""
 
-    attributes = {
-        0x8001: ("backlight_mode", MoesBacklight),
-        0x8002: ("power_on_state", PowerOnState),
-    }
+    attributes = TuyaOnOffManufCluster.attributes.copy()
+    attributes.update(
+        {
+            0x8001: ("backlight_mode", MoesBacklight),
+            0x8002: ("power_on_state", PowerOnState),
+        }
+    )
 
     dp_to_attribute: Dict[
         int, DPToAttributeMapping
@@ -410,7 +406,8 @@ class MoesSwitchManufCluster(TuyaOnOffManufCluster):
 class TuyaLevelControl(LevelControl, TuyaLocalCluster):
     """Tuya MCU Level cluster for dimmable device."""
 
-    attributes = {0x0000: ("current_level", t.uint8_t)}
+    attributes = LevelControl.attributes.copy()
+    attributes.update({0x0000: ("current_level", t.uint8_t)})
 
     async def command(
         self,


### PR DESCRIPTION
Fixes #1520

Currently a few unit tests are failing:

- [ ] `zhaquirks.tuya.mcu.TuyaOnOff`
- [ ] `zhaquirks.tuya.ts0601_dimmer.TuyaOnOffNM`
- [ ] `zhaquirks.xbee.XBeeCommon.DigitalIOCluster`

@javicalle for the Tuya clusters, them subclassing `zcl.OnOff` but then exposing only a single `on_off` attribute seems like it will break code expecting the other attributes to exist. Can the `OnOff` subclass be replaced with just `CustomCluster` or is this intentional?