### PR TITLE
Do not crash setup when custom quirk contains bad code

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -408,22 +408,27 @@ def test_quirk_loading_error(tmp_path: Path, caplog) -> None:
     (custom_quirks / "bosch").mkdir()
     (custom_quirks / "bosch/__init__.py").touch()
 
-    caplog.clear()
-
     # Syntax errors are swallowed
     (custom_quirks / "bosch/custom_quirk.py").write_text("1/")
 
+    caplog.clear()
     zhaquirks.setup(custom_quirks_path=str(custom_quirks))
-    assert "Unexpected exception importing component bosch.custom_quirk" in caplog.text
+    assert (
+        "Unexpected exception importing custom quirk 'bosch.custom_quirk'"
+        in caplog.text
+    )
+    assert "SyntaxError" in caplog.text
 
     # And so are import errors
     (custom_quirks / "bosch/custom_quirk.py").write_text("from os import foobarbaz7")
 
+    caplog.clear()
     zhaquirks.setup(custom_quirks_path=str(custom_quirks))
     assert (
-        "Error importing bosch.custom_quirk: cannot import name 'foobarbaz7' from 'os'"
+        "Unexpected exception importing custom quirk 'bosch.custom_quirk'"
         in caplog.text
     )
+    assert "cannot import name 'foobarbaz7' from 'os'" in caplog.text
 
 
 def test_custom_quirk_loading(

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -413,13 +413,13 @@ def test_quirk_loading_error(tmp_path: Path, caplog) -> None:
     # Syntax errors are swallowed
     (custom_quirks / "bosch/custom_quirk.py").write_text("1/")
 
-    zhaquirks.setup({zhaquirks.CUSTOM_QUIRKS_PATH: str(custom_quirks)})
+    zhaquirks.setup(custom_quirks_path=str(custom_quirks))
     assert "Unexpected exception importing component bosch.custom_quirk" in caplog.text
 
     # And so are import errors
     (custom_quirks / "bosch/custom_quirk.py").write_text("from os import foobarbaz7")
 
-    zhaquirks.setup({zhaquirks.CUSTOM_QUIRKS_PATH: str(custom_quirks)})
+    zhaquirks.setup(custom_quirks_path=str(custom_quirks))
     assert (
         "Error importing bosch.custom_quirk: cannot import name 'foobarbaz7' from 'os'"
         in caplog.text
@@ -516,7 +516,7 @@ class TestReplacementISWZPR1WP13(CustomDevice):
 '''
     )
 
-    zhaquirks.setup({zhaquirks.CUSTOM_QUIRKS_PATH: str(custom_quirks)})
+    zhaquirks.setup(custom_quirks_path=str(custom_quirks))
 
     assert not isinstance(zq.get_device(device), zhaquirks.bosch.motion.ISWZPR1WP13)
     assert type(zq.get_device(device)).__name__ == "TestReplacementISWZPR1WP13"

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -17,12 +17,11 @@ from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zdo import types as zdotypes
 
-from zhaquirks.const import (
+from .const import (
     ATTRIBUTE_ID,
     ATTRIBUTE_NAME,
     CLUSTER_COMMAND,
     COMMAND_ATTRIBUTE_UPDATED,
-    CUSTOM_QUIRKS_PATH,
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -388,11 +387,11 @@ class QuickInitDevice(CustomDevice):
         return device
 
 
-def setup(config: Optional[Dict[str, Any]] = None) -> None:
+def setup(custom_quirks_path: str | None = None) -> None:
     """Register all quirks with zigpy, including optional custom quirks."""
 
     # Import all quirks in the `zhaquirks` package first
-    for importer, modname, ispkg in pkgutil.walk_packages(
+    for importer, modname, _ispkg in pkgutil.walk_packages(
         path=__path__,
         prefix=__name__ + ".",
     ):
@@ -400,10 +399,25 @@ def setup(config: Optional[Dict[str, Any]] = None) -> None:
         importlib.import_module(modname)
 
     # Treat the custom quirk path (e.g. `/config/custom_quirks/`) itself as a module
-    if config and config.get(CUSTOM_QUIRKS_PATH):
-        path = pathlib.Path(config[CUSTOM_QUIRKS_PATH])
-        _LOGGER.debug("Loading custom quirks from %s", path)
+    if custom_quirks_path is None:
+        return
 
-        for importer, modname, ispkg in pkgutil.walk_packages(path=[str(path)]):
-            _LOGGER.debug("Loading custom quirks module %s", modname)
+    path = pathlib.Path(custom_quirks_path)
+    _LOGGER.debug("Loading custom quirks from %s", path)
+
+    loaded = False
+
+    for importer, modname, _ispkg in pkgutil.walk_packages(path=[str(path)]):
+        try:
             importer.find_module(modname).load_module(modname)
+        except ImportError as err:
+            _LOGGER.error("Error importing %s: %s", modname, err)
+        except Exception:
+            _LOGGER.exception("Unexpected exception importing component %s", modname)
+        else:
+            loaded = True
+
+    if loaded:
+        _LOGGER.warning(
+            "Loaded custom quirks. Please contribute it to https://github.com/zigpy/zha-device-handlers",
+        )

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -397,26 +397,24 @@ def setup(custom_quirks_path: str | None = None) -> None:
         path=__path__,
         prefix=__name__ + ".",
     ):
-        _LOGGER.debug("Loading quirks module %s", modname)
+        _LOGGER.debug("Loading quirks module %r", modname)
         importlib.import_module(modname)
 
     if custom_quirks_path is None:
         return
 
     path = pathlib.Path(custom_quirks_path)
-    _LOGGER.debug("Loading custom quirks from %s", path)
+    _LOGGER.debug("Loading custom quirks from %r", path)
 
     loaded = False
 
     # Treat the custom quirk path (e.g. `/config/custom_quirks/`) itself as a module
     for importer, modname, _ispkg in pkgutil.walk_packages(path=[str(path)]):
         try:
-            _LOGGER.debug("Loading custom quirks module %s", modname)
+            _LOGGER.debug("Loading custom quirk module %r", modname)
             importer.find_module(modname).load_module(modname)
-        except ImportError as err:
-            _LOGGER.error("Error importing %s: %s", modname, err)
         except Exception:
-            _LOGGER.exception("Unexpected exception importing component %s", modname)
+            _LOGGER.exception("Unexpected exception importing custom quirk %r", modname)
         else:
             loaded = True
 

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -422,5 +422,6 @@ def setup(custom_quirks_path: str | None = None) -> None:
 
     if loaded:
         _LOGGER.warning(
-            "Loaded custom quirks. Please contribute it to https://github.com/zigpy/zha-device-handlers",
+            "Loaded custom quirks. Please contribute them to"
+            " https://github.com/zigpy/zha-device-handlers"
         )

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -400,7 +400,6 @@ def setup(custom_quirks_path: str | None = None) -> None:
         _LOGGER.debug("Loading quirks module %s", modname)
         importlib.import_module(modname)
 
-    # Treat the custom quirk path (e.g. `/config/custom_quirks/`) itself as a module
     if custom_quirks_path is None:
         return
 
@@ -409,8 +408,10 @@ def setup(custom_quirks_path: str | None = None) -> None:
 
     loaded = False
 
+    # Treat the custom quirk path (e.g. `/config/custom_quirks/`) itself as a module
     for importer, modname, _ispkg in pkgutil.walk_packages(path=[str(path)]):
         try:
+            _LOGGER.debug("Loading custom quirks module %s", modname)
             importer.find_module(modname).load_module(modname)
         except ImportError as err:
             _LOGGER.error("Error importing %s: %s", modname, err)

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -1,4 +1,6 @@
 """Quirks implementations for the ZHA component of Homeassistant."""
+from __future__ import annotations
+
 import asyncio
 import importlib
 import logging

--- a/zhaquirks/const.py
+++ b/zhaquirks/const.py
@@ -62,7 +62,6 @@ COMMAND_STOP_ON_OFF = "stop_with_on_off"
 COMMAND_TILT = "Tilt"
 COMMAND_TOGGLE = "toggle"
 COMMAND_TRIPLE = "triple"
-CUSTOM_QUIRKS_PATH = "custom_quirks_path"
 DESCRIPTION = "description"
 DEVICE_TYPE = SIG_EP_TYPE
 DIM_DOWN = "dim_down"


### PR DESCRIPTION
Setup no longer crashes when importing a quirk raises any type of exception. Instead, it will now attempt to load the next custom quirks.

Breaking change: `setup` now takes the custom quirks path (str or None) instead of a dictionary from which we read a constant.

Also suggests to users of custom quirks to contribute them back.