### PR TITLE
Add non-doubling IKEA battery info clusters

### DIFF
--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -16,10 +16,12 @@ IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
 WWAH_CLUSTER_ID = 0xFC57  # decimal = 64599 ('Works with all Hubs' cluster)
 
 # PowerConfiguration cluster attributes
-BATTERY_VOLTAGE = PowerConfiguration.attributes_by_name["battery_voltage"]
-BATTERY_SIZE = PowerConfiguration.attributes_by_name["battery_size"]
-BATTERY_QUANTITY = PowerConfiguration.attributes_by_name["battery_quantity"]
-BATTERY_RATED_VOLTAGE = PowerConfiguration.attributes_by_name["battery_rated_voltage"]
+BATTERY_VOLTAGE = PowerConfiguration.attributes_by_name["battery_voltage"].id
+BATTERY_SIZE = PowerConfiguration.attributes_by_name["battery_size"].id
+BATTERY_QUANTITY = PowerConfiguration.attributes_by_name["battery_quantity"].id
+BATTERY_RATED_VOLTAGE = PowerConfiguration.attributes_by_name[
+    "battery_rated_voltage"
+].id
 
 
 class LightLinkCluster(CustomCluster, LightLink):

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -15,6 +15,12 @@ IKEA = "IKEA of Sweden"
 IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636
 WWAH_CLUSTER_ID = 0xFC57  # decimal = 64599 ('Works with all Hubs' cluster)
 
+# PowerConfiguration cluster attributes
+BATTERY_VOLTAGE = PowerConfiguration.attributes_by_name["battery_voltage"]
+BATTERY_SIZES = PowerConfiguration.attributes_by_name["battery_size"]
+BATTERY_QUANTITY = PowerConfiguration.attributes_by_name["battery_quantity"]
+BATTERY_RATED_VOLTAGE = PowerConfiguration.attributes_by_name["battery_rated_voltage"]
+
 
 class LightLinkCluster(CustomCluster, LightLink):
     """Ikea LightLink cluster."""
@@ -79,10 +85,6 @@ class ScenesCluster(CustomCluster, Scenes):
 class PowerConfig2AAACluster(PowerConfiguration):
     """Updating power attributes 2 AAA."""
 
-    BATTERY_SIZES = 0x0031
-    BATTERY_QUANTITY = 0x0033
-    BATTERY_RATED_VOLTAGE = 0x0034
-
     _CONSTANT_ATTRIBUTES = {
         BATTERY_SIZES: 4,
         BATTERY_QUANTITY: 2,
@@ -92,10 +94,6 @@ class PowerConfig2AAACluster(PowerConfiguration):
 
 class PowerConfig2CRCluster(PowerConfiguration):
     """Updating power attributes 2 CR2032."""
-
-    BATTERY_SIZES = 0x0031
-    BATTERY_QUANTITY = 0x0033
-    BATTERY_RATED_VOLTAGE = 0x0034
 
     _CONSTANT_ATTRIBUTES = {
         BATTERY_SIZES: 10,
@@ -107,10 +105,6 @@ class PowerConfig2CRCluster(PowerConfiguration):
 class PowerConfig1CRCluster(PowerConfiguration):
     """Updating power attributes 1 CR2032."""
 
-    BATTERY_SIZES = 0x0031
-    BATTERY_QUANTITY = 0x0033
-    BATTERY_RATED_VOLTAGE = 0x0034
-
     _CONSTANT_ATTRIBUTES = {
         BATTERY_SIZES: 10,
         BATTERY_QUANTITY: 1,
@@ -120,11 +114,6 @@ class PowerConfig1CRCluster(PowerConfiguration):
 
 class PowerConfig1CRXCluster(PowerConfiguration):
     """Updating power attributes 1 CR2032 and zero voltage."""
-
-    BATTERY_VOLTAGE = 0x0020
-    BATTERY_SIZES = 0x0031
-    BATTERY_QUANTITY = 0x0033
-    BATTERY_RATED_VOLTAGE = 0x0034
 
     _CONSTANT_ATTRIBUTES = {
         BATTERY_VOLTAGE: 0,

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -7,7 +7,7 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Scenes
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from zhaquirks import DoublingPowerConfigurationCluster
+from zhaquirks import DoublingPowerConfigurationCluster, PowerConfigurationCluster
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,7 +73,10 @@ class ScenesCluster(CustomCluster, Scenes):
     )
 
 
-class DoublingPowerConfiguration2AAACluster(DoublingPowerConfigurationCluster):
+# ZCL compliant IKEA power configuration clusters:
+
+
+class NormalPowerConfiguration2AAACluster(PowerConfigurationCluster):
     """Updating Power attributes 2 AAA."""
 
     BATTERY_SIZES = 0x0031
@@ -87,7 +90,7 @@ class DoublingPowerConfiguration2AAACluster(DoublingPowerConfigurationCluster):
     }
 
 
-class DoublingPowerConfiguration2CRCluster(DoublingPowerConfigurationCluster):
+class NormalPowerConfiguration2CRCluster(PowerConfigurationCluster):
     """Updating Power attributes 2 CR2032."""
 
     BATTERY_SIZES = 0x0031
@@ -101,7 +104,7 @@ class DoublingPowerConfiguration2CRCluster(DoublingPowerConfigurationCluster):
     }
 
 
-class DoublingPowerConfiguration1CRCluster(DoublingPowerConfigurationCluster):
+class NormalPowerConfiguration1CRCluster(PowerConfigurationCluster):
     """Updating Power attributes 1 CR2032."""
 
     BATTERY_SIZES = 0x0031
@@ -115,7 +118,7 @@ class DoublingPowerConfiguration1CRCluster(DoublingPowerConfigurationCluster):
     }
 
 
