### PR TITLE
Add "power outage memory" support for Aqara LED Bulb T1 (ZNLDP13LM)

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1539,3 +1539,58 @@ def test_aqara_acn003_signature_match(assert_signature_matches_quirk):
     assert_signature_matches_quirk(
         zhaquirks.xiaomi.aqara.light_acn.LumiLightAcn003, signature
     )
+
+
+def test_aqara_acn014_signature_match(assert_signature_matches_quirk):
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.FullFunctionDevice|MainsPowered|RxOnWhenIdle|AllocateAddress: 142>, manufacturer_code=4447, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 0x0104,
+                "device_type": "0x010c",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0002",
+                    "0x0003",
+                    "0x0004",
+                    "0x0005",
+                    "0x0006",
+                    "0x0008",
+                    "0x0009",
+                    "0x000c",
+                    "0x000f",
+                    "0x0012",
+                    "0x0300",
+                    "0x0702",
+                    "0x0b04",
+                    "0xfcc0",
+                ],
+                "out_clusters": ["0x000a", "0x0019"],
+            },
+            "21": {
+                "profile_id": 0x0104,
+                "device_type": "0x010c",
+                "in_clusters": ["0x000c"],
+                "out_clusters": [],
+            },
+            "31": {
+                "profile_id": 0x0104,
+                "device_type": "0x010c",
+                "in_clusters": ["0x000c"],
+                "out_clusters": [],
+            },
+            "242": {
+                "profile_id": 0xA1E0,
+                "device_type": "0x0061",
+                "in_clusters": [],
+                "out_clusters": ["0x0021"],
+            },
+        },
+        "manufacturer": "LUMI",
+        "model": "lumi.light.acn014",
+        "class": "zigpy.device.Device",
+    }
+
+    assert_signature_matches_quirk(
+        zhaquirks.xiaomi.aqara.light_acn.LumiLightAcn014, signature
+    )

--- a/zhaquirks/xiaomi/aqara/light_acn.py
+++ b/zhaquirks/xiaomi/aqara/light_acn.py
@@ -1,15 +1,23 @@
 from zigpy import types as t
-from zigpy.profiles import zha
+from zigpy.profiles import zgp, zha
 from zigpy.zcl.clusters.general import (
+    Alarms,
+    AnalogInput,
+    BinaryInput,
+    DeviceTemperature,
+    GreenPowerProxy,
     Groups,
     Identify,
     LevelControl,
+    MultistateInput,
     OnOff,
     Ota,
     Scenes,
     Time,
 )
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -19,7 +27,12 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.xiaomi import BasicCluster, XiaomiAqaraE1Cluster, XiaomiCustomDevice
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    XiaomiAqaraE1Cluster,
+    XiaomiCustomDevice,
+)
 
 
 class OppleClusterLight(XiaomiAqaraE1Cluster):
@@ -82,5 +95,101 @@ class LumiLightAcn003(XiaomiCustomDevice):
                     Ota.cluster_id,  # 0x0019
                 ],
             }
