### PR TITLE
A

### DIFF
--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -19,6 +19,7 @@ from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
 from zhaquirks.const import (
+    ALT_SHORT_PRESS,
     BUTTON,
     BUTTON_1,
     BUTTON_2,
@@ -60,6 +61,7 @@ from zhaquirks.const import (
 from zhaquirks.tuya import (
     TuyaNoBindPowerConfigurationCluster,
     TuyaSmartRemoteOnOffCluster,
+    TuyaZBExternalSwitchTypeCluster,
 )
 from zhaquirks.tuya.mcu import EnchantedDevice
 
@@ -411,4 +413,82 @@ class TuyaSmartRemote004F(EnchantedDevice):
             CLUSTER_ID: 8,
             ENDPOINT_ID: 1,
         },
+    }
+
+
+class TuyaSmartRemote004FSK(EnchantedDevice):
+    """Tuya Smart (Single) Knob device."""
+    signature = {
+        # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=0, *allocate_address=True, *complex_descriptor_available=False, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False, *is_valid=True, *logical_type=<LogicalType.EndDevice: 2>, *user_descriptor_available=False)",
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=260, device_version=1, input_clusters=[0, 1, 3, 4, 6, 4096, 57345], output_clusters=[25, 10, 3, 4, 6, 8, 4096])
+        MODELS_INFO: [
+            ("_TZ3000_kjfzuycl", "TS004F"),
+            ("_TZ3000_ja5osu5g", "TS004F"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LightLink.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    TuyaNoBindPowerConfigurationCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,  # Is needed for adding group then binding is not working.
+                    LightLink.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_ON, ENDPOINT_ID: 1, CLUSTER_ID: 6},
+        (DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1, CLUSTER_ID: 6},
+        (LONG_PRESS, BUTTON): {COMMAND: COMMAND_STEP, ENDPOINT_ID: 1, CLUSTER_ID: 8},
+        (LONG_RELEASE, BUTTON): {COMMAND: COMMAND_STOP,  ENDPOINT_ID: 1, CLUSTER_ID: 8},
+        (ALT_SHORT_PRESS, BUTTON): {
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 8,
+            PARAMS: {'transition_time': 1, 'options_mask': None, 'options_override': None},
+        },
+        (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
     }


### PR DESCRIPTION
## Proposed change
Add support for [Moes Smart Button](https://www.moeshouse.com/products/ip55-waterproof-smart-zigbee-scene-switch-wireless-remote-dimmer?_pos=87&_sid=426664fbd&_ss=r). 

## Additional information

At the moment known 2 versions of the Moes Smart Button (_TZ3000_kjfzuycl, _TZ3000_ja5osu5g), both look the same.
It was possible to add it with ZHA as a switch but not possible to create the events for press, double press, or long press. 
Fixes [#1697](https://github.com/zigpy/zha-device-handlers/issues/1697)

## Checklist
- [X] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
