### PR TITLE
New Ikea starkvind quirk

### DIFF
--- a/tests/test_ikea.py
+++ b/tests/test_ikea.py
@@ -1,0 +1,74 @@
+"""Tests for Ikea Starkvind quirks."""
+
+import zhaquirks.ikea.starkvind
+
+
+def test_ikea_starkvind(assert_signature_matches_quirk):
+    """Test new 'STARKVIND Air purifier table' signature is matched to its quirk."""
+
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4476, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 260,
+                "device_type": "0x0007",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0003",
+                    "0x0004",
+                    "0x0005",
+                    "0x0202",
+                    "0xfc57",
+                    "0xfc7d",
+                ],
+                "out_clusters": ["0x0019", "0x0400", "0x042a"],
+            },
+            "242": {
+                "profile_id": 41440,
+                "device_type": "0x0061",
+                "in_clusters": [],
+                "out_clusters": ["0x0021"],
+            },
+        },
+        "manufacturer": "IKEA of Sweden",
+        "model": "STARKVIND Air purifier",
+        "class": "ikea.starkvind.IkeaSTARKVIND",
+    }
+
+    assert_signature_matches_quirk(zhaquirks.ikea.starkvind.IkeaSTARKVIND, signature)
+
+
+def test_ikea_starkvind_v2(assert_signature_matches_quirk):
+    """Test new 'STARKVIND Air purifier table' signature is matched to its quirk."""
+
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4476, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 260,
+                "device_type": "0x0007",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0003",
+                    "0x0004",
+                    "0x0005",
+                    "0x0202",
+                    "0xfc57",
+                    "0xfc7c",
+                    "0xfc7d",
+                ],
+                "out_clusters": ["0x0019", "0x0400", "0x042a"],
+            },
+            "242": {
+                "profile_id": 41440,
+                "device_type": "0x0061",
+                "in_clusters": [],
+                "out_clusters": ["0x0021"],
+            },
+        },
+        "manufacturer": "IKEA of Sweden",
+        "model": "STARKVIND Air purifier table",
+        "class": "ikea.starkvind.IkeaSTARKVIND_v2",
+    }
+
+    assert_signature_matches_quirk(zhaquirks.ikea.starkvind.IkeaSTARKVIND_v2, signature)

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -10,8 +10,10 @@ from zigpy.zcl.clusters.lightlink import LightLink
 from zhaquirks import DoublingPowerConfigurationCluster
 
 _LOGGER = logging.getLogger(__name__)
+
 IKEA = "IKEA of Sweden"
 IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
+WWAH_CLUSTER_ID = 0xFC57  # decimal = 64599
 
 
 class LightLinkCluster(CustomCluster, LightLink):

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 IKEA = "IKEA of Sweden"
 IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
-WWAH_CLUSTER_ID = 0xFC57  # decimal = 64599
+WWAH_CLUSTER_ID = 0xFC57  # decimal = 64599 ('Works with all Hubs' cluster)
 
 
 class LightLinkCluster(CustomCluster, LightLink):

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -11,6 +11,7 @@ from zhaquirks import DoublingPowerConfigurationCluster
 
 _LOGGER = logging.getLogger(__name__)
 IKEA = "IKEA of Sweden"
+IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
 
 
 class LightLinkCluster(CustomCluster, LightLink):

--- a/zhaquirks/ikea/blinds.py
+++ b/zhaquirks/ikea/blinds.py
@@ -22,9 +22,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.ikea import IKEA
-
-IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID
 
 
 class IkeaTradfriRollerBlinds(CustomDevice):

--- a/zhaquirks/ikea/fivebtnremotezha.py
+++ b/zhaquirks/ikea/fivebtnremotezha.py
@@ -44,12 +44,11 @@ from zhaquirks.const import (
 )
 from zhaquirks.ikea import (
     IKEA,
+    IKEA_CLUSTER_ID,
     LightLinkCluster,
     PowerConfiguration1CRCluster,
     ScenesCluster,
 )
-
-IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
 
 
 class IkeaTradfriRemote1(CustomDevice):

