### PR TITLE
Add Philips RDM002 Tap Dial switch support, refactor Hue remotes

### DIFF
--- a/tests/test_philips.py
+++ b/tests/test_philips.py
@@ -1,0 +1,502 @@
+"""Tests for Philips quirks."""
+
+from unittest import mock
+
+import pytest
+from zigpy.zcl.foundation import ZCLHeader
+
+import zhaquirks
+from zhaquirks.const import (
+    COMMAND,
+    COMMAND_HOLD,
+    COMMAND_M_LONG_RELEASE,
+    DIM_DOWN,
+    DIM_UP,
+    DOUBLE_PRESS,
+    LONG_PRESS,
+    LONG_RELEASE,
+    QUADRUPLE_PRESS,
+    QUINTUPLE_PRESS,
+    RIGHT,
+    SHORT_PRESS,
+    SHORT_RELEASE,
+    TRIPLE_PRESS,
+    TURN_OFF,
+    TURN_ON,
+)
+import zhaquirks.philips
+from zhaquirks.philips import ButtonPressQueue
+from zhaquirks.philips.rdm001 import PhilipsROM001 as PhilipsRDM001
+from zhaquirks.philips.rom001 import PhilipsROM001
+from zhaquirks.philips.rwl022 import PhilipsRWL022
+from zhaquirks.philips.rwlfirstgen import PhilipsRWLFirstGen, PhilipsRWLFirstGen2
+
+zhaquirks.setup()
+
+
+@pytest.mark.parametrize(
+    "classes, triggers",
+    (
+        (
+            [PhilipsRWLFirstGen, PhilipsRWLFirstGen2, PhilipsRWL022],
+            {
+                (SHORT_PRESS, TURN_ON): {COMMAND: "on_press"},
+                (SHORT_PRESS, TURN_OFF): {COMMAND: "off_press"},
+                (SHORT_PRESS, DIM_UP): {COMMAND: "up_press"},
+                (SHORT_PRESS, DIM_DOWN): {COMMAND: "down_press"},
+                (LONG_PRESS, TURN_ON): {COMMAND: "on_hold"},
+                (LONG_PRESS, TURN_OFF): {COMMAND: "off_hold"},
+                (LONG_PRESS, DIM_UP): {COMMAND: "up_hold"},
+                (LONG_PRESS, DIM_DOWN): {COMMAND: "down_hold"},
+                (DOUBLE_PRESS, TURN_ON): {COMMAND: "on_double_press"},
+                (DOUBLE_PRESS, TURN_OFF): {COMMAND: "off_double_press"},
+                (DOUBLE_PRESS, DIM_UP): {COMMAND: "up_double_press"},
+                (DOUBLE_PRESS, DIM_DOWN): {COMMAND: "down_double_press"},
+                (TRIPLE_PRESS, TURN_ON): {COMMAND: "on_triple_press"},
+                (TRIPLE_PRESS, TURN_OFF): {COMMAND: "off_triple_press"},
+                (TRIPLE_PRESS, DIM_UP): {COMMAND: "up_triple_press"},
+                (TRIPLE_PRESS, DIM_DOWN): {COMMAND: "down_triple_press"},
+                (QUADRUPLE_PRESS, TURN_ON): {COMMAND: "on_quadruple_press"},
+                (QUADRUPLE_PRESS, TURN_OFF): {COMMAND: "off_quadruple_press"},
+                (QUADRUPLE_PRESS, DIM_UP): {COMMAND: "up_quadruple_press"},
+                (QUADRUPLE_PRESS, DIM_DOWN): {COMMAND: "down_quadruple_press"},
+                (QUINTUPLE_PRESS, TURN_ON): {COMMAND: "on_quintuple_press"},
+                (QUINTUPLE_PRESS, TURN_OFF): {COMMAND: "off_quintuple_press"},
+                (QUINTUPLE_PRESS, DIM_UP): {COMMAND: "up_quintuple_press"},
+                (QUINTUPLE_PRESS, DIM_DOWN): {COMMAND: "down_quintuple_press"},
+                (SHORT_RELEASE, TURN_ON): {COMMAND: "on_short_release"},
+                (SHORT_RELEASE, TURN_OFF): {COMMAND: "off_short_release"},
+                (SHORT_RELEASE, DIM_UP): {COMMAND: "up_short_release"},
+                (SHORT_RELEASE, DIM_DOWN): {COMMAND: "down_short_release"},
+                (LONG_RELEASE, TURN_ON): {COMMAND: "on_long_release"},
+                (LONG_RELEASE, TURN_OFF): {COMMAND: "off_long_release"},
+                (LONG_RELEASE, DIM_UP): {COMMAND: "up_long_release"},
+                (LONG_RELEASE, DIM_DOWN): {COMMAND: "down_long_release"},
+            },
+        ),
+        (
+            [PhilipsROM001],
+            {
+                (SHORT_PRESS, TURN_ON): {COMMAND: "on_press"},
+                (LONG_PRESS, TURN_ON): {COMMAND: "on_hold"},
+                (DOUBLE_PRESS, TURN_ON): {COMMAND: "on_double_press"},
+                (TRIPLE_PRESS, TURN_ON): {COMMAND: "on_triple_press"},
+                (QUADRUPLE_PRESS, TURN_ON): {COMMAND: "on_quadruple_press"},
+                (QUINTUPLE_PRESS, TURN_ON): {COMMAND: "on_quintuple_press"},
+                (SHORT_RELEASE, TURN_ON): {COMMAND: "on_short_release"},
+                (LONG_RELEASE, TURN_ON): {COMMAND: "on_long_release"},
+            },
+        ),
+        (
+            [PhilipsRDM001],
+            {
+                (SHORT_PRESS, TURN_ON): {COMMAND: "left_press"},
+                (LONG_PRESS, TURN_ON): {COMMAND: "left_hold"},
+                (DOUBLE_PRESS, TURN_ON): {COMMAND: "left_double_press"},
+                (TRIPLE_PRESS, TURN_ON): {COMMAND: "left_triple_press"},
+                (QUADRUPLE_PRESS, TURN_ON): {COMMAND: "left_quadruple_press"},
+                (QUINTUPLE_PRESS, TURN_ON): {COMMAND: "left_quintuple_press"},
+                (SHORT_RELEASE, TURN_ON): {COMMAND: "left_short_release"},
+                (LONG_RELEASE, TURN_ON): {COMMAND: "left_long_release"},
+                (SHORT_PRESS, RIGHT): {COMMAND: "right_press"},
+                (LONG_PRESS, RIGHT): {COMMAND: "right_hold"},
+                (DOUBLE_PRESS, RIGHT): {COMMAND: "right_double_press"},
+                (TRIPLE_PRESS, RIGHT): {COMMAND: "right_triple_press"},
+                (QUADRUPLE_PRESS, RIGHT): {COMMAND: "right_quadruple_press"},
+                (QUINTUPLE_PRESS, RIGHT): {COMMAND: "right_quintuple_press"},
+                (SHORT_RELEASE, RIGHT): {COMMAND: "right_short_release"},
+                (LONG_RELEASE, RIGHT): {COMMAND: "right_long_release"},
+            },
+        ),
+    ),
+)
+def test_legacy_remote_automation_triggers(classes, triggers):
+    """Ensure we don't break any automation triggers by changing their values."""
+
+    for cls in classes:
+        assert cls.device_automation_triggers == triggers
+
+
+class ManuallyFiredButtonPressQueue:
+    """Philips button queue to derive multiple press events."""
+
+    def __init__(self):
+        """Init."""
+        self.reset()
+
+    def fire(self):
+        """Fire the callback. Trigger after all inputs, before running assertions."""
+
+        if self._callback is not None:
+            self._callback(self._click_counter)
+
+    def reset(self):
+        """Reset the button press queue."""
+
+        self._click_counter = 0
+        self._callback = None
+        self._button = None
+
+    def press(self, callback, button):
+        """Process a button press."""
+        if button != self._button:
+            self._click_counter = 1
+        else:
+            self._click_counter += 1
+        self._button = button
+        self._callback = callback
+
+
+@pytest.mark.parametrize(
+    "dev, ep, button, events",
+    (
+        (
+            PhilipsRDM001,
+            1,
+            "left",
+            ["press", "press_release"],
+        ),
+        (
+            PhilipsROM001,
+            1,
+            "on",
+            ["press", "short_release"],
+        ),
+        (
+            PhilipsRWLFirstGen,
+            2,
+            "on",
+            ["press", "short_release"],
+        ),
+        (
+            PhilipsRWLFirstGen2,
+            2,
+            "on",
+            ["press", "short_release"],
+        ),
+        (
+            PhilipsRWL022,
+            1,
+            "on",
+            ["press", "short_release"],
+        ),
+    ),
+)
+def test_PhilipsRemoteCluster_short_press(
+    zigpy_device_from_quirk, dev, ep, button, events
+):
+    """Test PhilipsRemoteCluster short button press logic."""
+
+    device = zigpy_device_from_quirk(dev)
+
+    cluster = device.endpoints[ep].philips_remote_cluster
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+    cluster.button_press_queue = ManuallyFiredButtonPressQueue()
+
+    cluster.handle_cluster_request(ZCLHeader(), [1, 0, 0, 0, 0])
+    cluster.handle_cluster_request(ZCLHeader(), [1, 0, 2, 0, 0])
+    cluster.button_press_queue.fire()
+
+    assert listener.zha_send_event.call_count == 2
+
+    calls = [
+        mock.call(
+            f"{button}_{events[0]}",
+            {
+                "button": button,
+                "press_type": events[0],
+                "command_id": None,
+                "args": [1, 0, 0, 0, 0],
+            },
+        ),
+        mock.call(
+            f"{button}_{events[1]}",
+            {
+                "button": button,
+                "press_type": events[1],
+                "command_id": None,
+                "args": [1, 0, 2, 0, 0],
+            },
+        ),
+    ]
+
+    # TODO: remove any_order=True
+    listener.zha_send_event.assert_has_calls(calls, any_order=True)
+
+
+@pytest.mark.parametrize(
+    "dev, ep, button",
+    (
+        (
+            PhilipsROM001,
+            1,
+            "on",
+        ),
+        (
+            PhilipsRWLFirstGen,
+            2,
+            "on",
+        ),
+        (
+            PhilipsRWLFirstGen2,
+            2,
+            "on",
+        ),
+        (
+            PhilipsRWL022,
+            1,
+            "on",
+        ),
+    ),
+)
+@pytest.mark.parametrize(
+    "count, action_press_type",
+    (
+        (2, "double_press"),
+        (3, "triple_press"),
+        (4, "quadruple_press"),
+        (5, "quintuple_press"),
+    ),
+)
+def test_PhilipsRemoteCluster_multi_press(
+    zigpy_device_from_quirk,
+    dev,
+    ep,
+    button,
+    count,
+    action_press_type,
+):
+    """Test PhilipsRemoteCluster button multi-press logic."""
+
+    device = zigpy_device_from_quirk(dev)
+
+    cluster = device.endpoints[ep].philips_remote_cluster
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+    cluster.button_press_queue = ManuallyFiredButtonPressQueue()
+
+    for _ in range(0, count):
+        # btn1 short press
+        cluster.handle_cluster_request(ZCLHeader(), [1, 0, 0, 0, 0])
+        # btn1 short release
+        cluster.handle_cluster_request(ZCLHeader(), [1, 0, 2, 0, 0])
+    cluster.button_press_queue.fire()
+
+    # TODO: Due to a bug, single press events are sent during a multi-press sequence
+    # assert listener.zha_send_event.call_count == 1
+    args_button_id = 0
+    listener.zha_send_event.assert_has_calls(
+        [
+            mock.call(
+                f"{button}_{action_press_type}",
+                {
+                    "button": button,
+                    "press_type": action_press_type,
+                    "command_id": None,
+                    "args": [1, 0, args_button_id, 0, 0],
+                },
+            ),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "dev, ep",
+    (
+        # TODO: RDM001 passes through unknown buttons
+        # (PhilipsRDM001, 1),
+        (PhilipsROM001, 1),
+        (PhilipsRWLFirstGen, 2),
+        (PhilipsRWLFirstGen2, 2),
+        (PhilipsRWL022, 1),
+    ),
+)
+def test_PhilipsRemoteCluster_ignore_unknown_buttons(zigpy_device_from_quirk, dev, ep):
+    """Ensure PhilipsRemoteCluster ignores unknown buttons."""
+
+    device = zigpy_device_from_quirk(dev)
+
+    cluster = device.endpoints[ep].philips_remote_cluster
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    cluster.handle_cluster_request(ZCLHeader(), [99, 0, 0, 0, 0])
+
+    assert listener.zha_send_event.call_count == 0
+
+
+@pytest.mark.parametrize(
+    "dev, ep, button, release_press_type",
+    (
+        (
+            PhilipsROM001,
+            1,
+            "on",
+            COMMAND_M_LONG_RELEASE,
+        ),
+        (
+            PhilipsRDM001,
+            1,
+            "left",
+            "hold_release",
+        ),
+        (
+            PhilipsRWLFirstGen,
+            2,
+            "on",
+            COMMAND_M_LONG_RELEASE,
+        ),
+        (
+            PhilipsRWLFirstGen2,
+            2,
+            "on",
+            COMMAND_M_LONG_RELEASE,
+        ),
+        (
+            PhilipsRWL022,
+            1,
+            "on",
+            COMMAND_M_LONG_RELEASE,
+        ),
+    ),
+)
+@pytest.mark.parametrize(
+    "count",
+    (
+        (1),
+        (2),
+        (3),
+    ),
+)
+def test_PhilipsRemoteCluster_long_press(
+    zigpy_device_from_quirk, dev, ep, button, release_press_type, count
+):
+    """Test PhilipsRemoteCluster button long press logic."""
+
+    device = zigpy_device_from_quirk(dev)
+
+    cluster = device.endpoints[ep].philips_remote_cluster
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+    cluster.button_press_queue = ManuallyFiredButtonPressQueue()
+
+    cluster.handle_cluster_request(ZCLHeader(), [1, 0, 0, 0, 0])
+    for i in range(0, count):
+        # btn1 long press
+        cluster.handle_cluster_request(ZCLHeader(), [1, 0, 1, 0, (i + 1) * 40])
+
+    # btn1 long release
+    cluster.handle_cluster_request(ZCLHeader(), [1, 0, 3, 0, count * 40 + 10])
+    cluster.button_press_queue.fire()
+
+    # TODO: all remotes also fire short press events, hence the extra +1
+    assert listener.zha_send_event.call_count == count + 1 + 1
+
+    calls = []
+    for i in range(0, count):
+        calls.append(
+            mock.call(
+                f"{button}_{COMMAND_HOLD}",
+                {
+                    "button": button,
+                    "press_type": COMMAND_HOLD,
+                    "command_id": None,
+                    "args": [1, 0, 1, 0, (i + 1) * 40],
+                },
+            )
+        )
+    calls.append(
+        mock.call(
+            f"{button}_{release_press_type}",
+            {
+                "button": button,
+                "press_type": release_press_type,
+                "command_id": None,
+                "args": [1, 0, 3, 0, count * 40 + 10],
+            },
+        )
+    )
+
+    listener.zha_send_event.assert_has_calls(calls)
+
+
+@pytest.mark.parametrize(
+    "button_presses, result_count",
+    (
+        (
+            [1],
+            1,
+        ),
+        (
+            [1, 1],
+            2,
+        ),
+        (
+            [1, 1, 3, 3, 3, 2, 2, 2, 2],
+            4,
+        ),
+    ),
+)
+def test_ButtonPressQueue_presses_without_pause(button_presses, result_count):
+    """Test ButtonPressQueue presses without pause in between presses."""
+
+    q = ButtonPressQueue()
+    q._ms_threshold = 50
+    cb = mock.MagicMock()
+    for btn in button_presses:
+        q.press(cb, btn)
+
+    # await cluster.button_press_queue._task
+    # Instead of awaiting the job, significantly extending the time
+    # these tests need, we just abort it and call the callback
+    # ourselves.
+    assert q._task is not None
+    q._task.cancel()
+    q._ms_last_click = 0
+    q._callback(q._click_counter)
+    cb.assert_called_once_with(result_count)
+
+
+@pytest.mark.parametrize(
+    "press_sequence, results",
+    (
+        (
+            # switch buttons within a sequence,
+            # new sequence start with different button
+            (
+                [1, 1, 3, 3],
+                [2, 2, 2],
+            ),
+            (2, 3),
+        ),
+        (
+            # no button switch within a sequence,
+            # new sequence with same button
+            (
+                [1, 1, 1],
+                [1],
+            ),
+            (3, 1),
+        ),
+    ),
+)
+async def test_ButtonPressQueue_presses_with_pause(press_sequence, results):
+    """Test ButtonPressQueue with pauses in between button press sequences."""
+
+    q = ButtonPressQueue()
+    q._ms_threshold = 50
+    cb = mock.MagicMock()
+
+    for seq in press_sequence:
+        for btn in seq:
+            q.press(cb, btn)
+        await q._task
+
+    assert cb.call_count == len(results)
+
+    calls = []
+    for res in results:
+        calls.append(mock.call(res))
+
+    cb.assert_has_calls(calls)

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -197,7 +197,7 @@ class PhilipsRemoteCluster(CustomCluster):
         ] = None,
     ):
         """Handle the cluster command."""