-class DoublingPowerConfiguration1CRXCluster(DoublingPowerConfigurationCluster):
+class NormalPowerConfiguration1CRXCluster(PowerConfigurationCluster):
     """Updating Power attributes 1 CR2032 and Zero voltage."""
 
     BATTERY_VOLTAGE = 0x0020
@@ -129,3 +132,30 @@ class DoublingPowerConfiguration1CRXCluster(DoublingPowerConfigurationCluster):
         BATTERY_QUANTITY: 1,
         BATTERY_RATED_VOLTAGE: 30,
     }
+
+
+# doubling IKEA power configuration clusters:
+
+
+class DoublingPowerConfiguration2AAACluster(
+    DoublingPowerConfigurationCluster, NormalPowerConfiguration2AAACluster
+):
+    """Updating Power attributes 2 AAA."""
+
+
+class DoublingPowerConfiguration2CRCluster(
+    DoublingPowerConfigurationCluster, NormalPowerConfiguration2CRCluster
+):
+    """Updating Power attributes 2 CR2032."""
+
+
+class DoublingPowerConfiguration1CRCluster(
+    DoublingPowerConfigurationCluster, NormalPowerConfiguration1CRCluster
+):
+    """Updating Power attributes 1 CR2032."""
+
+
+class DoublingPowerConfiguration1CRXCluster(
+    DoublingPowerConfigurationCluster, NormalPowerConfiguration1CRXCluster
+):
+    """Updating Power attributes 1 CR2032 and Zero voltage."""

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -80,8 +80,6 @@ class ScenesCluster(CustomCluster, Scenes):
 
 
 # ZCL compliant IKEA power configuration clusters:
-
-
 class PowerConfig2AAACluster(CustomCluster, PowerConfiguration):
     """Updating power attributes 2 AAA."""
 
@@ -124,8 +122,6 @@ class PowerConfig1CRXCluster(CustomCluster, PowerConfiguration):
 
 
 # doubling IKEA power configuration clusters:
-
-
 class DoublingPowerConfig2AAACluster(
     DoublingPowerConfigurationCluster, PowerConfig2AAACluster
 ):

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -76,7 +76,7 @@ class ScenesCluster(CustomCluster, Scenes):
 # ZCL compliant IKEA power configuration clusters:
 
 
-class NormalPowerConfiguration2AAACluster(PowerConfigurationCluster):
+class NormalPowerConfig2AAACluster(PowerConfigurationCluster):
     """Updating power attributes 2 AAA."""
 
     BATTERY_SIZES = 0x0031
@@ -90,7 +90,7 @@ class NormalPowerConfiguration2AAACluster(PowerConfigurationCluster):
     }
 
 
-class NormalPowerConfiguration2CRCluster(PowerConfigurationCluster):
+class NormalPowerConfig2CRCluster(PowerConfigurationCluster):
     """Updating power attributes 2 CR2032."""
 
     BATTERY_SIZES = 0x0031
@@ -104,7 +104,7 @@ class NormalPowerConfiguration2CRCluster(PowerConfigurationCluster):
     }
 
 
-class NormalPowerConfiguration1CRCluster(PowerConfigurationCluster):
+class NormalPowerConfig1CRCluster(PowerConfigurationCluster):
     """Updating power attributes 1 CR2032."""
 
     BATTERY_SIZES = 0x0031
@@ -118,7 +118,7 @@ class NormalPowerConfiguration1CRCluster(PowerConfigurationCluster):
     }
 
 
-class NormalPowerConfiguration1CRXCluster(PowerConfigurationCluster):
+class NormalPowerConfig1CRXCluster(PowerConfigurationCluster):
     """Updating power attributes 1 CR2032 and zero voltage."""
 
     BATTERY_VOLTAGE = 0x0020
@@ -137,25 +137,25 @@ class NormalPowerConfiguration1CRXCluster(PowerConfigurationCluster):
 # doubling IKEA power configuration clusters:
 
 
