### PR TITLE
Fix using removed property for `GroupBoundCluster`

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -156,7 +156,7 @@ class GroupBoundCluster(CustomCluster):
         """Bind cluster to a group."""
         # Ensure coordinator is a member of the group
         application = self._endpoint.device.application
-        coordinator = application.get_device(application.ieee)
+        coordinator = application.get_device(application.state.node_info.ieee)
         await coordinator.add_to_group(
             self.COORDINATOR_GROUP_ID,
             name="Coordinator Group - Created by ZHAQuirks",


### PR DESCRIPTION
Caused by https://github.com/zigpy/zigpy/pull/1176

(Change is untested)
Failing checks are because this code doesn't seem to have tests at all.
(TODO for a future PR: add tests for the one device that uses this custom cluster)