### PR TITLE
Remove unused loggers, empty constructors

### DIFF
--- a/zhaquirks/bitron/thermostat.py
+++ b/zhaquirks/bitron/thermostat.py
@@ -1,7 +1,5 @@
 """Module for Bitron/SMaBiT thermostats."""
 
-import logging
-
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -25,8 +23,6 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class Av201032PowerConfigurationCluster(PowerConfigurationCluster):

--- a/zhaquirks/centralite/__init__.py
+++ b/zhaquirks/centralite/__init__.py
@@ -1,10 +1,8 @@
 """Centralite module for custom device handlers."""
-import logging
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
 
-_LOGGER = logging.getLogger(__name__)
 CENTRALITE = "CentraLite"
 
 

--- a/zhaquirks/edpwithus/__init__.py
+++ b/zhaquirks/edpwithus/__init__.py
@@ -1,10 +1,7 @@
 """EDP WithUs module."""
-import logging
 
 from zigpy.quirks import CustomCluster
 from zigpy.zcl.clusters.smartenergy import Metering
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class MeteringCluster(CustomCluster, Metering):

--- a/zhaquirks/hivehome/mot003V0.py
+++ b/zhaquirks/hivehome/mot003V0.py
@@ -1,5 +1,4 @@
 """Device handler for hivehome.com MOT003 sensors."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -22,8 +21,6 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.hivehome import HIVEHOME, MotionCluster
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class MOT003(CustomDevice):

--- a/zhaquirks/hivehome/mot003V6.py
+++ b/zhaquirks/hivehome/mot003V6.py
@@ -1,5 +1,4 @@
 """Device handler for hivehome.com MOT003 sensors."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -25,8 +24,6 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.hivehome import HIVEHOME, MotionCluster
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class MOT003(CustomDevice):

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -1,5 +1,4 @@
 """Ikea module."""
-import logging
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
@@ -7,8 +6,6 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import PowerConfiguration, Scenes
 
 from zhaquirks import DoublingPowerConfigurationCluster, EventableCluster
-
-_LOGGER = logging.getLogger(__name__)
 
 IKEA = "IKEA of Sweden"
 IKEA_CLUSTER_ID = 0xFC7C  # decimal = 64636

--- a/zhaquirks/ikea/starkvind.py
+++ b/zhaquirks/ikea/starkvind.py
@@ -1,7 +1,6 @@
 """Device handler for IKEA of Sweden STARKVIND Air purifier."""
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from zigpy.profiles import zgp, zha
@@ -28,8 +27,6 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, WWAH_CLUSTER_ID
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class IkeaAirpurifier(CustomCluster):

--- a/zhaquirks/konke/button.py
+++ b/zhaquirks/konke/button.py
@@ -1,5 +1,4 @@
 """Konke Button Remote."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -31,8 +30,6 @@ from zhaquirks.const import (
 from zhaquirks.konke import KONKE, KonkeOnOffCluster
 
 KONKE_CLUSTER_ID = 0xFCC0
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class KonkeButtonRemote1(CustomDevice):

--- a/zhaquirks/mli/tint.py
+++ b/zhaquirks/mli/tint.py
@@ -1,5 +1,4 @@
 """Tint remote."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -28,8 +27,6 @@ from zhaquirks.const import (
 
 TINT_SCENE_ATTR = 0x4005
 
-_LOGGER = logging.getLogger(__name__)
-
 
 class TintRemoteScenesCluster(LocalDataCluster, Scenes):
     """Tint remote cluster."""
@@ -51,10 +48,6 @@ class TintRemoteBasicCluster(CustomCluster, Basic):
     """Tint remote cluster."""
 
     cluster_id = Basic.cluster_id
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
 
     def handle_cluster_general_request(self, hdr, args, *, dst_addressing=None):
         """Send write_attributes value to TintRemoteSceneCluster."""

