### PR TITLE
Add yet another version of Tuya air sensor.

### DIFF
--- a/zhaquirks/tuya/air/ts0601_air_quality.py
+++ b/zhaquirks/tuya/air/ts0601_air_quality.py
@@ -85,6 +85,7 @@ class TuyaCO2SensorGPP(CustomDevice):
             ("_TZE200_ryfmq5rl", "TS0601"),
             ("_TZE200_yvx5lh6k", "TS0601"),
             ("_TZE200_dwcarsat", "TS0601"),
+            ("_TZE200_c2fmom5z", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
This one is square and black.

Device ID:
TS0601
_TZE200_c2fmom5z