### PR TITLE
Add Tuya Basic Valve TS0601 `_TZE200_1n2zev06` (#2633)

### DIFF
--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -137,6 +137,45 @@ class TuyaValve(CustomDevice):
     }
 
 
+class BasicTuyaValve(CustomDevice):
+    """Basic Tuya valve device."""
+
+    signature = {
+        MODELS_INFO: [("_TZE200_1n2zev06", "TS0601")],
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=81, device_version=1,
+        # input_clusters=[0, 4, 5, 61184], output_clusters=[25, 10])
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaValveManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaOnOff,
+                    TuyaValveManufCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            }
+        }
+    }
+
+
 class ParksideTuyaValveManufCluster(TuyaMCUCluster):
     """Manufacturer Specific Cluster for the _TZE200_htnnfasr water valve sold as PARKSIDE."""
 

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -51,6 +51,7 @@ class TuyaValveManufCluster(TuyaMCUCluster):
             0xEF02: ("state", t.enum8, True),
             0xEF03: ("last_valve_open_duration", t.uint32_t, True),
             0xEF04: ("dp_6", t.uint32_t, True),
+            0xEF05: ("valve_position", t.uint32_t, True),
         }
     )
 
@@ -83,6 +84,10 @@ class TuyaValveManufCluster(TuyaMCUCluster):
             TuyaMCUCluster.ep_attribute,
             "last_valve_open_duration",
         ),
+        102: DPToAttributeMapping(
+            TuyaMCUCluster.ep_attribute,
+            "valve_position",
+        ),
     }
 
     data_point_handlers = {
@@ -93,6 +98,7 @@ class TuyaValveManufCluster(TuyaMCUCluster):
         11: "_dp_2_attr_update",
         12: "_dp_2_attr_update",
         15: "_dp_2_attr_update",
+        102: "_dp_2_attr_update",
     }
 
 


### PR DESCRIPTION
Frankever Smart Water Valve (https://frankever.com/smart-watering-system)

## Proposed change
Adds Support for a Basic Tuya Water Valve, in my instance Frankever Smart Water Valve.
This water Valve only supports the `OnOff` cluster and has no other configurable functions.

This quirk fixes the ability to trigger the valve on and off.

## Additional information
Fixes #2633 

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
