### PR TITLE
Add support for Tuya Switch TZ3000_18ejxno0

### DIFF
--- a/zhaquirks/tuya/ts001x.py
+++ b/zhaquirks/tuya/ts001x.py
@@ -362,6 +362,83 @@ class Tuya_Double_No_N(TuyaSwitch):
         },
     }
 
+class Tuya_Double_No_N__TZ3000_18ejxno0(TuyaSwitch):
+    """Tuya 2 gang no neutral light switch, model TZ3000_18ejxno0"""
+
+    signature = {
+        # "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0,
+        # user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>,
+        # mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4417, maximum_buffer_size=66,
+        # maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66,
+        # descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False,
+        # *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False,
+        # *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
+        MODELS_INFO: [("_TZ3000_18ejxno0", "TS0012")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=100
+            # device_version=1
+            # input_clusters=[3, 4, 5, 6, 57344, 57345, 0]
+            # output_clusters=[a, 19]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    TuyaZBE000Cluster.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                    Basic.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=100
+            # device_version=1
+            # input_clusters=[4, 5, 6, 57345]
+            # output_clusters=[]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                    TuyaZBE000Cluster,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
 
 class Tuya_Triple_No_N(TuyaSwitch):
     """Tuya 3 gang no neutral light switch."""

--- a/zhaquirks/tuya/ts001x.py
+++ b/zhaquirks/tuya/ts001x.py
@@ -8,6 +8,7 @@ from zhaquirks.const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODEL,
+    MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
@@ -362,8 +363,9 @@ class Tuya_Double_No_N(TuyaSwitch):
         },
     }
 
+
 class Tuya_Double_No_N__TZ3000_18ejxno0(TuyaSwitch):
-    """Tuya 2 gang no neutral light switch, model TZ3000_18ejxno0"""
+    """Tuya 2 gang no neutral light switch, model TZ3000_18ejxno0."""
 
     signature = {
         # "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0,
@@ -439,6 +441,7 @@ class Tuya_Double_No_N__TZ3000_18ejxno0(TuyaSwitch):
             },
         },
     }
+
 
 class Tuya_Triple_No_N(TuyaSwitch):
     """Tuya 3 gang no neutral light switch."""

--- a/zhaquirks/tuya/ts001x.py
+++ b/zhaquirks/tuya/ts001x.py
@@ -8,7 +8,6 @@ from zhaquirks.const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODEL,
-    MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SKIP_CONFIGURATION,
@@ -364,8 +363,8 @@ class Tuya_Double_No_N(TuyaSwitch):
     }
 
 
-class Tuya_Double_No_N__TZ3000_18ejxno0(TuyaSwitch):
-    """Tuya 2 gang no neutral light switch, model TZ3000_18ejxno0."""
+class Tuya_Double_No_N_Plus(TuyaSwitch):
+    """Tuya 2 gang no neutral light switch."""
 
     signature = {
         # "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0,
@@ -375,23 +374,23 @@ class Tuya_Double_No_N__TZ3000_18ejxno0(TuyaSwitch):
         # descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False,
         # *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False,
         # *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
-        MODELS_INFO: [("_TZ3000_18ejxno0", "TS0012")],
+        MODEL: "TS0012",
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=100
             # device_version=1
-            # input_clusters=[3, 4, 5, 6, 57344, 57345, 0]
+            # input_clusters=[0, 3, 4, 5, 6, 57344, 57345]
             # output_clusters=[a, 19]>
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
+                    Basic.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     OnOff.cluster_id,
                     TuyaZBE000Cluster.cluster_id,
                     TuyaZBExternalSwitchTypeCluster.cluster_id,
-                    Basic.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
             },


### PR DESCRIPTION
A proper support for Tuya 2G Zigbee Switch `TZ3000_18ejxno0`.
The brand of the switch is `Moes`.
Interestengly, when attempting to use existing `MoesSwitchManufCluster` (which is used for TS0601 switches) it doesn't bind lights at all, so I used a generic `TuyaZBOnOffAttributeCluster` for the switch.
Another thing is that the switch by default came with `backlight_mode` set to `Light when On` (number `1`), which us useless.
After linking the switch I changed the backlight mode to `Light when Off` (number `2`) through modifying cluster attributes within `TuyaZBOnOffAttributeCluster` in Home Assistant UI.
