### PR TITLE
Fix `SKIP_CONFIGURATION` being set for enchanted Tuya devices

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -32,6 +32,7 @@ from zhaquirks.const import (
     ON,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    SKIP_CONFIGURATION,
     ZONE_STATUS_CHANGE_COMMAND,
 )
 from zhaquirks.tuya import (
@@ -1638,6 +1639,13 @@ async def test_tuya_spell(zigpy_device_from_quirk):
 
         for quirk in ENCHANTED_QUIRKS:
             device = zigpy_device_from_quirk(quirk)
+
+            # fail if SKIP_CONFIGURATION is set, as that will cause ZHA to not call bind()
+            if getattr(device, SKIP_CONFIGURATION, False):
+                pytest.fail(
+                    f"Enchanted quirk {quirk} has SKIP_CONFIGURATION set. "
+                    f"This is not allowed for enchanted devices."
+                )
 
             for cluster in itertools.chain(
                 device.endpoints[1].in_clusters.values(),

--- a/zhaquirks/tuya/ts001x.py
+++ b/zhaquirks/tuya/ts001x.py
@@ -10,7 +10,6 @@ from zhaquirks.const import (
     MODEL,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    SKIP_CONFIGURATION,
 )
 from zhaquirks.tuya import (
     TuyaSwitch,
@@ -50,7 +49,6 @@ class TuyaSingleNoNeutralSwitch(EnchantedDevice, TuyaSwitch):
     }
 
     replacement = {
-        SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -112,7 +110,6 @@ class TuyaDoubleNoNeutralSwitch(EnchantedDevice, TuyaSwitch):
     }
 
     replacement = {
-        SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -198,7 +195,6 @@ class TuyaTripleNoNeutralSwitch(EnchantedDevice, TuyaSwitch):
     }
 
     replacement = {
-        SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -264,7 +260,6 @@ class TuyaSingleNoNeutralSwitch_2(EnchantedDevice, TuyaSwitch):
         },
     }
     replacement = {
-        SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -328,7 +323,6 @@ class TuyaDoubleNoNeutralSwitch_2(EnchantedDevice, TuyaSwitch):
     }
 
     replacement = {
-        SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -416,7 +410,6 @@ class TuyaTripleNoNeutralSwitch_2(EnchantedDevice, TuyaSwitch):
     }
 
     replacement = {
-        SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The "Tuya spell" is required for many Tuya devices and is currently called when binding certain clusters.
These Tuya devices had `SKIP_CONFIGURATION` set which prevents the spell from being called at all, as ZHA does not call `bind()` for any cluster.

This PR adds a test to detect such invalid quirks and also removes `SKIP_CONFIGURATION` for the affected devices.

### TODO:
~~potentially figure out why `SKIP_CONFIGURATION` was added in the first place~~

@MattWestb @javicalle Sorry for the ping, but any ideas why this was used?
I guess it's just unnecessary to bind the `OnOff` and `Scenes` cluster (for this device)?
It shouldn't cause any harm if we try bind it though, right? I think that's what we're doing with other (similar?) Tuya devices.

Confirmed working in: https://github.com/home-assistant/core/issues/96452#issuecomment-1679185854

### Note:
The quirk only seems to:
1. remove the `Time` cluster from the replacement, as that was [apparently causing problems with the device turning itself off randomly ](https://github.com/zigpy/zha-device-handlers/pull/845#issuecomment-829218739)
2. add some custom attributes
3. cast the Tuya spell

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Should address the issues in:
- https://github.com/home-assistant/core/issues/96452
- https://github.com/zigpy/zha-device-handlers/issues/2344
- https://github.com/zigpy/zha-device-handlers/issues/1981


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
