### PR TITLE
Ensure quirk clusters are proper subclasses

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Fixtures for all tests."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 import zigpy.application
@@ -191,6 +191,9 @@ def assert_signature_matches_quirk():
                 return self.endpoints.get(key)
 
         test_dev = FakeDevice(signature)
+        test_dev._application = Mock()
+        test_dev._application._dblistener = None
+
         device = zigpy.quirks.get_device(test_dev)
         assert isinstance(device, quirk)
 

--- a/tests/test_konke.py
+++ b/tests/test_konke.py
@@ -77,7 +77,7 @@ async def test_konke_button(zigpy_device_from_quirk, quirk):
     """Test Konke button remotes."""
 
     device = zigpy_device_from_quirk(quirk)
-    cluster = device.endpoints[1].custom_on_off
+    cluster = device.endpoints[1].konke_on_off
 
     listener = mock.MagicMock()
     cluster.add_listener(listener)

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -700,8 +700,21 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
             base_cluster = list(base_clusters)[0]
 
             # Ensure the attribute IDs are extended
-            if not set(base_cluster.attributes) <= set(cluster.attributes):
+            base_attr_ids = set(base_cluster.attributes)
+            quirk_attr_ids = set(cluster.attributes)
+
+            if not base_attr_ids <= quirk_attr_ids:
                 pytest.fail(
                     f"Cluster {cluster} deletes parent class's attributes instead of"
-                    f" extending them: {base_cluster}"
+                    f" extending them: {base_attr_ids - quirk_attr_ids}"
+                )
+
+            # Ensure the attribute names are extended
+            base_attr_names = {a.name for a in base_cluster.attributes.values()}
+            quirk_attr_names = {a.name for a in cluster.attributes.values()}
+
+            if not base_attr_names <= quirk_attr_names:
+                pytest.fail(
+                    f"Cluster {cluster} deletes parent class's attributes instead of"
+                    f" extending them: {base_attr_names - quirk_attr_names}"
                 )

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -71,12 +71,18 @@ HUE_REMOTE_DEVICE_TRIGGERS = {
 }
 
 
-class OccupancyCluster(CustomCluster, OccupancySensing):
+class PhilipsOccupancySensing(CustomCluster):
     """Philips occupancy cluster."""
+
+    cluster_id = OccupancySensing.cluster_id
+    ep_attribute = "philips_occupancy"
 
     attributes = OccupancySensing.attributes.copy()
     attributes[0x0030] = ("sensitivity", t.uint8_t, True)
     attributes[0x0031] = ("sensitivity_max", t.uint8_t, True)
+
+    server_commands = OccupancySensing.server_commands.copy()
+    client_commands = OccupancySensing.client_commands.copy()
 
 
 class PhilipsBasicCluster(CustomCluster, Basic):

--- a/zhaquirks/philips/motion.py
+++ b/zhaquirks/philips/motion.py
@@ -27,7 +27,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.philips import PHILIPS, SIGNIFY, OccupancyCluster
+from zhaquirks.philips import PHILIPS, SIGNIFY, PhilipsOccupancySensing
 
 
 class BasicCluster(CustomCluster, Basic):
@@ -106,7 +106,7 @@ class PhilipsMotion(CustomDevice):
                     Identify.cluster_id,
                     IlluminanceMeasurement.cluster_id,
                     TemperatureMeasurement.cluster_id,
-                    OccupancyCluster,
+                    PhilipsOccupancySensing,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -152,7 +152,7 @@ class SignifyMotion(CustomDevice):
                     Identify.cluster_id,
                     IlluminanceMeasurement.cluster_id,
                     TemperatureMeasurement.cluster_id,
-                    OccupancyCluster,
+                    PhilipsOccupancySensing,
                 ],
                 OUTPUT_CLUSTERS: [
                     Basic.cluster_id,


### PR DESCRIPTION
A few quirk subclasses are "broken" because they subclass an existing cluster but modify it in an incompatible way: the Konke button, for example, uses an `OnOff` cluster subclass that does not have an `on_off` attribute. This breaks ZHA, which expects the `on_off` attribute to exist on an `OnOff` cluster.

(ZHA currently does not match by cluster class, however, and instead matches on cluster ID alone, so this theoretically could be fixed in just ZHA. I think it's better to not have this be a problem in the future).

This code is not runtime tested but unit tests pass with these corresponding ZHA changes: https://github.com/puddly/core/tree/puddly/20230427-fix-bad-quirk-cluster-attrs