### PR TITLE
Fix trying to update existing attributes in Tuya TRV quirk

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -946,31 +946,37 @@ class ZONNSMARTManufCluster(TuyaManufClusterAttributes):
         ZonnsmartManuClusterSelf = self
 
     attributes = TuyaManufClusterAttributes.attributes.copy()
-    attributes = {
-        ZONNSMART_MODE_ATTR: ("mode", t.uint8_t, True),
-        ZONNSMART_WINDOW_DETECT_ATTR: ("window_detection", t.uint8_t, True),
-        ZONNSMART_FROST_PROTECT_ATTR: ("frost_protection", t.uint8_t, True),
-        ZONNSMART_TARGET_TEMP_ATTR: ("target_temperature", t.uint32_t, True),
-        ZONNSMART_TEMPERATURE_ATTR: ("temperature", t.uint32_t, True),
-        ZONNSMART_TEMPERATURE_CALIBRATION_ATTR: (
-            "temperature_calibration",
-            t.int32s,
-            True,
-        ),
-        ZONNSMART_WEEK_FORMAT_ATTR: ("week_format", t.uint8_t, True),
-        ZONNSMART_HOLIDAY_TEMP_ATTR: ("holiday_temperature", t.uint32_t, True),
-        ZONNSMART_BATTERY_ATTR: ("battery", t.uint32_t, True),
-        ZONNSMART_UPTIME_TIME_ATTR: ("uptime", t.uint32_t, True),
-        ZONNSMART_CHILD_LOCK_ATTR: ("child_lock", t.uint8_t, True),
-        ZONNSMART_FAULT_DETECTION_ATTR: ("fault_detected", t.uint8_t, True),
-        ZONNSMART_BOOST_TIME_ATTR: ("boost_duration_seconds", t.uint32_t, True),
-        ZONNSMART_OPENED_WINDOW_TEMP: ("opened_window_temperature", t.uint32_t, True),
-        ZONNSMART_COMFORT_TEMP_ATTR: ("comfort_mode_temperature", t.uint32_t, True),
-        ZONNSMART_ECO_TEMP_ATTR: ("eco_mode_temperature", t.uint32_t, True),
-        ZONNSMART_HEATING_STOPPING_ATTR: ("heating_stop", t.uint8_t, True),
-        ZONNSMART_ONLINE_MODE_BOOL_ATTR: ("online_set", t.uint8_t, True),
-        ZONNSMART_ONLINE_MODE_ENUM_ATTR: ("online", t.uint8_t, True),
-    }
+    attributes.update(
+        {
+            ZONNSMART_MODE_ATTR: ("mode", t.uint8_t, True),
+            ZONNSMART_WINDOW_DETECT_ATTR: ("window_detection", t.uint8_t, True),
+            ZONNSMART_FROST_PROTECT_ATTR: ("frost_protection", t.uint8_t, True),
+            ZONNSMART_TARGET_TEMP_ATTR: ("target_temperature", t.uint32_t, True),
+            ZONNSMART_TEMPERATURE_ATTR: ("temperature", t.uint32_t, True),
+            ZONNSMART_TEMPERATURE_CALIBRATION_ATTR: (
+                "temperature_calibration",
+                t.int32s,
+                True,
+            ),
+            ZONNSMART_WEEK_FORMAT_ATTR: ("week_format", t.uint8_t, True),
+            ZONNSMART_HOLIDAY_TEMP_ATTR: ("holiday_temperature", t.uint32_t, True),
+            ZONNSMART_BATTERY_ATTR: ("battery", t.uint32_t, True),
+            ZONNSMART_UPTIME_TIME_ATTR: ("uptime", t.uint32_t, True),
+            ZONNSMART_CHILD_LOCK_ATTR: ("child_lock", t.uint8_t, True),
+            ZONNSMART_FAULT_DETECTION_ATTR: ("fault_detected", t.uint8_t, True),
+            ZONNSMART_BOOST_TIME_ATTR: ("boost_duration_seconds", t.uint32_t, True),
+            ZONNSMART_OPENED_WINDOW_TEMP: (
+                "opened_window_temperature",
+                t.uint32_t,
+                True,
+            ),
+            ZONNSMART_COMFORT_TEMP_ATTR: ("comfort_mode_temperature", t.uint32_t, True),
+            ZONNSMART_ECO_TEMP_ATTR: ("eco_mode_temperature", t.uint32_t, True),
+            ZONNSMART_HEATING_STOPPING_ATTR: ("heating_stop", t.uint8_t, True),
+            ZONNSMART_ONLINE_MODE_BOOL_ATTR: ("online_set", t.uint8_t, True),
+            ZONNSMART_ONLINE_MODE_ENUM_ATTR: ("online", t.uint8_t, True),
+        }
+    )
 
     DIRECT_MAPPED_ATTRS = {
         ZONNSMART_TEMPERATURE_ATTR: ("local_temperature", lambda value: value * 10),


### PR DESCRIPTION
## Proposed change
This fixes a small issue where the `attributes` attribute was reassigned due to incorrectly trying to copy other `attributes`.

This wasn't a big issue, as `TuyaManufClusterAttributes` (and inherited classes) don't seem to contain any `attributes`, but this would be an issue if this were to change in the future.

This PR corrects the code by doing what was originally tried.



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
