### PR TITLE
New Zonnsmart TS0601 TRV implementation, add scheduling 

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -470,7 +470,7 @@ async def test_zonnsmart_state_report(zigpy_device_from_quirk, quirk):
         tuya_cluster.handle_message(hdr, args)
 
     assert len(thermostat_listener.cluster_commands) == 0
-    assert len(thermostat_listener.attribute_updates) == 11
+    assert len(thermostat_listener.attribute_updates) == 13
     assert thermostat_listener.attribute_updates[0] == (0x0000, 2110)  # TEMP
     assert thermostat_listener.attribute_updates[1] == (0x0012, 2050)  # TARGET
     assert thermostat_listener.attribute_updates[4] == (0x0014, 1700)  # HOLIDAY

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -472,14 +472,14 @@ async def test_zonnsmart_state_report(zigpy_device_from_quirk, quirk):
     assert len(thermostat_listener.cluster_commands) == 0
     assert len(thermostat_listener.attribute_updates) == 13
     assert thermostat_listener.attribute_updates[0] == (0x0000, 2110)  # TEMP
-    assert thermostat_listener.attribute_updates[1] == (0x0012, 2050)  # TARGET
-    assert thermostat_listener.attribute_updates[4] == (0x0014, 1700)  # HOLIDAY
-    assert thermostat_listener.attribute_updates[5] == (0x0010, 110)  # OFFSET
-    assert thermostat_listener.attribute_updates[6] == (0x0025, 0)  # MANUAL
-    assert thermostat_listener.attribute_updates[7] == (0x4002, 1)
-    assert thermostat_listener.attribute_updates[8] == (0x0025, 1)  # SCHEDULE
-    assert thermostat_listener.attribute_updates[9] == (0x4002, 0)
-    assert thermostat_listener.attribute_updates[10] == (0x001C, 4)  # HEAT ON
+    assert thermostat_listener.attribute_updates[3] == (0x0012, 2050)  # TARGET
+    assert thermostat_listener.attribute_updates[6] == (0x0014, 1700)  # HOLIDAY
+    assert thermostat_listener.attribute_updates[7] == (0x0010, 110)  # OFFSET
+    assert thermostat_listener.attribute_updates[8] == (0x0025, 0)  # MANUAL
+    assert thermostat_listener.attribute_updates[9] == (0x4002, 1)
+    assert thermostat_listener.attribute_updates[10] == (0x0025, 1)  # SCHEDULE
+    assert thermostat_listener.attribute_updates[11] == (0x4002, 0)
+    assert thermostat_listener.attribute_updates[12] == (0x001C, 4)  # HEAT ON
 
     assert len(tuya_listener.cluster_commands) == 9
     assert len(tuya_listener.attribute_updates) == 9

--- a/zhaquirks/quirk_ids.py
+++ b/zhaquirks/quirk_ids.py
@@ -6,6 +6,7 @@ KONKE_BUTTON = "konke.button_remote"  # remote with custom handling in cluster h
 # Tuya
 TUYA_PLUG_ONOFF = "tuya.plug_on_off_attributes"  # plugs with configurable attributes on the OnOff cluster
 TUYA_PLUG_MANUFACTURER = "tuya.plug_manufacturer_attributes"  # plugs with configurable attributes on a custom cluster
