### PR TITLE
Add manufacturer support for _TZE200_dq1mfjug for Tuya TS0601 smoke detector ES63-D5Z

### DIFF
--- a/zhaquirks/tuya/ts0601_smoke.py
+++ b/zhaquirks/tuya/ts0601_smoke.py
@@ -79,6 +79,7 @@ class TuyaSmokeDetector0601(CustomDevice):
             ("_TZE200_aycxwiau", "TS0601"),
             ("_TZE200_ntcy3xu1", "TS0601"),
             ("_TZE200_vzekyi4c", "TS0601"),
+            ("_TZE200_dq1mfjug", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Add manufacturer support for _TZE200_dq1mfjug for Tuya TS0601 smoke detector ES63-D5Z

![Screenshot 2022-12-01 215726](https://user-images.githubusercontent.com/98490303/205147650-4a716840-452f-434a-8ac3-5650090fc902.png)

https://www.aliexpress.com/item/1005003564649452.html?spm=a2g0o.order_list.order_list_main.29.515c1802FW7Pbi
