### PR TITLE
fix tuya rcbo types

### DIFF
--- a/tests/test_tuya_rcbo.py
+++ b/tests/test_tuya_rcbo.py
@@ -211,7 +211,7 @@ async def test_report_values_rcbo(zigpy_device_from_quirk, frame, cluster, attri
     (
         (
             [],
-            b"\x01\x02\x00\x00\x01\x09\x02\x00\x04\x58\x02\x00\x00",
+            b"\x01\x02\x00\x00\x01\x09\x02\x00\x04\x00\x00\x02\x58",
             "on_off",
             {"countdown_timer": 600},
         ),

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -361,7 +361,7 @@ class TuyaOnOff(OnOff, TuyaLocalCluster):
             cluster_data = TuyaClusterData(
                 endpoint_id=self.endpoint.endpoint_id,
                 cluster_attr="on_off",
-                attr_value=command_id,
+                attr_value=bool(command_id),
                 expect_reply=expect_reply,
                 manufacturer=manufacturer,
             )

--- a/zhaquirks/tuya/ts0601_rcbo.py
+++ b/zhaquirks/tuya/ts0601_rcbo.py
@@ -88,13 +88,6 @@ class SelfTest(t.enum8):
     TEST = 0x01
 
 
-class Locking(t.enum8):
-    """Locking enum."""
-
-    CLEAR = 0x00
-    TRIP = 0x01
-
-
 class CostParameters(t.Struct):
     """Tuya cost parameters."""
 
@@ -170,7 +163,7 @@ class TuyaRCBOOnOff(TuyaOnOff, TuyaAttributesCluster):
             0x8000: ("child_lock", t.Bool),
             0x8002: ("power_on_state", PowerOnState),
             0xF090: ("countdown_timer", t.uint32_t),
-            0xF740: ("trip", Locking),
+            0xF740: ("trip", t.Bool),
         }
     )
 
@@ -367,7 +360,6 @@ class TuyaRCBOManufCluster(TuyaMCUCluster):
             TuyaRCBOOnOff.ep_attribute,
             "countdown_timer",
             TuyaDPType.VALUE,
-            dp_converter=lambda x: t.uint32_t.deserialize(x.serialize()[::-1])[0],
         ),
         TUYA_DP_FAULT_CODE: DPToAttributeMapping(
             TuyaRCBOElectricalMeasurement.ep_attribute,
@@ -503,7 +495,7 @@ class TuyaRCBOManufCluster(TuyaMCUCluster):
             TuyaRCBOMetering.ep_attribute, "clear_device_data", TuyaDPType.BOOL
         ),
         TUYA_DP_LOCKING: DPToAttributeMapping(
-            TuyaRCBOOnOff.ep_attribute, "trip", TuyaDPType.BOOL, lambda x: Locking(x)
+            TuyaRCBOOnOff.ep_attribute, "trip", TuyaDPType.BOOL
         ),
         TUYA_DP_TOTAL_REVERSE_ACTIVE_POWER: DPToAttributeMapping(
             TuyaRCBOMetering.ep_attribute,


### PR DESCRIPTION
Fix some types for rcbo (#1991)

1. countdown_timer should be big-endian, not little-endian
2. trip locking should be boolean, not enum
3. on_off should be boolean, not int

I've decided to raise this part separately from #2017 