### PR TITLE
Add support for _TZE200_yi4jtqq1 illuminance sensor.

### DIFF
--- a/zhaquirks/tuya/ts0601_illuminance.py
+++ b/zhaquirks/tuya/ts0601_illuminance.py
@@ -17,19 +17,16 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
 from zhaquirks.tuya import TuyaLocalCluster
-from zhaquirks.tuya.mcu import (
-    DPToAttributeMapping,
-    TuyaDPType,
-    TuyaMCUCluster,
-)
+from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaDPType, TuyaMCUCluster
 
 TUYA_BRIGHTNESS_LEVEL_DP = 0x01  # 0-2 "Low, Medium, High"
 TUYA_ILLUMINANCE_DP = 0x02  # [0, 0, 3, 232] illuminance
 
+
 class BrightnessLevel(t.enum8):
     """Brightness level enum."""
+
     LOW = 0x00
     MEDIUM = 0x01
     HIGH = 0x02

--- a/zhaquirks/tuya/ts0601_illuminance.py
+++ b/zhaquirks/tuya/ts0601_illuminance.py
@@ -17,7 +17,13 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import DPToAttributeMapping, TuyaLocalCluster, TuyaNewManufCluster
+
+from zhaquirks.tuya import TuyaLocalCluster
+from zhaquirks.tuya.mcu import (
+    DPToAttributeMapping,
+    TuyaDPType,
+    TuyaMCUCluster,
+)
 
 TUYA_BRIGHTNESS_LEVEL_DP = 0x01  # 0-2 "Low, Medium, High"
 TUYA_ILLUMINANCE_DP = 0x02  # [0, 0, 3, 232] illuminance
@@ -40,19 +46,21 @@ class TuyaIlluminanceMeasurement(IlluminanceMeasurement, TuyaLocalCluster):
     )
 
 
-class TuyaIlluminanceCluster(TuyaNewManufCluster):
+class TuyaIlluminanceCluster(TuyaMCUCluster):
     """Tuya Illuminance cluster."""
 
     dp_to_attribute: Dict[int, DPToAttributeMapping] = {
         TUYA_BRIGHTNESS_LEVEL_DP: DPToAttributeMapping(
             TuyaIlluminanceMeasurement.ep_attribute,
             "manufacturer_brightness_level",
-            lambda x: BrightnessLevel(x),
+            dp_type=TuyaDPType.ENUM,
+            converter=lambda x: BrightnessLevel(x),
         ),
         TUYA_ILLUMINANCE_DP: DPToAttributeMapping(
             TuyaIlluminanceMeasurement.ep_attribute,
             "measured_value",
-            lambda x: (10000.0 * math.log10(x) + 1.0 if x != 0 else 0),
+            dp_type=TuyaDPType.VALUE,
+            converter=lambda x: (10000.0 * math.log10(x) + 1.0 if x != 0 else 0),
         ),
     }
 
@@ -79,7 +87,7 @@ class TuyaIlluminance(CustomDevice):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaNewManufCluster.cluster_id,
+                    TuyaMCUCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },

--- a/zhaquirks/tuya/ts0601_illuminance.py
+++ b/zhaquirks/tuya/ts0601_illuminance.py
@@ -6,17 +6,8 @@ from typing import Dict
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 import zigpy.types as t
-from zigpy.zcl.clusters.general import (
-    Basic,
-    GreenPowerProxy,
-    Groups,
-    Ota,
-    Scenes,
-    Time,
-)
-from zigpy.zcl.clusters.measurement import (
-    IlluminanceMeasurement,
-)
+from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Groups, Ota, Scenes, Time
+from zigpy.zcl.clusters.measurement import IlluminanceMeasurement
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -26,12 +17,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import (
-    DPToAttributeMapping,
-    TuyaLocalCluster,
-    TuyaNewManufCluster,
-)
-
+from zhaquirks.tuya import DPToAttributeMapping, TuyaLocalCluster, TuyaNewManufCluster
 
 TUYA_BRIGHTNESS_LEVEL_ATTR = 0x01  # 0-2 "Low, Medium, High"
 TUYA_ILLUMINANCE_ATTR = 0x02  # [0, 0, 3, 232] illuminance

--- a/zhaquirks/tuya/ts0601_illuminance.py
+++ b/zhaquirks/tuya/ts0601_illuminance.py
@@ -38,7 +38,7 @@ class TuyaIlluminanceMeasurement(IlluminanceMeasurement, TuyaLocalCluster):
     attributes = IlluminanceMeasurement.attributes.copy()
     attributes.update(
         {
-            0xFF00: ("brightness_level", BrightnessLevel, True),
+            0xFF00: ("manufacturer_brightness_level", BrightnessLevel, True),
         }
     )
 

