### PR TITLE
Clean TuyaLevelControl attributes

### DIFF
--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -406,9 +406,6 @@ class MoesSwitchManufCluster(TuyaOnOffManufCluster):
 class TuyaLevelControl(LevelControl, TuyaLocalCluster):
     """Tuya MCU Level cluster for dimmable device."""
 
-    attributes = LevelControl.attributes.copy()
-    attributes.update({0x0000: ("current_level", t.uint8_t)})
-
     async def command(
         self,
         command_id: Union[foundation.GeneralCommand, int, t.uint8_t],


### PR DESCRIPTION
`LevelControl` already has the `current_level` attribute:
* https://github.com/zigpy/zigpy/blob/b166e2e1f22c49bad201d7ecdf202f0fc9b7b087/zigpy/zcl/clusters/general.py#L700

This code is remanent from PR #1526
