### PR TITLE
Fix bug in Aqara pet feeder

### DIFF
--- a/zhaquirks/xiaomi/aqara/feeder_acn001.py
+++ b/zhaquirks/xiaomi/aqara/feeder_acn001.py
@@ -161,7 +161,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             self._update_attribute(
                 ZCL_LAST_FEEDING_SOURCE, OppleCluster.FeedingSource(feeding_source)
             )
-            self._update_attribute(ZCL_LAST_FEEDING_SIZE, int(feeding_size))
+            self._update_attribute(ZCL_LAST_FEEDING_SIZE, int(feeding_size, base=16))
         elif attribute == PORTIONS_DISPENSED:
             portions_per_day, _ = types.uint16_t_be.deserialize(attribute_value)
             self._update_attribute(ZCL_PORTIONS_DISPENSED, portions_per_day)


### PR DESCRIPTION
## Fixes: 
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/bellows/ezsp/__init__.py", line 362, in handle_callback
    handler(*args)
  File "/usr/local/lib/python3.10/site-packages/bellows/zigbee/application.py", line 469, in ezsp_callback_handler
    self._handle_frame(*args)
  File "/usr/local/lib/python3.10/site-packages/bellows/zigbee/application.py", line 514, in _handle_frame
    self.packet_received(
  File "/usr/local/lib/python3.10/site-packages/zigpy/application.py", line 946, in packet_received
    self.handle_message(
  File "/usr/local/lib/python3.10/site-packages/zigpy/application.py", line 461, in handle_message
    return sender.handle_message(
  File "/usr/local/lib/python3.10/site-packages/zigpy/device.py", line 374, in handle_message
    self.endpoints[src_ep].handle_message(
  File "/usr/local/lib/python3.10/site-packages/zigpy/endpoint.py", line 224, in handle_message
    handler(hdr, args, dst_addressing=dst_addressing)
  File "/usr/local/lib/python3.10/site-packages/zigpy/zcl/__init__.py", line 379, in handle_message
    self.handle_cluster_general_request(hdr, args, dst_addressing=dst_addressing)
  File "/usr/local/lib/python3.10/site-packages/zigpy/zcl/__init__.py", line 425, in handle_cluster_general_request
    self._update_attribute(attr.attrid, value)
  File "/usr/local/lib/python3.10/site-packages/zhaquirks/xiaomi/aqara/feeder_acn001.py", line 140, in _update_attribute
    self._parse_feeder_attribute(value)
  File "/usr/local/lib/python3.10/site-packages/zhaquirks/xiaomi/aqara/feeder_acn001.py", line 164, in _parse_feeder_attribute
    self._update_attribute(ZCL_LAST_FEEDING_SIZE, int(feeding_size))
ValueError: invalid literal for int() with base 10: 'A'
```