### PR TITLE
Add _TZ3000_qeuvnohg Tongou TO-Q-SY1-JZT

### DIFF
--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1142,8 +1142,8 @@ class Plug_2AC_var03(CustomDevice):
             },
         },
     }
-    
-    
+
+
 class Plug_CB_Metering(EnchantedDevice):
     """Circuit breaker with monitoring, e.g. Tongou TO-Q-SY1-JZT. First one using this definition was _TZ3000_qeuvnohg."""
 

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -13,6 +13,7 @@ from zigpy.zcl.clusters.general import (
     Time,
 )
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.const import (
@@ -1138,6 +1139,72 @@ class Plug_2AC_var03(CustomDevice):
                     OnOff.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+class Plug_CB_Metering(EnchantedDevice):
+    """Circuit breaker with monitoring, e.g. Tongou TO-Q-SY1-JZT. First one using this definition was _TZ3000_qeuvnohg."""
+
+    signature = {
+        MODEL: "TS011F",
+        MODELS_INFO: [("_TZ3000_qeuvnohg", "TS011F")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=266
+            # device_version=1
+            # input_clusters=[0, 3, 4, 5, 6, 1026, 1794, 2820, 57344, 57345]
+            # output_clusters=[10, 25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    TemperatureMeasurement.cluster_id, # Note: no temperature sensor claimed in manual and it's constant -6.3C
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    TuyaZBE000Cluster.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # device_version=1
+            # input_clusters=[]
+            # output_clusters=[33]>
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                    TuyaZBMeteringCluster,
+                    TuyaZBElectricalMeasurement,
+                    TuyaZBE000Cluster,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
             },
         },
     }

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1142,6 +1142,8 @@ class Plug_2AC_var03(CustomDevice):
             },
         },
     }
+    
+    
 class Plug_CB_Metering(EnchantedDevice):
     """Circuit breaker with monitoring, e.g. Tongou TO-Q-SY1-JZT. First one using this definition was _TZ3000_qeuvnohg."""
 
@@ -1162,7 +1164,7 @@ class Plug_CB_Metering(EnchantedDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     OnOff.cluster_id,
-                    TemperatureMeasurement.cluster_id, # Note: no temperature sensor claimed in manual and it's constant -6.3C
+                    TemperatureMeasurement.cluster_id,  # Note: no temperature sensor claimed in manual and it's constant -6.3C
                     Metering.cluster_id,
                     ElectricalMeasurement.cluster_id,
                     TuyaZBE000Cluster.cluster_id,


### PR DESCRIPTION
Original [issue/2005](https://github.com/zigpy/zha-device-handlers/issues/2005) and [pull/2008](https://github.com/zigpy/zha-device-handlers/pull/2008). I'm not able to push to @zleba 's [zleba:tuyaCircuitBreaker](https://github.com/zleba/zha-device-handlers/tree/tuyaCircuitBreaker) as not a maintaner, therefore this PR.

Following @javicalle 's hint [here](https://github.com/zigpy/zha-device-handlers/issues/1764#issuecomment-1272390644), and once quirk is installed this problems are gone [(tested)](https://www.evernote.com/shard/s151/sh/9f06b277-d45f-4ff7-b4d3-d8d1287208b5/IXMgWdpsTeE8GjaIfgHdQwklEFCfUQhEXuyYIDv3WLzsrfltSovN_uYm0Q) through `DIVISOR` and `MULTIPLIER` in `tuya/__init__.py`.