### PR TITLE
Fix Tuya `_TZE200_t1blo2bj` siren toggle switch

### DIFF
--- a/zhaquirks/tuya/ts0601_siren.py
+++ b/zhaquirks/tuya/ts0601_siren.py
@@ -147,11 +147,11 @@ class TuyaSirenOnOff(LocalDataCluster, OnOff):
 
         if command_id in (0x0000, 0x0001):
             (res,) = await self.endpoint.tuya_manufacturer.write_attributes(
-                {TUYA_ALARM_ATTR: command_id}, manufacturer=manufacturer
+                {TUYA_ALARM_ATTR: bool(command_id)}, manufacturer=manufacturer
             )
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
-            ].schema(command_id=command_id, status=res[0].status)
+            ].schema(command_id=bool(command_id), status=res[0].status)
 
         return foundation.GENERAL_COMMANDS[
             foundation.GeneralCommand.Default_Response
@@ -293,7 +293,7 @@ class TuyaMCUSiren(OnOff, TuyaAttributesCluster):
                 endpoint_id=self.endpoint.endpoint_id,
                 cluster_name=self.ep_attribute,
                 cluster_attr="on_off",
-                attr_value=command_id,
+                attr_value=bool(command_id),
                 expect_reply=expect_reply,
                 manufacturer=foundation.ZCLHeader.NO_MANUFACTURER_ID,
             )

--- a/zhaquirks/tuya/ts0601_siren.py
+++ b/zhaquirks/tuya/ts0601_siren.py
@@ -147,11 +147,11 @@ class TuyaSirenOnOff(LocalDataCluster, OnOff):
 
         if command_id in (0x0000, 0x0001):
             (res,) = await self.endpoint.tuya_manufacturer.write_attributes(
-                {TUYA_ALARM_ATTR: bool(command_id)}, manufacturer=manufacturer
+                {TUYA_ALARM_ATTR: command_id}, manufacturer=manufacturer
             )
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
-            ].schema(command_id=bool(command_id), status=res[0].status)
+            ].schema(command_id=command_id, status=res[0].status)
 
         return foundation.GENERAL_COMMANDS[
             foundation.GeneralCommand.Default_Response


### PR DESCRIPTION
**Describe the bug**

Current setup: Volume is set, melody is set, alarm is set, duration is also set.

 _TZE200_t1blo2bj switch (toggle) doesn't work. Whenever the trigger is pressed, alarm doesn't turn on nor off. Looking at the logs I see the following:

`DEBUG (MainThread) [zigpy.zcl] [0x8971:1:0xef00] tuya_mcu_command: cluster_data=TuyaClusterData(endpoint_id=1, cluster_name='on_off', cluster_attr='on_off', attr_value=`**1**`, expect_reply=True, manufacturer=-1)`

Going to the device configuration, TuyaMCUCluster, and sending "1" to on_off, the siren turns on. Reading the value back returns "Bool.true" and once duration is passed, "Bool.false"

In the logs with manual command that works, I see the following:

`DEBUG (MainThread) [zigpy.zcl] [0x8971:1:0xef00] tuya_mcu_command: cluster_data=TuyaClusterData(endpoint_id=1, cluster_name='on_off', cluster_attr='on_off', attr_value=`**<Bool.true:1>**`, expect_reply=True, manufacturer=-1)`

So basically it's sending <Bool.true:1> (works) instead of just 1 (doesn't work).

Fix is forcing boolean conversion for "0" and "1".

**To Reproduce**
Steps to reproduce the behavior:
1. Go to ZHA devices
2. Click on the device you added ( _TZE200_t1blo2bj)
3. Scroll down to Toggle control switch
4. Nothing happens

**Expected behavior**
Siren turns on and off

**Screenshots**
n/a

<details>
{
  "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": "0x0403",
      "in_clusters": [
        "0x0000",
        "0x0004",
        "0x0005",
        "0x0006",
        "0xef00"
      ],
      "out_clusters": [
        "0x000a",
        "0x0019"
      ]
    },
    "242": {
      "profile_id": 41440,
      "device_type": "0x0061",
      "in_clusters": [],
      "out_clusters": [
        "0x0021"
      ]
    }
  },
  "manufacturer": "_TZE200_t1blo2bj",
  "model": "TS0601",
  "class": "ts0601_siren.TuyaSirenGPP_NoSensors"
}
</details>

**Additional context**
Add any other context about the problem here.
