### PR TITLE
Set TuyaData.dp_type automatically

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1,6 +1,7 @@
 """Tuya devices."""
 import dataclasses
 import datetime
+import enum
 import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -225,6 +226,30 @@ class TuyaData(t.Struct):
             self.raw = value.serialize()
         else:
             raise ValueError(f"Unknown {self.dp_type} datapoint type")
+
+    def __new__(cls, *args, **kwargs):
+        """Disable copy constrctor."""
+        return super().__new__(cls)
+
+    def __init__(self, value=None, function=0, *args, **kwargs):
+        """Convert from a zigpy typed value to a tuya data payload."""
+        if value is None:
+            return
+        elif isinstance(value, (t.bitmap8, t.bitmap16, t.bitmap32)):
+            self.dp_type = TuyaDPType.BITMAP
+        elif isinstance(value, (bool, t.Bool)):
+            self.dp_type = TuyaDPType.BOOL
+        elif isinstance(value, enum.Enum):
+            self.dp_type = TuyaDPType.ENUM
+        elif isinstance(value, int):
+            self.dp_type = TuyaDPType.VALUE
+        elif isinstance(value, str):
+            self.dp_type = TuyaDPType.STRING
+        elif isinstance(value, t.Struct):
+            self.dp_type = TuyaDPType.RAW
+
+        self.function = function
+        self.payload = value
 
 
 class Data(t.List, item_type=t.uint8_t):

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -247,7 +247,7 @@ class TuyaData(t.Struct):
             self.dp_type = TuyaDPType.VALUE
         elif isinstance(value, str):
             self.dp_type = TuyaDPType.STRING
-        elif isinstance(value, t.Struct):
+        else:
             self.dp_type = TuyaDPType.RAW
 
         self.payload = value

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -233,6 +233,8 @@ class TuyaData(t.Struct):
 
     def __init__(self, value=None, function=0, *args, **kwargs):
         """Convert from a zigpy typed value to a tuya data payload."""
+        self.function = function
+
         if value is None:
             return
         elif isinstance(value, (t.bitmap8, t.bitmap16, t.bitmap32)):
@@ -248,7 +250,6 @@ class TuyaData(t.Struct):
         elif isinstance(value, t.Struct):
             self.dp_type = TuyaDPType.RAW
 
-        self.function = function
         self.payload = value
 
 

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -18,9 +18,7 @@ from zhaquirks.tuya import (
     NoManufacturerCluster,
     PowerOnState,
     TuyaCommand,
-    TuyaData,
     TuyaDatapointData,
-    TuyaDPType,
     TuyaLocalCluster,
     TuyaNewManufCluster,
     TuyaTimePayload,
@@ -39,7 +37,6 @@ class DPToAttributeMapping:
 
     ep_attribute: str
     attribute_name: Union[str, tuple]
-    dp_type: TuyaDPType
     converter: Optional[
         Callable[
             [
@@ -229,7 +226,6 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
             cmd_payload.status = 0
             cmd_payload.tsn = self.endpoint.device.application.get_sequence()
 
-            datapoint_type = mapping.dp_type
             val = data.attr_value
             if mapping.dp_converter:
                 args = []
@@ -247,12 +243,8 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
                 val = mapping.dp_converter(*args)
             self.debug("value: %s", val)
 
-            tuya_data = TuyaData()
-            tuya_data.dp_type = datapoint_type
-            tuya_data.function = 0
-            tuya_data.payload = val
-            self.debug("raw: %s", tuya_data.raw)
-            dpd = TuyaDatapointData(dp, tuya_data)
+            dpd = TuyaDatapointData(dp, val)
+            self.debug("raw: %s", dpd.data.raw)
             cmd_payload.datapoints = [dpd]
 
             tuya_commands.append(cmd_payload)
@@ -417,36 +409,30 @@ class TuyaOnOffManufCluster(TuyaMCUCluster):
         1: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
-            dp_type=TuyaDPType.BOOL,
         ),
         2: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
-            dp_type=TuyaDPType.BOOL,
             endpoint_id=2,
         ),
         3: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
-            dp_type=TuyaDPType.BOOL,
             endpoint_id=3,
         ),
         4: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
-            dp_type=TuyaDPType.BOOL,
             endpoint_id=4,
         ),
         5: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
