### PR TITLE
Fix Tuya Haozee TRV deprecated `attridx` and usage

### DIFF
--- a/zhaquirks/tuya/ts0601_haozee.py
+++ b/zhaquirks/tuya/ts0601_haozee.py
@@ -228,8 +228,10 @@ class HY08WEThermostat(TuyaThermostatCluster):
         elif value == 2:
             prog_mode = self.ProgrammingOperationMode.Simple
             occupancy = self.Occupancy.Unoccupied
-        self._update_attribute(self.attridx["programing_oper_mode"], prog_mode)
-        self._update_attribute(self.attridx["occupancy"], occupancy)
+        self._update_attribute(
+            self.attributes_by_name["programing_oper_mode"].id, prog_mode
+        )
+        self._update_attribute(self.attributes_by_name["occupancy"].id, occupancy)
 
     def enabled_change(self, value):
         """System mode change."""
@@ -237,7 +239,7 @@ class HY08WEThermostat(TuyaThermostatCluster):
             mode = self.SystemMode.Off
         else:
             mode = self.SystemMode.Heat
-        self._update_attribute(self.attridx["system_mode"], mode)
+        self._update_attribute(self.attributes_by_name["system_mode"].id, mode)
 
 
 class HY08WEUserInterface(TuyaUserInterfaceCluster):


### PR DESCRIPTION
## Proposed change
This replaces the deprecated `attridx` property with `attributes_by_name`.
The code was also somewhat broken, as it tried to call `update_attribute` with a `ZCLAttributeDef` (and not an `int`).

So, that should be fixed too.

## Additional information
Untested, but similar to other Tuya TRVs now. The code was just broken before.
In the future, this should probably all be changed to use new-style zigpy `AttributeDefs` classes. But this isn't for that yet.

Note: **Codecov tests will fail when merging, as nothing of this was/is covered. All other tests pass.**

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
