### PR TITLE
Remove color-support for Tuya dimmer variation `_TZ3210_i680rtja`

### DIFF
--- a/zhaquirks/tuya/ts0501bs.py
+++ b/zhaquirks/tuya/ts0501bs.py
@@ -34,6 +34,7 @@ class DimmableLedController(CustomDevice):
             ("_TZ3210_9q49basr", "TS0501B"),
             ("_TZ3210_4zinq6io", "TS0501B"),
             ("_TZ3210_e5t9bfdv", "TS0501B"),
+            ("_TZ3210_i680rtja", "TS0501B"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=257


### PR DESCRIPTION
Remove invalid color-support for `_TZ3210_i680rtja` Tuya dimmer.