### PR TITLE
Fix attribute id for Inovelli fan switch VZM35-SN

### DIFF
--- a/zhaquirks/inovelli/__init__.py
+++ b/zhaquirks/inovelli/__init__.py
@@ -273,7 +273,7 @@ class Inovelli_VZM35SN_Cluster(Inovelli_VZM31SN_Cluster):
             0x001E: ("non_neutral_aux_med_gear_learn_value", t.uint8_t, True),
             0x001F: ("non_neutral_aux_low_gear_learn_value", t.uint8_t, True),
             0x0034: ("smart_fan_mode", t.Bool, True),
-            0x0106: ("smart_fan_led_display_levels", t.uint8_t, True),
+            0x0107: ("smart_fan_led_display_levels", t.uint8_t, True),
         }
     )
 


### PR DESCRIPTION
Smart Fan LED Display Levels is P263 instead of P262,

## Proposed change
<!--
  Explain your proposed change below.
-->
Smart Fan LED Display Levels is P263 instead of P262, updating the quirk to reflect that correction.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