--- a/zhaquirks/tuya/ts0601_illuminance.py
+++ b/zhaquirks/tuya/ts0601_illuminance.py
@@ -19,10 +19,14 @@ from zhaquirks.const import (
 )
 from zhaquirks.tuya import DPToAttributeMapping, TuyaLocalCluster, TuyaNewManufCluster
 
-TUYA_BRIGHTNESS_LEVEL_ATTR = 0x01  # 0-2 "Low, Medium, High"
-TUYA_ILLUMINANCE_ATTR = 0x02  # [0, 0, 3, 232] illuminance
+TUYA_BRIGHTNESS_LEVEL_DP = 0x01  # 0-2 "Low, Medium, High"
+TUYA_ILLUMINANCE_DP = 0x02  # [0, 0, 3, 232] illuminance
 
-TUYA_BRIGHTNESS_LEVEL_STR = ["Low", "Medium", "High"]
+class BrightnessLevel(t.enum8):
+    """Brightness level enum."""
+    LOW = 0x00
+    MEDIUM = 0x01
+    HIGH = 0x02
 
 
 class TuyaIlluminanceMeasurement(IlluminanceMeasurement, TuyaLocalCluster):
@@ -31,7 +35,7 @@ class TuyaIlluminanceMeasurement(IlluminanceMeasurement, TuyaLocalCluster):
     attributes = IlluminanceMeasurement.attributes.copy()
     attributes.update(
         {
-            0xFF00: ("brightness_level", t.CharacterString, True),
+            0xFF00: ("brightness_level", BrightnessLevel, True),
         }
     )
 
@@ -40,12 +44,12 @@ class TuyaIlluminanceCluster(TuyaNewManufCluster):
     """Tuya Illuminance cluster."""
 
     dp_to_attribute: Dict[int, DPToAttributeMapping] = {
-        TUYA_BRIGHTNESS_LEVEL_ATTR: DPToAttributeMapping(
+        TUYA_BRIGHTNESS_LEVEL_DP: DPToAttributeMapping(
             TuyaIlluminanceMeasurement.ep_attribute,
-            "brightness_level",
-            lambda x: TUYA_BRIGHTNESS_LEVEL_STR[x],
+            "manufacturer_brightness_level",
+            lambda x: BrightnessLevel(x),
         ),
-        TUYA_ILLUMINANCE_ATTR: DPToAttributeMapping(
+        TUYA_ILLUMINANCE_DP: DPToAttributeMapping(
             TuyaIlluminanceMeasurement.ep_attribute,
             "measured_value",
             lambda x: (10000.0 * math.log10(x) + 1.0 if x != 0 else 0),
@@ -53,8 +57,8 @@ class TuyaIlluminanceCluster(TuyaNewManufCluster):
     }
 
     data_point_handlers = {
-        TUYA_BRIGHTNESS_LEVEL_ATTR: "_dp_2_attr_update",
-        TUYA_ILLUMINANCE_ATTR: "_dp_2_attr_update",
+        TUYA_BRIGHTNESS_LEVEL_DP: "_dp_2_attr_update",
+        TUYA_ILLUMINANCE_DP: "_dp_2_attr_update",
     }
 
 

--- a/zhaquirks/tuya/ts0601_illuminance.py
+++ b/zhaquirks/tuya/ts0601_illuminance.py
@@ -1,12 +1,11 @@
-"""Tuya HOME-LUX illuminance sensor"""
+"""Tuya HOME-LUX illuminance sensor."""
 
 import math
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 import zigpy.types as t
-from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
@@ -18,9 +17,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.measurement import (
     IlluminanceMeasurement,
 )
-from zigpy.zcl.clusters.security import IasZone
 
-from zhaquirks import Bus, LocalDataCluster, MotionOnEvent
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -36,13 +33,15 @@ from zhaquirks.tuya import (
 )
 
 
-TUYA_BRIGHTNESS_LEVEL_ATTR = 0x01 # 0-2 "Low, Medium, High"
-TUYA_ILLUMINANCE_ATTR = 0x02 # [0, 0, 3, 232] illuminance
+TUYA_BRIGHTNESS_LEVEL_ATTR = 0x01  # 0-2 "Low, Medium, High"
+TUYA_ILLUMINANCE_ATTR = 0x02  # [0, 0, 3, 232] illuminance
 
-TUYA_BRIGHTNESS_LEVEL_STR = [ "Low", "Medium", "High" ]
+TUYA_BRIGHTNESS_LEVEL_STR = ["Low", "Medium", "High"]
+
 
 class TuyaIlluminanceMeasurement(IlluminanceMeasurement, TuyaLocalCluster):
     """Tuya local IlluminanceMeasurement cluster."""
+
     attributes = IlluminanceMeasurement.attributes.copy()
     attributes.update(
         {
@@ -50,29 +49,26 @@ class TuyaIlluminanceMeasurement(IlluminanceMeasurement, TuyaLocalCluster):
         }
     )
 
+
 class TuyaIlluminanceCluster(TuyaNewManufCluster):
     """Tuya Illuminance cluster."""
-
 
     dp_to_attribute: Dict[int, DPToAttributeMapping] = {
         TUYA_BRIGHTNESS_LEVEL_ATTR: DPToAttributeMapping(
             TuyaIlluminanceMeasurement.ep_attribute,
             "brightness_level",
-            lambda x: TUYA_BRIGHTNESS_LEVEL_STR[x]
+            lambda x: TUYA_BRIGHTNESS_LEVEL_STR[x],
         ),
-
-
         TUYA_ILLUMINANCE_ATTR: DPToAttributeMapping(
             TuyaIlluminanceMeasurement.ep_attribute,
             "measured_value",
-            lambda x: (10000.0 * math.log10(x) + 1.0 if x != 0 else 0)
+            lambda x: (10000.0 * math.log10(x) + 1.0 if x != 0 else 0),
         ),
     }
 
     data_point_handlers = {
         TUYA_BRIGHTNESS_LEVEL_ATTR: "_dp_2_attr_update",
         TUYA_ILLUMINANCE_ATTR: "_dp_2_attr_update",
-
     }
 
 
@@ -131,5 +127,3 @@ class TuyaIlluminance(CustomDevice):
             },
         }
     }
