### PR TITLE
Update "PyPi Publish" GitHub action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,12 +19,12 @@ jobs:
         python3 setup.py sdist bdist_wheel
     - name: Publish distribution to Test PyPI
       if: startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_TEST_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution to PyPI
       if: startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
See https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-
This branch hasn't received proper updates since a year.