### PR TITLE
XBee: Use dict for response event data

### DIFF
--- a/tests/test_xbee.py
+++ b/tests/test_xbee.py
@@ -347,7 +347,7 @@ async def test_remote_at_non_native(
     ].add_listener(listener)
 
     def mock_at_response(*args, **kwargs):
-        """Simulate remote AT comand response from device."""
+        """Simulate remote AT command response from device."""
         xbee3_device.handle_message(
             XBEE_PROFILE_ID,
             XBEE_AT_RESPONSE_CLUSTER,
@@ -472,7 +472,7 @@ async def test_remote_at_tx_failure(zigpy_device_from_quirk):
     ].add_listener(listener)
 
     def mock_at_response(*args, **kwargs):
-        """Simulate remote AT comand response from device."""
+        """Simulate remote AT command response from device."""
         xbee3_device.handle_message(
             XBEE_PROFILE_ID,
             XBEE_AT_RESPONSE_CLUSTER,

--- a/tests/test_xbee.py
+++ b/tests/test_xbee.py
@@ -28,7 +28,9 @@ async def test_basic_cluster(zigpy_device_from_quirk):
     """Test Basic cluster."""
 
     xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
-    basic_cluster = xbee3_device.endpoints[XBEE_DATA_ENDPOINT].in_clusters[Basic.cluster_id]
+    basic_cluster = xbee3_device.endpoints[XBEE_DATA_ENDPOINT].in_clusters[
+        Basic.cluster_id
+    ]
 
     # Check mandatory attributes
     succ, fail = await basic_cluster.read_attributes(("zcl_version", "power_source"))
@@ -42,7 +44,12 @@ async def test_digital_output(zigpy_device_from_quirk):
     xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
     onoff_cluster = xbee3_device.endpoints[0xD0].in_clusters[OnOff.cluster_id]
 
-    with mock.patch.object(xbee3_device.application, "remote_at_command", create=True, new_callable=mock.AsyncMock) as m1:
+    with mock.patch.object(
+        xbee3_device.application,
+        "remote_at_command",
+        create=True,
+        new_callable=mock.AsyncMock,
+    ) as m1:
         # Turn the switch on
         _, status = await onoff_cluster.command(1)
 
@@ -73,14 +80,27 @@ async def test_analog_output(zigpy_device_from_quirk):
     pwm_cluster = xbee3_device.endpoints[0xDA].in_clusters[AnalogOutput.cluster_id]
 
     # Check mandatory attributes
-    succ, fail = await pwm_cluster.read_attributes(("max_present_value", "min_present_value", "out_of_service", "resolution", "status_flags"))
+    succ, fail = await pwm_cluster.read_attributes(
+        (
+            "max_present_value",
+            "min_present_value",
+            "out_of_service",
+            "resolution",
+            "status_flags",
+        )
+    )
     assert succ["max_present_value"] == 1023.0
-    assert succ["min_present_value"] == 0.0 
+    assert succ["min_present_value"] == 0.0
     assert succ["out_of_service"] == 0
     assert succ["resolution"] == 1.0
     assert succ["status_flags"] == 0
 
-    with mock.patch.object(xbee3_device.application, "remote_at_command", create=True, new_callable=mock.AsyncMock) as m1:
+    with mock.patch.object(
+        xbee3_device.application,
+        "remote_at_command",
+        create=True,
+        new_callable=mock.AsyncMock,
+    ) as m1:
         # Write value
         (status,) = await pwm_cluster.write_attributes({"present_value": 122.9})
 
@@ -126,9 +146,22 @@ async def test_send_serial_data(zigpy_device_from_quirk):
     xbee3_device.application.request.reset_mock()
 
     # Send serial data
-    _, status = await xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[XBEE_DATA_CLUSTER].command(0, "Test UART data")
+    _, status = (
+        await xbee3_device.endpoints[XBEE_DATA_ENDPOINT]
+        .out_clusters[XBEE_DATA_CLUSTER]
+        .command(0, "Test UART data")
+    )
 
-    xbee3_device.application.request.assert_awaited_once_with(xbee3_device, XBEE_PROFILE_ID, XBEE_DATA_CLUSTER, XBEE_DATA_ENDPOINT, XBEE_DATA_ENDPOINT, 1, b'Test UART data', expect_reply=False)
+    xbee3_device.application.request.assert_awaited_once_with(
+        xbee3_device,
+        XBEE_PROFILE_ID,
+        XBEE_DATA_CLUSTER,
+        XBEE_DATA_ENDPOINT,
+        XBEE_DATA_ENDPOINT,
+        1,
+        b"Test UART data",
+        expect_reply=False,
+    )
     assert status == foundation.Status.SUCCESS
 
 
@@ -138,12 +171,22 @@ async def test_receive_serial_data(zigpy_device_from_quirk):
     xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
 
     listener = mock.MagicMock()
-    xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[LevelControl.cluster_id].add_listener(listener)
+    xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[
+        LevelControl.cluster_id
+    ].add_listener(listener)
 
     # Receive serial data
-    xbee3_device.handle_message(XBEE_PROFILE_ID, XBEE_DATA_CLUSTER, XBEE_DATA_ENDPOINT, XBEE_DATA_ENDPOINT, b'Test UART data')
+    xbee3_device.handle_message(
+        XBEE_PROFILE_ID,
+        XBEE_DATA_CLUSTER,
+        XBEE_DATA_ENDPOINT,
+        XBEE_DATA_ENDPOINT,
+        b"Test UART data",
+    )
 
-    listener.zha_send_event.assert_called_once_with("receive_data", {'data': "Test UART data"})
+    listener.zha_send_event.assert_called_once_with(
+        "receive_data", {"data": "Test UART data"}
+    )
 
 
 @pytest.mark.parametrize(
@@ -153,294 +196,270 @@ async def test_receive_serial_data(zigpy_device_from_quirk):
         (
             67,
             None,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeTP',
-            b'\x01TP\x00\x18',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeTP",
+            b"\x01TP\x00\x18",
             "tp_command_response",
-            24
+            24,
         ),
         # Read negative int16_t argument
         (
             67,
             None,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeTP',
-            b'\x01TP\x00\xfc',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeTP",
+            b"\x01TP\x00\xfc",
             "tp_command_response",
-            -4
+            -4,
         ),
         # Read string argument
         (
             8,
             None,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeNI',
-            b'\x01NI\x00My Test XBee Device',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeNI",
+            b"\x01NI\x00My Test XBee Device",
             "ni_command_response",
-            b'My Test XBee Device'
+            b"My Test XBee Device",
         ),
         # Write string argument
         (
             8,
-            b'My Test XBee Device', #TODO: Check how hass sends strings in zha.issue_zigbee_cluster_command
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeNIMy Test XBee Device',
-            b'\x01NI\x00',
+            b"My Test XBee Device",  # TODO: Check how hass sends strings in zha.issue_zigbee_cluster_command
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeNIMy Test XBee Device",
+            b"\x01NI\x00",
             "ni_command_response",
-            None
+            None,
         ),
         # Read uint64_t argument
         (
             15,
             None,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeOP',
-            b'\x01OP\x00\xFF\xEE\xDD\xCC\xBB\xAA\x99\x88',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeOP",
+            b"\x01OP\x00\xFF\xEE\xDD\xCC\xBB\xAA\x99\x88",
             "op_command_response",
-            0xffeeddccbbaa9988
+            0xFFEEDDCCBBAA9988,
         ),
         # Write uint64_t argument
         (
             15,
-            0xfedcba9876543210,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeOP\xFE\xDC\xBA\x98\x76\x54\x32\x10',
-            b'\x01OP\x00',
+            0xFEDCBA9876543210,
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeOP\xFE\xDC\xBA\x98\x76\x54\x32\x10",
+            b"\x01OP\x00",
             "op_command_response",
-            None
+            None,
         ),
         # Read uint32_t argument
         (
             1,
             None,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeDH',
-            b'\x01DH\x00\xFF\xEE\xDD\xCC',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeDH",
+            b"\x01DH\x00\xFF\xEE\xDD\xCC",
             "dh_command_response",
-            0xffeeddcc
+            0xFFEEDDCC,
         ),
         # Write uint32_t argument
         (
             2,
             0,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeDL\x00\x00\x00\x00',
-            b'\x01DL\x00',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeDL\x00\x00\x00\x00",
+            b"\x01DL\x00",
             "dl_command_response",
-            None
+            None,
         ),
         # Read uint16_t argument
         (
             65,
             None,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe%V',
-            b'\x01%V\x00\x0C\xE4',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe%V",
+            b"\x01%V\x00\x0C\xE4",
             "%v_command_response",
-            3300
+            3300,
         ),
         # Write uint16_t argument
         (
             66,
             2700,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeV+\x0A\x8C',
-            b'\x01V+\x00',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeV+\x0A\x8C",
+            b"\x01V+\x00",
             "v+_command_response",
-            None
+            None,
         ),
         # Read uint8_t argument
         (
             54,
             None,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeP0',
-            b'\x01P0\x00\x00',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeP0",
+            b"\x01P0\x00\x00",
             "p0_command_response",
-            0
+            0,
         ),
         # Write uint8_t argument
         (
             46,
             5,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeD0\x05',
-            b'\x01D0\x00',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeD0\x05",
+            b"\x01D0\x00",
             "d0_command_response",
-            None
+            None,
         ),
         # Read bool argument
         (
             31,
             None,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfePM',
-            b'\x01PM\x00\x00',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfePM",
+            b"\x01PM\x00\x00",
             "pm_command_response",
-            False
+            False,
         ),
         # Write bool argument
         (
             31,
             True,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfePM\x01',
-            b'\x01PM\x00',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfePM\x01",
+            b"\x01PM\x00",
             "pm_command_response",
-            None
+            None,
         ),
         # Command with no arguments
         (
             94,
             None,
-            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeAS',
-            b'\x01AS\x00',
+            b"2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeAS",
+            b"\x01AS\x00",
             "as_command_response",
-            None
+            None,
         ),
     ),
 )