-            dp_type=TuyaDPType.BOOL,
             endpoint_id=5,
         ),
         6: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
-            dp_type=TuyaDPType.BOOL,
             endpoint_id=6,
         ),
     }
@@ -480,7 +466,6 @@ class MoesSwitchManufCluster(TuyaOnOffManufCluster):
             14: DPToAttributeMapping(
                 TuyaMCUCluster.ep_attribute,
                 "power_on_state",
-                dp_type=TuyaDPType.ENUM,
                 converter=lambda x: PowerOnState(x),
             )
         }
@@ -490,7 +475,6 @@ class MoesSwitchManufCluster(TuyaOnOffManufCluster):
             15: DPToAttributeMapping(
                 TuyaMCUCluster.ep_attribute,
                 "backlight_mode",
-                dp_type=TuyaDPType.ENUM,
                 converter=lambda x: MoesBacklight(x),
             ),
         }
@@ -596,37 +580,31 @@ class TuyaLevelControlManufCluster(TuyaMCUCluster):
         1: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
-            dp_type=TuyaDPType.BOOL,
         ),
         2: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "current_level",
-            dp_type=TuyaDPType.VALUE,
             converter=lambda x: (x * 255) // 1000,
             dp_converter=lambda x: (x * 1000) // 255,
         ),
         3: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "minimum_level",
-            dp_type=TuyaDPType.VALUE,
             converter=lambda x: (x * 255) // 1000,
             dp_converter=lambda x: (x * 1000) // 255,
         ),
         4: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "bulb_type",
-            dp_type=TuyaDPType.ENUM,
         ),
         7: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
-            dp_type=TuyaDPType.BOOL,
             endpoint_id=2,
         ),
         8: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "current_level",
-            dp_type=TuyaDPType.VALUE,
             converter=lambda x: (x * 255) // 1000,
             dp_converter=lambda x: (x * 1000) // 255,
             endpoint_id=2,
@@ -634,7 +612,6 @@ class TuyaLevelControlManufCluster(TuyaMCUCluster):
         9: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "minimum_level",
-            dp_type=TuyaDPType.VALUE,
             converter=lambda x: (x * 255) // 1000,
             dp_converter=lambda x: (x * 1000) // 255,
             endpoint_id=2,
@@ -642,19 +619,16 @@ class TuyaLevelControlManufCluster(TuyaMCUCluster):
         10: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "bulb_type",
-            dp_type=TuyaDPType.ENUM,
             endpoint_id=2,
         ),
         15: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
-            dp_type=TuyaDPType.BOOL,
             endpoint_id=3,
         ),
         16: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "current_level",
-            dp_type=TuyaDPType.VALUE,
             converter=lambda x: (x * 255) // 1000,
             dp_converter=lambda x: (x * 1000) // 255,
             endpoint_id=3,
@@ -662,7 +636,6 @@ class TuyaLevelControlManufCluster(TuyaMCUCluster):
         17: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "minimum_level",
-            dp_type=TuyaDPType.VALUE,
             converter=lambda x: (x * 255) // 1000,
             dp_converter=lambda x: (x * 1000) // 255,
             endpoint_id=3,
@@ -670,7 +643,6 @@ class TuyaLevelControlManufCluster(TuyaMCUCluster):
         18: DPToAttributeMapping(
             TuyaLevelControl.ep_attribute,
             "bulb_type",
-            dp_type=TuyaDPType.ENUM,
             endpoint_id=3,
         ),
     }

--- a/zhaquirks/tuya/ts0601_garage.py
+++ b/zhaquirks/tuya/ts0601_garage.py
@@ -15,7 +15,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import NoManufacturerCluster
-from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaDPType, TuyaMCUCluster
+from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster
 
 TUYA_MANUFACTURER_GARAGE = "tuya_manufacturer_garage"
 
