### PR TITLE
Fix TuyaDPType.VALUE payload

### DIFF
--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -48,7 +48,7 @@ async def test_command(zigpy_device_from_quirk, quirk):
         m1.assert_called_with(
             61184,
             4,
-            b"\x01\x04\x00\x00\x03\x02\x02\x00\x04\x00\x00\x03r",
+            b"\x01\x04\x00\x00\x03\x02\x02\x00\x04r\x03\x00\x00",
             expect_reply=True,
             command_id=0,
         )
@@ -78,7 +78,7 @@ async def test_write_attr(zigpy_device_from_quirk, quirk):
         m1.assert_called_with(
             61184,
             2,
-            b"\x01\x02\x00\x00\x01\x03\x02\x00\x04\x00\x00\x00b",
+            b"\x01\x02\x00\x00\x01\x03\x02\x00\x04b\x00\x00\x00",
             expect_reply=False,
             command_id=0,
         )

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -135,7 +135,7 @@ async def test_tuya_methods(zigpy_device_from_quirk, quirk):
     assert len(result_1.datapoints) == 1
     assert result_1.datapoints[0].dp == 9
     assert result_1.datapoints[0].data.dp_type == TuyaDPType.VALUE
-    assert result_1.datapoints[0].data.raw == b"\x00\x00\x00b"
+    assert result_1.datapoints[0].data.raw == b"b\x00\x00\x00"
 
     tcd_2 = TuyaClusterData(
         endpoint_id=7, cluster_attr="not_exists_attribute", attr_value=25

--- a/tests/test_tuya_valve.py
+++ b/tests/test_tuya_valve.py
@@ -61,7 +61,7 @@ async def test_write_attr_psbzs(zigpy_device_from_quirk, quirk):
         m1.assert_called_with(
             61184,
             2,
-            b"\x01\x02\x00\x00\x01\x05\x02\x00\x04\x00\x00\x00\x0f",
+            b"\x01\x02\x00\x00\x01\x05\x02\x00\x04\x0f\x00\x00\x00",
             expect_reply=False,
             command_id=0,
         )

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -217,7 +217,7 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
             tuya_data = TuyaData()
             tuya_data.dp_type = datapoint_type
             tuya_data.function = 0
-            tuya_data.raw = t.LVBytes.deserialize(val)[0]
+            tuya_data.raw = bytes(reversed(val[1:]))
             self.debug("raw: %s", tuya_data.raw)
             dpd = TuyaDatapointData(dp, tuya_data)
             cmd_payload.datapoints = [dpd]


### PR DESCRIPTION
During the analisys of #1554 I have realized that something was wrong in the MCU logs for the `LevelControl`.
Comparing the status report from the device against the command send from HA it was clear that something don't work as expected:
```
2022-10-23 13:57:40.824 DEBUG (MainThread) [zigpy.zcl] [0x6F8F:1:0xef00] Received command 0x01 (TSN 101): get_data(data=
TuyaCommand(status=0, tsn=71, datapoints=[TuyaDatapointData(dp=2, data=TuyaData(dp_type=<TuyaDPType.VALUE: 2>, function=0, raw=b'\xfa\x00\x00\x00', *payload=250))]))

2022-10-23 13:57:41.933 DEBUG (MainThread) [zigpy.zcl] [0x6F8F:1:0xef00] tuya_command: 
TuyaCommand(status=0, tsn=97, datapoints=[TuyaDatapointData(dp=2, data=TuyaData(dp_type=<TuyaDPType.VALUE: 2>, function=0, raw=b'\x00\x00\x02\x8a', *payload=2315386880))])
```

Once identified and the fixed, the tests that validated against the observed value have also had to be fixed.

The fix only affects to the MCU commands sended with a `TuyaDPType.VALUE` (i.e: `current_level` for the `LevelControl` cluster). I can't be a breaking change because the current implementation is wrong. I don't think that could be the reason for some weird behavior in dimmers but I can't validate by myself.