### PR TITLE
Added support for model : _TZE200_vzekyi4c

### DIFF
--- a/zhaquirks/tuya/ts0601_smoke.py
+++ b/zhaquirks/tuya/ts0601_smoke.py
@@ -78,6 +78,7 @@ class TuyaSmokeDetector0601(CustomDevice):
         MODELS_INFO: [
             ("_TZE200_aycxwiau", "TS0601"),
             ("_TZE200_ntcy3xu1", "TS0601"),
+            ("_TZE200_vzekyi4c", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Smoke detection works. Though other readings like Battery do not show up. 

Fixes: [#1529](https://github.com/zigpy/zha-device-handlers/issues/1529)