-class DoublingPowerConfiguration2AAACluster(
-    DoublingPowerConfigurationCluster, NormalPowerConfiguration2AAACluster
+class DoublingPowerConfig2AAACluster(
+    DoublingPowerConfigurationCluster, NormalPowerConfig2AAACluster
 ):
     """Doubling power configuration cluster. Updating power attributes 2 AAA."""
 
 
-class DoublingPowerConfiguration2CRCluster(
-    DoublingPowerConfigurationCluster, NormalPowerConfiguration2CRCluster
+class DoublingPowerConfig2CRCluster(
+    DoublingPowerConfigurationCluster, NormalPowerConfig2CRCluster
 ):
     """Doubling power configuration cluster. Updating power attributes 2 CR2032."""
 
 
-class DoublingPowerConfiguration1CRCluster(
-    DoublingPowerConfigurationCluster, NormalPowerConfiguration1CRCluster
+class DoublingPowerConfig1CRCluster(
+    DoublingPowerConfigurationCluster, NormalPowerConfig1CRCluster
 ):
     """Doubling power configuration cluster. Updating power attributes 1 CR2032."""
 
 
-class DoublingPowerConfiguration1CRXCluster(
-    DoublingPowerConfigurationCluster, NormalPowerConfiguration1CRXCluster
+class DoublingPowerConfig1CRXCluster(
+    DoublingPowerConfigurationCluster, NormalPowerConfig1CRXCluster
 ):
     """Doubling power configuration cluster. Updating power attributes 1 CR2032 and zero voltage."""

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -77,7 +77,7 @@ class ScenesCluster(CustomCluster, Scenes):
 
 
 class NormalPowerConfiguration2AAACluster(PowerConfigurationCluster):
-    """Updating Power attributes 2 AAA."""
+    """Updating power attributes 2 AAA."""
 
     BATTERY_SIZES = 0x0031
     BATTERY_QUANTITY = 0x0033
@@ -91,7 +91,7 @@ class NormalPowerConfiguration2AAACluster(PowerConfigurationCluster):
 
 
 class NormalPowerConfiguration2CRCluster(PowerConfigurationCluster):
-    """Updating Power attributes 2 CR2032."""
+    """Updating power attributes 2 CR2032."""
 
     BATTERY_SIZES = 0x0031
     BATTERY_QUANTITY = 0x0033
@@ -105,7 +105,7 @@ class NormalPowerConfiguration2CRCluster(PowerConfigurationCluster):
 
 
 class NormalPowerConfiguration1CRCluster(PowerConfigurationCluster):
-    """Updating Power attributes 1 CR2032."""
+    """Updating power attributes 1 CR2032."""
 
     BATTERY_SIZES = 0x0031
     BATTERY_QUANTITY = 0x0033
@@ -119,7 +119,7 @@ class NormalPowerConfiguration1CRCluster(PowerConfigurationCluster):
 
 
 class NormalPowerConfiguration1CRXCluster(PowerConfigurationCluster):
-    """Updating Power attributes 1 CR2032 and Zero voltage."""
+    """Updating power attributes 1 CR2032 and zero voltage."""
 
     BATTERY_VOLTAGE = 0x0020
     BATTERY_SIZES = 0x0031
@@ -140,22 +140,22 @@ class NormalPowerConfiguration1CRXCluster(PowerConfigurationCluster):
 class DoublingPowerConfiguration2AAACluster(
     DoublingPowerConfigurationCluster, NormalPowerConfiguration2AAACluster
 ):
-    """Updating Power attributes 2 AAA."""
+    """Updating power attributes 2 AAA."""
 
 
 class DoublingPowerConfiguration2CRCluster(
     DoublingPowerConfigurationCluster, NormalPowerConfiguration2CRCluster
 ):
-    """Updating Power attributes 2 CR2032."""
+    """Updating power attributes 2 CR2032."""
 
 
 class DoublingPowerConfiguration1CRCluster(
     DoublingPowerConfigurationCluster, NormalPowerConfiguration1CRCluster
 ):
-    """Updating Power attributes 1 CR2032."""
+    """Updating power attributes 1 CR2032."""
 
 
 class DoublingPowerConfiguration1CRXCluster(
     DoublingPowerConfigurationCluster, NormalPowerConfiguration1CRXCluster
 ):
-    """Updating Power attributes 1 CR2032 and Zero voltage."""
+    """Updating power attributes 1 CR2032 and zero voltage."""

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -76,7 +76,7 @@ class ScenesCluster(CustomCluster, Scenes):
 # ZCL compliant IKEA power configuration clusters:
 
 
-class NormalPowerConfig2AAACluster(PowerConfigurationCluster):
+class PowerConfig2AAACluster(PowerConfigurationCluster):
     """Updating power attributes 2 AAA."""
 
     BATTERY_SIZES = 0x0031
@@ -90,7 +90,7 @@ class NormalPowerConfig2AAACluster(PowerConfigurationCluster):
     }
 
 
-class NormalPowerConfig2CRCluster(PowerConfigurationCluster):
+class PowerConfig2CRCluster(PowerConfigurationCluster):
     """Updating power attributes 2 CR2032."""
 
     BATTERY_SIZES = 0x0031
@@ -104,7 +104,7 @@ class NormalPowerConfig2CRCluster(PowerConfigurationCluster):
     }
 
 
-class NormalPowerConfig1CRCluster(PowerConfigurationCluster):
+class PowerConfig1CRCluster(PowerConfigurationCluster):
     """Updating power attributes 1 CR2032."""
 
     BATTERY_SIZES = 0x0031
@@ -118,7 +118,7 @@ class NormalPowerConfig1CRCluster(PowerConfigurationCluster):
     }
 
 
-class NormalPowerConfig1CRXCluster(PowerConfigurationCluster):
+class PowerConfig1CRXCluster(PowerConfigurationCluster):
     """Updating power attributes 1 CR2032 and zero voltage."""
 
     BATTERY_VOLTAGE = 0x0020
@@ -138,24 +138,24 @@ class NormalPowerConfig1CRXCluster(PowerConfigurationCluster):
 
 
 class DoublingPowerConfig2AAACluster(
-    DoublingPowerConfigurationCluster, NormalPowerConfig2AAACluster
+    DoublingPowerConfigurationCluster, PowerConfig2AAACluster
 ):
     """Doubling power configuration cluster. Updating power attributes 2 AAA."""
 
 
 class DoublingPowerConfig2CRCluster(
-    DoublingPowerConfigurationCluster, NormalPowerConfig2CRCluster
+    DoublingPowerConfigurationCluster, PowerConfig2CRCluster
 ):
     """Doubling power configuration cluster. Updating power attributes 2 CR2032."""
 
 
 class DoublingPowerConfig1CRCluster(
-    DoublingPowerConfigurationCluster, NormalPowerConfig1CRCluster
+    DoublingPowerConfigurationCluster, PowerConfig1CRCluster
 ):
     """Doubling power configuration cluster. Updating power attributes 1 CR2032."""
 
 
 class DoublingPowerConfig1CRXCluster(
-    DoublingPowerConfigurationCluster, NormalPowerConfig1CRXCluster
+    DoublingPowerConfigurationCluster, PowerConfig1CRXCluster
 ):
     """Doubling power configuration cluster. Updating power attributes 1 CR2032 and zero voltage."""

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -83,7 +83,7 @@ class ScenesCluster(CustomCluster, Scenes):
 
 # ZCL compliant IKEA power configuration clusters:
 class PowerConfig2AAACluster(CustomCluster, PowerConfiguration):
-    """Updating power attributes 2 AAA."""
+    """Updating power attributes: 2 AAA."""
 
     _CONSTANT_ATTRIBUTES = {
         BATTERY_SIZE: 4,
@@ -93,7 +93,7 @@ class PowerConfig2AAACluster(CustomCluster, PowerConfiguration):
 
 
 class PowerConfig2CRCluster(CustomCluster, PowerConfiguration):
-    """Updating power attributes 2 CR2032."""
+    """Updating power attributes: 2 CR2032."""
 
     _CONSTANT_ATTRIBUTES = {
         BATTERY_SIZE: 10,
@@ -103,7 +103,7 @@ class PowerConfig2CRCluster(CustomCluster, PowerConfiguration):
 
 
 class PowerConfig1CRCluster(CustomCluster, PowerConfiguration):
-    """Updating power attributes 1 CR2032."""
+    """Updating power attributes: 1 CR2032."""
 
     _CONSTANT_ATTRIBUTES = {
         BATTERY_SIZE: 10,
@@ -113,7 +113,7 @@ class PowerConfig1CRCluster(CustomCluster, PowerConfiguration):
 
 
 class PowerConfig1CRXCluster(CustomCluster, PowerConfiguration):
-    """Updating power attributes 1 CR2032 and zero voltage."""
+    """Updating power attributes: 1 CR2032 and zero voltage."""
 
     _CONSTANT_ATTRIBUTES = {
         BATTERY_VOLTAGE: 0,
@@ -127,22 +127,22 @@ class PowerConfig1CRXCluster(CustomCluster, PowerConfiguration):
 class DoublingPowerConfig2AAACluster(
     DoublingPowerConfigurationCluster, PowerConfig2AAACluster
 ):
-    """Doubling power configuration cluster. Updating power attributes 2 AAA."""
+    """Doubling power configuration cluster. Updating power attributes: 2 AAA."""
 
 
 class DoublingPowerConfig2CRCluster(
     DoublingPowerConfigurationCluster, PowerConfig2CRCluster
 ):
-    """Doubling power configuration cluster. Updating power attributes 2 CR2032."""
+    """Doubling power configuration cluster. Updating power attributes: 2 CR2032."""
 
 
 class DoublingPowerConfig1CRCluster(
     DoublingPowerConfigurationCluster, PowerConfig1CRCluster
 ):
-    """Doubling power configuration cluster. Updating power attributes 1 CR2032."""
+    """Doubling power configuration cluster. Updating power attributes: 1 CR2032."""
 
 
 class DoublingPowerConfig1CRXCluster(
     DoublingPowerConfigurationCluster, PowerConfig1CRXCluster
 ):
-    """Doubling power configuration cluster. Updating power attributes 1 CR2032 and zero voltage."""
+    """Doubling power configuration cluster. Updating power attributes: 1 CR2032 and zero voltage."""

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -82,7 +82,7 @@ class ScenesCluster(CustomCluster, Scenes):
 # ZCL compliant IKEA power configuration clusters:
 
 
-class PowerConfig2AAACluster(PowerConfiguration):
+class PowerConfig2AAACluster(CustomCluster, PowerConfiguration):
     """Updating power attributes 2 AAA."""
 
     _CONSTANT_ATTRIBUTES = {
@@ -92,7 +92,7 @@ class PowerConfig2AAACluster(PowerConfiguration):
     }
 
 
-class PowerConfig2CRCluster(PowerConfiguration):
+class PowerConfig2CRCluster(CustomCluster, PowerConfiguration):
     """Updating power attributes 2 CR2032."""
 
     _CONSTANT_ATTRIBUTES = {
@@ -102,7 +102,7 @@ class PowerConfig2CRCluster(PowerConfiguration):
     }
 
 
-class PowerConfig1CRCluster(PowerConfiguration):
+class PowerConfig1CRCluster(CustomCluster, PowerConfiguration):
     """Updating power attributes 1 CR2032."""
 
     _CONSTANT_ATTRIBUTES = {
@@ -112,7 +112,7 @@ class PowerConfig1CRCluster(PowerConfiguration):
     }
 
 
-class PowerConfig1CRXCluster(PowerConfiguration):
+class PowerConfig1CRXCluster(CustomCluster, PowerConfiguration):
     """Updating power attributes 1 CR2032 and zero voltage."""
 
     _CONSTANT_ATTRIBUTES = {

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -140,22 +140,22 @@ class NormalPowerConfiguration1CRXCluster(PowerConfigurationCluster):
 class DoublingPowerConfiguration2AAACluster(
     DoublingPowerConfigurationCluster, NormalPowerConfiguration2AAACluster
 ):
-    """Updating power attributes 2 AAA."""
+    """Doubling power configuration cluster. Updating power attributes 2 AAA."""
 
 
 class DoublingPowerConfiguration2CRCluster(
     DoublingPowerConfigurationCluster, NormalPowerConfiguration2CRCluster
 ):
-    """Updating power attributes 2 CR2032."""
+    """Doubling power configuration cluster. Updating power attributes 2 CR2032."""
 
 
 class DoublingPowerConfiguration1CRCluster(
     DoublingPowerConfigurationCluster, NormalPowerConfiguration1CRCluster
 ):
-    """Updating power attributes 1 CR2032."""
+    """Doubling power configuration cluster. Updating power attributes 1 CR2032."""
 
 
 class DoublingPowerConfiguration1CRXCluster(
     DoublingPowerConfigurationCluster, NormalPowerConfiguration1CRXCluster
 ):
-    """Updating power attributes 1 CR2032 and zero voltage."""
+    """Doubling power configuration cluster. Updating power attributes 1 CR2032 and zero voltage."""

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -4,10 +4,10 @@ import logging
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import Scenes
+from zigpy.zcl.clusters.general import PowerConfiguration, Scenes
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from zhaquirks import DoublingPowerConfigurationCluster, PowerConfigurationCluster
+from zhaquirks import DoublingPowerConfigurationCluster
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,7 +76,7 @@ class ScenesCluster(CustomCluster, Scenes):
 # ZCL compliant IKEA power configuration clusters:
 
 
-class PowerConfig2AAACluster(PowerConfigurationCluster):
+class PowerConfig2AAACluster(PowerConfiguration):
     """Updating power attributes 2 AAA."""
 
     BATTERY_SIZES = 0x0031
@@ -90,7 +90,7 @@ class PowerConfig2AAACluster(PowerConfigurationCluster):
     }
 
 
-class PowerConfig2CRCluster(PowerConfigurationCluster):
+class PowerConfig2CRCluster(PowerConfiguration):
     """Updating power attributes 2 CR2032."""
 
     BATTERY_SIZES = 0x0031
@@ -104,7 +104,7 @@ class PowerConfig2CRCluster(PowerConfigurationCluster):
     }
 
 
-class PowerConfig1CRCluster(PowerConfigurationCluster):
+class PowerConfig1CRCluster(PowerConfiguration):
     """Updating power attributes 1 CR2032."""
 
     BATTERY_SIZES = 0x0031
@@ -118,7 +118,7 @@ class PowerConfig1CRCluster(PowerConfigurationCluster):
     }
 
 
-class PowerConfig1CRXCluster(PowerConfigurationCluster):
+class PowerConfig1CRXCluster(PowerConfiguration):
     """Updating power attributes 1 CR2032 and zero voltage."""
 
     BATTERY_VOLTAGE = 0x0020

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -17,7 +17,7 @@ WWAH_CLUSTER_ID = 0xFC57  # decimal = 64599 ('Works with all Hubs' cluster)
 
 # PowerConfiguration cluster attributes
 BATTERY_VOLTAGE = PowerConfiguration.attributes_by_name["battery_voltage"]
-BATTERY_SIZES = PowerConfiguration.attributes_by_name["battery_size"]
+BATTERY_SIZE = PowerConfiguration.attributes_by_name["battery_size"]
 BATTERY_QUANTITY = PowerConfiguration.attributes_by_name["battery_quantity"]
 BATTERY_RATED_VOLTAGE = PowerConfiguration.attributes_by_name["battery_rated_voltage"]
 
@@ -86,7 +86,7 @@ class PowerConfig2AAACluster(PowerConfiguration):
     """Updating power attributes 2 AAA."""
 
     _CONSTANT_ATTRIBUTES = {
-        BATTERY_SIZES: 4,
+        BATTERY_SIZE: 4,
         BATTERY_QUANTITY: 2,
         BATTERY_RATED_VOLTAGE: 15,
     }
@@ -96,7 +96,7 @@ class PowerConfig2CRCluster(PowerConfiguration):
     """Updating power attributes 2 CR2032."""
 
     _CONSTANT_ATTRIBUTES = {
-        BATTERY_SIZES: 10,
+        BATTERY_SIZE: 10,
         BATTERY_QUANTITY: 2,
         BATTERY_RATED_VOLTAGE: 30,
     }
@@ -106,7 +106,7 @@ class PowerConfig1CRCluster(PowerConfiguration):
     """Updating power attributes 1 CR2032."""
 
     _CONSTANT_ATTRIBUTES = {
-        BATTERY_SIZES: 10,
+        BATTERY_SIZE: 10,
         BATTERY_QUANTITY: 1,
         BATTERY_RATED_VOLTAGE: 30,
     }
@@ -117,7 +117,7 @@ class PowerConfig1CRXCluster(PowerConfiguration):
 
     _CONSTANT_ATTRIBUTES = {
         BATTERY_VOLTAGE: 0,
-        BATTERY_SIZES: 10,
+        BATTERY_SIZE: 10,
         BATTERY_QUANTITY: 1,
         BATTERY_RATED_VOLTAGE: 30,
     }

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -73,7 +73,7 @@ class ScenesCluster(CustomCluster, Scenes):
     )
 
 
-class PowerConfiguration2AAACluster(DoublingPowerConfigurationCluster):
+class DoublingPowerConfiguration2AAACluster(DoublingPowerConfigurationCluster):
     """Updating Power attributes 2 AAA."""
 
     BATTERY_SIZES = 0x0031
@@ -87,7 +87,7 @@ class PowerConfiguration2AAACluster(DoublingPowerConfigurationCluster):
     }
 
 
-class PowerConfiguration2CRCluster(DoublingPowerConfigurationCluster):
+class DoublingPowerConfiguration2CRCluster(DoublingPowerConfigurationCluster):
     """Updating Power attributes 2 CR2032."""
 
     BATTERY_SIZES = 0x0031
@@ -101,7 +101,7 @@ class PowerConfiguration2CRCluster(DoublingPowerConfigurationCluster):
     }
 
 
