### PR TITLE
Fix data type for Tuya/Hiking power meter

### DIFF
--- a/zhaquirks/tuya/ts0601_din_power.py
+++ b/zhaquirks/tuya/ts0601_din_power.py
@@ -142,7 +142,7 @@ class HikingManufClusterDinPower(TuyaManufClusterAttributes):
 
     attributes = {
         HIKING_DIN_SWITCH_ATTR: ("switch", t.uint8_t, True),
-        HIKING_TOTAL_ENERGY_DELIVERED_ATTR: ("energy_delivered", t.uint16_t, True),
+        HIKING_TOTAL_ENERGY_DELIVERED_ATTR: ("energy_delivered", t.uint32_t, True),
         HIKING_TOTAL_ENERGY_RECEIVED_ATTR: ("energy_received", t.uint16_t, True),
         HIKING_VOLTAGE_CURRENT_ATTR: ("voltage_current", t.uint32_t, True),
         HIKING_POWER_ATTR: ("power", t.uint16_t, True),


### PR DESCRIPTION
Changes in commit 6386248 broke summary sensor on my Home Assistant. Probably, previous commit-author forgot to add this change to his commit.

