### PR TITLE
Remove re-setting final `cluster_id` when inherited already

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -184,7 +184,6 @@ class DoublingPowerConfigurationCluster(CustomCluster, PowerConfiguration):
     that don't follow the reporting spec.
     """
 
-    cluster_id = PowerConfiguration.cluster_id
     BATTERY_PERCENTAGE_REMAINING = 0x0021
 
     def _update_attribute(self, attrid, value):
@@ -196,7 +195,6 @@ class DoublingPowerConfigurationCluster(CustomCluster, PowerConfiguration):
 class PowerConfigurationCluster(CustomCluster, PowerConfiguration):
     """Common use power configuration cluster."""
 
-    cluster_id = PowerConfiguration.cluster_id
     BATTERY_VOLTAGE_ATTR = 0x0020
     BATTERY_PERCENTAGE_REMAINING = 0x0021
     MIN_VOLTS = 1.5  # old 2.1

--- a/zhaquirks/adeo/color_controller.py
+++ b/zhaquirks/adeo/color_controller.py
@@ -97,8 +97,6 @@ class AdeoManufacturerCluster(EventableCluster):
 class AdeoScenesCluster(Scenes, EventableCluster):
     """Scenes cluster to map preset buttons to the "view" command."""
 
-    cluster_id = Scenes.cluster_id
-
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)

--- a/zhaquirks/centralite/cl_3130.py
+++ b/zhaquirks/centralite/cl_3130.py
@@ -38,7 +38,6 @@ from zhaquirks.osram import OSRAM
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     """Custom PowerConfigurationCluster."""
 
-    cluster_id = PowerConfigurationCluster.cluster_id
     MIN_VOLTS = 2.1
     MAX_VOLTS = 3.0
 

--- a/zhaquirks/centralite/cl_3460L.py
+++ b/zhaquirks/centralite/cl_3460L.py
@@ -34,7 +34,6 @@ from zhaquirks.const import (
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     """Custom PowerConfigurationCluster."""
 
-    cluster_id = PowerConfigurationCluster.cluster_id
     MIN_VOLTS = 2.1
     MAX_VOLTS = 3.0
 

--- a/zhaquirks/centralite/motionandtemp.py
+++ b/zhaquirks/centralite/motionandtemp.py
@@ -36,7 +36,6 @@ from zhaquirks.const import (
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     """Custom PowerConfigurationCluster."""
 
-    cluster_id = PowerConfiguration.cluster_id
     MIN_VOLTS = 2.1
     MAX_VOLTS = 3.0
 

--- a/zhaquirks/ecolink/contact.py
+++ b/zhaquirks/ecolink/contact.py
@@ -21,7 +21,6 @@ from zhaquirks.const import (
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     """Custom PowerConfigurationCluster."""
 
-    cluster_id = PowerConfigurationCluster.cluster_id
     MIN_VOLTS = 2.1
     MAX_VOLTS = 3.0
 

--- a/zhaquirks/elko/__init__.py
+++ b/zhaquirks/elko/__init__.py
@@ -51,7 +51,6 @@ class ElkoUserInterfaceCluster(LocalDataCluster, UserInterface):
 class ElkoElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
     """Electrical measurement cluster for Elko Thermostats."""
 
-    cluster_id = ElectricalMeasurement.cluster_id
     ACTIVE_POWER_ID = 0x050B
 
     def __init__(self, *args, **kwargs):

--- a/zhaquirks/ikea/starkvind.py
+++ b/zhaquirks/ikea/starkvind.py
@@ -90,8 +90,6 @@ class IkeaAirpurifier(CustomCluster):
 class PM25Cluster(CustomCluster, PM25):
     """PM25 input cluster, only used to show PM2.5 values from IKEA cluster."""
 
-    cluster_id = PM25.cluster_id
-
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)

--- a/zhaquirks/innr/innr_sp120_plug.py
+++ b/zhaquirks/innr/innr_sp120_plug.py
@@ -31,7 +31,6 @@ MODEL = "SP 120"
 class MeteringCluster(CustomCluster, Metering):
     """Fix multiplier and divisor."""
 
-    cluster_id = Metering.cluster_id
     MULTIPLIER = 0x0301
     DIVISOR = 0x0302
     _CONSTANT_ATTRIBUTES = {MULTIPLIER: 1, DIVISOR: 100}
@@ -40,7 +39,6 @@ class MeteringCluster(CustomCluster, Metering):
 class ElectricalMeasurementCluster(CustomCluster, ElectricalMeasurement):
     """Fix multiplier and divisor."""
 
-    cluster_id = ElectricalMeasurement.cluster_id
     MULTIPLIER = 0x0602
     DIVISOR = 0x0603
     _CONSTANT_ATTRIBUTES = {MULTIPLIER: 1, DIVISOR: 1000}

--- a/zhaquirks/innr/innr_sp234_plug.py
+++ b/zhaquirks/innr/innr_sp234_plug.py
@@ -31,7 +31,6 @@ MODEL = "SP 234"
 class ElectricalMeasurementCluster(CustomCluster, ElectricalMeasurement):
     """Fix divisor."""
 
-    cluster_id = ElectricalMeasurement.cluster_id
     AC_POWER_DIVISOR = 0x0605
     _CONSTANT_ATTRIBUTES = {AC_POWER_DIVISOR: 1}
 

--- a/zhaquirks/keenhome/weather.py
+++ b/zhaquirks/keenhome/weather.py
@@ -31,8 +31,6 @@ from zhaquirks.xiaomi import LUMI
 class PressureMeasurementCluster(CustomCluster, PressureMeasurement):
     """Custom cluster representing Keen Home's pressure measurement."""
 
