### PR TITLE
DA Support for Styrbar Version 2.4.5

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -615,7 +615,7 @@ KNOWN_DUPLICATE_TRIGGERS = {
             (zhaquirks.aurora.aurora_dimmer.COLOR_DOWN, const.LEFT),
         ],
     ],
-    zhaquirks.ikea.fourbtnremote.IkeaTradfriRemote: [
+    zhaquirks.ikea.fourbtnremote.IkeaTradfriRemoteV1: [
         [
             (const.LONG_RELEASE, const.DIM_UP),
             (const.LONG_RELEASE, const.DIM_DOWN),

--- a/zhaquirks/ikea/fourbtnremote.py
+++ b/zhaquirks/ikea/fourbtnremote.py
@@ -50,7 +50,7 @@ from zhaquirks.ikea import (
 )
 
 
-class IkeaTradfriRemote(CustomDevice):
+class IkeaTradfriRemoteV1(CustomDevice):
     """Custom device representing IKEA of Sweden TRADFRI remote control V1.0.024."""
 
     signature = {
@@ -233,4 +233,4 @@ class IkeaTradfriRemoteV2(CustomDevice):
         }
     }
 
-    device_automation_triggers = IkeaTradfriRemote.device_automation_triggers.copy()
+    device_automation_triggers = IkeaTradfriRemoteV1.device_automation_triggers.copy()

--- a/zhaquirks/ikea/fourbtnremote.py
+++ b/zhaquirks/ikea/fourbtnremote.py
@@ -21,6 +21,7 @@ from zhaquirks.const import (
     COMMAND_OFF,
     COMMAND_ON,
     COMMAND_PRESS,
+    COMMAND_STOP,
     COMMAND_STOP_ON_OFF,
     DEVICE_TYPE,
     DIM_DOWN,
@@ -42,17 +43,18 @@ from zhaquirks.const import (
 )
 from zhaquirks.ikea import (
     IKEA,
+    IKEA_CLUSTER_ID,
     WWAH_CLUSTER_ID,
     PowerConfiguration2AAACluster,
     ScenesCluster,
 )
 
 
-class IkeaTradfriRemote(CustomDevice):
-    """Custom device representing IKEA of Sweden TRADFRI remote control."""
+class IkeaTradfriRemoteV1(CustomDevice):
+    """Custom device representing IKEA of Sweden TRADFRI remote control V1.0.024."""
 
     signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=2080
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=820
         # device_version=1
         # input_clusters=[0, 1, 3, 32, 4096, 64599]
         # output_clusters=[3, 6, 8, 25, 4096]>
@@ -126,7 +128,7 @@ class IkeaTradfriRemote(CustomDevice):
             PARAMS: {"move_mode": 1},
         },
         (LONG_RELEASE, DIM_DOWN): {
-            COMMAND: COMMAND_STOP_ON_OFF,
+            COMMAND: COMMAND_STOP,
             CLUSTER_ID: 8,
             ENDPOINT_ID: 1,
         },
@@ -169,3 +171,66 @@ class IkeaTradfriRemote(CustomDevice):
             },
         },
     }
+
+
+class IkeaTradfriRemoteV2(CustomDevice):
+    """Custom device representing IKEA of Sweden TRADFRI remote control Version 2.4.5."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=820
+        # device_version=1
+        # input_clusters=[0, 1, 3, 32, 4096, 64599, 64636]
+        # output_clusters=[3, 5, 6, 8, 25, 4096]>
+        MODELS_INFO: [(IKEA, "Remote Control N2")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                    WWAH_CLUSTER_ID,
+                    IKEA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    ScenesCluster.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration2AAACluster,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                    WWAH_CLUSTER_ID,
+                    IKEA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    ScenesCluster,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        }
+    }
+
+    device_automation_triggers = IkeaTradfriRemoteV1.device_automation_triggers.copy()

--- a/zhaquirks/ikea/fourbtnremote.py
+++ b/zhaquirks/ikea/fourbtnremote.py
@@ -50,7 +50,7 @@ from zhaquirks.ikea import (
 )
 
 
-class IkeaTradfriRemoteV1(CustomDevice):
+class IkeaTradfriRemote(CustomDevice):
     """Custom device representing IKEA of Sweden TRADFRI remote control V1.0.024."""
 
     signature = {
@@ -233,4 +233,4 @@ class IkeaTradfriRemoteV2(CustomDevice):
         }
     }
 
-    device_automation_triggers = IkeaTradfriRemoteV1.device_automation_triggers.copy()
+    device_automation_triggers = IkeaTradfriRemote.device_automation_triggers.copy()


### PR DESCRIPTION
The OTA is released but have lower version in the metadata (Thanks our Puddly for verifying it !!) so ZHA and Z2M is not updating it and its looks Dirigera also not updating them.
But the old trådfri gateway is doing it OK and ZHA is showing the new version of the firmware OK so we can getting user using them.

IKEA have changing dim down to using COMMAND_STOP instead of COMMAND_STOP_ON_OFF that was used for both dim up and down > Dim down was trigger DA dim up. The updated is dim down still triggering dim up DA for old firmware  but the updated is doing it OK.

Tested with both firmware and have using all DA for doing automatons !!!

Also some small cluster setting we is getting on the way.

Have fixing some wrong  spelling in the signature.

PS: for user having problem with right / left long pres: The device is sending one reset cycle for syncing all light bounded and in it is  also ON command sent and we cant do anything about it so ON DA is also triggered  and the release is sending random numbers so we cant using it in DA.
The device is one light controller if like getting mega clicks use one HA controllers that is sending "clicks" !!!

Edit: The OTA updating problem is documented here https://github.com/zigpy/zigpy/discussions/660#discussioncomment-4460743.

Edit 2: Group binding is gone 👎 👎 👎 