### PR TITLE
Add support for TS130F curtain controller variant by OXT

### DIFF
--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -166,6 +166,63 @@ class TuyaZemismartTS130F(CustomDevice):
         },
     }
 
+class TuyaOxtTS130F(CustomDevice):
+    """Tuya Oxt smart curtain roller shutter."""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0x0202, device_version=1, input_clusters=[0x0000, 0x0004, 0x0005, 0x0102], output_clusters=[0x000a, 0x0019])
+        # endpoint=242, profile=41440, device_type=0x0061, input_clusters=[], output_clusters=[0x0021]))
+        MODEL: "TS130F",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    WindowCovering.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+                # input_clusters=[]
+                # output_clusters=[33]
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaCoveringCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
 
 class TuyaTS130FTI2(CustomDevice):
     """Tuya smart curtain roller shutter Time In."""

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -167,12 +167,11 @@ class TuyaZemismartTS130F(CustomDevice):
     }
 
 
-class TuyaOxtTS130F(CustomDevice):
+class TuyaTS130FTOGP(CustomDevice):
     """Tuya Oxt smart curtain roller shutter."""
 
     signature = {
-        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0x0202, device_version=1, input_clusters=[0x0000, 0x0004, 0x0005, 0x0102], output_clusters=[0x000a, 0x0019])
-        # endpoint=242, profile=41440, device_type=0x0061, input_clusters=[], output_clusters=[0x0021]))
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0x0202, device_version=1, input_clusters=[0x0000, 0x0004, 0x0005, 0x0102], output_clusters=[0x000a, 0x0019], endpoint=242, profile=41440, device_type=0x0061, input_clusters=[], output_clusters=[0x0021])
         MODEL: "TS130F",
         ENDPOINTS: {
             1: {

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -173,9 +173,9 @@ class TuyaTS130FTOGP(CustomDevice):
     signature = {
         MODEL: "TS130F",
         ENDPOINTS: {
-            # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0202 
-            # device_version=1 
-            # input_clusters=[0x0000, 0x0004, 0x0005, 0x0102] 
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0202
+            # device_version=1
+            # input_clusters=[0x0000, 0x0004, 0x0005, 0x0102]
             # output_clusters=[0x000a, 0x0019]>
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -166,6 +166,7 @@ class TuyaZemismartTS130F(CustomDevice):
         },
     }
 
+
 class TuyaOxtTS130F(CustomDevice):
     """Tuya Oxt smart curtain roller shutter."""
 
@@ -223,6 +224,7 @@ class TuyaOxtTS130F(CustomDevice):
             },
         },
     }
+
 
 class TuyaTS130FTI2(CustomDevice):
     """Tuya smart curtain roller shutter Time In."""

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -171,9 +171,12 @@ class TuyaTS130FTOGP(CustomDevice):
     """Tuya Oxt smart curtain roller shutter."""
 
     signature = {
-        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0x0202, device_version=1, input_clusters=[0x0000, 0x0004, 0x0005, 0x0102], output_clusters=[0x000a, 0x0019], endpoint=242, profile=41440, device_type=0x0061, input_clusters=[], output_clusters=[0x0021])
         MODEL: "TS130F",
         ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0202 
+            # device_version=1 
+            # input_clusters=[0x0000, 0x0004, 0x0005, 0x0102] 
+            # output_clusters=[0x000a, 0x0019]>
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
@@ -188,10 +191,10 @@ class TuyaTS130FTOGP(CustomDevice):
                     Ota.cluster_id,
                 ],
             },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # input_clusters=[]
+            # output_clusters=[33]>
             242: {
-                # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
-                # input_clusters=[]
-                # output_clusters=[33]
                 PROFILE_ID: 41440,
                 DEVICE_TYPE: 97,
                 INPUT_CLUSTERS: [],


### PR DESCRIPTION
I just bought OXT curtain controller what did not work out of box. Adding that Quirk solve an issue.
Device identify it self as _TZ3210_dwytrmda TS130F and has that signature

```
{
  "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": "0x0202",
      "in_clusters": [
        "0x0000",
        "0x0004",
        "0x0005",
        "0x0102"
      ],
      "out_clusters": [
        "0x000a",
        "0x0019"
      ]
    },
    "242": {
      "profile_id": 41440,
      "device_type": "0x0061",
      "in_clusters": [],
      "out_clusters": [
        "0x0021"
      ]
    }
  },
  "manufacturer": "_TZ3210_dwytrmda",
  "model": "TS130F",
  "class": "zigpy.device.Device"
}
```
Its my first change here, so please verify it is to make sense.
