### PR TITLE
Support for Aqara H1 single rocker wall switch with neutral (n1aeu1)

### DIFF
--- a/zhaquirks/xiaomi/aqara/switch_h1.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1.py
@@ -1,0 +1,176 @@
+import copy
+import logging
+from enum import Enum
+
+from zhaquirks.const import (ALT_DOUBLE_PRESS, ALT_SHORT_PRESS, ARGS, ATTR_ID,
+                             BUTTON, CLUSTER_ID, COMMAND, COMMAND_DOUBLE,
+                             COMMAND_HOLD, COMMAND_OFF, COMMAND_SINGLE,
+                             COMMAND_TOGGLE, COMMAND_TRIPLE, DEVICE_TYPE,
+                             DOUBLE_PRESS, ENDPOINT_ID, ENDPOINTS,
+                             INPUT_CLUSTERS, LONG_PRESS, MODELS_INFO,
+                             OUTPUT_CLUSTERS, PROFILE_ID, SHORT_PRESS,
+                             TRIPLE_PRESS, ZHA_SEND_EVENT)
+from zhaquirks.xiaomi import (LUMI, DeviceTemperatureCluster,  # BasicCluster,
+                              OnOffCluster, XiaomiCustomDevice,
+                              XiaomiMeteringCluster)
+from zhaquirks.xiaomi.aqara.opple_remote import (MultistateInputCluster,
+                                                 OppleCluster)
+from zhaquirks.xiaomi.aqara.opple_switch import (OppleIndicatorLight,
+                                                 OppleOperationMode)
+from zigpy import types as t
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import (Alarms, Basic, GreenPowerProxy, Groups,
+                                        Identify, OnOff, Ota, Scenes, Time)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AqaraH1SwitchCluster(OppleCluster):
+    """Xiaomi mfg cluster implementation."""
+
+    attributes = copy.deepcopy(OppleCluster.attributes)
+
+    attributes.update(
+        {
+            0x0002: ("power_outage_count", t.uint8_t, True),
+            0x000A: ("switch_type", t.uint8_t, True),  # values can be: 1 or 2
+            0x00F0: ("reverse_indicator_light", OppleIndicatorLight, True),
+            0x0125: ("switch_mode", t.uint8_t, True),  # values can be: 1 or 2
+            0x0200: ("operation_mode", OppleOperationMode, True),
+            0x0201: ("power_outage_memory", t.Bool, True),
+            0x0202: ("auto_off", t.Bool, True),
+            0x0203: ("do_not_disturb", t.Bool, True),
+        }
+    )
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == 0x00FC:
+            self._current_state = PRESS_TYPES.get(value)
+            event_args = {
+                PRESS_TYPE: self._current_state,
+                ATTR_ID: attrid,
+                VALUE: value,
+            }
+            self.listener_event(ZHA_SEND_EVENT, self._current_state, event_args)
+            # show something in the sensor in HA
+            super()._update_attribute(0, self._current_state)
+
+
+class AqaraH1SingleRockerSwitch(XiaomiCustomDevice):
+    """Aqara H1 Single Rocker Switch (with neutral)."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.switch.n1aeu1")],
+        ENDPOINTS: {
+            #  input_clusters=[0, 2, 3, 4, 5, 6, 18, 64704], output_clusters=[10, 25]
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,  # 0
+                    DeviceTemperatureCluster.cluster_id,  # 2
+                    Identify.cluster_id,  # 3
+                    Groups.cluster_id,  # 4
+                    Scenes.cluster_id,  # 5
+                    OnOff.cluster_id,  # 6
+                    Alarms.cluster_id,  # 9
+                    XiaomiMeteringCluster.cluster_id,  # 0x0702
+                    0x0B04,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,  # 0x000a
+                    Ota.cluster_id,  # 0x0019
+                ],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,  # 0x0021
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,  # 0
+                    Identify.cluster_id,  # 3
+                    Groups.cluster_id,  # 4
+                    Scenes.cluster_id,  # 5
+                    OnOffCluster,  # 6
+                    Alarms.cluster_id,  # 9
+                    XiaomiMeteringCluster.cluster_id,  # 0x0702
+                    AqaraH1SwitchCluster,  # 0xFCC0 / 64704
+                    0x0B04,
+                ],
+                OUTPUT_CLUSTERS: [
+                    MultistateInputCluster,  # 18
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON): {
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 0,
+            COMMAND: COMMAND_SINGLE,
+            ARGS: {ATTR_ID: 0x00F9},
+        },
+        (DOUBLE_PRESS, BUTTON): {
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 0,
+            COMMAND: COMMAND_DOUBLE,
+            ARGS: {ATTR_ID: 0x00FA},
+        },
+        (TRIPLE_PRESS, BUTTON): {
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 0,
+            COMMAND: COMMAND_TRIPLE,
+            ARGS: {ATTR_ID: 0x00FB},
+        },
+        (LONG_PRESS, BUTTON): {CLUSTER_ID: AqaraH1SwitchCluster.cluster_id, COMMAND: COMMAND_HOLD},
+        (ALT_SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1, ARGS: []},
+        (ALT_DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1, ARGS: []},
+    }
+    #{
+    #    # triggers when operation_mode == event
+    #    # the button doesn't send an release event after hold
+    #    (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_SINGLE},
+    #    (DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_DOUBLE},
+    #    (TRIPLE_PRESS, BUTTON): {COMMAND: COMMAND_TRIPLE},
+    #    (LONG_PRESS, BUTTON): {COMMAND: COMMAND_1_HOLD},
+    #    # triggers when operation_mode == command
+    #    (ALT_SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1, ARGS: []},
+    #    (ALT_DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1, ARGS: []},
+    #    (COMMAND_BUTTON_SINGLE, BUTTON_1): {
+    #        ENDPOINT_ID: 1,
+    #        CLUSTER_ID: 18,
+    #        ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
+    #    },
+    #    (COMMAND_BUTTON_DOUBLE, BUTTON_1): {
+    #        ENDPOINT_ID: 1,
+    #        CLUSTER_ID: 18,
+    #        ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_DOUBLE, VALUE: 2},
+    #    },
+    #    (COMMAND_BUTTON_HOLD, BUTTON): {
+    #        ENDPOINT_ID: 1,
+    #        CLUSTER_ID: 0xFCC0,
+    #        # COMMAND: COMMAND_ATTRIBUTE_UPDATED,
+    #        ARGS: {ATTR_ID: 0x00FC, VALUE: False},
+    #    },
+    #}

--- a/zhaquirks/xiaomi/aqara/switch_h1.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1.py
@@ -14,12 +14,9 @@ from zigpy.zcl.clusters.general import (
 from zhaquirks.const import (
     ARGS,
     ATTR_ID,
-    ATTRIBUTE_ID,
-    ATTRIBUTE_NAME,
     BUTTON,
     CLUSTER_ID,
     COMMAND,
-    COMMAND_ATTRIBUTE_UPDATED,
     COMMAND_DOUBLE,
     COMMAND_HOLD,
     COMMAND_SINGLE,
@@ -34,7 +31,6 @@ from zhaquirks.const import (
     PRESS_TYPE,
     PROFILE_ID,
     SHORT_PRESS,
-    TRIPLE_PRESS,
     VALUE,
 )
 from zhaquirks.xiaomi import (
@@ -47,6 +43,10 @@ from zhaquirks.xiaomi import (
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 from zhaquirks.xiaomi.aqara.opple_switch import OppleSwitchCluster
+
+XIAOMI_COMMAND_SINGLE = "41_single"
+XIAOMI_COMMAND_DOUBLE = "41_double"
+XIAOMI_COMMAND_HOLD = "1_hold"
 
 
 class AqaraH1SingleRockerSwitch(XiaomiCustomDevice):
@@ -129,30 +129,19 @@ class AqaraH1SingleRockerSwitch(XiaomiCustomDevice):
         (SHORT_PRESS, BUTTON): {
             ENDPOINT_ID: 41,
             CLUSTER_ID: 18,
-            COMMAND: f"41_{COMMAND_SINGLE}",
+            COMMAND: XIAOMI_COMMAND_SINGLE,
             ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
         },
         (DOUBLE_PRESS, BUTTON): {
             ENDPOINT_ID: 41,
             CLUSTER_ID: 18,
-            COMMAND: f"41_{COMMAND_DOUBLE}",
+            COMMAND: XIAOMI_COMMAND_DOUBLE,
             ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_DOUBLE, VALUE: 2},
-        },
-        # when triple-pressed, you're technically getting an attribute update call, so not sure if it can be used
-        (TRIPLE_PRESS, BUTTON): {
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 0,
-            COMMAND: COMMAND_ATTRIBUTE_UPDATED,
-            ARGS: {
-                ATTRIBUTE_ID: 5,
-                ATTRIBUTE_NAME: "model",
-                VALUE: "lumi.switch.n1aeu1",
-            },
         },
         (LONG_PRESS, BUTTON): {
             ENDPOINT_ID: 1,
             CLUSTER_ID: 64704,
-            COMMAND: f"1_{COMMAND_HOLD}",
+            COMMAND: XIAOMI_COMMAND_HOLD,
             ARGS: {ATTR_ID: 0x00FC, PRESS_TYPE: COMMAND_HOLD, VALUE: 0},
         },
     }

--- a/zhaquirks/xiaomi/aqara/switch_h1.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1.py
@@ -1,7 +1,5 @@
-import copy
 import logging
 
-from zigpy import types as t
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
     Alarms,
@@ -26,10 +24,7 @@ from zhaquirks.const import (
     COMMAND_ATTRIBUTE_UPDATED,
     COMMAND_DOUBLE,
     COMMAND_HOLD,
-    COMMAND_OFF,
     COMMAND_SINGLE,
-    COMMAND_TOGGLE,
-    COMMAND_TRIPLE,
     DEVICE_TYPE,
     DOUBLE_PRESS,
     ENDPOINT_ID,
@@ -43,7 +38,6 @@ from zhaquirks.const import (
     SHORT_PRESS,
     TRIPLE_PRESS,
     VALUE,
-    ZHA_SEND_EVENT,
 )
 from zhaquirks.xiaomi import (
     LUMI,
@@ -53,12 +47,8 @@ from zhaquirks.xiaomi import (
     XiaomiCustomDevice,
     XiaomiMeteringCluster,
 )
-from zhaquirks.xiaomi.aqara.opple_remote import PRESS_TYPES, MultistateInputCluster
-from zhaquirks.xiaomi.aqara.opple_switch import (
-    OppleIndicatorLight,
-    OppleOperationMode,
-    OppleSwitchCluster,
-)
+from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
+from zhaquirks.xiaomi.aqara.opple_switch import OppleSwitchCluster
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -106,7 +96,7 @@ class AqaraH1SingleRockerSwitch(XiaomiCustomDevice):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     BasicCluster,  # 0
-                    DeviceTemperatureCluster.cluster_id, # 2
+                    DeviceTemperatureCluster.cluster_id,  # 2
                     Identify.cluster_id,  # 3
                     Groups.cluster_id,  # 4
                     Scenes.cluster_id,  # 5
@@ -143,13 +133,13 @@ class AqaraH1SingleRockerSwitch(XiaomiCustomDevice):
         (SHORT_PRESS, BUTTON): {
             ENDPOINT_ID: 41,
             CLUSTER_ID: 18,
-            COMMAND: '41_{}'.format(COMMAND_SINGLE),
+            COMMAND: f"41_{COMMAND_SINGLE}",
             ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
         },
         (DOUBLE_PRESS, BUTTON): {
             ENDPOINT_ID: 41,
             CLUSTER_ID: 18,
-            COMMAND: '41_{}'.format(COMMAND_DOUBLE),
+            COMMAND: f"41_{COMMAND_DOUBLE}",
             ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_DOUBLE, VALUE: 2},
         },
         # when triple-pressed, you're technically getting an attribute update call, so not sure if it can be used
@@ -157,12 +147,16 @@ class AqaraH1SingleRockerSwitch(XiaomiCustomDevice):
             ENDPOINT_ID: 1,
             CLUSTER_ID: 0,
             COMMAND: COMMAND_ATTRIBUTE_UPDATED,
-            ARGS: {ATTRIBUTE_ID: 5, ATTRIBUTE_NAME: 'model', VALUE: 'lumi.switch.n1aeu1'},
+            ARGS: {
+                ATTRIBUTE_ID: 5,
+                ATTRIBUTE_NAME: "model",
+                VALUE: "lumi.switch.n1aeu1",
+            },
         },
         (LONG_PRESS, BUTTON): {
             ENDPOINT_ID: 1,
             CLUSTER_ID: 64704,
-            COMMAND: '1_{}'.format(COMMAND_HOLD),
+            COMMAND: f"1_{COMMAND_HOLD}",
             ARGS: {ATTR_ID: 0x00FC, PRESS_TYPE: COMMAND_HOLD, VALUE: 0},
         },
     }

--- a/zhaquirks/xiaomi/aqara/switch_h1.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1.py
@@ -1,26 +1,62 @@
 import copy
 import logging
-from enum import Enum
 
-from zhaquirks.const import (ALT_DOUBLE_PRESS, ALT_SHORT_PRESS, ARGS, ATTR_ID,
-                             BUTTON, CLUSTER_ID, COMMAND, COMMAND_DOUBLE,
-                             COMMAND_HOLD, COMMAND_OFF, COMMAND_SINGLE,
-                             COMMAND_TOGGLE, COMMAND_TRIPLE, DEVICE_TYPE,
-                             DOUBLE_PRESS, ENDPOINT_ID, ENDPOINTS,
-                             INPUT_CLUSTERS, LONG_PRESS, MODELS_INFO,
-                             OUTPUT_CLUSTERS, PROFILE_ID, SHORT_PRESS,
-                             TRIPLE_PRESS, ZHA_SEND_EVENT)
-from zhaquirks.xiaomi import (LUMI, DeviceTemperatureCluster,  # BasicCluster,
-                              OnOffCluster, XiaomiCustomDevice,
-                              XiaomiMeteringCluster)
-from zhaquirks.xiaomi.aqara.opple_remote import (MultistateInputCluster,
-                                                 OppleCluster)
-from zhaquirks.xiaomi.aqara.opple_switch import (OppleIndicatorLight,
-                                                 OppleOperationMode)
 from zigpy import types as t
 from zigpy.profiles import zha
-from zigpy.zcl.clusters.general import (Alarms, Basic, GreenPowerProxy, Groups,
-                                        Identify, OnOff, Ota, Scenes, Time)
+from zigpy.zcl.clusters.general import (
+    Alarms,
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+
+from zhaquirks.const import (
+    ALT_DOUBLE_PRESS,
+    ALT_SHORT_PRESS,
+    ARGS,
+    ATTR_ID,
+    BUTTON,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_DOUBLE,
+    COMMAND_HOLD,
+    COMMAND_OFF,
+    COMMAND_SINGLE,
+    COMMAND_TOGGLE,
+    COMMAND_TRIPLE,
+    DEVICE_TYPE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    LONG_PRESS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PRESS_TYPE,
+    PROFILE_ID,
+    SHORT_PRESS,
+    TRIPLE_PRESS,
+    VALUE,
+    ZHA_SEND_EVENT,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    DeviceTemperatureCluster,
+    OnOffCluster,
+    XiaomiCustomDevice,
+    XiaomiMeteringCluster,
+)
+from zhaquirks.xiaomi.aqara.opple_remote import (
+    PRESS_TYPES,
+    MultistateInputCluster,
+    OppleCluster,
+)
+from zhaquirks.xiaomi.aqara.opple_switch import OppleIndicatorLight, OppleOperationMode
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -143,34 +179,37 @@ class AqaraH1SingleRockerSwitch(XiaomiCustomDevice):
             COMMAND: COMMAND_TRIPLE,
             ARGS: {ATTR_ID: 0x00FB},
         },
-        (LONG_PRESS, BUTTON): {CLUSTER_ID: AqaraH1SwitchCluster.cluster_id, COMMAND: COMMAND_HOLD},
+        (LONG_PRESS, BUTTON): {
+            CLUSTER_ID: AqaraH1SwitchCluster.cluster_id,
+            COMMAND: COMMAND_HOLD,
+        },
         (ALT_SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1, ARGS: []},
         (ALT_DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1, ARGS: []},
     }
-    #{
-    #    # triggers when operation_mode == event
-    #    # the button doesn't send an release event after hold
-    #    (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_SINGLE},
-    #    (DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_DOUBLE},
-    #    (TRIPLE_PRESS, BUTTON): {COMMAND: COMMAND_TRIPLE},
-    #    (LONG_PRESS, BUTTON): {COMMAND: COMMAND_1_HOLD},
-    #    # triggers when operation_mode == command
-    #    (ALT_SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1, ARGS: []},
-    #    (ALT_DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1, ARGS: []},
-    #    (COMMAND_BUTTON_SINGLE, BUTTON_1): {
-    #        ENDPOINT_ID: 1,
-    #        CLUSTER_ID: 18,
-    #        ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
-    #    },
-    #    (COMMAND_BUTTON_DOUBLE, BUTTON_1): {
-    #        ENDPOINT_ID: 1,
-    #        CLUSTER_ID: 18,
-    #        ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_DOUBLE, VALUE: 2},
-    #    },
-    #    (COMMAND_BUTTON_HOLD, BUTTON): {
-    #        ENDPOINT_ID: 1,
-    #        CLUSTER_ID: 0xFCC0,
-    #        # COMMAND: COMMAND_ATTRIBUTE_UPDATED,
-    #        ARGS: {ATTR_ID: 0x00FC, VALUE: False},
-    #    },
-    #}
+    # {
+    #     # triggers when operation_mode == event
+    #     # the button doesn't send an release event after hold
+    #     (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_SINGLE},
+    #     (DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_DOUBLE},
+    #     (TRIPLE_PRESS, BUTTON): {COMMAND: COMMAND_TRIPLE},
+    #     (LONG_PRESS, BUTTON): {COMMAND: COMMAND_1_HOLD},
+    #     # triggers when operation_mode == command
+    #     (ALT_SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1, ARGS: []},
+    #     (ALT_DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1, ARGS: []},
+    #     (COMMAND_BUTTON_SINGLE, BUTTON_1): {
+    #         ENDPOINT_ID: 1,
+    #         CLUSTER_ID: 18,
+    #         ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
+    #     },
+    #     (COMMAND_BUTTON_DOUBLE, BUTTON_1): {
+    #         ENDPOINT_ID: 1,
+    #         CLUSTER_ID: 18,
+    #         ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_DOUBLE, VALUE: 2},
+    #     },
+    #     (COMMAND_BUTTON_HOLD, BUTTON): {
+    #         ENDPOINT_ID: 1,
+    #         CLUSTER_ID: 0xFCC0,
+    #         # COMMAND: COMMAND_ATTRIBUTE_UPDATED,
+    #         ARGS: {ATTR_ID: 0x00FC, VALUE: False},
+    #     },
+    # }

--- a/zhaquirks/xiaomi/aqara/switch_h1.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1.py
@@ -1,4 +1,5 @@
 from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Alarms,
     Basic,
@@ -38,7 +39,6 @@ from zhaquirks.xiaomi import (
     BasicCluster,
     DeviceTemperatureCluster,
     OnOffCluster,
-    XiaomiCustomDevice,
     XiaomiMeteringCluster,
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
@@ -49,7 +49,7 @@ XIAOMI_COMMAND_DOUBLE = "41_double"
 XIAOMI_COMMAND_HOLD = "1_hold"
 
 
-class AqaraH1SingleRockerSwitch(XiaomiCustomDevice):
+class AqaraH1SingleRockerSwitch(CustomDevice):
     """Aqara H1 Single Rocker Switch (with neutral)."""
 
     signature = {

--- a/zhaquirks/xiaomi/aqara/switch_h1.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1.py
@@ -16,13 +16,14 @@ from zigpy.zcl.clusters.general import (
 )
 
 from zhaquirks.const import (
-    ALT_DOUBLE_PRESS,
-    ALT_SHORT_PRESS,
     ARGS,
     ATTR_ID,
+    ATTRIBUTE_ID,
+    ATTRIBUTE_NAME,
     BUTTON,
     CLUSTER_ID,
     COMMAND,
+    COMMAND_ATTRIBUTE_UPDATED,
     COMMAND_DOUBLE,
     COMMAND_HOLD,
     COMMAND_OFF,
@@ -46,51 +47,20 @@ from zhaquirks.const import (
 )
 from zhaquirks.xiaomi import (
     LUMI,
+    BasicCluster,
     DeviceTemperatureCluster,
     OnOffCluster,
     XiaomiCustomDevice,
     XiaomiMeteringCluster,
 )
-from zhaquirks.xiaomi.aqara.opple_remote import (
-    PRESS_TYPES,
-    MultistateInputCluster,
-    OppleCluster,
+from zhaquirks.xiaomi.aqara.opple_remote import PRESS_TYPES, MultistateInputCluster
+from zhaquirks.xiaomi.aqara.opple_switch import (
+    OppleIndicatorLight,
+    OppleOperationMode,
+    OppleSwitchCluster,
 )
-from zhaquirks.xiaomi.aqara.opple_switch import OppleIndicatorLight, OppleOperationMode
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class AqaraH1SwitchCluster(OppleCluster):
-    """Xiaomi mfg cluster implementation."""
-
-    attributes = copy.deepcopy(OppleCluster.attributes)
-
-    attributes.update(
-        {
-            0x0002: ("power_outage_count", t.uint8_t, True),
-            0x000A: ("switch_type", t.uint8_t, True),  # values can be: 1 or 2
-            0x00F0: ("reverse_indicator_light", OppleIndicatorLight, True),
-            0x0125: ("switch_mode", t.uint8_t, True),  # values can be: 1 or 2
-            0x0200: ("operation_mode", OppleOperationMode, True),
-            0x0201: ("power_outage_memory", t.Bool, True),
-            0x0202: ("auto_off", t.Bool, True),
-            0x0203: ("do_not_disturb", t.Bool, True),
-        }
-    )
-
-    def _update_attribute(self, attrid, value):
-        super()._update_attribute(attrid, value)
-        if attrid == 0x00FC:
-            self._current_state = PRESS_TYPES.get(value)
-            event_args = {
-                PRESS_TYPE: self._current_state,
-                ATTR_ID: attrid,
-                VALUE: value,
-            }
-            self.listener_event(ZHA_SEND_EVENT, self._current_state, event_args)
-            # show something in the sensor in HA
-            super()._update_attribute(0, self._current_state)
 
 
 class AqaraH1SingleRockerSwitch(XiaomiCustomDevice):
@@ -135,21 +105,30 @@ class AqaraH1SingleRockerSwitch(XiaomiCustomDevice):
             1: {
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
+                    BasicCluster,  # 0
+                    DeviceTemperatureCluster.cluster_id, # 2
                     Identify.cluster_id,  # 3
                     Groups.cluster_id,  # 4
                     Scenes.cluster_id,  # 5
                     OnOffCluster,  # 6
                     Alarms.cluster_id,  # 9
+                    MultistateInputCluster,  # 18
                     XiaomiMeteringCluster.cluster_id,  # 0x0702
-                    AqaraH1SwitchCluster,  # 0xFCC0 / 64704
+                    OppleSwitchCluster,  # 0xFCC0 / 64704
                     0x0B04,
                 ],
                 OUTPUT_CLUSTERS: [
-                    MultistateInputCluster,  # 18
                     Time.cluster_id,
                     Ota.cluster_id,
                 ],
+            },
+            41: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MultistateInputCluster,  # 18
+                ],
+                OUTPUT_CLUSTERS: [],
             },
             242: {
                 PROFILE_ID: 41440,
@@ -162,54 +141,28 @@ class AqaraH1SingleRockerSwitch(XiaomiCustomDevice):
 
     device_automation_triggers = {
         (SHORT_PRESS, BUTTON): {
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 0,
-            COMMAND: COMMAND_SINGLE,
-            ARGS: {ATTR_ID: 0x00F9},
+            ENDPOINT_ID: 41,
+            CLUSTER_ID: 18,
+            COMMAND: '41_{}'.format(COMMAND_SINGLE),
+            ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
         },
         (DOUBLE_PRESS, BUTTON): {
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 0,
-            COMMAND: COMMAND_DOUBLE,
-            ARGS: {ATTR_ID: 0x00FA},
+            ENDPOINT_ID: 41,
+            CLUSTER_ID: 18,
+            COMMAND: '41_{}'.format(COMMAND_DOUBLE),
+            ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_DOUBLE, VALUE: 2},
         },
+        # when triple-pressed, you're technically getting an attribute update call, so not sure if it can be used
         (TRIPLE_PRESS, BUTTON): {
             ENDPOINT_ID: 1,
             CLUSTER_ID: 0,
-            COMMAND: COMMAND_TRIPLE,
-            ARGS: {ATTR_ID: 0x00FB},
+            COMMAND: COMMAND_ATTRIBUTE_UPDATED,
+            ARGS: {ATTRIBUTE_ID: 5, ATTRIBUTE_NAME: 'model', VALUE: 'lumi.switch.n1aeu1'},
         },
         (LONG_PRESS, BUTTON): {
-            CLUSTER_ID: AqaraH1SwitchCluster.cluster_id,
-            COMMAND: COMMAND_HOLD,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 64704,
+            COMMAND: '1_{}'.format(COMMAND_HOLD),
+            ARGS: {ATTR_ID: 0x00FC, PRESS_TYPE: COMMAND_HOLD, VALUE: 0},
         },
-        (ALT_SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1, ARGS: []},
-        (ALT_DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1, ARGS: []},
     }
-    # {
-    #     # triggers when operation_mode == event
-    #     # the button doesn't send an release event after hold
-    #     (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_SINGLE},
-    #     (DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_DOUBLE},
-    #     (TRIPLE_PRESS, BUTTON): {COMMAND: COMMAND_TRIPLE},
-    #     (LONG_PRESS, BUTTON): {COMMAND: COMMAND_1_HOLD},
-    #     # triggers when operation_mode == command
-    #     (ALT_SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1, ARGS: []},
-    #     (ALT_DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1, ARGS: []},
-    #     (COMMAND_BUTTON_SINGLE, BUTTON_1): {
-    #         ENDPOINT_ID: 1,
-    #         CLUSTER_ID: 18,
-    #         ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
-    #     },
-    #     (COMMAND_BUTTON_DOUBLE, BUTTON_1): {
-    #         ENDPOINT_ID: 1,
-    #         CLUSTER_ID: 18,
-    #         ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_DOUBLE, VALUE: 2},
-    #     },
-    #     (COMMAND_BUTTON_HOLD, BUTTON): {
-    #         ENDPOINT_ID: 1,
-    #         CLUSTER_ID: 0xFCC0,
-    #         # COMMAND: COMMAND_ATTRIBUTE_UPDATED,
-    #         ARGS: {ATTR_ID: 0x00FC, VALUE: False},
-    #     },
-    # }

--- a/zhaquirks/xiaomi/aqara/switch_h1.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1.py
@@ -1,5 +1,3 @@
-import logging
-
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
     Alarms,
@@ -49,8 +47,6 @@ from zhaquirks.xiaomi import (
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 from zhaquirks.xiaomi.aqara.opple_switch import OppleSwitchCluster
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class AqaraH1SingleRockerSwitch(XiaomiCustomDevice):

--- a/zhaquirks/xiaomi/aqara/switch_h1.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1.py
@@ -89,6 +89,7 @@ class AqaraH1SingleRockerSwitch(CustomDevice):
     replacement = {
         ENDPOINTS: {
             1: {
+                PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     BasicCluster,  # 0


### PR DESCRIPTION
## Proposed change
Add missing support for the Aqara H1 single rocker wall switch (with neutral wire). The model is also known as: `WS-EUK03` or `lumi.switch.n1aeu1`

## Additional information
Everything at home is zigbee based but this is my first ever in-depth look into zigbee as well as contributing in that space so I only have basic understanding about how things should work. The contribution is heavily _inspired from the OppleSwitch_ and _OppleRemote_ implementations with some caveats which are better described in the checklist below.

**Some highlights while working on this**:
* **Operation mode is working fine**. You can set the switch to coupled / decoupled mode but I cannot get the switch_mode / switch_type functionality to work (I'm always receiving None values).
* I don't seem to be getting any ZHA events on any button press - short, double, long etc. Not sure what can be improved but I'm guessing the secret lies in some of the clusters being used (and whether they are set as input vs output clusters).

## Conclusion
Seems to be quite a straightforward addition but I'm currently lacking some additional context / knowledge to make this complete so I'd appreciate some support from the community on this one.

## Checklist
- [x] Operation mode is working as expected (coupled / decoupled)
- [x] Receive ZHA events on button press (short / double / long)
- [x] Automation triggers are properly configured
- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
