### PR TITLE
Support Miboxer FUT036Z LED controller

### DIFF
--- a/zhaquirks/tuya/ts0501bs.py
+++ b/zhaquirks/tuya/ts0501bs.py
@@ -35,6 +35,8 @@ class DimmableLedController(CustomDevice):
             ("_TZ3210_4zinq6io", "TS0501B"),
             ("_TZ3210_e5t9bfdv", "TS0501B"),
             ("_TZ3210_i680rtja", "TS0501B"),
+            ("_TZ3210_dxroobu3", "TS0501B"),
+            ("_TZ3210_dbilpfqk", "TS0501B"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=257


### PR DESCRIPTION


## Proposed change
Support the [Miboxer FUT036Z](https://www.zigbee2mqtt.io/devices/FUT036Z.html) LED controller.


## Additional information
Confirmed working with `dbilpfqk`. See also
Koenkk/zigbee-herdsman-converters@73ebbc4 and
Koenkk/zigbee-herdsman-converters@1c8de9a

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
