### PR TITLE
Use shared PyPi release workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,7 +6,7 @@ on:
       - released
 
 jobs:
-  shared-ci:
+  shared-build-and-publish:
     uses: zigpy/workflows/.github/workflows/publish-to-pypi.yml@main
     with:
       PYTHON_VERSION_DEFAULT: 3.9.15

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,30 +1,12 @@
-name: Publish distributions to PyPI and TestPyPI
-on: push
+name: Publish distributions to PyPI
+
+on:
+  release:
+    types:
+      - released
 
 jobs:
-  build-and-publish:
-    name: Build and publish distributions to PyPI and TestPyPI
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        version: 3.9
-    - name: Install wheel
-      run: >-
-        pip install wheel
-    - name: Build
-      run: >-
-        python3 setup.py sdist bdist_wheel
-    - name: Publish distribution to Test PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_TEST_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-    - name: Publish distribution to PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_TOKEN }}
+  shared-ci:
+    uses: zigpy/workflows/.github/workflows/publish-to-pypi.yml@main
+    with:
+      PYTHON_VERSION_DEFAULT: 3.9.15


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This should fix the PyPi GitHub release action. It uses the shared zigpy PyPi release workflow.
Failing log: <https://github.com/zigpy/zha-device-handlers/actions/runs/5729959163/job/15527723986>

As far as I can see, the issue was that `python3 setup.py sdist bdist_wheel` was still used for building instead of `python3 -m build`.

This change was somewhat tested in a private repo and seems to build correctly (with metadata now).

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