-        self.debug(
+        _LOGGER.debug(
             "%s - handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
             self.__class__.__name__,
             hdr.tsn,

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -1,6 +1,7 @@
 """Module for Philips quirks implementations."""
 
 import asyncio
+import itertools
 import logging
 import time
 from typing import Any, Optional, Union
@@ -15,7 +16,11 @@ from zhaquirks.const import (
     ARGS,
     BUTTON,
     COMMAND,
+    COMMAND_HOLD,
     COMMAND_ID,
+    COMMAND_M_LONG_RELEASE,
+    COMMAND_M_SHORT_RELEASE,
+    COMMAND_PRESS,
     DIM_DOWN,
     DIM_UP,
     DOUBLE_PRESS,
@@ -35,41 +40,6 @@ from zhaquirks.const import (
 PHILIPS = "Philips"
 SIGNIFY = "Signify Netherlands B.V."
 _LOGGER = logging.getLogger(__name__)
-
-HUE_REMOTE_DEVICE_TRIGGERS = {
-    (SHORT_PRESS, TURN_ON): {COMMAND: "on_press"},
-    (SHORT_PRESS, TURN_OFF): {COMMAND: "off_press"},
-    (SHORT_PRESS, DIM_UP): {COMMAND: "up_press"},
-    (SHORT_PRESS, DIM_DOWN): {COMMAND: "down_press"},
-    (LONG_PRESS, TURN_ON): {COMMAND: "on_hold"},
-    (LONG_PRESS, TURN_OFF): {COMMAND: "off_hold"},
-    (LONG_PRESS, DIM_UP): {COMMAND: "up_hold"},
-    (LONG_PRESS, DIM_DOWN): {COMMAND: "down_hold"},
-    (DOUBLE_PRESS, TURN_ON): {COMMAND: "on_double_press"},
-    (DOUBLE_PRESS, TURN_OFF): {COMMAND: "off_double_press"},
-    (DOUBLE_PRESS, DIM_UP): {COMMAND: "up_double_press"},
-    (DOUBLE_PRESS, DIM_DOWN): {COMMAND: "down_double_press"},
-    (TRIPLE_PRESS, TURN_ON): {COMMAND: "on_triple_press"},
-    (TRIPLE_PRESS, TURN_OFF): {COMMAND: "off_triple_press"},
-    (TRIPLE_PRESS, DIM_UP): {COMMAND: "up_triple_press"},
-    (TRIPLE_PRESS, DIM_DOWN): {COMMAND: "down_triple_press"},
-    (QUADRUPLE_PRESS, TURN_ON): {COMMAND: "on_quadruple_press"},
-    (QUADRUPLE_PRESS, TURN_OFF): {COMMAND: "off_quadruple_press"},
-    (QUADRUPLE_PRESS, DIM_UP): {COMMAND: "up_quadruple_press"},
-    (QUADRUPLE_PRESS, DIM_DOWN): {COMMAND: "down_quadruple_press"},
-    (QUINTUPLE_PRESS, TURN_ON): {COMMAND: "on_quintuple_press"},
-    (QUINTUPLE_PRESS, TURN_OFF): {COMMAND: "off_quintuple_press"},
-    (QUINTUPLE_PRESS, DIM_UP): {COMMAND: "up_quintuple_press"},
-    (QUINTUPLE_PRESS, DIM_DOWN): {COMMAND: "down_quintuple_press"},
-    (SHORT_RELEASE, TURN_ON): {COMMAND: "on_short_release"},
-    (SHORT_RELEASE, TURN_OFF): {COMMAND: "off_short_release"},
-    (SHORT_RELEASE, DIM_UP): {COMMAND: "up_short_release"},
-    (SHORT_RELEASE, DIM_DOWN): {COMMAND: "down_short_release"},
-    (LONG_RELEASE, TURN_ON): {COMMAND: "on_long_release"},
-    (LONG_RELEASE, TURN_OFF): {COMMAND: "off_long_release"},
-    (LONG_RELEASE, DIM_UP): {COMMAND: "up_long_release"},
-    (LONG_RELEASE, DIM_DOWN): {COMMAND: "down_long_release"},
-}
 
 
 class PhilipsOccupancySensing(CustomCluster):
@@ -138,6 +108,39 @@ class ButtonPressQueue:
         self._task = asyncio.ensure_future(self._job())
 
 
+class Button:
+    """Represents a remote button, including string literals used in triggers and actions."""
+
+    def __init__(
+        self, id: str, trigger: str | None = None, action: str | None = None
+    ) -> None:
+        """Init."""
+        self.id = id
+        self.trigger = trigger or id
+        self.action = action or id
+
+    def __repr__(self) -> str:
+        """Repr."""
+        return f"<Button id={self.id}, trigger={self.trigger}, action={self.action}>"
+
+
+class PressType:
+    """Represents a remote button press-type, including string literals used in triggers and actions."""
+
+    def __init__(
+        self, name: str, action: str, arg: str | None = None, trigger: str | None = None
+    ) -> None:
+        """Init."""
+        self.name = name
+        self.action = action
+        self.arg = arg or action
+        self.trigger = trigger or name
+
+    def __repr__(self) -> str:
+        """Repr."""
+        return f"<PressType name={self.name}, action={self.action}, trigger={self.trigger}, arg={self.arg}>"
+
+
 class PhilipsRemoteCluster(CustomCluster):
     """Philips remote cluster."""
 
@@ -152,15 +155,35 @@ class PhilipsRemoteCluster(CustomCluster):
                 "param2": t.uint24_t,
                 "press_type": t.uint8_t,
                 "param4": t.uint8_t,
-                "param5": t.uint8_t,
-                "param6": t.uint8_t,
+                "param5": t.uint16_t,
             },
             False,
             is_manufacturer_specific=True,
         )
     }
-    BUTTONS = {1: "on", 2: "up", 3: "down", 4: "off"}
-    PRESS_TYPES = {0: "press", 1: "hold", 2: "short_release", 3: "long_release"}
+
+    BUTTONS: dict[int, Button] = {}
+
+    PRESS_TYPES: dict[int, PressType] = {
+        # We omit "short_press" and "short_release" on purpose, so it
+        # won't interfere with simulated multi-press events. We emit
+        # them in the multi-press code later on.
+        # 0: SHORT_PRESS,
+        1: PressType(LONG_PRESS, COMMAND_HOLD),
+        # 2: SHORT_RELEASE,
+        3: PressType(LONG_RELEASE, COMMAND_M_LONG_RELEASE),
+    }
+
+    MULTI_PRESS_EVENTS: dict[int, PressType] = {
+        2: PressType(DOUBLE_PRESS, "double_press"),
+        3: PressType(TRIPLE_PRESS, "triple_press"),
+        4: PressType(QUADRUPLE_PRESS, "quadruple_press"),
+        5: PressType(QUINTUPLE_PRESS, "quintuple_press"),
+    }
+    SIMULATE_SHORT_EVENTS = [
+        PressType(SHORT_PRESS, COMMAND_PRESS),
+        PressType(SHORT_RELEASE, COMMAND_M_SHORT_RELEASE),
+    ]
 
     button_press_queue = ButtonPressQueue()
 
@@ -174,48 +197,133 @@ class PhilipsRemoteCluster(CustomCluster):
         ] = None,
     ):
         """Handle the cluster command."""
