### PR TITLE
Wrap command value in TuyaMCUSiren

### DIFF
--- a/zhaquirks/tuya/ts0601_siren.py
+++ b/zhaquirks/tuya/ts0601_siren.py
@@ -293,7 +293,7 @@ class TuyaMCUSiren(OnOff, TuyaAttributesCluster):
                 endpoint_id=self.endpoint.endpoint_id,
                 cluster_name=self.ep_attribute,
                 cluster_attr="on_off",
-                attr_value=command_id,
+                attr_value=bool(command_id),
                 expect_reply=expect_reply,
                 manufacturer=foundation.ZCLHeader.NO_MANUFACTURER_ID,
             )


### PR DESCRIPTION
Wrap the value in a `bool()` to fix DataType detection
Fixes: #2311