@@ -44,38 +44,31 @@ class TuyaGarageManufCluster(NoManufacturerCluster, TuyaMCUCluster):
         1: DPToAttributeMapping(
             TUYA_MANUFACTURER_GARAGE,
             "button",
-            dp_type=TuyaDPType.BOOL,
         ),
         2: DPToAttributeMapping(
             TUYA_MANUFACTURER_GARAGE,
             "dp_2",
-            dp_type=TuyaDPType.VALUE,
         ),
         3: DPToAttributeMapping(
             TUYA_MANUFACTURER_GARAGE,
             "contact_sensor",
-            dp_type=TuyaDPType.BOOL,
         ),
         4: DPToAttributeMapping(
             TUYA_MANUFACTURER_GARAGE,
             "dp_4",
-            dp_type=TuyaDPType.VALUE,
         ),
         5: DPToAttributeMapping(
             TUYA_MANUFACTURER_GARAGE,
             "dp_5",
-            dp_type=TuyaDPType.VALUE,
         ),
         11: DPToAttributeMapping(
             TUYA_MANUFACTURER_GARAGE,
             "dp_11",
-            dp_type=TuyaDPType.BOOL,
         ),
         # garage door status (open, closed, ...)
         12: DPToAttributeMapping(
             TUYA_MANUFACTURER_GARAGE,
             "dp_12",
-            dp_type=TuyaDPType.ENUM,
         ),
     }
 

--- a/zhaquirks/tuya/ts0601_illuminance.py
+++ b/zhaquirks/tuya/ts0601_illuminance.py
@@ -18,7 +18,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import TuyaLocalCluster
-from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaDPType, TuyaMCUCluster
+from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster
 
 TUYA_BRIGHTNESS_LEVEL_DP = 0x01  # 0-2 "Low, Medium, High"
 TUYA_ILLUMINANCE_DP = 0x02  # [0, 0, 3, 232] illuminance
@@ -50,13 +50,11 @@ class TuyaIlluminanceCluster(TuyaMCUCluster):
         TUYA_BRIGHTNESS_LEVEL_DP: DPToAttributeMapping(
             TuyaIlluminanceMeasurement.ep_attribute,
             "manufacturer_brightness_level",
-            dp_type=TuyaDPType.ENUM,
             converter=lambda x: BrightnessLevel(x),
         ),
         TUYA_ILLUMINANCE_DP: DPToAttributeMapping(
             TuyaIlluminanceMeasurement.ep_attribute,
             "measured_value",
-            dp_type=TuyaDPType.VALUE,
             converter=lambda x: (10000.0 * math.log10(x) + 1.0 if x != 0 else 0),
         ),
     }

--- a/zhaquirks/tuya/ts0601_rcbo.py
+++ b/zhaquirks/tuya/ts0601_rcbo.py
@@ -34,7 +34,6 @@ from zhaquirks.tuya.mcu import (
     DPToAttributeMapping,
     TuyaAttributesCluster,
     TuyaClusterData,
-    TuyaDPType,
     TuyaMCUCluster,
     TuyaOnOff,
 )
