### PR TITLE
Add Tuya knob TS004F `_TZ3000_abrsvsou` variant

### DIFF
--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -78,6 +78,7 @@ class TuyaSmartRemote004FROK(EnchantedDevice):
             ("_TZ3000_ixla93vd", "TS004F"),
             ("_TZ3000_qja6nq5z", "TS004F"),
             ("_TZ3000_csflgqj2", "TS004F"),
+            ("_TZ3000_abrsvsou", "TS004F"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Adding "_TZ3000_abrsvsou", "TS004F"
https://github.com/Koenkk/zigbee-herdsman-converters/pull/5715

## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
