### PR TITLE
Add quirk for IKEA SYMFONISK sound remote gen 2 (E2123)

### DIFF
--- a/tests/test_ikea.py
+++ b/tests/test_ikea.py
@@ -75,8 +75,8 @@ def test_ikea_starkvind_v2(assert_signature_matches_quirk):
     assert_signature_matches_quirk(zhaquirks.ikea.starkvind.IkeaSTARKVIND_v2, signature)
 
 
-def test_ikea_sound_remote_gen2(assert_signature_matches_quirk):
-    """Test new 'SYMFONISK sound remote gen2' signature is matched to its quirk."""
+def test_ikea_sound_remote_gen2_v1(assert_signature_matches_quirk):
+    """Test new 'SYMFONISK sound remote gen2' with V1.0.012 signature is matched to its quirk."""
 
     signature = {
         "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4476, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
@@ -105,9 +105,9 @@ def test_ikea_sound_remote_gen2(assert_signature_matches_quirk):
         },
         "manufacturer": "IKEA of Sweden",
         "model": "SYMFONISK sound remote gen2",
-        "class": "ikea.symfonisk.IkeaSYMFONISKRemote2",
+        "class": "ikea.symfonisk.IkeaSYMFONISKRemoteGen2V1",
     }
 
     assert_signature_matches_quirk(
-        zhaquirks.ikea.symfonisk.IkeaSYMFONISKRemote2, signature
+        zhaquirks.ikea.symfonisk.IkeaSYMFONISKRemoteGen2V1, signature
     )

--- a/tests/test_ikea.py
+++ b/tests/test_ikea.py
@@ -1,6 +1,7 @@
 """Tests for Ikea Starkvind quirks."""
 
 import zhaquirks.ikea.starkvind
+import zhaquirks.ikea.symfonisk
 
 
 def test_ikea_starkvind(assert_signature_matches_quirk):
@@ -72,3 +73,39 @@ def test_ikea_starkvind_v2(assert_signature_matches_quirk):
     }
 
     assert_signature_matches_quirk(zhaquirks.ikea.starkvind.IkeaSTARKVIND_v2, signature)
+
+
+def test_ikea_sound_remote_gen2(assert_signature_matches_quirk):
+    """Test new 'SYMFONISK sound remote gen2' signature is matched to its quirk."""
+
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4476, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 260,
+                "device_type": "0x0006",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0001",
+                    "0x0003",
+                    "0x0020",
+                    "0x1000",
+                    "0xfc57"
+                ],
+                "out_clusters": [
+                    "0x0003",
+                    "0x0004",
+                    "0x0006",
+                    "0x0008",
+                    "0x0019",
+                    "0x1000",
+                    "0xfc7f"
+                ]
+            }
+        },
+        "manufacturer": "IKEA of Sweden",
+        "model": "SYMFONISK sound remote gen2",
+        "class": "ikea.symfonisk.IkeaSYMFONISKRemote2",
+    }
+
+    assert_signature_matches_quirk(zhaquirks.ikea.symfonisk.IkeaSYMFONISKRemote2, signature)

--- a/tests/test_ikea.py
+++ b/tests/test_ikea.py
@@ -90,7 +90,7 @@ def test_ikea_sound_remote_gen2(assert_signature_matches_quirk):
                     "0x0003",
                     "0x0020",
                     "0x1000",
-                    "0xfc57"
+                    "0xfc57",
                 ],
                 "out_clusters": [
                     "0x0003",
@@ -99,8 +99,8 @@ def test_ikea_sound_remote_gen2(assert_signature_matches_quirk):
                     "0x0008",
                     "0x0019",
                     "0x1000",
-                    "0xfc7f"
-                ]
+                    "0xfc7f",
+                ],
             }
         },
         "manufacturer": "IKEA of Sweden",
@@ -108,4 +108,6 @@ def test_ikea_sound_remote_gen2(assert_signature_matches_quirk):
         "class": "ikea.symfonisk.IkeaSYMFONISKRemote2",
     }
 
-    assert_signature_matches_quirk(zhaquirks.ikea.symfonisk.IkeaSYMFONISKRemote2, signature)
+    assert_signature_matches_quirk(
+        zhaquirks.ikea.symfonisk.IkeaSYMFONISKRemote2, signature
+    )

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -9,7 +9,7 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Scenes, LevelControl
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from zhaquirks import DoublingPowerConfigurationCluster, Bus
+from zhaquirks import DoublingPowerConfigurationCluster
 
 from zhaquirks.const import ZHA_SEND_EVENT
 