-async def test_remote_at_non_native(zigpy_device_from_quirk, command_id, request_value, request_data, response_data, response_command, response_value):
+async def test_remote_at_non_native(
+    zigpy_device_from_quirk,
+    command_id,
+    request_value,
+    request_data,
+    response_data,
+    response_command,
+    response_value,
+):
     """Test remote AT commands with non-XBee coordinator."""
 
     xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
 
     listener = mock.MagicMock()
-    xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[LevelControl.cluster_id].add_listener(listener)
+    xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[
+        LevelControl.cluster_id
+    ].add_listener(listener)
 
     def mock_at_response(*args, **kwargs):
         """Simulate remote AT comand response from device."""
-        xbee3_device.handle_message(XBEE_PROFILE_ID, XBEE_AT_RESPONSE_CLUSTER, XBEE_AT_ENDPOINT, XBEE_AT_ENDPOINT, response_data)
+        xbee3_device.handle_message(
+            XBEE_PROFILE_ID,
+            XBEE_AT_RESPONSE_CLUSTER,
+            XBEE_AT_ENDPOINT,
+            XBEE_AT_ENDPOINT,
+            response_data,
+        )
         return mock.DEFAULT
+
     xbee3_device.application.request.reset_mock()
     xbee3_device.application.request.configure_mock(side_effect=mock_at_response)
 
     # Send remote AT command request