-    cluster_id = PressureMeasurement.cluster_id
-
     KEEN_MEASURED_VALUE_ATTR = 0x0020
     MEASURED_VALUE_ATTR = 0x0000
 

--- a/zhaquirks/mli/tint.py
+++ b/zhaquirks/mli/tint.py
@@ -31,8 +31,6 @@ TINT_SCENE_ATTR = 0x4005
 class TintRemoteScenesCluster(LocalDataCluster, Scenes):
     """Tint remote cluster."""
 
-    cluster_id = Scenes.cluster_id
-
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
@@ -46,8 +44,6 @@ class TintRemoteScenesCluster(LocalDataCluster, Scenes):
 
 class TintRemoteBasicCluster(CustomCluster, Basic):
     """Tint remote cluster."""
-
-    cluster_id = Basic.cluster_id
 
     def handle_cluster_general_request(self, hdr, args, *, dst_addressing=None):
         """Send write_attributes value to TintRemoteSceneCluster."""

--- a/zhaquirks/netvox/z308e3ed.py
+++ b/zhaquirks/netvox/z308e3ed.py
@@ -18,7 +18,6 @@ from zhaquirks.const import (
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     """Custom PowerConfigurationCluster."""
 
-    cluster_id = PowerConfigurationCluster.cluster_id
     MIN_VOLTS = 2.1
     MAX_VOLTS = 3.0
 

--- a/zhaquirks/salus/sp600.py
+++ b/zhaquirks/salus/sp600.py
@@ -27,7 +27,6 @@ from zhaquirks.salus import COMPUTIME
 class TemperatureMeasurementCluster(CustomCluster, TemperatureMeasurement):
     """Temperature cluster that divides value by 2."""
 
-    cluster_id = TemperatureMeasurement.cluster_id
     ATTR_ID = 0
 
     def _update_attribute(self, attrid, value):

--- a/zhaquirks/smartthings/tag_v4.py
+++ b/zhaquirks/smartthings/tag_v4.py
@@ -19,7 +19,6 @@ ARRIVAL_SENSOR_DEVICE_TYPE = 0x8000
 class FastPollingPowerConfigurationCluster(PowerConfigurationCluster):
     """FastPollingPowerConfigurationCluster."""
 
-    cluster_id = PowerConfigurationCluster.cluster_id
     FREQUENCY = 45
     MINIMUM_CHANGE = 1
 
@@ -50,8 +49,6 @@ class FastPollingPowerConfigurationCluster(PowerConfigurationCluster):
 # stealing this for tracking alerts
 class TrackingCluster(LocalDataCluster, BinaryInput):
     """Tracking cluster."""
-
-    cluster_id = BinaryInput.cluster_id
 
     def __init__(self, *args, **kwargs):
         """Init."""

--- a/zhaquirks/terncy/__init__.py
+++ b/zhaquirks/terncy/__init__.py
@@ -57,7 +57,6 @@ ZONE_TYPE = 0x0001
 class IlluminanceMeasurementCluster(CustomCluster, IlluminanceMeasurement):
     """Terncy Illuminance Measurement Cluster."""
 
-    cluster_id = IlluminanceMeasurement.cluster_id
     ATTR_ID = 0
 
     def _update_attribute(self, attrid, value):
@@ -69,7 +68,6 @@ class IlluminanceMeasurementCluster(CustomCluster, IlluminanceMeasurement):
 class TemperatureMeasurementCluster(CustomCluster, TemperatureMeasurement):
     """Terncy Temperature Cluster."""
 
-    cluster_id = TemperatureMeasurement.cluster_id
     ATTR_ID = 0
 
     def _update_attribute(self, attrid, value):

--- a/zhaquirks/thirdreality/button.py
+++ b/zhaquirks/thirdreality/button.py
@@ -30,7 +30,6 @@ from zhaquirks.thirdreality import THIRD_REALITY
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     """Custom PowerConfigurationCluster."""
 
-    cluster_id = PowerConfigurationCluster.cluster_id
     MIN_VOLTS = 2.1
     MAX_VOLTS = 3.0
 
@@ -45,8 +44,6 @@ MOVEMENT_TYPE = {
 
 class MultistateInputCluster(CustomCluster, MultistateInput):
     """Multistate input cluster."""
-
-    cluster_id = MultistateInput.cluster_id
 
     def __init__(self, *args, **kwargs):
         """Init."""

--- a/zhaquirks/thirdreality/switch.py
+++ b/zhaquirks/thirdreality/switch.py
@@ -19,7 +19,6 @@ from zhaquirks.thirdreality import THIRD_REALITY
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     """Custom PowerConfigurationCluster."""
 
-    cluster_id = PowerConfigurationCluster.cluster_id
     MIN_VOLTS = 2.1
     MAX_VOLTS = 3.0
 

--- a/zhaquirks/tuya/ts0210.py
+++ b/zhaquirks/tuya/ts0210.py
@@ -28,7 +28,6 @@ IAS_VIBRATION_SENSOR = 0x5F02
 class VibrationCluster(LocalDataCluster, MotionOnEvent, IasZone):
     """Tuya Motion Sensor."""
 
-    cluster_id = IasZone.cluster_id
     _CONSTANT_ATTRIBUTES = {ZONE_TYPE: IasZone.ZoneType.Vibration_Movement_Sensor}
     reset_s = 15
 

--- a/zhaquirks/tuya/ts0211.py
+++ b/zhaquirks/tuya/ts0211.py
@@ -26,8 +26,6 @@ from zhaquirks.const import (
 class IasZoneDoorbellCluster(CustomCluster, IasZone):
     """Custom IasZone cluster for the doorbell."""
 
-    cluster_id = IasZone.cluster_id
-
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,

--- a/zhaquirks/tuya/ts0601_din_power.py
+++ b/zhaquirks/tuya/ts0601_din_power.py
@@ -66,8 +66,6 @@ class TuyaManufClusterDinPower(TuyaManufClusterAttributes):
 class TuyaPowerMeasurement(LocalDataCluster, ElectricalMeasurement):
     """Custom class for power, voltage and current measurement."""
 
-    cluster_id = ElectricalMeasurement.cluster_id
-
     POWER_ID = 0x050B
     VOLTAGE_ID = 0x0505
     CURRENT_ID = 0x0508
@@ -120,7 +118,6 @@ class TuyaPowerMeasurement(LocalDataCluster, ElectricalMeasurement):
 class TuyaElectricalMeasurement(LocalDataCluster, Metering):
     """Custom class for total energy measurement."""
 
-    cluster_id = Metering.cluster_id
     CURRENT_DELIVERED_ID = 0x0000
     CURRENT_RECEIVED_ID = 0x0001
     POWER_WATT = 0x0000

--- a/zhaquirks/tuya/ts0601_siren.py
+++ b/zhaquirks/tuya/ts0601_siren.py
@@ -158,7 +158,6 @@ class TuyaSirenOnOff(LocalDataCluster, OnOff):
 class TuyaTemperatureMeasurement(LocalDataCluster, TemperatureMeasurement):
     """Temperature cluster acting from events from temperature bus."""
 
-    cluster_id = TemperatureMeasurement.cluster_id
     ATTR_ID = 0
 
     def __init__(self, *args, **kwargs):
@@ -174,7 +173,6 @@ class TuyaTemperatureMeasurement(LocalDataCluster, TemperatureMeasurement):
 class TuyaRelativeHumidity(LocalDataCluster, RelativeHumidity):
     """Humidity cluster acting from events from humidity bus."""
 
-    cluster_id = RelativeHumidity.cluster_id
     ATTR_ID = 0
 
     def __init__(self, *args, **kwargs):

--- a/zhaquirks/tuya/ts0601_trv_sas.py
+++ b/zhaquirks/tuya/ts0601_trv_sas.py
@@ -117,8 +117,6 @@ class ManufacturerThermostatCluster(TuyaManufClusterAttributes):
 class ThermostatCluster(TuyaThermostatCluster):
     """Thermostat cluster."""
 
-    cluster_id = Thermostat.cluster_id
-
     _CONSTANT_ATTRIBUTES = {
         MIN_HEAT_SETPOINT_ATTR: 500,
         MAX_HEAT_SETPOINT_ATTR: 3000,

--- a/zhaquirks/universalelectronics/contact_sensor.py
+++ b/zhaquirks/universalelectronics/contact_sensor.py
@@ -20,7 +20,6 @@ from zhaquirks.const import (
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     """Custom PowerConfigurationCluster."""
 
-    cluster_id = PowerConfigurationCluster.cluster_id
     MIN_VOLTS = 2.1
     MAX_VOLTS = 3.0
 

--- a/zhaquirks/visonic/mct340e.py
+++ b/zhaquirks/visonic/mct340e.py
@@ -24,7 +24,6 @@ OSRAM_CLUSTER = 0xFD00  # 64768 base 10
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     """Custom PowerConfigurationCluster."""
 
-    cluster_id = PowerConfigurationCluster.cluster_id
     MIN_VOLTS = 2.1
     MAX_VOLTS = 3.0
 

--- a/zhaquirks/xiaomi/aqara/cube.py
+++ b/zhaquirks/xiaomi/aqara/cube.py
@@ -167,8 +167,6 @@ class Cube(XiaomiQuickInitDevice):
     class MultistateInputCluster(CustomCluster, MultistateInput):
         """Multistate input cluster."""
 
-        cluster_id = MultistateInput.cluster_id
-
         def __init__(self, *args, **kwargs):
             """Init."""
             self._current_state = {}
@@ -201,8 +199,6 @@ class Cube(XiaomiQuickInitDevice):
 
     class AnalogInputCluster(CustomCluster, AnalogInput):
         """Analog input cluster."""
-
-        cluster_id = AnalogInput.cluster_id
 
         def __init__(self, *args, **kwargs):
             """Init."""

--- a/zhaquirks/xiaomi/aqara/cube_aqgl01.py
+++ b/zhaquirks/xiaomi/aqara/cube_aqgl01.py
@@ -155,8 +155,6 @@ extend_dict(MOVEMENT_TYPE, FLIP, range(FLIP_BEGIN, FLIP_END))
 class MultistateInputCluster(CustomCluster, MultistateInput):
     """Multistate input cluster."""
 
-    cluster_id = MultistateInput.cluster_id
-
     def __init__(self, *args, **kwargs):
         """Init."""
         self._current_state = {}
@@ -188,8 +186,6 @@ class MultistateInputCluster(CustomCluster, MultistateInput):
 
 class AnalogInputCluster(CustomCluster, AnalogInput):
     """Analog input cluster."""
-
-    cluster_id = AnalogInput.cluster_id
 
     def __init__(self, *args, **kwargs):
         """Init."""

--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -98,8 +98,6 @@ OPPLE_MFG_CODE = 0x115F
 class MultistateInputCluster(CustomCluster, MultistateInput):
     """Multistate input cluster."""
 
-    cluster_id = MultistateInput.cluster_id
-
     def __init__(self, *args, **kwargs):
         """Init."""
         self._current_state = None

--- a/zhaquirks/xiaomi/aqara/remote_b186acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b186acn01.py
@@ -57,8 +57,6 @@ class RemoteB186ACN01(XiaomiQuickInitDevice):
     class MultistateInputCluster(CustomCluster, MultistateInput):
         """Multistate input cluster."""
 
-        cluster_id = MultistateInput.cluster_id
-
         def __init__(self, *args, **kwargs):
             """Init."""
             self._current_state = None

--- a/zhaquirks/xiaomi/aqara/remote_b286acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b286acn01.py
@@ -67,8 +67,6 @@ class RemoteB286ACN01(XiaomiCustomDevice):
     class MultistateInputCluster(CustomCluster, MultistateInput):
         """Multistate input cluster."""
 
-        cluster_id = MultistateInput.cluster_id
-
         def __init__(self, *args, **kwargs):
             """Init."""
             self._current_state = None

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -85,6 +85,8 @@ class VibrationAQ1(XiaomiQuickInitDevice):
     class MultistateInputCluster(CustomCluster, MultistateInput):
         """Multistate input cluster."""
 
+        cluster_id = DoorLock.cluster_id
+
         def __init__(self, *args, **kwargs):
             """Init."""
             self._current_state = {}

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -85,8 +85,6 @@ class VibrationAQ1(XiaomiQuickInitDevice):
     class MultistateInputCluster(CustomCluster, MultistateInput):
         """Multistate input cluster."""
 
-        cluster_id = DoorLock.cluster_id
-
         def __init__(self, *args, **kwargs):
             """Init."""
             self._current_state = {}

--- a/zhaquirks/xiaomi/mija/sensor_switch.py
+++ b/zhaquirks/xiaomi/mija/sensor_switch.py
@@ -73,7 +73,6 @@ class MijaButton(XiaomiQuickInitDevice):
     class MijaOnOff(CustomCluster, OnOff):
         """Mija on off cluster."""
 
-        cluster_id = OnOff.cluster_id
         hold_duration: float = 1.0
 
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Proposed change
This removes setting the (supposedly) final `cluster_id` when it's already set due to being inherited.


## Additional information


## Checklist
- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
