### PR TITLE
Remove the call to `on_off` cluster in `TuyaLevelControl`

### DIFF
--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -420,21 +420,8 @@ class TuyaLevelControl(LevelControl, TuyaLocalCluster):
             command_id,
             args,
         )
-        # (move_to_level_with_on_off --> send the on_off command first)
-        if command_id == 0x0004:
-            cluster_data = TuyaClusterData(
-                endpoint_id=self.endpoint.endpoint_id,
-                cluster_attr="on_off",
-                attr_value=args[1],
-                expect_reply=expect_reply,
-                manufacturer=manufacturer,
-            )
-            self.endpoint.device.command_bus.listener_event(
-                TUYA_MCU_COMMAND,
-                cluster_data,
-            )
-
         # (move_to_level, move, move_to_level_with_on_off)
+        # (move_to_level_with_on_off --> ZHA have the `ForceOnLight` implementation)
         if command_id in (0x0000, 0x0001, 0x0004):
             cluster_data = TuyaClusterData(
                 endpoint_id=self.endpoint.endpoint_id,


### PR DESCRIPTION
This PR will remove the call to `on_off` cluster when calling the `move_to_level_with_on_off` in the `TuyaLevelControl` (MCU) cluster.
The current quirk is completely wrong and needs to be fixed.

TL;DR;
But let me explain it from the begining...

In #1489 (ignoring some good practices) a call to the `on_off` cluster is added in the `move_to_level_with_on_off` command. This change is caused by a change in HA where dimmers now invoke this command (before the call from HA was different).
Some users report that the behavior of their devices has changed and that now its devices do not turn on when using the dimmer bar from HA.
The programmer in charge of #1489, misreading the arguments to the `move_to_level_with_on_off` command, (mistakenly) sets `args[1]` to the `on/off` value of the device.
He thought that invoking the `on/off` command for those devices that respected the standard couldn't hurt, and that on those that didn't it would be an improvement. 
What could go wrong? Spoiler: `args[1]` is actually the ` transition_time`:
* https://github.com/zigpy/zigpy/blob/dev/zigpy/zcl/clusters/general.py#L761-L765

This is the origin of the reported issues (or at least some of them).


Since the time this 'improvement' was implemented, ZHA has also evolved and now implements a mechanism to force the invocation of the `on` command for those devices that do not respect the standard:
* https://github.com/home-assistant/core/blob/dev/homeassistant/components/zha/light.py#L889-L897

With the new approach, the call is removed from the quirk because ZHA already have a mechanism to force the call to the `on` command.
Now the devices detected as problematic can be added in ZHA (just a single place).