### PR TITLE
Fix ZHA startup `on_off` error in 2023.5.0b2

### DIFF
--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -21,22 +21,17 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import TuyaZBExternalSwitchTypeCluster
+from zhaquirks.tuya import SwitchBackLight, TuyaZBExternalSwitchTypeCluster
 
 ATTR_CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
 CMD_GO_TO_LIFT_PERCENTAGE = 0x0005
 
 
-class TuyaWithBacklightOnOffCluster(CustomCluster):
-    """TuyaSmartCurtainOnOffCluster: fire events corresponding to press type."""
+class TuyaWithBacklightOnOffCluster(CustomCluster, OnOff):
+    """Tuya Zigbee On Off cluster with extra attributes."""
 
-    cluster_id = OnOff.cluster_id
-
-    LIGHT_MODE_1 = {0x8001: 0}
-    LIGHT_MODE_2 = {0x8001: 1}
-    LIGHT_MODE_3 = {0x8001: 2}
-
-    attributes = {0x8001: ("backlight_mode", t.enum8)}
+    attributes = OnOff.attributes.copy()
+    attributes.update({0x8001: ("backlight_mode", SwitchBackLight)})
 
 
 class MotorMode(t.enum8):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
A few Tuya quirks did not properly subclass `OnOff` and omitted necessary attributes. I've added exhaustive unit tests that should catch this error in the future for all clusters.

https://github.com/home-assistant/core/issues/92219

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
