### PR TITLE
Add Tuya Smoke Detector TS0601 `_TZE204_ntcy3xu1` variation

### DIFF
--- a/zhaquirks/tuya/ts0601_smoke.py
+++ b/zhaquirks/tuya/ts0601_smoke.py
@@ -81,6 +81,7 @@ class TuyaSmokeDetector0601(CustomDevice):
             ("_TZE200_m9skfctm", "TS0601"),
             ("_TZE200_ntcy3xu1", "TS0601"),
             ("_TZE200_vzekyi4c", "TS0601"),
+            ("_TZE204_ntcy3xu1", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change

Added support for Tuya Smoke Detector TS0601 _TZE204_ntcy3xu1 model


## Additional information

A freshly ordered smoke detector came with a new model name _TZE204_ntcy3xu1, previously the same kind devices was with model name _TZE200_ntcy3xu1.


## Checklist

- [ x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