@@ -356,68 +355,56 @@ class TuyaRCBOManufCluster(TuyaMCUCluster):
         TUYA_DP_STATE: DPToAttributeMapping(
             TuyaRCBOOnOff.ep_attribute,
             "on_off",
-            TuyaDPType.BOOL,
         ),
         TUYA_DP_COUNTDOWN_TIMER: DPToAttributeMapping(
             TuyaRCBOOnOff.ep_attribute,
             "countdown_timer",
-            TuyaDPType.VALUE,
         ),
         TUYA_DP_FAULT_CODE: DPToAttributeMapping(
             TuyaRCBOElectricalMeasurement.ep_attribute,
             "alarm",
-            TuyaDPType.ENUM,
             lambda x: FaultCode(x),
         ),
         TUYA_DP_RELAY_STATUS: DPToAttributeMapping(
             TuyaRCBOOnOff.ep_attribute,
             "power_on_state",
-            TuyaDPType.ENUM,
             lambda x: PowerOnState(x),
         ),
         TUYA_DP_CHILD_LOCK: DPToAttributeMapping(
             TuyaRCBOOnOff.ep_attribute,
             "child_lock",
-            TuyaDPType.BOOL,
         ),
         TUYA_DP_VOLTAGE: DPToAttributeMapping(
             TuyaRCBOElectricalMeasurement.ep_attribute,
             "rms_voltage",
-            TuyaDPType.RAW,
             lambda x: x[1] | x[0] << 8,
         ),
         TUYA_DP_CURRENT: DPToAttributeMapping(
             TuyaRCBOElectricalMeasurement.ep_attribute,
             "rms_current",
-            TuyaDPType.RAW,
             lambda x: x[2] | x[1] << 8,
         ),
         TUYA_DP_ACTIVE_POWER: DPToAttributeMapping(
             TuyaRCBOElectricalMeasurement.ep_attribute,
             "active_power",
-            TuyaDPType.RAW,
             lambda x: x[2] | x[1] << 8,
         ),
         TUYA_DP_LEAKAGE_CURRENT: DPToAttributeMapping(
             TuyaRCBOElectricalMeasurement.ep_attribute,
             "leakage_current",
-            TuyaDPType.VALUE,
         ),
         TUYA_DP_TEMPERATURE: DPToAttributeMapping(
             TuyaRCBODeviceTemperature.ep_attribute,
             "current_temperature",
-            TuyaDPType.VALUE,
             lambda x: x * 100,
         ),
         TUYA_DP_REMAINING_ENERGY: DPToAttributeMapping(
             TuyaRCBOMetering.ep_attribute,
             "remaining_energy",
-            TuyaDPType.VALUE,
         ),
         TUYA_DP_COST_PARAMETERS: DPToAttributeMapping(
             TuyaRCBOMetering.ep_attribute,
             ("cost_parameters", "cost_parameters_enabled"),
-            TuyaDPType.RAW,
             lambda x: (x[1] | x[0] << 8, x[2]),
             lambda *fields: CostParameters(*fields),
         ),
@@ -432,7 +419,6 @@ class TuyaRCBOManufCluster(TuyaMCUCluster):
                 "over_leakage_current_alarm",
                 "self_test",
             ),
-            TuyaDPType.RAW,
             lambda x: (x[0], x[1], x[2], x[4] | x[3] << 8, x[5], x[6], SelfTest(x[7])),
             lambda *fields: LeakageParameters(*fields),
         ),
@@ -445,7 +431,6 @@ class TuyaRCBOManufCluster(TuyaMCUCluster):
                 "rms_extreme_under_voltage",
                 "under_voltage_trip",
             ),
