### PR TITLE
Quirks for Foluu Smart Thermostatic Valve Regulator

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1679,6 +1679,7 @@ class ZonnsmartTV01_ZG(TuyaThermostat):
             ("_TZE200_husqqvux", "TS0601"),
             ("_TZE200_kly8gjlz", "TS0601"),
             ("_TZE200_hue3yfsn", "TS0601"),  # TV02-ZG
+            ("_TZE200_mudxchsu", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Tested using Home Assistant + ZHA

Seems to be an Zonnsmart style TV05-ZG as described [here](https://github.com/zigpy/zigpy/discussions/653#)

Link to Product: [Amazon.de](https://www.amazon.de/gp/product/B0B3LZTXR7/ref=ppx_yo_dt_b_asin_title_o00_s00?ie=UTF8&psc=1)