--- a/zhaquirks/osram/lightifyx4.py
+++ b/zhaquirks/osram/lightifyx4.py
@@ -1,6 +1,5 @@
 """Osram Lightify X4 device."""
 import copy
-import logging
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -44,9 +43,6 @@ from zhaquirks.osram import OSRAM
 OSRAM_DEVICE = 0x0810  # 2064 base 10
 OSRAM_CLUSTER = 0xFD00  # 64768 base 10
 OSRAM_MFG_CODE = 0x110C
-
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class OsramButtonCluster(CustomCluster):

--- a/zhaquirks/samjin/__init__.py
+++ b/zhaquirks/samjin/__init__.py
@@ -1,5 +1,4 @@
 """Module for Samjin quirks implementations."""
-import logging
 from typing import Any, List, Optional, Union
 
 from zigpy.quirks import CustomCluster
@@ -8,8 +7,6 @@ from zigpy.zcl import foundation
 import zigpy.zcl.clusters.security
 
 from zhaquirks.const import ARGS, COMMAND_ID, PRESS_TYPE, ZHA_SEND_EVENT
-
-_LOGGER = logging.getLogger(__name__)
 
 DOUBLE = 2
 HOLD = 3

--- a/zhaquirks/samjin/button.py
+++ b/zhaquirks/samjin/button.py
@@ -1,5 +1,4 @@
 """Samjin button device."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -31,8 +30,6 @@ from zhaquirks.const import (
     SHORT_PRESS,
 )
 from zhaquirks.samjin import SAMJIN, SamjinIASCluster
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class SamjinButton(CustomDevice):

--- a/zhaquirks/samjin/button2.py
+++ b/zhaquirks/samjin/button2.py
@@ -1,5 +1,4 @@
 """Samjin button device."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -30,8 +29,6 @@ from zhaquirks.const import (
     SHORT_PRESS,
 )
 from zhaquirks.samjin import SAMJIN, SamjinIASCluster
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class SamjinButton(CustomDevice):

--- a/zhaquirks/siglis/zigfred.py
+++ b/zhaquirks/siglis/zigfred.py
@@ -115,11 +115,6 @@ class ZigfredCluster(CustomCluster):
 class ZigfredUno(CustomDevice):
     """zigfred uno device handler."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        _LOGGER.info("Initializing zigfred uno")
-        super().__init__(*args, **kwargs)
-
     signature = {
         MODELS_INFO: [("Siglis", "zigfred uno")],
         ENDPOINTS: {
@@ -266,11 +261,6 @@ class ZigfredUno(CustomDevice):
 
 class ZigfredPlus(CustomDevice):
     """zigfred plus device handler."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        _LOGGER.info("Initializing zigfred plus")
