### PR TITLE
Add support for different Paulmann manufacturer name

### DIFF
--- a/tests/test_paulmann.py
+++ b/tests/test_paulmann.py
@@ -1,9 +1,12 @@
 """Tests for Paulmann quirks."""
 
+import pytest
+
 import zhaquirks.paulmann.fourbtnremote
 
 
-def test_fourbtnremote_signature(assert_signature_matches_quirk):
+@pytest.mark.parametrize("manufacturer", ("Paulmann LichtGmbH", "Paulmann Licht GmbH"))
+def test_fourbtnremote_signature(assert_signature_matches_quirk, manufacturer):
     """Test PaulmannRemote4Btn signature is matched to its quirk."""
     signature = {
         "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4644, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
@@ -39,7 +42,7 @@ def test_fourbtnremote_signature(assert_signature_matches_quirk):
                 ],
             },
         },
-        "manufacturer": "Paulmann LichtGmbH",
+        "manufacturer": manufacturer,
         "model": "501.34",
         "class": "paulmann.fourbtnremote.PaulmannRemote4Btn",
     }

--- a/zhaquirks/paulmann/__init__.py
+++ b/zhaquirks/paulmann/__init__.py
@@ -1,3 +1,4 @@
 """Paulmann module."""
 
 PAULMANN = "Paulmann LichtGmbH"
+PAULMANN_VARIANT = "Paulmann Licht GmbH"

--- a/zhaquirks/paulmann/fourbtnremote.py
+++ b/zhaquirks/paulmann/fourbtnremote.py
@@ -38,7 +38,7 @@ from zhaquirks.const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
-from zhaquirks.paulmann import PAULMANN
+from zhaquirks.paulmann import PAULMANN, PAULMANN_VARIANT
 
 
 class PaulmannRemote4Btn(CustomDevice):
@@ -49,7 +49,7 @@ class PaulmannRemote4Btn(CustomDevice):
         # device_version=0
         # input_clusters=[0, 1, 3, 2821, 4096]
         # output_clusters=[3, 4, 5, 6, 8, 25, 768, 4096]>
-        MODELS_INFO: [(PAULMANN, "501.34")],
+        MODELS_INFO: [(PAULMANN, "501.34"), (PAULMANN_VARIANT, "501.34")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Add support for slightly different Paulmann manufacturer name. Some switches have `Paulmann LichtGmbH`, newer models have `Paulmann Licht GmbH` as manufacturer name.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Fixes #2662 


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
