### PR TITLE
Ensure all ZCL command definitions use dictionaries

### DIFF
--- a/zhaquirks/tuya/ts110e.py
+++ b/zhaquirks/tuya/ts110e.py
@@ -57,7 +57,7 @@ class F000LevelControlCluster(NoManufacturerCluster, LevelControl):
     server_commands = LevelControl.server_commands.copy()
     server_commands[TUYA_CUSTOM_LEVEL_COMMAND] = foundation.ZCLCommandDef(
         "moveToLevelTuya",
-        (TuyaLevelPayload,),
+        {"payload": TuyaLevelPayload},
         is_manufacturer_specific=False,
     )
 


### PR DESCRIPTION
A single Tuya device is still using the old ZCL command format (which would have caused runtime errors).