### PR TITLE
Add python 3.10 to tox and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CACHE_VERSION: 1
-  DEFAULT_PYTHON: 3.7
+  DEFAULT_PYTHON: '3.9.14'
   PRE_COMMIT_HOME: ~/.cache/pre-commit
 
 jobs:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.8.14', '3.9.14', '3.10.7']
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2
@@ -280,7 +280,7 @@ jobs:
     needs: prepare-base
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.8.14', '3.9.14', '3.10.7']
     name: >-
       Run tests Python ${{ matrix.python-version }}
     steps:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,12 @@ class MockApp(zigpy.application.ControllerApplication):
     async def permit_with_key(self, *args, **kwargs):
         """Mock permit_with_key."""
 
+    async def reset_network_info(self, *args, **kwargs):
+        """Mock reset_network_info."""
+
+    async def send_packet(self, *args, **kwargs):
+        """Mock send_packet."""
+
     async def start_network(self, *args, **kwargs):
         """Mock start_network."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, lint, black
+envlist = py38, py39, py310, lint, black
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Hi,

I've opened this PR to reproduce some errors I am facing with python 3.10 when running tests.

All of them are like this one:
```
ERROR tests/test_xiaomi.py::test_xiaomi_battery[2985-118] - TypeError: Can't instantiate abstract class MockApp with abstract methods reset_network_info, send_packet
```

Note: python 3.10 is supported by Home Assistant since 2022/07, see https://www.home-assistant.io/blog/2022/07/06/release-20227/#improved-stability-and-performance-and-python-310