### PR TITLE
Bump isort to 5.12.0 in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
           - pydocstyle==6.1.1
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 


### PR DESCRIPTION
See https://github.com/PyCQA/isort/issues/2077
Fixed by https://github.com/PyCQA/isort/pull/2078 in [isort 5.12.0](https://github.com/PyCQA/isort/releases/tag/5.12.0)

Will resolve the issue that https://github.com/zigpy/zha-device-handlers/pull/2146 runs into (when rebased)