### PR TITLE
Add EVOLVEO Heat M30v2 TRV

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1529,6 +1529,7 @@ class MoesHY368_Type1(TuyaThermostat):
             ("_TZE200_4eeyebrt", "TS0601"),
             ("_TZE200_cpmgn2cf", "TS0601"),
             ("_TZE200_9sfg7gm0", "TS0601"),
+            ("_TZE200_8whxpsiw", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Adds the manufacturer code `_TZE200_8whxpsiw` for the EVOLVEO Heat M30v2 TRV.

Fixes: #1798