### PR TITLE
Clean up Aqara Roller Curtain E1 quirk, add tests

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -13,8 +13,8 @@ from zigpy.zcl.clusters.general import (
     AnalogInput,
     AnalogOutput,
     DeviceTemperature,
-    OnOff,
     MultistateOutput,
+    OnOff,
     PowerConfiguration,
 )
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -11,8 +11,10 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import (
     AnalogInput,
+    AnalogOutput,
     DeviceTemperature,
     OnOff,
+    MultistateOutput,
     PowerConfiguration,
 )
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
@@ -1447,4 +1449,64 @@ async def test_xiaomi_e1_driver_light_level(
             illuminance_listener.attribute_updates[0][1]
             == 10000 * math.log10(converted_level) + 1
         )
+    )
+
+
+@pytest.mark.parametrize(
+    "command, value",
+    [
+        (WindowCovering.ServerCommandDefs.up_open.id, 1),
+        (WindowCovering.ServerCommandDefs.down_close.id, 0),
+        (WindowCovering.ServerCommandDefs.stop.id, 2),
+    ],
+)
+async def test_xiaomi_e1_roller_commands_1(zigpy_device_from_quirk, command, value):
+    """Test Aqara E1 roller commands for basic movement functions using MultistateOutput Cluster."""
+    device = zigpy_device_from_quirk(
+        zhaquirks.xiaomi.aqara.roller_curtain_e1.RollerE1AQ
+    )
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    multistate_cluster = device.endpoints[1].multistate_output
+    multistate_cluster._write_attributes = mock.AsyncMock(
+        return_value=(
+            [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],
+        )
+    )
+    attr_id = MultistateOutput.AttributeDefs.present_value.id
+
+    # test command
+    await window_covering_cluster.command(command)
+    assert multistate_cluster._write_attributes.call_count == 1
+    assert multistate_cluster._write_attributes.call_args[0][0][0].attrid == attr_id
+    assert multistate_cluster._write_attributes.call_args[0][0][0].value.value == value
+
+
+@pytest.mark.parametrize(
+    "command, value",
+    [
+        (WindowCovering.ServerCommandDefs.go_to_lift_percentage.id, 60),
+    ],
+)
+async def test_xiaomi_e1_roller_commands_2(zigpy_device_from_quirk, command, value):
+    """Test Aqara E1 roller commands for go to lift percentage using AnalogOutput cluster."""
+    device = zigpy_device_from_quirk(
+        zhaquirks.xiaomi.aqara.roller_curtain_e1.RollerE1AQ
+    )
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    analog_cluster = device.endpoints[1].analog_output
+    analog_cluster._write_attributes = mock.AsyncMock(
+        return_value=(
+            [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],
+        )
+    )
+    attr_id = AnalogOutput.AttributeDefs.present_value.id
+
+    # test go to lift percentage command
+    await window_covering_cluster.go_to_lift_percentage(value)
+    assert analog_cluster._write_attributes.call_count == 1
+    assert analog_cluster._write_attributes.call_args[0][0][0].attrid == attr_id
+    assert (
+        analog_cluster._write_attributes.call_args[0][0][0].value.value == 100 - value
     )

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -60,15 +60,14 @@ class XiaomiAqaraRollerE1(XiaomiAqaraE1Cluster):
 class AnalogOutputRollerE1(CustomCluster, AnalogOutput):
     """Analog output cluster, only used to relay current_value to WindowCovering."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Init."""
