### PR TITLE
Use minimum battery threshold to calc percent

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -199,8 +199,8 @@ class PowerConfigurationCluster(CustomCluster, PowerConfiguration):
     BATTERY_RATED_VOLTAGE = 0x0034
     BATTERY_VOLTAGE_MIN_THRESHOLD = 0x0036
     BATTERY_PERCENTAGE_REMAINING = 0x0021
-    MIN_VOLTS = 15  # old 2.1
-    MAX_VOLTS = 28  # old 3.2
+    MIN_VOLTS = 1.5  # old 2.1
+    MAX_VOLTS = 2.8  # old 3.2
 
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
@@ -211,8 +211,8 @@ class PowerConfigurationCluster(CustomCluster, PowerConfiguration):
             )
 
     def _calculate_battery_percentage(self, raw_value):
-        volts_min = self.get(self.BATTERY_VOLTAGE_MIN_THRESHOLD, self.MIN_VOLTS)
-        volts_max = self.get(self.BATTERY_RATED_VOLTAGE, self.MAX_VOLTS)
+        volts_min = self.get(self.BATTERY_VOLTAGE_MIN_THRESHOLD, self.MIN_VOLTS * 10)
+        volts_max = self.get(self.BATTERY_RATED_VOLTAGE, self.MAX_VOLTS * 10)
         volts = raw_value
         volts = max(volts, volts_min)
         volts = min(volts, volts_max)


### PR DESCRIPTION

## Proposed change
<!--
  Explain your proposed change below.
-->

Use minimum battery threshold to calc percent

This fixes the Aqara TVOC sensor battery reporting which seem to have a minimum voltage of 2.7 set for its battery alarm by default.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

This could for example change the behaviour of sensors with a nominal value of 3.0, which may not always report 100% even on new batteries. I do think that might be less of a concern. We could of course let max be nominal minus 0.1 volt. 

Reference: https://github.com/zigpy/zha-device-handlers/pull/208/files#r352357340

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