-
-

--- a/zhaquirks/tuya/ts0601_illuminance.py
+++ b/zhaquirks/tuya/ts0601_illuminance.py
@@ -1,0 +1,135 @@
+"""Tuya HOME-LUX illuminance sensor"""
+
+import math
+from typing import Dict, Optional, Tuple, Union
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Ota,
+    Scenes,
+    Time,
+)
+from zigpy.zcl.clusters.measurement import (
+    IlluminanceMeasurement,
+)
+from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks import Bus, LocalDataCluster, MotionOnEvent
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.tuya import (
+    DPToAttributeMapping,
+    TuyaLocalCluster,
+    TuyaNewManufCluster,
+)
+
+
+TUYA_BRIGHTNESS_LEVEL_ATTR = 0x01 # 0-2 "Low, Medium, High"
+TUYA_ILLUMINANCE_ATTR = 0x02 # [0, 0, 3, 232] illuminance
+
+TUYA_BRIGHTNESS_LEVEL_STR = [ "Low", "Medium", "High" ]
+
+class TuyaIlluminanceMeasurement(IlluminanceMeasurement, TuyaLocalCluster):
+    """Tuya local IlluminanceMeasurement cluster."""
+    attributes = IlluminanceMeasurement.attributes.copy()
+    attributes.update(
+        {
+            0xFF00: ("brightness_level", t.CharacterString, True),
+        }
+    )
+
+class TuyaIlluminanceCluster(TuyaNewManufCluster):
+    """Tuya Illuminance cluster."""
+
+
+    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+        TUYA_BRIGHTNESS_LEVEL_ATTR: DPToAttributeMapping(
+            TuyaIlluminanceMeasurement.ep_attribute,
+            "brightness_level",
+            lambda x: TUYA_BRIGHTNESS_LEVEL_STR[x]
+        ),
+
+
+        TUYA_ILLUMINANCE_ATTR: DPToAttributeMapping(
+            TuyaIlluminanceMeasurement.ep_attribute,
+            "measured_value",
+            lambda x: (10000.0 * math.log10(x) + 1.0 if x != 0 else 0)
+        ),
+    }
+
+    data_point_handlers = {
+        TUYA_BRIGHTNESS_LEVEL_ATTR: "_dp_2_attr_update",
+        TUYA_ILLUMINANCE_ATTR: "_dp_2_attr_update",
+
+    }
+
+
+class TuyaIlluminance(CustomDevice):
+    """HOME-LUX illuminance sensor. Sense maximum 1000 lumen."""
+
+    signature = {
+        #  endpoint=1, profile=260, device_type=81, device_version=1,
+        #  input_clusters=[4, 5, 61184, 0], output_clusters=[25, 10])
+        MODELS_INFO: [
+            ("_TZE200_yi4jtqq1", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaNewManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+                # input_clusters=[]
+                # output_clusters=[33]
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaIlluminanceCluster,
+                    TuyaIlluminanceMeasurement,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }
+
+


### PR DESCRIPTION
This is a simple illuminance sensort with a maximum of 1000 lumen. So it's only really suited for inside, not outside.

The quirk provide both the raw lumen value as well as the low/medium/high brightness level.