### PR TITLE
Enable `ints` up to 8 bytes

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -249,7 +249,16 @@ class Data(t.List, item_type=t.uint8_t):
         """Convert from a tuya data payload to an int typed value."""
         # first uint8_t is the length of the remaining data
         # tuya data is in big endian whereas ztypes use little endian
-        ints = {1: t.int8s, 2: t.int16s, 3: t.int24s, 4: t.int32s}
+        ints = {
+            1: t.int8s,
+            2: t.int16s,
+            3: t.int24s,
+            4: t.int32s,
+            5: t.int40s,
+            6: t.int48s,
+            7: t.int56s,
+            8: t.int64s,
+        }
         return ints[self[0]].deserialize(bytes(reversed(self[1:])))[0]
 
     def __iter__(self):


### PR DESCRIPTION
Update the `Data` `__int__` to enable up to 8 bytes

Fixes: #2243