### PR TITLE
Add Tuya blind motor (Amazon US - HILADUO) `_TZE200_9p5xmj5r` variant

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -373,7 +373,6 @@ class TuyaMoesCover0601(TuyaWindowCover):
             ("_TZE200_7eue9vhc", "TS0601"),
             ("_TZE200_bv1jcqqu", "TS0601"),
             ("_TZE200_nw1r9hp6", "TS0601"),
-            ("_TZE200_9p5xmj5r", "TS0601")
         ],
         ENDPOINTS: {
             1: {
@@ -481,6 +480,7 @@ class TuyaMoesCover0601_inv_position(TuyaWindowCover):
             ("_TZE200_3i3exuay", "TS0601"),
             ("_TZE200_nogaemzt", "TS0601"),
             ("_TZE200_dng9fn0k", "TS0601"),
+            ("_TZE200_9p5xmj5r", "TS0601"),
         ],
         ENDPOINTS: {
             1: {

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -373,6 +373,7 @@ class TuyaMoesCover0601(TuyaWindowCover):
             ("_TZE200_7eue9vhc", "TS0601"),
             ("_TZE200_bv1jcqqu", "TS0601"),
             ("_TZE200_nw1r9hp6", "TS0601"),
+            ("_TZE200_9p5xmj5r", "TS0601")
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
This roller blind is sold on Amazon USA under the brand name HILADUO.

I have already added this as a custom quirk and tested it with my own blinds.

## Proposed change
<!--
 adding another Tuya blind controller model
-->


## Additional information
<!--
just one line to add another model
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
