### PR TITLE
Clean up IKEA quirks

### DIFF
--- a/zhaquirks/ikea/shortcutbtn.py
+++ b/zhaquirks/ikea/shortcutbtn.py
@@ -37,7 +37,12 @@ from zhaquirks.const import (
     SHORT_PRESS,
     TURN_ON,
 )
-from zhaquirks.ikea import IKEA, LightLinkCluster, PowerConfiguration1CRCluster
+from zhaquirks.ikea import (
+    IKEA,
+    IKEA_CLUSTER_ID,
+    LightLinkCluster,
+    PowerConfiguration1CRCluster,
+)
 
 
 class IkeaTradfriShortcutBtn(CustomDevice):
@@ -137,7 +142,7 @@ class IkeaTradfriShortcutBtn2(CustomDevice):
                     Alarms.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,
-                    0xFC7C,  # IKEA Cluster
+                    IKEA_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,

--- a/zhaquirks/ikea/tradfriplug.py
+++ b/zhaquirks/ikea/tradfriplug.py
@@ -13,6 +13,14 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
 from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID
 
 
@@ -20,14 +28,15 @@ class TradfriPlug(CustomDevice):
     """Tradfri Plug."""
 
     signature = {
-        "endpoints": {
+        MODELS_INFO: [(IKEA, "TRADFRI control outlet")],
+        ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=266
             # device_version=0
             # input_clusters=[0, 3, 4, 5, 6, 8, 64636] output_clusters=[5, 25, 32]>
             1: {
-                "profile_id": zha.PROFILE_ID,
-                "device_type": zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
-                "input_clusters": [
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
@@ -36,7 +45,7 @@ class TradfriPlug(CustomDevice):
                     LevelControl.cluster_id,
                     IKEA_CLUSTER_ID,
                 ],
-                "output_clusters": [
+                OUTPUT_CLUSTERS: [
                     Scenes.cluster_id,
                     Ota.cluster_id,
                     PollControl.cluster_id,
@@ -46,30 +55,29 @@ class TradfriPlug(CustomDevice):
             # device_version=0
             # input_clusters=[4096] output_clusters=[4096]>
             2: {
-                "profile_id": 0xC05E,
-                "device_type": zll.DeviceType.ON_OFF_PLUGIN_UNIT,
-                "input_clusters": [LightLink.cluster_id],
-                "output_clusters": [LightLink.cluster_id],
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.ON_OFF_PLUGIN_UNIT,
+                INPUT_CLUSTERS: [LightLink.cluster_id],
+                OUTPUT_CLUSTERS: [LightLink.cluster_id],
             },
             # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
             # device_version=0
             # input_clusters=[33] output_clusters=[33]>
             242: {
-                "profile_id": 0xA1E0,
-                "device_type": 0x0061,
-                "input_clusters": [33],
-                "output_clusters": [33],
+                PROFILE_ID: 0xA1E0,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [33],
+                OUTPUT_CLUSTERS: [33],
             },
         },
-        "manufacturer": IKEA,
     }
 
     replacement = {
-        "endpoints": {
+        ENDPOINTS: {
             1: {
-                "profile_id": zha.PROFILE_ID,
-                "device_type": zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
-                "input_clusters": [
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
@@ -77,7 +85,7 @@ class TradfriPlug(CustomDevice):
                     OnOff.cluster_id,
                     IKEA_CLUSTER_ID,
                 ],
-                "output_clusters": [
+                OUTPUT_CLUSTERS: [
                     Scenes.cluster_id,
                     Ota.cluster_id,
                     PollControl.cluster_id,


### PR DESCRIPTION
- use constant in the shortcut button quirk

This mostly cleans up the IKEA TRADFRI plug quirk:
- use constants instead of strings
- add model name (so we're not only matching on manufacturer and cluster signature)

I think this quirk is only used for older TRADFRI plug firmware versions, but it would be good to also have the newer signature, as that still exposes the `LevelControl` cluster IIRC (and we should probably remove that, as ZHA creates a bunch of config entities for that).