### PR TITLE
Add Smartwings WM25L-Z quirk

### DIFF
--- a/tests/test_smartwings.py
+++ b/tests/test_smartwings.py
@@ -1,0 +1,30 @@
+"""Tests for Smartwings."""
+from unittest import mock
+
+import pytest
+from zigpy.zcl.clusters.closures import WindowCovering
+
+from zhaquirks.smartwings.wm25lz import WM25LBlinds
+
+
+@pytest.mark.parametrize("quirk", (WM25LBlinds,))
+async def test_smartwings_inverted_commands(zigpy_device_from_quirk, quirk):
+    """Test that the Smartwings WM25/L-Z blind quirk inverts the up/down commands."""
+
+    device = zigpy_device_from_quirk(quirk)
+    device.request = mock.AsyncMock()
+
+    covering_cluster = device.endpoints[1].window_covering
+
+    close_command_id = WindowCovering.commands_by_name["down_close"].id
+    open_command_id = WindowCovering.commands_by_name["up_open"].id
+
+    # close cover and check if the command is inverted
+    await covering_cluster.command(close_command_id)
+    assert len(device.request.mock_calls) == 1
+    assert device.request.mock_calls[0][1][5] == b"\x01\x01\x00"
+
+    # open cover and check if the command is inverted
+    await covering_cluster.command(open_command_id)
+    assert len(device.request.mock_calls) == 2
+    assert device.request.mock_calls[1][1][5] == b"\x01\x02\x01"

--- a/zhaquirks/smartwings/__init__.py
+++ b/zhaquirks/smartwings/__init__.py
@@ -1,0 +1,1 @@
+"""SmartWings devices."""

--- a/zhaquirks/smartwings/wm25-l-z.py
+++ b/zhaquirks/smartwings/wm25-l-z.py
@@ -41,6 +41,7 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
         self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None
     ):
         """Override default command to invert percent lift value."""
+
         if command_id == self.CMD_GO_TO_LIFT_PERCENTAGE:
             percent = args[0]
             # Invert the percentage value

--- a/zhaquirks/smartwings/wm25-l-z.py
+++ b/zhaquirks/smartwings/wm25-l-z.py
@@ -1,0 +1,103 @@
+"""Device handler for Smartwings WM25L-Z blinds."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    Ota,
+    PowerConfiguration,
+    Scenes,
+)
+
+from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
+    """WindowCovering cluster implementation.
+    This implementation inverts the reported covering percent for non standard
+    devices that don't follow the reporting spec.
+    """
+
+    cluster_id = WindowCovering.cluster_id
+    CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
+    CMD_GO_TO_LIFT_PERCENTAGE = 0x0005
+
+    def _update_attribute(self, attrid, value):
+        if attrid == self.CURRENT_POSITION_LIFT_PERCENTAGE:
+            value = 100 - value
+        super()._update_attribute(attrid, value)
+
+    async def command(
+        self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None
+    ):
+        """Override default command to invert percent lift value."""
+        if command_id == self.CMD_GO_TO_LIFT_PERCENTAGE:
+            percent = args[0]
+            # Invert the percentage value
+            percent = 100 - percent
+            v = (percent,)
+            return await super().command(command_id, *v)
+        return await super().command(
+            command_id,
+            *args,
+            manufacturer=manufacturer,
+            expect_reply=expect_reply,
+            tsn=tsn
+        )
+
+
+class WM25LBlinds(CustomDevice):
+    """Custom device representing Smartwings WM25/L-Z roller blinds."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=514
+        # device_version=1
+        # input_clusters=[0, 1, 3, 4, 5, 32, 258]
+        # output_clusters=[3, 25]>
+        MODELS_INFO: [
+            ("Smartwings", "WM25/L-Z"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    WindowCovering.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DoublingPowerConfigurationCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    InvertedWindowCoveringCluster,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
+            }
+        }
+    }

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -38,6 +38,7 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
         *args,
         manufacturer=None,
         expect_reply=True,
+        tries=1,
         tsn=None,
         **kwargs
     ):
@@ -53,6 +54,7 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
             *args,
             manufacturer=manufacturer,
             expect_reply=expect_reply,
