### PR TITLE
Adding missing TOGGLE = "Toggle"

### DIFF
--- a/zhaquirks/const.py
+++ b/zhaquirks/const.py
@@ -104,6 +104,7 @@ SHORT_PRESS = "remote_button_short_press"
 ALT_SHORT_PRESS = "remote_button_alt_short_press"
 SKIP_CONFIGURATION = SIG_SKIP_CONFIG
 SHORT_RELEASE = "remote_button_short_release"
+TOGGLE = "Toggle"
 TRIPLE_PRESS = "remote_button_triple_press"
 TURN_OFF = "turn_off"
 TURN_ON = "turn_on"


### PR DESCRIPTION
Command  `COMMAND_TOGGLE` is implanted but not one toggle button that making the command then pressing it.

I need it for Symfonsk 2 or must we implanting `Play`, `Next` and `Privies ` instead of Toggle, Right and Left button. pressed.

Device request with picture of the device  https://github.com/zigpy/zha-device-handlers/issues/2223