-    _, status = await xbee3_device.endpoints[XBEE_AT_ENDPOINT].out_clusters[XBEE_AT_REQUEST_CLUSTER].command(command_id, request_value)
+    _, status = (
+        await xbee3_device.endpoints[XBEE_AT_ENDPOINT]
+        .out_clusters[XBEE_AT_REQUEST_CLUSTER]
+        .command(command_id, request_value)
+    )
 
     xbee3_device.application.request.configure_mock(side_effect=None)
 
-    xbee3_device.application.request.assert_awaited_once_with(xbee3_device, XBEE_PROFILE_ID, XBEE_AT_REQUEST_CLUSTER, XBEE_AT_ENDPOINT, XBEE_AT_ENDPOINT, 1, request_data, expect_reply=False)
+    xbee3_device.application.request.assert_awaited_once_with(
+        xbee3_device,
+        XBEE_PROFILE_ID,
+        XBEE_AT_REQUEST_CLUSTER,
+        XBEE_AT_ENDPOINT,
+        XBEE_AT_ENDPOINT,
+        1,
+        request_data,
+        expect_reply=False,
+    )
     assert status == foundation.Status.SUCCESS
-    listener.zha_send_event.assert_called_once_with(response_command, {'response': response_value})
+    listener.zha_send_event.assert_called_once_with(
+        response_command, {"response": response_value}
+    )
 
 
 @pytest.mark.parametrize(
     "command_id, command, request_value, response_value",
     (
         # Read positive int16_t argument
-        (
-            67,
-            "TP",
-            None,
-            24
-        ),
+        (67, "TP", None, 24),
         # Read negative int16_t argument
-        (
-            67,
-            "TP",
-            None,
-            -4
-        ),
+        (67, "TP", None, -4),
         # Read string argument
-        (
-            8,
-            "NI",
-            None,
-            "My Test XBee Device"
-        ),
+        (8, "NI", None, "My Test XBee Device"),
         # Write string argument
-        (
-            8,
-            "NI",
-            "My Test XBee Device",
-            None
-        ),
+        (8, "NI", "My Test XBee Device", None),
         # Read uint64_t argument
-        (
-            15,
-            "OP",
-            None,
-            0xffeeddccbbaa9988
-        ),
+        (15, "OP", None, 0xFFEEDDCCBBAA9988),
         # Write uint64_t argument
-        (
-            15,
-            "OP",
-            0xfedcba9876543210,
-            None
-        ),
+        (15, "OP", 0xFEDCBA9876543210, None),
         # Read uint32_t argument
-        (
-            1,
-            "DH",
-            None,
-            0xffeeddcc
-        ),
+        (1, "DH", None, 0xFFEEDDCC),
         # Write uint32_t argument
-        (
-            2,
-            "DL",
-            0,
-            None
-        ),
+        (2, "DL", 0, None),
         # Read uint16_t argument
-        (
-            65,
-            "%V",
-            None,
-            3300
-        ),
+        (65, "%V", None, 3300),
         # Write uint16_t argument
-        (
-            66,
-            "V+",
-            2700,
-            None
-        ),
+        (66, "V+", 2700, None),
         # Read uint8_t argument
-        (
-            54,
-            "P0",
-            None,
-            0
-        ),
+        (54, "P0", None, 0),
         # Write uint8_t argument
-        (
-            46,
-            "D0",
-            5,
-            None
-        ),
+        (46, "D0", 5, None),
         # Read bool argument
-        (
-            31,
-            "PM",
-            None,
-            False
-        ),
+        (31, "PM", None, False),
         # Write bool argument
-        (
-            31,
-            "PM",
-            True,
-            None
-        ),
+        (31, "PM", True, None),
         # Command with no arguments
-        (
-            94,
-            "AS",
-            None,
-            None
-        ),
+        (94, "AS", None, None),
     ),
 )
-async def test_remote_at_native(zigpy_device_from_quirk, command_id, command, request_value, response_value):
+async def test_remote_at_native(
+    zigpy_device_from_quirk, command_id, command, request_value, response_value
+):
     """Test remote AT commands with XBee coordinator."""
 
     xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
 
     listener = mock.MagicMock()
-    xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[LevelControl.cluster_id].add_listener(listener)
+    xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[
+        LevelControl.cluster_id
+    ].add_listener(listener)
 
-    with mock.patch.object(xbee3_device.application, "remote_at_command", create=True, new_callable=mock.AsyncMock) as m1:
+    with mock.patch.object(
+        xbee3_device.application,
+        "remote_at_command",
+        create=True,
+        new_callable=mock.AsyncMock,
+    ) as m1:
         m1.configure_mock(return_value=response_value)
 
         # Send remote AT command request
-        _, status = await xbee3_device.endpoints[XBEE_AT_ENDPOINT].out_clusters[XBEE_AT_REQUEST_CLUSTER].command(command_id, request_value)
+        _, status = (
+            await xbee3_device.endpoints[XBEE_AT_ENDPOINT]
+            .out_clusters[XBEE_AT_REQUEST_CLUSTER]
+            .command(command_id, request_value)
+        )
 
         if request_value is None:
-            m1.assert_awaited_once_with(0x1234, command, apply_changes=True, encryption=False)
+            m1.assert_awaited_once_with(
+                0x1234, command, apply_changes=True, encryption=False
+            )
         else:
