### PR TITLE
Remove custom LightLink cluster for IKEA ZB3 controllers

### DIFF
--- a/zhaquirks/ikea/fivebtnremote.py
+++ b/zhaquirks/ikea/fivebtnremote.py
@@ -369,7 +369,7 @@ class IkeaTradfriRemote4(IkeaTradfriRemote1):
                     DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                     IKEA_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -431,7 +431,7 @@ class IkeaTradfriRemote5(IkeaTradfriRemote1):
                     PowerConfig1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                     WWAH_CLUSTER_ID,
                     IKEA_CLUSTER_ID,
                 ],

--- a/zhaquirks/ikea/fivebtnremote.py
+++ b/zhaquirks/ikea/fivebtnremote.py
@@ -248,7 +248,7 @@ class IkeaTradfriRemote2(IkeaTradfriRemote1):
                     DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                     IKEA_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [

--- a/zhaquirks/ikea/motionzha.py
+++ b/zhaquirks/ikea/motionzha.py
@@ -28,7 +28,6 @@ from zhaquirks.ikea import (
     IKEA_CLUSTER_ID,
     WWAH_CLUSTER_ID,
     DoublingPowerConfig2CRCluster,
-    LightLinkCluster,
 )
 
 
@@ -75,7 +74,7 @@ class IkeaTradfriMotionE1745_Var01(CustomDevice):
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     Diagnostic.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -134,7 +133,7 @@ class IkeaTradfriMotionE1745_Var02(CustomDevice):
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                     IKEA_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -193,7 +192,7 @@ class IkeaTradfriMotionE1525_Var01(CustomDevice):
                     DoublingPowerConfig2CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                     IKEA_CLUSTER_ID,
                     WWAH_CLUSTER_ID,
                 ],

--- a/zhaquirks/ikea/shortcutbtn.py
+++ b/zhaquirks/ikea/shortcutbtn.py
@@ -37,11 +37,7 @@ from zhaquirks.const import (
     SHORT_PRESS,
     TURN_ON,
 )
-from zhaquirks.ikea import (
-    IKEA,
-    IKEA_CLUSTER_ID,
-    DoublingPowerConfig1CRCluster,
-)
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, DoublingPowerConfig1CRCluster
 
 
 class IkeaTradfriShortcutBtn(CustomDevice):

--- a/zhaquirks/ikea/shortcutbtn.py
+++ b/zhaquirks/ikea/shortcutbtn.py
@@ -41,7 +41,6 @@ from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
     DoublingPowerConfig1CRCluster,
-    LightLinkCluster,
 )
 
 
@@ -90,7 +89,7 @@ class IkeaTradfriShortcutBtn(CustomDevice):
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -167,7 +166,7 @@ class IkeaTradfriShortcutBtn2(CustomDevice):
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -94,7 +94,7 @@ class IkeaTradfriRemote2Btn(CustomDevice):
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                     IKEA_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -43,8 +43,8 @@ from zhaquirks.const import (
 from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
-    LightLinkCluster,
     DoublingPowerConfig1CRCluster,
+    LightLinkCluster,
 )
 
 

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -44,7 +44,6 @@ from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
     DoublingPowerConfig1CRCluster,
-    LightLinkCluster,
 )
 
 

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -43,6 +43,7 @@ from zhaquirks.const import (
 from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
+    LightLinkCluster,
     DoublingPowerConfig1CRCluster,
 )
 
@@ -145,7 +146,7 @@ class IkeaTradfriRemote2BtnZLL(CustomDevice):
         # device_version=248
         # input_clusters=[0, 1, 3, 9, 258, 4096, 64636]
         # output_clusters=[3, 4, 6, 8, 25, 258, 4096]>
-        MODELS_INFO: IkeaTradfriRemote2Btn.signature[MODELS_INFO].copy(),
+        MODELS_INFO: [(IKEA, "TRADFRI on/off switch")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zll.PROFILE_ID,
@@ -159,25 +160,41 @@ class IkeaTradfriRemote2BtnZLL(CustomDevice):
                     LightLink.cluster_id,
                     IKEA_CLUSTER_ID,
                 ],
-                OUTPUT_CLUSTERS: IkeaTradfriRemote2Btn.signature[ENDPOINTS][1][
-                    OUTPUT_CLUSTERS
-                ].copy(),
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    WindowCovering.cluster_id,
+                    LightLink.cluster_id,
+                ],
             }
         },
     }
-    signature[ENDPOINTS][1][INPUT_CLUSTERS].append(WindowCovering.cluster_id)
 
     replacement = {
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zll.PROFILE_ID,
                 DEVICE_TYPE: zll.DeviceType.CONTROLLER,
-                INPUT_CLUSTERS: IkeaTradfriRemote2Btn.replacement[ENDPOINTS][1][
-                    INPUT_CLUSTERS
-                ].copy(),
-                OUTPUT_CLUSTERS: IkeaTradfriRemote2Btn.replacement[ENDPOINTS][1][
-                    OUTPUT_CLUSTERS
-                ].copy(),
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DoublingPowerConfig1CRCluster,
+                    Identify.cluster_id,
+                    Alarms.cluster_id,
+                    LightLinkCluster,
+                    IKEA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    WindowCovering.cluster_id,
+                    LightLink.cluster_id,
+                ],
             }
         }
     }


### PR DESCRIPTION
IKEA first gen controllers was ZLL and was using one random ZLL group for sending commands to lights. All controllers have getting Zigbee 3 so its not needed / make errors then paring the device with ZB3 firmware.
I have not looking  on device that was released with with ZLL firmware witch device classes is ZB3 but Shortcut button was never having ZLL firmware as Symfonisk (its OK implanted).

If some like we can pinpointing the other controllers and doing the same so not getting error then pairing them but is mush work finding the ZB3 device classes.