-        _LOGGER.debug(
-            "PhilipsRemoteCluster - handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
+        self.debug(
+            "%s - handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
+            self.__class__.__name__,
             hdr.tsn,
             hdr.command_id,
             args,
         )
 
-        button = self.BUTTONS.get(args[0], args[0])
-        press_type = self.PRESS_TYPES.get(args[2], args[2])
+        button = self.BUTTONS.get(args[0])
+        _LOGGER.debug(
+            "%s - handle_cluster_request button id: [%s], button name: [%s]",
+            self.__class__.__name__,
+            args[0],
+            button,
+        )
+        # Bail on unknown buttons. (This gets rid of dial button "presses")
+        if button is None:
+            return
+
+        press_type = self.PRESS_TYPES.get(args[2])
+        if (
+            press_type is None
+            and self.SIMULATE_SHORT_EVENTS is not None
+            and args[2] == 2
+        ):
+            press_type = self.SIMULATE_SHORT_EVENTS[1]
+        if press_type is None:
+            return
+
+        duration = args[4]
+        _LOGGER.debug(
+            "%s - handle_cluster_request button press type: [%s], duration: [%s]",
+            self.__class__.__name__,
+            press_type,
+            duration,
+        )
 
         event_args = {
-            BUTTON: button,
-            PRESS_TYPE: press_type,
+            BUTTON: button.id,
+            PRESS_TYPE: press_type.arg,
             COMMAND_ID: hdr.command_id,
+            "duration": duration,
             ARGS: args,
         }
 
         def send_press_event(click_count):
             _LOGGER.debug(
-                "PhilipsRemoteCluster - send_press_event click_count: [%s]", click_count
+                "%s - send_press_event click_count: [%s]",
+                self.__class__.__name__,
+                click_count,
             )
             press_type = None
             if click_count == 1:
-                press_type = "press"
-            elif click_count == 2:
-                press_type = "double_press"
-            elif click_count == 3:
-                press_type = "triple_press"
-            elif click_count == 4:
-                press_type = "quadruple_press"
-            elif click_count > 4:
-                press_type = "quintuple_press"
+                press_type = self.PRESS_TYPES.get(0) or self.SIMULATE_SHORT_EVENTS[0]
+            elif click_count > 1:
+                press_type = self.MULTI_PRESS_EVENTS[min(click_count, 5)]
 
-            if press_type:
+            _LOGGER.debug(
+                "%s - send_press_event evaluated press_type: [%s]",
+                self.__class__.__name__,
+                press_type,
+            )
+            if press_type is not None:
                 # Override PRESS_TYPE
-                event_args[PRESS_TYPE] = press_type
-                action = f"{button}_{press_type}"
+                event_args[PRESS_TYPE] = press_type.arg
+                event_args[ARGS] = list(event_args[ARGS])
+                event_args[ARGS][2] = 0 if click_count < 2 else 2 + min(click_count, 5)
+                action = f"{button.action}_{press_type.action}"
+                _LOGGER.debug(
+                    "%s - send_press_event emitting action: [%s] event_args: %s",
+                    self.__class__.__name__,
+                    action,
+                    event_args,
+                )
                 self.listener_event(ZHA_SEND_EVENT, action, event_args)
 
+            # simulate short release event, if needed for this device type
+            if (
+                press_type.name == SHORT_PRESS
+                and self.SIMULATE_SHORT_EVENTS is not None
+            ):
+                press_type = self.PRESS_TYPES.get(2) or self.SIMULATE_SHORT_EVENTS[1]
+                sim_event_args = event_args.copy()
+                sim_event_args[PRESS_TYPE] = press_type.arg
+                sim_event_args[ARGS] = sim_event_args[ARGS].copy()
+                sim_event_args[ARGS][2] = 2
+                action = f"{button.action}_{press_type.action}"
+                _LOGGER.debug(
+                    "%s - send_press_event emitting simulated action: [%s]",
+                    self.__class__.__name__,
+                    action,
+                )
+                self.listener_event(ZHA_SEND_EVENT, action, sim_event_args)
+
         # Derive Multiple Presses
-        if press_type == "press":
-            self.button_press_queue.press(send_press_event, button)
+        if press_type.name == SHORT_RELEASE:
+            self.button_press_queue.press(send_press_event, button.id)
         else:
-            action = f"{button}_{press_type}"
+            action = f"{button.action}_{press_type.action}"
             self.listener_event(ZHA_SEND_EVENT, action, event_args)
+
+    @classmethod
+    def generate_device_automation_triggers(cls, additional=None):
+        """Generate automation triggers based on device buttons and press-types."""
+        triggers = {}
+        for button in cls.BUTTONS.values():
+            press_types = [cls.PRESS_TYPES.values()]
+            if cls.SIMULATE_SHORT_EVENTS is not None:
+                press_types.append(cls.SIMULATE_SHORT_EVENTS)
+                press_types.append(cls.MULTI_PRESS_EVENTS.values())
+            for press_type in itertools.chain(*press_types):
+                triggers[(press_type.trigger, button.trigger)] = {
+                    COMMAND: f"{button.action}_{press_type.action}"
+                }
+
+        if additional:
+            triggers.update(additional)
+
+        return triggers
+
+
+class PhilipsRwlRemoteCluster(PhilipsRemoteCluster):
+    """Philips remote cluster for RWL devices."""
+
+    BUTTONS = {
+        1: Button("on", TURN_ON),
+        2: Button("up", DIM_UP),
+        3: Button("down", DIM_DOWN),
+        4: Button("off", TURN_OFF),
+    }

--- a/zhaquirks/philips/rdm002.py
+++ b/zhaquirks/philips/rdm002.py
@@ -1,4 +1,4 @@
-"""Philips ROM001 device."""
+"""Signify RDM002 device."""
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -15,17 +15,24 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lightlink import LightLink
 
 from zhaquirks.const import (
-    COMMAND_HOLD,
-    COMMAND_ON,
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    BUTTON_4,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_STEP_ON_OFF,
     DEVICE_TYPE,
+    DIM_DOWN,
+    DIM_UP,
+    ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
-    LONG_PRESS,
-    LONG_RELEASE,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
+    PARAMS,
     PROFILE_ID,
-    TURN_ON,
+    SHORT_PRESS,
 )
 from zhaquirks.philips import (
     PHILIPS,
@@ -33,39 +40,44 @@ from zhaquirks.philips import (
     Button,
     PhilipsBasicCluster,
     PhilipsRemoteCluster,
-    PressType,
 )
 
-DEVICE_SPECIFIC_UNKNOWN = 64512
+DIAL_TRIGGERS = {
+    (SHORT_PRESS, DIM_UP): {
+        COMMAND: COMMAND_STEP_ON_OFF,
+        CLUSTER_ID: 8,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 0},
+    },
+    (SHORT_PRESS, DIM_DOWN): {
+        COMMAND: COMMAND_STEP_ON_OFF,
+        CLUSTER_ID: 8,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 1},
+    },
+}
 
 
-class PhilipsRom001RemoteCluster(PhilipsRemoteCluster):
-    """Philips remote cluster for ROM001."""
+class PhilipsRdm002RemoteCluster(PhilipsRemoteCluster):
+    """Philips remote cluster for RDM002."""
 
     BUTTONS = {
-        1: Button(COMMAND_ON, TURN_ON, COMMAND_ON),
-    }
-
-    PRESS_TYPES: dict[int, PressType] = {
-        # We omit "short_press" and "short_release" on purpose, so it
-        # won't interfere with simulated multi-press events. We emit
-        # them in the multi-press code later on.
-        # 0: SHORT_PRESS,
-        1: PressType(LONG_PRESS, COMMAND_HOLD),
-        # 2: SHORT_RELEASE,
-        3: PressType(LONG_RELEASE, "long_release", "hold_release"),
+        1: Button(BUTTON_1),
+        2: Button(BUTTON_2),
+        3: Button(BUTTON_3),
+        4: Button(BUTTON_4),
     }
 
 
