### PR TITLE
Fix int overflow for Tuya energy sum sensor

### DIFF
--- a/zhaquirks/tuya/ts0601_din_power.py
+++ b/zhaquirks/tuya/ts0601_din_power.py
@@ -40,7 +40,7 @@ class TuyaManufClusterDinPower(TuyaManufClusterAttributes):
     """Manufacturer Specific Cluster of the Tuya Power Meter device."""
 
     attributes = {
-        TUYA_TOTAL_ENERGY_ATTR: ("energy", t.uint16_t, True),
+        TUYA_TOTAL_ENERGY_ATTR: ("energy", t.uint32_t, True),
         TUYA_CURRENT_ATTR: ("current", t.int16s, True),
         TUYA_POWER_ATTR: ("power", t.uint16_t, True),
         TUYA_VOLTAGE_ATTR: ("voltage", t.uint16_t, True),


### PR DESCRIPTION
## Proposed change
Hotfix for overflow exception


## Additional information
Debug log from Home Assistant:
```
2023-05-11 05:05:43.066 DEBUG (MainThread) [zigpy_znp.api] Received command: AF.IncomingMsg.Callback(GroupId=0x0000, ClusterId=61184, SrcAddr=0x4EBB, SrcEndpoint=1, DstEndpoint=1, WasBroadcast=<Bool.false: 0>, LQI=18, SecurityUse=<Bool.false: 0>, TimeStamp=4079236, TSN=0, Data=b'\x09\x07\x01\x00\x79\x11\x02\x00\x04\x00\x16\x77\xD9', MacSrcAddr=0x4EBB, MsgResultRadius=29)
2023-05-11 05:05:43.068 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x4EBB), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=0, profile_id=260, cluster_id=61184, data=Serialized[b'\t\x07\x01\x00y\x11\x02\x00\x04\x00\x16w\xd9'], tx_options=<TransmitOptions.NONE: 0>, radius=29, non_member_radius=0, lqi=18, rssi=None)
2023-05-11 05:05:43.070 DEBUG (MainThread) [zigpy.zcl] [0x4EBB:1:0xef00] Received ZCL frame: b'\t\x07\x01\x00y\x11\x02\x00\x04\x00\x16w\xd9'
2023-05-11 05:05:43.071 DEBUG (MainThread) [zigpy.zcl] [0x4EBB:1:0xef00] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 1>, disable_default_response=0, reserved=0, *is_cluster=True, *is_general=False), tsn=7, command_id=1, *direction=<Direction.Client_to_Server: 1>)
2023-05-11 05:05:43.073 DEBUG (MainThread) [zigpy.zcl] [0x4EBB:1:0xef00] Decoded ZCL frame: TuyaManufClusterDinPower:get_data(param=Command(status=0, tsn=121, command_id=529, function=0, data=[4, 0, 22, 119, 217]))
2023-05-11 05:05:43.073 DEBUG (MainThread) [zigpy.zcl] [0x4EBB:1:0xef00] Received command 0x01 (TSN 7): get_data(param=Command(status=0, tsn=121, command_id=529, function=0, data=[4, 0, 22, 119, 217]))
2023-05-11 05:05:43.074 DEBUG (MainThread) [zhaquirks.tuya] [0x4ebb:1:0xef00] Received value [0, 22, 119, 217] for attribute 0x0211 (command 0x0001)
2023-05-11 05:05:43.075 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
File "/usr/local/lib/python3.10/site-packages/zigpy_znp/zigbee/application.py", line 609, in on_af_message
	self.packet_received(
File "/usr/local/lib/python3.10/site-packages/zigpy/application.py", line 1007, in packet_received
	self.handle_message(
File "/usr/local/lib/python3.10/site-packages/zigpy/application.py", line 522, in handle_message
	return sender.handle_message(
File "/usr/local/lib/python3.10/site-packages/zigpy/device.py", line 374, in handle_message
	self.endpoints[src_ep].handle_message(
File "/usr/local/lib/python3.10/site-packages/zigpy/endpoint.py", line 230, in handle_message
	handler(hdr, args, dst_addressing=dst_addressing)
File "/usr/local/lib/python3.10/site-packages/zigpy/zcl/__init__.py", line 380, in handle_message
	self.handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
File "/usr/local/lib/python3.10/site-packages/zhaquirks/tuya/__init__.py", line 494, in handle_cluster_request
	zvalue = ztype(tuya_data)
File "/usr/local/lib/python3.10/site-packages/zigpy/types/basic.py", line 94, in __new__
	raise ValueError(
ValueError: 1472473 is not an unsigned 16 bit integer
```


## Checklist
- [x] The changes are tested and work correctly (tested with custom quirk file)
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
