### PR TITLE
Add quirk IDs to Tuya plugs

### DIFF
--- a/zhaquirks/quirk_ids.py
+++ b/zhaquirks/quirk_ids.py
@@ -1,4 +1,4 @@
-"""Quirk IDs used for matching quirked devinces in ZHA."""
+"""Quirk IDs used for matching quirked devices in ZHA."""
 
 # Tuya
 TUYA_PLUG_ONOFF = "tuya.plug_on_off_attributes"

--- a/zhaquirks/quirk_ids.py
+++ b/zhaquirks/quirk_ids.py
@@ -1,5 +1,5 @@
 """Quirk IDs used for matching quirked devices in ZHA."""
 
 # Tuya
-TUYA_PLUG_ONOFF = "tuya.plug_on_off_attributes"
-TUYA_PLUG_MANUFACTURER = "tuya.plug_manufacturer_attributes"
+TUYA_PLUG_ONOFF = "tuya.plug_on_off_attributes"  # plugs with configurable attributes on the OnOff cluster
+TUYA_PLUG_MANUFACTURER = "tuya.plug_manufacturer_attributes"  # plugs with configurable attributes on a custom cluster

--- a/zhaquirks/quirk_ids.py
+++ b/zhaquirks/quirk_ids.py
@@ -1,0 +1,5 @@
+"""Quirk IDs used for matching quirked devinces in ZHA."""
+
+# Tuya
+TUYA_PLUG_ONOFF = "tuya.plug_on_off_attributes"
+TUYA_PLUG_MANUFACTURER = "tuya.plug_manufacturer_attributes"

