### PR TITLE
[WIP] Implement Aqara E1 TRV schedule support

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -955,56 +955,81 @@ async def test_xiaomi_e1_thermostat_attribute_update(zigpy_device_from_quirk, qu
     assert power_config_listener.attribute_updates[0][0] == zcl_battery_percentage_id
     assert power_config_listener.attribute_updates[0][1] == 100  # ZCL is doubled
 
-@pytest.mark.parametrize("schedule_settings", [
-    'mon,tue,wed,thu,fri|8:00,24.0|18:00,17.0|23:00,22.0|8:00,22.0',
-    'mon,tue,wed,thu,fri,sat,sun|8:00,24.0|18:00,17.0|23:00,22.0|8:00,22.0',
-    'mon|8:00,21.5|18:30,17.5|23:00,22.0|8:00,22.5',
-])
-async def test_xiaomi_e1_thermostat_schedule_settings_string_representation(schedule_settings):
+
+@pytest.mark.parametrize(
+    "schedule_settings",
+    [
+        "mon,tue,wed,thu,fri|8:00,24.0|18:00,17.0|23:00,22.0|8:00,22.0",
+        "mon,tue,wed,thu,fri,sat,sun|8:00,24.0|18:00,17.0|23:00,22.0|8:00,22.0",
+        "mon|8:00,21.5|18:30,17.5|23:00,22.0|8:00,22.5",
+    ],
+)
+async def test_xiaomi_e1_thermostat_schedule_settings_string_representation(
+    schedule_settings,
+):
     """Test creation of ScheduleSettings from str and converting back to same str"""
 
     s = ScheduleSettings(schedule_settings)
     assert str(s) == schedule_settings
 
-@pytest.mark.parametrize("schedule_settings", [
-    'invalid|8:00,24.0|18:00,17.0|23:00,22.0|8:00,22.0',
-    'mon,tue,wed,thu,fri|8:00,24.0|18:00,17.0|23:00,22.0',
-    'mon,tue,wed,thu,fri|8:00,24.0|18:00,17.0|23:00,22.0|8:00,22.0|9:00,25.0',
-    'mon,tue,wed,thu,fri,sat,sun,some_day|8:00,24.0|18:00,17.0|23:00,22.0|8:00,22.0',
-    'mon|some_time,21.5|18:30,17.5|23:00,22.0|8:00,22.5',
-    'mon|8:00,some_temp|18:30,17.5|23:00,22.0|8:00,22.5',
-    'mon,tue,wed,thu,fri|8:00,24.0|8:30,17.0|23:00,22.0|8:00,22.0',
-    'mon,tue,wed,thu,fri|8:00,24.0|18:00,17.0|23:00,22.0|9:00,22.0',
-    'mon,tue,wed,thu,fri|8:00.24.0|18:00,17.0|23:00,22.0|9:00,22.0',
-    'mon,tue,wed,thu,fri|-8:00,24.0|18:00,17.0|23:00,22.0|9:00,22.0',
-    'mon,tue,wed,thu,fri|8:00,24.0|18:00,17.0|23:00,22.0|25:00,22.0',
-    'mon,tue,wed,thu,fri|8:00,03.0|18:00,17.0|23:00,22.0|9:00,22.0',
-    'mon,tue,wed,thu,fri|8:00,31.0|18:00,17.0|23:00,22.0|9:00,22.0',
-    b'\x04>\x01\xe0\x00\x00\t`\x048\x00\x00\x06\xa4\x05d\x00\x00\x08\x98\x81\xe0\x00\x00\x08\x98\x00',
-    b'\x00>\x01\xe0\x00\x00\t`\x048\x00\x00\x06\xa4\x05d\x00\x00\x08\x98\x81\xe0\x00\x00\x08\x98',
-    b'\x04\x01\x01\xe0\x00\x00\t`\x048\x00\x00\x06\xa4\x05d\x00\x00\x08\x98\x81\xe0\x00\x00\x08\x98',
-    None,
-])
-async def test_xiaomi_e1_thermostat_schedule_settings_data_validation(schedule_settings):
+
+@pytest.mark.parametrize(
+    "schedule_settings",
+    [
+        "invalid|8:00,24.0|18:00,17.0|23:00,22.0|8:00,22.0",
+        "mon,tue,wed,thu,fri|8:00,24.0|18:00,17.0|23:00,22.0",
+        "mon,tue,wed,thu,fri|8:00,24.0|18:00,17.0|23:00,22.0|8:00,22.0|9:00,25.0",
+        "mon,tue,wed,thu,fri,sat,sun,some_day|8:00,24.0|18:00,17.0|23:00,22.0|8:00,22.0",
+        "mon|some_time,21.5|18:30,17.5|23:00,22.0|8:00,22.5",
+        "mon|8:00,some_temp|18:30,17.5|23:00,22.0|8:00,22.5",
+        "mon,tue,wed,thu,fri|8:00,24.0|8:30,17.0|23:00,22.0|8:00,22.0",
+        "mon,tue,wed,thu,fri|8:00,24.0|18:00,17.0|23:00,22.0|9:00,22.0",
+        "mon,tue,wed,thu,fri|8:00.24.0|18:00,17.0|23:00,22.0|9:00,22.0",
+        "mon,tue,wed,thu,fri|-8:00,24.0|18:00,17.0|23:00,22.0|9:00,22.0",
+        "mon,tue,wed,thu,fri|8:00,24.0|18:00,17.0|23:00,22.0|25:00,22.0",
+        "mon,tue,wed,thu,fri|8:00,03.0|18:00,17.0|23:00,22.0|9:00,22.0",
+        "mon,tue,wed,thu,fri|8:00,31.0|18:00,17.0|23:00,22.0|9:00,22.0",
+        b"\x04>\x01\xe0\x00\x00\t`\x048\x00\x00\x06\xa4\x05d\x00\x00\x08\x98\x81\xe0\x00\x00\x08\x98\x00",
+        b"\x00>\x01\xe0\x00\x00\t`\x048\x00\x00\x06\xa4\x05d\x00\x00\x08\x98\x81\xe0\x00\x00\x08\x98",
+        b"\x04\x01\x01\xe0\x00\x00\t`\x048\x00\x00\x06\xa4\x05d\x00\x00\x08\x98\x81\xe0\x00\x00\x08\x98",
+        None,
+    ],
+)
+async def test_xiaomi_e1_thermostat_schedule_settings_data_validation(
+    schedule_settings,
+):
     """Test data validation of ScheduleSettings class"""
 
     with pytest.raises(Exception):
         ScheduleSettings(schedule_settings)
 
-@pytest.mark.parametrize("schedule_event", [
-    b'\x01\xe0\x00\x00',
-    None,
-])
+
+@pytest.mark.parametrize(
+    "schedule_event",
+    [
+        b"\x01\xe0\x00\x00",
+        None,
+    ],
+)
 async def test_xiaomi_e1_thermostat_schedule_event_data_validation(schedule_event):
     """Test data validation of ScheduleEvent class"""
 
     with pytest.raises(Exception):
         ScheduleEvent(schedule_event)
 
-@pytest.mark.parametrize("schedule_settings, expected_bytes", [
-    ('mon,tue,wed,thu,fri|8:00,24.0|18:00,17.0|23:00,22.0|8:00,22.0', b'\x04>\x01\xe0\x00\x00\t`\x048\x00\x00\x06\xa4\x05d\x00\x00\x08\x98\x81\xe0\x00\x00\x08\x98')
-])
-async def test_xiaomi_e1_thermostat_schedule_settings_serialization(schedule_settings, expected_bytes):
+
+@pytest.mark.parametrize(
+    "schedule_settings, expected_bytes",
+    [
+        (
+            "mon,tue,wed,thu,fri|8:00,24.0|18:00,17.0|23:00,22.0|8:00,22.0",
+            b"\x04>\x01\xe0\x00\x00\t`\x048\x00\x00\x06\xa4\x05d\x00\x00\x08\x98\x81\xe0\x00\x00\x08\x98",
+        )
+    ],
+)
+async def test_xiaomi_e1_thermostat_schedule_settings_serialization(
+    schedule_settings, expected_bytes
+):
     """Test that serialization works correctly."""
 
     s = ScheduleSettings(schedule_settings)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This change implements support for schedule settings attribute on aqara E1 trv

This is a work in progress, because for now I cannot seem to set this attribute.
Logs show that correct byte sequence is serialized, but when I read the attribute back I always get a default value.
Any help is appreciated to solving this.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Fixes #2359 

This is implemented with the help of zigbee2mqtt repository, specifically these 2 files:
https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/devices/xiaomi.js
https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/lib/xiaomi.js

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
