### PR TITLE
Add Aqara T1 door sensor support

### DIFF
--- a/zhaquirks/xiaomi/aqara/magnet_agl02.py
+++ b/zhaquirks/xiaomi/aqara/magnet_agl02.py
@@ -1,0 +1,67 @@
+"""Quirk for Aqara T1 door sensor lumi.magnet.agl02."""
+
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import Basic, Identify, OnOff, Ota, PowerConfiguration
+from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import (
+    BasicCluster,
+    XiaomiAqaraE1Cluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
+)
+
+
+class MagnetT1(XiaomiCustomDevice):
+    """Aqara T1 door sensor quirk."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.battery_size = 11
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        MODELS_INFO: [("LUMI", "lumi.magnet.agl02")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    XiaomiPowerConfiguration,
+                    Identify.cluster_id,
+                    XiaomiAqaraE1Cluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    OnOff.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Adds support for the Aqara T1 door sensor.
This device seems to use the `OnOff` cluster instead of the `IasZone` cluster.
(Should we also change the `DeviceType` then. If yes, to what though? Doesn't really matter for functionality)

It's possible that the other cluster is used, because coordinators are sending Xiaomi manufacturer codes during pairing, so the sensor thinks it's paired to a Xiaomi hub and then uses the `OnOff` cluster instead of `IasZone` cluster. This is just a guess though.

So this quirk fixes the actual open/close sensor functionality and also adds battery measurement support through Xiaomi's attribute reports.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
See https://github.com/home-assistant/core/issues/100805
Fixes #2631


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
