### PR TITLE
Remove `LevelControl` cluster for TRADFRI plug

### DIFF
--- a/zhaquirks/ikea/tradfriplug.py
+++ b/zhaquirks/ikea/tradfriplug.py
@@ -25,7 +25,7 @@ from zhaquirks.const import (
 from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID
 
 
-class TradfriPlug(CustomDevice):
+class TradfriPlug1(CustomDevice):
     """Tradfri Plug."""
 
     signature = {
@@ -93,4 +93,74 @@ class TradfriPlug(CustomDevice):
                 ],
             }
         }
+    }
+
+
+class TradfriPlug2(CustomDevice):
+    """Tradfri Plug."""
+
+    signature = {
+        MODELS_INFO: [(IKEA, "TRADFRI control outlet")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=266
+            # device_version=0
+            # input_clusters=[0, 3, 4, 5, 6, 8, 4096] output_clusters=[5, 25, 32]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Scenes.cluster_id,
+                    Ota.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # device_version=0
+            # input_clusters=[33] output_clusters=[33]>
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Scenes.cluster_id,
+                    Ota.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
     }

--- a/zhaquirks/ikea/tradfriplug.py
+++ b/zhaquirks/ikea/tradfriplug.py
@@ -104,7 +104,7 @@ class TradfriPlug2(CustomDevice):
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=266
             # device_version=0
-            # input_clusters=[0, 3, 4, 5, 6, 8, 4096] output_clusters=[5, 25, 32]>
+            # input_clusters=[0, 3, 4, 5, 6, 8, 4096] output_clusters=[5, 25, 32, 4096]>
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This removes the `LevelControl` cluster for the IKEA TRADFRI plug to not create the `on_level` and other settings entities in ZHA, as that can cause confusion about whether or not the on/off plug is a dimmer.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
The original quirk for older firmware already removed the `LevelControl` cluster. This PR also does it for newer firmware versions.
See https://github.com/home-assistant/core/issues/100454 for context


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