+            tries=tries,
             tsn=tsn,
             **kwargs,
         )

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -30,11 +30,17 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
     """
 
     cluster_id = WindowCovering.cluster_id
-    CMD_GO_UP = 0x0001 #reported as down_close in ZHA commands
-    CMD_GO_DOWN = 0x0000 #reported as up_open in ZHA commands
-    
+    CMD_GO_UP = 0x0001  # reported as down_close in ZHA commands
+    CMD_GO_DOWN = 0x0000  # reported as up_open in ZHA commands
+
     async def command(
-        self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None, **kwargs
+        self,
+        command_id,
+        *args,
+        manufacturer=None,
+        expect_reply=True,
+        tsn=None,
+        **kwargs
     ):
         """Override default commands for up and down. they are backwards."""
 
@@ -50,6 +56,7 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
             tsn=tsn,
             **kwargs,
         )
+
 
 class WM25LBlinds(CustomDevice):
     """Custom device representing Smartwings WM25LZ blinds."""

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -1,4 +1,4 @@
-"""Device handler for Smartwings WM25L-Z blinds."""
+"""Device handler for Smartwings blinds."""
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy.zcl.clusters.closures import WindowCovering
@@ -58,7 +58,7 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
 
 
 class WM25LBlinds(CustomDevice):
-    """Custom device representing Smartwings WM25/L-Z roller blinds."""
+    """Custom device representing Smartwings WM25LZ blinds."""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=514

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -30,11 +30,11 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
     """
 
     cluster_id = WindowCovering.cluster_id
-    CMD_GO_UP = 0x0001  # reported as down_close in ZHA commands
-    CMD_GO_DOWN = 0x0000  # reported as up_open in ZHA commands
-
+    CMD_GO_UP = 0x0001 #reported as down_close in ZHA commands
+    CMD_GO_DOWN = 0x0000 #reported as up_open in ZHA commands
+    
     async def command(
-        self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None
+        self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None, **kwargs
     ):
         """Override default commands for up and down. they are backwards."""
 
@@ -47,9 +47,9 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
             *args,
             manufacturer=manufacturer,
             expect_reply=expect_reply,
-            tsn=tsn
+            tsn=tsn,
+            **kwargs,
         )
-
 
 class WM25LBlinds(CustomDevice):
     """Custom device representing Smartwings WM25LZ blinds."""

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -1,6 +1,10 @@
 """Device handler for Smartwings blinds."""
