### PR TITLE
Add "consumer connected" attribute to Xiaomi EU plugs

### DIFF
--- a/zhaquirks/xiaomi/aqara/plug_eu.py
+++ b/zhaquirks/xiaomi/aqara/plug_eu.py
@@ -68,6 +68,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     attributes = {
         0x0009: ("mode", types.uint8_t, True),
         0x0201: ("power_outage_memory", types.Bool, True),
+        0x0207: ("consumer_connected", types.Bool, True),
     }
     # This only exists on older firmware versions. Newer versions always have the behavior as if this was set to true
     attr_config = {0x0009: 0x01}


### PR DESCRIPTION
For zha-quirks, this fixes https://github.com/zigpy/zha-device-handlers/issues/2181
Follow-up PR for ZHA to create the binary sensor:
- https://github.com/home-assistant/core/pull/88194

Tested using a Xiaomi `MAEU01` plug on v32 and v41 firmware. 
https://github.com/zigpy/zha-device-handlers/issues/2181 mentions it also works on an `MMEU01` plug (so the other Xiaomi EU plug).