### PR TITLE
Add battery reporting for Zemismart ZM85EL cover motors

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -13,9 +13,12 @@ from zhaquirks.const import (
 from zhaquirks.tuya import (
     TuyaManufacturerWindowCover,
     TuyaManufCluster,
+    TuyaPowerConfigurationCluster,
     TuyaWindowCover,
     TuyaWindowCoverControl,
 )
+
+ZEMISMART_BATTERY_ATTR = 0x0D
 
 
 class TuyaZemismartSmartCover0601(TuyaWindowCover):
@@ -173,7 +176,6 @@ class TuyaZemismartSmartCover0601_3(TuyaWindowCover):
         MODELS_INFO: [
             ("_TZE200_fzo2pocs", "TS0601"),
             ("_TZE200_iossyxra", "TS0601"),
-            ("_TZE200_pw7mji0l", "TS0601"),
         ],
         ENDPOINTS: {
             1: {
@@ -249,6 +251,62 @@ class TuyaZemismartSmartCover0601_3_inv_position(TuyaWindowCover):
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
         },
+    }
+
+
+class TuyaZemismartSmartCover0601_3_battery(TuyaWindowCover):
+    """Tuya Zemismart blind/curtain controller device."""
+
+    tuya_battery_attr = ZEMISMART_BATTERY_ATTR
+
+    signature = {
+        # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098,
+        #                    maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264,
+        #                    maximum_outgoing_transfer_size=82, descriptor_capability_field=0)",
+        # "endpoints": {
+        # "1": { "profile_id": 260, "device_type": "0x0051", "in_clusters": [ "0x0000", "0x0004","0x0005","0xef00"], "out_clusters": ["0x000a","0x0019"] }
+        # },
+        # "manufacturer": "_TZE200_68nvbio9",
+        # "model": "TS0601",
+        # "class": "zigpy.device.Device"
+        # }
+        MODELS_INFO: [
+            # ZM85EL-1Z
+            ("_TZE200_68nvbio9", "TS0601"),
+            ("_TZE200_pw7mji0l", "TS0601"),
+            # ZM85EL-2Z
+            ("_TZE200_cf1sl3tj", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufacturerWindowCover,
+                    TuyaWindowCoverControl,
+                    TuyaPowerConfigurationCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            }
+        }
     }
 
 
@@ -366,10 +424,8 @@ class TuyaMoesCover0601(TuyaWindowCover):
             ("_TZE200_gubdgai2", "TS0601"),
             ("_TZE200_5sbebbzs", "TS0601"),
             ("_TZE200_hsgrhjpf", "TS0601"),
-            ("_TZE200_68nvbio9", "TS0601"),
             ("_TZE200_ergbiejo", "TS0601"),
             ("_TZE200_nhyj64w2", "TS0601"),
-            ("_TZE200_cf1sl3tj", "TS0601"),
             ("_TZE200_7eue9vhc", "TS0601"),
             ("_TZE200_bv1jcqqu", "TS0601"),
         ],


### PR DESCRIPTION
## Proposed change
Zemismart ZM85EL series devices that I own report battery status as Tuya attribute `0x0D`. This PR adds optional support for reporting battery level to `TuyaManufacturerWindowCover` and moves the 3 manufacturer ids of these devices to a new quirk, with battery support enabled.

## Additional information
ZM85EL manufacturer ids are:

- `_TZE200_pw7mji0l` [ZM85EL-1Z](https://zigbee.blakadder.com/Zemismart_ZM85EL-1Z.html) (added in #1616) - I **do not** own a device with this id
- `_TZE200_68nvbio9` alternative id for ZM85EL-1Z bought from Zemismart store on Aliexpress (added in #1349) - I own this device
- `_TZE200_cf1sl3tj` [ZM85EL-2Z](https://zigbee.blakadder.com/Zemismart_ZM85EL-2Z.html) (added in #1652) - I own this device

These devices appeared in different quirks which have the same signatures and configuration.

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works



Related: #3118