+TUYA_TRV_ZONNSMART = "tuya.trv_zonnsmart"  # ZonnSmart TRV
 
 # Xiaomi
 XIAOMI_AQARA_VIBRATION_AQ1 = (

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1019,25 +1019,25 @@ class ZONNSMARTScheduleSet(t.FixedList, item_type=t.uint8_t, length=31):
         day = periods[0]
         periods.pop(0)
         if day == "monday" or day == "mon":
-            b += [0x1]
+            b += [0b00000001]
         elif day == "tuesday" or day == "tue":
-            b += [0x2]
+            b += [0b00000010]
         elif day == "wednesday" or day == "wed":
-            b += [0x4]
+            b += [0b00000100]
         elif day == "thursday" or day == "thu":
-            b += [0x8]
+            b += [0b00001000]
         elif day == "friday" or day == "fri":
-            b += [0x10]
+            b += [0b00010000]
         elif day == "saturday" or day == "sat":
-            b += [0x20]
+            b += [0b00100000]
         elif day == "sunday" or day == "sun":
-            b += [0x40]
+            b += [0b01000000]
         elif day == "work" or day == "mon-fri":
-            b += [0x1F]
+            b += [0b00011111]
         elif day == "weekend" or day == "sat-sun":
-            b += [0x60]
+            b += [0b01100000]
         elif day == "week" or day == "mon-sun":
-            b += [0x7F]
+            b += [0b01111111]
         else:
             raise ValueError(
                 "Invalid day provided, should be a day of the week or 'mon-fri', 'sat-sun' or 'mon-sun'"

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1002,6 +1002,7 @@ class ZONNSMARTScheduleSet(t.FixedList, item_type=t.uint8_t, length=31):
 
     def __init__(self, value, *args, **kwargs):
         """Parse the schedule string and serialize it."""
+        self.raw = []
 
         super().__init__(*args, **kwargs)
         if value is None:

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1057,6 +1057,7 @@ class ZONNSMARTScheduleSet(t.FixedList, item_type=t.uint8_t, length=31):
                 raise ValueError("Invalid time : " + tokens[0] + ":" + tokens[1])
             if time <= prevTime:
                 raise ValueError("Period time must always increase")
+            prevTime = time
             temperature = int(float(tokens[2]) * 10)
             if (
                 temperature < ZONNSMART_MIN_TEMPERATURE_VAL / 10

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1379,14 +1379,18 @@ class ZONNSMARTThermostat(TuyaThermostatCluster):
         """Set heating state based on current and set temperature."""
         if attrid == ZONNSMART_TEMPERATURE_ATTR:
             temp_current = value * 10
-            temp_set = self._attr_cache.get(
-                self.attributes_by_name["occupied_heating_setpoint"].id
+            temp_set = (
+                self._attr_cache.get(
+                    self.attributes_by_name["occupied_heating_setpoint"].id
+                )
+                or temp_current
             )
         elif attrid == ZONNSMART_TARGET_TEMP_ATTR:
-            temp_current = self._attr_cache.get(
-                self.attributes_by_name["local_temperature"].id
-            )
             temp_set = value * 10
+            temp_current = (
+                self._attr_cache.get(self.attributes_by_name["local_temperature"].id)
+                or temp_set
+            )
         else:
             return
 

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -18,6 +18,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.quirk_ids import TUYA_TRV_ZONNSMART
 from zhaquirks.tuya import (
     TuyaManufClusterAttributes,
     TuyaPowerConfigurationCluster2AA,
@@ -1651,6 +1652,8 @@ class MoesHY368_Type2(TuyaThermostat):
 
 class ZonnsmartTV01_ZG(TuyaThermostat):
     """ZONNSMART TV01-ZG Thermostatic radiator valve."""
+
+    quirk_id = TUYA_TRV_ZONNSMART
 
     def __init__(self, *args, **kwargs):
         """Init device."""


### PR DESCRIPTION
**This PR does the following :**

 - FIx OnOff clusters when you have multiple TRV (only the last one added was working)
 - Use updates() for the ZONNSMARTManufCluster attributes
 - Fix local_temperature_calibration read back from the TRV
 - Implement the holiday_start_stop attribute
 - Implement scheduling support in the ZONNSMARTManufCluster
 - Enable time setting on the TRV

**Scheduling details :**

Schedules can be read from the schedule_<day> attributes. They cannot be queried from the TRV directly, you must first use the *Online* button to force the TRV to send the values or set the schedule using the schedule_set attribute. Until you do so, the schedules will appear empty.

The default schedule for a day on my TRV is the following : 
`06:00/17.0 12:00/21.0 14:00/17.0 17:00/21.0 24:00/17.0`
The temperature will vary in the following way : 
 - 00:00 -> 06:00 : 17C
 - 06:00 -> 12:00 : 21C
 - 12:00 -> 14:00 : 17C
 - 14:00 -> 17:00 : 21C
 - 17:00 -> 24:00 : 17C

You can set the schedule for a single day or multiple day with the following syntax : 
`<day> <period> <period> ...`
For example, writing the value `mon 09:00/17 21:00/21.5 24:00/17` to the schedule_set attribute will set the temperature in the morning and evening to 17C and 21.5C between 9AM and 9PM.

`day` can be any off `mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun`, `mon-fri`, `sat-sun`, `mon-sun`. The last 3 will set the schedule for multiple days at once.

**Holiday start - stop :**
The holiday_start_stop will not be populated until you use the *Online* button.
The syntax is the following : `2022/12/01 01:01 | 2022/12/31 12:00`.
In the above example the whole month of December 2022 will be set as holiday and the TRV will switch automatically to the holiday temperature set in the holiday_temperature attribute.
Once the end date is reached, it will switch back to the scheduled/auto mode.


HA PR: https://github.com/home-assistant/core/pull/87546