### PR TITLE
Bump zigpy

### DIFF
--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -13,4 +13,4 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.52
+zigpy>=0.53

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     keywords="zha quirks homeassistant hass",
     packages=find_packages(exclude=["tests"]),
     python_requires=">=3.8",
-    install_requires=["zigpy>=0.52"],
+    install_requires=["zigpy>=0.53"],
     tests_require=["pytest"],
 )


### PR DESCRIPTION
Zigpy 0.53 introduces big-endian types, which will help us simplify some of the code that reimplements them.