-            TuyaDPType.RAW,
             lambda x: (
                 x[1] | x[0] << 8,
                 x[2],
@@ -465,7 +450,6 @@ class TuyaRCBOManufCluster(TuyaMCUCluster):
         TUYA_DP_CURRENT_THRESHOLD: DPToAttributeMapping(
             TuyaRCBOElectricalMeasurement.ep_attribute,
             ("ac_current_overload", "over_current_trip", "ac_alarms_mask"),
-            TuyaDPType.RAW,
             lambda x: (
                 (x[2] | x[1] << 8 | x[0] << 16),
                 x[3],
@@ -478,42 +462,34 @@ class TuyaRCBOManufCluster(TuyaMCUCluster):
         TUYA_DP_TEMPERATURE_THRESHOLD: DPToAttributeMapping(
             TuyaRCBODeviceTemperature.ep_attribute,
             ("high_temp_thres", "over_temp_trip", "dev_temp_alarm_mask"),
-            TuyaDPType.RAW,
             lambda x: (x[0] if x[0] <= 127 else x[0] - 256, x[1], x[2] << 1),
             lambda x, y, z: TemperatureSetting(x, y, bool(z & 0x02)),
         ),
         TUYA_DP_TOTAL_ACTIVE_POWER: DPToAttributeMapping(
             TuyaRCBOMetering.ep_attribute,
             "current_summ_delivered",
-            TuyaDPType.VALUE,
         ),
         TUYA_DP_EQUIPMENT_NUMBER_AND_TYPE: DPToAttributeMapping(
             TuyaRCBOMetering.ep_attribute,
             "meter_number",
-            TuyaDPType.STRING,
             lambda x: x.rstrip(),
         ),
         TUYA_DP_CLEAR_ENERGY: DPToAttributeMapping(
-            TuyaRCBOMetering.ep_attribute, "clear_device_data", TuyaDPType.BOOL
+            TuyaRCBOMetering.ep_attribute, "clear_device_data"
         ),
-        TUYA_DP_LOCKING: DPToAttributeMapping(
-            TuyaRCBOOnOff.ep_attribute, "trip", TuyaDPType.BOOL
-        ),
+        TUYA_DP_LOCKING: DPToAttributeMapping(TuyaRCBOOnOff.ep_attribute, "trip"),
         TUYA_DP_TOTAL_REVERSE_ACTIVE_POWER: DPToAttributeMapping(
             TuyaRCBOMetering.ep_attribute,
             "current_summ_received",
-            TuyaDPType.VALUE,
         ),
         TUYA_DP_HISTORICAL_VOLTAGE: DPToAttributeMapping(
             TuyaRCBOElectricalMeasurement.ep_attribute,
             "rms_historical_voltage",
-            TuyaDPType.RAW,
             lambda x: x[1] | x[0] << 8,
         ),
         TUYA_DP_HISTORICAL_CURRENT: DPToAttributeMapping(
             TuyaRCBOElectricalMeasurement.ep_attribute,
             "rms_historical_current",
-            TuyaDPType.RAW,
             lambda x: x[2] | x[1] << 8,
         ),
     }

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -21,7 +21,7 @@ from zhaquirks.const import (
     SKIP_CONFIGURATION,
 )
 from zhaquirks.tuya import TuyaLocalCluster, TuyaPowerConfigurationCluster2AAA
-from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaDPType, TuyaMCUCluster
+from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster
 
 
 class TuyaTemperatureMeasurement(TemperatureMeasurement, TuyaLocalCluster):
@@ -54,19 +54,16 @@ class TemperatureHumidityManufCluster(TuyaMCUCluster):
         1: DPToAttributeMapping(
             TuyaTemperatureMeasurement.ep_attribute,
             "measured_value",
-            dp_type=TuyaDPType.VALUE,
             converter=lambda x: x * 10,  # decidegree to centidegree
         ),
         2: DPToAttributeMapping(
             TuyaRelativeHumidity.ep_attribute,
             "measured_value",
-            dp_type=TuyaDPType.VALUE,
             # converter=lambda x: x * 10,  --> move conversion to TuyaRelativeHumidity cluster
         ),
         4: DPToAttributeMapping(
             TuyaPowerConfigurationCluster2AAA.ep_attribute,
             "battery_percentage_remaining",
-            dp_type=TuyaDPType.VALUE,
             converter=lambda x: x * 2,  # double reported percentage
         ),
     }
@@ -227,19 +224,16 @@ class SoilManufCluster(TuyaMCUCluster):
         5: DPToAttributeMapping(
             TuyaTemperatureMeasurement.ep_attribute,
             "measured_value",
-            dp_type=TuyaDPType.VALUE,
             converter=lambda x: x * 100,
         ),
         3: DPToAttributeMapping(
             TuyaSoilMoisture.ep_attribute,
             "measured_value",
-            dp_type=TuyaDPType.VALUE,
             converter=lambda x: x * 100,
         ),
         15: DPToAttributeMapping(
             TuyaPowerConfigurationCluster2AAA.ep_attribute,
             "battery_percentage_remaining",
-            dp_type=TuyaDPType.VALUE,
             converter=lambda x: x * 2,  # double reported percentage
         ),
     }

--- a/zhaquirks/tuya/ts0601_siren.py
+++ b/zhaquirks/tuya/ts0601_siren.py
@@ -33,7 +33,6 @@ from zhaquirks.tuya.mcu import (
     DPToAttributeMapping,
     TuyaAttributesCluster,
     TuyaClusterData,
-    TuyaDPType,
     TuyaMCUCluster,
 )
 
