### PR TITLE
Remove custom LDS LightLinkCluster

### DIFF
--- a/zhaquirks/lds/__init__.py
+++ b/zhaquirks/lds/__init__.py
@@ -1,29 +1,2 @@
 """LDS module."""
-import logging
-
-from zigpy.quirks import CustomCluster
-from zigpy.zcl.clusters.lightlink import LightLink
-
-_LOGGER = logging.getLogger(__name__)
 MANUFACTURER = "LDS"
-
-
-class LightLinkCluster(CustomCluster, LightLink):
-    """LDS LightLink cluster."""
-
-    async def bind(self):
-        """Bind LightLink cluster to coordinator."""
-        application = self._endpoint.device.application
-        try:
-            coordinator = application.get_device(application.ieee)
-        except KeyError:
-            _LOGGER.warning("Aborting - unable to locate required coordinator device.")
-            return
-        group_list = await self.get_group_identifiers(0)
-        group_record = group_list[2]
-        group_id = group_record[0].group_id
-        status = await coordinator.add_to_group(
-            group_id,
-            name=f"{str(self.endpoint.device.ieee)} - {self.endpoint.manufacturer} {self.endpoint.model}",
-        )
-        return [status]

--- a/zhaquirks/lds/cctswitch.py
+++ b/zhaquirks/lds/cctswitch.py
@@ -37,7 +37,7 @@ from zhaquirks.const import (
     SHORT_PRESS,
     TURN_ON,
 )
-from zhaquirks.lds import MANUFACTURER, LightLinkCluster
+from zhaquirks.lds import MANUFACTURER
 
 
 class CCTSwitch(CustomDevice):
@@ -81,7 +81,7 @@ class CCTSwitch(CustomDevice):
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
-                    LightLinkCluster,
+                    LightLink.cluster_id,
                     0xFD01,
                 ],
                 OUTPUT_CLUSTERS: [


### PR DESCRIPTION
Basically https://github.com/zigpy/zha-device-handlers/pull/2326 but for "LDS".

#### Copied Description:

This removes adding the coordinator to the LightLink group for LDS devices.
[This code was merged into ZHA](https://github.com/home-assistant/core/blob/1aa8e942240629f1629da183c0ce43b1068f356b/homeassistant/components/zha/core/channels/lightlink.py#L26-L49) at some point, so this code in quirks should be not be needed now.

The existing code is broken due the removal of deprecated properties: https://github.com/zigpy/zigpy/pull/1176

"Binding/adding coordinator to LL group" was broken in HA versions 2023.4.0, 2023.4.1, 2023.4.2, but is fixed with the upcoming 2023.4.3 release.