### PR TITLE
Clean up illuminance cluster code for Aqara P1 motion sensor

### DIFF
--- a/zhaquirks/xiaomi/aqara/motion_ac02.py
+++ b/zhaquirks/xiaomi/aqara/motion_ac02.py
@@ -20,7 +20,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.xiaomi import (
-    IlluminanceMeasurementCluster,
+    LocalIlluminanceMeasurementCluster,
     MotionCluster,
     OccupancyCluster,
     XiaomiAqaraE1Cluster,
@@ -70,17 +70,8 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         return result
 
 
-class LocalIlluminanceMeasurementCluster(
-    LocalDataCluster, IlluminanceMeasurementCluster
-):
-    """Local illuminance measurement cluster."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        if self.AttributeDefs.measured_value.id not in self._attr_cache:
-            # put a default value so the sensor is created
-            self._update_attribute(self.AttributeDefs.measured_value.id, 0)
+class IlluminanceMeasurementClusterP1(LocalIlluminanceMeasurementCluster):
+    """Local illuminance measurement cluster that also discards more invalid values sent by this device."""
 
     def _update_attribute(self, attrid, value):
         if attrid == self.AttributeDefs.measured_value.id and (
@@ -146,7 +137,7 @@ class LumiMotionAC02(CustomDevice):
                     Identify.cluster_id,
                     LocalOccupancyCluster,
                     LocalMotionCluster,
-                    LocalIlluminanceMeasurementCluster,
+                    IlluminanceMeasurementClusterP1,
                     OppleCluster,
                 ],
                 OUTPUT_CLUSTERS: [


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This slightly cleans up the illuminance cluster class used by the Aqara P1 motion sensor class.
Other quirks now use the `LocalIlluminanceMeasurementCluster` class. The P1 motion sensor basically needs that class AND also needs to drop more invalid values, because earlier firmware versions of this device sent buggy values.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
There are unit tests since some recent PR that check if the invalid values are dropped. This still works as expected.

This PR is related to https://github.com/zigpy/zha-device-handlers/pull/2629/files which added the cluster to the "main Xiaomi file"


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