-        super().__init__(*args, **kwargs)
-
-        self.update_attribute(self.AttributeDefs.max_present_value.id, float(0x064))
-        self.update_attribute(self.AttributeDefs.min_present_value.id, 0.0)
-        self.update_attribute(self.AttributeDefs.out_of_service.id, 0)
-        self.update_attribute(self.AttributeDefs.resolution.id, 1.0)
-        self.update_attribute(self.AttributeDefs.status_flags.id, 0x00)
+    _CONSTANT_ATTRIBUTES = {
+        AnalogOutput.AttributeDefs.description.id: "Current position",
+        AnalogOutput.AttributeDefs.max_present_value.id: float(0x064),
+        AnalogOutput.AttributeDefs.min_present_value.id: 0.0,
+        AnalogOutput.AttributeDefs.out_of_service.id: 0,
+        AnalogOutput.AttributeDefs.resolution.id: 1.0,
+        AnalogOutput.AttributeDefs.status_flags.id: 0x00,
+    }
 
     def _update_attribute(self, attrid: int, value: Any) -> None:
         super()._update_attribute(attrid, value)

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -62,7 +62,7 @@ class AnalogOutputRollerE1(CustomCluster, AnalogOutput):
 
     _CONSTANT_ATTRIBUTES = {
         AnalogOutput.AttributeDefs.description.id: "Current position",
-        AnalogOutput.AttributeDefs.max_present_value.id: float(0x064),
+        AnalogOutput.AttributeDefs.max_present_value.id: 100.0,
         AnalogOutput.AttributeDefs.min_present_value.id: 0.0,
         AnalogOutput.AttributeDefs.out_of_service.id: 0,
         AnalogOutput.AttributeDefs.resolution.id: 1.0,

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -21,7 +21,6 @@ from zigpy.zcl.clusters.general import (
     Scenes,
     Time,
 )
-from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 
 from zhaquirks import CustomCluster
 from zhaquirks.const import (
@@ -35,23 +34,15 @@ from zhaquirks.const import (
 from zhaquirks.xiaomi import (
     LUMI,
     BasicCluster,
+    XiaomiAqaraE1Cluster,
     XiaomiCluster,
     XiaomiCustomDevice,
     XiaomiPowerConfiguration,
 )
 
-PRESENT_VALUE = 0x0055
-CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
-GO_TO_LIFT_PERCENTAGE = 0x0005
-DOWN_CLOSE = 0x0001
-UP_OPEN = 0x0000
-STOP = 0x0002
 
-
-class XiaomiAqaraRollerE1(XiaomiCluster, ManufacturerSpecificCluster):
+class XiaomiAqaraRollerE1(XiaomiAqaraE1Cluster):
     """Xiaomi mfg cluster implementation specific for E1 Roller."""
-
-    cluster_id = 0xFCC0
 
     attributes = XiaomiCluster.attributes.copy()
     attributes.update(
@@ -69,35 +60,28 @@ class XiaomiAqaraRollerE1(XiaomiCluster, ManufacturerSpecificCluster):
 class AnalogOutputRollerE1(CustomCluster, AnalogOutput):
     """Analog output cluster, only used to relay current_value to WindowCovering."""
 
-    cluster_id = AnalogOutput.cluster_id
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Init."""
         super().__init__(*args, **kwargs)
 
-        self._update_attribute(0x0041, float(0x064))  # max_present_value
-        self._update_attribute(0x0045, 0.0)  # min_present_value
-        self._update_attribute(0x0051, 0)  # out_of_service
-        self._update_attribute(0x006A, 1.0)  # resolution
-        self._update_attribute(0x006F, 0x00)  # status_flags
+        self.update_attribute(self.AttributeDefs.max_present_value.id, float(0x064))
+        self.update_attribute(self.AttributeDefs.min_present_value.id, 0.0)
+        self.update_attribute(self.AttributeDefs.out_of_service.id, 0)
+        self.update_attribute(self.AttributeDefs.resolution.id, 1.0)
+        self.update_attribute(self.AttributeDefs.status_flags.id, 0x00)
 
     def _update_attribute(self, attrid: int, value: Any) -> None:
         super()._update_attribute(attrid, value)
 
-        if attrid == PRESENT_VALUE:
-            self.endpoint.window_covering._update_attribute(
-                CURRENT_POSITION_LIFT_PERCENTAGE, (100 - value)
+        if attrid == self.AttributeDefs.present_value.id:
+            self.endpoint.window_covering.update_attribute(
+                WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+                (100 - value),
             )
 
 
 class WindowCoveringRollerE1(CustomCluster, WindowCovering):
     """Window covering cluster to receive commands that are sent to the AnalogOutput's present_value to move the motor."""
-
-    cluster_id = WindowCovering.cluster_id
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Init."""
-        super().__init__(*args, **kwargs)
 
     async def command(
         self,
@@ -113,28 +97,28 @@ class WindowCoveringRollerE1(CustomCluster, WindowCovering):
         We either overwrite analog_output's current_value or multistate_output's current
         value to make the roller work.
         """
-        if command_id == UP_OPEN:
+        if command_id == WindowCovering.ServerCommandDefs.up_open.id:
             (res,) = await self.endpoint.multistate_output.write_attributes(
                 {"present_value": 1}
             )
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=res[0].status)
-        if command_id == DOWN_CLOSE:
+        if command_id == WindowCovering.ServerCommandDefs.down_close.id:
             (res,) = await self.endpoint.multistate_output.write_attributes(
                 {"present_value": 0}
             )
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=res[0].status)
-        if command_id == GO_TO_LIFT_PERCENTAGE:
+        if command_id == WindowCovering.ServerCommandDefs.go_to_lift_percentage.id:
             (res,) = await self.endpoint.analog_output.write_attributes(
                 {"present_value": (100 - args[0])}
             )
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=res[0].status)
-        if command_id == STOP:
+        if command_id == WindowCovering.ServerCommandDefs.stop.id:
             (res,) = await self.endpoint.multistate_output.write_attributes(
                 {"present_value": 2}
             )
@@ -152,7 +136,10 @@ class MultistateOutputRollerE1(CustomCluster, MultistateOutput):
     attributes = MultistateOutput.attributes.copy()
     attributes.update(
         {
-            0x0055: ("present_value", t.uint16_t),
+            MultistateOutput.AttributeDefs.present_value.id: (
+                "present_value",
+                t.uint16_t,
+            ),
         }
     )
 

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -37,7 +37,7 @@ from zhaquirks.xiaomi import (
     XiaomiAqaraE1Cluster,
     XiaomiCluster,
     XiaomiCustomDevice,
-    XiaomiPowerConfiguration,
+    XiaomiPowerConfigurationPercent,
 )
 
 
@@ -143,17 +143,6 @@ class MultistateOutputRollerE1(CustomCluster, MultistateOutput):
     )
 
 
