### PR TITLE
Add support for Sinopé LM4110-ZB level monitor

### DIFF
--- a/zhaquirks/sinope/sensor.py
+++ b/zhaquirks/sinope/sensor.py
@@ -1,12 +1,14 @@
-"""Module to handle quirks of the  Sinopé Technologies water leak sensor WL4200 and WL4200S.
+"""Module to handle quirks of the Sinopé Technologies water leak sensor and level monitor.
 
 It add manufacturer attributes for IasZone cluster for the water leak alarm.
+Supported devices are WL4200, WL4200S and LM4110-ZB
 """
 
 import zigpy.profiles.zha as zha_p
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
 from zigpy.zcl.clusters.general import (
+    AnalogInput,
     Basic,
     Identify,
     Ota,
@@ -37,7 +39,9 @@ class SinopeManufacturerCluster(CustomCluster):
     name = "Sinopé Manufacturer specific"
     ep_attribute = "sinope_manufacturer_specific"
     attributes = {
+        0x0003: ("firmware_number", t.uint16_t, True),
         0x0004: ("firmware_version", t.CharacterString, True),
+        0x0200: ("unknown", t.bitmap32, True),
         0xFFFD: ("cluster_revision", t.uint16_t, True),
     }
 
@@ -164,6 +168,60 @@ class SinopeTechnologiesSensor2(CustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
+                    Ota.cluster_id,
+                ],
+            }
+        }
+    }
+
+
+class SinopeTechnologiesLevelMonitor(CustomDevice):
+    """SinopeTechnologiesLevelMonitor custom device."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=0
+        # device_version=0 input_clusters=[0, 1, 3, 12, 32, 1026, 2821, 65281]
+        # output_clusters=[25]>
+        MODELS_INFO: [
+            (SINOPE, "LM4110-ZB"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha_p.PROFILE_ID,
+                DEVICE_TYPE: zha_p.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    AnalogInput.cluster_id,
+                    PollControl.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    SINOPE_MANUFACTURER_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha_p.PROFILE_ID,
+                DEVICE_TYPE: zha_p.DeviceType.METER_INTERFACE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    AnalogInput.cluster_id,
+                    PollControl.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    SinopeManufacturerCluster,
+                ],
+                OUTPUT_CLUSTERS: [
                     Ota.cluster_id,
                 ],
             }

--- a/zhaquirks/sinope/sensor.py
+++ b/zhaquirks/sinope/sensor.py
@@ -41,7 +41,7 @@ class SinopeManufacturerCluster(CustomCluster):
     attributes = {
         0x0003: ("firmware_number", t.uint16_t, True),
         0x0004: ("firmware_version", t.CharacterString, True),
-        0x0200: ("unknown", t.bitmap32, True),
+        0x0200: ("unknown_attr_1", t.bitmap32, True),
         0xFFFD: ("cluster_revision", t.uint16_t, True),
     }
 


### PR DESCRIPTION
## Proposed change
<!--
  Added support for the new LM4110-ZB ltank level monitro from Sinopé.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
