### PR TITLE
Changing battery to ZVL standard.

### DIFF
--- a/zhaquirks/ikea/fourbtnremote.py
+++ b/zhaquirks/ikea/fourbtnremote.py
@@ -214,7 +214,7 @@ class IkeaTradfriRemoteV2(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration2AAACluster,
+                    PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,


### PR DESCRIPTION
The remote is using ZCL standard as all other 23.X firmware controllers but have one bug that is making it sending 255 = not known or not valid reading.  Its is better getting 127% battery as 255% and hope IKEA is fixing the bug sooner or later.