@@ -319,28 +318,23 @@ class NeoSirenManufCluster(TuyaMCUCluster):
         5: DPToAttributeMapping(
             TuyaMCUSiren.ep_attribute,
             "volume",
-            dp_type=TuyaDPType.ENUM,
             converter=lambda x: NeoAlarmVolume(x),
         ),
         7: DPToAttributeMapping(
             TuyaMCUSiren.ep_attribute,
             "alarm_duration",
-            dp_type=TuyaDPType.VALUE,
         ),
         13: DPToAttributeMapping(
             TuyaMCUSiren.ep_attribute,
             "on_off",
-            dp_type=TuyaDPType.BOOL,
         ),
         15: DPToAttributeMapping(
             TuyaMCUSiren.ep_attribute,
             "battery",
-            dp_type=TuyaDPType.VALUE,
         ),
         21: DPToAttributeMapping(
             TuyaMCUSiren.ep_attribute,
             "melody",
-            dp_type=TuyaDPType.ENUM,
             converter=lambda x: NeoAlarmMelody(x),
         ),
     }

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -21,7 +21,6 @@ from zhaquirks.tuya import TuyaLocalCluster
 from zhaquirks.tuya.mcu import (
     DPToAttributeMapping,
     EnchantedDevice,
-    TuyaDPType,
     TuyaMCUCluster,
     TuyaOnOff,
     TuyaOnOffNM,
@@ -59,37 +58,30 @@ class TuyaValveManufCluster(TuyaMCUCluster):
         1: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
-            dp_type=TuyaDPType.BOOL,
         ),
         5: DPToAttributeMapping(
             TuyaValveWaterConsumed.ep_attribute,
             "current_summ_delivered",
-            TuyaDPType.VALUE,
         ),
         6: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "dp_6",
-            TuyaDPType.VALUE,
         ),
         7: DPToAttributeMapping(
             DoublingPowerConfigurationCluster.ep_attribute,
             "battery_percentage_remaining",
-            TuyaDPType.VALUE,
         ),
         11: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "time_left",
-            TuyaDPType.VALUE,
         ),
         12: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "state",
-            TuyaDPType.VALUE,
         ),
         15: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "last_valve_open_duration",
-            TuyaDPType.VALUE,
         ),
     }
 
@@ -162,33 +154,27 @@ class ParksideTuyaValveManufCluster(TuyaMCUCluster):
         1: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
-            TuyaDPType.BOOL,
         ),
         5: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "timer_duration",
-            TuyaDPType.VALUE,
         ),
         6: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "timer_time_left",
-            TuyaDPType.VALUE,
         ),
         11: DPToAttributeMapping(
             TuyaPowerConfigurationCluster.ep_attribute,
             "battery_percentage_remaining",
-            TuyaDPType.VALUE,
         ),
         108: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "frost_lock",
-            TuyaDPType.BOOL,
             lambda x: not x,  # invert for lock entity
         ),
         109: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "frost_lock_reset",
-            TuyaDPType.BOOL,
         ),
     }
 
@@ -289,52 +275,42 @@ class GiexValveManufCluster(TuyaMCUCluster):
         1: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "irrigation_mode",
-            dp_type=TuyaDPType.BOOL,
         ),
         2: DPToAttributeMapping(
             TuyaOnOffNM.ep_attribute,
             "on_off",
-            dp_type=TuyaDPType.BOOL,
         ),
         101: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "irrigation_start_time",
-            dp_type=TuyaDPType.VALUE,
         ),
         102: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "irrigation_end_time",
-            dp_type=TuyaDPType.VALUE,
         ),
         103: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "irrigation_num_times",
-            dp_type=TuyaDPType.VALUE,
         ),
         104: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "irrigation_target",
-            dp_type=TuyaDPType.VALUE,
         ),
         105: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "irrigation_interval",
-            dp_type=TuyaDPType.VALUE,
         ),
         108: DPToAttributeMapping(
             TuyaPowerConfigurationCluster.ep_attribute,
             "battery_percentage_remaining",
-            dp_type=TuyaDPType.VALUE,
         ),
         111: DPToAttributeMapping(
             TuyaValveWaterConsumed.ep_attribute,
             "current_summ_delivered",
-            dp_type=TuyaDPType.VALUE,
         ),
         114: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "irrigation_duration",
-            dp_type=TuyaDPType.VALUE,
         ),
     }
 


### PR DESCRIPTION
This is also a part separated from #2017 

This PR adds the `tuya.TuyaData.__init__()` constructor that automatically maps TuyaData.dp_type from zigpy type. That allows to remove the `dp_type` field from the `tuya.mcu.DPToAttributeMapping` mapping which may simplify the things.

This is up to the developers to decide whether this is needed or not.