### PR TITLE
Fix docs comment regarding `TuyaEnchantableCluster`

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -544,7 +544,7 @@ class TuyaEnchantableCluster(CustomCluster):
     - clusters which would be bound, but that changed their ep_attribute
 
     Make sure to add a subclass of TuyaEnchantableCluster to the quirk replacement. Tests will fail if this is not done.
-    Classes like TuyaOnOff, TuyaZBOnOffAttributeCluster, TuyaSmartRemoteOnOffCluster already inherit from this class.
+    Classes like TuyaOnOff, TuyaZBOnOffAttributeCluster, TuyaNoBindPowerConfigurationCluster inherit from this class.
     """
 
     async def bind(self):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The `TuyaSmartRemoteOnOffCluster` cluster class does not (and can not) inherit `TuyaEnchantableCluster`, as it's not bound due to changing the `ep_attribute`.

This PR changes that comment.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
