### PR TITLE
Add trigger LED attribute to Hue motion sensors

### DIFF
--- a/zhaquirks/philips/motion.py
+++ b/zhaquirks/philips/motion.py
@@ -1,6 +1,7 @@
 """Quirk for Philips motion sensors."""
 from zigpy.profiles import zha, zll
-from zigpy.quirks import CustomDevice
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -27,6 +28,13 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.philips import PHILIPS, SIGNIFY, OccupancyCluster
+
+
+class BasicCluster(CustomCluster, Basic):
+    """Hue Motion Basic cluster."""
+
+    attributes = Basic.attributes.copy()
+    attributes[0x0033] = ("trigger_indicator", t.Bool, True)
 
 
 class PhilipsMotion(CustomDevice):


### PR DESCRIPTION
Tested and working on an indoor v2 ``SML003`` Hue motion sensor.

Attribute reads as: ``Bool.false`` or ``Bool.true``
Write attribute as: ``0`` or ``1`` (to disable or enable green trigger LED)

I'll also look at adding config entities for all Hue motion sensor options in HA Core itself.