### PR TITLE
Add initial support for Insta NEXENTRO Pushbutton Interface

### DIFF
--- a/zhaquirks/insta/__init__.py
+++ b/zhaquirks/insta/__init__.py
@@ -1,0 +1,3 @@
+"""Module for Insta quirks implementations."""
+
+INSTA = "Insta GmbH"

--- a/zhaquirks/insta/nexentro_pushbutton_interface.py
+++ b/zhaquirks/insta/nexentro_pushbutton_interface.py
@@ -1,0 +1,176 @@
+"""Device handler for Insta NEXENTRO Pushbutton Interface."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import Basic, Identify, Groups, Scenes, OnOff, LevelControl, Ota, GreenPowerProxy
+from zigpy.zcl.clusters.lighting import Color
+
+from zhaquirks import MODELS_INFO, ENDPOINTS, PROFILE_ID, DEVICE_TYPE, INPUT_CLUSTERS, OUTPUT_CLUSTERS
+from zhaquirks.const import SHORT_PRESS, TURN_ON, COMMAND, COMMAND_ON, TURN_OFF, COMMAND_OFF, COMMAND_TOGGLE, BUTTON, \
+    OPEN, CLOSE, COMMAND_MOVE_ON_OFF, DIM_UP, COMMAND_MOVE, DIM_DOWN, COMMAND_STOP, STOP, ENDPOINT_ID, ALT_SHORT_PRESS
+from zhaquirks.insta import INSTA
+
+COMMAND_OPEN = "up_open"
+COMMAND_CLOSE = "down_close"
+COMMAND_STORE = "store"
+COMMAND_RECALL = "recall"
+
+
+class InstaNexentroPushbuttonInterface(CustomDevice):
+    signature = {
+        MODELS_INFO: [(INSTA, "NEXENTRO Pushbutton Interface")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=4 profile=260 device_type=261
+            # device_version=1
+            # input_clusters=[0, 3]
+            # output_clusters=[3, 4, 5, 6, 8, 25, 768]>
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    Color.cluster_id,
+                ],
+            },
+            # <SimpleDescriptor endpoint=5 profile=260 device_type=261
+            # device_version=1
+            # input_clusters=[0, 3]
+            # output_clusters=[3, 4, 5, 6, 8, 25, 768]>
+            5: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    Color.cluster_id,
+                ],
+            },
+            # <SimpleDescriptor endpoint=7 profile=260 device_type=515
+            # device_version=1
+            # input_clusters=[0, 3]
+            # output_clusters=[3, 4, 25, 258]>
+            7: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Ota.cluster_id,
+                    WindowCovering.cluster_id,
+                ],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # device_version=1
+            # input_clusters=[]
+            # output_clusters=[33]>
+            242: {
+                PROFILE_ID: 0xA1E0,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [
+                ],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id
+                ],
+            }
+        }
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    Color.cluster_id,
+                ],
+            },
+            5: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    Color.cluster_id,
+                ],
+            },
+            7: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Ota.cluster_id,
+                    WindowCovering.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: 0xA1E0,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [
+                ],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id
+                ],
+            }
+        }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, ENDPOINT_ID: 4},
+        (ALT_SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, ENDPOINT_ID: 5},
+        (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 4},
+        (ALT_SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 5},
+        (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 4},
+        (ALT_SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 5},
+        (SHORT_PRESS, OPEN): {COMMAND: COMMAND_OPEN},
+        (SHORT_PRESS, CLOSE): {COMMAND: COMMAND_CLOSE},
+        (SHORT_PRESS, DIM_UP): {COMMAND: COMMAND_MOVE_ON_OFF, ENDPOINT_ID: 4},
+        (ALT_SHORT_PRESS, DIM_UP): {COMMAND: COMMAND_MOVE_ON_OFF, ENDPOINT_ID: 5},
+        (SHORT_PRESS, DIM_DOWN): {COMMAND: COMMAND_MOVE, ENDPOINT_ID: 4},
+        (ALT_SHORT_PRESS, DIM_DOWN): {COMMAND: COMMAND_MOVE, ENDPOINT_ID: 5},
+        (SHORT_PRESS, STOP): {COMMAND: COMMAND_STOP, ENDPOINT_ID: 4},
+        (ALT_SHORT_PRESS, STOP): {COMMAND: COMMAND_STOP, ENDPOINT_ID: 5},
+    }

--- a/zhaquirks/insta/nexentro_pushbutton_interface.py
+++ b/zhaquirks/insta/nexentro_pushbutton_interface.py
@@ -2,12 +2,46 @@
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.closures import WindowCovering
-from zigpy.zcl.clusters.general import Basic, Identify, Groups, Scenes, OnOff, LevelControl, Ota, GreenPowerProxy
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    Scenes,
+)
 from zigpy.zcl.clusters.lighting import Color
 
-from zhaquirks import MODELS_INFO, ENDPOINTS, PROFILE_ID, DEVICE_TYPE, INPUT_CLUSTERS, OUTPUT_CLUSTERS
-from zhaquirks.const import SHORT_PRESS, TURN_ON, COMMAND, COMMAND_ON, TURN_OFF, COMMAND_OFF, COMMAND_TOGGLE, BUTTON, \
-    OPEN, CLOSE, COMMAND_MOVE_ON_OFF, DIM_UP, COMMAND_MOVE, DIM_DOWN, COMMAND_STOP, STOP, ENDPOINT_ID, ALT_SHORT_PRESS
+from zhaquirks import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.const import (
+    ALT_SHORT_PRESS,
+    BUTTON,
+    CLOSE,
+    COMMAND,
+    COMMAND_MOVE,
+    COMMAND_MOVE_ON_OFF,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_STOP,
+    COMMAND_TOGGLE,
+    DIM_DOWN,
+    DIM_UP,
+    ENDPOINT_ID,
+    OPEN,
+    SHORT_PRESS,
+    STOP,
+    TURN_OFF,
+    TURN_ON,
+)
 from zhaquirks.insta import INSTA
 
 COMMAND_OPEN = "up_open"
@@ -17,6 +51,8 @@ COMMAND_RECALL = "recall"
 
 
 class InstaNexentroPushbuttonInterface(CustomDevice):
+    """Insta NEXENTRO Pushbutton Interface device."""
+
     signature = {
         MODELS_INFO: [(INSTA, "NEXENTRO Pushbutton Interface")],
         ENDPOINTS: {
@@ -87,13 +123,10 @@ class InstaNexentroPushbuttonInterface(CustomDevice):
             242: {
                 PROFILE_ID: 0xA1E0,
                 DEVICE_TYPE: 0x0061,
-                INPUT_CLUSTERS: [
-                ],
-                OUTPUT_CLUSTERS: [
-                    GreenPowerProxy.cluster_id
-                ],
-            }
-        }
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
     }
 
     replacement = {
@@ -149,12 +182,9 @@ class InstaNexentroPushbuttonInterface(CustomDevice):
             242: {
                 PROFILE_ID: 0xA1E0,
                 DEVICE_TYPE: 0x0061,
-                INPUT_CLUSTERS: [
-                ],
-                OUTPUT_CLUSTERS: [
-                    GreenPowerProxy.cluster_id
-                ],
-            }
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
         }
     }
 


### PR DESCRIPTION
This is my quirk which fixes #2084

I'm not sure about some of my design choices, so please leave a comment what do you think :)

This is the device:
![Probi_57004000_1024_1024](https://user-images.githubusercontent.com/11720038/213223796-d5e876d7-0249-4f31-aa05-1669ae28a9c2.png)

This is their app to control it:
![image](https://user-images.githubusercontent.com/11720038/213225827-5fcb3060-9881-4541-9bc5-b2187fef12ee.png)

- As you can use the two inputs E1 and E2 for most of the functions individually I used `SHORT_PRESS` for E1 and `ALT_SHORT_PRESS` for E2. Not sure what would be better
- The next thing is, that I don't know what the Control setting of the app should do. It sends these I events
```
<Event zha_event[L]: device_ieee=84:2e:14:ff:fe:a4:80:c1, unique_id=84:2e:14:ff:fe:a4:80:c1:4:0x0008, device_id=a751568436a0fe45653ef0d2ceae20f3, endpoint_id=4, cluster_id=8, command=move, args=[<MoveMode.Down: 1>, 51, <bitmap8.0: 0>, <bitmap8.0: 0>], params=move_mode=MoveMode.Down, rate=51, options_mask=bitmap8.0, options_override=bitmap8.0>
<Event zha_event[L]: device_ieee=84:2e:14:ff:fe:a4:80:c1, unique_id=84:2e:14:ff:fe:a4:80:c1:4:0x0008, device_id=a751568436a0fe45653ef0d2ceae20f3, endpoint_id=4, cluster_id=8, command=move_with_on_off, args=[<MoveMode.Up: 0>, 51], params=move_mode=MoveMode.Up, rate=51>
<Event zha_event[L]: device_ieee=84:2e:14:ff:fe:a4:80:c1, unique_id=84:2e:14:ff:fe:a4:80:c1:4:0x0008, device_id=a751568436a0fe45653ef0d2ceae20f3, endpoint_id=4, cluster_id=8, command=stop, args=[<bitmap8.0: 0>, <bitmap8.0: 0>], params=options_mask=bitmap8.0, options_override=bitmap8.0>
```
  I mapped it to DIM, but I'm not sure if it's correct.
- I'm really confused about the scene mode. I don't know what it should do. It sendd some weird events:
```
<Event zha_event[L]: device_ieee=84:2e:14:ff:fe:a4:80:c1, unique_id=84:2e:14:ff:fe:a4:80:c1:4:0x0005, device_id=a751568436a0fe45653ef0d2ceae20f3, endpoint_id=4, cluster_id=5, command=store, args=[0x8CEE, 0], params=group_id=0x8CEE, scene_id=0>
<Event zha_event[L]: device_ieee=84:2e:14:ff:fe:a4:80:c1, unique_id=84:2e:14:ff:fe:a4:80:c1:5:0x0005, device_id=a751568436a0fe45653ef0d2ceae20f3, endpoint_id=5, cluster_id=5, command=recall, args=[0xD475, 0, 10], params=group_id=0xD475, scene_id=0, transition_time=10>
```
- For the switch mode I used a button. It sends a `toggle`-command and I wasn't sure what fits the best.

Feel free to leave some improvement thoughts. It's my first quirk