### PR TITLE
Add "long release event" for IKEA 5-button remotes

### DIFF
--- a/zhaquirks/ikea/fivebtnremote.py
+++ b/zhaquirks/ikea/fivebtnremote.py
@@ -27,6 +27,8 @@ from zhaquirks.const import (
     COMMAND_RELEASE,
     COMMAND_STEP,
     COMMAND_STEP_ON_OFF,
+    COMMAND_STOP,
+    COMMAND_STOP_ON_OFF,
     COMMAND_TOGGLE,
     DEVICE_TYPE,
     DIM_DOWN,
@@ -36,6 +38,7 @@ from zhaquirks.const import (
     INPUT_CLUSTERS,
     LEFT,
     LONG_PRESS,
+    LONG_RELEASE,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PARAMS,
@@ -137,6 +140,11 @@ class IkeaTradfriRemote1(CustomDevice):
             ENDPOINT_ID: 1,
             PARAMS: {"move_mode": 0},
         },
+        (LONG_RELEASE, DIM_UP): {
+            COMMAND: COMMAND_STOP_ON_OFF,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+        },
         (SHORT_PRESS, DIM_DOWN): {
             COMMAND: COMMAND_STEP,
             CLUSTER_ID: 8,
@@ -148,6 +156,11 @@ class IkeaTradfriRemote1(CustomDevice):
             CLUSTER_ID: 8,
             ENDPOINT_ID: 1,
             PARAMS: {"move_mode": 1},
+        },
+        (LONG_RELEASE, DIM_DOWN): {
+            COMMAND: COMMAND_STOP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
         },
         (SHORT_PRESS, LEFT): {
             COMMAND: COMMAND_PRESS,


### PR DESCRIPTION
Adds "long release triggers" for up and down buttons.

~~Also do a refactor to avoid copy pasting triggers definition, since they are mostly the same.~~
-> Refactor done in https://github.com/zigpy/zha-device-handlers/pull/2155

This is tested with the very first version of the remote, the one defined in `fivebtnremote.py`.