### PR TITLE
LifeControl MCLH-08 quirk added

### DIFF
--- a/zhaquirks/lifecontrol/__init__.py
+++ b/zhaquirks/lifecontrol/__init__.py
@@ -1,0 +1,1 @@
+"""Module for LifeControl devices quirks."""

--- a/zhaquirks/lifecontrol/vocsensor.py
+++ b/zhaquirks/lifecontrol/vocsensor.py
@@ -1,9 +1,7 @@
 """Nexturn VOC Sensor"""
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
-import zigpy.types as t
-from zigpy.zcl.foundation import ZCLAttributeDef, ZCLCommandDef
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, PowerConfiguration, Identify
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement, RelativeHumidity, CarbonDioxideConcentration
 from zigpy.zcl.clusters.hvac import Thermostat
@@ -20,21 +18,21 @@ from zhaquirks.const import (
 
 
 class LifeControlMCLH08PowerConfiguration(LocalDataCluster, PowerConfiguration):
-    '''Power configuration is reported and cannot be requested'''
+    """Power configuration is reported and cannot be requested"""
 
     cluster_id = PowerConfiguration.cluster_id
 
 
 class LifeControlMCLH08RelativeHumidity(LocalDataCluster, RelativeHumidity):
-    '''Humidity is reported in temperature cluster and cannot be requested'''
+    """Humidity is reported in temperature cluster and cannot be requested"""
 
 
 class LifeControlMCLH08CarbonDioxideConcentration(LocalDataCluster, CarbonDioxideConcentration):
-    '''CO2 is reported in temperature cluster and cannot be requested'''
+    """CO2 is reported in temperature cluster and cannot be requested"""
 
 
 class LifeControlMCLH08Temperature(LocalDataCluster, TemperatureMeasurement):
-    '''Device reports all measurements as datapoints of temperature cluster and it cannot be queried'''
+    """Device reports all measurements as datapoints of temperature cluster and it cannot be queried"""
 
     cluster_id = TemperatureMeasurement.cluster_id
 
@@ -59,12 +57,12 @@ class LifeControlMCLH08AirQualitySensor(CustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: 0x0301,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,                  # 0x0000
-                    PowerConfiguration.cluster_id,     # 0x0001
-                    Identify.cluster_id,               # 0x0003
-                    Thermostat.cluster_id,             # 0x0201
-                    TemperatureMeasurement.cluster_id, # 0x0402
-                    RelativeHumidity.cluster_id,       # 0x0405
+                    Basic.cluster_id,  # 0x0000
+                    PowerConfiguration.cluster_id,  # 0x0001
+                    Identify.cluster_id,  # 0x0003
+                    Thermostat.cluster_id,  # 0x0201
+                    TemperatureMeasurement.cluster_id,  # 0x0402
+                    RelativeHumidity.cluster_id,  # 0x0405
                 ],
                 OUTPUT_CLUSTERS: [],
             }

--- a/zhaquirks/lifecontrol/vocsensor.py
+++ b/zhaquirks/lifecontrol/vocsensor.py
@@ -2,11 +2,15 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Basic, PowerConfiguration, Identify
-from zigpy.zcl.clusters.measurement import TemperatureMeasurement, RelativeHumidity, CarbonDioxideConcentration
+from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
 from zigpy.zcl.clusters.hvac import Thermostat
-from zhaquirks import LocalDataCluster
+from zigpy.zcl.clusters.measurement import (
+    CarbonDioxideConcentration,
+    RelativeHumidity,
+    TemperatureMeasurement,
+)
 
+from zhaquirks import LocalDataCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -27,7 +31,9 @@ class LifeControlMCLH08RelativeHumidity(LocalDataCluster, RelativeHumidity):
     """Humidity is reported in temperature cluster and cannot be requested"""
 
 
