### PR TITLE
feat: Neo Siren _TZE200_nlrfgpny with solar panel

### DIFF
--- a/zhaquirks/tuya/ts0601_siren.py
+++ b/zhaquirks/tuya/ts0601_siren.py
@@ -401,3 +401,45 @@ class TuyaSirenGPP_NoSensors(CustomDevice):
             },
         }
     }
+
+
+class TuyaSirenSolar(CustomDevice):
+    """NEO Tuya Siren without sensor."""
+
+    signature = {
+        #  endpoint=1 profile=260 device_type=81 device_version=1 input_clusters=[0, 4, 5, 61184]
+        #  output_clusters=[25, 10]>
+        MODELS_INFO: [
+            ("_TZE200_nlrfgpny", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_WARNING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    NeoSirenManufCluster,
+                    TuyaMCUSiren,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            },
+        }
+    }


### PR DESCRIPTION
## Proposed change
Add quirk for the Neo Siren _TZE200_nlrfgpny TS0601.


## Additional information
With this modification I have the on/off switch working but the other entities are not shown in the device [ts0601_siren.py#L314](https://github.com/zigpy/zha-device-handlers/blob/92c9fbc6d01a5d86f78d64183302b906aa7d8215/zhaquirks/tuya/ts0601_siren.py#L314).  I had to remove the green proxy cluster because it's missing for this device version.

Given the discussion on [zigbee2mqtt#17325](https://github.com/Koenkk/zigbee2mqtt/discussions/17325), they didn't find the volume control for this model and didn't make the battery reporting working.

I don´t know what I am missing and how to debug at this point. Could you point out how I can debug the NeoSirenManufCluster ?


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
