### PR TITLE
Fix missing asserts in Tuya cluster tests

### DIFF
--- a/tests/test_tuya_clusters.py
+++ b/tests/test_tuya_clusters.py
@@ -161,14 +161,14 @@ def test_tuya_data_bitmap():
 
     data = b"\x05\x00\x02\x40\x02"
     r, _ = TuyaData.deserialize(data)
-    r.payload == 0x4002
+    assert r.payload == 0x0240
 
     r.payload = t.bitmap16(0x2004)
     assert r.raw == b"\x20\x04"
 
     data = b"\x05\x00\x04\x40\x02\x80\x01"
     r, _ = TuyaData.deserialize(data)
-    r.payload == 0x40028001
+    assert r.payload == 0x1800240
 
     r.payload = t.bitmap32(0x10082004)
     assert r.raw == b"\x10\x08\x20\x04"


### PR DESCRIPTION
## Proposed change
Fix missing asserts in Tuya cluster tests.
It looks like these were supposed to be checking `r.payload`.

However, the values they were supposedly trying to check for differ from the actual values.
The new values seem like they could be correct, but I'd like some confirmation on if this is correct, so if the tested code and tests are good.
@Shulyaka You seem to also have worked on this in the past. Can you say if the changes are correct?

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
