### PR TITLE
Allow configuring transmit power on TI Z-Stack routers

### DIFF
--- a/zhaquirks/texasinstruments/__init__.py
+++ b/zhaquirks/texasinstruments/__init__.py
@@ -1,0 +1,1 @@
+"""Texas Instruments devices."""

--- a/zhaquirks/texasinstruments/router.py
+++ b/zhaquirks/texasinstruments/router.py
@@ -25,7 +25,7 @@ class TiRouter(CustomDevice):
     """Texas Instruments Z-Stack router device."""
 
     signature = {
-        MODELS_INFO: [("TexasInstruments", "ti.router"), ("TubesZB", "tubeszb.router")],
+        MODELS_INFO: [("TexasInstruments", "ti.router")],
         ENDPOINTS: {
             8: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/texasinstruments/router.py
+++ b/zhaquirks/texasinstruments/router.py
@@ -1,0 +1,69 @@
+"""Texas Instruments Z-Stack router device."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Identify
+
+from zhaquirks import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class BasicCluster(CustomCluster, Basic):
+    """Texas Instruments Basic cluster."""
+
+    attributes = Basic.attributes.copy()
+    attributes[0x1337] = ("transmit_power", t.int8s, False)
+
+
+class TiRouter(CustomDevice):
+    """Texas Instruments Z-Stack router device."""
+
+    signature = {
+        MODELS_INFO: [("TexasInstruments", "ti.router"), ("TubesZB", "tubeszb.router")],
+        ENDPOINTS: {
+            8: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: 0x00FF,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            8: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: 0x00FF,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    BasicCluster,
+                ],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }


### PR DESCRIPTION
### Changes
Z-Stack router firmware ``20221102`` and above adds a ``transmit_power`` attribute on the ``Basic cluster``.
This quirk makes that attribute accessible through ZHA.

~~I also added ``TubesZB``/``tubeszb.router`` to the signature, even though it doesn't support the configurable attribute yet, but I'm sure he'll add it in the future. cc @tube0013 (still on the Z-Stack ``dev`` branch as of right now though)~~
Edit: It's possible that no new updates will be made for "TubesZB" custom router firmware and as current versions don't support the configurable attribute, I removed it from the signature entirely.

(A config entity in ZHA could also be added. For older versions, a ~~warning~~ debug message will be printed on startup saying that the attribute isn't supported for routers running older firmware.)
(PR for ZHA config entity: https://github.com/home-assistant/core/pull/81520)

Closes https://github.com/zigpy/zha-device-handlers/issues/1884
Z2M converter commit: https://github.com/Koenkk/zigbee-herdsman-converters/commit/8fb1ba4c232e451af1e9953b8c476c2f4b2ef561
Z-Stack ``firmware.patch`` commit: https://github.com/Koenkk/Z-Stack-firmware/commit/3d43a50acdc09d6ff12605de4a5d104389c69e85
Z-Stack issue: https://github.com/Koenkk/Z-Stack-firmware/issues/341

The quirk is tested and works.

### Testing
This quirk will likely be available in Home Assistant 2022.12.0 or later.
If you want to test it now, download the [router.py](https://raw.githubusercontent.com/zigpy/zha-device-handlers/55802e2b67af1877189186683451fdfb9429309f/zhaquirks/texasinstruments/router.py) file and put it in your configured ``custom_zha_quirks`` directory. Then, restart Home Assistant.
For now, you can change the transmit power using the "Manage Zigbee Device" UI -> "Clusters".
Select ``BasicCluster`` and ``transmit_power``. Then, you can read the attribute. If your firmware supports it, it'll return a number (like ``5`` or ``9``). If your firmware is still unsupported, it'll return ``None`` and you'll need to update your router firmware.
To change the transmit power, simply replace the number in the upper text field (leave the lower text field empty) and then click "Set Zigbee attribute". You can re-read the attribute to verify that the change worked.

Also, make sure to remove the custom quirk as soon as it's merged into Home Assistant.