### PR TITLE
Add color support for Tint E14 RGB CCT lights

### DIFF
--- a/zhaquirks/mli/tintE14rgbcct.py
+++ b/zhaquirks/mli/tintE14rgbcct.py
@@ -1,0 +1,113 @@
+"""Tint E14 RGB CCT."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    Scenes,
+)
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class TintRGBCCTColorCluster(CustomCluster, Color):
+    """Tint RGB+CCT Lighting custom cluster."""
+
+    # Set correct capabilities to ct, xy, hs
+    # Tint bulbs do not correctly report this attribute
+    _CONSTANT_ATTRIBUTES = {0x400A: 0b11111}
+
+
+class TintRGBCCTLight(CustomDevice):
+    """Tint E14 RGB+CCT Lighting device."""
+
+    signature = {
+        MODELS_INFO: [("MLI", "tint-ExtendedColor")],
+        ENDPOINTS: {
+            1: {
+                #   "profile_id": 260,
+                #   "device_type": "0x010d",
+                #   "in_clusters": [
+                #     "0x0000",
+                #     "0x0003",
+                #     "0x0004",
+                #     "0x0005",
+                #     "0x0006",
+                #     "0x0008",
+                #     "0x0300",
+                #     "0x1000",
+                #     "0x100f"
+                #   ],
+                #   "out_clusters": [
+                #     "0x0019"
+                #   ]
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.EXTENDED_COLOR_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                    4111,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                #   "profile_id": 41440,
+                #   "device_type": "0x0061",
+                #   "in_clusters": [],
+                #   "out_clusters": [
+                #     "0x0021"
+                #   ]
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.EXTENDED_COLOR_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    TintRGBCCTColorCluster,
+                    LightLink.cluster_id,
+                    4111,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }

--- a/zhaquirks/mli/tintE14rgbcct.py
+++ b/zhaquirks/mli/tintE14rgbcct.py
@@ -23,7 +23,10 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 
-MANUFACTURER_SPECIFIC_CLUSTER_ID = 0x100F  # decimal = 4111
+
+class TintManufacturerSpecificCluster(CustomCluster):
+    """Tint manufacturer specific cluster."""
+    cluster_id = 0x100F  # not inside the manufacturer specific cluster range
 
 
 class TintRGBCCTColorCluster(CustomCluster, Color):
@@ -41,22 +44,6 @@ class TintRGBCCTLight(CustomDevice):
         MODELS_INFO: [("MLI", "tint-ExtendedColor")],
         ENDPOINTS: {
             1: {
-                #   "profile_id": 260,
-                #   "device_type": "0x010d",
-                #   "in_clusters": [
-                #     "0x0000",
-                #     "0x0003",
-                #     "0x0004",
-                #     "0x0005",
-                #     "0x0006",
-                #     "0x0008",
-                #     "0x0300",
-                #     "0x1000",
-                #     "0x100f"
-                #   ],
-                #   "out_clusters": [
-                #     "0x0019"
-                #   ]
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.EXTENDED_COLOR_LIGHT,
                 INPUT_CLUSTERS: [
@@ -68,17 +55,11 @@ class TintRGBCCTLight(CustomDevice):
                     LevelControl.cluster_id,
                     Color.cluster_id,
                     LightLink.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                    TintManufacturerSpecificCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
             242: {
-                #   "profile_id": 41440,
-                #   "device_type": "0x0061",
-                #   "in_clusters": [],
-                #   "out_clusters": [
-                #     "0x0021"
-                #   ]
                 PROFILE_ID: 41440,
                 DEVICE_TYPE: 97,
                 INPUT_CLUSTERS: [],
@@ -101,7 +82,7 @@ class TintRGBCCTLight(CustomDevice):
                     LevelControl.cluster_id,
                     TintRGBCCTColorCluster,
                     LightLink.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                    TintManufacturerSpecificCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },

--- a/zhaquirks/mli/tintE14rgbcct.py
+++ b/zhaquirks/mli/tintE14rgbcct.py
@@ -26,6 +26,7 @@ from zhaquirks.const import (
 
 class TintManufacturerSpecificCluster(CustomCluster):
     """Tint manufacturer specific cluster."""
+    
     cluster_id = 0x100F  # not inside the manufacturer specific cluster range
 
 

--- a/zhaquirks/mli/tintE14rgbcct.py
+++ b/zhaquirks/mli/tintE14rgbcct.py
@@ -26,7 +26,7 @@ from zhaquirks.const import (
 
 class TintManufacturerSpecificCluster(CustomCluster):
     """Tint manufacturer specific cluster."""
-    
+
     cluster_id = 0x100F  # not inside the manufacturer specific cluster range
 
 

--- a/zhaquirks/mli/tintE14rgbcct.py
+++ b/zhaquirks/mli/tintE14rgbcct.py
@@ -23,6 +23,8 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 
+MANUFACTURER_SPECIFIC_CLUSTER_ID = 0x100F  # decimal = 4111
+
 
 class TintRGBCCTColorCluster(CustomCluster, Color):
     """Tint RGB+CCT Lighting custom cluster."""
@@ -66,7 +68,7 @@ class TintRGBCCTLight(CustomDevice):
                     LevelControl.cluster_id,
                     Color.cluster_id,
                     LightLink.cluster_id,
-                    4111,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -99,7 +101,7 @@ class TintRGBCCTLight(CustomDevice):
                     LevelControl.cluster_id,
                     TintRGBCCTColorCluster,
                     LightLink.cluster_id,
-                    4111,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },

--- a/zhaquirks/mli/tintE14rgbcct.py
+++ b/zhaquirks/mli/tintE14rgbcct.py
@@ -35,7 +35,7 @@ class TintRGBCCTColorCluster(CustomCluster, Color):
 
     # Set correct capabilities to ct, xy, hs
     # Tint bulbs do not correctly report this attribute
-    _CONSTANT_ATTRIBUTES = {0x400A: 0b11111}
+    _CONSTANT_ATTRIBUTES = {0x400A: 0b11110}
 
 
 class TintRGBCCTLight(CustomDevice):


### PR DESCRIPTION
Related to #1773 

Add color capabilities to Tint E14 lights

the device is: https://zigbee.blakadder.com/Muller_Licht_404019.html