-            m1.assert_awaited_once_with(0x1234, command, request_value, apply_changes=True, encryption=False)
+            m1.assert_awaited_once_with(
+                0x1234, command, request_value, apply_changes=True, encryption=False
+            )
         assert status == foundation.Status.SUCCESS
-        listener.zha_send_event.assert_called_once_with(command.lower() + "_command_response", {'response': response_value})
+        listener.zha_send_event.assert_called_once_with(
+            command.lower() + "_command_response", {"response": response_value}
+        )
 
 
 async def test_remote_at_tx_failure(zigpy_device_from_quirk):
@@ -449,18 +468,31 @@ async def test_remote_at_tx_failure(zigpy_device_from_quirk):
     xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
 
     listener = mock.MagicMock()
-    xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[LevelControl.cluster_id].add_listener(listener)
+    xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[
+        LevelControl.cluster_id
+    ].add_listener(listener)
 
     def mock_at_response(*args, **kwargs):
         """Simulate remote AT comand response from device."""
-        xbee3_device.handle_message(XBEE_PROFILE_ID, XBEE_AT_RESPONSE_CLUSTER, XBEE_AT_ENDPOINT, XBEE_AT_ENDPOINT, b'\x01TP\x04')
+        xbee3_device.handle_message(
+            XBEE_PROFILE_ID,
+            XBEE_AT_RESPONSE_CLUSTER,
+            XBEE_AT_ENDPOINT,
+            XBEE_AT_ENDPOINT,
+            b"\x01TP\x04",
+        )
         return mock.DEFAULT
+
     xbee3_device.application.request.reset_mock()
     xbee3_device.application.request.configure_mock(side_effect=mock_at_response)
 
     # Send remote AT command request
     with pytest.raises(RuntimeError) as excinfo:
-        _, status = await xbee3_device.endpoints[XBEE_AT_ENDPOINT].out_clusters[XBEE_AT_REQUEST_CLUSTER].command(67)
+        _, status = (
+            await xbee3_device.endpoints[XBEE_AT_ENDPOINT]
+            .out_clusters[XBEE_AT_REQUEST_CLUSTER]
+            .command(67)
+        )
 
     assert str(excinfo.value) == "AT Command response: TX_FAILURE"
     xbee3_device.application.request.configure_mock(side_effect=None)
@@ -471,25 +503,38 @@ async def test_io_sample_report(zigpy_device_from_quirk):
 
     xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
 
-    digital_listeners = [ClusterListener(xbee3_device.endpoints[e].on_off) for e in range(0xd0, 0xdd)]
-    analog_listeners = [ClusterListener(xbee3_device.endpoints[e if e != 0xd4 else 0xd7].analog_input) for e in range(0xd0, 0xd5)]
+    digital_listeners = [
+        ClusterListener(xbee3_device.endpoints[e].on_off) for e in range(0xD0, 0xDD)
+    ]
+    analog_listeners = [
+        ClusterListener(xbee3_device.endpoints[e if e != 0xD4 else 0xD7].analog_input)
+        for e in range(0xD0, 0xD5)
+    ]
 
-#   {'digital_pins': [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1], 'analog_pins': [1, 0, 1, 0, 0, 0, 0, 1], 'digital_samples': [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0], 'analog_samples': [341, 0, 682, 0, 0, 0, 0, 3305]}
-    xbee3_device.handle_message(XBEE_PROFILE_ID, XBEE_IO_CLUSTER, XBEE_DATA_ENDPOINT, XBEE_DATA_ENDPOINT, b'\x01\x55\x55\x85\x11\x11\x01\x55\x02\xAA\x0c\xe9')
+    #   {'digital_pins': [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1], 'analog_pins': [1, 0, 1, 0, 0, 0, 0, 1], 'digital_samples': [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0], 'analog_samples': [341, 0, 682, 0, 0, 0, 0, 3305]}
+    xbee3_device.handle_message(
+        XBEE_PROFILE_ID,
+        XBEE_IO_CLUSTER,
+        XBEE_DATA_ENDPOINT,
+        XBEE_DATA_ENDPOINT,
+        b"\x01\x55\x55\x85\x11\x11\x01\x55\x02\xAA\x0c\xe9",
+    )
 
     for i in range(len(digital_listeners)):
         assert len(digital_listeners[i].cluster_commands) == 0
-        assert len(digital_listeners[i].attribute_updates) == (i+1)%2
-        if (i+1)%2:
-            assert digital_listeners[i].attribute_updates[0] == (0x0000, (i/2+1)%2)
+        assert len(digital_listeners[i].attribute_updates) == (i + 1) % 2
+        if (i + 1) % 2:
+            assert digital_listeners[i].attribute_updates[0] == (
+                0x0000,
+                (i / 2 + 1) % 2,
+            )
 
     for i in range(len(analog_listeners)):
         assert len(analog_listeners[i].cluster_commands) == 0
-        assert len(analog_listeners[i].attribute_updates) == (i+1)%2
-        if (i+1)%2:
+        assert len(analog_listeners[i].attribute_updates) == (i + 1) % 2
+        if (i + 1) % 2:
             assert analog_listeners[i].attribute_updates[0][0] == 0x0055
 
     assert 33.33333 < analog_listeners[0].attribute_updates[0][1] < 33.33334
     assert 66.66666 < analog_listeners[2].attribute_updates[0][1] < 66.66667
     assert analog_listeners[4].attribute_updates[0] == (0x0055, 3.305)
-

