### PR TITLE
Handle Tuya multiple attributes reports

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -1458,7 +1458,6 @@ async def test_handle_get_data(zigpy_device_from_quirk, quirk):
 
     ts0601_sensor = zigpy_device_from_quirk(quirk)
     tuya_cluster = ts0601_sensor.endpoints[1].tuya_manufacturer
-    # thermostat_cluster = ts0601_sensor.endpoints[1].thermostat
 
     message = b"\x09\xE0\x02\x0B\x33\x01\x02\x00\x04\x00\x00\x00\xFD\x02\x02\x00\x04\x00\x00\x00\x47\x04\x02\x00\x04\x00\x00\x00\x64"
     hdr, data = tuya_cluster.deserialize(message)

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -22,7 +22,7 @@ from zhaquirks.const import (
     PROFILE_ID,
     ZONE_STATE,
 )
-from zhaquirks.tuya import Data, TuyaManufClusterAttributes
+from zhaquirks.tuya import Data, TuyaManufClusterAttributes, TuyaNewManufCluster
 import zhaquirks.tuya.ts0042
 import zhaquirks.tuya.ts0043
 import zhaquirks.tuya.ts0601_electric_heating
@@ -1405,3 +1405,69 @@ def test_ts0601_valve_signature(assert_signature_matches_quirk):
         "class": "ts0601_valve.TuyaValve",
     }
     assert_signature_matches_quirk(zhaquirks.tuya.ts0601_valve.TuyaValve, signature)
+
+
+def test_multiple_attributes_report():
+    """Test a multi attribute report from Tuya device."""
+
+    ep = mock.Mock()  # fake endpoint object
+
+    message = (
+        b"\x09\x7B\x02\x01\x0F\x01\x01\x00\x01\x01\x05\x02\x00\x04\x00\x00\x00\x07"
+    )
+    hdr, data = TuyaNewManufCluster(ep).deserialize(message)
+
+    assert data
+    assert data.data
+    assert data.data.datapoints
+    assert len(data.data.datapoints) == 2
+    assert data.data.datapoints[0].dp == 1
+    assert data.data.datapoints[1].dp == 5
+
+    message = b"\x09\xE0\x02\x0B\x33\x01\x02\x00\x04\x00\x00\x00\xFD\x02\x02\x00\x04\x00\x00\x00\x47\x04\x02\x00\x04\x00\x00\x00\x64\x0A\x02\x00\x04\x00\x00\x01\x68\x0B\x02\x00\x04\x00\x00\x00\xC8"
+    hdr, data = TuyaNewManufCluster(ep).deserialize(message)
+
+    assert data
+    assert data.data
+    assert data.data.datapoints
+    assert len(data.data.datapoints) == 5
+    assert data.data.datapoints[0].dp == 1
+    assert data.data.datapoints[1].dp == 2
+    assert data.data.datapoints[2].dp == 4
+    assert data.data.datapoints[3].dp == 10
+    assert data.data.datapoints[4].dp == 11
+
+    message = b"\x09\xE1\x02\x0B\x34\x0C\x02\x00\x04\x00\x00\x00\x46\x0D\x02\x00\x04\x00\x00\x00\x14\x11\x02\x00\x04\x00\x00\x00\x1E\x09\x04\x00\x01\x01"
+    hdr, data = TuyaNewManufCluster(ep).deserialize(message)
+
+    assert data
+    assert data.data
+    assert data.data.datapoints
+    assert len(data.data.datapoints) == 4
+    assert data.data.datapoints[0].dp == 12
+    assert data.data.datapoints[1].dp == 13
+    assert data.data.datapoints[2].dp == 17
+    assert data.data.datapoints[3].dp == 9
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.tuya.ts0601_sensor.TuyaTempHumiditySensor,)
+)
+async def test_handle_get_data(zigpy_device_from_quirk, quirk):
+    """Test handle_get_data for multiple attributes."""
+
+    ts0601_sensor = zigpy_device_from_quirk(quirk)
+    tuya_cluster = ts0601_sensor.endpoints[1].tuya_manufacturer
+    # thermostat_cluster = ts0601_sensor.endpoints[1].thermostat
+
+    message = b"\x09\xE0\x02\x0B\x33\x01\x02\x00\x04\x00\x00\x00\xFD\x02\x02\x00\x04\x00\x00\x00\x47\x04\x02\x00\x04\x00\x00\x00\x64"
+    hdr, data = tuya_cluster.deserialize(message)
+
+    status = tuya_cluster.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+
+    message = b"\x09\xE0\x02\x0B\x33\x01\x02\x00\x04\x00\x00\x00\xFD\x02\x02\x00\x04\x00\x00\x00\x47\xFF\x02\x00\x04\x00\x00\x00\x64"
+    hdr, data = tuya_cluster.deserialize(message)
+
+    status = tuya_cluster.handle_get_data(data.data)
+    assert status == foundation.Status.UNSUPPORTED_ATTRIBUTE

--- a/tests/test_tuya_clusters.py
+++ b/tests/test_tuya_clusters.py
@@ -12,6 +12,7 @@ from zhaquirks.tuya import (
     TUYA_SET_TIME,
     TuyaCommand,
     TuyaData,
+    TuyaDatapointData,
     TuyaNewManufCluster,
 )
 