+from typing import Any
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -30,13 +34,13 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
 
     async def command(
         self,
-        command_id,
+        command_id: foundation.GeneralCommand | int | t.uint8_t,
         *args,
-        manufacturer=None,
-        expect_reply=True,
-        tries=1,
-        tsn=None,
-        **kwargs
+        manufacturer: int | t.uint16_t | None = None,
+        expect_reply: bool = True,
+        tries: int = 1,
+        tsn: int | t.uint8_t | None = None,
+        **kwargs: Any,
     ):
         """Override default commands for up and down. They need to be backwards."""
         # swap up and down commands

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -23,9 +23,11 @@ from zhaquirks.const import (
 
 
 class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
-    """WindowCovering cluster implementation.
+    """
+    WindowCovering cluster implementation.
     This implementation inverts the reported covering percent for non standard
-    devices that don't follow the reporting spec."""
+    devices that don't follow the reporting spec.
+    """
 
     cluster_id = WindowCovering.cluster_id
     CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -1,4 +1,6 @@
 """Device handler for Smartwings blinds."""
+from __future__ import annotations
+
 from typing import Any
 
 from zigpy.profiles import zha

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -29,8 +29,8 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
     devices that don't follow the reporting spec.
     """
 
-    CMD_GO_UP = WindowCovering.commands_by_name["down_close"].id
-    CMD_GO_DOWN = WindowCovering.commands_by_name["up_open"].id
+    CMD_UP_OPEN = WindowCovering.commands_by_name["up_open"].id
+    CMD_DOWN_CLOSE = WindowCovering.commands_by_name["down_close"].id
 
     async def command(
         self,
@@ -42,12 +42,12 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
         tsn=None,
         **kwargs
     ):
-        """Override default commands for up and down. they are backwards."""
-
-        if command_id == self.CMD_GO_UP:
-            command_id = self.CMD_GO_DOWN
-        elif command_id == self.CMD_GO_DOWN:
-            command_id = self.CMD_GO_UP
+        """Override default commands for up and down. They need to be backwards."""
+        # swap up and down commands
+        if command_id == self.CMD_UP_OPEN:
+            command_id = self.CMD_DOWN_CLOSE
+        elif command_id == self.CMD_DOWN_CLOSE:
+            command_id = self.CMD_UP_OPEN
 
         return await super().command(
             command_id,

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -30,25 +30,18 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
     """
 
     cluster_id = WindowCovering.cluster_id
-    CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
-    CMD_GO_TO_LIFT_PERCENTAGE = 0x0005
-
-    def _update_attribute(self, attrid, value):
-        if attrid == self.CURRENT_POSITION_LIFT_PERCENTAGE:
-            value = 100 - value
-        super()._update_attribute(attrid, value)
+    CMD_GO_UP = 0x0001  # reported as down_close in ZHA commands
+    CMD_GO_DOWN = 0x0000  # reported as up_open in ZHA commands
 
     async def command(
         self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None
     ):
-        """Override default command to invert percent lift value."""
+        """Override default commands for up and down. they are backwards."""
 
-        if command_id == self.CMD_GO_TO_LIFT_PERCENTAGE:
-            percent = args[0]
-            # Invert the percentage value
-            percent = 100 - percent
-            v = (percent,)
-            return await super().command(command_id, *v)
+        if command_id == self.CMD_GO_UP:
+            return await super().command(self.CMD_GO_DOWN, *args)
+        if command_id == self.CMD_GO_DOWN:
+            return await super().command(self.CMD_GO_UP, *args)
         return await super().command(
             command_id,
             *args,

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -23,11 +23,7 @@ from zhaquirks.const import (
 
 
 class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
-    """WindowCovering cluster implementation.
-
-    This implementation inverts the reported covering percent for non standard
-    devices that don't follow the reporting spec.
-    """
+    """This WindowCovering cluster implementation inverts the commands for up and down."""
 
     CMD_UP_OPEN = WindowCovering.commands_by_name["up_open"].id
     CMD_DOWN_CLOSE = WindowCovering.commands_by_name["down_close"].id

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -1,7 +1,7 @@
 """Device handler for Smartwings blinds."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Coroutine
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -43,7 +43,7 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
         tries: int = 1,
         tsn: int | t.uint8_t | None = None,
         **kwargs: Any,
-    ):
+    ) -> Coroutine:
         """Override default commands for up and down. They need to be backwards."""
         # swap up and down commands
         if command_id == self.CMD_UP_OPEN:

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -23,8 +23,8 @@ from zhaquirks.const import (
 
 
 class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
-    """
-    WindowCovering cluster implementation.
+    """WindowCovering cluster implementation.
+
     This implementation inverts the reported covering percent for non standard
     devices that don't follow the reporting spec.
     """

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -29,9 +29,8 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
     devices that don't follow the reporting spec.
     """
 
-    cluster_id = WindowCovering.cluster_id
-    CMD_GO_UP = 0x0001  # reported as down_close in ZHA commands
-    CMD_GO_DOWN = 0x0000  # reported as up_open in ZHA commands
+    CMD_GO_UP = WindowCovering.commands_by_name["down_close"].id
+    CMD_GO_DOWN = WindowCovering.commands_by_name["up_open"].id
 
     async def command(
         self,
@@ -45,9 +44,10 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
         """Override default commands for up and down. they are backwards."""
 
         if command_id == self.CMD_GO_UP:
-            return await super().command(self.CMD_GO_DOWN, *args)
-        if command_id == self.CMD_GO_DOWN:
-            return await super().command(self.CMD_GO_UP, *args)
+            command_id = self.CMD_GO_DOWN
+        elif command_id == self.CMD_GO_DOWN:
+            command_id = self.CMD_GO_UP
+
         return await super().command(
             command_id,
             *args,

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -25,8 +25,7 @@ from zhaquirks.const import (
 class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
     """WindowCovering cluster implementation.
     This implementation inverts the reported covering percent for non standard
-    devices that don't follow the reporting spec.
-    """
+    devices that don't follow the reporting spec."""
 
     cluster_id = WindowCovering.cluster_id
     CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008


### PR DESCRIPTION
Fixes: #1689 

Initial support for Smartwings blinds/shades - they all seem to use the same zigbee motor/variant. In some or all cases the the blinds need to be inverted with the included physical RF remote as per the instructions included with the blinds/shades.

Thanks to @warllo54 and @haywiremk for the actual work here, this was pulled for #1689 and it works for me 😀

