### PR TITLE
New ts0601_sensor square

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -119,7 +119,7 @@ async def test_singleswitch_state_report(zigpy_device_from_quirk, quirk):
     switch_cluster = switch_dev.endpoints[1].on_off
     switch_listener = ClusterListener(switch_cluster)
 
-    tuya_cluster = switch_dev.endpoints[1].moes_switch_manufacturer
+    tuya_cluster = switch_dev.endpoints[1].tuya_manufacturer
 
     hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_ON)
     tuya_cluster.handle_message(hdr, args)
@@ -150,7 +150,7 @@ async def test_doubleswitch_state_report(zigpy_device_from_quirk, quirk):
     switch2_cluster = switch_dev.endpoints[2].on_off
     switch2_listener = ClusterListener(switch2_cluster)
 
-    tuya_cluster = switch_dev.endpoints[1].moes_switch_manufacturer
+    tuya_cluster = switch_dev.endpoints[1].tuya_manufacturer
 
     assert len(switch1_listener.cluster_commands) == 0
     assert len(switch1_listener.attribute_updates) == 0
@@ -215,7 +215,7 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
     switch_dev = zigpy_device_from_quirk(quirk)
 
     switch_cluster = switch_dev.endpoints[1].on_off
-    tuya_cluster = switch_dev.endpoints[1].moes_switch_manufacturer
+    tuya_cluster = switch_dev.endpoints[1].tuya_manufacturer
 
     with mock.patch.object(
         tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS


### PR DESCRIPTION
Add the new ts0601 sensor definition `_TZE200_qoy0ekbd`.
To avoid duplicate code, I have moved the Tuya -> Zigbee value conversion from the `dp_to_attribute` to the `TuyaRelativeHumidity` cluster. Not happy with the solution but I don't find any better one to avoid duplicate the `TemperatureHumidityManufCluster`.

Now the device can define a `RH_MULTIPLIER` to apply to value. If not defined, defaults to `100`.

Fixes: #1670 
Fixes: #1724