-class PhilipsROM001(CustomDevice):
-    """Philips ROM001 device."""
+class PhilipsRDM002(CustomDevice):
+    """Philips RDM002 device."""
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=2096
         #  device_version=1
         #  input_clusters=[0, 1, 3, 64512, 4096]
         #  output_clusters=[25, 0, 3, 4, 6, 8, 5, 4096]>
-        MODELS_INFO: [(PHILIPS, "ROM001"), (SIGNIFY, "ROM001")],
+        MODELS_INFO: [(PHILIPS, "RDM002"), (SIGNIFY, "RDM002")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -74,7 +86,7 @@ class PhilipsROM001(CustomDevice):
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
-                    DEVICE_SPECIFIC_UNKNOWN,
+                    PhilipsRdm002RemoteCluster.cluster_id,
                     LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -95,12 +107,12 @@ class PhilipsROM001(CustomDevice):
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.NON_COLOR_SCENE_CONTROLLER,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     PhilipsBasicCluster,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
-                    PhilipsRom001RemoteCluster,
+                    PhilipsRdm002RemoteCluster,
                     LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -118,5 +130,5 @@ class PhilipsROM001(CustomDevice):
     }
 
     device_automation_triggers = (
-        PhilipsRom001RemoteCluster.generate_device_automation_triggers()
+        PhilipsRdm002RemoteCluster.generate_device_automation_triggers(DIAL_TRIGGERS)
     )

