### PR TITLE
HEIMAN SmokeSensor-N-3.0 support & Update import

### DIFF
--- a/zhaquirks/heiman/smoke.py
+++ b/zhaquirks/heiman/smoke.py
@@ -226,21 +226,6 @@ class HeimanSmokeN30(CustomDevice):
     }
 
     replacement = {
-        NODE_DESCRIPTOR: zigpy.zdo.types.NodeDescriptor(
-            logical_type=2,
-            complex_descriptor_available=0,
-            user_descriptor_available=0,
-            reserved=0,
-            aps_flags=0,
-            frequency_band=8,
-            mac_capability_flags=128 & 0b1111_1011,
-            manufacturer_code=4619,
-            maximum_buffer_size=127,
-            maximum_incoming_transfer_size=100,
-            server_mask=11264,
-            maximum_outgoing_transfer_size=100,
-            descriptor_capability_field=0,
-        ),
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/heiman/smoke.py
+++ b/zhaquirks/heiman/smoke.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.general import Alarms, Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.security import IasWd, IasZone
 import zigpy.zdo.types

--- a/zhaquirks/heiman/smoke.py
+++ b/zhaquirks/heiman/smoke.py
@@ -2,8 +2,8 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.general import Alarms, Basic, Identify, Ota, PowerConfiguration
+from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.security import IasWd, IasZone
 import zigpy.zdo.types
 

--- a/zhaquirks/heiman/smoke.py
+++ b/zhaquirks/heiman/smoke.py
@@ -1,6 +1,6 @@
 """Smoke Sensor."""
 
-import zigpy.profiles.zha
+from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Alarms, Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.security import IasWd, IasZone
@@ -30,8 +30,8 @@ class HeimanSmokYDLV10(CustomDevice):
         MODELS_INFO: [(HEIMAN, "SMOK_YDLV10")],
         ENDPOINTS: {
             1: {
-                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
-                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.IAS_ZONE,
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
@@ -53,8 +53,8 @@ class HeimanSmokYDLV10(CustomDevice):
         ),
         ENDPOINTS: {
             1: {
-                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
-                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.IAS_ZONE,
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
@@ -89,8 +89,8 @@ class HeimanSmokCO_V15(CustomDevice):
             # "in_clusters": ["0x0000","0x0001","0x0003","0x0009","0x0500"],
             # "out_clusters": ["0x0019"]
             1: {
-                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
-                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.IAS_ZONE,
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
@@ -111,8 +111,8 @@ class HeimanSmokCO_V15(CustomDevice):
         ),
         ENDPOINTS: {
             1: {
-                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
-                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.IAS_ZONE,
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
@@ -139,8 +139,8 @@ class HeimanSmokCO_CTPG(CustomDevice):
                 # "device_type": "0x0402",
                 # "in_clusters": ["0x0000","0x0001","0x0003","0x0009","0x0500"]
                 # "out_clusters": ["0x0019"]
-                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
-                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.IAS_ZONE,
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
@@ -173,14 +173,83 @@ class HeimanSmokCO_CTPG(CustomDevice):
         ),
         ENDPOINTS: {
             1: {
-                PROFILE_ID: zigpy.profiles.zha.PROFILE_ID,
-                DEVICE_TYPE: zigpy.profiles.zha.DeviceType.IAS_ZONE,
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+
+class HeimanSmokeN30(CustomDevice):
+    """SmokeN30 quirk."""
+
+    # NodeDescriptor(
+    #     logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0,
+    #     frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>,
+    #     manufacturer_code=4619, maximum_buffer_size=127, maximum_incoming_transfer_size=100, server_mask=11264, maximum_outgoing_transfer_size=100,
+    #     descriptor_capability_field=<DescriptorCapability.NONE: 0>,
+    #     *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False,
+    #     *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)
+    signature = {
+        MODELS_INFO: [("HEIMAN", "SmokeSensor-N-3.0")],
+        ENDPOINTS: {
+            # "profile_id": 260,"device_type": "0x0402",
+            # "in_clusters": ["0x0000","0x0001","0x0003","0x0500","0x0502","0x0b05"],
+            # "out_clusters": ["0x0019"]
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                    IasWd.cluster_id,
+                    Diagnostic.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        NODE_DESCRIPTOR: zigpy.zdo.types.NodeDescriptor(
+            logical_type=2,
+            complex_descriptor_available=0,
+            user_descriptor_available=0,
+            reserved=0,
+            aps_flags=0,
+            frequency_band=8,
+            mac_capability_flags=128 & 0b1111_1011,
+            manufacturer_code=4619,
+            maximum_buffer_size=127,
+            maximum_incoming_transfer_size=100,
+            server_mask=11264,
+            maximum_outgoing_transfer_size=100,
+            descriptor_capability_field=0,
+        ),
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                    Diagnostic.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Ota.cluster_id,


### PR DESCRIPTION
The quirk to support HEIMAN SmokeSensor-N-3.0.

The device is exposing IasWd cluster which is not applicable for this device.
Before fix:
![Screenshot 2023-01-31 at 17 28 46](https://user-images.githubusercontent.com/630000/215852188-9286706d-05dd-462c-9ff9-63071b29f056.png)

After fix:
![Screenshot 2023-01-31 at 19 27 41](https://user-images.githubusercontent.com/630000/215852462-2307cf36-684c-4337-b98a-1d67f0c96372.png)

An additional small change is a way the zha.profiles are imported.