### PR TITLE
Set `ep_attribute` of Xiaomi class to `"opple_cluster"`

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -49,7 +49,6 @@ from zhaquirks.xiaomi import (
     XIAOMI_AQARA_ATTRIBUTE_E1,
     XIAOMI_NODE_DESC,
     BasicCluster,
-    XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
     XiaomiQuickInitDevice,
     handle_quick_init,
@@ -1341,7 +1340,7 @@ async def test_xiaomi_t1_door_sensor(
     assert on_off_listener.attribute_updates[1][0] == OnOff.AttributeDefs.on_off.id
     assert on_off_listener.attribute_updates[1][1] == t.Bool.false
 
-    opple_cluster = device.endpoints[1].in_clusters[XiaomiAqaraE1Cluster.cluster_id]
+    opple_cluster = device.endpoints[1].opple_cluster
     ClusterListener(opple_cluster)
 
     power_cluster = device.endpoints[1].power
@@ -1422,7 +1421,7 @@ async def test_xiaomi_e1_driver_light_level(
     """Test Aqara E1 driver light level cluster conversion."""
     device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.driver_curtain_e1.DriverE1)
 
-    opple_cluster = device.endpoints[1].in_clusters[XiaomiAqaraE1Cluster.cluster_id]
+    opple_cluster = device.endpoints[1].opple_cluster
     opple_listener = ClusterListener(opple_cluster)
     opple_zcl_iilluminance_id = 0x0429
 

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -447,6 +447,7 @@ class XiaomiAqaraE1Cluster(XiaomiCluster, ManufacturerSpecificCluster):
     """Xiaomi mfg cluster implementation."""
 
     cluster_id = 0xFCC0
+    ep_attribute = "opple_cluster"
 
 
 class BinaryOutputInterlock(CustomCluster, BinaryOutput):

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -18,7 +18,6 @@ from zigpy.zcl.clusters.general import (
     PowerConfiguration,
 )
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
-from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 from zigpy.zcl.clusters.measurement import (
     IlluminanceMeasurement,
     PressureMeasurement,
@@ -443,7 +442,7 @@ class BasicCluster(XiaomiCluster, Basic):
     """Xiaomi basic cluster implementation."""
 
 
-class XiaomiAqaraE1Cluster(XiaomiCluster, ManufacturerSpecificCluster):
+class XiaomiAqaraE1Cluster(XiaomiCluster):
     """Xiaomi mfg cluster implementation."""
 
     cluster_id = 0xFCC0

--- a/zhaquirks/xiaomi/aqara/feeder_acn001.py
+++ b/zhaquirks/xiaomi/aqara/feeder_acn001.py
@@ -96,7 +96,6 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         Manual = 0x00
         Schedule = 0x01
 
-    ep_attribute: str = "opple_cluster"
     attributes = {
         ZCL_FEEDING: ("feeding", types.Bool, True),
         ZCL_LAST_FEEDING_SOURCE: ("last_feeding_source", FeedingSource, True),

--- a/zhaquirks/xiaomi/aqara/illumination.py
+++ b/zhaquirks/xiaomi/aqara/illumination.py
@@ -74,7 +74,6 @@ class Illumination(XiaomiCustomDevice):
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Opple cluster with configurable detection interval."""
 
-    ep_attribute = "opple_cluster"
     attributes = {
         0x0000: ("detection_interval", types.uint16_t, True),
     }

--- a/zhaquirks/xiaomi/aqara/motion_ac01.py
+++ b/zhaquirks/xiaomi/aqara/motion_ac01.py
@@ -53,7 +53,6 @@ class AqaraPresenceEvents(types.enum8):
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Opple cluster."""
 
-    ep_attribute = "opple_cluster"
     attributes = {
         PRESENCE: ("presence", types.uint8_t, True),
         MONITORING_MODE: ("monitoring_mode", types.uint8_t, True),

--- a/zhaquirks/xiaomi/aqara/motion_ac02.py
+++ b/zhaquirks/xiaomi/aqara/motion_ac02.py
@@ -37,7 +37,6 @@ _LOGGER = logging.getLogger(__name__)
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Opple cluster."""
 
-    ep_attribute = "opple_cluster"
     attributes = {
         DETECTION_INTERVAL: ("detection_interval", types.uint8_t, True),
         MOTION_SENSITIVITY: ("motion_sensitivity", types.uint8_t, True),

--- a/zhaquirks/xiaomi/aqara/motion_agl04.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl04.py
@@ -33,7 +33,6 @@ MOTION_SENSITIVITY = 0x010C
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Opple cluster."""
 
-    ep_attribute = "opple_cluster"
     attributes = {
         DETECTION_INTERVAL: ("detection_interval", types.uint8_t, True),
         MOTION_SENSITIVITY: ("motion_sensitivity", types.uint8_t, True),

--- a/zhaquirks/xiaomi/aqara/plug_eu.py
+++ b/zhaquirks/xiaomi/aqara/plug_eu.py
@@ -60,7 +60,6 @@ async def remove_from_ep(dev: zigpy.device.Device) -> None:
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Opple cluster."""
 
-    ep_attribute = "opple_cluster"
     attributes = {
         0x0009: ("mode", types.uint8_t, True),
         0x0201: ("power_outage_memory", types.Bool, True),

--- a/zhaquirks/xiaomi/aqara/remote_h1.py
+++ b/zhaquirks/xiaomi/aqara/remote_h1.py
@@ -54,8 +54,6 @@ BOTH_BUTTONS = "both_buttons"
 class AqaraRemoteManuSpecificCluster(XiaomiAqaraE1Cluster):
     """Aqara manufacturer specific settings."""
 
-    ep_attribute = "aqara_cluster"
-
     # manufacture override code: 4447 (0x115f)
     # to get/set these attributes, you might need to click the button 5 times
     # quickly.

--- a/zhaquirks/xiaomi/aqara/smoke.py
+++ b/zhaquirks/xiaomi/aqara/smoke.py
@@ -50,7 +50,6 @@ SMOKE_DENSITY_DBM_MAP = {
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Opple cluster."""
 
-    ep_attribute = "opple_cluster"
     attributes = {
         BUZZER_MANUAL_MUTE: ("buzzer_manual_mute", types.uint8_t, True),
         SELF_TEST: ("self_test", types.Bool, True),

--- a/zhaquirks/xiaomi/aqara/switch_t1.py
+++ b/zhaquirks/xiaomi/aqara/switch_t1.py
@@ -40,7 +40,6 @@ from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Xiaomi Aqara T1 relay cluster."""
 
-    ep_attribute = "opple_cluster"
     attributes = {
         0x000A: ("switch_type", t.uint8_t, True),
         0x0201: ("power_outage_memory", t.Bool, True),

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -126,8 +126,6 @@ class ThermostatCluster(CustomCluster, Thermostat):
 class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
     """Aqara manufacturer specific settings."""
 
-    ep_attribute = "opple_cluster"
-
     attributes = XiaomiAqaraE1Cluster.attributes.copy()
     attributes.update(
         {

--- a/zhaquirks/xiaomi/aqara/tvoc.py
+++ b/zhaquirks/xiaomi/aqara/tvoc.py
@@ -79,7 +79,6 @@ class TVOCDisplayUnit(t.enum_factory(t.uint8_t)):
 class TVOCCluster(XiaomiAqaraE1Cluster):
     """Aqara LUMI Config cluster."""
 
-    ep_attribute = "aqara_cluster"
     attributes = {
         DISPLAY_UNIT: ("display_unit", TVOCDisplayUnit, True),
     }


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This sets `ep_attribute = "opple_cluster"` in the `XiaomiAqaraE1Cluster` class and removes the assignment from all classes that inherit from this class.

Two quirks also used `"aqara_cluster"` as the `ep_attribute` instead. All quirks seem to have "standardized" upon using `"opple_cluster"` as the `ep_attribute`. So this PR also changes those two quirks.

From what I can see, the `ep_attribute` of those two quirks was never used anywhere, so we are free to change it without causing any issues. This addresses part of the late review in https://github.com/zigpy/zha-device-handlers/pull/2408/files#r1236909366

Lastly, it also removes inheriting `ManufacturerSpecificCluster` in `XiaomiAqaraE1Cluster`. 
`ManufacturerSpecificCluster` marks `name` and `ep_attribute` as `Final`, but we're re-assigning them.
There's no reason to inherit from `ManufacturerSpecificCluster` in this case. It's mostly used as an internal class for zigpy for non-quirked devices.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