--- a/zhaquirks/ikea/fourbtnremote.py
+++ b/zhaquirks/ikea/fourbtnremote.py
@@ -40,9 +40,12 @@ from zhaquirks.const import (
     TURN_OFF,
     TURN_ON,
 )
-from zhaquirks.ikea import IKEA, PowerConfiguration2AAACluster, ScenesCluster
-
-WWAH_CLUSTER_ID = 0xFC57  # decimal = 64599
+from zhaquirks.ikea import (
+    IKEA,
+    WWAH_CLUSTER_ID,
+    PowerConfiguration2AAACluster,
+    ScenesCluster,
+)
 
 
 class IkeaTradfriRemote(CustomDevice):

--- a/zhaquirks/ikea/motionzha.py
+++ b/zhaquirks/ikea/motionzha.py
@@ -23,9 +23,12 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.ikea import IKEA, LightLinkCluster, PowerConfiguration2CRCluster
-
-IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
+from zhaquirks.ikea import (
+    IKEA,
+    IKEA_CLUSTER_ID,
+    LightLinkCluster,
+    PowerConfiguration2CRCluster,
+)
 
 
 class IkeaTradfriMotion(CustomDevice):

--- a/zhaquirks/ikea/opencloseremote.py
+++ b/zhaquirks/ikea/opencloseremote.py
@@ -35,13 +35,12 @@ from zhaquirks.const import (
     SHORT_PRESS,
     ZHA_SEND_EVENT,
 )
-from zhaquirks.ikea import IKEA, PowerConfiguration1CRCluster
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, PowerConfiguration1CRCluster
 
 COMMAND_CLOSE = "down_close"
 COMMAND_STOP_OPENING = "stop_opening"
 COMMAND_STOP_CLOSING = "stop_closing"
 COMMAND_OPEN = "up_open"
-IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
 
 
 class IkeaWindowCovering(CustomCluster, WindowCovering):

--- a/zhaquirks/ikea/starkvind.py
+++ b/zhaquirks/ikea/starkvind.py
@@ -27,9 +27,8 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, WWAH_CLUSTER_ID
 
-WWAH_CLUSTER_ID = 0xFC57  # decimal = 64599
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/zhaquirks/ikea/starkvind.py
+++ b/zhaquirks/ikea/starkvind.py
@@ -221,24 +221,14 @@ class IkeaSTARKVIND(CustomDevice):
     }
 
 
