### PR TITLE
Deduplicate Xiaomi plug constructor

### DIFF
--- a/zhaquirks/xiaomi/aqara/plug.py
+++ b/zhaquirks/xiaomi/aqara/plug.py
@@ -129,15 +129,8 @@ class Plug(XiaomiCustomDevice):
     }
 
 
-class Plug2(XiaomiCustomDevice):
+class Plug2(Plug):
     """lumi.plug with alternative signature."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.voltage_bus = Bus()
-        self.consumption_bus = Bus()
-        self.power_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         MODELS_INFO: Plug.signature[MODELS_INFO],


### PR DESCRIPTION
The constructor is the same in `Plug` and this also makes the `plug.py` quirk more similar to the `plug_eu.py` quirk.