### PR TITLE
Pass `**kwargs` to super call in `F000LevelControlCluster`

### DIFF
--- a/zhaquirks/tuya/ts110e.py
+++ b/zhaquirks/tuya/ts110e.py
@@ -125,7 +125,9 @@ class F000LevelControlCluster(NoManufacturerCluster, LevelControl):
                 tsn=tsn,
             )
 
-        return super().command(command_id, *args, manufacturer, expect_reply, tsn, **kwargs)
+        return super().command(
+            command_id, *args, manufacturer, expect_reply, tsn, **kwargs
+        )
 
 
 class DimmerSwitchWithNeutral1Gang(TuyaDimmerSwitch):

--- a/zhaquirks/tuya/ts110e.py
+++ b/zhaquirks/tuya/ts110e.py
@@ -125,7 +125,7 @@ class F000LevelControlCluster(NoManufacturerCluster, LevelControl):
                 tsn=tsn,
             )
 
-        return super().command(command_id, *args, manufacturer, expect_reply, tsn)
+        return super().command(command_id, *args, manufacturer, expect_reply, tsn, **kwargs)
 
 
 class DimmerSwitchWithNeutral1Gang(TuyaDimmerSwitch):


### PR DESCRIPTION
Probably not needed because the call is not used but...