### PR TITLE
Add "power outage memory" support for Aqara ceiling light L1-350

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1509,3 +1509,33 @@ async def test_xiaomi_e1_roller_commands_2(zigpy_device_from_quirk, command, val
     assert (
         analog_cluster._write_attributes.call_args[0][0][0].value.value == 100 - value
     )
+
+
+def test_aqara_acn003_signature_match(assert_signature_matches_quirk):
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.FullFunctionDevice|MainsPowered|RxOnWhenIdle|AllocateAddress: 142>, manufacturer_code=4447, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 0x0104,
+                "device_type": "0x0102",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0003",
+                    "0x0004",
+                    "0x0005",
+                    "0x0006",
+                    "0x0008",
+                    "0x0300",
+                    "0xfcc0",
+                ],
+                "out_clusters": ["0x000a", "0x0019"],
+            }
+        },
+        "manufacturer": "Aqara",
+        "model": "lumi.light.acn003",
+        "class": "aqara_light.LumiLightAcn003",
+    }
+
+    assert_signature_matches_quirk(
+        zhaquirks.xiaomi.aqara.light_acn.LumiLightAcn003, signature
+    )

--- a/zhaquirks/xiaomi/aqara/light_acn.py
+++ b/zhaquirks/xiaomi/aqara/light_acn.py
@@ -31,10 +31,10 @@ class OppleClusterLight(XiaomiAqaraE1Cluster):
 
 
 class LumiLightAcn003(XiaomiCustomDevice):
-    """Aqara ceiling light L1-350 also known as Xiaomi ZNXDD01LM.
+    """Quirk for Aqara ceiling light L1-350 also known as Xiaomi ZNXDD01LM.
 
     Provides dimmable light control with color temperature setting.
-    This quirk adds support for power on behavior by adding OppleCluster.power_outage_memory attribute.
+    This quirk adds support for power on behavior by adding the power_outage_memory attribute.
     """
 
     signature = {
@@ -53,7 +53,7 @@ class LumiLightAcn003(XiaomiCustomDevice):
                     OnOff.cluster_id,  # 0x0006
                     LevelControl.cluster_id,  # 0x0008
                     Color.cluster_id,  # 0x0300
-                    OppleClusterLight.cluster_id,  # 0xFCC0 - Manufacture Specific
+                    OppleClusterLight.cluster_id,  # 0xFCC0 - manufacturer specific
                 ],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,  # 0x000A

--- a/zhaquirks/xiaomi/aqara/light_acn.py
+++ b/zhaquirks/xiaomi/aqara/light_acn.py
@@ -1,0 +1,86 @@
+from zigpy import types as t
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import (
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+from zigpy.zcl.clusters.lighting import Color
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import BasicCluster, XiaomiAqaraE1Cluster, XiaomiCustomDevice
+
+
+class OppleClusterLight(XiaomiAqaraE1Cluster):
+    """Add Opple cluster for power outage memory attribute."""
+
+    attributes = {
+        0x0201: ("power_outage_memory", t.Bool, True),
+    }
+
+
+class LumiLightAcn003(XiaomiCustomDevice):
+    """Aqara ceiling light L1-350 also known as Xiaomi ZNXDD01LM.
+
+    Provides dimmable light control with color temperature setting.
+    This quirk adds support for power on behavior by adding OppleCluster.power_outage_memory attribute.
+    """
+
+    signature = {
+        MODELS_INFO: [
+            ("Aqara", "lumi.light.acn003"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    BasicCluster.cluster_id,  # 0x0000
+                    Identify.cluster_id,  # 0x0003
+                    Groups.cluster_id,  # 0x0004
+                    Scenes.cluster_id,  # 0x0005
+                    OnOff.cluster_id,  # 0x0006
+                    LevelControl.cluster_id,  # 0x0008
+                    Color.cluster_id,  # 0x0300
+                    OppleClusterLight.cluster_id,  # 0xFCC0 - Manufacture Specific
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,  # 0x000A
+                    Ota.cluster_id,  # 0x0019
+                ],
+            }
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,  # 0x0003
+                    Groups.cluster_id,  # 0x0004
+                    Scenes.cluster_id,  # 0x0005
+                    OnOff.cluster_id,  # 0x0006
+                    LevelControl.cluster_id,  # 0x0008
+                    Color.cluster_id,  # 0x0300
+                    OppleClusterLight,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,  # 0x000A
+                    Ota.cluster_id,  # 0x0019
+                ],
+            }
+        }
+    }


### PR DESCRIPTION
## Proposed change
This quirk adds support for power on behavior configuration of the device. Fixes #2649

## Additional information
Test just verifies that signature definition is correct

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