@@ -132,17 +133,35 @@ def test_tuya_data_bitmap_invalid():
         (
             TUYA_GET_DATA,
             "handle_get_data",
-            (TuyaCommand(0, 2, 2, TuyaData(1, 0, b"\x01\x01")),),
+            (
+                TuyaCommand(
+                    status=0,
+                    tsn=2,
+                    datapoints=[TuyaDatapointData(2, TuyaData(1, 0, b"\x01\x01"))],
+                ),
+            ),
         ),
         (
             TUYA_SET_DATA_RESPONSE,
             "handle_set_data_response",
-            (TuyaCommand(0, 2, 2, TuyaData(1, 0, b"\x01\x01")),),
+            (
+                TuyaCommand(
+                    status=0,
+                    tsn=2,
+                    datapoints=[TuyaDatapointData(2, TuyaData(1, 0, b"\x01\x01"))],
+                ),
+            ),
         ),
         (
             TUYA_ACTIVE_STATUS_RPT,
             "handle_active_status_report",
-            (TuyaCommand(0, 2, 2, TuyaData(1, 0, b"\x01\x01")),),
+            (
+                TuyaCommand(
+                    status=0,
+                    tsn=2,
+                    datapoints=[TuyaDatapointData(2, TuyaData(1, 0, b"\x01\x01"))],
+                ),
+            ),
         ),
         (TUYA_SET_TIME, "handle_set_time_request", (0x1234,)),
     ),
@@ -153,7 +172,7 @@ def test_tuya_cluster_request(
 ):
     """Test cluster specific request."""
 
-    hdr = zcl_f.ZCLHeader.general(1, cmd_id, is_reply=True)
+    hdr = zcl_f.ZCLHeader.general(1, cmd_id, direction=zcl_f.Direction.Client_to_Server)
     hdr.frame_control.disable_default_response = False
 
     with mock.patch.object(TuyaCluster, handler_name) as handler:
@@ -168,7 +187,7 @@ def test_tuya_cluster_request(
 def test_tuya_cluster_request_unk_command(default_rsp_mock, TuyaCluster):
     """Test cluster specific request handler -- no handler."""
 
-    hdr = zcl_f.ZCLHeader.general(1, 0xFE, is_reply=True)
+    hdr = zcl_f.ZCLHeader.general(1, 0xFE, direction=zcl_f.Direction.Client_to_Server)
     hdr.frame_control.disable_default_response = False
 
     TuyaCluster.handle_cluster_request(hdr, (mock.sentinel.args,))
@@ -180,7 +199,7 @@ def test_tuya_cluster_request_unk_command(default_rsp_mock, TuyaCluster):
 def test_tuya_cluster_request_no_handler(default_rsp_mock, TuyaCluster):
     """Test cluster specific request handler -- no handler."""
 
-    hdr = zcl_f.ZCLHeader.general(1, 0xFE, is_reply=True)
+    hdr = zcl_f.ZCLHeader.general(1, 0xFE, direction=zcl_f.Direction.Client_to_Server)
     hdr.frame_control.disable_default_response = False
 
     new_client_commands = TuyaCluster.client_commands.copy()

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -69,9 +69,11 @@ async def test_tuya_methods(zigpy_device_from_quirk, quirk):
 
     result_1 = tuya_cluster.from_cluster_data(tcd_1)
     assert result_1
-    assert result_1.dp == 9
-    assert result_1.data.dp_type == TuyaDPType.VALUE
-    assert result_1.data.raw == b"\x00\x00\x00b"
+    assert result_1.datapoints
+    assert len(result_1.datapoints) == 1
+    assert result_1.datapoints[0].dp == 9
+    assert result_1.datapoints[0].data.dp_type == TuyaDPType.VALUE
+    assert result_1.datapoints[0].data.raw == b"\x00\x00\x00b"
 
     tcd_2 = TuyaClusterData(
         endpoint_id=7, cluster_attr="not_exists_attribute", attr_value=25

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -583,17 +583,3 @@ class EnchantedDevice(CustomDevice):
         attr_to_read = [4, 0, 1, 5, 7, 0xFFFE]
         basic_cluster = self.endpoints[1].in_clusters[0]
         await basic_cluster.read_attributes(attr_to_read)
-
-
-# class EnchantedBasicCluster(Basic):
-#     """Class for enchanted Tuya devices which needs to be unlocked by casting a 'spell'."""
-
-#     def __init__(self, endpoint, is_server: bool = True):
-#         """Initialize with task."""
-#         super().__init__(endpoint, is_server)
-#         self._init_device_task = asyncio.create_task(self.spell())
-
-#     async def spell(self) -> None:
-#         """Initialize device so that all endpoints become available."""
-#         attr_to_read = [4, 0, 1, 5, 7, 0xFFFE]
-#         await self.read_attributes(attr_to_read)


### PR DESCRIPTION
This PR enable handle reports with multiple attributes from Tuya devices.

All credits goes to @puddly:
* https://github.com/zigpy/zha-device-handlers/issues/1566#issuecomment-1133066260

My first approach was to include the `dp` attribute inside the already existing `TuyaData` class, but most of the deserialization tests break and I haven't been able to fix them.

The tests of the new functionality have been added.