### PR TITLE
Enable `setuptools-git-versioning`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zha-quirks"
-version = "0.0.101"
+dynamic = ["version"]
 description = "Library implementing Zigpy quirks for ZHA in Home Assistant"
 urls = {repository = "https://github.com/zigpy/zha-device-handlers"}
 authors = [
@@ -26,7 +26,7 @@ testing = [
 ]
 
 [tool.setuptools-git-versioning]
-enabled = false
+enabled = true
 
 [tool.isort]
 # https://github.com/timothycrosley/isort


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Part 3 of https://github.com/zigpy/zha-device-handlers/pull/2491 and https://github.com/zigpy/zha-device-handlers/pull/2495. This PR enables Git versioning and dynamically computes the package version from the latest Git tag.

For future releases, just create one on GitHub and make sure the tag is set appropriately. No further PRs are necessary:

<img width="348" alt="image" src="https://github.com/zigpy/zha-device-handlers/assets/32534428/b852ebbe-bbd7-415a-9e61-ba973f28913e">

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
