### PR TITLE
Add support for TreatLife motion sensor

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -1408,6 +1408,25 @@ def test_ts0601_valve_signature(assert_signature_matches_quirk):
     assert_signature_matches_quirk(zhaquirks.tuya.ts0601_valve.TuyaValve, signature)
 
 
+def test_ts0601_motion_signature(assert_signature_matches_quirk):
+    """Test TS0601 motion by TreatLife remote signature is matched to its quirk."""
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 260,
+                "device_type": "0x0051",
+                "in_clusters": ["0x0000", "0x0004", "0x0005", "0xef00"],
+                "out_clusters": ["0x000a", "0x0019"],
+            }
+        },
+        "manufacturer": "_TZE200_ppuj1vem",
+        "model": "TS0601",
+        "class": "zigpy.device.Device",
+    }
+    assert_signature_matches_quirk(zhaquirks.tuya.ts0601_motion.NeoMotion, signature)
+
+
 def test_multiple_attributes_report():
     """Test a multi attribute report from Tuya device."""
 

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -302,6 +302,7 @@ class NeoMotion(CustomDevice):
         #  output_clusters=[10, 25]>
         MODELS_INFO: [
             ("_TZE200_7hfcudw5", "TS0601"),
+            ("_TZE200_ppuj1vem", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
This adds support for the TreatLife motion sensor, which is basically rebranded Tuya TS0601. 
The change just adds a new signature to the tuya.ts0601_motion.NeoMotion quirk and a test to verify signature matching.
The change has been tested on a local Home Assistant instance and verified to work with the sensor.


## Additional information


## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
