### PR TITLE
Add basic support for Moes ZSS-QY-HP

### DIFF
--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -349,6 +349,7 @@ class MmwRadarMotion(CustomDevice):
             ("_TZE200_sfiy5tfs", "TS0601"),
             ("_TZE200_mrf6vtua", "TS0601"),
             ("_TZE200_ztc6ggyl", "TS0601"),
+            ("_TZE200_wukb7rhc", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Add support for `_TZE200_wukb7rhc` which is the model I own and could verify as working

https://zigbee.blakadder.com/Moes_ZSS-QY-HP.html