### PR TITLE
Apply humidity correction to Sonoff SNZB-02 sensor

### DIFF
--- a/zhaquirks/sonoff/snzb-02.py
+++ b/zhaquirks/sonoff/snzb-02.py
@@ -1,0 +1,66 @@
+"""Sonoff SNZB-02 temperature/humidity sensor."""
+from zigpy.profiles import zha
+from zigpy.profiles.zha import DeviceType
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
+from zigpy.zcl.clusters.measurement import RelativeHumidity, TemperatureMeasurement
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class SonoffRelativeHumidityCluster(CustomCluster, RelativeHumidity):
+    """Fixes too high humidity values reported by Sonoff SNZB-02."""
+
+    def _update_attribute(self, attrid, value):
+        # drop values above and below documented range for this sensor
+        # and apply a 6% correction
+        if attrid == 0 and (0 <= value <= 9999):
+            super()._update_attribute(attrid, value * 0.94)
+
+
+class TemperatureHumidtySensor(CustomDevice):
+    """Sonoff SNZB-02 temperature/humidity sensor."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type="0x0302"
+        # device_version=1
+        # input_clusters=["0x0000", "0x0001", "0x0003", "0x0402", "0x0405"]
+        # output_clusters=["0x0003"]>
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: DeviceType.TEMPERATURE_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    RelativeHumidity.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    SonoffRelativeHumidityCluster,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id],
+            }
+        }
+    }


### PR DESCRIPTION
## Proposed change
The Sonoff SNZB-02 sensor reports too high humidity values. I compared to the newer SNZB-02D and Aqara Temperature/Humidity sensor. Those two are very close to each other in humidity values. The SNZB-02 is about 6% off in my messured environments 

Here is a screenshot before and after applying the quirk:
<img width="1861" alt="Bildschirmfoto 2023-08-28 um 14 41 09" src="https://github.com/zigpy/zha-device-handlers/assets/1482002/3529ac60-248e-46b9-a489-ae4f18822f71">


## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