--- a/zhaquirks/philips/rwl022.py
+++ b/zhaquirks/philips/rwl022.py
@@ -22,12 +22,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.philips import (
-    HUE_REMOTE_DEVICE_TRIGGERS,
-    SIGNIFY,
-    PhilipsBasicCluster,
-    PhilipsRemoteCluster,
-)
+from zhaquirks.philips import SIGNIFY, PhilipsBasicCluster, PhilipsRwlRemoteCluster
 
 DEVICE_SPECIFIC_UNKNOWN = 64512
 
@@ -75,7 +70,7 @@ class PhilipsRWL022(CustomDevice):
                     PhilipsBasicCluster,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
-                    PhilipsRemoteCluster,
+                    PhilipsRwlRemoteCluster,
                     LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -92,4 +87,6 @@ class PhilipsRWL022(CustomDevice):
         }
     }
 
-    device_automation_triggers = HUE_REMOTE_DEVICE_TRIGGERS
+    device_automation_triggers = (
+        PhilipsRwlRemoteCluster.generate_device_automation_triggers()
+    )

--- a/zhaquirks/philips/rwlfirstgen.py
+++ b/zhaquirks/philips/rwlfirstgen.py
@@ -23,11 +23,10 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.philips import (
-    HUE_REMOTE_DEVICE_TRIGGERS,
     PHILIPS,
     SIGNIFY,
     PhilipsBasicCluster,
-    PhilipsRemoteCluster,
+    PhilipsRwlRemoteCluster,
 )
 
 DEVICE_SPECIFIC_UNKNOWN = 64512
