### PR TITLE
Don't use `TuyaData.raw` directly

### DIFF
--- a/tests/test_tuya_clusters.py
+++ b/tests/test_tuya_clusters.py
@@ -143,7 +143,7 @@ def test_tuya_data_bitmap():
     assert r.raw == b"\x40"
     assert r.payload == 0x40
 
-    r.payload = t.bitmap8(0x82)
+    r.payload = 0x82
     assert r.raw == b"\x82"
 
     data = b"\x05\x00\x02\x40\x02"

--- a/tests/test_tuya_clusters.py
+++ b/tests/test_tuya_clusters.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+import zigpy.types as t
 import zigpy.zcl.foundation as zcl_f
 
 from zhaquirks.tuya import (
@@ -10,6 +11,7 @@ from zhaquirks.tuya import (
     TUYA_GET_DATA,
     TUYA_SET_DATA_RESPONSE,
     TUYA_SET_TIME,
+    BigEndianInt16,
     TuyaCommand,
     TuyaData,
     TuyaDatapointData,
@@ -26,6 +28,27 @@ def tuya_cluster(zigpy_device_mock):
     return cluster
 
 
+def test_tuya_data_raw():
+    """Test tuya "Raw" datatype."""
+
+    class Test(t.Struct):
+        test_bool: t.Bool
+        test_uint16_t_be: BigEndianInt16
+
+    data = b"\x00\x00\x03\x01\x02\x46"
+    extra = b"extra data"
+
+    r, rest = TuyaData.deserialize(data + extra)
+    assert rest == extra
+
+    assert r.dp_type == 0
+    assert r.raw == b"\x01\x02\x46"
+    assert Test.deserialize(r.payload)[0] == Test(True, 582)
+
+    r.payload = Test(False, 314)
+    assert r.raw == b"\x00\x01\x3a"
+
+
 def test_tuya_data_value():
     """Test tuya "Value" datatype."""
 
@@ -38,6 +61,9 @@ def test_tuya_data_value():
     assert r.dp_type == 2
     assert r.raw == b"\x00\x00\x02\xdb"
     assert r.payload == 731
+
+    r.payload = 582
+    assert r.raw == b"\x00\x00\x02\x46"
 
 
 def test_tuya_data_bool():
@@ -53,6 +79,9 @@ def test_tuya_data_bool():
     assert r.raw == b"\x00"
     assert not r.payload
 
+    r.payload = True
+    assert r.raw == b"\x01"
+
     data = b"\x01\x00\x01\x01"
     extra = b"extra data"
 
@@ -62,6 +91,9 @@ def test_tuya_data_bool():
     assert r.dp_type == 1
     assert r.raw == b"\x01"
     assert r.payload
+
+    r.payload = False
+    assert r.raw == b"\x00"
 
 
 def test_tuya_data_enum():
@@ -77,6 +109,9 @@ def test_tuya_data_enum():
     assert r.raw == b"\x40"
     assert r.payload == 0x40
 
+    r.payload = 0x42
+    assert r.raw == b"\x42"
+
 
 def test_tuya_data_string():
     """Test tuya String datatype."""
@@ -90,6 +125,9 @@ def test_tuya_data_string():
     assert r.dp_type == 3
     assert r.raw == b"Tuya"
     assert r.payload == "Tuya"
+
+    r.payload = "Data"
+    assert r.raw == b"Data"
 
 
 def test_tuya_data_bitmap():
@@ -105,13 +143,22 @@ def test_tuya_data_bitmap():
     assert r.raw == b"\x40"
     assert r.payload == 0x40
 
+    r.payload = t.bitmap8(0x82)
+    assert r.raw == b"\x82"
+
     data = b"\x05\x00\x02\x40\x02"
     r, _ = TuyaData.deserialize(data)
     r.payload == 0x4002
 
+    r.payload = t.bitmap16(0x2004)
+    assert r.raw == b"\x20\x04"
+
     data = b"\x05\x00\x04\x40\x02\x80\x01"
     r, _ = TuyaData.deserialize(data)
     r.payload == 0x40028001
+
+    r.payload = t.bitmap32(0x10082004)
+    assert r.raw == b"\x10\x08\x20\x04"
 
 
 def test_tuya_data_bitmap_invalid():
@@ -125,6 +172,25 @@ def test_tuya_data_bitmap_invalid():
 
     with pytest.raises(ValueError):
         r.payload
+
+
+def test_tuya_data_unknown():
+    """Test tuya unknown datatype."""
+
+    data = b"\x06\x00\x04\x03\x02\x01\x00"
+    extra = b"extra data"
+
+    r, rest = TuyaData.deserialize(data + extra)
+    assert rest == extra
+
+    assert r.dp_type == 6
+    assert r.raw == b"\x03\x02\x01\x00"
+
+    with pytest.raises(ValueError):
+        r.payload
+
+    with pytest.raises(ValueError):
+        r.payload = 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tuya_clusters.py
+++ b/tests/test_tuya_clusters.py
@@ -36,7 +36,7 @@ def test_tuya_data_value():
     assert rest == extra
 
     assert r.dp_type == 2
-    assert r.raw == b"\xdb\x02\x00\x00"
+    assert r.raw == b"\x00\x00\x02\xdb"
     assert r.payload == 731
 
 

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -4,16 +4,14 @@ import datetime
 from unittest import mock
 
 import pytest
-import zigpy.types as t
 from zigpy.zcl import foundation
 
 import zhaquirks
-from zhaquirks.tuya import TUYA_MCU_VERSION_RSP, TUYA_SET_TIME
+from zhaquirks.tuya import TUYA_MCU_VERSION_RSP, TUYA_SET_TIME, TuyaDPType
 from zhaquirks.tuya.mcu import (
     ATTR_MCU_VERSION,
     TuyaAttributesCluster,
     TuyaClusterData,
-    TuyaDPType,
     TuyaMCUCluster,
 )
 
@@ -215,13 +213,6 @@ async def test_tuya_methods(zigpy_device_from_quirk, quirk):
 
 async def test_tuya_mcu_classes():
     """Test tuya conversion from Data to ztype and reverse."""
-
-    # Test TuyaDPType class
-    assert len(TuyaDPType) == 6
-    assert TuyaDPType.BOOL.ztype == t.Bool
-    # no ztype for TuyaDPType.RAW
-    assert not TuyaDPType.RAW.ztype
-    assert TuyaDPType(3) == TuyaDPType.STRING
 
     # Test TuyaMCUCluster.MCUVersion class
     mcu_version = TuyaMCUCluster.MCUVersion.deserialize(b"\x00\x03\x82")[0]

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -218,6 +218,8 @@ class TuyaData(t.Struct):
         elif self.dp_type == TuyaDPType.ENUM:
             self.raw = t.enum8(value).serialize()
         elif self.dp_type == TuyaDPType.BITMAP:
+            if not isinstance(value, (t.bitmap8, t.bitmap16, t.bitmap32)):
+                value = t.bitmap8(value)
             self.raw = value.serialize()[::-1]
         elif self.dp_type == TuyaDPType.RAW:
             self.raw = value.serialize()

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -214,15 +214,11 @@ class TuyaData(t.Struct):
         elif self.dp_type == TuyaDPType.BOOL:
             self.raw = t.Bool(value).serialize()
         elif self.dp_type == TuyaDPType.STRING:
-            self.raw = value
+            self.raw = value.encode("utf8")
         elif self.dp_type == TuyaDPType.ENUM:
             self.raw = t.enum8(value).serialize()
         elif self.dp_type == TuyaDPType.BITMAP:
-            bitmaps = {1: t.bitmap8, 2: t.bitmap16, 4: t.bitmap32}
-            try:
-                self.raw = bitmaps[len(value)](value).serialize()
-            except KeyError as exc:
-                raise ValueError(f"Wrong bitmap length: {len(value)}") from exc
+            self.raw = value.serialize()[::-1]
         elif self.dp_type == TuyaDPType.RAW:
             self.raw = value.serialize()
         else:

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -212,12 +212,13 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
                 else:
                     args.append(val)
                 val = mapping.dp_converter(*args)
-                self.debug("converted: %s", val)
+            self.debug("value: %s", val)
 
             tuya_data = TuyaData()
             tuya_data.dp_type = datapoint_type
             tuya_data.function = 0
             tuya_data.payload = val
+            self.debug("raw: %s", tuya_data.raw)
             dpd = TuyaDatapointData(dp, tuya_data)
             cmd_payload.datapoints = [dpd]
 

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -15,12 +15,12 @@ from zhaquirks.tuya import (
     TUYA_MCU_VERSION_RSP,
     TUYA_SET_DATA,
     TUYA_SET_TIME,
-    Data,
     NoManufacturerCluster,
     PowerOnState,
     TuyaCommand,
     TuyaData,
     TuyaDatapointData,
+    TuyaDPType,
     TuyaLocalCluster,
     TuyaNewManufCluster,
     TuyaTimePayload,
@@ -28,24 +28,6 @@ from zhaquirks.tuya import (
 
 # New manufacturer attributes
 ATTR_MCU_VERSION = 0xEF00
-
-
-class TuyaDPType(t.enum8):
-    """Tuya DataPoint Type."""
-
-    RAW = 0x00, None
-    BOOL = 0x01, t.Bool
-    VALUE = 0x02, t.uint32_t
-    STRING = 0x03, None
-    ENUM = 0x04, t.enum8
-    BITMAP = 0x05, None
-
-    def __new__(cls, value, ztype):
-        """Overload instance to store the ztype."""
-
-        member = t.enum8.__new__(cls, value)
-        member.ztype = ztype
-        return member
 
 
 @dataclasses.dataclass
@@ -231,20 +213,11 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
                     args.append(val)
                 val = mapping.dp_converter(*args)
                 self.debug("converted: %s", val)
-            if datapoint_type.ztype:
-                val = datapoint_type.ztype(val)
-                self.debug("ztype: %s", val)
-            val = Data.from_value(val)
-            self.debug("from_value: %s", val)
 
             tuya_data = TuyaData()
             tuya_data.dp_type = datapoint_type
             tuya_data.function = 0
-            if datapoint_type == TuyaDPType.RAW:
-                tuya_data.raw = bytes(reversed(val[1:]))
-            else:
-                tuya_data.raw = t.LVBytes.deserialize(val)[0]
-            self.debug("raw: %s", tuya_data.raw)
+            tuya_data.payload = val
             dpd = TuyaDatapointData(dp, tuya_data)
             cmd_payload.datapoints = [dpd]
 


### PR DESCRIPTION
I think this is the least controversial part of #2017, I decided to raise it separately to make the review process easier.

`tuya.TuyaData.raw` is no longer affected on deserialization. That allows to remove the overloaded `deserialize()` method. It also fixes a cosmetic issue that payload is wrongly calculated in the logs for outgoing messages. Instead, a setter for the `TuyaData.payload` was added so that `raw` is no longer read or written directly.

Supersedes #1984