### PR TITLE
add "ep_attribute = "tuya_window_covering" in TS130F quirk

### DIFF
--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -42,6 +42,8 @@ class TuyaWithBacklightOnOffCluster(CustomCluster):
 class TuyaCoveringCluster(CustomCluster, WindowCovering):
     """TuyaSmartCurtainWindowCoveringCluster: Allow to setup Window covering tuya devices."""
 
+    ep_attribute = "tuya_window_covering"
+
     attributes = WindowCovering.attributes.copy()
     attributes.update({0xF000: ("tuya_moving_state", t.enum8)})
     attributes.update({0xF001: ("calibration", t.enum8)})


### PR DESCRIPTION
fixes #2120

overwrite the ep_attribute value for later use in HA and expose the configurable device attributes in the frontend.