-class PowerConfigurationRollerE1(XiaomiPowerConfiguration):
-    """Power cluster which ignores Xiaomi voltage reports."""
-
-    def _update_battery_percentage(self, voltage_mv: int) -> None:
-        """Ignore Xiaomi voltage reports, so they're not used to calculate battery percentage."""
-        # This device sends battery percentage reports which are handled using a XiaomiCluster and
-        # the inherited XiaomiPowerConfiguration cluster.
-        # This device might also send Xiaomi battery reports, so we only want to use those for the voltage attribute,
-        # but not for the battery percentage. XiaomiPowerConfiguration.battery_reported() still updates the voltage.
-
-
 class RollerE1AQ(XiaomiCustomDevice):
     """Aqara Roller Shade Driver E1 device."""
 
@@ -215,7 +204,7 @@ class RollerE1AQ(XiaomiCustomDevice):
                     MultistateOutputRollerE1,
                     Scenes.cluster_id,
                     WindowCoveringRollerE1,
-                    PowerConfigurationRollerE1,
+                    XiaomiPowerConfigurationPercent,
                 ],
                 OUTPUT_CLUSTERS: [
                     Ota.cluster_id,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This cleans up the Aqara Roller Curtain E1 quirk a bit and adds some test.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Changed are untested, but shouldn't change anything, as it mostly just replaces "magic numbers" with getting the `id` from `AttributeDefs`.
EDIT: Unit tests are added now.

Previous PRs:
- https://github.com/zigpy/zha-device-handlers/pull/1242
- https://github.com/zigpy/zha-device-handlers/pull/1421


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
