### PR TITLE
Use shared default Python version for PyPi workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,7 +3,7 @@ name: Publish distributions to PyPI
 on:
   release:
     types:
-      - released
+      - published
 
 jobs:
   shared-build-and-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,7 +8,5 @@ on:
 jobs:
   shared-build-and-publish:
     uses: zigpy/workflows/.github/workflows/publish-to-pypi.yml@main
-    with:
-      PYTHON_VERSION_DEFAULT: 3.9.15
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This aligns the PyPi release workflow with other zigpy repos by removing the `with` section for `PYTHON_VERSION_DEFAULT`.
This is to be kept and updated centrally in the [zigpy/workflows](https://github.com/zigpy/workflows) repository.

It also changes the trigger from `released` to published`, as it's slightly more correct (even though it doesn't really matter).
This would also upload "pre-releases" to PyPi.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
For reference, see: https://github.com/zigpy/zigpy/pull/1239


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