-class IkeaSTARKVIND_v2(CustomDevice):
+class IkeaSTARKVIND_v2(IkeaSTARKVIND):
     """STARKVIND Air purifier by IKEA of Sweden."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.pm25_bus = Bus()
-        self.change_fan_mode_bus = Bus()
-        self.change_fan_mode_ha_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=7 (0x0007)
         # device_version=0
         # input_clusters=[0, 3, 4, 5, 514, 64599, 64637] output_clusters=[25, 1024, 1066]>
-        MODELS_INFO: [
-            (IKEA, "STARKVIND Air purifier"),
-            (IKEA, "STARKVIND Air purifier table"),
-        ],
+        MODELS_INFO: IkeaSTARKVIND.signature[MODELS_INFO].copy(),
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/ikea/starkvind.py
+++ b/zhaquirks/ikea/starkvind.py
@@ -27,7 +27,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.ikea import IKEA
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID
 
 WWAH_CLUSTER_ID = 0xFC57  # decimal = 64599
 _LOGGER = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ class IkeaAirpurifier(CustomCluster):
         """Override wrong writes to thermostat attributes."""
         if "fan_mode" in attributes:
             fan_mode = attributes.get("fan_mode")
-            if fan_mode > 1 and fan_mode < 11:
+            if fan_mode and fan_mode > 1 and fan_mode < 11:
                 fan_mode = fan_mode * 5
                 return await super().write_attributes(
                     {"fan_mode": fan_mode}, manufacturer
@@ -199,6 +199,93 @@ class IkeaSTARKVIND(CustomDevice):
                     Groups.cluster_id,  # 4
                     Scenes.cluster_id,  # 5
                     WWAH_CLUSTER_ID,  # 64599  0xFC57
+                    IkeaAirpurifier,  # 64637  0xFC7D control air purifier with manufacturer-specific attributes
+                    PM25Cluster,  # 1066    0x042A PM2.5 Measurement Cluster
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,  # 25      0x0019
+                    IlluminanceMeasurement.cluster_id,  # 1024    0x0400
+                ],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # device_version=0
+            # input_clusters=[33] output_clusters=[33]>
+            242: {
+                PROFILE_ID: 0xA1E0,  # 41440 (dec)
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,  # 0x0021 = GreenPowerProxy.cluster_id
+                ],
+            },
+        },
+    }
+
+
+class IkeaSTARKVIND_v2(CustomDevice):
+    """STARKVIND Air purifier by IKEA of Sweden."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.pm25_bus = Bus()
+        self.change_fan_mode_bus = Bus()
+        self.change_fan_mode_ha_bus = Bus()
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=7 (0x0007)
+        # device_version=0
+        # input_clusters=[0, 3, 4, 5, 514, 64599, 64637] output_clusters=[25, 1024, 1066]>
+        MODELS_INFO: [
+            (IKEA, "STARKVIND Air purifier"),
+            (IKEA, "STARKVIND Air purifier table"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COMBINED_INTERFACE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,  # 0
+                    Identify.cluster_id,  # 3
+                    Groups.cluster_id,  # 4
+                    Scenes.cluster_id,  # 5
+                    Fan.cluster_id,  # 514    0x0202
+                    WWAH_CLUSTER_ID,  # 64599  0xFC57
+                    IKEA_CLUSTER_ID,  # 64636  0xFC7C
+                    IkeaAirpurifier.cluster_id,  # 64637  0xFC7D
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,  # 25      0x0019
+                    IlluminanceMeasurement.cluster_id,  # 1024    0x0400
+                    PM25.cluster_id,  # 1066    0x042A PM2.5 Measurement Cluster
+                ],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # device_version=0
+            # input_clusters=[33] output_clusters=[33]>
+            242: {
+                PROFILE_ID: 0xA1E0,  # 41440 (dec)
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,  # 0x0021 = GreenPowerProxy.cluster_id
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COMBINED_INTERFACE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,  # 0
+                    Identify.cluster_id,  # 3
+                    Groups.cluster_id,  # 4
+                    Scenes.cluster_id,  # 5
+                    WWAH_CLUSTER_ID,  # 64599  0xFC57
+                    IKEA_CLUSTER_ID,  # 64636  0xFC7C
                     IkeaAirpurifier,  # 64637  0xFC7D control air purifier with manufacturer-specific attributes
                     PM25Cluster,  # 1066    0x042A PM2.5 Measurement Cluster
                 ],

--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -38,9 +38,7 @@ from zhaquirks.const import (
     TRIPLE_PRESS,
     TURN_ON,
 )
-from zhaquirks.ikea import IKEA, PowerConfiguration1CRCluster
-
-IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, PowerConfiguration1CRCluster
 
 
 class IkeaSYMFONISK1(CustomDevice):

--- a/zhaquirks/ikea/tradfriplug.py
+++ b/zhaquirks/ikea/tradfriplug.py
@@ -13,9 +13,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from zhaquirks.ikea import IKEA
-
-IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID
 
 
 class TradfriPlug(CustomDevice):

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -40,9 +40,12 @@ from zhaquirks.const import (
     TURN_OFF,
     TURN_ON,
 )
-from zhaquirks.ikea import IKEA, LightLinkCluster, PowerConfiguration1CRCluster
-
-IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
+from zhaquirks.ikea import (
+    IKEA,
+    IKEA_CLUSTER_ID,
+    LightLinkCluster,
+    PowerConfiguration1CRCluster,
+)
 
 
 class IkeaTradfriRemote2Btn(CustomDevice):


### PR DESCRIPTION
New quirk version for the Ikea 'STARKVIND Air purifier table'.
Just cloned the previous one with the new signature.

Also some constants have been refactored.

To fix a `mypy` validation a value check has been added `if fan_mode and fan_mode > 1 and fan_mode < 11:`.

Related to: #1846