### PR TITLE
Remove Aqara MAEU01 plugs from group 0

### DIFF
--- a/zhaquirks/xiaomi/aqara/plug_mmeu01.py
+++ b/zhaquirks/xiaomi/aqara/plug_mmeu01.py
@@ -1,4 +1,4 @@
-"""Xiaomi lumi.plug.mmeu01 plug."""
+"""Xiaomi Aqara EU plugs."""
 import logging
 
 from zigpy.profiles import zha
@@ -45,7 +45,7 @@ XIAOMI_DEVICE_TYPE = 0x61
 OPPLE_MFG_CODE = 0x115F
 
 
-class Plug(XiaomiCustomDevice):
+class PlugMMEU01(XiaomiCustomDevice):
     """lumi.plug.mmeu01 plug."""
 
     def __init__(self, *args, **kwargs):
@@ -141,14 +141,14 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         return result
 
 
-class PlugMAEU01(Plug):
+class PlugMAEU01(PlugMMEU01):
     """lumi.plug.maeu01 plug."""
 
     signature = {
         MODELS_INFO: [
             (LUMI, "lumi.plug.maeu01"),
         ],
-        ENDPOINTS: Plug.signature[ENDPOINTS],
+        ENDPOINTS: PlugMMEU01.signature[ENDPOINTS],
     }
 
     replacement = {


### PR DESCRIPTION
Whilst working on https://github.com/zigpy/zha-device-handlers/pull/1656, I noticed that all IKEA 4-button remotes control the device and that it doesn't seem possible to remove the MAEU01 plug from group 0 (in which it's in by default) using the HA UI.

Related:
- https://github.com/Koenkk/zigbee2mqtt/issues/2059#issuecomment-539123089
- https://github.com/Koenkk/zigbee-herdsman/commit/345249218f3ec490641d69bb6e3a29cfbeccb691
- https://github.com/Koenkk/zigbee-herdsman-converters/commit/01deaeede43ea9590258fcbd55227511d06e2f40

(Note: The first commit is just a slight cleanup. Only the second commit includes the actual changes)

Also, it doesn't look like something similar is implemented anywhere else, so I'm not sure if the proposed changes are actually "good" but they do seem to work.