--- a/tests/test_xbee.py
+++ b/tests/test_xbee.py
@@ -1,0 +1,495 @@
+"""Test XBee device."""
+
+from unittest import mock
+
+import pytest
+
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import AnalogOutput, Basic, OnOff, LevelControl
+
+from tests.common import ClusterListener
+
+import zhaquirks
+from zhaquirks.xbee.xbee3_io import XBee3Sensor
+from zhaquirks.xbee import (
+    XBEE_AT_REQUEST_CLUSTER,
+    XBEE_AT_RESPONSE_CLUSTER,
+    XBEE_AT_ENDPOINT,
+    XBEE_DATA_CLUSTER,
+    XBEE_DATA_ENDPOINT,
+    XBEE_PROFILE_ID,
+    XBEE_IO_CLUSTER,
+)
+
+zhaquirks.setup()
+
+
+async def test_basic_cluster(zigpy_device_from_quirk):
+    """Test Basic cluster."""
+
+    xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
+    basic_cluster = xbee3_device.endpoints[XBEE_DATA_ENDPOINT].in_clusters[Basic.cluster_id]
+
+    # Check mandatory attributes
+    succ, fail = await basic_cluster.read_attributes(("zcl_version", "power_source"))
+    assert succ["zcl_version"] == 2
+    assert succ["power_source"] == Basic.PowerSource.Unknown
+
+
+async def test_digital_output(zigpy_device_from_quirk):
+    """Test XBeeOnOff cluster."""
+
+    xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
+    onoff_cluster = xbee3_device.endpoints[0xD0].in_clusters[OnOff.cluster_id]
+
+    with mock.patch.object(xbee3_device.application, "remote_at_command", create=True, new_callable=mock.AsyncMock) as m1:
+        # Turn the switch on
+        _, status = await onoff_cluster.command(1)
+
+        m1.assert_awaited_once()
+        assert m1.await_args[0][1] == "D0"
+        assert m1.await_args[0][2] == 5
+
+        succ, fail = await onoff_cluster.read_attributes(("on_off",))
+        assert succ["on_off"] == 1
+        m1.reset_mock()
+
+        # Turn the switch off
+        _, status = await onoff_cluster.command(0)
+
+        m1.assert_awaited_once()
+        assert m1.await_args[0][1] == "D0"
+        assert m1.await_args[0][2] == 4
+        m1.reset_mock()
+
+        succ, fail = await onoff_cluster.read_attributes(("on_off",))
+        assert succ["on_off"] == 0
+
+
+async def test_analog_output(zigpy_device_from_quirk):
+    """Test XBeePWM cluster."""
+
+    xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
+    pwm_cluster = xbee3_device.endpoints[0xDA].in_clusters[AnalogOutput.cluster_id]
+
+    # Check mandatory attributes
+    succ, fail = await pwm_cluster.read_attributes(("max_present_value", "min_present_value", "out_of_service", "resolution", "status_flags"))
+    assert succ["max_present_value"] == 1023.0
+    assert succ["min_present_value"] == 0.0 
+    assert succ["out_of_service"] == 0
+    assert succ["resolution"] == 1.0
+    assert succ["status_flags"] == 0
+
+    with mock.patch.object(xbee3_device.application, "remote_at_command", create=True, new_callable=mock.AsyncMock) as m1:
+        # Write value
+        (status,) = await pwm_cluster.write_attributes({"present_value": 122.9})
+
+        assert m1.await_count == 2
+        assert m1.await_args_list[0][0][1] == "M0"
+        assert m1.await_args_list[0][0][2] == 123
+        assert m1.await_args_list[1][0][1] == "P0"
+        assert m1.await_args_list[1][0][2] == 2
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
+        m1.reset_mock()
+
+        # Write value with numeric attribute id
+        (status,) = await pwm_cluster.write_attributes({0x0055: 234})
+
+        assert m1.await_count == 2
+        assert m1.await_args_list[0][0][1] == "M0"
+        assert m1.await_args_list[0][0][2] == 234
+        assert m1.await_args_list[1][0][1] == "P0"
+        assert m1.await_args_list[1][0][2] == 2
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
+        m1.reset_mock()
+
+        # Read value
+        m1.configure_mock(return_value=345)
+
+        succ, fail = await pwm_cluster.read_attributes(("present_value",))
+
+        assert succ["present_value"] == 345.0
+        m1.assert_awaited_once()
+        assert m1.await_args[0][1] == "M0"
+        assert len(m1.await_args[0]) == 2
+        m1.reset_mock()
+
+
+async def test_send_serial_data(zigpy_device_from_quirk):
+    """Test sending serial data to XBee device."""
+
+    xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
+    xbee3_device.application.request.reset_mock()
+
+    # Send serial data
+    _, status = await xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[XBEE_DATA_CLUSTER].command(0, "Test UART data")
+
+    xbee3_device.application.request.assert_awaited_once_with(xbee3_device, XBEE_PROFILE_ID, XBEE_DATA_CLUSTER, XBEE_DATA_ENDPOINT, XBEE_DATA_ENDPOINT, 1, b'Test UART data', expect_reply=False)
+    assert status == foundation.Status.SUCCESS
+
+
+async def test_receive_serial_data(zigpy_device_from_quirk):
+    """Test receiving serial data to XBee device."""
+
+    xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
+
+    listener = mock.MagicMock()
+    xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[LevelControl.cluster_id].add_listener(listener)
+
+    # Receive serial data
+    xbee3_device.handle_message(XBEE_PROFILE_ID, XBEE_DATA_CLUSTER, XBEE_DATA_ENDPOINT, XBEE_DATA_ENDPOINT, b'Test UART data')
+
+    listener.zha_send_event.assert_called_once_with("receive_data", {'data': "Test UART data"})
+
+
+@pytest.mark.parametrize(
+    "command_id, request_value, request_data, response_data, response_command, response_value",
+    (
+        # Read positive int16_t argument
+        (
+            67,
+            None,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeTP',
+            b'\x01TP\x00\x18',
+            "tp_command_response",
+            24
+        ),
+        # Read negative int16_t argument
+        (
+            67,
+            None,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeTP',
+            b'\x01TP\x00\xfc',
+            "tp_command_response",
+            -4
+        ),
+        # Read string argument
+        (
+            8,
+            None,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeNI',
+            b'\x01NI\x00My Test XBee Device',
+            "ni_command_response",
+            b'My Test XBee Device'
+        ),
+        # Write string argument
+        (
+            8,
+            b'My Test XBee Device', #TODO: Check how hass sends strings in zha.issue_zigbee_cluster_command
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeNIMy Test XBee Device',
+            b'\x01NI\x00',
+            "ni_command_response",
+            None
+        ),
+        # Read uint64_t argument
+        (
+            15,
+            None,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeOP',
+            b'\x01OP\x00\xFF\xEE\xDD\xCC\xBB\xAA\x99\x88',
+            "op_command_response",
+            0xffeeddccbbaa9988
+        ),
+        # Write uint64_t argument
+        (
+            15,
+            0xfedcba9876543210,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeOP\xFE\xDC\xBA\x98\x76\x54\x32\x10',
+            b'\x01OP\x00',
+            "op_command_response",
+            None
+        ),
+        # Read uint32_t argument
+        (
+            1,
+            None,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeDH',
+            b'\x01DH\x00\xFF\xEE\xDD\xCC',
+            "dh_command_response",
+            0xffeeddcc
+        ),
+        # Write uint32_t argument
+        (
+            2,
+            0,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeDL\x00\x00\x00\x00',
+            b'\x01DL\x00',
+            "dl_command_response",
+            None
+        ),
+        # Read uint16_t argument
+        (
+            65,
+            None,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe%V',
+            b'\x01%V\x00\x0C\xE4',
+            "%v_command_response",
+            3300
+        ),
+        # Write uint16_t argument
+        (
+            66,
+            2700,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeV+\x0A\x8C',
+            b'\x01V+\x00',
+            "v+_command_response",
+            None
+        ),
+        # Read uint8_t argument
+        (
+            54,
+            None,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeP0',
+            b'\x01P0\x00\x00',
+            "p0_command_response",
+            0
+        ),
+        # Write uint8_t argument
+        (
+            46,
+            5,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeD0\x05',
+            b'\x01D0\x00',
+            "d0_command_response",
+            None
+        ),
+        # Read bool argument
+        (
+            31,
+            None,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfePM',
+            b'\x01PM\x00\x00',
+            "pm_command_response",
+            False
+        ),
+        # Write bool argument
+        (
+            31,
+            True,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfePM\x01',
+            b'\x01PM\x00',
+            "pm_command_response",
+            None
+        ),
+        # Command with no arguments
+        (
+            94,
+            None,
+            b'2\x00\x02\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeAS',
+            b'\x01AS\x00',
+            "as_command_response",
+            None
+        ),
+    ),
+)
+async def test_remote_at_non_native(zigpy_device_from_quirk, command_id, request_value, request_data, response_data, response_command, response_value):
+    """Test remote AT commands with non-XBee coordinator."""
+
+    xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
+
+    listener = mock.MagicMock()
+    xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[LevelControl.cluster_id].add_listener(listener)
+
+    def mock_at_response(*args, **kwargs):
+        """Simulate remote AT comand response from device."""
+        xbee3_device.handle_message(XBEE_PROFILE_ID, XBEE_AT_RESPONSE_CLUSTER, XBEE_AT_ENDPOINT, XBEE_AT_ENDPOINT, response_data)
+        return mock.DEFAULT
+    xbee3_device.application.request.reset_mock()
+    xbee3_device.application.request.configure_mock(side_effect=mock_at_response)
+
+    # Send remote AT command request
+    _, status = await xbee3_device.endpoints[XBEE_AT_ENDPOINT].out_clusters[XBEE_AT_REQUEST_CLUSTER].command(command_id, request_value)
+
+    xbee3_device.application.request.configure_mock(side_effect=None)
+
+    xbee3_device.application.request.assert_awaited_once_with(xbee3_device, XBEE_PROFILE_ID, XBEE_AT_REQUEST_CLUSTER, XBEE_AT_ENDPOINT, XBEE_AT_ENDPOINT, 1, request_data, expect_reply=False)
+    assert status == foundation.Status.SUCCESS
+    listener.zha_send_event.assert_called_once_with(response_command, {'response': response_value})
+
+
+@pytest.mark.parametrize(
+    "command_id, command, request_value, response_value",
+    (
+        # Read positive int16_t argument
+        (
+            67,
+            "TP",
+            None,
+            24
+        ),
+        # Read negative int16_t argument
+        (
+            67,
+            "TP",
+            None,
+            -4
+        ),
+        # Read string argument
+        (
+            8,
+            "NI",
+            None,
+            "My Test XBee Device"
+        ),
+        # Write string argument
+        (
+            8,
+            "NI",
+            "My Test XBee Device",
+            None
+        ),
+        # Read uint64_t argument
+        (
+            15,
+            "OP",
+            None,
+            0xffeeddccbbaa9988
+        ),
+        # Write uint64_t argument
+        (
+            15,
+            "OP",
+            0xfedcba9876543210,
+            None
+        ),
+        # Read uint32_t argument
+        (
+            1,
+            "DH",
+            None,
+            0xffeeddcc
+        ),
+        # Write uint32_t argument
+        (
+            2,
+            "DL",
+            0,
+            None
+        ),
+        # Read uint16_t argument
+        (
+            65,
+            "%V",
+            None,
+            3300
+        ),
+        # Write uint16_t argument
+        (
+            66,
+            "V+",
+            2700,
+            None
+        ),
+        # Read uint8_t argument
+        (
+            54,
+            "P0",
+            None,
+            0
+        ),
+        # Write uint8_t argument
+        (
+            46,
+            "D0",
+            5,
+            None
+        ),
+        # Read bool argument
+        (
+            31,
+            "PM",
+            None,
+            False
+        ),
+        # Write bool argument
+        (
+            31,
+            "PM",
+            True,
+            None
+        ),
+        # Command with no arguments
+        (
+            94,
+            "AS",
+            None,
+            None
+        ),
+    ),
+)
+async def test_remote_at_native(zigpy_device_from_quirk, command_id, command, request_value, response_value):
+    """Test remote AT commands with XBee coordinator."""
+
+    xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
+
+    listener = mock.MagicMock()
+    xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[LevelControl.cluster_id].add_listener(listener)
+
+    with mock.patch.object(xbee3_device.application, "remote_at_command", create=True, new_callable=mock.AsyncMock) as m1:
+        m1.configure_mock(return_value=response_value)
+
+        # Send remote AT command request
+        _, status = await xbee3_device.endpoints[XBEE_AT_ENDPOINT].out_clusters[XBEE_AT_REQUEST_CLUSTER].command(command_id, request_value)
+
+        if request_value is None:
+            m1.assert_awaited_once_with(0x1234, command, apply_changes=True, encryption=False)
+        else:
+            m1.assert_awaited_once_with(0x1234, command, request_value, apply_changes=True, encryption=False)
+        assert status == foundation.Status.SUCCESS
+        listener.zha_send_event.assert_called_once_with(command.lower() + "_command_response", {'response': response_value})
+
+
+async def test_remote_at_tx_failure(zigpy_device_from_quirk):
+    """Test remote AT commands with non-XBee coordinator with tx failure."""
+
+    xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
+
+    listener = mock.MagicMock()
+    xbee3_device.endpoints[XBEE_DATA_ENDPOINT].out_clusters[LevelControl.cluster_id].add_listener(listener)
+
+    def mock_at_response(*args, **kwargs):
+        """Simulate remote AT comand response from device."""
+        xbee3_device.handle_message(XBEE_PROFILE_ID, XBEE_AT_RESPONSE_CLUSTER, XBEE_AT_ENDPOINT, XBEE_AT_ENDPOINT, b'\x01TP\x04')
+        return mock.DEFAULT
+    xbee3_device.application.request.reset_mock()
+    xbee3_device.application.request.configure_mock(side_effect=mock_at_response)
+
+    # Send remote AT command request
+    with pytest.raises(RuntimeError) as excinfo:
+        _, status = await xbee3_device.endpoints[XBEE_AT_ENDPOINT].out_clusters[XBEE_AT_REQUEST_CLUSTER].command(67)
+
+    assert str(excinfo.value) == "AT Command response: TX_FAILURE"
+    xbee3_device.application.request.configure_mock(side_effect=None)
+
+
+async def test_io_sample_report(zigpy_device_from_quirk):
+    """Test DigitalIOCluster cluster."""
+
+    xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
+
+    digital_listeners = [ClusterListener(xbee3_device.endpoints[e].on_off) for e in range(0xd0, 0xdd)]
+    analog_listeners = [ClusterListener(xbee3_device.endpoints[e if e != 0xd4 else 0xd7].analog_input) for e in range(0xd0, 0xd5)]
+
+#   {'digital_pins': [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1], 'analog_pins': [1, 0, 1, 0, 0, 0, 0, 1], 'digital_samples': [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0], 'analog_samples': [341, 0, 682, 0, 0, 0, 0, 3305]}
+    xbee3_device.handle_message(XBEE_PROFILE_ID, XBEE_IO_CLUSTER, XBEE_DATA_ENDPOINT, XBEE_DATA_ENDPOINT, b'\x01\x55\x55\x85\x11\x11\x01\x55\x02\xAA\x0c\xe9')
+
+    for i in range(len(digital_listeners)):
+        assert len(digital_listeners[i].cluster_commands) == 0
+        assert len(digital_listeners[i].attribute_updates) == (i+1)%2
+        if (i+1)%2:
+            assert digital_listeners[i].attribute_updates[0] == (0x0000, (i/2+1)%2)
+
+    for i in range(len(analog_listeners)):
+        assert len(analog_listeners[i].cluster_commands) == 0
+        assert len(analog_listeners[i].attribute_updates) == (i+1)%2
+        if (i+1)%2:
+            assert analog_listeners[i].attribute_updates[0][0] == 0x0055
+
+    assert 33.33333 < analog_listeners[0].attribute_updates[0][1] < 33.33334
+    assert 66.66666 < analog_listeners[2].attribute_updates[0][1] < 66.66667
+    assert analog_listeners[4].attribute_updates[0] == (0x0055, 3.305)
+