-class PowerConfiguration1CRCluster(DoublingPowerConfigurationCluster):
+class DoublingPowerConfiguration1CRCluster(DoublingPowerConfigurationCluster):
     """Updating Power attributes 1 CR2032."""
 
     BATTERY_SIZES = 0x0031
@@ -115,7 +115,7 @@ class PowerConfiguration1CRCluster(DoublingPowerConfigurationCluster):
     }
 
 
-class PowerConfiguration1CRXCluster(DoublingPowerConfigurationCluster):
+class DoublingPowerConfiguration1CRXCluster(DoublingPowerConfigurationCluster):
     """Updating Power attributes 1 CR2032 and Zero voltage."""
 
     BATTERY_VOLTAGE = 0x0020

--- a/zhaquirks/ikea/dimmer.py
+++ b/zhaquirks/ikea/dimmer.py
@@ -30,7 +30,7 @@ from zhaquirks.const import (
     RIGHT,
     ROTATED,
 )
-from zhaquirks.ikea import IKEA, DoublingPowerConfiguration1CRXCluster
+from zhaquirks.ikea import IKEA, DoublingPowerConfig1CRXCluster
 
 
 class IkeaDimmer(CustomDevice):
@@ -72,7 +72,7 @@ class IkeaDimmer(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration1CRXCluster,
+                    DoublingPowerConfig1CRXCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,

--- a/zhaquirks/ikea/dimmer.py
+++ b/zhaquirks/ikea/dimmer.py
@@ -30,7 +30,7 @@ from zhaquirks.const import (
     RIGHT,
     ROTATED,
 )
-from zhaquirks.ikea import IKEA, PowerConfiguration1CRXCluster
+from zhaquirks.ikea import IKEA, DoublingPowerConfiguration1CRXCluster
 
 
 class IkeaDimmer(CustomDevice):
@@ -72,7 +72,7 @@ class IkeaDimmer(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration1CRXCluster,
+                    DoublingPowerConfiguration1CRXCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,

--- a/zhaquirks/ikea/fivebtnremote.py
+++ b/zhaquirks/ikea/fivebtnremote.py
@@ -53,7 +53,7 @@ from zhaquirks.ikea import (
     WWAH_CLUSTER_ID,
     DoublingPowerConfig1CRCluster,
     LightLinkCluster,
-    NormalPowerConfig1CRCluster,
+    PowerConfig1CRCluster,
     ScenesCluster,
 )
 
@@ -428,7 +428,7 @@ class IkeaTradfriRemote5(IkeaTradfriRemote1):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    NormalPowerConfig1CRCluster,
+                    PowerConfig1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLinkCluster,

--- a/zhaquirks/ikea/fivebtnremote.py
+++ b/zhaquirks/ikea/fivebtnremote.py
@@ -51,9 +51,9 @@ from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
     WWAH_CLUSTER_ID,
-    DoublingPowerConfiguration1CRCluster,
+    DoublingPowerConfig1CRCluster,
     LightLinkCluster,
-    NormalPowerConfiguration1CRCluster,
+    NormalPowerConfig1CRCluster,
     ScenesCluster,
 )
 
@@ -245,7 +245,7 @@ class IkeaTradfriRemote2(IkeaTradfriRemote1):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration1CRCluster,
+                    DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLinkCluster,
@@ -306,7 +306,7 @@ class IkeaTradfriRemote3(IkeaTradfriRemote1):
                 DEVICE_TYPE: zha.DeviceType.COLOR_SCENE_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration1CRCluster,
+                    DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     LightLinkCluster,
@@ -366,7 +366,7 @@ class IkeaTradfriRemote4(IkeaTradfriRemote1):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration1CRCluster,
+                    DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLinkCluster,
@@ -428,7 +428,7 @@ class IkeaTradfriRemote5(IkeaTradfriRemote1):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    NormalPowerConfiguration1CRCluster,
+                    NormalPowerConfig1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLinkCluster,

--- a/zhaquirks/ikea/fivebtnremote.py
+++ b/zhaquirks/ikea/fivebtnremote.py
@@ -51,8 +51,8 @@ from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
     WWAH_CLUSTER_ID,
+    DoublingPowerConfiguration1CRCluster,
     LightLinkCluster,
-    PowerConfiguration1CRCluster,
     ScenesCluster,
 )
 
