### PR TITLE
tuya mcu enhancements

### DIFF
--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -15,7 +15,6 @@ from zhaquirks.tuya.mcu import (
     TuyaClusterData,
     TuyaDPType,
     TuyaMCUCluster,
-    TuyaReverseStruct,
 )
 
 from tests.common import ClusterListener, MockDatetime
@@ -253,10 +252,3 @@ async def test_tuya_mcu_classes():
         TuyaClusterData(manufacturer="xiaomi")
     with pytest.raises(ValueError):
         TuyaClusterData(manufacturer=b"")
-
-    # Test TuyaReverseStruct class
-    class Test(TuyaReverseStruct):
-        first: t.uint8_t
-        second: t.uint16_t
-
-    assert Test(1, 0x0203).serialize() == b"\x01\x02\x03"

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -259,4 +259,4 @@ async def test_tuya_mcu_classes():
         first: t.uint8_t
         second: t.uint16_t
 
-    assert Test(1, 0x0203).serialize() == b"\x03\x02\x01"
+    assert Test(1, 0x0203).serialize() == b"\x01\x02\x03"

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -132,11 +132,12 @@ async def test_tuya_methods(zigpy_device_from_quirk, quirk):
 
     result_1 = tuya_cluster.from_cluster_data(tcd_1)
     assert result_1
