### PR TITLE
Added _TZE204_ztc6ggyl manufacturer to TS0601_motion

### DIFF
--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -349,6 +349,7 @@ class MmwRadarMotion(CustomDevice):
             ("_TZE200_sfiy5tfs", "TS0601"),
             ("_TZE200_mrf6vtua", "TS0601"),
             ("_TZE200_ztc6ggyl", "TS0601"),
+            ("_TZE204_ztc6ggyl", "TS0601"),
             ("_TZE200_wukb7rhc", "TS0601"),
         ],
         ENDPOINTS: {


### PR DESCRIPTION
Bought a presence sensor with mmWave like this:
![image](https://user-images.githubusercontent.com/28559492/202744255-f2e370b5-316c-482d-b41c-2c92d7f89977.png)

The manufacturer is different so I added it to the supported models.