### PR TITLE
Improve Aqara E1 thermostat quirk

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -6,6 +6,7 @@ import pytest
 import zigpy.device
 import zigpy.types as t
 from zigpy.zcl import foundation
+from zigpy.zcl.clusters.hvac import Thermostat
 from zigpy.zcl.clusters.security import IasZone
 
 import zhaquirks
@@ -526,6 +527,62 @@ async def test_xiaomi_eu_plug_power(zigpy_device_from_quirk, quirk):
     assert len(se_listener.attribute_updates) == 1
     assert se_listener.attribute_updates[0][0] == 0
     assert se_listener.attribute_updates[0][1] == 1  # multiplied by 1000
+
+
+@pytest.mark.parametrize("quirk", (zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001,))
+async def test_xiaomi_e1_thermostat(zigpy_device_from_quirk, quirk):
+    """Test system_mode rw redirection to OppleCluster on Xiaomi E1 thermostat."""
+
+    device = zigpy_device_from_quirk(quirk)
+
+    opple_cluster = device.endpoints[1].opple_cluster
+    opple_cluster._read_attributes = mock.AsyncMock()
+    opple_cluster._write_attributes = mock.AsyncMock()
+
+    ClusterListener(opple_cluster)
+
+    thermostat_cluster = device.endpoints[1].thermostat
+    thermostat_cluster._read_attributes = mock.AsyncMock()
+    thermostat_cluster._write_attributes = mock.AsyncMock()
+    ClusterListener(thermostat_cluster)
+
+    await thermostat_cluster.read_attributes(
+        [Thermostat.attributes_by_name["system_mode"].id]
+    )
+
+    # check that system_mode reads were directed to the Opple cluster
+    assert len(thermostat_cluster._read_attributes.mock_calls) == 0
+    assert len(opple_cluster._read_attributes.mock_calls) == 3
+
+    thermostat_cluster._read_attributes.reset_mock()
+    opple_cluster._read_attributes.reset_mock()
+
+    # check that other attribute reads are not redirected
+    await thermostat_cluster.read_attributes(
+        [Thermostat.attributes_by_name["unoccupied_heating_setpoint"].id]
+    )
+
+    assert len(thermostat_cluster._read_attributes.mock_calls) == 4
+    assert len(opple_cluster._read_attributes.mock_calls) == 0
+
+    await thermostat_cluster.write_attributes(
+        {Thermostat.attributes_by_name["system_mode"].id: Thermostat.SystemMode.Heat}
+    )
+
+    # check that system_mode writes were directed to the Opple cluster
+    assert len(thermostat_cluster._write_attributes.mock_calls) == 0
+    assert len(opple_cluster._write_attributes.mock_calls) == 3
+
+    thermostat_cluster._write_attributes.reset_mock()
+    opple_cluster._write_attributes.reset_mock()
+
+    # check that other attribute writes are not redirected
+    await thermostat_cluster.write_attributes(
+        {Thermostat.attributes_by_name["unoccupied_heating_setpoint"].id: 2000}
+    )
+
+    assert len(thermostat_cluster._write_attributes.mock_calls) == 3
+    assert len(opple_cluster._write_attributes.mock_calls) == 0
 
 
 @pytest.mark.parametrize(

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -1,4 +1,6 @@
 """Aqara E1 Radiator Thermostat Quirk."""
+from __future__ import annotations
+
 from typing import Any
 
 from zigpy.profiles import zha

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -135,7 +135,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
             PRESET: ("preset", t.uint8_t, True),
             WINDOW_DETECTION: ("window_detection", t.uint8_t, True),
             VALVE_DETECTION: ("valve_detection", t.uint8_t, True),
-            VALVE_ALARM: ("valve_alarm", t.uint32_t, True),
+            VALVE_ALARM: ("valve_alarm", t.uint8_t, True),
             CHILD_LOCK: ("child_lock", t.uint8_t, True),
             AWAY_PRESET_TEMPERATURE: ("away_preset_temperature", t.uint32_t, True),
             WINDOW_OPEN: ("window_open", t.uint8_t, True),

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -77,7 +77,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
             if "system_mode" in attributes:
                 remaining_attributes.remove("system_mode")
 
-            successful_r, failed_r = await self.endpoint.aqara_cluster.read_attributes(
+            successful_r, failed_r = await self.endpoint.opple_cluster.read_attributes(
                 [SYSTEM_MODE], allow_cache, only_cache, manufacturer
             )
             # convert Xiaomi system_mode to ZCL attribute
@@ -113,7 +113,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
         # write system_mode to Xiaomi cluster if applicable
         if system_mode_value is not None:
             self.debug("Passing 'system_mode' write to Xiaomi cluster")
-            result += await self.endpoint.aqara_cluster.write_attributes(
+            result += await self.endpoint.opple_cluster.write_attributes(
                 {SYSTEM_MODE: min(int(system_mode_value), 1)}
             )
 
@@ -126,7 +126,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
 class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
     """Aqara manufacturer specific settings."""
 
-    ep_attribute = "aqara_cluster"
+    ep_attribute = "opple_cluster"
 
     attributes = XiaomiAqaraE1Cluster.attributes.copy()
     attributes.update(

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -22,6 +22,28 @@ from zhaquirks.xiaomi import (
     XiaomiPowerConfiguration,
 )
 
+ZCL_SYSTEM_MODE = Thermostat.attributes_by_name["system_mode"].id
+
+XIAOMI_SYSTEM_MODE_MAP = {
+    0: Thermostat.SystemMode.Off,
+    1: Thermostat.SystemMode.Heat,
+}
+
+SYSTEM_MODE = 0x0271
+PRESET = 0x0272
+WINDOW_DETECTION = 0x0273
+VALVE_DETECTION = 0x0274
+VALVE_ALARM = 0x0275
+CHILD_LOCK = 0x0277
+AWAY_PRESET_TEMPERATURE = 0x0279
+WINDOW_OPEN = 0x027A
+CALIBRATED = 0x027B
+SCHEDULE = 0x027D
+SENSOR = 0x027E
+BATTERY_PERCENTAGE = 0x040A
+
+XIAOMI_CLUSTER_ID = 0xFCC0
+
 
 class ThermostatCluster(CustomCluster, Thermostat):
     """Thermostat cluster."""
@@ -41,40 +63,62 @@ class ThermostatCluster(CustomCluster, Thermostat):
         manufacturer: int | t.uint16_t | None = None,
     ):
         """Pass reading attributes to Xiaomi cluster if applicable."""
-        if "system_mode" in attributes:
+        successful_r, failed_r = {}, {}
+        remaining_attributes = attributes.copy()
+
+        # read system_mode from Xiaomi cluster (can be numeric or string)
+        if ZCL_SYSTEM_MODE in attributes or "system_mode" in attributes:
             self.debug("Passing 'system_mode' read to Xiaomi cluster")
-            return await self.endpoint.aqara_cluster.read_attributes(
+
+            if ZCL_SYSTEM_MODE in attributes:
+                remaining_attributes.remove(ZCL_SYSTEM_MODE)
+            if "system_mode" in attributes:
+                remaining_attributes.remove("system_mode")
+
+            successful_r, failed_r = await self.endpoint.aqara_cluster.read_attributes(
                 [SYSTEM_MODE], allow_cache, only_cache, manufacturer
             )
-        return await super().read_attributes(
-            attributes, allow_cache, only_cache, manufacturer
-        )
+            # convert Xiaomi system_mode to ZCL attribute
+            if SYSTEM_MODE in successful_r:
+                successful_r[ZCL_SYSTEM_MODE] = XIAOMI_SYSTEM_MODE_MAP[
+                    successful_r.pop(SYSTEM_MODE)
+                ]
+        # read remaining attributes from thermostat cluster
+        if remaining_attributes:
+            remaining_result = await super().read_attributes(
+                remaining_attributes, allow_cache, only_cache, manufacturer
+            )
+            successful_r.update(remaining_result[0])
+            failed_r.update(remaining_result[1])
+        return successful_r, failed_r
 
     async def write_attributes(
         self, attributes: dict[str | int, Any], manufacturer: int | None = None
     ) -> list:
         """Pass writing attributes to Xiaomi cluster if applicable."""
+        result = []
+        remaining_attributes = attributes.copy()
+        system_mode_value = None
+
+        # check if system_mode is being written (can be numeric or string)
+        if ZCL_SYSTEM_MODE in attributes:
+            remaining_attributes.pop(ZCL_SYSTEM_MODE)
+            system_mode_value = attributes.get(ZCL_SYSTEM_MODE)
         if "system_mode" in attributes:
+            remaining_attributes.pop("system_mode")
+            system_mode_value = attributes.get("system_mode")
+
+        # write system_mode to Xiaomi cluster if applicable
+        if system_mode_value is not None:
             self.debug("Passing 'system_mode' write to Xiaomi cluster")
-            return await self.endpoint.aqara_cluster.write_attributes(
-                {SYSTEM_MODE: min(int(attributes.get("system_mode")), 1)}
+            result += await self.endpoint.aqara_cluster.write_attributes(
+                {SYSTEM_MODE: min(int(system_mode_value), 1)}
             )
-        return await super().write_attributes(attributes, manufacturer)
 
-
-SYSTEM_MODE = 0x0271
-PRESET = 0x0272
-WINDOW_DETECTION = 0x0273
-VALVE_DETECTION = 0x0274
-VALVE_ALARM = 0x0275
-CHILD_LOCK = 0x0277
-AWAY_PRESET_TEMPERATURE = 0x0279
-WINDOW_OPEN = 0x027A
-CALIBRATED = 0x027B
-SENSOR = 0x027E
-BATTERY_PERCENTAGE = 0x040A
-
-XIAOMI_CLUSTER_ID = 0xFCC0
+        # write remaining attributes to thermostat cluster
+        if remaining_attributes:
+            result += await super().write_attributes(remaining_attributes, manufacturer)
+        return result
 
 
 class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
@@ -94,6 +138,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
             AWAY_PRESET_TEMPERATURE: ("away_preset_temperature", t.uint32_t, True),
             WINDOW_OPEN: ("window_open", t.uint8_t, True),
             CALIBRATED: ("calibrated", t.uint8_t, True),
+            SCHEDULE: ("schedule", t.uint8_t, True),
             SENSOR: ("sensor", t.uint8_t, True),
             BATTERY_PERCENTAGE: ("battery_percentage", t.uint8_t, True),
         }
@@ -104,6 +149,11 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         if attrid == BATTERY_PERCENTAGE:
             self.endpoint.device.battery_bus.listener_event(
                 "battery_percent_reported", value
+            )
+        elif attrid == SYSTEM_MODE:
+            # update ZCL system_mode attribute (e.g. on attribute reports)
+            self.endpoint.thermostat.update_attribute(
+                ZCL_SYSTEM_MODE, XIAOMI_SYSTEM_MODE_MAP[value]
             )
         super()._update_attribute(attrid, value)
 
@@ -127,12 +177,12 @@ class AGL001(XiaomiCustomDevice):
                     Thermostat.cluster_id,
                     Time.cluster_id,
                     XiaomiPowerConfiguration.cluster_id,
-                    XIAOMI_CLUSTER_ID,
+                    AqaraThermostatSpecificCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
                     Thermostat.cluster_id,
-                    XIAOMI_CLUSTER_ID,
+                    AqaraThermostatSpecificCluster.cluster_id,
                 ],
             }
         },


### PR DESCRIPTION
This PR does the following:
- it fixes system mode (couldn't turn off before)
- it adds other Xiaomi attributes (supersedes https://github.com/zigpy/zha-device-handlers/pull/2237 and part of https://github.com/zigpy/zha-device-handlers/pull/2109 
- it adds the OTA cluster

Tested and working so far.

Possible TODOs:
- add basic tests ✅ 
- do the external sensor temp stuff (-> hopefully in a future PR)
- implement more?
- implement entities in ZHA (separate PR)
- attribute for 0x270 (write 1 to calibrate?)

To test this, you should be able to download the modified `zhaquirks/xiaomi/aqara/thermostat_agl001.py` file and put that in your custom quirks directory.