### PR TITLE
Fix SmartThings quirk, add test to verify uniqueness of cluster IDs

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -772,3 +772,28 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
                     f"Cluster {cluster} deletes parent class's attributes instead of"
                     f" extending them: {base_attr_names - quirk_attr_names}"
                 )
+
+
+@pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)
+def test_no_duplicate_clusters(quirk: CustomDevice) -> None:
+    """Verify no quirks contain clusters with duplicate cluster ids in the replacement."""
+
+    def check_for_duplicate_cluster_ids(clusters) -> None:
+        used_cluster_ids = set()
+
+        for cluster in clusters:
+            if isinstance(cluster, int):
+                cluster_id = cluster
+            else:
+                cluster_id = cluster.cluster_id
+
+            if cluster_id in used_cluster_ids:
+                pytest.fail(
+                    f"Cluster ID 0x{cluster_id:04X} is used more than once in the"
+                    f" replacement for endpoint {ep_id} in {quirk}"
+                )
+            used_cluster_ids.add(cluster_id)
+
+    for ep_id, ep_data in quirk.replacement[ENDPOINTS].items():
+        check_for_duplicate_cluster_ids(ep_data.get(INPUT_CLUSTERS, []))
+        check_for_duplicate_cluster_ids(ep_data.get(OUTPUT_CLUSTERS, []))

--- a/zhaquirks/smartthings/multi.py
+++ b/zhaquirks/smartthings/multi.py
@@ -12,6 +12,13 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
+from zhaquirks import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
 from zhaquirks.smartthings import SmartThingsAccelCluster
 
 
@@ -19,14 +26,14 @@ class SmartthingsMultiPurposeSensor(CustomDevice):
     """Custom device representing a Smartthings Multi Purpose Sensor."""
 
     signature = {
-        "endpoints": {
+        ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=1026
             # device_version=0 input_clusters=[0, 1, 3, 32, 1026, 1280, 64514]
             # output_clusters=[3, 25]>
             1: {
-                "profile_id": zha.PROFILE_ID,
-                "device_type": zha.DeviceType.IAS_ZONE,
-                "input_clusters": [
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
@@ -35,25 +42,24 @@ class SmartthingsMultiPurposeSensor(CustomDevice):
                     IasZone.cluster_id,
                     SmartThingsAccelCluster.cluster_id,
                 ],
-                "output_clusters": [Identify.cluster_id, Ota.cluster_id],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
             }
         }
     }
 
     replacement = {
-        "endpoints": {
+        ENDPOINTS: {
             1: {
-                "input_clusters": [
+                INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     TemperatureMeasurement.cluster_id,
                     IasZone.cluster_id,
-                    SmartThingsAccelCluster.cluster_id,
                     SmartThingsAccelCluster,
                 ],
-                "output_clusters": [Identify.cluster_id, Ota.cluster_id],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
             }
         }
     }


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The `SmartthingsMultiPurposeSensor` quirk had both the cluster id and the modified cluster class in the replacement.
This PR fixes that issue by removing the cluster id. It also replaces the strings with constants.

A basic test is also added to verify that the `INPUT_CLUSTERS` section and the `OUTPUT_CLUSTERS` section of a `REPLACEMENT` for a quirk do not contain the same cluster id multiple times.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
The issue was found in https://github.com/home-assistant/core/issues/92505, but that issue seems to be a different one.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
