### PR TITLE
Fix Aqara vibration sensor tilt angle calculation

### DIFF
--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -105,9 +105,9 @@ class VibrationAQ1(XiaomiQuickInitDevice):
                         SEND_EVENT, self._current_state[STATUS_TYPE_ATTR], {}
                     )
             elif attrid == ORIENTATION_ATTR:
-                x = value & 0xFFFF
-                y = (value >> 16) & 0xFFFF
-                z = (value >> 32) & 0xFFFF
+                x = ((value & 0xFFFF) ^ 0x8000) - 0x8000                        
+                y = (((value >> 16) & 0xFFFF) ^ 0x8000) - 0x8000                
+                z = (((value >> 32) & 0xFFFF) ^ 0x8000) - 0x8000
                 X = 0.0 + x
                 Y = 0.0 + y
                 Z = 0.0 + z


### PR DESCRIPTION
## Proposed change

DJT11LM device tilt angle conversion is repaired.


## Additional information
The calculation of the tilt angles is erroneous because the symbol bit is not respected, so the angles shown in the zha_event are erroneous and meaningless.


## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works


Fix the issue #2669 
