### PR TITLE
Add custom Tuya `OnOff` cluster to two TS011F models

### DIFF
--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -600,7 +600,7 @@ class Plug_4AC_2USB(CustomDevice):
 class Plug_TZ3210_2AC(CustomDevice):
     """TS0011F 2 outlet plug."""
 
-    # quirk_id = TUYA_PLUG_ONOFF  # TODO: Why does this quirk not have OnOffAttributeCluster??
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS011F",
@@ -663,7 +663,7 @@ class Plug_TZ3210_2AC(CustomDevice):
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    OnOff.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
                     TuyaZBMeteringCluster,
                     TuyaZBElectricalMeasurement,
                     TuyaNewManufCluster,
@@ -677,7 +677,7 @@ class Plug_TZ3210_2AC(CustomDevice):
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    OnOff.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
                     TuyaNewManufCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
@@ -695,7 +695,7 @@ class Plug_TZ3210_2AC(CustomDevice):
 class Plug_TZ3210_1AC(CustomDevice):
     """TS0011F 1 outlet plug."""
 
-    # quirk_id = TUYA_PLUG_ONOFF  # TODO: Why does this quirk not have OnOffAttributeCluster??
+    quirk_id = TUYA_PLUG_ONOFF
 
     signature = {
         MODEL: "TS011F",
@@ -742,7 +742,7 @@ class Plug_TZ3210_1AC(CustomDevice):
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    OnOff.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
                     TuyaZBMeteringCluster,
                     TuyaZBElectricalMeasurement,
                     TuyaNewManufCluster,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This also adds the custom Tuya `TuyaZBOnOffAttributeCluster` cluster to two more TS011F Tuya plug variations.
It seems like it was forgotten in the initial PR. All other plugs support this.

I noticed this during https://github.com/zigpy/zha-device-handlers/pull/2674, but wanted to have another commit for this, as  this change is more than just adding quirk IDs.

Having this custom cluster also allows us to add the `TUYA_PLUG_ONOFF` quirk ID, so ZHA will create config entities for this plug (in case the attributes are supported).

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Original PR (that likely missed this): https://github.com/zigpy/zha-device-handlers/pull/1460


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
