### PR TITLE
Fix battery reporting for `_TZE200_yjjdcqsq`, `_TZE200_9yapgbuv`

### DIFF
--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -74,6 +74,7 @@ class TemperatureHumidityManufCluster(TuyaMCUCluster):
         4: "_dp_2_attr_update",
     }
 
+
 class TemperatureHumidityBatteryStatesManufCluster(TuyaMCUCluster):
     """Tuya Manufacturer Cluster with Temperature and Humidity data points. Battery states 25, 50 and 100%."""
 
@@ -100,6 +101,7 @@ class TemperatureHumidityBatteryStatesManufCluster(TuyaMCUCluster):
         2: "_dp_2_attr_update",
         3: "_dp_2_attr_update",
     }
+
 
 class TuyaTempHumiditySensor(CustomDevice):
     """Custom device representing tuya temp and humidity sensor with e-ink screen."""

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -79,16 +79,8 @@ class TemperatureHumidityBatteryStatesManufCluster(TuyaMCUCluster):
     """Tuya Manufacturer Cluster with Temperature and Humidity data points. Battery states 25, 50 and 100%."""
 
     dp_to_attribute: Dict[int, DPToAttributeMapping] = {
-        1: DPToAttributeMapping(
-            TuyaTemperatureMeasurement.ep_attribute,
-            "measured_value",
-            converter=lambda x: x * 10,  # decidegree to centidegree
-        ),
-        2: DPToAttributeMapping(
-            TuyaRelativeHumidity.ep_attribute,
-            "measured_value",
-            # converter=lambda x: x * 10,  --> move conversion to TuyaRelativeHumidity cluster
-        ),
+        1: TemperatureHumidityManufCluster.dp_to_attribute[1],
+        2: TemperatureHumidityManufCluster.dp_to_attribute[2],
         3: DPToAttributeMapping(
             TuyaPowerConfigurationCluster2AAA.ep_attribute,
             "battery_percentage_remaining",

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -74,7 +74,7 @@ class TemperatureHumidityManufCluster(TuyaMCUCluster):
         4: "_dp_2_attr_update",
     }
 
-class TemperatureHumidityBatteryStatesManufCluster(TuyaMCUCluster, TuyaManufClusterAttributes):
+class TemperatureHumidityBatteryStatesManufCluster(TuyaMCUCluster):
     """Tuya Manufacturer Cluster with Temperature and Humidity data points. Battery states 25, 50 and 100%."""
 
     dp_to_attribute: Dict[int, DPToAttributeMapping] = {


### PR DESCRIPTION
Both devices report battery status in three levels: low, middle, and high instead of reporting a battery percentage. I confirmed this with the official TuYa App and TuYa IoT Platform. See Issue #2281. I tested this for both devices: _TZE200_yjjdcqsq and _TZE200_9yapgbuv.


## Proposed change
Since there is no option for battery level in ZHA, this fix converts the levels into equal percentage numbers 25%, 50% and 100%.


## Additional information
Fixes #2281


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
