### PR TITLE
Add support for Inovelli VZM31-SN firmware version 2.08

### DIFF
--- a/zhaquirks/inovelli/VZM31SN.py
+++ b/zhaquirks/inovelli/VZM31SN.py
@@ -29,8 +29,8 @@ INOVELLI_VZM31SN_CLUSTER_ID = 64561
 WWAH_CLUSTER_ID = 64599
 
 
-class InovelliVZM31SNv11(CustomDevice):
-    """VZM31-SN 2 in 1 Switch/Dimmer Module."""
+class InovelliVZM31SNv12(CustomDevice):
+    """VZM31-SN 2 in 1 Switch/Dimmer Module Firmware version 2.08 and above."""
 
     signature = {
         MODELS_INFO: [("Inovelli", "VZM31-SN")],
@@ -39,29 +39,34 @@ class InovelliVZM31SNv11(CustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Metering.cluster_id,  # 1794
-                    ElectricalMeasurement.cluster_id,  # 2820
-                    Diagnostic.cluster_id,  # 2821
-                    INOVELLI_VZM31SN_CLUSTER_ID,  # 64561
-                    WWAH_CLUSTER_ID,  # 64599
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    INOVELLI_VZM31SN_CLUSTER_ID,
+                    WWAH_CLUSTER_ID,
                 ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],  # 19
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [Basic.cluster_id, Identify.cluster_id],  # 0  # 3
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                ],
                 OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    INOVELLI_VZM31SN_CLUSTER_ID,  # 64561
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    INOVELLI_VZM31SN_CLUSTER_ID,
                 ],
             },
             242: {
@@ -79,35 +84,124 @@ class InovelliVZM31SNv11(CustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Metering.cluster_id,  # 1794
-                    ElectricalMeasurement.cluster_id,  # 2820
-                    Diagnostic.cluster_id,  # 2821
-                    Inovelli_VZM31SN_Cluster,  # 64561
-                    WWAH_CLUSTER_ID,  # 64599
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
+                    WWAH_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Ota.cluster_id,  # 19
-                    Inovelli_VZM31SN_Cluster,  # 64561
+                    Ota.cluster_id,
                 ],
             },
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [Basic.cluster_id, Identify.cluster_id],  # 0  # 3
+                INPUT_CLUSTERS: [Basic.cluster_id, Identify.cluster_id],
                 OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Inovelli_VZM31SN_Cluster,  # 64561
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
+                ],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [0x0021],
+            },
+        },
+    }
+
+    device_automation_triggers = INOVELLI_AUTOMATION_TRIGGERS
+
+
+class InovelliVZM31SNv11(CustomDevice):
+    """VZM31-SN 2 in 1 Switch/Dimmer Module."""
+
+    signature = {
+        MODELS_INFO: [("Inovelli", "VZM31-SN")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    INOVELLI_VZM31SN_CLUSTER_ID,
+                    WWAH_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: DeviceType.DIMMER_SWITCH,
+                INPUT_CLUSTERS: [Basic.cluster_id, Identify.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    INOVELLI_VZM31SN_CLUSTER_ID,
+                ],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [0x0021],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
+                    WWAH_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: DeviceType.DIMMER_SWITCH,
+                INPUT_CLUSTERS: [Basic.cluster_id, Identify.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
                 ],
             },
             242: {
@@ -132,29 +226,29 @@ class InovelliVZM31SNv10(CustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Metering.cluster_id,  # 1794
-                    ElectricalMeasurement.cluster_id,  # 2820
-                    Diagnostic.cluster_id,  # 2821
-                    INOVELLI_VZM31SN_CLUSTER_ID,  # 64561
-                    WWAH_CLUSTER_ID,  # 64599
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    INOVELLI_VZM31SN_CLUSTER_ID,
+                    WWAH_CLUSTER_ID,
                 ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],  # 3  # 19
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
             },
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [Basic.cluster_id, Identify.cluster_id],  # 0  # 3
+                INPUT_CLUSTERS: [Basic.cluster_id, Identify.cluster_id],
                 OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    INOVELLI_VZM31SN_CLUSTER_ID,  # 64561
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    INOVELLI_VZM31SN_CLUSTER_ID,
                 ],
             },
         },
