### PR TITLE
Add quirk for extended on/off cluster of TS011F _TYZB01_hlla45kx

### DIFF
--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1071,3 +1071,69 @@ class Plug_v2(EnchantedDevice):
             },
         },
     }
+
+
+class Plug_2AC_hlla45kx(CustomDevice):
+    """Tuya 2 outlet with child lock support."""
+
+    signature = {
+        MODEL: "TS011F",
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=9
+            # device_version=0
+            # input_clusters=[0, 10, 4, 5, 6]
+            # output_clusters=[25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Time.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=9
+            # device_version=0
+            # input_clusters=[4, 5, 6]
+            # output_clusters=[]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            }
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Time.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster
+                ],
+                OUTPUT_CLUSTERS: [],
+            }
+        },
+    }

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1,7 +1,8 @@
 """TS011F plug."""
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
@@ -34,6 +35,13 @@ from zhaquirks.tuya import (
     TuyaZBOnOffAttributeCluster,
 )
 from zhaquirks.tuya.mcu import EnchantedDevice
+
+
+class TuyaZBOnOffChildLockAttributeCluster(CustomCluster, OnOff):
+    """Tuya Zigbee On Off cluster with extra child-lock attribute."""
+
+    attributes = OnOff.attributes.copy()
+    attributes.update({0x8000: ("child_lock", t.Bool)})
 
 
 class Plug(EnchantedDevice):
@@ -1121,7 +1129,7 @@ class Plug_2AC_hlla45kx(CustomDevice):
                     Time.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaZBOnOffAttributeCluster,
+                    TuyaZBOnOffChildLockAttributeCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -1131,8 +1139,9 @@ class Plug_2AC_hlla45kx(CustomDevice):
                 INPUT_CLUSTERS: [
                     Groups.cluster_id,
                     Scenes.cluster_id,
+                    OnOff.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
-            }
+            },
         },
     }

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -2,7 +2,6 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
-import zigpy.types as t
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1085,7 +1085,7 @@ class Plug_2AC_hlla45kx(CustomDevice):
     """Tuya 2 outlet with child lock support."""
 
     signature = {
-        MODEL: "TS011F",
+        MODELS_INFO: [("_TYZB01_hlla45kx", "TS011F")],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=9
             # device_version=0

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -26,6 +26,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import (
+    PowerOnState,
     TuyaNewManufCluster,
     TuyaZBE000Cluster,
     TuyaZBElectricalMeasurement,
@@ -35,13 +36,6 @@ from zhaquirks.tuya import (
     TuyaZBOnOffAttributeCluster,
 )
 from zhaquirks.tuya.mcu import EnchantedDevice
-
-
-class TuyaZBOnOffChildLockAttributeCluster(CustomCluster, OnOff):
-    """Tuya Zigbee On Off cluster with extra child-lock attribute."""
-
-    attributes = OnOff.attributes.copy()
-    attributes.update({0x8000: ("child_lock", t.Bool)})
 
 
 class Plug(EnchantedDevice):
@@ -1081,8 +1075,16 @@ class Plug_v2(EnchantedDevice):
     }
 
 
-class Plug_2AC_hlla45kx(CustomDevice):
-    """Tuya 2 outlet with child lock support."""
+class TuyaZBOnOffVariantCluster(CustomCluster, OnOff):
+    """Tuya Zigbee On Off cluster variant with only child-lock and power-restore state attributes."""
+
+    attributes = OnOff.attributes.copy()
+    attributes.update({0x8000: ("child_lock", t.Bool)})
+    attributes.update({0x8002: ("power_on_state", PowerOnState)})
+
+
+class Plug_2AC_var03(CustomDevice):
+    """Tuya 2 socket wall outlet with child lock and power-restore state support."""
 
     signature = {
         MODELS_INFO: [("_TYZB01_hlla45kx", "TS011F")],
@@ -1129,7 +1131,7 @@ class Plug_2AC_hlla45kx(CustomDevice):
                     Time.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaZBOnOffChildLockAttributeCluster,
+                    TuyaZBOnOffVariantCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1,7 +1,7 @@
 """TS011F plug."""
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomDevice
 import zigpy.types as t
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -26,7 +26,6 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import (
-    PowerOnState,
     TuyaNewManufCluster,
     TuyaZBE000Cluster,
     TuyaZBElectricalMeasurement,
@@ -1075,19 +1074,11 @@ class Plug_v2(EnchantedDevice):
     }
 
 
-class TuyaZBOnOffVariantCluster(CustomCluster, OnOff):
-    """Tuya Zigbee On Off cluster variant with only child-lock and power-restore state attributes."""
-
-    attributes = OnOff.attributes.copy()
-    attributes.update({0x8000: ("child_lock", t.Bool)})
-    attributes.update({0x8002: ("power_on_state", PowerOnState)})
-
-
 class Plug_2AC_var03(CustomDevice):
     """Tuya 2 socket wall outlet with child lock and power-restore state support."""
 
     signature = {
-        MODELS_INFO: [("_TYZB01_hlla45kx", "TS011F")],
+        MODEL: "TS011F",
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=9
             # device_version=0
@@ -1131,7 +1122,11 @@ class Plug_2AC_var03(CustomDevice):
                     Time.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaZBOnOffVariantCluster,
+                    # N.B. The ClickSmart CMA30036 (_TYZB01_hlla45kx), supports
+                    #      but does not implement the backlight_mode extended
+                    #      attribute. For this device, changing this attribute
+                    #      has no effect on the switch lights.
+                    TuyaZBOnOffAttributeCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1091,7 +1091,7 @@ class Plug_2AC_hlla45kx(CustomDevice):
                     Time.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    OnOff.cluster_id
+                    OnOff.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -1108,7 +1108,7 @@ class Plug_2AC_hlla45kx(CustomDevice):
                     OnOff.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
-            }
+            },
         },
     }
     replacement = {
@@ -1121,7 +1121,7 @@ class Plug_2AC_hlla45kx(CustomDevice):
                     Time.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaZBOnOffAttributeCluster
+                    TuyaZBOnOffAttributeCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -1131,7 +1131,6 @@ class Plug_2AC_hlla45kx(CustomDevice):
                 INPUT_CLUSTERS: [
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaZBOnOffAttributeCluster
                 ],
                 OUTPUT_CLUSTERS: [],
             }


### PR DESCRIPTION
Rebased [PR#2080](https://github.com/zigpy/zha-device-handlers/pull/2080)

Sold in the UK as the [Scolmore ClickSmart+ 30036](https://zigbee.blakadder.com/ClickSmart_CMA30036.html) Double Socket this device [supports](https://github.com/Koenkk/zigbee2mqtt/discussions/10831#discussioncomment-2137035) a child-lock / key-guard function which is enabled by using a Tuya extended on/off cluster.