### PR TITLE
Make `TS011F` plugs inherit `EnchantedDevice`

### DIFF
--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -35,7 +35,7 @@ from zhaquirks.tuya import (
 from zhaquirks.tuya.mcu import EnchantedDevice
 
 
-class Plug(CustomDevice):
+class Plug(EnchantedDevice):
     """Tuya plug with restore power state support."""
 
     signature = {


### PR DESCRIPTION
There are reports that some Blitzwolf SHP 15 plugs (depending on its version) don't report the On/Off update from the physical device. The `herdsman-converters` lib have 3 implementations for the `TS011F` plugs, 2 of them 'implements' the EnchantedDevice approach:
* https://github.com/Koenkk/zigbee-herdsman-converters/blob/96563772e92eb459bf52c10e241c3a725968bcab/devices/tuya.js#L2185

My assumption is that the use of the `EnchantedDevice` cannot be harmful. Also I have not located implementations that could be affected if a device starts to behave in a 'standard' way, *but* there are no guarantees on what will happen and I do not know the scope (of devices) that the change can affect.

If the change is considered too risky, I can try to narrow it down to only the devices that have been reported, but I'll need to check how to match 2 compatible signatures and ensure priority is resolved in the desired order:
```python
        MODEL: "TS011F",
vs 
        MODELS_INFO: [("TS011F", "_TZ3000_u5u4cakc")],
```

Fix: #1787