### PR TITLE
Refactor `NoManufacturerCluster` classes

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -270,7 +270,6 @@ class TuyaCommand(t.Struct):
     data: TuyaData
 
 
-# based on https://github.com/zigpy/zha-device-handlers/blob/b802c1fb2cf2682f9a4722bfb57a1958cad9dad7/zhaquirks/tuya/ts0601_dimmer.py#L26
 class NoManufacturerCluster(CustomCluster):
     """Forces the NO manufacturer id in command."""
 

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -305,7 +305,6 @@ class TuyaOnOff(OnOff, TuyaLocalCluster):
         ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
 
 
-# based on https://github.com/zigpy/zha-device-handlers/blob/b802c1fb2cf2682f9a4722bfb57a1958cad9dad7/zhaquirks/tuya/ts0601_dimmer.py#L48
 class TuyaOnOffNM(NoManufacturerCluster, TuyaOnOff):
     """Tuya OnOff cluster with NoManufacturerID."""
 

--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -15,40 +15,13 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import TuyaDimmerSwitch
+from zhaquirks.tuya import NoManufacturerCluster, TuyaDimmerSwitch
 from zhaquirks.tuya.mcu import (
     TuyaInWallLevelControl,
     TuyaLevelControlManufCluster,
     TuyaOnOff,
+    TuyaOnOffNM,
 )
-
-
-class NoManufacturerCluster(CustomCluster):
-    """Forces the NO manufacturer id in command."""
-
-    async def command(
-        self,
-        command_id: Union[foundation.GeneralCommand, int, t.uint8_t],
-        *args,
-        manufacturer: Optional[Union[int, t.uint16_t]] = None,
-        expect_reply: bool = True,
-        tsn: Optional[Union[int, t.uint8_t]] = None,
-    ):
-        """Override the default Cluster command."""
-        self.debug("Setting the NO manufacturer id in command: %s", command_id)
-        return await super().command(
-            command_id,
-            *args,
-            manufacturer=foundation.ZCLHeader.NO_MANUFACTURER_ID,
-            expect_reply=expect_reply,
-            tsn=tsn,
-        )
-
-
-class TuyaOnOffNM(NoManufacturerCluster, TuyaOnOff):
-    """Tuya OnOff cluster with NoManufacturerID."""
-
-    pass
 
 
 class TuyaInWallLevelControlNM(NoManufacturerCluster, TuyaInWallLevelControl):

--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -1,10 +1,5 @@
 """Tuya based touch switch."""
-from typing import Optional, Union
-
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster
-import zigpy.types as t
-from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Groups, Ota, Scenes, Time
 
 from zhaquirks.const import (


### PR DESCRIPTION
PR #1559 makes use of `NoManufacturerCluster` creating a new generic implementation outside of `ts0601_dimmer` file.
Once merged, a class refactor is needed to remove duplicate code.