### PR TITLE
Fix reading PM2.5 attribute in IKEA Starkvind quirk

### DIFF
--- a/zhaquirks/ikea/starkvind.py
+++ b/zhaquirks/ikea/starkvind.py
@@ -121,7 +121,7 @@ class PM25Cluster(CustomCluster, PM25):
                 await self.endpoint.device.endpoints[1]
                 .in_clusters[64637]
                 .read_attributes(
-                    {"air_quality_25pm"},
+                    ["air_quality_25pm"],
                     allow_cache=allow_cache,
                     only_cache=only_cache,
                     manufacturer=manufacturer,


### PR DESCRIPTION
## Proposed change
An IKEA Starkvind device was not showing a PM2.5 sensor in Home Assistant. Upon investigation, Python was throwing a `TypeError: 'set' object is not subscriptable` in `read_attributes`. This appears to be because code in `starkvind.py` was calling `read_attributes` with a set for the attributes arg, but the type signature says that argument should be a list. So I made that very simple change.


## Additional information
I'm brand new to this project and unfamiliar with the code. But the way the code is structured here (a call to one attribute in the PM2.5 cluster is redirected to another attribute in a custom manufacturer cluster) feels a little odd -- is there a different best practice to do this? In particular, with the current code, it looks like if `PM25Cluster.read_attributes` is called with multiple attributes at once, one of which is `measured_value`, it will quietly return only one attribute in its response and ignore any others.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
