### PR TITLE
Fix lumi.plug implementation

### DIFF
--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -331,6 +331,7 @@ class XiaomiCluster(CustomCluster):
                 }
             )
         elif self.endpoint.device.model in [
+            "lumi.plug",
             "lumi.plug.maus01",
             "lumi.plug.maeu01",
             "lumi.plug.mmeu01",

--- a/zhaquirks/xiaomi/aqara/plug.py
+++ b/zhaquirks/xiaomi/aqara/plug.py
@@ -2,7 +2,6 @@
 import logging
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster
 from zigpy.zcl.clusters.general import (
     AnalogInput,
     Basic,
@@ -37,25 +36,6 @@ from zhaquirks.xiaomi import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class AnalogInputClusterTotalPower(CustomCluster, AnalogInput):
-    """Analog input cluster, used to relay total power consumption information to Metering."""
-
-    cluster_id = AnalogInput.cluster_id
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self._current_state = {}
-        super().__init__(*args, **kwargs)
-
-    def _update_attribute(self, attrid, value):
-        super()._update_attribute(attrid, value)
-        # UNCOMMENT BELOW TO TEST 2nd PART OF POSSIBLE FIX
-        # if value is not None and value >= 0:
-        #     self.endpoint.device.consumption_bus.listener_event(
-        #         CONSUMPTION_REPORTED, value
-        #     )
 
 
 class Plug(XiaomiCustomDevice):
@@ -142,7 +122,7 @@ class Plug(XiaomiCustomDevice):
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.METER_INTERFACE,
-                INPUT_CLUSTERS: [AnalogInputClusterTotalPower],
+                INPUT_CLUSTERS: [AnalogInput.cluster_id],
                 OUTPUT_CLUSTERS: [AnalogInput.cluster_id],
             },
         },
@@ -236,7 +216,7 @@ class Plug2(XiaomiCustomDevice):
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.METER_INTERFACE,
-                INPUT_CLUSTERS: [AnalogInputClusterTotalPower],
+                INPUT_CLUSTERS: [AnalogInput.cluster_id],
                 OUTPUT_CLUSTERS: [AnalogInput.cluster_id],
             },
             100: {

--- a/zhaquirks/xiaomi/aqara/plug.py
+++ b/zhaquirks/xiaomi/aqara/plug.py
@@ -32,6 +32,7 @@ from zhaquirks.xiaomi import (
     AnalogInputCluster,
     BasicCluster,
     ElectricalMeasurementCluster,
+    MeteringCluster,
     XiaomiCustomDevice,
 )
 
@@ -128,6 +129,7 @@ class Plug(XiaomiCustomDevice):
                     BinaryOutput.cluster_id,
                     Time.cluster_id,
                     ElectricalMeasurementCluster,
+                    MeteringCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
             },

--- a/zhaquirks/xiaomi/aqara/plug.py
+++ b/zhaquirks/xiaomi/aqara/plug.py
@@ -223,6 +223,7 @@ class Plug2(XiaomiCustomDevice):
                     BinaryOutput.cluster_id,
                     Time.cluster_id,
                     ElectricalMeasurementCluster,
+                    MeteringCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
             },

