### PR TITLE
Add missing model info quirk for TUYA TZE200

### DIFF
--- a/zhaquirks/tuya/air/ts0601_air_quality.py
+++ b/zhaquirks/tuya/air/ts0601_air_quality.py
@@ -34,6 +34,7 @@ class TuyaCO2Sensor(CustomDevice):
         MODELS_INFO: [
             ("_TZE200_8ygsuhe1", "TS0601"),
             ("_TZE200_yvx5lh6k", "TS0601"),
+            ("_TZE200_dwcarsat", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
This commit adds a missing model info quirk for TUYA TZE200 without which it'll only show VOClevel sensor instead of all the available sensors on the device.