### PR TITLE
Add TREDANSEN block-out cellul blind

### DIFF
--- a/zhaquirks/ikea/blinds.py
+++ b/zhaquirks/ikea/blinds.py
@@ -38,6 +38,7 @@ class IkeaTradfriRollerBlinds(CustomDevice):
         MODELS_INFO: [
             (IKEA, "FYRTUR block-out roller blind"),
             (IKEA, "KADRILJ roller blind"),
+            (IKEA, "TREDANSEN block-out cellul blind"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Add "TREDANSEN block-out cellul blind" Model to existing Ikea Blind quirk to fix the report battery % remaining

```
    "manufacturer": "IKEA of Sweden",
    "model": "TREDANSEN block-out cellul blind",
    "name": "IKEA of Sweden TREDANSEN block-out cellul blind",
    "manufacturer_code": 4476,
    "power_source": "Battery or Unknown",
    "device_type": "EndDevice",
    "signature": {
      "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4476, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
      "endpoints": {
        "1": {
          "profile_id": 260,
          "device_type": "0x0202",
          "in_clusters": [
            "0x0000",
            "0x0001",
            "0x0003",
            "0x0004",
            "0x0005",
            "0x0020",
            "0x0102",
            "0x1000",
            "0xfc7c"
          ],
          "out_clusters": [
            "0x0019",
            "0x1000"
          ]
        }
      }
    },
 ```