### PR TITLE
Add Tuya TS011F plug variant, add Tuya `0x1888` cluster class

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1108,7 +1108,7 @@ class TuyaZBE000Cluster(CustomCluster):
 
     name = "Tuya Manufacturer Specific 0"
     cluster_id = TUYA_CLUSTER_E000_ID
-    ep_attribute = "tuya_manufacturer_specific_0"
+    ep_attribute = "tuya_manufacturer_specific_57344"
 
 
 # Tuya Zigbee Cluster 0xE001 Implementation
@@ -1135,7 +1135,7 @@ class TuyaZB1888Cluster(CustomCluster):
 
     name = "Tuya Manufacturer Specific 1"
     cluster_id = TUYA_CLUSTER_1888_ID
-    ep_attribute = "tuya_manufacturer_specific_1"
+    ep_attribute = "tuya_manufacturer_specific_6280"
 
 
 # Tuya Window Cover Implementation

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -30,6 +30,7 @@ from zhaquirks.const import (
 TUYA_CLUSTER_ID = 0xEF00
 TUYA_CLUSTER_E000_ID = 0xE000
 TUYA_CLUSTER_E001_ID = 0xE001
+TUYA_CLUSTER_1888_ID = 0x1888
 # ---------------------------------------------------------
 # Tuya Cluster Commands
 # ---------------------------------------------------------
@@ -1105,9 +1106,9 @@ class TuyaZBElectricalMeasurement(CustomCluster, ElectricalMeasurement):
 class TuyaZBE000Cluster(CustomCluster):
     """Tuya manufacturer specific cluster 57344."""
 
-    name = "Tuya Manufacturer Specific"
+    name = "Tuya Manufacturer Specific 0"
     cluster_id = TUYA_CLUSTER_E000_ID
-    ep_attribute = "tuya_is_pita_0"
+    ep_attribute = "tuya_manufacturer_specific_0"
 
 
 # Tuya Zigbee Cluster 0xE001 Implementation
@@ -1126,6 +1127,15 @@ class TuyaZBExternalSwitchTypeCluster(CustomCluster):
     cluster_id = TUYA_CLUSTER_E001_ID
     ep_attribute = "tuya_external_switch_type"
     attributes = {0xD030: ("external_switch_type", ExternalSwitchType)}
+
+
+# Tuya Zigbee Cluster 0x1888 Implementation
+class TuyaZB1888Cluster(CustomCluster):
+    """Tuya manufacturer specific cluster 6280."""
+
+    name = "Tuya Manufacturer Specific 1"
+    cluster_id = TUYA_CLUSTER_1888_ID
+    ep_attribute = "tuya_manufacturer_specific_1"
 
 
 # Tuya Window Cover Implementation

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1095,7 +1095,7 @@ class Plug_v3(EnchantedDevice):
                     ElectricalMeasurement.cluster_id,
                     LightLink.cluster_id,
                     0x1888,
-                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                    TuyaZBE000Cluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Ota.cluster_id,
@@ -1128,7 +1128,7 @@ class Plug_v3(EnchantedDevice):
                     TuyaZBElectricalMeasurement,
                     LightLink.cluster_id,
                     0x1888,
-                    TuyaZBExternalSwitchTypeCluster,
+                    TuyaZBE000Cluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Ota.cluster_id,

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -13,6 +13,7 @@ from zigpy.zcl.clusters.general import (
     Time,
 )
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.lightlink import LightLink
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
@@ -1069,6 +1070,77 @@ class Plug_v2(EnchantedDevice):
                     TuyaZBExternalSwitchTypeCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+
+class Plug_v3(EnchantedDevice):
+    """Tuya TS011F plug. One plug is _Tz3000_0Zfrhq4I."""
+
+    signature = {
+        MODEL: "TS011F",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    Time.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    LightLink.cluster_id,
+                    0x1888,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                    Time.cluster_id,
+                    TuyaZBMeteringClusterWithUnit,
+                    TuyaZBElectricalMeasurement,
+                    LightLink.cluster_id,
+                    0x1888,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
             },
         },
     }

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -28,6 +28,7 @@ from zhaquirks.const import (
 )
 from zhaquirks.tuya import (
     TuyaNewManufCluster,
+    TuyaZB1888Cluster,
     TuyaZBE000Cluster,
     TuyaZBElectricalMeasurement,
     TuyaZBExternalSwitchTypeCluster,
@@ -1094,7 +1095,7 @@ class Plug_v3(EnchantedDevice):
                     Metering.cluster_id,
                     ElectricalMeasurement.cluster_id,
                     LightLink.cluster_id,
-                    0x1888,
+                    TuyaZB1888Cluster.cluster_id,
                     TuyaZBE000Cluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -1127,7 +1128,7 @@ class Plug_v3(EnchantedDevice):
                     TuyaZBMeteringClusterWithUnit,
                     TuyaZBElectricalMeasurement,
                     LightLink.cluster_id,
-                    0x1888,
+                    TuyaZB1888Cluster,
                     TuyaZBE000Cluster,
                 ],
                 OUTPUT_CLUSTERS: [


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Adds yet another variant of the Tuya `TS011F` plug.
Not sure if `TuyaZBMeteringClusterWithUnit` is required or if `TuyaZBMeteringCluster` is enough. (Couldn't we even merge those two classes?)

It also adds a class for the Tuya `0x1888` cluster (which is outside the manufacturer specific range, thus tests fail unless it has a custom cluster class).

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Fixes https://github.com/zigpy/zha-device-handlers/issues/2573
✅  ~~Waiting for confirmation in that issue that the custom quirk works~~

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
