### PR TITLE
Fix Heiman CO_CTPG Carbon Monoxide sensor

### DIFF
--- a/zhaquirks/heiman/smoke.py
+++ b/zhaquirks/heiman/smoke.py
@@ -126,3 +126,65 @@ class HeimanSmokCO_V15(CustomDevice):
             },
         },
     }
+
+
+class HeimanSmokCO_CTPG(CustomDevice):
+    """CO_CTPG quirk."""
+
+    signature = {
+        MODELS_INFO: [(HEIMAN, "CO_CTPG")],
+        ENDPOINTS: {
+            1: {
+                # "profile_id": 260,
+                # "device_type": "0x0402",
+                # "in_clusters": ["0x0000","0x0001","0x0003","0x0009","0x0500"]
+                # "out_clusters": ["0x0019"]
+                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
+                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Alarms.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        NODE_DESCRIPTOR: zigpy.zdo.types.NodeDescriptor(
+            logical_type=2,
+            complex_descriptor_available=0,
+            user_descriptor_available=0,
+            reserved=0,
+            aps_flags=0,
+            frequency_band=8,
+            mac_capability_flags=132 & 0b1111_1011,
+            manufacturer_code=4627,
+            maximum_buffer_size=64,
+            maximum_incoming_transfer_size=0,
+            server_mask=0,
+            maximum_outgoing_transfer_size=0,
+            descriptor_capability_field=3,
+        ),
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
+                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Alarms.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }


### PR DESCRIPTION
Heiman CO_CTPG Carbon Monoxide sensor reports as MainsPowered and drops from network. The quirk just fix the `NODE_DESCRIPTOR`

Fix: #1995