### PR TITLE
Add Tuya cover TS0601 `_TZE200_bv1jcqqu` variant

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -371,6 +371,7 @@ class TuyaMoesCover0601(TuyaWindowCover):
             ("_TZE200_nhyj64w2", "TS0601"),
             ("_TZE200_cf1sl3tj", "TS0601"),
             ("_TZE200_7eue9vhc", "TS0601"),
+            ("_TZE200_bv1jcqqu", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Adds support for Zemismart ZM25RZ01 Roller Shade Motor. Fixes #2360

## Proposed change
<!--
  Explain your proposed change below.
-->

Add support for Zemismart ZM25RZ01 Roller Shade Motor.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
