### PR TITLE
Add Tuya cover TS0601 `_TZE200_dng9fn0k` variant

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -479,6 +479,7 @@ class TuyaMoesCover0601_inv_position(TuyaWindowCover):
             ("_TZE200_zuz7f94z", "TS0601"),
             ("_TZE200_3i3exuay", "TS0601"),
             ("_TZE200_nogaemzt", "TS0601"),
+            ("_TZE200_dng9fn0k", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change

- One of the blinds that I own wasn't working with ZHA. Upon looking further, this quirk seems to make it work locally. This quirk seems to be the same that some of my other blinds are using.


## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
