### PR TITLE
Don't bind power config for Tuya TS004F remotes, use remote OnOff cluster

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -871,12 +871,6 @@ class TuyaLocalCluster(LocalDataCluster):
         return self._update_attribute(attr.id, value)
 
 
-class TuyaPowerConfigurationClusterEnchantable(
-    TuyaEnchantableCluster, PowerConfiguration
-):
-    """Enchantable PowerConfiguration cluster."""
-
-
 class _TuyaNoBindPowerConfigurationCluster(CustomCluster, PowerConfiguration):
     """PowerConfiguration cluster that prevents setting up binding/attribute reports in order to stop battery drain.
 

--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -59,9 +59,8 @@ from zhaquirks.const import (
     TURN_ON,
 )
 from zhaquirks.tuya import (
-    TuyaPowerConfigurationClusterEnchantable,
+    TuyaNoBindPowerConfigurationCluster,
     TuyaSmartRemoteOnOffCluster,
-    TuyaZBOnOffAttributeCluster,
 )
 from zhaquirks.tuya.mcu import EnchantedDevice
 
@@ -114,7 +113,7 @@ class TuyaSmartRemote004FROK(EnchantedDevice, CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    TuyaPowerConfigurationClusterEnchantable,
+                    TuyaNoBindPowerConfigurationCluster,
                     Identify.cluster_id,
                     Groups.cluster_id,  # Is needed for adding group then binding is not working.
                     LightLink.cluster_id,
@@ -230,7 +229,7 @@ class TuyaSmartRemote004FDMS(EnchantedDevice, CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    TuyaPowerConfigurationClusterEnchantable,
+                    TuyaNoBindPowerConfigurationCluster,
                     Identify.cluster_id,
                     Groups.cluster_id,  # Is needed for adding group then binding is not working.
                     LightLink.cluster_id,
@@ -361,7 +360,7 @@ class TuyaSmartRemote004F(EnchantedDevice, CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
+                    TuyaNoBindPowerConfigurationCluster,
                     Identify.cluster_id,
                     Groups.cluster_id,  # Is needed for adding group then binding is not working.
                     LightLink.cluster_id,
@@ -372,7 +371,7 @@ class TuyaSmartRemote004F(EnchantedDevice, CustomDevice):
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TuyaZBOnOffAttributeCluster,
+                    TuyaSmartRemoteOnOffCluster,
                     LevelControl.cluster_id,
                     LightLink.cluster_id,
                 ],


### PR DESCRIPTION
This uses `TuyaNoBindPowerConfigurationCluster` for all three remotes/quirks in the `TS004F` file to avoid binding the power configuration cluster.

It also replaces the `TuyaZBOnOffAttributeCluster` with the `TuyaSmartRemoteOnOffCluster` cluster that's used by the other models.
=> This is somewhat to avoid having two enchanted clusters, the other two models already used that cluster, and it also prevents binding the OnOff cluster (due to the different `ep_attribute`, so I guess that's one less cluster bound).
We don't have tests for this, but I don't think it should break anything(?) (Even if, the impact should be somewhat minimal and I can revert/fix it.)
Any ideas if this is okay?

Lastly, it also removes the `TuyaPowerConfigurationClusterEnchantable` cluster class, as it was only used by those TS004F models and since Tuya gateways apparently don't bind that cluster even, we likely won't need it again.

cc @MattWestb (and maybe @javicalle 😄)