### PR TITLE
Add Aqara T1 illumination sensor `lumi.sen_ill.agl01`

### DIFF
--- a/zhaquirks/xiaomi/aqara/illumination.py
+++ b/zhaquirks/xiaomi/aqara/illumination.py
@@ -1,8 +1,8 @@
-"""Quirk for lumi.sen_ill.mgl01 illumination sensor."""
+"""Quirk for Aqara illumination sensor."""
 import logging
 
 from zigpy.profiles import zha
-from zigpy.zcl.clusters.general import Basic, Identify
+from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement
 from zigpy.zdo.types import NodeDescriptor
 
@@ -22,23 +22,27 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Illumination(XiaomiCustomDevice):
-    """Aqara LUMI lumi.sen_ill.mgl01."""
+    """Aqara LUMI illumination sensor."""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=262
         # device_version=1
-        # input_clusters=[0, 1024, 3, 1]
+        # input_clusters=[0, 1, 3, 1024]
         # output_clusters=[3]>
-        MODELS_INFO: [(LUMI, "lumi.sen_ill.mgl01"), ("XIAOMI", "lumi.sen_ill.mgl01")],
+        MODELS_INFO: [
+            (LUMI, "lumi.sen_ill.mgl01"),
+            (LUMI, "lumi.sen_ill.agl01"),
+            ("XIAOMI", "lumi.sen_ill.mgl01"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.LIGHT_SENSOR,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     IlluminanceMeasurement.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Identify.cluster_id],
             }

--- a/zhaquirks/xiaomi/aqara/illumination.py
+++ b/zhaquirks/xiaomi/aqara/illumination.py
@@ -28,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Illumination(XiaomiCustomDevice):
-    """Aqara LUMI illumination sensor."""
+    """Aqara LUMI lumi.sen_ill.mgl01 illumination sensor."""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=262


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Adds support for the Aqara T1 illumination sensor `lumi.sen_ill.agl01`.

This adds:
- the power source
- adds the battery entity
- adds the `OppleCluster` with a `detection_interval` attribute (1 to 59 seconds)

Tested and confirmed working in: #2462

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Fixes #2462


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
