### PR TITLE
Added manufacturer support ts0601_dimmer.py

### DIFF
--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -48,6 +48,7 @@ class TuyaSingleSwitchDimmer(TuyaDimmerSwitch):
             ("_TZE200_la2c2uo9", "TS0601"),
             ("_TZE200_1agwnems", "TS0601"),  # TODO: validation pending?
             ("_TZE200_9cxuhakf", "TS0601"),  # Added for Mercator IKUU SSWM-DIMZ Device
+            ("_TZE200_p0gzbqct", "TS0601"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0051


### PR DESCRIPTION
Added manufacturer support __TZE200_p0gzbqct_ for **Tuya** _TS0601_ dimmer.

![Moes ZigBee rotary dimmer](https://user-images.githubusercontent.com/27698952/204511311-ac12da44-ff4a-42e5-ac00-fb2ed008c63d.png)

**Diagnostics:**
[zha-a8555298c8fc2afd66118b96bd1bcba7-_TZE200_p0gzbqct TS0601-4de8d6f86f79ccbd10f83b5d36fb57aa.json.txt](https://github.com/zigpy/zha-device-handlers/files/10106278/zha-a8555298c8fc2afd66118b96bd1bcba7-_TZE200_p0gzbqct.TS0601-4de8d6f86f79ccbd10f83b5d36fb57aa.json.txt)

**Link to the dimmer on Aliexpress:** [MOES Official Store](https://www.aliexpress.com/item/3256804318804615.html)