@@ -125,8 +125,15 @@ class ShortcutCluster(CustomCluster):
 
         if hdr.command_id == 0x01:
             self.debug("%s: sending ZHA event", self.name)
+
+            event_args = {
+                "step_mode": (LevelControl.StepMode.Up if args.shortcut_mode == 1 else LevelControl.StepMode.Down),
+                "step_size": args.param1,
+                "transition_time": 0
+            }
+
             self.endpoint.device.levelcontrol_bus.listener_event(
-                "listener_event", ZHA_SEND_EVENT, "step_with_on_off", { "step_mode": (args.shortcut_mode - 1), "step_size": args.param1, "transition_time": 0}
+                "listener_event", ZHA_SEND_EVENT, "step_with_on_off", event_args
             )
 
 

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -86,10 +86,10 @@ class LevelControlCluster(CustomCluster, LevelControl):
         self.endpoint.device.levelcontrol_bus.add_listener(self)
 
 
-class ShortcutCluster(CustomCluster):
+class V1ShortcutCluster(CustomCluster):
     """Ikea Shortcut Button cluster."""
 
-    name = "ShortcutCluster"
+    name = "V1ShortcutCluster"
     cluster_id = 0xFC7F
 
     server_commands = {

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -1,16 +1,14 @@
 """Ikea module."""
 import logging
-
 from typing import Any, List, Optional, Union
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import Scenes, LevelControl
+from zigpy.zcl.clusters.general import LevelControl, Scenes
 from zigpy.zcl.clusters.lightlink import LightLink
 
 from zhaquirks import DoublingPowerConfigurationCluster
-
 from zhaquirks.const import ZHA_SEND_EVENT
 
 _LOGGER = logging.getLogger(__name__)
@@ -78,7 +76,7 @@ class ScenesCluster(CustomCluster, Scenes):
 
 
 class LevelControlCluster(CustomCluster, LevelControl):
-    """Ikea LevelControl Cluster for SYMFONISK Sound Control Gen2"""
+    """Ikea LevelControl Cluster for SYMFONISK sound remote Gen2."""
 
     cluster_id = LevelControl.cluster_id
 
@@ -102,7 +100,7 @@ class ShortcutCluster(CustomCluster):
                 "param1": t.int8s,
             },
             False,
-            is_manufacturer_specific=True
+            is_manufacturer_specific=True,
         ),
     }
 
@@ -127,9 +125,13 @@ class ShortcutCluster(CustomCluster):
             self.debug("%s: sending ZHA event", self.name)
 
             event_args = {
-                "step_mode": (LevelControl.StepMode.Up if args.shortcut_mode == 1 else LevelControl.StepMode.Down),
+                "step_mode": (
+                    LevelControl.StepMode.Up
+                    if args.shortcut_mode == 1
+                    else LevelControl.StepMode.Down
+                ),
                 "step_size": args.param1,
-                "transition_time": 0
+                "transition_time": 0,
             }
 
             self.endpoint.device.levelcontrol_bus.listener_event(

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -78,8 +78,6 @@ class ScenesCluster(CustomCluster, Scenes):
 class LevelControlCluster(CustomCluster, LevelControl):
     """Ikea LevelControl Cluster for SYMFONISK sound remote Gen2."""
 
-    cluster_id = LevelControl.cluster_id
-
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -75,15 +75,6 @@ class ScenesCluster(CustomCluster, Scenes):
     )
 
 