@@ -244,7 +244,7 @@ class IkeaTradfriRemote2(IkeaTradfriRemote1):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration1CRCluster,
+                    DoublingPowerConfiguration1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLinkCluster,
@@ -305,7 +305,7 @@ class IkeaTradfriRemote3(IkeaTradfriRemote1):
                 DEVICE_TYPE: zha.DeviceType.COLOR_SCENE_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration1CRCluster,
+                    DoublingPowerConfiguration1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     LightLinkCluster,
@@ -365,7 +365,7 @@ class IkeaTradfriRemote4(IkeaTradfriRemote1):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration1CRCluster,
+                    DoublingPowerConfiguration1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLinkCluster,

--- a/zhaquirks/ikea/fivebtnremote.py
+++ b/zhaquirks/ikea/fivebtnremote.py
@@ -53,6 +53,7 @@ from zhaquirks.ikea import (
     WWAH_CLUSTER_ID,
     DoublingPowerConfiguration1CRCluster,
     LightLinkCluster,
+    NormalPowerConfiguration1CRCluster,
     ScenesCluster,
 )
 
@@ -427,7 +428,7 @@ class IkeaTradfriRemote5(IkeaTradfriRemote1):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
+                    NormalPowerConfiguration1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLinkCluster,

--- a/zhaquirks/ikea/fourbtnremote.py
+++ b/zhaquirks/ikea/fourbtnremote.py
@@ -45,7 +45,7 @@ from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
     WWAH_CLUSTER_ID,
