### PR TITLE
Deleting _TZE200_2ekuz3dz

### DIFF
--- a/zhaquirks/tuya/ts0601_trv_sas.py
+++ b/zhaquirks/tuya/ts0601_trv_sas.py
@@ -277,7 +277,6 @@ class Thermostat_TZE200_c88teujp(TuyaThermostat):
             ("_TZE200_yw7cahqs", "TS0601"),
             ("_TZE200_9gvruqf5", "TS0601"),
             ("_TZE200_zuhszj9s", "TS0601"),
-            ("_TZE200_2ekuz3dz", "TS0601"),
             ("_TZE200_zr9c0day", "TS0601"),
             ("_TZE200_0dvm9mva", "TS0601"),
             ("_TZE200_h4cgnbzg", "TS0601"),


### PR DESCRIPTION
This ID is wrong its one Thermostat and have one working quirk. Then the thermostat is loaded before the TRV is also matching the thermostat and is not the TRV so its not braking any device onlyy fixing one old error.

https://github.com/zigpy/zha-device-handlers/blob/6b8cd2cd03804842765b37519622849d7c5ddb80/zhaquirks/tuya/ts0601_electric_heating.py#L144