@@ -166,35 +260,35 @@ class InovelliVZM31SNv10(CustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Metering.cluster_id,  # 1794
-                    ElectricalMeasurement.cluster_id,  # 2820
-                    Diagnostic.cluster_id,  # 2821
-                    Inovelli_VZM31SN_Cluster,  # 64561
-                    WWAH_CLUSTER_ID,  # 64599
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
+                    WWAH_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Ota.cluster_id,  # 19
-                    Inovelli_VZM31SN_Cluster,  # 64561
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
                 ],
             },
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [Basic.cluster_id, Identify.cluster_id],  # 0  # 3
+                INPUT_CLUSTERS: [Basic.cluster_id, Identify.cluster_id],
                 OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Inovelli_VZM31SN_Cluster,  # 64561
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
                 ],
             },
         },
@@ -213,29 +307,29 @@ class InovelliVZM31SNv9(CustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMER_SWITCH,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Metering.cluster_id,  # 1794
-                    ElectricalMeasurement.cluster_id,  # 2820
-                    Diagnostic.cluster_id,  # 2821
-                    INOVELLI_VZM31SN_CLUSTER_ID,  # 64561
-                    WWAH_CLUSTER_ID,  # 64599
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    INOVELLI_VZM31SN_CLUSTER_ID,
+                    WWAH_CLUSTER_ID,
                 ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],  # 3  # 19
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
             },
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],  # 3
+                INPUT_CLUSTERS: [Identify.cluster_id],
                 OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    INOVELLI_VZM31SN_CLUSTER_ID,  # 64561
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    INOVELLI_VZM31SN_CLUSTER_ID,
                 ],
             },
         },
@@ -247,35 +341,35 @@ class InovelliVZM31SNv9(CustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Metering.cluster_id,  # 1794
-                    ElectricalMeasurement.cluster_id,  # 2820
-                    Diagnostic.cluster_id,  # 2821
-                    Inovelli_VZM31SN_Cluster,  # 64561
-                    WWAH_CLUSTER_ID,  # 64599
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
+                    WWAH_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Ota.cluster_id,  # 19
-                    Inovelli_VZM31SN_Cluster,  # 64561
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
                 ],
             },
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],  # 3
+                INPUT_CLUSTERS: [Identify.cluster_id],
                 OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Inovelli_VZM31SN_Cluster,  # 64561
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
                 ],
             },
         },
@@ -294,27 +388,27 @@ class InovelliVZM31SN(CustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMER_SWITCH,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Metering.cluster_id,  # 1794
-                    ElectricalMeasurement.cluster_id,  # 2820
-                    INOVELLI_VZM31SN_CLUSTER_ID,  # 64561
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    INOVELLI_VZM31SN_CLUSTER_ID,
                 ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],  # 3  # 19
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
             },
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],  # 3
+                INPUT_CLUSTERS: [Identify.cluster_id],
                 OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    INOVELLI_VZM31SN_CLUSTER_ID,  # 64561
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    INOVELLI_VZM31SN_CLUSTER_ID,
                 ],
             },
         },
@@ -326,34 +420,34 @@ class InovelliVZM31SN(CustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Metering.cluster_id,  # 1794
-                    ElectricalMeasurement.cluster_id,  # 2820
-                    Diagnostic.cluster_id,  # 2821
-                    Inovelli_VZM31SN_Cluster,  # 64561
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
                 ],
                 OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Ota.cluster_id,  # 19
-                    Inovelli_VZM31SN_Cluster,  # 64561
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
                 ],
             },
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],  # 3
+                INPUT_CLUSTERS: [Identify.cluster_id],
                 OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Inovelli_VZM31SN_Cluster,  # 64561
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Inovelli_VZM31SN_Cluster,
                 ],
             },
         },


### PR DESCRIPTION
This PR:

- Removes fake output clusters from endpoint 1 now that binding works as expected
- Removes un-needed group and scene clusters from endpoint 2 that are necessary to hack around limitations in ST and Habitat where group binding is unavailable
- Removes comments that aren't needed