### PR TITLE
Add Aqara E1 water leak sensor quirk

### DIFF
--- a/zhaquirks/xiaomi/aqara/water_acn001.py
+++ b/zhaquirks/xiaomi/aqara/water_acn001.py
@@ -1,0 +1,62 @@
+"""Quirk for Aqara E1 water leak sensor lumi.flood.acn001."""
+
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
+from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    XiaomiAqaraE1Cluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
+)
+
+XIAOMI_CLUSTER_ID = 0xFCC0
+
+
+class WaterE1(XiaomiCustomDevice):
+    """Aqara E1 water leak sensor quirk."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.flood.acn001")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                    XIAOMI_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    XiaomiPowerConfiguration,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                    XiaomiAqaraE1Cluster,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
+            },
+        },
+    }


### PR DESCRIPTION
This quirk adds battery measurement on the Aqara E1 water leak sensor.

Fixes https://github.com/zigpy/zha-device-handlers/issues/2247
-> Confirmed working.

The "naming scheme" and so on follows the E1 magnet variant, as both sensors basically have very similar quirks (but use different batteries).

Some of the Aqara quirks could probably be cleaned up in the future (in terms of naming and so on).