--- a/tests/test_xbee.py
+++ b/tests/test_xbee.py
@@ -3,23 +3,22 @@
 from unittest import mock
 
 import pytest
-
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import AnalogOutput, Basic, OnOff, LevelControl
-
-from tests.common import ClusterListener
+from zigpy.zcl.clusters.general import AnalogOutput, Basic, LevelControl, OnOff
 
 import zhaquirks
-from zhaquirks.xbee.xbee3_io import XBee3Sensor
 from zhaquirks.xbee import (
+    XBEE_AT_ENDPOINT,
     XBEE_AT_REQUEST_CLUSTER,
     XBEE_AT_RESPONSE_CLUSTER,
-    XBEE_AT_ENDPOINT,
     XBEE_DATA_CLUSTER,
     XBEE_DATA_ENDPOINT,
-    XBEE_PROFILE_ID,
     XBEE_IO_CLUSTER,
+    XBEE_PROFILE_ID,
 )
+from zhaquirks.xbee.xbee3_io import XBee3Sensor
+
+from tests.common import ClusterListener
 
 zhaquirks.setup()
 

--- a/xbee.md
+++ b/xbee.md
@@ -29,51 +29,7 @@ To use the functionality, enable it with `V+` command and configure periodic sam
 
 ## PWM Output
 
