### PR TITLE
Fix async unit tests

### DIFF
--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1,4 +1,3 @@
-asynctest
 isort
 black
 flake8
@@ -12,5 +11,6 @@ pylint
 pytest-cov
 pytest-sugar
 pytest-timeout
-pytest
+pytest-asyncio
+pytest>=7.1.3
 zigpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [tool:pytest]
+asyncio_mode = auto
 testpaths = tests
 norecursedirs = .git testing_config
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     keywords="zha quirks homeassistant hass",
     packages=find_packages(exclude=["tests"]),
     python_requires=">=3",
-    install_requires=["zigpy>=0.45.1"],
+    install_requires=["zigpy>=0.51.1"],
     tests_require=["pytest"],
 )

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,5 @@
 """Quirks common helpers."""
+import asyncio
 import datetime
 
 ZCL_IAS_MOTION_COMMAND = b"\t!\x00\x01\x00\x00\x00\x00\x00"
@@ -37,3 +38,17 @@ class MockDatetime(datetime.datetime):
         """Return testvalue."""
 
         return cls(1970, 1, 1, 2, 0, 0)
+
+
+async def wait_for_zigpy_tasks() -> None:
+    """Wait for all running zigpy tasks to finish."""
+    tasks = []
+
+    for task in asyncio.all_tasks():
+        coro = task.get_coro()
+
+        # TODO: track tasks within zigpy
+        if "CatchingTaskMixin" in coro.__qualname__:
+            tasks.append(task)
+
+    await asyncio.gather(*tasks)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,6 @@
 """Fixtures for all tests."""
 
-try:
-    from unittest.mock import AsyncMock as CoroutineMock
-except ImportError:
-    from asynctest import CoroutineMock
+from unittest.mock import AsyncMock
 
 import pytest
 import zigpy.application
@@ -79,8 +76,8 @@ class MockApp(zigpy.application.ControllerApplication):
     async def add_endpoint(self, descriptor):
         """Mock add_endpoint."""
 
-    mrequest = CoroutineMock()
-    request = CoroutineMock(return_value=(foundation.Status.SUCCESS, None))
+    mrequest = AsyncMock()
+    request = AsyncMock(return_value=(foundation.Status.SUCCESS, None))
 
 
 @pytest.fixture(name="MockAppController")

--- a/tests/test_kof.py
+++ b/tests/test_kof.py
@@ -10,8 +10,6 @@ import zigpy.zdo.types as zdo_t
 import zhaquirks
 import zhaquirks.kof.kof_mr101z
 
-from tests.conftest import CoroutineMock
-
 zhaquirks.setup()
 
 Default_Response = foundation.GENERAL_COMMANDS[
@@ -35,7 +33,7 @@ async def test_kof_no_reply():
         }
         client_commands = {}
 
-    ep = CoroutineMock()
+    ep = mock.AsyncMock()
     ep.device.application.get_sequence = mock.MagicMock(return_value=4)
 
     cluster = TestCluster(ep)

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -31,7 +31,7 @@ import zhaquirks.tuya.ts0601_siren
 import zhaquirks.tuya.ts0601_trv
 import zhaquirks.tuya.ts0601_valve
 
-from tests.common import ClusterListener, MockDatetime
+from tests.common import ClusterListener, MockDatetime, wait_for_zigpy_tasks
 
 zhaquirks.setup()
 
@@ -222,6 +222,7 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
     ) as m1:
 
         rsp = await switch_cluster.command(0x0000)
+        await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
             2,
@@ -232,6 +233,7 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
         assert rsp.status == 0
 
         rsp = await switch_cluster.command(0x0001)
+        await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
             4,
@@ -242,6 +244,7 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
         assert rsp.status == 0
 
     rsp = await switch_cluster.command(0x0002)
+    await wait_for_zigpy_tasks()
     assert rsp.status == foundation.Status.UNSUP_CLUSTER_COMMAND
 
 
@@ -1221,6 +1224,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
 
         hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SET_TIME_REQUEST)
         tuya_cluster.handle_message(hdr, args)
+        await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
             21,

--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -7,7 +7,7 @@ from zigpy.zcl import foundation
 
 import zhaquirks
 
-from tests.common import ClusterListener
+from tests.common import ClusterListener, wait_for_zigpy_tasks
 
 zhaquirks.setup()
 
@@ -31,6 +31,7 @@ async def test_command(zigpy_device_from_quirk, quirk):
         tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
     ) as m1:
         rsp = await switch2_cluster.command(0x0001)
+        await wait_for_zigpy_tasks()
 
         m1.assert_called_with(
             61184,
@@ -42,6 +43,7 @@ async def test_command(zigpy_device_from_quirk, quirk):
         assert rsp.status == foundation.Status.SUCCESS
 
         rsp = await dimmer1_cluster.command(0x0000, 225)
+        await wait_for_zigpy_tasks()
 
         m1.assert_called_with(
             61184,
@@ -63,11 +65,8 @@ async def test_write_attr(zigpy_device_from_quirk, quirk):
     tuya_cluster = dimmer_dev.endpoints[1].tuya_manufacturer
     dimmer1_cluster = dimmer_dev.endpoints[1].level
 
-    async def async_success(*args, **kwargs):
-        return foundation.Status.SUCCESS
-
     with mock.patch.object(
-        tuya_cluster.endpoint, "request", side_effect=async_success
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
     ) as m1:
 
         (status,) = await dimmer1_cluster.write_attributes(
@@ -75,6 +74,7 @@ async def test_write_attr(zigpy_device_from_quirk, quirk):
                 "minimum_level": 25,
             }
         )
+        await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
             2,

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -406,7 +406,4 @@ def setup(config: Optional[Dict[str, Any]] = None) -> None:
 
         for importer, modname, ispkg in pkgutil.walk_packages(path=[str(path)]):
             _LOGGER.debug("Loading custom quirks module %s", modname)
-            loader = importer.find_module(modname)
-            spec = importlib.util.spec_from_loader(loader.name, loader)
-            module = importlib.util.module_from_spec(spec)
-            loader.exec_module(module)
+            importer.find_module(modname).load_module(modname)

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -406,4 +406,7 @@ def setup(config: Optional[Dict[str, Any]] = None) -> None:
 
         for importer, modname, ispkg in pkgutil.walk_packages(path=[str(path)]):
             _LOGGER.debug("Loading custom quirks module %s", modname)
-            importer.find_module(modname).load_module(modname)
+            loader = importer.find_module(modname)
+            spec = importlib.util.spec_from_loader(loader.name, loader)
+            module = importlib.util.module_from_spec(spec)
+            loader.exec_module(module)


### PR DESCRIPTION
Existing async unit tests weren't running due to old pytest and a missing pytest-asyncio dependency.