### PR TITLE
Remove custom IKEA LightLinkCluster

### DIFF
--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -5,7 +5,6 @@ from zigpy.quirks import CustomCluster
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import PowerConfiguration, Scenes
-from zigpy.zcl.clusters.lightlink import LightLink
 
 from zhaquirks import DoublingPowerConfigurationCluster, EventableCluster
 
@@ -26,33 +25,6 @@ BATTERY_QUANTITY = PowerConfiguration.attributes_by_name["battery_quantity"].id
 BATTERY_RATED_VOLTAGE = PowerConfiguration.attributes_by_name[
     "battery_rated_voltage"
 ].id
-
-
-class LightLinkCluster(CustomCluster, LightLink):
-    """Ikea LightLink cluster."""
-
-    async def bind(self):
-        """Bind LightLink cluster to coordinator."""
-        application = self._endpoint.device.application
-        try:
-            coordinator = application.get_device(application.ieee)
-        except KeyError:
-            _LOGGER.warning("Aborting - unable to locate required coordinator device.")
-            return
-        group_list = await self.get_group_identifiers(0)
-        try:
-            group_record = group_list[2]
-            group_id = group_record[0].group_id
-        except IndexError:
-            _LOGGER.warning(
-                "unable to locate required group info - falling back to group 0x0000."
-            )
-            group_id = 0x0000
-        status = await coordinator.add_to_group(
-            group_id,
-            name="Default Lightlink Group",
-        )
-        return [status]
 
 
 class ScenesCluster(CustomCluster, Scenes):

--- a/zhaquirks/ikea/fivebtnremote.py
+++ b/zhaquirks/ikea/fivebtnremote.py
@@ -52,7 +52,6 @@ from zhaquirks.ikea import (
     IKEA_CLUSTER_ID,
     WWAH_CLUSTER_ID,
     DoublingPowerConfig1CRCluster,
-    LightLinkCluster,
     PowerConfig1CRCluster,
     ScenesCluster,
 )
@@ -103,7 +102,7 @@ class IkeaTradfriRemote1(CustomDevice):
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     Diagnostic.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -309,7 +308,7 @@ class IkeaTradfriRemote3(IkeaTradfriRemote1):
                     DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,

--- a/zhaquirks/ikea/motion.py
+++ b/zhaquirks/ikea/motion.py
@@ -21,7 +21,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.ikea import IKEA, DoublingPowerConfig2CRCluster, LightLinkCluster
+from zhaquirks.ikea import IKEA, DoublingPowerConfig2CRCluster
 
 
 class IkeaTradfriMotion(CustomDevice):
@@ -67,7 +67,7 @@ class IkeaTradfriMotion(CustomDevice):
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     Diagnostic.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -40,12 +40,7 @@ from zhaquirks.const import (
     TURN_OFF,
     TURN_ON,
 )
-from zhaquirks.ikea import (
-    IKEA,
-    IKEA_CLUSTER_ID,
-    DoublingPowerConfig1CRCluster,
-    LightLinkCluster,
-)
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, DoublingPowerConfig1CRCluster
 
 
 class IkeaTradfriRemote2Btn(CustomDevice):
@@ -183,7 +178,7 @@ class IkeaTradfriRemote2BtnZLL(CustomDevice):
                     DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                     IKEA_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [


### PR DESCRIPTION
This removes adding the coordinator to the LightLink group for IKEA devices.
[This code was merged into ZHA](https://github.com/home-assistant/core/blob/1aa8e942240629f1629da183c0ce43b1068f356b/homeassistant/components/zha/core/channels/lightlink.py#L26-L49) at some point, so this code in quirks should be not be needed now.

The existing code is broken due the removal of deprecated properties: https://github.com/zigpy/zigpy/pull/1176

"Binding/adding coordinator to LL group" was broken in HA versions 2023.4.0, 2023.4.1, 2023.4.2, but is fixed with the upcoming 2023.4.3 release.