--- a/zhaquirks/tuya/ts000x.py
+++ b/zhaquirks/tuya/ts000x.py
@@ -20,6 +20,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.quirk_ids import TUYA_PLUG_ONOFF
 from zhaquirks.tuya import (
     TuyaZBE000Cluster,
     TuyaZBElectricalMeasurement,
@@ -32,6 +33,8 @@ from zhaquirks.tuya.mcu import EnchantedDevice
 
 class Switch_1G_GPP(EnchantedDevice):
     """Tuya 1 gang switch module with restore power state support."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS0001",
@@ -88,6 +91,8 @@ class Switch_1G_GPP(EnchantedDevice):
 
 class Switch_1G_Metering(EnchantedDevice):
     """Tuya 1 gang switch with metering support."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS0001",
@@ -147,6 +152,8 @@ class Switch_1G_Metering(EnchantedDevice):
 
 class Switch_2G_GPP(EnchantedDevice):
     """Tuya 2 gang switch module with restore power state support."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS0002",
@@ -236,6 +243,8 @@ class Switch_2G_GPP(EnchantedDevice):
 class Switch_2G_Metering(EnchantedDevice):
     """Tuya 2 gang switch with metering support."""
 
+    quirk_id = TUYA_PLUG_ONOFF
+
     signature = {
         MODEL: "TS0002",
         ENDPOINTS: {
@@ -323,6 +332,8 @@ class Switch_2G_Metering(EnchantedDevice):
 
 class Switch_2G_Var03(EnchantedDevice):
     """Tuya 2 gang (variation 03)."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS0002",
@@ -415,6 +426,8 @@ class Switch_2G_Var03(EnchantedDevice):
 
 class Switch_3G_GPP(EnchantedDevice):
     """Tuya 3 gang switch module with restore power state support."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS0003",
@@ -530,6 +543,8 @@ class Switch_3G_GPP(EnchantedDevice):
 class Switch_3G_Metering(EnchantedDevice):
     """Tuya 3 gang switch with metering support."""
 
+    quirk_id = TUYA_PLUG_ONOFF
+
     signature = {
         MODEL: "TS0003",
         ENDPOINTS: {
@@ -640,6 +655,8 @@ class Switch_3G_Metering(EnchantedDevice):
 
 class Switch_3G_GPP_Var2(EnchantedDevice):
     """Tuya 3 gang switch module."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS0003",
@@ -753,6 +770,8 @@ class Switch_3G_GPP_Var2(EnchantedDevice):
 
 class Switch_4G_GPP(EnchantedDevice):
     """Tuya 4 gang switch module with restore power state support."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS0004",
@@ -894,6 +913,8 @@ class Switch_4G_GPP(EnchantedDevice):
 class Switch_4G_Metering(EnchantedDevice):
     """Tuya 4 gang switch with metering support."""
 
+    quirk_id = TUYA_PLUG_ONOFF
+
     signature = {
         MODEL: "TS0004",
         ENDPOINTS: {
@@ -1027,6 +1048,8 @@ class Switch_4G_Metering(EnchantedDevice):
 
 class Switch_4G_GPP_Var2(EnchantedDevice):
     """Tuya 4 gang switch module."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS0004",

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -26,6 +26,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.quirk_ids import TUYA_PLUG_ONOFF
 from zhaquirks.tuya import (
     TuyaNewManufCluster,
     TuyaZB1888Cluster,
@@ -41,6 +42,8 @@ from zhaquirks.tuya.mcu import EnchantedDevice
 
 class Plug(EnchantedDevice):
     """Tuya plug with restore power state support."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS011F",
@@ -102,6 +105,8 @@ class Plug(EnchantedDevice):
 class Plug_1AC(CustomDevice):
     """Tuya plug without metering with restore power state support."""
 
+    quirk_id = TUYA_PLUG_ONOFF
+
     signature = {
         MODEL: "TS011F",
         ENDPOINTS: {
@@ -159,6 +164,8 @@ class Plug_1AC(CustomDevice):
 
 class Plug_2AC_2USB(EnchantedDevice):
     """Tuya 2 outlet + 2 USB with restore power state support."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODELS_INFO: [("_TZ3000_3zofvcaa", "TS011F")],
@@ -297,6 +304,8 @@ class Plug_2AC_2USB(EnchantedDevice):
 class Plug_3AC_4USB(CustomDevice):
     """Tuya 3 outlet + 4 USB with restore power state support."""
 
+    quirk_id = TUYA_PLUG_ONOFF
+
     signature = {
         MODEL: "TS011F",
         ENDPOINTS: {
@@ -406,6 +415,8 @@ class Plug_3AC_4USB(CustomDevice):
 
 class Plug_4AC_2USB(CustomDevice):
     """Tuya 4 outlet + 2 USB surge protector with restore power state support."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS011F",
@@ -589,6 +600,8 @@ class Plug_4AC_2USB(CustomDevice):
 class Plug_TZ3210_2AC(CustomDevice):
     """TS0011F 2 outlet plug."""
 
+    # quirk_id = TUYA_PLUG_ONOFF  # TODO: Why does this quirk not have OnOffAttributeCluster??
+
     signature = {
         MODEL: "TS011F",
         ENDPOINTS: {
@@ -682,6 +695,8 @@ class Plug_TZ3210_2AC(CustomDevice):
 class Plug_TZ3210_1AC(CustomDevice):
     """TS0011F 1 outlet plug."""
 
+    # quirk_id = TUYA_PLUG_ONOFF  # TODO: Why does this quirk not have OnOffAttributeCluster??
+
     signature = {
         MODEL: "TS011F",
         ENDPOINTS: {
@@ -746,6 +761,8 @@ class Plug_TZ3210_1AC(CustomDevice):
 
 class Plug_4AC_2USB_cfnprab5(EnchantedDevice):
     """Tuya 4 outlet + 2 USB surge protector with restore power state support."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS011F",
@@ -913,6 +930,8 @@ class Plug_4AC_2USB_cfnprab5(EnchantedDevice):
 class Plug_4AC_2USB_Metering(EnchantedDevice):
     """Tuya Tuya 4 outlet + 2 USB with power metering."""
 
+    quirk_id = TUYA_PLUG_ONOFF
+
     signature = {
         MODEL: "TS011F",
         ENDPOINTS: {
@@ -1031,6 +1050,8 @@ class Plug_4AC_2USB_Metering(EnchantedDevice):
 class Plug_v2(EnchantedDevice):
     """Another TS011F Tuya plug. First one using this definition is _TZ3000_okaz9tjs."""
 
+    quirk_id = TUYA_PLUG_ONOFF
+
     signature = {
         MODEL: "TS011F",
         ENDPOINTS: {
@@ -1078,6 +1099,8 @@ class Plug_v2(EnchantedDevice):
 
 class Plug_v3(EnchantedDevice):
     """Tuya TS011F plug. One plug is _Tz3000_0Zfrhq4I."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS011F",
@@ -1150,6 +1173,8 @@ class Plug_v3(EnchantedDevice):
 class Plug_2AC_var03(CustomDevice):
     """Tuya 2 socket wall outlet with child lock and power-restore state support."""
 
+    quirk_id = TUYA_PLUG_ONOFF
+
     signature = {
         MODEL: "TS011F",
         ENDPOINTS: {
@@ -1220,6 +1245,8 @@ class Plug_2AC_var03(CustomDevice):
 class Plug_CB_Metering(EnchantedDevice):
     """Circuit breaker with monitoring, e.g. Tongou TO-Q-SY1-JZT. First one using this definition was _TZ3000_qeuvnohg."""
 
+    quirk_id = TUYA_PLUG_ONOFF
+
     signature = {
         MODEL: "TS011F",
         MODELS_INFO: [("_TZ3000_qeuvnohg", "TS011F")],
@@ -1287,6 +1314,8 @@ class Plug_CB_Metering(EnchantedDevice):
 
 class Plug_2AC_var05(EnchantedDevice):
     """Immax TS0011F 2 outlet plug."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS011F",

--- a/zhaquirks/tuya/ts0121_plug.py
+++ b/zhaquirks/tuya/ts0121_plug.py
@@ -22,6 +22,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.quirk_ids import TUYA_PLUG_ONOFF
 from zhaquirks.tuya import (
     TuyaNewManufCluster,
     TuyaZBE000Cluster,
@@ -34,6 +35,8 @@ from zhaquirks.tuya import (
 
 class Plug(CustomDevice):
     """Tuya TS0121 plug with restore tuya power state support."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS0121",
@@ -78,6 +81,8 @@ class Plug(CustomDevice):
 
 class TS0121B(CustomDevice):
     """Tuya TS0121 plug with restore tuya power state support and ZGP endpoint."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS0121",
@@ -136,6 +141,8 @@ class TS0121B(CustomDevice):
 
 class TS0121_Var03(CustomDevice):
     """Tuya TS0121 plug DeviceType.MAIN_POWER_OUTLET."""
+
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS0121",

--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -10,6 +10,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.quirk_ids import TUYA_PLUG_MANUFACTURER
 from zhaquirks.tuya import TuyaSwitch
 from zhaquirks.tuya.mcu import (
     MoesSwitchManufCluster,
@@ -21,6 +22,8 @@ from zhaquirks.tuya.mcu import (
 
 class TuyaSingleSwitchTI(TuyaSwitch):
     """Tuya single channel switch time on in cluster device."""
+
+    quirk_id = TUYA_PLUG_MANUFACTURER
 
     signature = {
         # "node_descriptor": "<NodeDescriptor byte1=1 byte2=64 mac_capability_flags=142 manufacturer_code=4098
@@ -67,6 +70,8 @@ class TuyaSingleSwitchTI(TuyaSwitch):
 
 class TuyaSingleSwitchTO(TuyaSwitch):
     """Tuya single channel switch time on out cluster device."""
+
+    quirk_id = TUYA_PLUG_MANUFACTURER
 
     signature = {
         # "node_descriptor": "<NodeDescriptor byte1=1 byte2=64 mac_capability_flags=142 manufacturer_code=4098
@@ -176,6 +181,8 @@ class TuyaSingleSwitch_GP(TuyaSwitch):
 class TuyaDoubleSwitchTO(TuyaSwitch):
     """Tuya double channel switch time on out cluster device."""
 
+    quirk_id = TUYA_PLUG_MANUFACTURER
+
     signature = {
         # "node_descriptor": "<NodeDescriptor byte1=1 byte2=64 mac_capability_flags=142 manufacturer_code=4098
         #                       maximum_buffer_size=82 maximum_incoming_transfer_size=82 server_mask=11264
@@ -230,6 +237,8 @@ class TuyaDoubleSwitchTO(TuyaSwitch):
 
 class TuyaDoubleSwitch_GP(TuyaSwitch):
     """Tuya double channel switch with GreenPowerProxy cluster device."""
+
+    quirk_id = TUYA_PLUG_MANUFACTURER
 
     signature = {
         MODELS_INFO: [
@@ -297,6 +306,8 @@ class TuyaDoubleSwitch_GP(TuyaSwitch):
 class TuyaTripleSwitchTO(TuyaSwitch):
     """Tuya triple channel switch time on out cluster device."""
 
+    quirk_id = TUYA_PLUG_MANUFACTURER
+
     signature = {
         MODELS_INFO: [
             # ("_TZE200_kyfqmmyl", "TS0601"),  ## candidate reported in #716
@@ -352,6 +363,8 @@ class TuyaTripleSwitchTO(TuyaSwitch):
 
 class TuyaTripleSwitch_GP(TuyaSwitch):
     """Tuya triple channel switch with GreenPowerProxy cluster device."""
+
+    quirk_id = TUYA_PLUG_MANUFACTURER
 
     signature = {
         MODELS_INFO: [
@@ -426,6 +439,8 @@ class TuyaTripleSwitch_GP(TuyaSwitch):
 
 class TuyaQuadrupleSwitchTO(TuyaSwitch):
     """Tuya quadruple channel switch time on out cluster device."""
+
+    quirk_id = TUYA_PLUG_MANUFACTURER
 
     signature = {
         MODELS_INFO: [
@@ -574,6 +589,8 @@ class TuyaQuadrupleSwitch_GP(TuyaSwitch):
 class TuyaSextupleSwitchTO(TuyaSwitch):
     """Tuya sextuple channel switch time on out cluster device."""
 
+    quirk_id = TUYA_PLUG_MANUFACTURER
+
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=81
         # input_clusters=[0x0000,0x0004,0x0005,0xEF00]
@@ -655,6 +672,8 @@ class TuyaSextupleSwitchTO(TuyaSwitch):
 
 class TuyaSextupleSwitchTO_GP(TuyaSwitch):
     """Tuya sextuple channel switch time on out cluster device with GreenPowerProxy cluster device."""
+
+    quirk_id = TUYA_PLUG_MANUFACTURER
 
     signature = {
         MODELS_INFO: [


### PR DESCRIPTION
## Proposed change
This adds quirk IDs which are later used in another Home Assistant PR to let ZHA match against these `quirk_ids`.


## Additional information
- Reference for base ZHA quirks ID PR: https://github.com/home-assistant/core/pull/102482

This PR can already be merged independently.

- These quirk IDs will be used by: https://github.com/home-assistant/core/pull/102489

## Checklist
- [x] The changes are tested and work correctly (with linked PRs above)
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
