### PR TITLE
Fix lumi plug maus01 energy monitoring and configuration

### DIFF
--- a/zhaquirks/xiaomi/aqara/plug_maus01.py
+++ b/zhaquirks/xiaomi/aqara/plug_maus01.py
@@ -26,13 +26,14 @@ from zhaquirks.const import (
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    SKIP_CONFIGURATION,
 )
 from zhaquirks.xiaomi import (
     LUMI,
     AnalogInputCluster,
     BasicCluster,
     ElectricalMeasurementCluster,
+    MeteringCluster,
+    XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
 )
 
@@ -106,7 +107,6 @@ class Plug(XiaomiCustomDevice):
         },
     }
     replacement = {
-        SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -122,6 +122,8 @@ class Plug(XiaomiCustomDevice):
                     BinaryOutput.cluster_id,
                     Time.cluster_id,
                     ElectricalMeasurementCluster,
+                    XiaomiAqaraE1Cluster,
+                    MeteringCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
             },


### PR DESCRIPTION
This PR removes the skip configuration flag and adds 2 missing clusters so that energy monitoring works correctly. There are several other functions supported by the device that I'll add in a subsequent PR. 

<img width="407" alt="image" src="https://user-images.githubusercontent.com/1335687/210271392-1e7a10fb-12af-4f84-ad09-bd7a664431c2.png">