-XBee3 provides two PWM outputs. They are not currently exposed automatically, you must use `zha.set_zigbee_cluster_attribute` service.
-
-To use the functionality, you must configure an `input_number` and an automation for each PWM pin you want to use as per the following example (replace ieee with the one of your device):
-```
-input_number:
-  pwm0:
-    name: PWM0
-    min: 0
-    max: 1023
-  pwm1:
-    name: PWM1
-    min: 0
-    max: 1023
-automation:
-  - id: '1574205383149'
-    alias: XBee PWM0
-    description: 'Update cluster attribute on slider change for PWM0'
-    trigger:
-    - entity_id: input_number.pwm0
-      platform: state
-    action:
-    - service: zha.set_zigbee_cluster_attribute
-      data_template:
-        ieee: 00:13:a2:00:41:a0:7e:1a
-        endpoint_id: 218
-        cluster_id: 13
-        cluster_type: in
-        attribute: 85
-        value: '{{ trigger.to_state.state }}'
-  - id: '1574205383150'
-    alias: XBee PWM1
-    description: 'Update cluster attribute on slider change for PWM1'
-    trigger:
-    - entity_id: input_number.pwm1
-      platform: state
-    action:
-    - service: zha.set_zigbee_cluster_attribute
-      data_template:
-        ieee: 00:13:a2:00:41:a0:7e:1a
-        endpoint_id: 219
-        cluster_id: 13
-        cluster_type: in
-        attribute: 85
-        value: '{{ trigger.to_state.state }}'
-```
+XBee3 provides two PWM outputs. They are exposed as `number` entities.
 
 ## UART
 
