### PR TITLE
Add Heiman SmokeSensor-EF-3.0 support

### DIFF
--- a/zhaquirks/heiman/smoke.py
+++ b/zhaquirks/heiman/smoke.py
@@ -2,7 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Alarms, Basic, Identify, Ota, PowerConfiguration
+from zigpy.zcl.clusters.general import Alarms, Basic, Identify, Ota, PollControl, PowerConfiguration
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.security import IasWd, IasZone
 import zigpy.zdo.types
@@ -238,6 +238,64 @@ class HeimanSmokeN30(CustomDevice):
                     Diagnostic.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+
+class HeimanSmokeEF30(CustomDevice):
+    """SmokeEF30 quirk."""
+
+    # NodeDescriptor(
+    #     logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0,
+    #     frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>,
+    #     manufacturer_code=4619, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82,
+    #     descriptor_capability_field=<DescriptorCapability.NONE: 0>,
+    #     *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False,
+    #     *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)
+    signature = {
+        MODELS_INFO: [("HEIMAN", "SmokeSensor-EF-3.0")],
+        ENDPOINTS: {
+            # "profile_id": "0x0104", "device_type": "0x0402",
+            # "input_clusters": ["0x0000", "0x0001", "0x0003", "0x0020", "0x0500", "0x0502", "0x0b05"],
+            #  "output_clusters": ["0x0003", "0x0019"]
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    IasZone.cluster_id,
+                    IasWd.cluster_id,
+                    Diagnostic.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    IasZone.cluster_id,
+                    Diagnostic.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
                     Ota.cluster_id,
                 ],
             },

--- a/zhaquirks/heiman/smoke.py
+++ b/zhaquirks/heiman/smoke.py
@@ -2,7 +2,14 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Alarms, Basic, Identify, Ota, PollControl, PowerConfiguration
+from zigpy.zcl.clusters.general import (
+    Alarms,
+    Basic,
+    Identify,
+    Ota,
+    PollControl,
+    PowerConfiguration,
+)
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.security import IasWd, IasZone
 import zigpy.zdo.types


### PR DESCRIPTION
## Proposed change

This PR adds support for the Heiman SmokeSensor-EF-3.0. The quirk is pretty similar to #2157 but it looks like this device has an additional input cluster (`PollControl`).

## Additional information

None.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