+        }
+    }
+
+
+class LumiLightAcn014(XiaomiCustomDevice):
+    """Quirk for Aqara LED Bulb T1 also known as Xiaomi ZNLDP13LM.
+
+    It identifies itself as lumi.light.acn014, however someone reported there are devices with the same model number
+    but identification lumi.light.cwac02.
+    Provides dimmable light control with color temperature setting.
+    This quirk adds support for power on behavior by adding power_outage_memory attribute.
+    """
+
+    signature = {
+        MODELS_INFO: [
+            (LUMI, "lumi.light.acn014"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                INPUT_CLUSTERS: [
+                    BasicCluster.cluster_id,  # 0x0000
+                    DeviceTemperature.cluster_id,  # 0x0002
+                    Identify.cluster_id,  # 0x0003
+                    Groups.cluster_id,  # 0x0004
+                    Scenes.cluster_id,  # 0x0005
+                    OnOff.cluster_id,  # 0x0006
+                    LevelControl.cluster_id,  # 0x0008
+                    Alarms.cluster_id,  # 0x0009
+                    AnalogInput.cluster_id,  # 0x000C
+                    BinaryInput.cluster_id,  # 0x000F
+                    MultistateInput.cluster_id,  # 0x0012
+                    Color.cluster_id,  # 0x0300
+                    Metering.cluster_id,  # 0x0702
+                    ElectricalMeasurement.cluster_id,  # 0x0B04
+                    OppleClusterLight.cluster_id,  # 0xFCC0 - Manufacture Specific
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,  # 0x000A
+                    Ota.cluster_id,  # 0x0019
+                ],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                INPUT_CLUSTERS: [
+                    AnalogInput.cluster_id,  # 0x000C
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            31: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                INPUT_CLUSTERS: [
+                    AnalogInput.cluster_id,  # 0x000C
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,  # 0x0021
+                ],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_TEMPERATURE_LIGHT,
+                INPUT_CLUSTERS: [
+                    BasicCluster,  # 0x0000
+                    DeviceTemperature.cluster_id,  # 0x0002
+                    Identify.cluster_id,  # 0x0003
+                    Groups.cluster_id,  # 0x0004
+                    Scenes.cluster_id,  # 0x0005
+                    OnOff.cluster_id,  # 0x0006
+                    LevelControl.cluster_id,  # 0x0008
+                    Alarms.cluster_id,  # 0x0009
+                    AnalogInput.cluster_id,  # 0x000C
+                    BinaryInput.cluster_id,  # 0x000F
+                    MultistateInput.cluster_id,  # 0x0012
+                    Color.cluster_id,  # 0x0300
+                    Metering.cluster_id,  # 0x0702
+                    ElectricalMeasurement.cluster_id,  # 0x0B04
+                    OppleClusterLight,  # 0xFCC0 - Manufacture Specific
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,  # 0x000A
+                    Ota.cluster_id,  # 0x0019
+                ],
+            },
         }
     }

--- a/zhaquirks/xiaomi/aqara/light_acn.py
+++ b/zhaquirks/xiaomi/aqara/light_acn.py
@@ -179,11 +179,8 @@ class LumiLightAcn014(XiaomiCustomDevice):
                     LevelControl.cluster_id,  # 0x0008
                     Alarms.cluster_id,  # 0x0009
                     AnalogInput.cluster_id,  # 0x000C
-                    BinaryInput.cluster_id,  # 0x000F
                     MultistateInput.cluster_id,  # 0x0012
                     Color.cluster_id,  # 0x0300
-                    Metering.cluster_id,  # 0x0702
-                    ElectricalMeasurement.cluster_id,  # 0x0B04
                     OppleClusterLight,  # 0xFCC0 - manufacturer specific
                 ],
                 OUTPUT_CLUSTERS: [

--- a/zhaquirks/xiaomi/aqara/light_acn.py
+++ b/zhaquirks/xiaomi/aqara/light_acn.py
@@ -188,5 +188,13 @@ class LumiLightAcn014(XiaomiCustomDevice):
                     Ota.cluster_id,  # 0x0019
                 ],
             },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,  # 0x0021
+                ],
+            },
         }
     }

--- a/zhaquirks/xiaomi/aqara/light_acn.py
+++ b/zhaquirks/xiaomi/aqara/light_acn.py
@@ -131,7 +131,7 @@ class LumiLightAcn014(XiaomiCustomDevice):
                     Color.cluster_id,  # 0x0300
                     Metering.cluster_id,  # 0x0702
                     ElectricalMeasurement.cluster_id,  # 0x0B04
-                    OppleClusterLight.cluster_id,  # 0xFCC0 - Manufacture Specific
+                    OppleClusterLight.cluster_id,  # 0xFCC0 - manufacturer specific
                 ],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,  # 0x000A
@@ -184,7 +184,7 @@ class LumiLightAcn014(XiaomiCustomDevice):
                     Color.cluster_id,  # 0x0300
                     Metering.cluster_id,  # 0x0702
                     ElectricalMeasurement.cluster_id,  # 0x0B04
-                    OppleClusterLight,  # 0xFCC0 - Manufacture Specific
+                    OppleClusterLight,  # 0xFCC0 - manufacturer specific
                 ],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,  # 0x000A


### PR DESCRIPTION
## Proposed change
This quirk adds support for power on behavior configuration to [Aqara LED Bulb T1 aka Xiaomi ZNLDP13LM](https://zigbee.blakadder.com/Aqara_ZNLDP13LM.html).

## Additional information
None


## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
