### PR TITLE
Extra signature for Elko Super TR on firmware 1.2.0R

### DIFF
--- a/zhaquirks/elko/smart_super_thermostat.py
+++ b/zhaquirks/elko/smart_super_thermostat.py
@@ -150,6 +150,17 @@ class ElkoSuperTRThermostat(ElkoThermostat):
                     Identify.cluster_id,
                     Ota.cluster_id,
                 ],
+            },
+            2: {
+                PROFILE_ID: zha_p.PROFILE_ID,
+                DEVICE_TYPE: zha_p.DeviceType.THERMOSTAT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Thermostat.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                ],
             }
         },
     }


### PR DESCRIPTION
My version of Elko Super TR was not picked up by the quirk, so I've added the specific signature for this firmware/model to make it work fully.