### PR TITLE
Add support for BTicino L4003C light switch

### DIFF
--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -26,3 +26,31 @@ async def test_legrand_battery(zigpy_device_from_quirk, voltage, bpr):
     power_cluster = device.endpoints[1].power
     power_cluster.update_attribute(0x0020, voltage)
     assert power_cluster["battery_percentage_remaining"] == bpr
+
+
+def test_light_switch_with_neutral_signature(assert_signature_matches_quirk):
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=1, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4129, maximum_buffer_size=89, maximum_incoming_transfer_size=63, server_mask=10752, maximum_outgoing_transfer_size=63, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 260,
+                "device_type": "0x0100",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0003",
+                    "0x0004",
+                    "0x0005",
+                    "0x0006",
+                    "0x000f",
+                    "0xfc01",
+                ],
+                "out_clusters": ["0x0000", "0x0019", "0xfc01"],
+            }
+        },
+        "manufacturer": " Legrand",
+        "model": " Light switch with neutral",
+        "class": "zigpy.device.Device",
+    }
+    assert_signature_matches_quirk(
+        zhaquirks.legrand.switch.LightSwitchWithNeutral, signature
+    )

--- a/zhaquirks/legrand/__init__.py
+++ b/zhaquirks/legrand/__init__.py
@@ -1,2 +1,30 @@
 """Module for Legrand devices."""
+
+from zigpy.quirks import CustomCluster
+import zigpy.types as t
+from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
+
+from zhaquirks import PowerConfigurationCluster
+
 LEGRAND = "Legrand"
+MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFC01  # decimal = 64513
+
+
+class LegrandCluster(CustomCluster, ManufacturerSpecificCluster):
+    """LegrandCluster."""
+
+    cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID
+    name = "LegrandCluster"
+    ep_attribute = "legrand_cluster"
+    attributes = {
+        0x0000: ("dimmer", t.data16, True),
+        0x0001: ("led_dark", t.Bool, True),
+        0x0002: ("led_on", t.Bool, True),
+    }
+
+
+class LegrandPowerConfigurationCluster(PowerConfigurationCluster):
+    """PowerConfiguration conversor 'V --> %' for Legrand devices."""
+
+    MIN_VOLTS = 2.5
+    MAX_VOLTS = 3.0

--- a/zhaquirks/legrand/dimmer.py
+++ b/zhaquirks/legrand/dimmer.py
@@ -1,7 +1,7 @@
-"""Device handler for Legrand Dimmer switch w/o neutral."""
+"""Module for Legrand dimmers."""
+
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
-import zigpy.types as t
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
     BinaryInput,
@@ -15,7 +15,6 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 from zigpy.zcl.clusters.lighting import Ballast
-from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 
 from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
@@ -26,29 +25,12 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.legrand import LEGRAND
-
-MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFC01  # decimal = 64513
-
-
-class LegrandCluster(CustomCluster, ManufacturerSpecificCluster):
-    """LegrandCluster."""
-
-    cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID
-    name = "LegrandCluster"
-    ep_attribute = "legrand_cluster"
-    attributes = {
-        0x0000: ("dimmer", t.data16, True),
-        0x0001: ("led_dark", t.Bool, True),
-        0x0002: ("led_on", t.Bool, True),
-    }
-
-
-class LegrandPowerConfigurationCluster(PowerConfigurationCluster):
-    """PowerConfiguration conversor 'V --> %' for Legrand devices."""
-
-    MIN_VOLTS = 2.5
-    MAX_VOLTS = 3.0
+from zhaquirks.legrand import (
+    LEGRAND,
+    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+    LegrandCluster,
+    LegrandPowerConfigurationCluster,
+)
 
 
 class DimmerWithoutNeutral(CustomDevice):

--- a/zhaquirks/legrand/switch.py
+++ b/zhaquirks/legrand/switch.py
@@ -1,0 +1,98 @@
+"""Module for Legrand switches (without dimming functionality)."""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    BinaryInput,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+)
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.legrand import LEGRAND, MANUFACTURER_SPECIFIC_CLUSTER_ID, LegrandCluster
+
+
+class SwitchWithNeutral(CustomDevice):
+    """Light switch with neutral wire."""
+
+    signature = {
+        # {
+        #     "endpoints": {
+        #         "1": {
+        #         "profile_id": 260,
+        #         "device_type": "0x0100",
+        #         "in_clusters": [
+        #             "0x0000",
+        #             "0x0003",
+        #             "0x0004",
+        #             "0x0005",
+        #             "0x0006",
+        #             "0x000f",
+        #             "0xfc01"
+        #         ],
+        #         "out_clusters": [
+        #             "0x0000",
+        #             "0x0019",
+        #             "0xfc01"
+        #         ]
+        #         }
+        #     },
+        #     "manufacturer": " Legrand",
+        #     "model": " Light switch with neutral",
+        # }
+        MODELS_INFO: [(f" {LEGRAND}", " Light switch with neutral")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    BinaryInput.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Ota.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    BinaryInput.cluster_id,
+                    LegrandCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Ota.cluster_id,
+                    LegrandCluster,
+                ],
+            }
+        }
+    }

--- a/zhaquirks/legrand/switch.py
+++ b/zhaquirks/legrand/switch.py
@@ -23,7 +23,7 @@ from zhaquirks.const import (
 from zhaquirks.legrand import LEGRAND, MANUFACTURER_SPECIFIC_CLUSTER_ID, LegrandCluster
 
 
-class SwitchWithNeutral(CustomDevice):
+class LightSwitchWithNeutral(CustomDevice):
     """Light switch with neutral wire."""
 
     signature = {

--- a/zhaquirks/legrand/switch.py
+++ b/zhaquirks/legrand/switch.py
@@ -27,30 +27,9 @@ class LightSwitchWithNeutral(CustomDevice):
     """Light switch with neutral wire."""
 
     signature = {
-        # {
-        #     "endpoints": {
-        #         "1": {
-        #         "profile_id": 260,
-        #         "device_type": "0x0100",
-        #         "in_clusters": [
-        #             "0x0000",
-        #             "0x0003",
-        #             "0x0004",
-        #             "0x0005",
-        #             "0x0006",
-        #             "0x000f",
-        #             "0xfc01"
-        #         ],
-        #         "out_clusters": [
-        #             "0x0000",
-        #             "0x0019",
-        #             "0xfc01"
-        #         ]
-        #         }
-        #     },
-        #     "manufacturer": " Legrand",
-        #     "model": " Light switch with neutral",
-        # }
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=256
+        # input_clusters=[0, 3, 4, 5, 6, 15, 64513]
+        # output_clusters=[0, 25, 64513]>
         MODELS_INFO: [(f" {LEGRAND}", " Light switch with neutral")],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
Add support for BTicino L4003C connected light switches.


## Additional information
The L4003 is in many ways identical to the L4411C, differing only in the absence of the dimming functionality and the absence of the ``LevelControl`` cluster.

I've moved some classes out of ``dimmer.py`` to reuse them in the new ``switch.py`` module.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
