### PR TITLE
Fix reported values for Tuya Air sensor

### DIFF
--- a/zhaquirks/tuya/air/__init__.py
+++ b/zhaquirks/tuya/air/__init__.py
@@ -52,9 +52,9 @@ class TuyaCO2ManufCluster(TuyaNewManufCluster):
 
     dp_to_attribute: Dict[int, DPToAttributeMapping] = {
         2: DPToAttributeMapping(
-            TuyaAirQualityCO2.ep_attribute,
+            TuyaAirQualityFormaldehyde.ep_attribute,
             "measured_value",
-            lambda x: x * 1e-6,
+            lambda x: x * 1e-9,
         ),
         18: DPToAttributeMapping(
             TuyaAirQualityTemperature.ep_attribute, "measured_value", lambda x: x * 10
@@ -66,7 +66,7 @@ class TuyaCO2ManufCluster(TuyaNewManufCluster):
             TuyaAirQualityVOC.ep_attribute, "measured_value", lambda x: x * 1e-6
         ),
         22: DPToAttributeMapping(
-            TuyaAirQualityFormaldehyde.ep_attribute,
+            TuyaAirQualityCO2.ep_attribute,
             "measured_value",
             lambda x: x * 1e-6,
         ),


### PR DESCRIPTION
CO2 and Formaldehyd values were mixed up. Also the formaldehyd value always reported wrong values, I can prove it by being still alive :)

The formaldehyd value is now in the 0.00X ppm range normaly. That means we need also the increase the decimals in HA zha/sensor.py from 0 to 3 or the value will always be zero.  Shall I create also a pull request for HA?

@cloudbr34k84 you seem to had the same problem in https://github.com/zigpy/zha-device-handlers/issues/1313 , could you verify that this is solving the issue for you as well?