@@ -99,14 +98,16 @@ class PhilipsRWLFirstGen(CustomDevice):
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     BinaryInput.cluster_id,
-                    PhilipsRemoteCluster,
+                    PhilipsRwlRemoteCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
         }
     }
 
-    device_automation_triggers = HUE_REMOTE_DEVICE_TRIGGERS
+    device_automation_triggers = (
+        PhilipsRwlRemoteCluster.generate_device_automation_triggers()
+    )
 
 
 class PhilipsRWLFirstGen2(CustomDevice):
@@ -173,11 +174,13 @@ class PhilipsRWLFirstGen2(CustomDevice):
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     BinaryInput.cluster_id,
-                    PhilipsRemoteCluster,
+                    PhilipsRwlRemoteCluster,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
         }
     }
 
-    device_automation_triggers = HUE_REMOTE_DEVICE_TRIGGERS
+    device_automation_triggers = (
+        PhilipsRwlRemoteCluster.generate_device_automation_triggers()
+    )


### PR DESCRIPTION
Add suport for [Philps Hue Tap Dial Switch](https://www.philips-hue.com/en-us/p/hue-tap-dial-switch/046677578800) (RDM002).
This PR also refactors all Hue remotes to "generate" the device triggers and removes a lot of duplicated code.
The device triggers changed are backwards-compatible (verified in tests).