-    PowerConfiguration2AAACluster,
+    DoublingPowerConfiguration2AAACluster,
     ScenesCluster,
 )
 
@@ -89,7 +89,7 @@ class IkeaTradfriRemoteV1(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration2AAACluster,
+                    DoublingPowerConfiguration2AAACluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,

--- a/zhaquirks/ikea/fourbtnremote.py
+++ b/zhaquirks/ikea/fourbtnremote.py
@@ -45,7 +45,7 @@ from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
     WWAH_CLUSTER_ID,
-    DoublingPowerConfiguration2AAACluster,
+    DoublingPowerConfig2AAACluster,
     ScenesCluster,
 )
 
@@ -89,7 +89,7 @@ class IkeaTradfriRemoteV1(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration2AAACluster,
+                    DoublingPowerConfig2AAACluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,

--- a/zhaquirks/ikea/motion.py
+++ b/zhaquirks/ikea/motion.py
@@ -21,7 +21,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.ikea import IKEA, LightLinkCluster, PowerConfiguration2CRCluster
+from zhaquirks.ikea import IKEA, DoublingPowerConfiguration2CRCluster, LightLinkCluster
 
 
 class IkeaTradfriMotion(CustomDevice):
@@ -63,7 +63,7 @@ class IkeaTradfriMotion(CustomDevice):
                 DEVICE_TYPE: zll.DeviceType.ON_OFF_SENSOR,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration2CRCluster,
+                    DoublingPowerConfiguration2CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     Diagnostic.cluster_id,

--- a/zhaquirks/ikea/motion.py
+++ b/zhaquirks/ikea/motion.py
@@ -21,7 +21,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.ikea import IKEA, DoublingPowerConfiguration2CRCluster, LightLinkCluster
+from zhaquirks.ikea import IKEA, DoublingPowerConfig2CRCluster, LightLinkCluster
 
 
 class IkeaTradfriMotion(CustomDevice):
@@ -63,7 +63,7 @@ class IkeaTradfriMotion(CustomDevice):
                 DEVICE_TYPE: zll.DeviceType.ON_OFF_SENSOR,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration2CRCluster,
+                    DoublingPowerConfig2CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     Diagnostic.cluster_id,

--- a/zhaquirks/ikea/motionzha.py
+++ b/zhaquirks/ikea/motionzha.py
@@ -27,8 +27,8 @@ from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
     WWAH_CLUSTER_ID,
+    DoublingPowerConfiguration2CRCluster,
     LightLinkCluster,
-    PowerConfiguration2CRCluster,
 )
 
 
