### PR TITLE
Add IKEA Rodret dimmer support

### DIFF
--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -143,6 +143,16 @@ class ShortcutV2Cluster(EventableCluster):
 
 
 # ZCL compliant IKEA power configuration clusters:
+class PowerConfig1AAACluster(CustomCluster, PowerConfiguration):
+    """Updating power attributes: 2 AAA."""
+
+    _CONSTANT_ATTRIBUTES = {
+        BATTERY_SIZE: 4,
+        BATTERY_QUANTITY: 1,
+        BATTERY_RATED_VOLTAGE: 15,
+    }
+
+
 class PowerConfig2AAACluster(CustomCluster, PowerConfiguration):
     """Updating power attributes: 2 AAA."""
 

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -202,8 +202,8 @@ class IkeaRodretRemote2Btn(CustomDevice):
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=2080
         # device_version=1
-        # input_clusters=[0, 1, 3, 9, 32, 4096, 64636]
-        # output_clusters=[3, 4, 6, 8, 25, 258, 4096]>
+        # input_clusters=[0, 1, 3, 32, 4096, 64636]
+        # output_clusters=[3, 4, 6, 8, 258, 4096]>
         MODELS_INFO: [(IKEA, "RODRET Dimmer")],
         ENDPOINTS: {
             1: {

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -85,7 +85,7 @@ class IkeaTradfriRemote2Btn(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfig1CRCluster,
+                    PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -196,6 +196,7 @@ class IkeaTradfriRemote2BtnZLL(CustomDevice):
 
     device_automation_triggers = IkeaTradfriRemote2Btn.device_automation_triggers.copy()
 
+
 class IkeaRodretRemote2Btn(CustomDevice):
     """Custom device representing IKEA of Sweden RODRET remote control."""
 
@@ -236,7 +237,7 @@ class IkeaRodretRemote2Btn(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfig1CRCluster,
+                    PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -195,3 +195,63 @@ class IkeaTradfriRemote2BtnZLL(CustomDevice):
     }
 
     device_automation_triggers = IkeaTradfriRemote2Btn.device_automation_triggers.copy()
+
+class IkeaRodretRemote2Btn(CustomDevice):
+    """Custom device representing IKEA of Sweden RODRET remote control."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=2080
+        # device_version=1
+        # input_clusters=[0, 1, 3, 9, 32, 4096, 64636]
+        # output_clusters=[3, 4, 6, 8, 25, 258, 4096]>
+        MODELS_INFO: [(IKEA, "RODRET Dimmer")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                    IKEA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DoublingPowerConfig1CRCluster,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                    IKEA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        }
+    }
+
+    device_automation_triggers = IkeaTradfriRemote2Btn.device_automation_triggers.copy()

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -40,7 +40,12 @@ from zhaquirks.const import (
     TURN_OFF,
     TURN_ON,
 )
-from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, DoublingPowerConfig1CRCluster
+from zhaquirks.ikea import (
+    IKEA,
+    IKEA_CLUSTER_ID,
+    DoublingPowerConfig1CRCluster,
+    PowerConfig1AAACluster,
+)
 
 
 class IkeaTradfriRemote2Btn(CustomDevice):
@@ -237,7 +242,7 @@ class IkeaRodretRemote2Btn(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
+                    PowerConfig1AAACluster,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,

--- a/zhaquirks/ikea/twobtnremote.py
+++ b/zhaquirks/ikea/twobtnremote.py
@@ -85,7 +85,7 @@ class IkeaTradfriRemote2Btn(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
+                    DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     PollControl.cluster_id,


### PR DESCRIPTION
## Proposed change
Added signature to match Ikea's Rodret dimmer button.

## Additional information
Rodret is basically same as Tradfri without alarm input cluster and without window covering output cluster. Tested as a standalone quirk

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
