### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - --safe
           - --quiet
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8


### PR DESCRIPTION
Seems that flake8 has been moved to github, but I can't tell for sure.

In the github repo they state that it is a licit change:
* https://github.com/PyCQA/flake8/issues/1737