### PR TITLE
Adding new / old TS0011 and TS0013 version.

### DIFF
--- a/zhaquirks/tuya/ts001x.py
+++ b/zhaquirks/tuya/ts001x.py
@@ -21,6 +21,7 @@ from zhaquirks.tuya import (
 from zhaquirks.tuya.mcu import EnchantedDevice
 
 
+# NoNeutralSwitch family = without tuya cluster and Identify.
 class TuyaSingleNoNeutralSwitch(EnchantedDevice, TuyaSwitch):
     """Tuya 1 gang no neutral light switch."""
 
@@ -138,80 +139,6 @@ class TuyaDoubleNoNeutralSwitch(EnchantedDevice, TuyaSwitch):
     }
 
 
-class TuyaDoubleNoNeutralSwitch_2(EnchantedDevice, TuyaSwitch):
-    """Tuya 2 gang no neutral light switch (v2)."""
-
-    signature = {
-        # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098,
-        # maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264,
-        # maximum_outgoing_transfer_size=82, descriptor_capability_field=0)
-        # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098,
-        # maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264,
-        # maximum_outgoing_transfer_size=82, descriptor_capability_field=0)"
-        MODEL: "TS0012",
-        ENDPOINTS: {
-            # <SimpleDescriptor endpoint=1 profile=260 device_type=100
-            # device_version=1
-            # input_clusters=["0x0000", "0x0003", "0x0004", "0x0005", "0x0006"]
-            # output_clusters=["0x000a", "0x0019"]>
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
-            },
-            # <SimpleDescriptor endpoint=2 profile=260 device_type=100
-            # device_version=1
-            # input_clusters=[4, 5, 6]
-            # output_clusters=[]>
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
-
-    replacement = {
-        SKIP_CONFIGURATION: True,
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    TuyaZBOnOffAttributeCluster,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    TuyaZBOnOffAttributeCluster,
-                ],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
-
-
 class TuyaTripleNoNeutralSwitch(EnchantedDevice, TuyaSwitch):
     """Tuya 3 gang no neutral light switch."""
 
@@ -308,6 +235,226 @@ class TuyaTripleNoNeutralSwitch(EnchantedDevice, TuyaSwitch):
     }
 
 
+# Switch_2 family = Normal NoNeutralSwitch (without tuya cluster) and with Identify.
+class TuyaSingleNoNeutralSwitch_2(EnchantedDevice, TuyaSwitch):
+    """Tuya 1 gang no neutral light switch (v2)."""
+
+    signature = {
+        # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098,
+        # maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264,
+        # maximum_outgoing_transfer_size=82, descriptor_capability_field=0)
+        MODEL: "TS0011",
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=100
+            # device_version=1
+            # input_clusters=[0, 3, 4, 5, 6]
+            # output_clusters=[a, 19]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        SKIP_CONFIGURATION: True,
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }
+
+
+class TuyaDoubleNoNeutralSwitch_2(EnchantedDevice, TuyaSwitch):
+    """Tuya 2 gang no neutral light switch (v2)."""
+
+    signature = {
+        # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098,
+        # maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264,
+        # maximum_outgoing_transfer_size=82, descriptor_capability_field=0)
+        # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098,
+        # maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264,
+        # maximum_outgoing_transfer_size=82, descriptor_capability_field=0)"
+        MODEL: "TS0012",
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=100
+            # device_version=1
+            # input_clusters=["0x0000", "0x0003", "0x0004", "0x0005", "0x0006"]
+            # output_clusters=["0x000a", "0x0019"]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=100
+            # device_version=1
+            # input_clusters=[4, 5, 6]
+            # output_clusters=[]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        SKIP_CONFIGURATION: True,
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+
+class Tuya_TripleNoNeutralSwitch_2(EnchantedDevice, TuyaSwitch):
+    """Tuya 3 gang no neutral light switch (v2)."""
+
+    signature = {
+        # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098,
+        # maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264,
+        # maximum_outgoing_transfer_size=82, descriptor_capability_field=0)
+        # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098,
+        # maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264,
+        # maximum_outgoing_transfer_size=82, descriptor_capability_field=0)"
+        MODEL: "TS0013",
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=100
+            # device_version=1
+            # input_clusters=[0, 3, 4, 5, 6]
+            # output_clusters=[a, 19]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=100
+            # device_version=1
+            # input_clusters=[4, 5, 6]
+            # output_clusters=[]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            # <SimpleDescriptor endpoint=3 profile=260 device_type=100
+            # device_version=1
+            # input_clusters=[4, 5, 6]
+            # output_clusters=[]>
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        SKIP_CONFIGURATION: True,
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+
+# No Neutral switches with tuya clusters.
 class Tuya_Single_No_N(EnchantedDevice, TuyaSwitch):
     """Tuya 1 gang no neutral light switch."""
 


### PR DESCRIPTION
Putting in comments for 2 family and adding TS0011 and TS0013 to the current TS0012 version.

Looks like have making changing of other classes but i have moving then together in family:

```
# NoNeutralSwitch family = without tuya cluster and Identify.
# Switch_2 family = Normal NoNeutralSwitch (without tuya cluster) and with Identify.

```
Other with tuya clusters is not touched.