### PR TITLE
Add yet another TS0043 variant

### DIFF
--- a/zhaquirks/tuya/ts0043.py
+++ b/zhaquirks/tuya/ts0043.py
@@ -192,6 +192,103 @@ class TuyaSmartRemote0043TO(CustomDevice):
     }
 
 
+class TuyaSmartRemote0043TOPlusA(CustomDevice):
+    """Tuya 3-button remote device with time on out cluster."""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0, device_version=1, input_clusters=[0, 1, 6, 57344], output_clusters=[10, 25]))
+        # SizePrefixedSimpleDescriptor(endpoint=2, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
+        # SizePrefixedSimpleDescriptor(endpoint=3, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
+        # SizePrefixedSimpleDescriptor(endpoint=4, profile=260, device_type=0, device_version=1, input_clusters=[1, 6], output_clusters=[])
+        MODEL: "TS0043",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                    TuyaZBE000Cluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                    TuyaZBE000Cluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    PowerConfiguration.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
+        (SHORT_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: DOUBLE_PRESS},
+        (SHORT_PRESS, BUTTON_3): {ENDPOINT_ID: 3, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_3): {ENDPOINT_ID: 3, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_3): {ENDPOINT_ID: 3, COMMAND: DOUBLE_PRESS},
+    }
+
+
 class TuyaSmartRemote0043TOPlusB(CustomDevice):
     """Tuya 3-button remote device with time on out cluster."""
 


### PR DESCRIPTION
This one reports four on/off switches , just like the `TuyaSmartRemote0042TOPlusA` does, and also in general the profile looks just like that (except with one more physical button). Thus I named this quirk `TuyaSmartRemote0043TOPlusA`.

However, I did deviate in the modelling of the replacement endpoints, and instead of copying them from the TS0042 variant, I decided to model them more closely on the other TS0043 variants. (I have no clue if that's a good or bad idea, advice is highly welcome, I am new to this).

I got it [from AliExpress](https://de.aliexpress.com/item/1005004775066234.html?spm=a2g0o.order_list.order_list_main.47.42b45c5fBbHuxw&gatewayAdapt=glo2deu). 

![Tuya-ZigBee-Wireless-Wand-Schalter-1-2-3Gang-Wifi-Automatisierung-Push-Taste-Batterie-Powered-Zigbee-Gateway jpg_640x640](https://user-images.githubusercontent.com/241512/211172226-c5f50662-428b-4a63-ba4f-a5d53bcd3f82.jpg)

The profile looks like what was reported on issue #1699 so perhaps this PR fixes that, too, although there we have `"manufacturer": "_TZ3000_uyjmm0et",`  while for mine the id is `_TZ3000_w3c7ouru`.

Likewise, issue #1683 with `_TZ3000_kkahwiyu` probably is resolved by this.

Finally, I think issue #1557 is related, and a similar quirk ought to be added for TS0041, but I don't have such a device to test.