@@ -71,7 +71,7 @@ class IkeaTradfriMotionE1745_Var01(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration2CRCluster,
+                    DoublingPowerConfiguration2CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     Diagnostic.cluster_id,
@@ -130,7 +130,7 @@ class IkeaTradfriMotionE1745_Var02(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration2CRCluster,
+                    DoublingPowerConfiguration2CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,
@@ -190,7 +190,7 @@ class IkeaTradfriMotionE1525_Var01(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration2CRCluster,
+                    DoublingPowerConfiguration2CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLinkCluster,

--- a/zhaquirks/ikea/motionzha.py
+++ b/zhaquirks/ikea/motionzha.py
@@ -27,7 +27,7 @@ from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
     WWAH_CLUSTER_ID,
-    DoublingPowerConfiguration2CRCluster,
+    DoublingPowerConfig2CRCluster,
     LightLinkCluster,
 )
 
@@ -71,7 +71,7 @@ class IkeaTradfriMotionE1745_Var01(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration2CRCluster,
+                    DoublingPowerConfig2CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     Diagnostic.cluster_id,
@@ -130,7 +130,7 @@ class IkeaTradfriMotionE1745_Var02(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration2CRCluster,
+                    DoublingPowerConfig2CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,
@@ -190,7 +190,7 @@ class IkeaTradfriMotionE1525_Var01(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration2CRCluster,
+                    DoublingPowerConfig2CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLinkCluster,

--- a/zhaquirks/ikea/opencloseremote.py
+++ b/zhaquirks/ikea/opencloseremote.py
@@ -35,7 +35,7 @@ from zhaquirks.const import (
     SHORT_PRESS,
     ZHA_SEND_EVENT,
 )
-from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, DoublingPowerConfiguration1CRCluster
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, DoublingPowerConfig1CRCluster
 
 COMMAND_CLOSE = "down_close"
 COMMAND_STOP_OPENING = "stop_opening"
@@ -120,7 +120,7 @@ class IkeaTradfriOpenCloseRemote(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration1CRCluster,
+                    DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,

--- a/zhaquirks/ikea/opencloseremote.py
+++ b/zhaquirks/ikea/opencloseremote.py
@@ -35,7 +35,7 @@ from zhaquirks.const import (
     SHORT_PRESS,
     ZHA_SEND_EVENT,
 )
-from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, PowerConfiguration1CRCluster
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, DoublingPowerConfiguration1CRCluster
 
 COMMAND_CLOSE = "down_close"
 COMMAND_STOP_OPENING = "stop_opening"
@@ -120,7 +120,7 @@ class IkeaTradfriOpenCloseRemote(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration1CRCluster,
+                    DoublingPowerConfiguration1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,

--- a/zhaquirks/ikea/shortcutbtn.py
+++ b/zhaquirks/ikea/shortcutbtn.py
@@ -40,8 +40,8 @@ from zhaquirks.const import (
 from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
+    DoublingPowerConfiguration1CRCluster,
     LightLinkCluster,
-    PowerConfiguration1CRCluster,
 )
 
 
@@ -86,7 +86,7 @@ class IkeaTradfriShortcutBtn(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration1CRCluster,
+                    DoublingPowerConfiguration1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,
@@ -163,7 +163,7 @@ class IkeaTradfriShortcutBtn2(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration1CRCluster,
+                    DoublingPowerConfiguration1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,

--- a/zhaquirks/ikea/shortcutbtn.py
+++ b/zhaquirks/ikea/shortcutbtn.py
@@ -40,7 +40,7 @@ from zhaquirks.const import (
 from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
-    DoublingPowerConfiguration1CRCluster,
+    DoublingPowerConfig1CRCluster,
     LightLinkCluster,
 )
 
@@ -86,7 +86,7 @@ class IkeaTradfriShortcutBtn(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration1CRCluster,
+                    DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,
@@ -163,7 +163,7 @@ class IkeaTradfriShortcutBtn2(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration1CRCluster,
+                    DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,

--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -38,7 +38,7 @@ from zhaquirks.const import (
     TRIPLE_PRESS,
     TURN_ON,
 )
-from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, DoublingPowerConfiguration1CRCluster
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, DoublingPowerConfig1CRCluster
 
 
 class IkeaSYMFONISK1(CustomDevice):
@@ -80,7 +80,7 @@ class IkeaSYMFONISK1(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration1CRCluster,
+                    DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,
@@ -176,7 +176,7 @@ class IkeaSYMFONISK2(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration1CRCluster,
+                    DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,

--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -38,7 +38,7 @@ from zhaquirks.const import (
     TRIPLE_PRESS,
     TURN_ON,
 )
-from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, PowerConfiguration1CRCluster
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, DoublingPowerConfiguration1CRCluster
 
 
 class IkeaSYMFONISK1(CustomDevice):
@@ -80,7 +80,7 @@ class IkeaSYMFONISK1(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration1CRCluster,
+                    DoublingPowerConfiguration1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,
@@ -176,7 +176,7 @@ class IkeaSYMFONISK2(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration1CRCluster,
+                    DoublingPowerConfiguration1CRCluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -43,7 +43,7 @@ from zhaquirks.const import (
 from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
-    DoublingPowerConfiguration1CRCluster,
+    DoublingPowerConfig1CRCluster,
     LightLinkCluster,
 )
 
@@ -90,7 +90,7 @@ class IkeaTradfriRemote2Btn(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfiguration1CRCluster,
+                    DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -43,8 +43,8 @@ from zhaquirks.const import (
 from zhaquirks.ikea import (
     IKEA,
     IKEA_CLUSTER_ID,
+    DoublingPowerConfiguration1CRCluster,
     LightLinkCluster,
-    PowerConfiguration1CRCluster,
 )
 
 
@@ -90,7 +90,7 @@ class IkeaTradfriRemote2Btn(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration1CRCluster,
+                    DoublingPowerConfiguration1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,


### PR DESCRIPTION
Originates from: https://github.com/zigpy/zha-device-handlers/pull/2273#pullrequestreview-1346844044
cc @MattWestb 

Newer IKEA devices no longer need a doubling of the reported battery percentage. This adds the new clusters that still set the battery information but no longer double the value.
I've split this up from the the Symfonisk PR, as it's a lot of "changes" (without them actual being changes). So the other PR doesn't get cluttered. I will rebase the Symfonisk PR on these changes when this gets merged (no need for you to do anything MattWestb – if this works as expected).

It also renames all doubling clusters to include `Doubling`.

I've also changed the "updated IKEA five button remote" to use the (normal/compliant/non-doubling) `PowerConfig1CRCluster`: https://github.com/zigpy/zha-device-handlers/commit/68510d03ff711884dcaff43df78709d67dc4f4c0

The changes are easier to see when going through the commits one by one (although there are a lot of commits now).