### PR TITLE
Fix Xiaoyan CL001 CCT range, remove RGB color picker 

### DIFF
--- a/zhaquirks/terncy/cl001.py
+++ b/zhaquirks/terncy/cl001.py
@@ -1,0 +1,95 @@
+"""Quirk for Xiaoyan CL001 ceiling light."""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    Scenes,
+)
+from zigpy.zcl.clusters.lighting import (
+    Color,
+)
+from zigpy.zcl.clusters.lightlink import (
+    LightLink,
+)
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class CustomColorCluster(CustomCluster, Color):
+    """Set actual supported CCT range and remove RGB color picker since hardware does not support it."""
+
+    _CONSTANT_ATTRIBUTES = {
+        ## AttributeDefs not merged yet.
+        #Color.AttributeDefs.color_capabilities.id: Color.ColorCapabilities.Color_temperature,
+        #Color.AttributeDefs.color_temp_physical_min.id: 50,
+        #Color.AttributeDefs.color_temp_physical_max.id: 500,
+        Color.attributes_by_name["color_capabilities"].id: Color.ColorCapabilities.Color_temperature,
+        Color.attributes_by_name["color_temp_physical_min"].id: 50,
+        Color.attributes_by_name["color_temp_physical_max"].id: 500,
+    }
+
+class LuminousElement(CustomDevice):
+    """System call, generate luminous element. Adhere."""
+
+    signature = {
+        MODELS_INFO: [("Xiaoyan", "CL001")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                    0xFCCC,
+                    0xFCCD,
+                    0xFCCE,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    CustomColorCluster,
+                    LightLink.cluster_id,
+                    0xFCCC,
+                    0xFCCD,
+                    0xFCCE,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }

--- a/zhaquirks/terncy/cl001.py
+++ b/zhaquirks/terncy/cl001.py
@@ -26,13 +26,13 @@ from zhaquirks.const import (
 class CustomColorCluster(CustomCluster, Color):
     """Set actual supported CCT range and remove RGB color picker since hardware does not support it."""
 
+    """
+    #AttributeDefs not merged yet. Update below after AttributeDefs has been merged.
+    Color.AttributeDefs.color_capabilities.id: Color.ColorCapabilities.Color_temperature,
+    Color.AttributeDefs.color_temp_physical_min.id: 50,
+    Color.AttributeDefs.color_temp_physical_max.id: 500,
+    """
     _CONSTANT_ATTRIBUTES = {
-        """
-        #AttributeDefs not merged yet.
-        Color.AttributeDefs.color_capabilities.id: Color.ColorCapabilities.Color_temperature,
-        Color.AttributeDefs.color_temp_physical_min.id: 50,
-        Color.AttributeDefs.color_temp_physical_max.id: 500,
-        """
         Color.attributes_by_name["color_capabilities"].id: Color.ColorCapabilities.Color_temperature,
         Color.attributes_by_name["color_temp_physical_min"].id: 50,
         Color.attributes_by_name["color_temp_physical_max"].id: 500,

--- a/zhaquirks/terncy/cl001.py
+++ b/zhaquirks/terncy/cl001.py
@@ -24,7 +24,7 @@ from zhaquirks.const import (
 )
 
 
-class FixedColorCluster(CustomCluster, Color):
+class ColorClusterTerncy(CustomCluster, Color):
     """Set actual supported CCT range and remove RGB color picker since hardware does not support it."""
 
     _CONSTANT_ATTRIBUTES = {

--- a/zhaquirks/terncy/cl001.py
+++ b/zhaquirks/terncy/cl001.py
@@ -34,8 +34,8 @@ class ColorClusterTerncy(CustomCluster, Color):
     }
 
 
-class LuminousElement(CustomDevice):
-    """System call, generate luminous element. Adhere."""
+class TerncyLightCCT(CustomDevice):
+    """Terncy Light CCT device."""
 
     signature = {
         MODELS_INFO: [("Xiaoyan", "CL001")],

--- a/zhaquirks/terncy/cl001.py
+++ b/zhaquirks/terncy/cl001.py
@@ -13,6 +13,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
+
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -23,7 +24,7 @@ from zhaquirks.const import (
 )
 
 
-class CustomColorCluster(CustomCluster, Color):
+class FixedColorCluster(CustomCluster, Color):
     """Set actual supported CCT range and remove RGB color picker since hardware does not support it."""
 
     _CONSTANT_ATTRIBUTES = {
@@ -74,7 +75,7 @@ class LuminousElement(CustomDevice):
                     Scenes.cluster_id,
                     OnOff.cluster_id,
                     LevelControl.cluster_id,
-                    CustomColorCluster,
+                    FixedColorCluster,
                     LightLink.cluster_id,
                     0xFCCC,
                     0xFCCD,

--- a/zhaquirks/terncy/cl001.py
+++ b/zhaquirks/terncy/cl001.py
@@ -26,17 +26,12 @@ from zhaquirks.const import (
 class CustomColorCluster(CustomCluster, Color):
     """Set actual supported CCT range and remove RGB color picker since hardware does not support it."""
 
-    """
-    #AttributeDefs not merged yet. Update below after AttributeDefs has been merged.
-    Color.AttributeDefs.color_capabilities.id: Color.ColorCapabilities.Color_temperature,
-    Color.AttributeDefs.color_temp_physical_min.id: 50,
-    Color.AttributeDefs.color_temp_physical_max.id: 500,
-    """
     _CONSTANT_ATTRIBUTES = {
-        Color.attributes_by_name["color_capabilities"].id: Color.ColorCapabilities.Color_temperature,
-        Color.attributes_by_name["color_temp_physical_min"].id: 50,
-        Color.attributes_by_name["color_temp_physical_max"].id: 500,
+        Color.AttributeDefs.color_capabilities.id: Color.ColorCapabilities.Color_temperature,
+        Color.AttributeDefs.color_temp_physical_min.id: 50,
+        Color.AttributeDefs.color_temp_physical_max.id: 500,
     }
+
 
 class LuminousElement(CustomDevice):
     """System call, generate luminous element. Adhere."""

--- a/zhaquirks/terncy/cl001.py
+++ b/zhaquirks/terncy/cl001.py
@@ -11,12 +11,8 @@ from zigpy.zcl.clusters.general import (
     Ota,
     Scenes,
 )
-from zigpy.zcl.clusters.lighting import (
-    Color,
-)
-from zigpy.zcl.clusters.lightlink import (
-    LightLink,
-)
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.lightlink import LightLink
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -31,10 +27,12 @@ class CustomColorCluster(CustomCluster, Color):
     """Set actual supported CCT range and remove RGB color picker since hardware does not support it."""
 
     _CONSTANT_ATTRIBUTES = {
-        ## AttributeDefs not merged yet.
-        #Color.AttributeDefs.color_capabilities.id: Color.ColorCapabilities.Color_temperature,
-        #Color.AttributeDefs.color_temp_physical_min.id: 50,
-        #Color.AttributeDefs.color_temp_physical_max.id: 500,
+        """
+        #AttributeDefs not merged yet.
+        Color.AttributeDefs.color_capabilities.id: Color.ColorCapabilities.Color_temperature,
+        Color.AttributeDefs.color_temp_physical_min.id: 50,
+        Color.AttributeDefs.color_temp_physical_max.id: 500,
+        """
         Color.attributes_by_name["color_capabilities"].id: Color.ColorCapabilities.Color_temperature,
         Color.attributes_by_name["color_temp_physical_min"].id: 50,
         Color.attributes_by_name["color_temp_physical_max"].id: 500,

--- a/zhaquirks/terncy/cl001.py
+++ b/zhaquirks/terncy/cl001.py
@@ -75,7 +75,7 @@ class LuminousElement(CustomDevice):
                     Scenes.cluster_id,
                     OnOff.cluster_id,
                     LevelControl.cluster_id,
-                    FixedColorCluster,
+                    ColorClusterTerncy,
                     LightLink.cluster_id,
                     0xFCCC,
                     0xFCCD,


### PR DESCRIPTION
## Proposed change
<!--
  Fixed CCT range and removing RGB color picker for Xiaoyan CL001 as the light does not support RGB
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works

P.S. I was told to tag you here, @TheJulianJES . Thanks for generating the quirk for me.