--- a/zhaquirks/xiaomi/aqara/plug.py
+++ b/zhaquirks/xiaomi/aqara/plug.py
@@ -2,9 +2,11 @@
 import logging
 
 from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster
 from zigpy.zcl.clusters.general import (
     AnalogInput,
     Basic,
+    BinaryInput,
     BinaryOutput,
     DeviceTemperature,
     Groups,
@@ -24,7 +26,6 @@ from zhaquirks.const import (
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    SKIP_CONFIGURATION,
 )
 from zhaquirks.xiaomi import (
     LUMI,
@@ -35,6 +36,25 @@ from zhaquirks.xiaomi import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class AnalogInputClusterTotalPower(CustomCluster, AnalogInput):
+    """Analog input cluster, used to relay total power consumption information to Metering."""
+
+    cluster_id = AnalogInput.cluster_id
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self._current_state = {}
+        super().__init__(*args, **kwargs)
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        # UNCOMMENT BELOW TO TEST 2nd PART OF POSSIBLE FIX
+        # if value is not None and value >= 0:
+        #     self.endpoint.device.consumption_bus.listener_event(
+        #         CONSUMPTION_REPORTED, value
+        #     )
 
 
 class Plug(XiaomiCustomDevice):
@@ -93,7 +113,6 @@ class Plug(XiaomiCustomDevice):
         },
     }
     replacement = {
-        SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -121,8 +140,107 @@ class Plug(XiaomiCustomDevice):
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.METER_INTERFACE,
+                INPUT_CLUSTERS: [AnalogInputClusterTotalPower],
+                OUTPUT_CLUSTERS: [AnalogInput.cluster_id],
+            },
+        },
+    }
+
+
+class Plug2(XiaomiCustomDevice):
+    """lumi.plug with alternative signature."""
+
+    signature = {
+        MODELS_INFO: Plug.signature[MODELS_INFO],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=81
+            # device_version=1
+            # input_clusters=[0, 4, 3, 6, 16, 5, 10, 1, 2]
+            # output_clusters=[25, 10]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    DeviceTemperature.cluster_id,
+                    Groups.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    Scenes.cluster_id,
+                    BinaryOutput.cluster_id,
+                    Time.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=9
+            # device_version=1
+            # input_clusters=[12]
+            # output_clusters=[12, 4]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
+                INPUT_CLUSTERS: [AnalogInput.cluster_id],
+                OUTPUT_CLUSTERS: [AnalogInput.cluster_id, Groups.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=3 profile=260 device_type=83
+            # device_version=1
+            # input_clusters=[12]
+            # output_clusters=[12]>
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.METER_INTERFACE,
                 INPUT_CLUSTERS: [AnalogInput.cluster_id],
                 OUTPUT_CLUSTERS: [AnalogInput.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=100 profile=260 device_type=263
+            # device_version=1
+            # input_clusters=[15]
+            # output_clusters=[4, 15]>
+            100: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                INPUT_CLUSTERS: [BinaryInput.cluster_id],
+                OUTPUT_CLUSTERS: [Groups.cluster_id, BinaryInput.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    PowerConfiguration.cluster_id,
+                    DeviceTemperature.cluster_id,
+                    Groups.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    Scenes.cluster_id,
+                    BinaryOutput.cluster_id,
+                    Time.cluster_id,
+                    ElectricalMeasurementCluster,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
+                INPUT_CLUSTERS: [AnalogInputCluster],
+                OUTPUT_CLUSTERS: [AnalogInput.cluster_id, Groups.cluster_id],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.METER_INTERFACE,
+                INPUT_CLUSTERS: [AnalogInputClusterTotalPower],
+                OUTPUT_CLUSTERS: [AnalogInput.cluster_id],
+            },
+            100: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                INPUT_CLUSTERS: [BinaryInput.cluster_id],
+                OUTPUT_CLUSTERS: [Groups.cluster_id, BinaryInput.cluster_id],
             },
         },
     }


### PR DESCRIPTION
This quirk is for the (Australian/Chinese?) Xiaomi `lumi.plug` model.

The PR correctly implements the "total summation delivered" sensor (similar to EU plug implementation).
It also adds another signature for the plug.

The changes were tested as a custom quirk and seem to be working: https://github.com/zigpy/zha-device-handlers/issues/1135#issuecomment-1384890259

Fixes https://github.com/zigpy/zha-device-handlers/issues/1135, fixes https://github.com/zigpy/zha-device-handlers/issues/1049
Already closed but also properly fixes https://github.com/zigpy/zha-device-handlers/issues/515, fixes https://github.com/zigpy/zha-device-handlers/issues/397

Superseeds old PR: https://github.com/zigpy/zha-device-handlers/pull/1211

--- 

NOTE: The old `AnalogInput` sensors (introduced as a workaround) could/should also be removed from ZHA after merging, as all Xiaomi plugs have proper entities available with this quirk then. See:
- https://github.com/home-assistant/core/pull/86261