-        super().__init__(*args, **kwargs)
 
     signature = {
         MODELS_INFO: [("Siglis", "zigfred plus")],

--- a/zhaquirks/smartthings/tag_v4.py
+++ b/zhaquirks/smartthings/tag_v4.py
@@ -1,5 +1,4 @@
 """Device handler for smartthings tagV4 sensors."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -13,8 +12,6 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 ARRIVAL_SENSOR_DEVICE_TYPE = 0x8000
 

--- a/zhaquirks/sonoff/button.py
+++ b/zhaquirks/sonoff/button.py
@@ -1,6 +1,4 @@
 """Device handler for eWeLink WB01."""
-import logging
-
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Identify, OnOff, PowerConfiguration
@@ -22,15 +20,9 @@ from zhaquirks.const import (
     SHORT_PRESS,
 )
 
-_LOGGER = logging.getLogger(__name__)
-
 
 class SonoffButton(CustomDevice):
     """Custom device representing sonoff devices."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=0 device_version=0

--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -1,8 +1,6 @@
 """Tuya TS004F devices."""
 from __future__ import annotations
 
-import logging
-
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -64,8 +62,6 @@ from zhaquirks.tuya import (
     TuyaZBExternalSwitchTypeCluster,
 )
 from zhaquirks.tuya.mcu import EnchantedDevice
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class TuyaSmartRemote004FROK(EnchantedDevice):

--- a/zhaquirks/tuya/ts0210.py
+++ b/zhaquirks/tuya/ts0210.py
@@ -1,6 +1,5 @@
 """TS0210 vibration sensor."""
 
-import logging
 from typing import Optional, Tuple, Union
 
 from zigpy.profiles import zha
@@ -21,8 +20,6 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import TuyaManufCluster
-
-_LOGGER = logging.getLogger(__name__)
 
 ZONE_TYPE = 0x0001
 IAS_VIBRATION_SENSOR = 0x5F02

--- a/zhaquirks/tuya/ts0601_electric_heating.py
+++ b/zhaquirks/tuya/ts0601_electric_heating.py
@@ -1,5 +1,4 @@
 """Map from manufacturer to standard clusters for electric heating thermostats."""
-import logging
 
 from zigpy.profiles import zha
 import zigpy.types as t
@@ -30,8 +29,6 @@ MOESBHT_MANUAL_MODE_ATTR = 0x0402  # [1] false [0] true /!\ inverted
 MOESBHT_ENABLED_ATTR = 0x0101  # [0] off [1] on
 MOESBHT_RUNNING_MODE_ATTR = 0x0424  # [1] idle [0] heating /!\ inverted
 MOESBHT_CHILD_LOCK_ATTR = 0x0128  # [0] unlocked [1] child-locked
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class MoesBHTManufCluster(TuyaManufClusterAttributes):

--- a/zhaquirks/tuya/ts0601_haozee.py
+++ b/zhaquirks/tuya/ts0601_haozee.py
@@ -1,5 +1,4 @@
 """Map from manufacturer to standard clusters for thermostatic valves."""
-import logging
 
 import zigpy.profiles.zha
 import zigpy.types as t
@@ -71,8 +70,6 @@ HAOZEE_CURRENT_MODE_ATTR = 0x0480  # [0] manual [1] auto [2] away
 HAOZEE_FAULT_ATTR = 0x0582  # Known fault codes: [4] E2 external sensor error
 
 # Unknown DP - descaling on/off, window detection, window detection settings
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class HY08WEManufCluster(TuyaManufClusterAttributes):

--- a/zhaquirks/tuya/ts0601_siren.py
+++ b/zhaquirks/tuya/ts0601_siren.py
@@ -1,5 +1,4 @@
 """Map from manufacturer to standard clusters for the NEO Siren device."""
-import logging
 from typing import Dict, Optional, Union
 
 from zigpy.profiles import zgp, zha
@@ -49,8 +48,6 @@ TUYA_ALARM_MIN_HUMID_ATTR = 0x026D  # [0,0,0,18] min alarm humidity threshold
 TUYA_ALARM_MAX_HUMID_ATTR = 0x026E  # [0,0,0,18] max alarm humidity threshold
 TUYA_MELODY_ATTR = 0x0466  # [5] Melody
 TUYA_VOLUME_ATTR = 0x0474  # [0]/[1]/[2] Volume 0-low, 2-high
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class NeoAlarmVolume(t.enum8):

--- a/zhaquirks/visonic/mct340e.py
+++ b/zhaquirks/visonic/mct340e.py
@@ -1,5 +1,4 @@
 """Visonic MCT340E device."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -20,9 +19,6 @@ from zhaquirks.const import (
 
 OSRAM_DEVICE = 0x0810  # 2064 base 10
 OSRAM_CLUSTER = 0xFD00  # 64768 base 10
-
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):

--- a/zhaquirks/xiaomi/aqara/ctrl_neutral.py
+++ b/zhaquirks/xiaomi/aqara/ctrl_neutral.py
@@ -1,5 +1,4 @@
 """Xiaomi aqara single key wall switch devices."""
-import logging
 
 from zigpy import types as t
 from zigpy.profiles import zha
@@ -59,8 +58,6 @@ XIAOMI_CLUSTER_ID = 0xFFFF
 XIAOMI_DEVICE_TYPE = 0x5F01
 XIAOMI_DEVICE_TYPE2 = 0x5F02
 XIAOMI_DEVICE_TYPE3 = 0x5F03
-
-_LOGGER = logging.getLogger(__name__)
 
 # click attr 0xF000
 # single click 0x3FF1F00

--- a/zhaquirks/xiaomi/aqara/cube.py
+++ b/zhaquirks/xiaomi/aqara/cube.py
@@ -1,5 +1,4 @@
 """Xiaomi mija lumi cube device."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
@@ -146,8 +145,6 @@ SIDES = {
     KNOCK_5_VALUE: 5,
     KNOCK_6_VALUE: 6,
 }
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def extend_dict(dictionary, value, ranges):

--- a/zhaquirks/xiaomi/aqara/cube_aqgl01.py
+++ b/zhaquirks/xiaomi/aqara/cube_aqgl01.py
@@ -1,5 +1,4 @@
 """Xiaomi aqara magic cube device."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
@@ -142,8 +141,6 @@ SIDES = {
     KNOCK_5_VALUE: 5,
     KNOCK_6_VALUE: 6,
 }
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def extend_dict(dictionary, value, ranges):

--- a/zhaquirks/xiaomi/aqara/illumination.py
+++ b/zhaquirks/xiaomi/aqara/illumination.py
@@ -1,5 +1,4 @@
 """Quirk for Aqara illumination sensor."""
-import logging
 
 from zigpy.profiles import zha
 import zigpy.types as types
@@ -23,8 +22,6 @@ from zhaquirks.xiaomi import (
     XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class Illumination(XiaomiCustomDevice):

--- a/zhaquirks/xiaomi/aqara/light_aqcn2.py
+++ b/zhaquirks/xiaomi/aqara/light_aqcn2.py
@@ -1,5 +1,4 @@
 """Quirk for Xiaomi Aqara Smart LED bulb ZNLDP12LM."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.closures import WindowCovering
@@ -33,8 +32,6 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.xiaomi import LUMI, BasicCluster, XiaomiCustomDevice
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class LightAqcn02(XiaomiCustomDevice):

--- a/zhaquirks/xiaomi/aqara/magnet_aq2.py
+++ b/zhaquirks/xiaomi/aqara/magnet_aq2.py
@@ -1,5 +1,4 @@
 """Xiaomi aqara contact sensor device."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Groups, Identify, OnOff
@@ -25,8 +24,6 @@ from zhaquirks.xiaomi import (
 
 OPEN_CLOSE_DEVICE_TYPE = 0x5F01
 XIAOMI_CLUSTER_ID = 0xFFFF
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class MagnetAQ2(XiaomiQuickInitDevice):

--- a/zhaquirks/xiaomi/aqara/motion_ac01.py
+++ b/zhaquirks/xiaomi/aqara/motion_ac01.py
@@ -1,7 +1,6 @@
 """Quirk for aqara lumi.motion.ac01."""
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from zigpy.profiles import zha
@@ -32,8 +31,6 @@ MOTION_SENSITIVITY = 0x010C
 APPROACH_DISTANCE = 0x0146
 RESET_NO_PRESENCE_STATUS = 0x0157
 SENSOR = "sensor"
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class AqaraPresenceEvents(types.enum8):

--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -1,5 +1,4 @@
 """Xiaomi aqara opple remote devices."""
-import logging
 
 from zigpy.profiles import zha
 import zigpy.types as types
@@ -94,8 +93,6 @@ COMMAND_6_RELEASE = "6_release"
 
 OPPLE_CLUSTER_ID = 0xFCC0
 OPPLE_MFG_CODE = 0x115F
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class MultistateInputCluster(CustomCluster, MultistateInput):

--- a/zhaquirks/xiaomi/aqara/plug.py
+++ b/zhaquirks/xiaomi/aqara/plug.py
@@ -1,5 +1,4 @@
 """Xiaomi lumi.plug plug."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
@@ -33,8 +32,6 @@ from zhaquirks.xiaomi import (
     MeteringCluster,
     XiaomiCustomDevice,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class Plug(XiaomiCustomDevice):

--- a/zhaquirks/xiaomi/aqara/plug_eu.py
+++ b/zhaquirks/xiaomi/aqara/plug_eu.py
@@ -1,5 +1,4 @@
 """Xiaomi Aqara EU plugs."""
-import logging
 
 import zigpy
 from zigpy.profiles import zgp, zha
@@ -37,8 +36,6 @@ from zhaquirks.xiaomi import (
     XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 OPPLE_MFG_CODE = 0x115F
 

--- a/zhaquirks/xiaomi/aqara/plug_maus01.py
+++ b/zhaquirks/xiaomi/aqara/plug_maus01.py
@@ -1,5 +1,4 @@
 """Xiaomi lumi.plug.maus01 plug."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
@@ -35,8 +34,6 @@ from zhaquirks.xiaomi import (
     XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class Plug(XiaomiCustomDevice):

--- a/zhaquirks/xiaomi/aqara/relay_c2acn01.py
+++ b/zhaquirks/xiaomi/aqara/relay_c2acn01.py
@@ -1,5 +1,4 @@
 """Xiaomi lumi.relay.c2acn01 relay."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
@@ -34,8 +33,6 @@ from zhaquirks.xiaomi import (
     ElectricalMeasurementCluster,
     XiaomiCustomDevice,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class Relay(XiaomiCustomDevice):

--- a/zhaquirks/xiaomi/aqara/remote_b186acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b186acn01.py
@@ -1,5 +1,4 @@
 """Xiaomi aqara single key switch device."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
@@ -50,8 +49,6 @@ XIAOMI_CLUSTER_ID = 0xFFFF
 XIAOMI_DEVICE_TYPE = 0x5F01
 XIAOMI_DEVICE_TYPE2 = 0x5F02
 XIAOMI_DEVICE_TYPE3 = 0x5F03
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class RemoteB186ACN01(XiaomiQuickInitDevice):

--- a/zhaquirks/xiaomi/aqara/remote_b286acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b286acn01.py
@@ -1,5 +1,4 @@
 """Xiaomi aqara double key switch device."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
@@ -60,8 +59,6 @@ XIAOMI_CLUSTER_ID = 0xFFFF
 XIAOMI_DEVICE_TYPE = 0x5F01
 XIAOMI_DEVICE_TYPE2 = 0x5F02
 XIAOMI_DEVICE_TYPE3 = 0x5F03
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class RemoteB286ACN01(XiaomiCustomDevice):

--- a/zhaquirks/xiaomi/aqara/sensor_switch_aq3.py
+++ b/zhaquirks/xiaomi/aqara/sensor_switch_aq3.py
@@ -1,5 +1,4 @@
 """Xiaomi aqara button sensor."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Identify, MultistateInput, OnOff
@@ -55,8 +54,6 @@ MOVEMENT_TYPE = {
     B1ACN01_RELEASE: COMMAND_RELEASE,
     SHAKE: COMMAND_SHAKE,
 }
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class MultistateInputCluster(CustomCluster, MultistateInput):

--- a/zhaquirks/xiaomi/aqara/switch_aq2.py
+++ b/zhaquirks/xiaomi/aqara/switch_aq2.py
@@ -1,5 +1,4 @@
 """Xiaomi aqara button sensor."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Groups, OnOff
@@ -39,8 +38,6 @@ from zhaquirks.xiaomi import (
 BUTTON_DEVICE_TYPE = 0x5F01
 ON_OFF = "on_off"
 XIAOMI_CLUSTER_ID = 0xFFFF
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class SwitchAQ2(XiaomiQuickInitDevice):

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -1,5 +1,4 @@
 """Xiaomi aqara smart motion sensor device."""
-import logging
 import math
 
 from zigpy.profiles import zha
@@ -63,8 +62,6 @@ MEASUREMENT_TYPE = {
     TILT_VALUE: "Tilt",
     DROP_VALUE: "Drop",
 }
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class VibrationAQ1(XiaomiQuickInitDevice):

--- a/zhaquirks/xiaomi/aqara/weather.py
+++ b/zhaquirks/xiaomi/aqara/weather.py
@@ -1,5 +1,4 @@
 """Xiaomi aqara weather sensor device."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Groups, Identify
@@ -28,8 +27,6 @@ from zhaquirks.xiaomi import (
 
 TEMPERATURE_HUMIDITY_DEVICE_TYPE = 0x5F01
 XIAOMI_CLUSTER_ID = 0xFFFF
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class Weather(XiaomiQuickInitDevice):

--- a/zhaquirks/xiaomi/mija/motion.py
+++ b/zhaquirks/xiaomi/mija/motion.py
@@ -1,5 +1,4 @@
 """Xiaomi mija body sensor."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
@@ -34,7 +33,6 @@ from zhaquirks.xiaomi import (
 )
 
 XIAOMI_CLUSTER_ID = 0xFFFF
-_LOGGER = logging.getLogger(__name__)
 
 
 class Motion(XiaomiQuickInitDevice):

--- a/zhaquirks/xiaomi/mija/sensor_ht.py
+++ b/zhaquirks/xiaomi/mija/sensor_ht.py
@@ -1,5 +1,4 @@
 """Xiaomi mija weather sensor device."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
@@ -33,8 +32,6 @@ TEMPERATURE_HUMIDITY_DEVICE_TYPE = 0x5F01
 TEMPERATURE_HUMIDITY_DEVICE_TYPE2 = 0x5F02
 TEMPERATURE_HUMIDITY_DEVICE_TYPE3 = 0x5F03
 XIAOMI_CLUSTER_ID = 0xFFFF
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class Weather(XiaomiCustomDevice):

--- a/zhaquirks/xiaomi/mija/sensor_magnet.py
+++ b/zhaquirks/xiaomi/mija/sensor_magnet.py
@@ -1,5 +1,4 @@
 """Xiaomi aqara contact sensor device."""
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
@@ -32,8 +31,6 @@ from zhaquirks.xiaomi import (
 
 OPEN_CLOSE_DEVICE_TYPE = 0x5F01
 XIAOMI_CLUSTER_ID = 0xFFFF
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class Magnet(XiaomiQuickInitDevice):

--- a/zhaquirks/xiaomi/mija/sensor_switch.py
+++ b/zhaquirks/xiaomi/mija/sensor_switch.py
@@ -1,6 +1,5 @@
 """Xiaomi mija button device."""
 import asyncio
-import logging
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
@@ -54,8 +53,6 @@ from zhaquirks.xiaomi import (
 )
 
 XIAOMI_CLUSTER_ID = 0xFFFF
-
-_LOGGER = logging.getLogger(__name__)
 
 CLICK_TYPE_MAP = {
     2: COMMAND_DOUBLE,

--- a/zhaquirks/xiaomi/mija/smoke.py
+++ b/zhaquirks/xiaomi/mija/smoke.py
@@ -12,7 +12,6 @@ High Sensitivity: 0x0101000011010003,
 Medium Sensitivity: 0x0102000011010003,
 Low Sensitivity: 0x0103000011010003.
 """
-import logging
 
 from zigpy.profiles import zha
 import zigpy.types as t
@@ -44,8 +43,6 @@ from zhaquirks.xiaomi import (
     XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class XiaomiSmokeIASCluster(CustomCluster, IasZone):


### PR DESCRIPTION
## Proposed change
This removes unused logger instances and empty ``__init__`` functions.

## Additional information
One quirk contained a constructor with an INFO log output of ``Initializing zigfred uno`` which I also removed.

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
