### PR TITLE
Add quirk for extended on/off cluster of TS011F _TYZB01_hlla45kx

### DIFF
--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1,7 +1,8 @@
 """TS011F plug."""
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
@@ -33,6 +34,13 @@ from zhaquirks.tuya import (
     TuyaZBOnOffAttributeCluster,
 )
 from zhaquirks.tuya.mcu import EnchantedDevice
+
+
+class TuyaZBOnOffChildLockAttributeCluster(CustomCluster, OnOff):
+    """Tuya Zigbee On Off cluster with extra child-lock attribute."""
+
+    attributes = OnOff.attributes.copy()
+    attributes.update({0x8000: ("child_lock", t.Bool)})
 
 
 class Plug(EnchantedDevice):
@@ -1072,7 +1080,7 @@ class Plug_2AC_hlla45kx(CustomDevice):
                     Time.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaZBOnOffAttributeCluster,
+                    TuyaZBOnOffChildLockAttributeCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -1082,8 +1090,9 @@ class Plug_2AC_hlla45kx(CustomDevice):
                 INPUT_CLUSTERS: [
                     Groups.cluster_id,
                     Scenes.cluster_id,
+                    OnOff.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
-            }
+            },
         },
     }

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1036,7 +1036,7 @@ class Plug_2AC_hlla45kx(CustomDevice):
     """Tuya 2 outlet with child lock support."""
 
     signature = {
-        MODEL: "TS011F",
+        MODELS_INFO: [("_TYZB01_hlla45kx", "TS011F")],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=9
             # device_version=0

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1022,3 +1022,69 @@ class Plug_4AC_2USB_Metering(EnchantedDevice):
             },
         },
     }
+
+
+class Plug_2AC_hlla45kx(CustomDevice):
+    """Tuya 2 outlet with child lock support."""
+
+    signature = {
+        MODEL: "TS011F",
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=9
+            # device_version=0
+            # input_clusters=[0, 10, 4, 5, 6]
+            # output_clusters=[25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Time.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=9
+            # device_version=0
+            # input_clusters=[4, 5, 6]
+            # output_clusters=[]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            }
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Time.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster
+                ],
+                OUTPUT_CLUSTERS: [],
+            }
+        },
+    }

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1042,7 +1042,7 @@ class Plug_2AC_hlla45kx(CustomDevice):
                     Time.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    OnOff.cluster_id
+                    OnOff.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -1059,7 +1059,7 @@ class Plug_2AC_hlla45kx(CustomDevice):
                     OnOff.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
-            }
+            },
         },
     }
     replacement = {
@@ -1072,7 +1072,7 @@ class Plug_2AC_hlla45kx(CustomDevice):
                     Time.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaZBOnOffAttributeCluster
+                    TuyaZBOnOffAttributeCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -1082,7 +1082,6 @@ class Plug_2AC_hlla45kx(CustomDevice):
                 INPUT_CLUSTERS: [
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaZBOnOffAttributeCluster
                 ],
                 OUTPUT_CLUSTERS: [],
             }


### PR DESCRIPTION
Sold in the UK as the [Scolmore ClickSmart+ 30036](https://zigbee.blakadder.com/ClickSmart_CMA30036.html) Double Socket this device [supports](https://github.com/Koenkk/zigbee2mqtt/discussions/10831#discussioncomment-2137035) a child-lock / key-guard function which is enabled by using the Tuya extended on/off cluster.