### PR TITLE
Add support for Onesti EasyCode Touch lock

### DIFF
--- a/zhaquirks/onesti/__init__.py
+++ b/zhaquirks/onesti/__init__.py
@@ -1,0 +1,1 @@
+"""Quirks for Onesti Products AS devices."""

--- a/zhaquirks/onesti/easycodetouch.py
+++ b/zhaquirks/onesti/easycodetouch.py
@@ -1,25 +1,24 @@
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice, CustomCluster
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.closures import DoorLock
 from zigpy.zcl.clusters.general import (
     Basic,
-    PowerConfiguration,
     Groups,
     Identify,
-    Scenes,
     Ota,
-)
-from zigpy.zcl.clusters.closures import (
-    DoorLock,
+    PowerConfiguration,
+    Scenes,
 )
 import zigpy.zdo.types
+
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
+    NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    NODE_DESCRIPTOR,
 )
 
 MANUFACTURER_SPECIFIC_PROFILE_ID = 0xFEA2
@@ -28,7 +27,8 @@ MANUFACTURER_SPECIFIC_PROFILE_ID = 0xFEA2
 class BatteryBasicCluster(CustomCluster, Basic):
     """Basic cluster implementation.
     This implementation sets power source to battery
-    and removes incorrect MainsPowered-flag."""
+    and removes incorrect MainsPowered-flag.
+    """
 
     cluster_id = Basic.cluster_id
     POWER_SOURCE = 0x0007

--- a/zhaquirks/onesti/easycodetouch.py
+++ b/zhaquirks/onesti/easycodetouch.py
@@ -1,0 +1,99 @@
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice, CustomCluster
+from zigpy.zcl.clusters.general import (
+    Basic,
+    PowerConfiguration,
+    Groups,
+    Identify,
+    Scenes,
+    Ota,
+)
+from zigpy.zcl.clusters.closures import (
+    DoorLock,
+)
+import zigpy.zdo.types
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    NODE_DESCRIPTOR,
+)
+
+MANUFACTURER_SPECIFIC_PROFILE_ID = 0xFEA2
+
+
+class BatteryBasicCluster(CustomCluster, Basic):
+    """Basic cluster implementation.
+    This implementation sets power source to battery
+    and removes incorrect MainsPowered-flag."""
+
+    cluster_id = Basic.cluster_id
+    POWER_SOURCE = 0x0007
+
+    _CONSTANT_ATTRIBUTES = {
+        POWER_SOURCE: Basic.PowerSource.Battery,
+    }
+
+
+class EasyCodeTouch(CustomDevice):
+    """onesti.easycodetouch"""
+
+    signature = {
+        MODELS_INFO: [("Onesti Products AS", "EasyCodeTouch")],
+        ENDPOINTS: {
+            # SimpleDescriptor(endpoint=11, profile=260, device_type=10,
+            # device_version=1,
+            # input_clusters=[0, 1, 3, 5, 4, 257, 65186],
+            # output_clusters=[25])
+            11: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DOOR_LOCK,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Groups.cluster_id,
+                    Identify.cluster_id,
+                    Scenes.cluster_id,
+                    DoorLock.cluster_id,
+                    MANUFACTURER_SPECIFIC_PROFILE_ID,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        NODE_DESCRIPTOR: zigpy.zdo.types.NodeDescriptor(
+            logical_type=2,
+            complex_descriptor_available=0,
+            user_descriptor_available=0,
+            reserved=0,
+            aps_flags=0,
+            frequency_band=8,
+            mac_capability_flags=136,
+            manufacturer_code=4660,
+            maximum_buffer_size=108,
+            maximum_incoming_transfer_size=127,
+            server_mask=11264,
+            maximum_outgoing_transfer_size=127,
+            descriptor_capability_field=0,
+        ),
+        ENDPOINTS: {
+            11: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DOOR_LOCK,
+                INPUT_CLUSTERS: [
+                    BatteryBasicCluster,
+                    PowerConfiguration.cluster_id,
+                    Groups.cluster_id,
+                    Identify.cluster_id,
+                    Scenes.cluster_id,
+                    DoorLock.cluster_id,
+                    MANUFACTURER_SPECIFIC_PROFILE_ID,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }

--- a/zhaquirks/onesti/easycodetouch.py
+++ b/zhaquirks/onesti/easycodetouch.py
@@ -1,5 +1,5 @@
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.closures import DoorLock
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -24,22 +24,8 @@ from zhaquirks.const import (
 MANUFACTURER_SPECIFIC_PROFILE_ID = 0xFEA2
 
 
-class BatteryBasicCluster(CustomCluster, Basic):
-    """Basic cluster implementation.
-    This implementation sets power source to battery
-    and removes incorrect MainsPowered-flag.
-    """
-
-    cluster_id = Basic.cluster_id
-    POWER_SOURCE = 0x0007
-
-    _CONSTANT_ATTRIBUTES = {
-        POWER_SOURCE: Basic.PowerSource.Battery,
-    }
-
-
 class EasyCodeTouch(CustomDevice):
-    """onesti.easycodetouch"""
+    """Onesti EasyCodeTouch quirk."""
 
     signature = {
         MODELS_INFO: [("Onesti Products AS", "EasyCodeTouch")],
@@ -65,6 +51,20 @@ class EasyCodeTouch(CustomDevice):
         },
     }
     replacement = {
+        # "node_descriptor": "NodeDescriptor(
+        # logical_type=<LogicalType.EndDevice: 2>,
+        # complex_descriptor_available=0,
+        # user_descriptor_available=0,
+        # reserved=0,
+        # aps_flags=0,
+        # frequency_band=<FrequencyBand.Freq2400MHz: 8>,
+        # mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered: 140>,
+        # manufacturer_code=4660,
+        # maximum_buffer_size=108,
+        # maximum_incoming_transfer_size=127,
+        # server_mask=11264,
+        # maximum_outgoing_transfer_size=127,
+        # descriptor_capability_field=<DescriptorCapability.NONE: 0>,
         NODE_DESCRIPTOR: zigpy.zdo.types.NodeDescriptor(
             logical_type=2,
             complex_descriptor_available=0,
@@ -85,7 +85,7 @@ class EasyCodeTouch(CustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.DOOR_LOCK,
                 INPUT_CLUSTERS: [
-                    BatteryBasicCluster,
+                    Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                     Groups.cluster_id,
                     Identify.cluster_id,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This adds support for Onesti EasyCode Touch door lock.
The quirk removes incorrect MainsPowered-flag from NODE_DESCRIPTOR, making battery percentage visible in HA.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