-class LevelControlCluster(CustomCluster, LevelControl):
-    """Ikea LevelControl Cluster for SYMFONISK sound remote Gen2."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.levelcontrol_bus.add_listener(self)
-
-
 class V1ShortcutCluster(CustomCluster):
     """Ikea Shortcut Button cluster."""
 
@@ -132,8 +123,8 @@ class V1ShortcutCluster(CustomCluster):
                 "transition_time": 0,
             }
 
-            self.endpoint.device.levelcontrol_bus.listener_event(
-                "listener_event", ZHA_SEND_EVENT, "step_with_on_off", event_args
+            self.endpoint.out_clusters[8].listener_event(
+                ZHA_SEND_EVENT, "step_with_on_off", event_args
             )
 
 

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -75,8 +75,16 @@ class ScenesCluster(CustomCluster, Scenes):
     )
 
 
+class V1ShortcutEventData(foundation.CommandSchema):
+    """Ikea Shortcut Button cluster event data for Variant 1."""
+
+    step_mode: LevelControl.StepMode
+    step_size: int
+    transition_time: int
+
+
 class V1ShortcutCluster(CustomCluster):
-    """Ikea Shortcut Button cluster."""
+    """Ikea Shortcut Button cluster for Variant 1."""
 
     name = "V1ShortcutCluster"
     cluster_id = 0xFC7F
@@ -113,15 +121,15 @@ class V1ShortcutCluster(CustomCluster):
         if hdr.command_id == 0x01:
             self.debug("%s: sending ZHA event", self.name)
 
-            event_args = {
-                "step_mode": (
+            event_args = V1ShortcutEventData(
+                step_mode=(
                     LevelControl.StepMode.Up
                     if args.shortcut_mode == 1
                     else LevelControl.StepMode.Down
                 ),
-                "step_size": args.param1,
-                "transition_time": 0,
-            }
+                step_size=args.param1,
+                transition_time=0,
+            )
 
             self.endpoint.out_clusters[8].listener_event(
                 ZHA_SEND_EVENT, "step_with_on_off", event_args

--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -305,31 +305,31 @@ class IkeaSYMFONISKRemoteGen2V1(CustomDevice):
         (SHORT_PRESS, BUTTON_1): {
             COMMAND: COMMAND_STEP_ON_OFF,
             CLUSTER_ID: 8,
-            "args": {"step_mode": 0, "step_size": 1},
+            PARAMS: {"step_mode": 0, "step_size": 1},
         },
         (SHORT_PRESS, BUTTON_2): {
             COMMAND: COMMAND_STEP_ON_OFF,
             CLUSTER_ID: 8,
-            "args": {"step_mode": 1, "step_size": 1},
+            PARAMS: {"step_mode": 1, "step_size": 1},
         },
         (DOUBLE_PRESS, BUTTON_1): {
             COMMAND: COMMAND_STEP_ON_OFF,
             CLUSTER_ID: 8,
-            "args": {"step_mode": 0, "step_size": 2},
+            PARAMS: {"step_mode": 0, "step_size": 2},
         },
         (DOUBLE_PRESS, BUTTON_2): {
             COMMAND: COMMAND_STEP_ON_OFF,
             CLUSTER_ID: 8,
-            "args": {"step_mode": 1, "step_size": 2},
+            PARAMS: {"step_mode": 1, "step_size": 2},
         },
         (LONG_PRESS, BUTTON_1): {
             COMMAND: COMMAND_STEP_ON_OFF,
             CLUSTER_ID: 8,
-            "args": {"step_mode": 0, "step_size": 3},
+            PARAMS: {"step_mode": 0, "step_size": 3},
         },
         (LONG_PRESS, BUTTON_2): {
             COMMAND: COMMAND_STEP_ON_OFF,
             CLUSTER_ID: 8,
-            "args": {"step_mode": 1, "step_size": 3},
+            PARAMS: {"step_mode": 1, "step_size": 3},
         },
     }

--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -15,7 +15,6 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lightlink import LightLink
 
 from zhaquirks import Bus
-
 from zhaquirks.const import (
     BUTTON_1,
     BUTTON_2,
@@ -28,11 +27,14 @@ from zhaquirks.const import (
     COMMAND_STOP,
     COMMAND_TOGGLE,
     DEVICE_TYPE,
+    DIM_DOWN,
+    DIM_UP,
     DOUBLE_PRESS,
     ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
     LEFT,
+    LONG_PRESS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PARAMS,
@@ -40,14 +42,19 @@ from zhaquirks.const import (
     RIGHT,
     ROTATED,
     SHORT_PRESS,
-    LONG_PRESS,
     STOP,
     TRIPLE_PRESS,
     TURN_ON,
-    DIM_UP,
-    DIM_DOWN,
 )
-from zhaquirks.ikea import IKEA, WWAH_CLUSTER_ID, IKEA_CLUSTER_ID, LevelControlCluster, ShortcutCluster, PowerConfiguration1CRCluster, PowerConfiguration2AAACluster
+from zhaquirks.ikea import (
+    IKEA,
+    IKEA_CLUSTER_ID,
+    WWAH_CLUSTER_ID,
+    LevelControlCluster,
+    PowerConfiguration1CRCluster,
+    PowerConfiguration2AAACluster,
+    ShortcutCluster,
+)
 
 
 class IkeaSYMFONISK1(CustomDevice):
@@ -240,7 +247,7 @@ class IkeaSYMFONISKRemote2(CustomDevice):
                     LevelControl.cluster_id,
                     Ota.cluster_id,
                     LightLink.cluster_id,
-                    ShortcutCluster.cluster_id
+                    ShortcutCluster.cluster_id,
                 ],
             }
         },
@@ -295,7 +302,7 @@ class IkeaSYMFONISKRemote2(CustomDevice):
         (SHORT_PRESS, LEFT): {
             COMMAND: COMMAND_STEP,
             CLUSTER_ID: 8,
-            PARAMS: {"step_mode": 1}
+            PARAMS: {"step_mode": 1},
         },
         (SHORT_PRESS, RIGHT): {
             COMMAND: COMMAND_STEP,

--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -19,8 +19,6 @@ from zhaquirks import Bus
 from zhaquirks.const import (
     BUTTON_1,
     BUTTON_2,
-    BUTTON_3,
-    BUTTON_4,
     CLUSTER_ID,
     COMMAND,
     COMMAND_MOVE,
@@ -42,6 +40,7 @@ from zhaquirks.const import (
     RIGHT,
     ROTATED,
     SHORT_PRESS,
+    LONG_PRESS,
     STOP,
     TRIPLE_PRESS,
     TURN_ON,
@@ -285,6 +284,14 @@ class IkeaSYMFONISKRemote2(CustomDevice):
             COMMAND: COMMAND_MOVE_ON_OFF,
             PARAMS: {"move_mode": 1},
         },
+        (LONG_PRESS, DIM_UP): {
+            COMMAND: COMMAND_MOVE,
+            PARAMS: {"move_mode": 0},
+        },
+        (LONG_PRESS, DIM_DOWN): {
+            COMMAND: COMMAND_MOVE,
+            PARAMS: {"move_mode": 1},
+        },
         (SHORT_PRESS, LEFT): {
             COMMAND: COMMAND_STEP,
             CLUSTER_ID: 8,
@@ -298,11 +305,31 @@ class IkeaSYMFONISKRemote2(CustomDevice):
         (SHORT_PRESS, BUTTON_1): {
             COMMAND: COMMAND_STEP_ON_OFF,
             CLUSTER_ID: 8,
-            "args": {"step_mode": 0},
+            "args": {"step_mode": 0, "step_size": 1},
         },
         (SHORT_PRESS, BUTTON_2): {
             COMMAND: COMMAND_STEP_ON_OFF,
             CLUSTER_ID: 8,
-            "args": {"step_mode": 1},
+            "args": {"step_mode": 1, "step_size": 1},
+        },
+        (DOUBLE_PRESS, BUTTON_1): {
+            COMMAND: COMMAND_STEP_ON_OFF,
+            CLUSTER_ID: 8,
+            "args": {"step_mode": 0, "step_size": 2},
+        },
+        (DOUBLE_PRESS, BUTTON_2): {
+            COMMAND: COMMAND_STEP_ON_OFF,
+            CLUSTER_ID: 8,
+            "args": {"step_mode": 1, "step_size": 2},
+        },
+        (LONG_PRESS, BUTTON_1): {
+            COMMAND: COMMAND_STEP_ON_OFF,
+            CLUSTER_ID: 8,
+            "args": {"step_mode": 0, "step_size": 3},
+        },
+        (LONG_PRESS, BUTTON_2): {
+            COMMAND: COMMAND_STEP_ON_OFF,
+            CLUSTER_ID: 8,
+            "args": {"step_mode": 1, "step_size": 3},
         },
     }

--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -53,7 +53,7 @@ from zhaquirks.ikea import (
     LevelControlCluster,
     PowerConfiguration1CRCluster,
     PowerConfiguration2AAACluster,
-    ShortcutCluster,
+    V1ShortcutCluster,
 )
 
 
@@ -214,8 +214,8 @@ class IkeaSYMFONISK2(CustomDevice):
     device_automation_triggers = IkeaSYMFONISK1.device_automation_triggers.copy()
 
 
-class IkeaSYMFONISKRemote2(CustomDevice):
-    """Custom device representing IKEA of Sweden SYMFONISK sound remote gen2."""
+class IkeaSYMFONISKRemoteGen2V1(CustomDevice):
+    """Custom device representing IKEA of Sweden SYMFONISK sound remote gen2 V1.0.012."""
 
     def __init__(self, *args, **kwargs):
         """Init."""
@@ -247,7 +247,7 @@ class IkeaSYMFONISKRemote2(CustomDevice):
                     LevelControl.cluster_id,
                     Ota.cluster_id,
                     LightLink.cluster_id,
-                    ShortcutCluster.cluster_id,
+                    V1ShortcutCluster.cluster_id,
                 ],
             }
         },
@@ -264,7 +264,7 @@ class IkeaSYMFONISKRemote2(CustomDevice):
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,
-                    IKEA_CLUSTER_ID,
+                    WWAH_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -273,7 +273,7 @@ class IkeaSYMFONISKRemote2(CustomDevice):
                     LevelControlCluster,
                     Ota.cluster_id,
                     LightLink.cluster_id,
-                    ShortcutCluster,
+                    V1ShortcutCluster,
                 ],
             }
         }

--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -274,35 +274,35 @@ class IkeaSYMFONISKRemote2(CustomDevice):
     }
 
     device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {  # Play
+        (SHORT_PRESS, TURN_ON): {
             COMMAND: COMMAND_TOGGLE,
         },
-        (SHORT_PRESS, DIM_UP): {  # Lauter
+        (SHORT_PRESS, DIM_UP): {
             COMMAND: COMMAND_MOVE_ON_OFF,
             PARAMS: {"move_mode": 0},
         },
-        (SHORT_PRESS, DIM_DOWN): {  # Leiser
+        (SHORT_PRESS, DIM_DOWN): {
             COMMAND: COMMAND_MOVE_ON_OFF,
             PARAMS: {"move_mode": 1},
         },
-        (SHORT_PRESS, BUTTON_1): {  # Prev
+        (SHORT_PRESS, LEFT): {
             COMMAND: COMMAND_STEP,
             CLUSTER_ID: 8,
             PARAMS: {"step_mode": 1}
         },
-        (SHORT_PRESS, BUTTON_2): {  # Next
+        (SHORT_PRESS, RIGHT): {
             COMMAND: COMMAND_STEP,
             CLUSTER_ID: 8,
             PARAMS: {"step_mode": 0},
         },
-        (SHORT_PRESS, BUTTON_3): {  # One dot
+        (SHORT_PRESS, BUTTON_1): {
             COMMAND: COMMAND_STEP_ON_OFF,
             CLUSTER_ID: 8,
-            PARAMS: {"step_mode": 0},
+            "args": {"step_mode": 0},
         },
-        (SHORT_PRESS, BUTTON_4): {  # Two dot
+        (SHORT_PRESS, BUTTON_2): {
             COMMAND: COMMAND_STEP_ON_OFF,
             CLUSTER_ID: 8,
-            PARAMS: {"step_mode": 1},
+            "args": {"step_mode": 1},
         },
     }

--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -14,7 +14,6 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from zhaquirks import Bus
 from zhaquirks.const import (
     BUTTON_1,
     BUTTON_2,
@@ -50,7 +49,6 @@ from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
     WWAH_CLUSTER_ID,
-    LevelControlCluster,
     PowerConfiguration1CRCluster,
     PowerConfiguration2AAACluster,
     V1ShortcutCluster,
@@ -217,11 +215,6 @@ class IkeaSYMFONISK2(CustomDevice):
 class IkeaSYMFONISKRemoteGen2V1(CustomDevice):
     """Custom device representing IKEA of Sweden SYMFONISK sound remote gen2 V1.0.012."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.levelcontrol_bus = Bus()
-        super().__init__(*args, **kwargs)
-
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=6
         # device_version=1
@@ -270,7 +263,7 @@ class IkeaSYMFONISKRemoteGen2V1(CustomDevice):
                     Identify.cluster_id,
                     Groups.cluster_id,
                     OnOff.cluster_id,
-                    LevelControlCluster,
+                    LevelControl.cluster_id,
                     Ota.cluster_id,
                     LightLink.cluster_id,
                     V1ShortcutCluster,


### PR DESCRIPTION
Initial support for the new SYMFONISK sound remote gen 2. This might need some testing with more software versions as noted in issue #2223.

Every button can be used as a trigger for automations (and supported buttons even with long press and double press).