### PR TITLE
Update GitHub stale action to v7

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,7 +24,7 @@ jobs:
           operations-per-run: 150
           remove-stale-when-updated: true
           stale-issue-label: "stale"
-          exempt-issue-labels: "no-stale,help-wanted"
+          exempt-issue-labels: "no stale,help wanted"
           stale-issue-message: >
             There hasn't been any activity on this issue recently. Due to the
             high number of incoming GitHub notifications, we have to clean some
@@ -36,7 +36,7 @@ jobs:
             This issue has now been marked as stale and will be closed if no
             further activity occurs. Thank you for your contributions.
           stale-pr-label: "stale"
-          exempt-pr-labels: "no-stale"
+          exempt-pr-labels: "no stale"
           stale-pr-message: >
             There hasn't been any activity on this pull request recently. This
             pull request has been automatically marked as stale because of that
@@ -52,14 +52,14 @@ jobs:
         uses: actions/stale@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          only-labels: "needs-more-information"
+          only-labels: "needs more information"
           days-before-stale: 60
           days-before-close: 7
           days-before-pr-close: -1
           operations-per-run: 50
           remove-stale-when-updated: true
           stale-issue-label: "stale"
-          exempt-issue-labels: "no-stale,help-wanted"
+          exempt-issue-labels: "no stale,help wanted"
           stale-issue-message: >
             There hasn't been any activity on this issue recently. Due to the
             high number of incoming GitHub notifications, we have to clean some

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
       # - No PRs marked as no-stale
       # - No issues marked as no-stale or help-wanted
       - name: 180 days stale issues & PRs policy
-        uses: actions/stale@v4
+        uses: actions/stale@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 180
@@ -49,7 +49,7 @@ jobs:
       # - No Issues marked as no-stale or help-wanted
       # - No PRs (-1)
       - name: Needs more information stale issues policy
-        uses: actions/stale@v4
+        uses: actions/stale@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           only-labels: "needs-more-information"


### PR DESCRIPTION
This updates the GitHub stale action from v4 to v7.
Starting with v6, the action now closes issues with "not_planned" instead of "completed" as the reason (so a grey icon instead of the magenta colored one).

Furthermore, the labels for the issues that should be kept open (even if stale) are also updated to reflect the label changes which contain spaces.
(This should be working, as https://github.com/actions/stale/issues/98 was supposedly fixed. If it does not, dashes will have to be added to those labels and changed here too. It's not really an issue though, as none/few issues/PRs have this label applied.)

This also fixes: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
and it fixes: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Changelog: https://github.com/actions/stale/releases (v5, v6, v7)