### PR TITLE
Add Aqara T1 water leak sensor support

### DIFF
--- a/zhaquirks/xiaomi/aqara/water_agl02.py
+++ b/zhaquirks/xiaomi/aqara/water_agl02.py
@@ -14,7 +14,12 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.xiaomi import BasicCluster, XiaomiCustomDevice, XiaomiPowerConfiguration
+from zhaquirks.xiaomi import (
+    BasicCluster,
+    XiaomiAqaraE1Cluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
+)
 
 
 class WaterT1(XiaomiCustomDevice):
@@ -52,6 +57,7 @@ class WaterT1(XiaomiCustomDevice):
                     XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     IasZone.cluster_id,
+                    XiaomiAqaraE1Cluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Ota.cluster_id,

--- a/zhaquirks/xiaomi/aqara/water_agl02.py
+++ b/zhaquirks/xiaomi/aqara/water_agl02.py
@@ -1,0 +1,61 @@
+"""Quirk for Aqara T1 water leak sensor lumi.flood.agl02."""
+
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
+from zigpy.zcl.clusters.security import IasZone
+from zigpy.zdo.types import NodeDescriptor
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    NODE_DESCRIPTOR,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import BasicCluster, XiaomiCustomDevice, XiaomiPowerConfiguration
+
+
+class WaterT1(XiaomiCustomDevice):
+    """Aqara T1 water leak sensor quirk."""
+
+    signature = {
+        MODELS_INFO: [("LUMI", "lumi.flood.agl02")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        NODE_DESCRIPTOR: NodeDescriptor(
+            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
+        ),
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    XiaomiPowerConfiguration,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Adds support for the Aqara T1 water leak sensor.

This replaces the node descriptor with one that sets `is_mains_powered` to `False`, as the device wrongly reports this as `True`.
It also replaces the `Basic` cluster with the Xiaomi `BasicCluster`, so that Xiaomi specific attribute reports are parsed correctly. EDIT: A hidden "Xiaomi Aqara Opple" is also added to `replacement`, as newer revisions send the Xiaomi attribute reports there, instead of on the Basic cluster.
The `PowerConfiguration` cluster is replaced with the Xiaomi `XiaomiPowerConfiguration` cluster, so that the battery reports are correctly populated on that cluster.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Fixes https://github.com/zigpy/zha-device-handlers/issues/2582
Currently waiting for confirmation that this quirk fixes all the issues.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