-    assert result_1.datapoints
-    assert len(result_1.datapoints) == 1
-    assert result_1.datapoints[0].dp == 9
-    assert result_1.datapoints[0].data.dp_type == TuyaDPType.VALUE
-    assert result_1.datapoints[0].data.raw == b"\x00\x00\x00b"
+    assert len(result_1) == 1
+    assert result_1[0].datapoints
+    assert len(result_1[0].datapoints) == 1
+    assert result_1[0].datapoints[0].dp == 9
+    assert result_1[0].datapoints[0].data.dp_type == TuyaDPType.VALUE
+    assert result_1[0].datapoints[0].data.raw == b"\x00\x00\x00b"
 
     tcd_2 = TuyaClusterData(
         endpoint_id=7, cluster_attr="not_exists_attribute", attr_value=25

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -15,6 +15,7 @@ from zhaquirks.tuya.mcu import (
     TuyaClusterData,
     TuyaDPType,
     TuyaMCUCluster,
+    TuyaReverseStruct,
 )
 
 from tests.common import ClusterListener, MockDatetime
@@ -251,3 +252,10 @@ async def test_tuya_mcu_classes():
         TuyaClusterData(manufacturer="xiaomi")
     with pytest.raises(ValueError):
         TuyaClusterData(manufacturer=b"")
+
+    # Test TuyaReverseStruct class
+    class Test(TuyaReverseStruct):
+        first: t.uint8_t
+        second: t.uint16_t
+
+    assert Test(1, 0x0203).serialize() == b"\x03\x02\x01"

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -179,7 +179,12 @@ class TuyaData(t.Struct):
         res.dp_type, data = TuyaDPType.deserialize(data)
         res.function, data = t.uint8_t.deserialize(data)
         res.raw, data = t.LVBytes.deserialize(data)
-        if res.dp_type not in (TuyaDPType.BITMAP, TuyaDPType.STRING, TuyaDPType.ENUM):
+        if res.dp_type not in (
+            TuyaDPType.BITMAP,
+            TuyaDPType.STRING,
+            TuyaDPType.ENUM,
+            TuyaDPType.RAW,
+        ):
             res.raw = res.raw[::-1]
         return res, data
 
@@ -201,7 +206,7 @@ class TuyaData(t.Struct):
             except KeyError as exc:
                 raise ValueError(f"Wrong bitmap length: {len(self.raw)}") from exc
         elif self.dp_type == TuyaDPType.RAW:
-            return self.raw[::-1]
+            return self.raw
 
         raise ValueError(f"Unknown {self.dp_type} datapoint type")
 

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1327,7 +1327,7 @@ class DPToAttributeMapping:
     """Container for datapoint to cluster attribute update mapping."""
 
     ep_attribute: str
-    attribute_name: str | tuple
+    attribute_name: Union[str, tuple]
     converter: Optional[
         Callable[
             [

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -303,7 +303,7 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
                 )
             ) and (
                 (
-                    dp_mapping.endpoint_id == None
+                    dp_mapping.endpoint_id is None
                     and endpoint_id == self.endpoint.endpoint_id
                 )
                 or (endpoint_id == dp_mapping.endpoint_id)

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -103,7 +103,7 @@ class TuyaReverseStruct(t.Struct):
         self.fields.reverse()
         result = super().serialize()
         self.fields.reverse()
-        return result
+        return result[::-1]
 
 
 class TuyaPowerConfigurationCluster(

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -93,19 +93,6 @@ class MoesBacklight(t.enum8):
     freeze = 0x03
 
 
-class TuyaReverseStruct(t.Struct):
-    """Type that serializes with reverse field order."""
-
-    deserialize = None
-
-    def serialize(self) -> bytes:
-        """Reverse the field order before serializtion."""
-        self.fields.reverse()
-        result = super().serialize()
-        self.fields.reverse()
-        return result[::-1]
-
-
 class TuyaPowerConfigurationCluster(
     TuyaLocalCluster, DoublingPowerConfigurationCluster
 ):

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -53,7 +53,7 @@ class DPToAttributeMapping:
     """Container for datapoint to cluster attribute update mapping."""
 
     ep_attribute: str
-    attribute_name: str | tuple
+    attribute_name: Union[str, tuple]
     dp_type: TuyaDPType
     converter: Optional[
         Callable[


### PR DESCRIPTION
I am working on a quirk for Tuya ts0601 _TZE200_hkdl5fmv circuit breaker (https://aliexpress.com/item/1005004749980758.html)
I've found out that some of the features cannot be implemented without some enhancements to tuya base classes. This is the PR for them.

Identified gaps:
1. The support for `TuyaDPType.RAW` is incomplete. If the device sends a DP with RAW type, we are unable to get the payload.
2. A single Tuya datapoint may correspond to several zcl attributes. For example, threshold parameters and alarm settings may come in a single RAW datapoint.
3. A single zcl attribute may correspond to several Tuya datapoints. For example, voltage and current alarm configuration may come in different DPs but correspond to the same `ac_alarms_mask` attribute.
4. When writing attributes on `TuyaAttributesCluster`, the local cache is not updated.

Solution:
1. The `TuyaData.payload` was enhanced to handle `TuyaDPType.RAW` case.
2. `DPToAttributeMapping.attribute_name` can now be a tuple containing several attributes. `DPToAttributeMapping.converter` must also return a tuple with the corresponding attribute values. `DPToAttributeMapping.dp_converter` will receive as many arguments as there are attributes for this DP. For the attribute that is being updated, the new value will be provided, for the rest attributes the cached values will be used.
3. A new class `AttributeWithMask` is introduced. If `DPToAttributeMapping.converter` returns an instance of this class, then only part of the attribute value that corresponds to the mask is updated.
4. `TuyaAttributesCluster.write_attributes()` was enhanced to call `super().write_attributes()`, and the `LocalDataCluster` does the rest.

Example usage:

```python
class LeakageParameters(t.Struct):
    self_test_auto_days: t.uint8_t
    self_test_auto_hours: t.uint8_t
    self_test_auto: t.Bool
    over_leakage_current_threshold: BigEndianInt16
    over_leakage_current_trip: t.Bool
    over_leakage_current_alarm: t.Bool
    self_test: SelfTest


class TemperatureSetting(t.Struct):
    over_temperature_threshold: t.int8s
    over_temperature_trip: t.Bool
    over_temperature_alarm: t.Bool


class TuyaRCBOElectricalMeasurement(ElectricalMeasurement, TuyaAttributesCluster):
    ...


class TuyaRCBODeviceTemperature(DeviceTemperature, TuyaAttributesCluster):
    ...


class TuyaRCBOManufCluster(TuyaMCUCluster):
    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
        ...
        109: DPToAttributeMapping(
            TuyaRCBOElectricalMeasurement.ep_attribute,
            (
                "self_test_auto_days",
                "self_test_auto_hours",
                "self_test_auto",
                "over_leakage_current_threshold",
                "over_leakage_current_trip",
                "over_leakage_current_alarm",
                "self_test",
            ),
            TuyaDPType.RAW,
            lambda x: (x[0], x[1], x[2], x[4] | x[3] << 8, x[5], x[6], SelfTest(x[7])),
            lambda *fields: LeakageParameters(*fields),
        ),
        112: DPToAttributeMapping(
            TuyaRCBODeviceTemperature.ep_attribute,
            ("high_temp_thres", "over_temp_trip", "dev_temp_alarm_mask"),
            TuyaDPType.RAW,
            lambda x: (x[0], x[1], AttributeWithMask(x[2] << 1, 0x02)),
            lambda x, y, z: TemperatureSetting(x, y, z & 0x02),
        ),
    }
```