### PR TITLE
Add Xiaomi E1 driver curtain support

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -8,6 +8,7 @@ import pytest
 import zigpy.device
 import zigpy.types as t
 from zigpy.zcl import foundation
+from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import (
     AnalogInput,
     DeviceTemperature,
@@ -51,6 +52,7 @@ from zhaquirks.xiaomi import (
     XiaomiQuickInitDevice,
     handle_quick_init,
 )
+import zhaquirks.xiaomi.aqara.driver_curtain_e1
 from zhaquirks.xiaomi.aqara.feeder_acn001 import (
     FEEDER_ATTR,
     ZCL_CHILD_LOCK,
@@ -1362,3 +1364,43 @@ async def test_xiaomi_t1_door_sensor(
     assert power_listener.attribute_updates[0][1] == expected_results[0]
     assert power_listener.attribute_updates[1][0] == zcl_power_percent_id
     assert power_listener.attribute_updates[1][1] == expected_results[1]
+
+
+@pytest.mark.parametrize(
+    "command, command_id, value",
+    [
+        (
+            WindowCovering.ServerCommandDefs.up_open.id,
+            WindowCovering.ServerCommandDefs.go_to_lift_percentage.id,
+            0,
+        ),
+        (
+            WindowCovering.ServerCommandDefs.down_close.id,
+            WindowCovering.ServerCommandDefs.go_to_lift_percentage.id,
+            100,
+        ),
+        (
+            WindowCovering.ServerCommandDefs.stop.id,
+            WindowCovering.ServerCommandDefs.stop.id,
+            None,
+        ),
+    ],
+)
+async def test_xiaomi_e1_driver_commands(
+    zigpy_device_from_quirk, command, command_id, value
+):
+    """Test Aqara E1 driver commands for basic movement functions using WindowCovering cluster."""
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.driver_curtain_e1.DriverE1)
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    p = mock.patch.object(window_covering_cluster, "request", mock.AsyncMock())
+
+    with p as request_mock:
+        request_mock.return_value = (foundation.Status.SUCCESS, "done")
+
+        # test command
+        await window_covering_cluster.command(command)
+        assert request_mock.call_count == 1
+        assert request_mock.call_args[0][1] == command_id
+        if value is not None:
+            assert request_mock.call_args[0][3] == value

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1404,34 +1404,3 @@ async def test_xiaomi_e1_driver_commands(
         assert request_mock.call_args[0][1] == command_id
         if value is not None:
             assert request_mock.call_args[0][3] == value
-
-
-# @pytest.mark.parametrize(
-#     "set_percentage, expected_percentage, motor_mode",
-#     [
-#         (40, 40, None),
-#         (40, 40, 0),
-#         (40, 60, WindowCovering.WindowCoveringMode.Motor_direction_reversed),
-#     ],
-# )
-# async def test_xiaomi_e1_driver_inverted(
-#     zigpy_device_from_quirk, set_percentage, expected_percentage, motor_mode
-# ):
-#     """Test Aqara E1 driver lift percentage gets inverted depending on motor mode."""
-#     device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.driver_curtain_e1.DriverE1)
-#     window_covering_cluster = device.endpoints[1].window_covering
-#
-#     # set motor mode
-#     if motor_mode is not None:
-#         motor_mode_id = WindowCovering.AttributeDefs.window_covering_mode.id
-#         window_covering_cluster.update_attribute(motor_mode_id, motor_mode)
-#         assert window_covering_cluster.get(motor_mode_id) == motor_mode
-#
-#     window_covering_listener = ClusterListener(window_covering_cluster)
-#     window_lift_id = WindowCovering.AttributeDefs.current_position_lift_percentage.id
-#
-#     # fake lift percentage attribute report
-#     window_covering_cluster.update_attribute(window_lift_id, set_percentage)
-#     assert len(window_covering_listener.attribute_updates) == 1
-#     assert window_covering_listener.attribute_updates[0][0] == window_lift_id
-#     assert window_covering_listener.attribute_updates[0][1] == expected_percentage

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1404,3 +1404,34 @@ async def test_xiaomi_e1_driver_commands(
         assert request_mock.call_args[0][1] == command_id
         if value is not None:
             assert request_mock.call_args[0][3] == value
+
+
+@pytest.mark.parametrize(
+    "set_percentage, expected_percentage, motor_mode",
+    [
+        (40, 40, None),
+        (40, 40, 0),
+        (40, 60, WindowCovering.WindowCoveringMode.Motor_direction_reversed),
+    ],
+)
+async def test_xiaomi_e1_driver_inverted(
+    zigpy_device_from_quirk, set_percentage, expected_percentage, motor_mode
+):
+    """Test Aqara E1 driver lift percentage gets inverted depending on motor mode."""
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.driver_curtain_e1.DriverE1)
+    window_covering_cluster = device.endpoints[1].window_covering
+
+    # set motor mode
+    if motor_mode is not None:
+        motor_mode_id = WindowCovering.AttributeDefs.window_covering_mode.id
+        window_covering_cluster.update_attribute(motor_mode_id, motor_mode)
+        assert window_covering_cluster.get(motor_mode_id) == motor_mode
+
+    window_covering_listener = ClusterListener(window_covering_cluster)
+    window_lift_id = WindowCovering.AttributeDefs.current_position_lift_percentage.id
+
+    # fake lift percentage attribute report
+    window_covering_cluster.update_attribute(window_lift_id, set_percentage)
+    assert len(window_covering_listener.attribute_updates) == 1
+    assert window_covering_listener.attribute_updates[0][0] == window_lift_id
+    assert window_covering_listener.attribute_updates[0][1] == expected_percentage

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1406,32 +1406,32 @@ async def test_xiaomi_e1_driver_commands(
             assert request_mock.call_args[0][3] == value
 
 
-@pytest.mark.parametrize(
-    "set_percentage, expected_percentage, motor_mode",
-    [
-        (40, 40, None),
-        (40, 40, 0),
-        (40, 60, WindowCovering.WindowCoveringMode.Motor_direction_reversed),
-    ],
-)
-async def test_xiaomi_e1_driver_inverted(
-    zigpy_device_from_quirk, set_percentage, expected_percentage, motor_mode
-):
-    """Test Aqara E1 driver lift percentage gets inverted depending on motor mode."""
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.driver_curtain_e1.DriverE1)
-    window_covering_cluster = device.endpoints[1].window_covering
-
-    # set motor mode
-    if motor_mode is not None:
-        motor_mode_id = WindowCovering.AttributeDefs.window_covering_mode.id
-        window_covering_cluster.update_attribute(motor_mode_id, motor_mode)
-        assert window_covering_cluster.get(motor_mode_id) == motor_mode
-
-    window_covering_listener = ClusterListener(window_covering_cluster)
-    window_lift_id = WindowCovering.AttributeDefs.current_position_lift_percentage.id
-
-    # fake lift percentage attribute report
-    window_covering_cluster.update_attribute(window_lift_id, set_percentage)
-    assert len(window_covering_listener.attribute_updates) == 1
-    assert window_covering_listener.attribute_updates[0][0] == window_lift_id
-    assert window_covering_listener.attribute_updates[0][1] == expected_percentage
+# @pytest.mark.parametrize(
+#     "set_percentage, expected_percentage, motor_mode",
+#     [
+#         (40, 40, None),
+#         (40, 40, 0),
+#         (40, 60, WindowCovering.WindowCoveringMode.Motor_direction_reversed),
+#     ],
+# )
+# async def test_xiaomi_e1_driver_inverted(
+#     zigpy_device_from_quirk, set_percentage, expected_percentage, motor_mode
+# ):
+#     """Test Aqara E1 driver lift percentage gets inverted depending on motor mode."""
+#     device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.driver_curtain_e1.DriverE1)
+#     window_covering_cluster = device.endpoints[1].window_covering
+#
+#     # set motor mode
+#     if motor_mode is not None:
+#         motor_mode_id = WindowCovering.AttributeDefs.window_covering_mode.id
+#         window_covering_cluster.update_attribute(motor_mode_id, motor_mode)
+#         assert window_covering_cluster.get(motor_mode_id) == motor_mode
+#
+#     window_covering_listener = ClusterListener(window_covering_cluster)
+#     window_lift_id = WindowCovering.AttributeDefs.current_position_lift_percentage.id
+#
+#     # fake lift percentage attribute report
+#     window_covering_cluster.update_attribute(window_lift_id, set_percentage)
+#     assert len(window_covering_listener.attribute_updates) == 1
+#     assert window_covering_listener.attribute_updates[0][0] == window_lift_id
+#     assert window_covering_listener.attribute_updates[0][1] == expected_percentage

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -457,7 +457,7 @@ class BinaryOutputInterlock(CustomCluster, BinaryOutput):
 
 
 class XiaomiPowerConfiguration(PowerConfiguration, LocalDataCluster):
-    """Xiaomi power configuration cluster implementation."""
+    """Xiaomi power configuration cluster implementation used for devices that only send battery voltage."""
 
     BATTERY_VOLTAGE_ATTR = PowerConfiguration.AttributeDefs.battery_voltage.id
     BATTERY_PERCENTAGE_REMAINING = (
@@ -499,6 +499,23 @@ class XiaomiPowerConfiguration(PowerConfiguration, LocalDataCluster):
         )
 
         self._update_attribute(self.BATTERY_PERCENTAGE_REMAINING, percent)
+
+
+class XiaomiPowerConfigurationPercent(XiaomiPowerConfiguration):
+    """Power cluster which ignores Xiaomi voltage reports for calculating battery percentage
+
+    Devices that use this cluster (E1 curtain driver/roller) already send the battery percentage on their own
+    as a separate attribute, but additionally also send the battery voltage.
+    This class only uses the voltage reports for the voltage attribute, but not for the battery percentage.
+    The battery percentage is used as is from the battery percentage reports using inherited battery_percent_reported().
+    """
+
+    def _update_battery_percentage(self, voltage_mv: int) -> None:
+        """Ignore Xiaomi voltage reports, so they're not used to calculate battery percentage."""
+        # This device sends battery percentage reports which are handled using a XiaomiCluster and
+        # the inherited XiaomiPowerConfiguration cluster.
+        # This device might also send Xiaomi battery reports, so we only want to use those for the voltage attribute,
+        # but not for the battery percentage. XiaomiPowerConfiguration.battery_reported() still updates the voltage.
 
 
 class OccupancyCluster(OccupancyWithReset):
@@ -623,6 +640,19 @@ class IlluminanceMeasurementCluster(CustomCluster, IlluminanceMeasurement):
         if attrid == self.AttributeDefs.measured_value.id and value > 0:
             value = 10000 * math.log10(value) + 1
         super()._update_attribute(attrid, value)
+
+
+class LocalIlluminanceMeasurementCluster(
+    LocalDataCluster, IlluminanceMeasurementCluster
+):
+    """Illuminance measurement cluster based on LocalDataCluster."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        if self.AttributeDefs.measured_value.id not in self._attr_cache:
+            # put a default value so the sensor is created
+            self._update_attribute(self.AttributeDefs.measured_value.id, 0)
 
 
 class OnOffCluster(OnOff, CustomCluster):

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -52,7 +52,7 @@ class WindowCoveringE1(CustomCluster, WindowCovering):
             # TODO: should this always be reversed?
             if (
                 self.get(WindowCovering.AttributeDefs.window_covering_mode.id, 0)
-                & WindowCovering.WindowCoveringMode.Motor_direction_reversed,
+                & WindowCovering.WindowCoveringMode.Motor_direction_reversed
             ):
                 value = 100 - value
         super()._update_attribute(attrid, value)

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -29,6 +29,13 @@ from zhaquirks.xiaomi import (
     XiaomiPowerConfiguration,
 )
 
+HAND_OPEN = 0x0401
+POSITIONS_STORED = 0x0402
+STORE_POSITION = 0x0407
+HOOKS_LOCK = 0x0427
+HOOKS_STATE = 0x0428
+LIGHT_LEVEL = 0x0429
+
 
 class XiaomiAqaraDriverE1(XiaomiAqaraE1Cluster):
     """Xiaomi mfg cluster implementation specific for E1 Driver."""
@@ -36,8 +43,12 @@ class XiaomiAqaraDriverE1(XiaomiAqaraE1Cluster):
     attributes = XiaomiCluster.attributes.copy()
     attributes.update(
         {
-            0x0402: ("positions_stored", t.Bool, True),
-            0x0407: ("store_position", t.uint8_t, True),
+            HAND_OPEN: ("hand_open", t.Bool, True),
+            POSITIONS_STORED: ("positions_stored", t.Bool, True),
+            STORE_POSITION: ("store_position", t.uint8_t, True),
+            HOOKS_LOCK: ("hooks_lock", t.uint8_t, True),
+            HOOKS_STATE: ("hooks_state", t.uint8_t, True),
+            LIGHT_LEVEL: ("light_level", t.uint8_t, True),
         }
     )
 

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -8,6 +8,7 @@ from zigpy.profiles import zha
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration, Time
+from zigpy.zcl.clusters.measurement import IlluminanceMeasurement
 from zigpy.zdo.types import NodeDescriptor
 
 from zhaquirks import CustomCluster
@@ -22,6 +23,7 @@ from zhaquirks.const import (
 )
 from zhaquirks.xiaomi import (
     BasicCluster,
+    IlluminanceMeasurementCluster,
     LUMI,
     XiaomiAqaraE1Cluster,
     XiaomiCluster,
@@ -51,6 +53,14 @@ class XiaomiAqaraDriverE1(XiaomiAqaraE1Cluster):
             LIGHT_LEVEL: ("light_level", t.uint8_t, True),
         }
     )
+
+    def _update_attribute(self, attrid, value):
+        if attrid == LIGHT_LEVEL:
+            self.endpoint.illuminance.update_attribute(
+                IlluminanceMeasurement.AttributeDefs.measured_value.id,
+                value * 50,
+            )
+        super()._update_attribute(attrid, value)
 
 
 class WindowCoveringE1(CustomCluster, WindowCovering):
@@ -156,6 +166,7 @@ class DriverE1(XiaomiCustomDevice):
                     Identify.cluster_id,
                     Time.cluster_id,
                     WindowCoveringE1,
+                    IlluminanceMeasurementCluster,
                     XiaomiAqaraDriverE1,
                 ],
                 OUTPUT_CLUSTERS: [

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -152,10 +152,10 @@ class DriverE1(XiaomiCustomDevice):
         },
     }
     replacement = {
-        # TODO: needed?
-        # NODE_DESCRIPTOR: NodeDescriptor(
-        #     0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        # ),
+        # TODO: verify if this is correct
+        NODE_DESCRIPTOR: NodeDescriptor(
+            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
+        ),
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -81,19 +81,6 @@ class LocalIlluminanceMeasurementCluster(
 class WindowCoveringE1(CustomCluster, WindowCovering):
     """Xiaomi Window Covering cluster that inverts the motor direction if needed."""
 
-    # TODO: commented out for now
-    # def _update_attribute(self, attrid, value):
-    #     if attrid == WindowCovering.AttributeDefs.current_position_lift_percentage.id:
-    #         # TODO: improve this check? remove default? initialize? does the motor save this attr?
-    #         # TODO: should we do this in HA? (does it have a way now to invert motor?)
-    #         # TODO: should this always be reversed?
-    #         if (
-    #             self.get(WindowCovering.AttributeDefs.window_covering_mode.id, 0)
-    #             & WindowCovering.WindowCoveringMode.Motor_direction_reversed
-    #         ):
-    #             value = 100 - value
-    #     super()._update_attribute(attrid, value)
-
     async def command(
         self,
         command_id: foundation.GeneralCommand | int | t.uint8_t,

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -110,8 +110,6 @@ class WindowCoveringE1(CustomCluster, WindowCovering):
         elif command_id == WindowCovering.ServerCommandDefs.down_close.id:
             command_id = WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
             args = (100,)  # TODO: inverted?
-        # elif command_id == WindowCovering.ServerCommandDefs.go_to_lift_percentage.id:
-        #     args = (100 - args[0],)  # TODO: needed to invert here? (depending on attr?)
 
         return await super().command(
             command_id,

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -93,10 +93,10 @@ class WindowCoveringE1(CustomCluster, WindowCovering):
         """Overwrite the open/close commands to call the lift percentage command instead."""
         if command_id == WindowCovering.ServerCommandDefs.up_open.id:
             command_id = WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
-            args = (0,)  # TODO: inverted?
+            args = (0,)
         elif command_id == WindowCovering.ServerCommandDefs.down_close.id:
             command_id = WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
-            args = (100,)  # TODO: inverted?
+            args = (100,)
 
         return await super().command(
             command_id,

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -187,7 +187,6 @@ class DriverE1(XiaomiCustomDevice):
                     Identify.cluster_id,
                     Time.cluster_id,
                     Ota.cluster_id,
-                    # XiaomiAqaraDriverE1, # TODO: keep in OUTPUT too?
                 ],
             }
         },

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -1,0 +1,157 @@
+"""Aqara Curtain Driver E1 device."""
+from __future__ import annotations
+
+from typing import Any
+
+from zigpy import types as t
+from zigpy.profiles import zha
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration, Time
+from zigpy.zdo.types import NodeDescriptor
+
+from zhaquirks import CustomCluster
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    NODE_DESCRIPTOR,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import (
+    BasicCluster,
+    LUMI,
+    XiaomiAqaraE1Cluster,
+    XiaomiCluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
+)
+
+
+class XiaomiAqaraDriverE1(XiaomiAqaraE1Cluster):
+    """Xiaomi mfg cluster implementation specific for E1 Driver."""
+
+    attributes = XiaomiCluster.attributes.copy()
+    attributes.update(
+        {
+            0x0402: ("positions_stored", t.Bool, True),
+            0x0407: ("store_position", t.uint8_t, True),
+        }
+    )
+
+
+class WindowCoveringE1(CustomCluster, WindowCovering):
+    """Xiaomi Window Covering cluster that inverts the motor direction if needed."""
+
+    def _update_attribute(self, attrid, value):
+        if attrid == WindowCovering.AttributeDefs.current_position_lift_percentage.id:
+            # TODO: improve this check? remove default? initialize? does the motor save this attr?
+            # TODO: should we do this in HA? (does it have a way now to invert motor?)
+            # TODO: should this always be reversed?
+            if (
+                self.get(WindowCovering.AttributeDefs.window_covering_mode.id, 0)
+                & WindowCovering.WindowCoveringMode.Motor_direction_reversed,
+            ):
+                value = 100 - value
+        super()._update_attribute(attrid, value)
+
+    async def command(
+        self,
+        command_id: foundation.GeneralCommand | int | t.uint8_t,
+        *args: Any,
+        manufacturer: int | t.uint16_t | None = None,
+        expect_reply: bool = True,
+        tsn: int | t.uint8_t | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Overwrite the open/close commands to call the lift percentage command instead."""
+        if command_id == WindowCovering.ServerCommandDefs.up_open.id:
+            command_id = WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
+            args = (0,)  # TODO: inverted?
+        elif command_id == WindowCovering.ServerCommandDefs.down_close.id:
+            command_id = WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
+            args = (100,)  # TODO: inverted?
+        # elif command_id == WindowCovering.ServerCommandDefs.go_to_lift_percentage.id:
+        #     args = (100 - args[0],)  # TODO: needed to invert here? (depending on attr?)
+
+        return await super().command(
+            command_id,
+            *args,
+            manufacturer=manufacturer,
+            expect_reply=expect_reply,
+            tsn=tsn,
+            **kwargs,
+        )
+
+
+# TODO: check if cluster works
+# TODO: currently duplicated with roller_curtain_e1.py
+class PowerConfigurationDriverE1(XiaomiPowerConfiguration):
+    """Power cluster which ignores Xiaomi voltage reports."""
+
+    def _update_battery_percentage(self, voltage_mv: int) -> None:
+        """Ignore Xiaomi voltage reports, so they're not used to calculate battery percentage."""
+        # This device sends battery percentage reports which are handled using a XiaomiCluster and
+        # the inherited XiaomiPowerConfiguration cluster.
+        # This device might also send Xiaomi battery reports, so we only want to use those for the voltage attribute,
+        # but not for the battery percentage. XiaomiPowerConfiguration.battery_reported() still updates the voltage.
+
+
+class DriverE1(XiaomiCustomDevice):
+    """Aqara Curtain Driver E1 device."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.curtain.agl001")],
+        ENDPOINTS: {
+            # <SizePrefixedSimpleDescriptor endpoint=1 profile=260 device_type=263
+            # device_version=1
+            # input_clusters=[0, 1, 3, 10, 258, 64704]
+            # output_clusters=[3, 10, 25, 64704]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Time.cluster_id,
+                    WindowCovering.cluster_id,
+                    XiaomiAqaraDriverE1.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                    XiaomiAqaraDriverE1.cluster_id,
+                ],
+            }
+        },
+    }
+    replacement = {
+        # TODO: needed?
+        # NODE_DESCRIPTOR: NodeDescriptor(
+        #     0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
+        # ),
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    PowerConfigurationDriverE1,
+                    Identify.cluster_id,
+                    Time.cluster_id,
+                    WindowCoveringE1,
+                    XiaomiAqaraDriverE1,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                    # XiaomiAqaraDriverE1, # TODO: keep in OUTPUT too?
+                ],
+            }
+        },
+    }

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -45,17 +45,18 @@ class XiaomiAqaraDriverE1(XiaomiAqaraE1Cluster):
 class WindowCoveringE1(CustomCluster, WindowCovering):
     """Xiaomi Window Covering cluster that inverts the motor direction if needed."""
 
-    def _update_attribute(self, attrid, value):
-        if attrid == WindowCovering.AttributeDefs.current_position_lift_percentage.id:
-            # TODO: improve this check? remove default? initialize? does the motor save this attr?
-            # TODO: should we do this in HA? (does it have a way now to invert motor?)
-            # TODO: should this always be reversed?
-            if (
-                self.get(WindowCovering.AttributeDefs.window_covering_mode.id, 0)
-                & WindowCovering.WindowCoveringMode.Motor_direction_reversed
-            ):
-                value = 100 - value
-        super()._update_attribute(attrid, value)
+    # TODO: commented out for now
+    # def _update_attribute(self, attrid, value):
+    #     if attrid == WindowCovering.AttributeDefs.current_position_lift_percentage.id:
+    #         # TODO: improve this check? remove default? initialize? does the motor save this attr?
+    #         # TODO: should we do this in HA? (does it have a way now to invert motor?)
+    #         # TODO: should this always be reversed?
+    #         if (
+    #             self.get(WindowCovering.AttributeDefs.window_covering_mode.id, 0)
+    #             & WindowCovering.WindowCoveringMode.Motor_direction_reversed
+    #         ):
+    #             value = 100 - value
+    #     super()._update_attribute(attrid, value)
 
     async def command(
         self,

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -65,7 +65,7 @@ class XiaomiAqaraDriverE1(XiaomiAqaraE1Cluster):
 
 
 class WindowCoveringE1(CustomCluster, WindowCovering):
-    """Xiaomi Window Covering cluster that inverts the motor direction if needed."""
+    """Xiaomi Window Covering cluster that maps open/close to lift percentage."""
 
     async def command(
         self,

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -22,9 +22,9 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.xiaomi import (
+    LUMI,
     BasicCluster,
     IlluminanceMeasurementCluster,
-    LUMI,
     XiaomiAqaraE1Cluster,
     XiaomiCluster,
     XiaomiCustomDevice,

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -26,7 +26,6 @@ from zhaquirks.xiaomi import (
     BasicCluster,
     IlluminanceMeasurementCluster,
     XiaomiAqaraE1Cluster,
-    XiaomiCluster,
     XiaomiCustomDevice,
     XiaomiPowerConfiguration,
 )
@@ -42,7 +41,7 @@ LIGHT_LEVEL = 0x0429
 class XiaomiAqaraDriverE1(XiaomiAqaraE1Cluster):
     """Xiaomi mfg cluster implementation specific for E1 Driver."""
 
-    attributes = XiaomiCluster.attributes.copy()
+    attributes = XiaomiAqaraE1Cluster.attributes.copy()
     attributes.update(
         {
             HAND_OPEN: ("hand_open", t.Bool, True),


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
~~https://github.com/zigpy/zha-device-handlers/pull/2620 should be merged first. This PR then needs to be rebased (for the test file).~~
This PR will be merged first, other than rebased. It'll use some cluster classes from this PR.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Supersedes https://github.com/zigpy/zha-device-handlers/pull/1648
Fixes #2003

Changes are all untested. I'm also not sure if this is the right way to use the motor mode. It's in the original quirk and a HA PR for the inverted motor mode has already been merged (even though the quirk was never merged).

There are still some TODOs in the PR (which is also why `pre-commit` fails).

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
