### PR TITLE
Add Tuya TS0501 fan controller quirk

### DIFF
--- a/zhaquirks/tuya/ts0501_fan_switch.py
+++ b/zhaquirks/tuya/ts0501_fan_switch.py
@@ -30,7 +30,7 @@ class FanCluster(CustomCluster, Fan):
         return result
 
 
-class TS0501FanController(CustomDevice):
+class TS0501FanSwitch(CustomDevice):
     """TS0501 fan switch custom device implementation."""
 
     signature = {

--- a/zhaquirks/tuya/ts0501_fan_switch.py
+++ b/zhaquirks/tuya/ts0501_fan_switch.py
@@ -13,7 +13,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import TUYA_CLUSTER_ID
+from zhaquirks.tuya import TUYA_CLUSTER_ID, TuyaManufCluster
 
 
 class FanCluster(CustomCluster, Fan):
@@ -68,7 +68,7 @@ class TS0501FanController(CustomDevice):
                     Scenes.cluster_id,
                     OnOff.cluster_id,
                     FanCluster,
-                    TUYA_CLUSTER_ID,
+                    TuyaManufCluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,

--- a/zhaquirks/tuya/ts0501_fan_switch.py
+++ b/zhaquirks/tuya/ts0501_fan_switch.py
@@ -1,0 +1,79 @@
+"""Quirk for TS0501 fan switch."""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
+from zigpy.zcl.clusters.hvac import Fan
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.tuya import TUYA_CLUSTER_ID
+
+
+class FanCluster(CustomCluster, Fan):
+    """Custom fan cluster."""
+
+    attr_config = {
+        Fan.attributes_by_name["fan_mode_sequence"].id: Fan.FanModeSequence.Low_Med_High
+    }
+
+    async def bind(self):
+        """Bind fan cluster and write attributes."""
+        result = await super().bind()
+        await self.write_attributes(self.attr_config)
+        return result
+
+
+class TS0501FanController(CustomDevice):
+    """TS0501 fan switch custom device implementation."""
+
+    signature = {
+        MODELS_INFO: [("_TZ3210_lzqq3u4r", "TS0501")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    Fan.cluster_id,
+                    TUYA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    FanCluster,
+                    TUYA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }


### PR DESCRIPTION
Fixes https://github.com/zigpy/zha-device-handlers/issues/2264
(Confirmed working in that issue)

This changes the `fan_mode_sequence` to `Low_Med_High` on pairing, so the physical switch still cycles through all modes properly.

(Not sure what use the Tuya cluster has, but had to pick one `CustomCluster` with the Tuya ID, as the Tuya cluster ID is outside of the range designated for manufacturers (so tests checking for a valid cluster range wouldn't pass before).
Is this fine?)