@@ -91,7 +47,8 @@ automation:
       event_data:
         device_ieee: 00:13:a2:00:12:34:56:78
         command: receive_data
-        args: Home
+        args:
+          data: Home
     action:
       service: zha.issue_zigbee_cluster_command
       data:
@@ -122,7 +79,7 @@ template:
         command: tp_command_response
     sensor:
       - name: "XBee Temperature"
-        state: '{{ trigger.event.data.args }}'
+        state: '{{ trigger.event.data.args.response }}'
         unit_of_measurement: "°C"
         device_class: temperature
         state_class: measurement

--- a/xbee.md
+++ b/xbee.md
@@ -61,7 +61,7 @@ automation:
         args: Assistant
 ```
 
-## Raw AT Commands
+## Remote AT Commands
 
 Like with UART, you can send remote AT commands with `zha.issue_zigbee_cluster_command` service.
 If the command is unsuccessful, you will get an exception in the logs. If it is successful, the response will be available as `zha_event` event.

--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -490,7 +490,7 @@ class XBeeRemoteATRequest(LocalDataCluster):
         hdr = foundation.ZCLHeader.cluster(tsn, command_id)
         self._endpoint.device.endpoints[232].out_clusters[
             LevelControl.cluster_id
-        ].handle_cluster_request(hdr, value)
+        ].handle_cluster_request(hdr, {"response": value})
 
         # XXX: Is command_id=0x00 correct?
         return foundation.GENERAL_COMMANDS[
@@ -785,7 +785,7 @@ class XBeeCommon(CustomDevice):
             if hdr.command_id == DATA_IN_CMD:
                 self._endpoint.out_clusters[
                     LevelControl.cluster_id
-                ].handle_cluster_request(hdr, args[0])
+                ].handle_cluster_request(hdr, {"data": args[0]))
             else:
                 super().handle_cluster_request(hdr, args)
 

--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -785,7 +785,7 @@ class XBeeCommon(CustomDevice):
             if hdr.command_id == DATA_IN_CMD:
                 self._endpoint.out_clusters[
                     LevelControl.cluster_id
-                ].handle_cluster_request(hdr, {"data": args[0]))
+                ].handle_cluster_request(hdr, {"data": args[0]})
             else:
                 super().handle_cluster_request(hdr, args)
 


### PR DESCRIPTION
This is a breaking change that might require some modifications in user configuration (automations or trigger-based sensors).
But without this change those automations are probably broken anyway for any modern HA release (I think since 2022.4.1).

Since https://github.com/home-assistant/core/pull/69631 ZHA now requires the event data to be dict and does not accepts plain strings (see https://github.com/home-assistant/core/blob/dev/homeassistant/components/zha/core/channels/base.py#L405).
This PR fixes XBee quirk to provide that. The data for Serial data event is sent as {"data": ...} and the AT command responses are sent as {"response": ...}.
Also updating some outdated info in readme for PWM.