-class LifeControlMCLH08CarbonDioxideConcentration(LocalDataCluster, CarbonDioxideConcentration):
+class LifeControlMCLH08CarbonDioxideConcentration(
+    LocalDataCluster, CarbonDioxideConcentration
+):
     """CO2 is reported in temperature cluster and cannot be requested"""
 
 
@@ -40,7 +46,9 @@ class LifeControlMCLH08Temperature(LocalDataCluster, TemperatureMeasurement):
         if attrid == 0x0001:
             self.endpoint.humidity.update_attribute(0x0000, value)
         elif attrid == 0x0002:
-            self.endpoint.carbon_dioxide_concentration.update_attribute(0x0000, value / 1000000)
+            self.endpoint.carbon_dioxide_concentration.update_attribute(
+                0x0000, value / 1000000
+            )
         else:
             super()._update_attribute(attrid, value)
 

--- a/zhaquirks/lifecontrol/vocsensor.py
+++ b/zhaquirks/lifecontrol/vocsensor.py
@@ -1,0 +1,88 @@
+"""Nexturn VOC Sensor"""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl.foundation import ZCLAttributeDef, ZCLCommandDef
+from zigpy.zcl.clusters.general import Basic, PowerConfiguration, Identify
+from zigpy.zcl.clusters.measurement import TemperatureMeasurement, RelativeHumidity, CarbonDioxideConcentration
+from zigpy.zcl.clusters.hvac import Thermostat
+from zhaquirks import LocalDataCluster
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class LifeControlMCLH08PowerConfiguration(LocalDataCluster, PowerConfiguration):
+    '''Power configuration is reported and cannot be requested'''
+
+    cluster_id = PowerConfiguration.cluster_id
+
+
+class LifeControlMCLH08RelativeHumidity(LocalDataCluster, RelativeHumidity):
+    '''Humidity is reported in temperature cluster and cannot be requested'''
+
+
+class LifeControlMCLH08CarbonDioxideConcentration(LocalDataCluster, CarbonDioxideConcentration):
+    '''CO2 is reported in temperature cluster and cannot be requested'''
+
+
+class LifeControlMCLH08Temperature(LocalDataCluster, TemperatureMeasurement):
+    '''Device reports all measurements as datapoints of temperature cluster and it cannot be queried'''
+
+    cluster_id = TemperatureMeasurement.cluster_id
+
+    def _update_attribute(self, attrid, value):
+        if attrid == 0x0001:
+            self.endpoint.humidity.update_attribute(0x0000, value)
+        elif attrid == 0x0002:
+            self.endpoint.carbon_dioxide_concentration.update_attribute(0x0000, value / 1000000)
+        else:
+            super()._update_attribute(attrid, value)
+
+
+class LifeControlMCLH08AirQualitySensor(CustomDevice):
+    """LifeControl MCLH-08 Air Quality Sensor"""
+
+    signature = {
+        MODELS_INFO: [
+            ("Nexturn", "VOC_Sensor"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: 0x0301,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,                  # 0x0000
+                    PowerConfiguration.cluster_id,     # 0x0001
+                    Identify.cluster_id,               # 0x0003
+                    Thermostat.cluster_id,             # 0x0201
+                    TemperatureMeasurement.cluster_id, # 0x0402
+                    RelativeHumidity.cluster_id,       # 0x0405
+                ],
+                OUTPUT_CLUSTERS: [],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: 0x0301,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    LifeControlMCLH08PowerConfiguration,
+                    LifeControlMCLH08Temperature,
+                    LifeControlMCLH08RelativeHumidity,
+                    LifeControlMCLH08CarbonDioxideConcentration,
+                ],
+                OUTPUT_CLUSTERS: [],
+            }
+        }
+    }


### PR DESCRIPTION
## Proposed change
Added support for LifeControl MCLH-08 

## Additional information
Device reports all measurements as datapoints of Temperature cluster, neither of which can be requested, only automatic reports arrive.
1. I cannot find out how to expose TVOC to HomeAssistant
2. This is my first experience of writing quirk, review and advices are much appreciated.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
