### PR TITLE
Change first gen Hue motion replacement cluster to endpoint 2 for trigger LED

### DIFF
--- a/zhaquirks/philips/motion.py
+++ b/zhaquirks/philips/motion.py
@@ -88,7 +88,7 @@ class PhilipsMotion(CustomDevice):
                 DEVICE_TYPE: zll.DeviceType.ON_OFF_SENSOR,
                 INPUT_CLUSTERS: [Basic.cluster_id],
                 OUTPUT_CLUSTERS: [
-                    BasicCluster,
+                    Basic.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
@@ -101,7 +101,7 @@ class PhilipsMotion(CustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,
+                    BasicCluster,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     IlluminanceMeasurement.cluster_id,


### PR DESCRIPTION
First-gen Hue motion sensors have two endpoints with a Basic cluster (out) each.
For those older sensors, the LED trigger indicator attribute is on the Basic cluster on endpoint 2 (and not 1).
With these changes, it's now also tested and working on the first-gen sensors ``SML001`` and ``SML002``.

(Previously only working for second gen sensors: ``SML003`` and ``SML004``)
(The quirk for those sensors models is unaffected by this change, as it's a separate quirk in the same file.)

This should be the **final PR** regarding the Hue motion sensor LED trigger indicator.
(Follow-up to #1812, #1813)