### PR TITLE
`move_to_level_with_on_off`: don't send `on_off` when already on

### DIFF
--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -114,19 +114,39 @@ async def test_tuya_methods(zigpy_device_from_quirk, quirk):
     tcd_1 = TuyaClusterData(endpoint_id=2, cluster_attr="minimum_level", attr_value=25)
 
     tcd_switch1_on = TuyaClusterData(
-        endpoint_id=1, cluster_attr="on_off", attr_value=1, expect_reply=True
+        endpoint_id=1,
+        cluster_name="on_off",
+        cluster_attr="on_off",
+        attr_value=1,
+        expect_reply=True,
     )
     tcd_dimmer2_on = TuyaClusterData(
-        endpoint_id=2, cluster_attr="on_off", attr_value=1, expect_reply=True
+        endpoint_id=2,
+        cluster_name="on_off",
+        cluster_attr="on_off",
+        attr_value=1,
+        expect_reply=True,
     )
     tcd_dimmer2_off = TuyaClusterData(
-        endpoint_id=2, cluster_attr="on_off", attr_value=0, expect_reply=True
+        endpoint_id=2,
+        cluster_name="on_off",
+        cluster_attr="on_off",
+        attr_value=0,
+        expect_reply=True,
     )
     tcd_dimmer2_level = TuyaClusterData(
-        endpoint_id=2, cluster_attr="current_level", attr_value=75, expect_reply=True
+        endpoint_id=2,
+        cluster_name="level",
+        cluster_attr="current_level",
+        attr_value=75,
+        expect_reply=True,
     )
     tcd_dimmer2_level0 = TuyaClusterData(
-        endpoint_id=2, cluster_attr="current_level", attr_value=0, expect_reply=True
+        endpoint_id=2,
+        cluster_name="level",
+        cluster_attr="current_level",
+        attr_value=0,
+        expect_reply=True,
     )
 
     result_1 = tuya_cluster.from_cluster_data(tcd_1)
@@ -187,30 +207,29 @@ async def test_tuya_methods(zigpy_device_from_quirk, quirk):
         m1.assert_called_with(tcd_dimmer2_level)  # current_level
         assert m1.call_count == 7
 
-        # test `move_to_level_with_on_off` quirk (call on_off + current_level)
+        # test `move_to_level_with_on_off` quirk (call on_off only)
         rsp = await dimmer2_cluster.command(0x0004)
         assert rsp.status == foundation.Status.SUCCESS
-        m1.assert_any_call(tcd_dimmer2_off)  # on_off
-        m1.assert_called_with(tcd_dimmer2_level0)  # current_level
-        assert m1.call_count == 9
+        m1.assert_called_with(tcd_dimmer2_off)  # on_off
+        assert m1.call_count == 8
 
         # test `move_to_level` quirk (only call current_level)
         rsp = await dimmer2_cluster.command(0x0000)
         assert rsp.status == foundation.Status.SUCCESS
         m1.assert_called_with(tcd_dimmer2_level0)  # current_level
-        assert m1.call_count == 10
+        assert m1.call_count == 9
 
         # test `move_to_level` quirk (only call current_level)
         rsp = await dimmer2_cluster.command(0x0000, 75)
         assert rsp.status == foundation.Status.SUCCESS
         m1.assert_called_with(tcd_dimmer2_level)  # current_level
-        assert m1.call_count == 11
+        assert m1.call_count == 10
 
         # test `move_to_level` quirk (only call current_level)
         rsp = await dimmer2_cluster.command(0x0000, level=75)
         assert rsp.status == foundation.Status.SUCCESS
         m1.assert_called_with(tcd_dimmer2_level)  # current_level
-        assert m1.call_count == 12
+        assert m1.call_count == 11
 
 
 async def test_tuya_mcu_classes():

--- a/zhaquirks/tuya/ts0601_rcbo.py
+++ b/zhaquirks/tuya/ts0601_rcbo.py
@@ -201,6 +201,7 @@ class TuyaRCBOOnOff(TuyaOnOff, TuyaAttributesCluster):
 
             cluster_data = TuyaClusterData(
                 endpoint_id=self.endpoint.endpoint_id,
+                cluster_name=self.ep_attribute,
                 cluster_attr="trip",
                 attr_value=True,
                 expect_reply=expect_reply,
@@ -335,6 +336,7 @@ class TuyaRCBOMetering(Metering, TuyaAttributesCluster):
         if command_id == 0x73:
             cluster_data = TuyaClusterData(
                 endpoint_id=self.endpoint.endpoint_id,
+                cluster_name=self.ep_attribute,
                 cluster_attr="clear_device_data",
                 attr_value=True,
                 expect_reply=expect_reply,

--- a/zhaquirks/tuya/ts0601_siren.py
+++ b/zhaquirks/tuya/ts0601_siren.py
@@ -292,6 +292,7 @@ class TuyaMCUSiren(OnOff, TuyaAttributesCluster):
         if command_id in (0x0000, 0x0001):
             cluster_data = TuyaClusterData(
                 endpoint_id=self.endpoint.endpoint_id,
+                cluster_name=self.ep_attribute,
                 cluster_attr="on_off",
                 attr_value=command_id,
                 expect_reply=expect_reply,


### PR DESCRIPTION
Fixes #1554 
See also: #1748, #1754

The problem:
ZCL defines the `move_to_level_with_on_off` which HA `zha` integration uses to control the brightness.
The Tuya dimmers don't have this command. The quirk has implemented this command by subsequently issuing `on_off` and `move_to_level` commands.
However it was found out that not all Tuya dimmers behave same on the `on_off` command: some of them switch brightness to 100% upon it, that means that changing brightness from 50% to 55% will first briefly transition through 100%.

This PR addresses the issue by remembering the current state and only issuing `on_off` command when needed:
1. If the device is off and the requested brightness level is positive, the current behavior is preserved (`on_off`, then `move_to_level`)
2. If the device is already on and the requested brightness level is positive, only `move_to_level` is issued
3. If the device is on and the requested brightness level is zero, only `on_off` command is issued to switch off the device
4. If the device is off and the requested brightness level is zero, the command does nothing

To save the current state, the `TuyaMCUCluster` was enhanced to save the respective attributes on `tuya_mcu_command`.
And to do that, an additional field `cluster_name` was added to the `TuyaClusterData` struct.