### PR TITLE
Add power configuration cluster to ZLinky_TIC (requires firmware v12.0+)

### DIFF
--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -206,8 +206,4 @@ class ZLinkyTICFWV12(ZLinkyTIC):
     signature[MODELS_INFO] = [(LIXEE, "ZLinky_TIC_FW_V12")]
 
     # Insert PowerConfiguration cluster in signature for devices with firmware v12.0+
-    signature[ENDPOINTS][1][INPUT_CLUSTERS] = (
-        signature[ENDPOINTS][1][INPUT_CLUSTERS][:1]
-        + [PowerConfiguration.cluster_id]
-        + signature[ENDPOINTS][1][INPUT_CLUSTERS][1:]
-    )
+    signature[ENDPOINTS][1][INPUT_CLUSTERS].insert(1, PowerConfiguration.cluster_id)

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -1,4 +1,6 @@
 """Quirk for ZLinky_TIC."""
+from copy import deepcopy
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
@@ -193,3 +195,19 @@ class ZLinkyTIC(CustomDevice):
             },
         },
     }
+
+
+class ZLinkyTICFWV12(ZLinkyTIC):
+    """ZLinky_TIC from LiXee with firmware v12.0+."""
+
+    signature = deepcopy(ZLinkyTIC.signature)
+
+    # Update model info
+    signature[MODELS_INFO] = [(LIXEE, "ZLinky_TIC_FW_V12")]
+
+    # Insert PowerConfiguration cluster in signature for devices with firmware v12.0+
+    signature[ENDPOINTS][1][INPUT_CLUSTERS] = (
+        signature[ENDPOINTS][1][INPUT_CLUSTERS][:1]
+        + [PowerConfiguration.cluster_id]
+        + signature[ENDPOINTS][1][INPUT_CLUSTERS][1:]
+    )

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -2,7 +2,13 @@
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Identify, Ota
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Identify,
+    Ota,
+    PowerConfiguration,
+)
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement, MeterIdentification
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 from zigpy.zcl.clusters.smartenergy import Metering
@@ -147,6 +153,7 @@ class ZLinkyTIC(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.METER_INTERFACE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     Metering.cluster_id,
                     MeterIdentification.cluster_id,
@@ -170,6 +177,7 @@ class ZLinkyTIC(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.METER_INTERFACE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     ZLinkyTICMetering,
                     MeterIdentification.cluster_id,

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -153,7 +153,6 @@ class ZLinkyTIC(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.METER_INTERFACE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     Metering.cluster_id,
                     MeterIdentification.cluster_id,

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -202,8 +202,5 @@ class ZLinkyTICFWV12(ZLinkyTIC):
 
     signature = deepcopy(ZLinkyTIC.signature)
 
-    # Update model info
-    signature[MODELS_INFO] = [(LIXEE, "ZLinky_TIC_FW_V12")]
-
     # Insert PowerConfiguration cluster in signature for devices with firmware v12.0+
     signature[ENDPOINTS][1][INPUT_CLUSTERS].insert(1, PowerConfiguration.cluster_id)


### PR DESCRIPTION
For reference:
* https://github.com/fairecasoimeme/Zlinky_TIC/releases/tag/v12.0
* https://github.com/fairecasoimeme/Zlinky_TIC#powerconfiguration-cluster-0x0001----from-v12

Marked as draft as I'm unsure how this affects devices with pre-v12.0 firmware.