### PR TITLE
Add support for Tuya TS1001 based remote dimmers

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -274,6 +274,62 @@ def test_ts0121_signature(assert_signature_matches_quirk):
     assert_signature_matches_quirk(zhaquirks.tuya.ts0121_plug.Plug, signature)
 
 
+def test_ts1001_signature(assert_signature_matches_quirk):
+    """Test TS1001 remote dimmer signature is matched to its quirk."""
+    signatures = [
+        {
+            "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
+            "endpoints": {
+                "1": {
+                    "profile_id": 260,
+                    "device_type": "0x0104",
+                    "in_clusters": ["0x0000", "0x0001", "0x0003", "0x0004", "0x1000"],
+                    "out_clusters": [
+                        "0x0003",
+                        "0x0004",
+                        "0x0005",
+                        "0x0006",
+                        "0x0008",
+                        "0x000a",
+                        "0x0019",
+                        "0x1000",
+                    ],
+                }
+            },
+            "manufacturer": "_TYZB01_7qf81wty",
+            "model": "TS1001",
+            "class": "zhaquirks.tuya.ts1001.TuyaRemoteTS1001",
+        },
+        {
+            "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=0)",
+            "endpoints": {
+                "1": {
+                    "profile_id": 260,
+                    "device_type": "0x0104",
+                    "in_clusters": ["0x0000", "0x0001", "0x0003", "0x0004", "0x1000"],
+                    "out_clusters": [
+                        "0x0003",
+                        "0x0004",
+                        "0x0005",
+                        "0x0006",
+                        "0x0008",
+                        "0x000a",
+                        "0x0019",
+                        "0x1000",
+                    ],
+                }
+            },
+            "manufacturer": "_TYZB01_bngwdjsr",
+            "model": "TS1001",
+            "class": "zhaquirks.tuya.ts1001.TuyaRemoteTS1001",
+        },
+    ]
+    for signature in signatures:
+        assert_signature_matches_quirk(
+            zhaquirks.tuya.ts1001.TuyaRemoteTS1001, signature
+        )
+
+
 async def test_tuya_data_conversion():
     """Test tuya conversion from Data to ztype and reverse."""
     assert t.uint32_t(Data([4, 0, 0, 1, 39])) == 295

--- a/zhaquirks/tuya/ts1001.py
+++ b/zhaquirks/tuya/ts1001.py
@@ -1,0 +1,144 @@
+"""Tuya based remote dimmer switch."""
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    PowerConfiguration,
+    Scenes,
+    Time,
+)
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from zhaquirks.const import (
+    BUTTON,
+    COMMAND,
+    COMMAND_MOVE,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_STEP,
+    COMMAND_STOP,
+    DEVICE_TYPE,
+    DIM_DOWN,
+    DIM_UP,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    LONG_PRESS,
+    LONG_RELEASE,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PARAMS,
+    PROFILE_ID,
+    SHORT_PRESS,
+    TURN_OFF,
+    TURN_ON,
+)
+from zhaquirks.tuya import TuyaDimmerSwitch, TuyaOnOff
+
+
+class TuyaRemoteTS1001(TuyaDimmerSwitch):
+    """TS1001 remote control with triggers."""
+
+    signature = {
+        MODELS_INFO: [
+            ("_TYZB01_7qf81wty", "TS1001"),  # Immax NEO 07087-2 Smart Remote Control v2
+            ("_TYZB01_bngwdjsr", "TS1001"),  # Livarno Lux Remote Control Dimmer
+        ],
+        ENDPOINTS: {
+            # Endpoint id=1
+            # in=[basic:0x0000, power:0x0001, identify:0x0003, groups:0x0004, lightlink:0x1000]
+            # out=[ota:0x0019, time:0x000A, identify:0x0003, groups:0x0004, scenes:0x0005, on_off:0x0006, level:0x0008, lightlink:0x1000]
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaOnOff,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, TURN_ON): {
+            COMMAND: COMMAND_ON,
+        },
+        (SHORT_PRESS, TURN_OFF): {
+            COMMAND: COMMAND_OFF,
+        },
+        (SHORT_PRESS, DIM_UP): {
+            COMMAND: COMMAND_STEP,
+            PARAMS: {
+                "step_mode": 0,
+                "step_size": 51,
+                "transition_time": 10,
+            },
+        },
+        (SHORT_PRESS, DIM_DOWN): {
+            COMMAND: COMMAND_STEP,
+            PARAMS: {
+                "step_mode": 1,
+                "step_size": 51,
+                "transition_time": 10,
+            },
+        },
+        (LONG_PRESS, DIM_UP): {
+            COMMAND: COMMAND_MOVE,
+            PARAMS: {
+                "move_mode": 0,
+                "rate": 51,
+            },
+        },
+        (LONG_PRESS, DIM_DOWN): {
+            COMMAND: COMMAND_MOVE,
+            PARAMS: {
+                "move_mode": 1,
+                "rate": 51,
+            },
+        },
+        (LONG_RELEASE, BUTTON): {
+            COMMAND: COMMAND_STOP,
+        },
+    }

--- a/zhaquirks/tuya/ts1001.py
+++ b/zhaquirks/tuya/ts1001.py
@@ -36,10 +36,10 @@ from zhaquirks.const import (
     TURN_OFF,
     TURN_ON,
 )
-from zhaquirks.tuya import TuyaDimmerSwitch, TuyaOnOff
+from zhaquirks.tuya import TuyaOnOff, TuyaSwitch
 
 
-class TuyaRemoteTS1001(TuyaDimmerSwitch):
+class TuyaRemoteTS1001(TuyaSwitch):
     """TS1001 remote control with triggers."""
 
     signature = {


### PR DESCRIPTION
Fixes #2239 and should also fix #613 (have not tested Lidl remote myself as I have no device but all signatures and event codes does match)

Thanks to @tetele for most of the work for this quirk