### PR TITLE
Add Tuya TS0601 PCIe on/off controller `_TZE204_6fk3gewc` support

### DIFF
--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -127,6 +127,7 @@ class TuyaSingleSwitch_GP(TuyaSwitch):
     signature = {
         MODELS_INFO: [
             ("_TZE200_gbagoilo", "TS0601"),  # reported in #1634
+            ("_TZE204_6fk3gewc", "TS0601"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=51 device_version=1


### PR DESCRIPTION
## Proposed change
<!--
  
-->
Add support for new device Tuya TS0601 PCIe on/off controller by _TZE204_6fk3gewc manufacturer. 
This device is working the exact same way as Tuya TS0601 device by _TZE200_gbagoilo manufacturer.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
