### PR TITLE
Add the `on_off` call in the `move_to_level_with_on_off` command

### DIFF
--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -420,8 +420,21 @@ class TuyaLevelControl(LevelControl, TuyaLocalCluster):
             command_id,
             args,
         )
+        # (move_to_level_with_on_off --> send the on_off command first)
+        if command_id == 0x0004:
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_attr="on_off",
+                attr_value=bool(args[0]),  # maybe must be compared against `minimum_level` attribute
+                expect_reply=expect_reply,
+                manufacturer=manufacturer,
+            )
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cluster_data,
+            )
+
         # (move_to_level, move, move_to_level_with_on_off)
-        # (move_to_level_with_on_off --> ZHA have the `ForceOnLight` implementation)
         if command_id in (0x0000, 0x0001, 0x0004):
             cluster_data = TuyaClusterData(
                 endpoint_id=self.endpoint.endpoint_id,

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -425,7 +425,9 @@ class TuyaLevelControl(LevelControl, TuyaLocalCluster):
             cluster_data = TuyaClusterData(
                 endpoint_id=self.endpoint.endpoint_id,
                 cluster_attr="on_off",
-                attr_value=bool(args[0]),  # maybe must be compared against `minimum_level` attribute
+                attr_value=bool(
+                    args[0]
+                ),  # maybe must be compared against `minimum_level` attribute
                 expect_reply=expect_reply,
                 manufacturer=manufacturer,
             )


### PR DESCRIPTION
Implement the `on_off` call in the `move_to_level_with_on_off` command for the MCU Tuya devices. 
The previous implementation was removed in #1748. Originally introduced in #1489

After some discussion in https://github.com/zigpy/zha-device-handlers/pull/1748#issuecomment-1244931971 I really believe that the implementation must be done inside the handler library better than expect to add all the devices in the ZHA implementation. This way the handlers library would fully implement the `move_to_level_with_on_off` for the MCU devices.

Fixes: #1694