### PR TITLE
Round power values for Aqara EU plugs

### DIFF
--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -586,7 +586,7 @@ class ElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
 
     def power_reported(self, value):
         """Power reported."""
-        self._update_attribute(self.POWER_ID, value * 10)
+        self._update_attribute(self.POWER_ID, round(value * 10))
 
     def voltage_reported(self, value):
         """Voltage reported."""
@@ -594,7 +594,7 @@ class ElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
 
     def consumption_reported(self, value):
         """Consumption reported."""
-        self._update_attribute(self.CONSUMPTION_ID, value * 1000)
+        self._update_attribute(self.CONSUMPTION_ID, round(value * 1000))
 
 
 class MeteringCluster(LocalDataCluster, Metering):
@@ -621,7 +621,7 @@ class MeteringCluster(LocalDataCluster, Metering):
 
     def consumption_reported(self, value):
         """Consumption reported."""
-        self._update_attribute(self.CURRENT_SUMM_DELIVERED_ID, value * 1000)
+        self._update_attribute(self.CURRENT_SUMM_DELIVERED_ID, round(value * 1000))
 
 
 class IlluminanceMeasurementCluster(CustomCluster, IlluminanceMeasurement):


### PR DESCRIPTION
The Aqara EU plugs provide power values like ``85.41999816894531``.
These are then multiplied by ten (for ``active_power``) or by 1000 for the total sum sensor, so ZHA can later divide it and show more accurate numbers (have decimal numbers).

However, ``active_power`` should only be type ``t.int16s`` (and others also int).
Previously, HA properly rounded the still very long number with a decimal point in the HA interface.
The number was saved with a wrong type in the database though (so ``85.41999816894531`` instead of ``85`` for 8.5W).

Upon restarting or the automatic 30 seconds ``active_power`` polling (which also happens for fake/data attributes), the attribute was re-read, type-converted, and then re-saved. Here, the numbers after the decimal point are just cut off instead of rounding, so it'll cause jumps in certain scenarios.

Basically, we should just round() the number to an ``int`` here to make the quirk "ZCL compliant".

Fixes (closed even though it's not fixed):
- https://github.com/home-assistant/core/issues/84084

For reference, also see:
- https://github.com/zigpy/zigpy/issues/1041
- https://github.com/home-assistant/core/issues/84713 (this PR won't fix that issue, but it's possibly a similar issue)

---

@puddly [proposed doing some larger changes](https://github.com/zigpy/zigpy/issues/1041#issuecomment-1367650121) to make the previous invalid behavior impossible (doing proper type conversion before saving it to the database and logging an error in case of quirks calling ``update_attribute`` with wrong data types).
~~So not sure if these changes should be implemented together or not.~~ Should be fine.

(I did confirm that this fixes the issue for Aqara EU plugs (and also them dipping their total sum sensor causing a HA warning))