### PR TITLE
Add Tuya battery cluster for TS0001 fingerbot

### DIFF
--- a/zhaquirks/tuya/ts0001_fingerbot.py
+++ b/zhaquirks/tuya/ts0001_fingerbot.py
@@ -143,6 +143,7 @@ class TuyaFingerbot(EnchantedDevice):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
+                    TuyaPowerConfigurationCluster,
                     OnOffEnchantable,
                     TuyaFingerbotCluster,
                 ],


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This adds the missing `LocalDataCluster` that accepts the battery reports from the Tuya datapoints.
`TuyaPowerConfigurationCluster` also doubles the battery reports, as ZCL/ZHA expect 200% to actually be 100%.

@abmantis You seem to have this device, is it possible for you to test if this change works? (and the battery entity shows up in HA + gets populated after some time?)

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

Related Tuya fingerbot PRs:
- https://github.com/zigpy/zha-device-handlers/pull/2506
- https://github.com/zigpy/zha-device-handlers/pull/2554
- (https://github.com/zigpy/zha-device-handlers/pull/2567)

(Python 3.12.x test failure is expected, as zigpy broke with Python 3.12 rc2)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
