### PR TITLE
RDM001: add automation triggers for right switch

### DIFF
--- a/zhaquirks/philips/rdm001.py
+++ b/zhaquirks/philips/rdm001.py
@@ -25,7 +25,6 @@ from zhaquirks.const import (
     DOUBLE_PRESS,
     ENDPOINTS,
     INPUT_CLUSTERS,
-    LEFT,
     LONG_PRESS,
     LONG_RELEASE,
     MODELS_INFO,
@@ -38,6 +37,7 @@ from zhaquirks.const import (
     SHORT_PRESS,
     SHORT_RELEASE,
     TRIPLE_PRESS,
+    TURN_ON,
     ZHA_SEND_EVENT,
 )
 from zhaquirks.philips import PHILIPS, SIGNIFY
@@ -177,14 +177,14 @@ class PhilipsROM001(CustomDevice):
     }
 
     device_automation_triggers = {
-        (SHORT_PRESS, LEFT): {COMMAND: "left_press"},
-        (LONG_PRESS, LEFT): {COMMAND: "left_hold"},
-        (DOUBLE_PRESS, LEFT): {COMMAND: "left_double_press"},
-        (TRIPLE_PRESS, LEFT): {COMMAND: "left_triple_press"},
-        (QUADRUPLE_PRESS, LEFT): {COMMAND: "left_quadruple_press"},
-        (QUINTUPLE_PRESS, LEFT): {COMMAND: "left_quintuple_press"},
-        (SHORT_RELEASE, LEFT): {COMMAND: "left_short_release"},
-        (LONG_RELEASE, LEFT): {COMMAND: "left_long_release"},
+        (SHORT_PRESS, TURN_ON): {COMMAND: "left_press"},
+        (LONG_PRESS, TURN_ON): {COMMAND: "left_hold"},
+        (DOUBLE_PRESS, TURN_ON): {COMMAND: "left_double_press"},
+        (TRIPLE_PRESS, TURN_ON): {COMMAND: "left_triple_press"},
+        (QUADRUPLE_PRESS, TURN_ON): {COMMAND: "left_quadruple_press"},
+        (QUINTUPLE_PRESS, TURN_ON): {COMMAND: "left_quintuple_press"},
+        (SHORT_RELEASE, TURN_ON): {COMMAND: "left_short_release"},
+        (LONG_RELEASE, TURN_ON): {COMMAND: "left_long_release"},
         (SHORT_PRESS, RIGHT): {COMMAND: "right_press"},
         (LONG_PRESS, RIGHT): {COMMAND: "right_hold"},
         (DOUBLE_PRESS, RIGHT): {COMMAND: "right_double_press"},

--- a/zhaquirks/philips/rdm001.py
+++ b/zhaquirks/philips/rdm001.py
@@ -25,6 +25,7 @@ from zhaquirks.const import (
     DOUBLE_PRESS,
     ENDPOINTS,
     INPUT_CLUSTERS,
+    LEFT,
     LONG_PRESS,
     LONG_RELEASE,
     MODELS_INFO,
@@ -33,10 +34,10 @@ from zhaquirks.const import (
     PROFILE_ID,
     QUADRUPLE_PRESS,
     QUINTUPLE_PRESS,
+    RIGHT,
     SHORT_PRESS,
     SHORT_RELEASE,
     TRIPLE_PRESS,
-    TURN_ON,
     ZHA_SEND_EVENT,
 )
 from zhaquirks.philips import PHILIPS, SIGNIFY
@@ -176,12 +177,20 @@ class PhilipsROM001(CustomDevice):
     }
 
     device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {COMMAND: "left_press"},
-        (LONG_PRESS, TURN_ON): {COMMAND: "left_hold"},
-        (DOUBLE_PRESS, TURN_ON): {COMMAND: "left_double_press"},
-        (TRIPLE_PRESS, TURN_ON): {COMMAND: "left_triple_press"},
-        (QUADRUPLE_PRESS, TURN_ON): {COMMAND: "left_quadruple_press"},
-        (QUINTUPLE_PRESS, TURN_ON): {COMMAND: "left_quintuple_press"},
-        (SHORT_RELEASE, TURN_ON): {COMMAND: "left_short_release"},
-        (LONG_RELEASE, TURN_ON): {COMMAND: "left_long_release"},
+        (SHORT_PRESS, LEFT): {COMMAND: "left_press"},
+        (LONG_PRESS, LEFT): {COMMAND: "left_hold"},
+        (DOUBLE_PRESS, LEFT): {COMMAND: "left_double_press"},
+        (TRIPLE_PRESS, LEFT): {COMMAND: "left_triple_press"},
+        (QUADRUPLE_PRESS, LEFT): {COMMAND: "left_quadruple_press"},
+        (QUINTUPLE_PRESS, LEFT): {COMMAND: "left_quintuple_press"},
+        (SHORT_RELEASE, LEFT): {COMMAND: "left_short_release"},
+        (LONG_RELEASE, LEFT): {COMMAND: "left_long_release"},
+        (SHORT_PRESS, RIGHT): {COMMAND: "right_press"},
+        (LONG_PRESS, RIGHT): {COMMAND: "right_hold"},
+        (DOUBLE_PRESS, RIGHT): {COMMAND: "right_double_press"},
+        (TRIPLE_PRESS, RIGHT): {COMMAND: "right_triple_press"},
+        (QUADRUPLE_PRESS, RIGHT): {COMMAND: "right_quadruple_press"},
+        (QUINTUPLE_PRESS, RIGHT): {COMMAND: "right_quintuple_press"},
+        (SHORT_RELEASE, RIGHT): {COMMAND: "right_short_release"},
+        (LONG_RELEASE, RIGHT): {COMMAND: "right_long_release"},
     }


### PR DESCRIPTION
The Philips Hue Wall Switch Module (RDM001) supports up to two switches. If the right switch is enabled, can be controlled by the PhilipsBasicCluster attribute `mode` (`0x0034`). Apparently, the only device events which currently get emitted are the ones for the left switch.

This PR adds device triggers for the commands of the right switch. The triggers for the left switch are also affected by this PR to not have them named differently. Therefore, this PR is a **breaking change**.

Related issues: #858 