### PR TITLE
Support for the Aqara H1 single rocker `WS-EUK01` (no neutral)

### DIFF
--- a/zhaquirks/xiaomi/aqara/switch_h1.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1.py
@@ -49,7 +49,32 @@ XIAOMI_COMMAND_DOUBLE = "41_double"
 XIAOMI_COMMAND_HOLD = "1_hold"
 
 
-class AqaraH1SingleRockerSwitchWithNeutral(CustomDevice, AqaraH1SingleRockerDeviceTriggers):
+class AqaraH1SingleRockerBase(CustomDevice):
+    """Device automation triggers for the Aqara H1 Single Rocker Switches"""
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON): {
+            ENDPOINT_ID: 41,
+            CLUSTER_ID: 18,
+            COMMAND: XIAOMI_COMMAND_SINGLE,
+            ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
+        },
+        (DOUBLE_PRESS, BUTTON): {
+            ENDPOINT_ID: 41,
+            CLUSTER_ID: 18,
+            COMMAND: XIAOMI_COMMAND_DOUBLE,
+            ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_DOUBLE, VALUE: 2},
+        },
+        (LONG_PRESS, BUTTON): {
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 64704,
+            COMMAND: XIAOMI_COMMAND_HOLD,
+            ARGS: {ATTR_ID: 0x00FC, PRESS_TYPE: COMMAND_HOLD, VALUE: 0},
+        },
+    }
+
+
+class AqaraH1SingleRockerSwitchWithNeutral(AqaraH1SingleRockerBase):
     """Aqara H1 Single Rocker Switch (with neutral)."""
 
     signature = {
@@ -127,7 +152,7 @@ class AqaraH1SingleRockerSwitchWithNeutral(CustomDevice, AqaraH1SingleRockerDevi
     }
 
 
-class AqaraH1SingleRockerSwitchNoNeutral(CustomDevice, AqaraH1SingleRockerDeviceTriggers):
+class AqaraH1SingleRockerSwitchNoNeutral(AqaraH1SingleRockerBase):
     """Aqara H1 Single Rocker Switch (no neutral)."""
 
     signature = {
@@ -197,30 +222,5 @@ class AqaraH1SingleRockerSwitchNoNeutral(CustomDevice, AqaraH1SingleRockerDevice
                 INPUT_CLUSTERS: [],
                 OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
             },
-        },
-    }
-
-
-class AqaraH1SingleRockerDeviceTriggers(CustomDevice):
-    """Device automation triggers for the Aqara H1 Single Rocker Switches"""
-
-    device_automation_triggers = {
-        (SHORT_PRESS, BUTTON): {
-            ENDPOINT_ID: 41,
-            CLUSTER_ID: 18,
-            COMMAND: XIAOMI_COMMAND_SINGLE,
-            ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
-        },
-        (DOUBLE_PRESS, BUTTON): {
-            ENDPOINT_ID: 41,
-            CLUSTER_ID: 18,
-            COMMAND: XIAOMI_COMMAND_DOUBLE,
-            ARGS: {ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_DOUBLE, VALUE: 2},
-        },
-        (LONG_PRESS, BUTTON): {
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 64704,
-            COMMAND: XIAOMI_COMMAND_HOLD,
-            ARGS: {ATTR_ID: 0x00FC, PRESS_TYPE: COMMAND_HOLD, VALUE: 0},
         },
     }

--- a/zhaquirks/xiaomi/aqara/switch_h1.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1.py
@@ -49,7 +49,7 @@ XIAOMI_COMMAND_DOUBLE = "41_double"
 XIAOMI_COMMAND_HOLD = "1_hold"
 
 
-class AqaraH1SingleRockerSwitch(CustomDevice):
+class AqaraH1SingleRockerSwitchWithNeutral(CustomDevice, AqaraH1SingleRockerDeviceTriggers):
     """Aqara H1 Single Rocker Switch (with neutral)."""
 
     signature = {
@@ -125,6 +125,84 @@ class AqaraH1SingleRockerSwitch(CustomDevice):
             },
         },
     }
+
+
+class AqaraH1SingleRockerSwitchNoNeutral(CustomDevice, AqaraH1SingleRockerDeviceTriggers):
+    """Aqara H1 Single Rocker Switch (no neutral)."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.switch.l1aeu1")],
+        ENDPOINTS: {
+            #  input_clusters=[0, 2, 3, 4, 5, 6, 9], output_clusters=[10, 25]
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,  # 0
+                    DeviceTemperatureCluster.cluster_id,  # 2
+                    Identify.cluster_id,  # 3
+                    Groups.cluster_id,  # 4
+                    Scenes.cluster_id,  # 5
+                    OnOff.cluster_id,  # 6
+                    Alarms.cluster_id,  # 9
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,  # 0x000a
+                    Ota.cluster_id,  # 0x0019
+                ],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,  # 0x0021
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,  # 0
+                    DeviceTemperatureCluster.cluster_id,  # 2
+                    Identify.cluster_id,  # 3
+                    Groups.cluster_id,  # 4
+                    Scenes.cluster_id,  # 5
+                    OnOffCluster,  # 6
+                    Alarms.cluster_id,  # 9
+                    MultistateInputCluster,  # 18
+                    OppleSwitchCluster,  # 0xFCC0 / 64704
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            41: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MultistateInputCluster,  # 18
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+
+class AqaraH1SingleRockerDeviceTriggers(CustomDevice):
+    """Device automation triggers for the Aqara H1 Single Rocker Switches"""
 
     device_automation_triggers = {
         (SHORT_PRESS, BUTTON): {


### PR DESCRIPTION
## Proposed change
Add missing support for the Aqara H1 single rocker wall switch (**no** neutral wire). The model is also known as: `WS-EUK01` or `lumi.switch.l1aeu1`


## Additional information
This is based upon my previous contribution for the version with neutral wire (see: https://github.com/zigpy/zha-device-handlers/pull/2385). The switches are almost identical apart from the energy/power monitoring which the "no neutral" version lacks so I've tried to reuse as much of the existing implementation as I possibly could.


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
