### PR TITLE
Ignore missing default reply for GLEDOPTO AC dimmer

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -390,6 +390,44 @@ class QuickInitDevice(CustomDevice):
         return device
 
 
+class NoReplyMixin:
+    """A simple mixin.
+
+    Allows a cluster to have configurable list of command
+    ids that do not generate an explicit reply.
+    """
+
+    void_input_commands: set[int] = {}
+
+    async def command(self, command, *args, expect_reply=None, **kwargs):
+        """Override the default Cluster command.
+
+        expect_reply behavior is based on void_input_commands.
+        Note that this method changes the default value of
+        expect_reply to None. This allows the caller to explicitly force
+        expect_reply to true.
+        """
+
+        if expect_reply is None and command in self.void_input_commands:
+            cmd_expect_reply = False
+        elif expect_reply is None:
+            cmd_expect_reply = True  # the default
+        else:
+            cmd_expect_reply = expect_reply
+
+        rsp = await super().command(
+            command, *args, expect_reply=cmd_expect_reply, **kwargs
+        )
+
+        if expect_reply is None and command in self.void_input_commands:
+            # Pretend we received a default reply
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command, status=foundation.Status.SUCCESS)
+
+        return rsp
+
+
 def setup(custom_quirks_path: str | None = None) -> None:
     """Register all quirks with zigpy, including optional custom quirks."""
 

--- a/zhaquirks/gledopto/glsd001.py
+++ b/zhaquirks/gledopto/glsd001.py
@@ -1,0 +1,77 @@
+"""Quirk for GLEDOPTO GL-SD-001."""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    Scenes,
+)
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.kof.kof_mr101z import NoReplyMixin
+
+
+class LevelControlNoReply(NoReplyMixin, CustomCluster, LevelControl):
+    """LevelControl cluster that does not require default responses."""
+
+    void_input_commands = {cmd.id for cmd in LevelControl.commands_by_name.values()}
+
+
+class GledoptoGlSd001(CustomDevice):
+    """Gledopto GL-SD-001 dimmer custom device implementation."""
+
+    signature = {
+        MODELS_INFO: [("GLEDOPTO", "GL-SD-001")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControlNoReply,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }

--- a/zhaquirks/gledopto/glsd001.py
+++ b/zhaquirks/gledopto/glsd001.py
@@ -13,6 +13,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
+from zhaquirks import NoReplyMixin
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -21,7 +22,6 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.kof.kof_mr101z import NoReplyMixin
 
 
 class LevelControlNoReply(NoReplyMixin, CustomCluster, LevelControl):


### PR DESCRIPTION
Fixes https://github.com/zigpy/zha-device-handlers/issues/2308

This GLEDOPTO dimmer does not generate default responses for the `LevelControl` cluster.
The `NoReplyMixin` fakes a reply for ZHA/zigpy.

In the [second commit](https://github.com/zigpy/zha-device-handlers/commit/051a879759139de8310508b613629338d388ec4c), `NoReplyMixin` is refactored out of the KOF quirk into the main quirks `__init__.py` file, as it's now used by different manufacturers. I also expect some other devices to need this.

(`NoReplyMixin` already has units tests with the KOF quirk)