### PR TITLE
Add smoke density attribute for Mijia Smoke Detector

### DIFF
--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -84,6 +84,8 @@ CONSUMPTION_REPORTED = "consumption_reported"
 VOLTAGE_REPORTED = "voltage_reported"
 ILLUMINANCE_MEASUREMENT = "illuminance_measurement"
 ILLUMINANCE_REPORTED = "illuminance_reported"
+SMOKE_DENSITY = "smoke_density"
+SMOKE_DENSITY_REPORTED = "smoke_density_reported"
 XIAOMI_AQARA_ATTRIBUTE = 0xFF01
 XIAOMI_AQARA_ATTRIBUTE_E1 = 0x00F7
 XIAOMI_ATTR_3 = "X-attrib-3"
@@ -299,6 +301,10 @@ class XiaomiCluster(CustomCluster):
                 "update_battery_percentage",
                 attributes[BATTERY_PERCENTAGE_REMAINING_ATTRIBUTE],
             )
+        if SMOKE_DENSITY in attributes:
+            self.endpoint.device.smoke_density_bus.listener_event(
+                SMOKE_DENSITY_REPORTED, attributes[SMOKE_DENSITY]
+            )
 
     def _parse_aqara_attributes(self, value):
         """Parse non standard attributes."""
@@ -362,6 +368,8 @@ class XiaomiCluster(CustomCluster):
             attribute_names.update({323: PRESENCE_EVENT})
             attribute_names.update({324: MONITORING_MODE})
             attribute_names.update({326: APPROACH_DISTANCE})
+        elif self.endpoint.device.model == "lumi.sensor_smoke":
+            attribute_names.update({100: SMOKE_DENSITY})
         result = {}
 
         # Some attribute reports end with a stray null byte


### PR DESCRIPTION
I didn't find any reference for measurement of a kind "smoke density" in Zigbee Cluster Library Specification, so instead I am doing translation of nested attribute `100` in attribute `0xFF01`/`65281` ("aqara attributes") to AnalogInput cluster (as described in tutorial via `Bus()` mechanism), while also setting description to "Smoke Density".

This is basically ZHA implemention of Z2M's basic cluster processing for this smoke sensor, [see](https://github.com/Koenkk/zigbee-herdsman-converters/blob/2636217a818d08ec3a2ec2fe4c84a9c1afa99041/lib/xiaomi.js#L245).