### PR TITLE
Add missing local `MeteringCluster` to Aqara `lumi.relay.c2acn01`

### DIFF
--- a/zhaquirks/xiaomi/aqara/relay_c2acn01.py
+++ b/zhaquirks/xiaomi/aqara/relay_c2acn01.py
@@ -32,6 +32,7 @@ from zhaquirks.xiaomi import (
     BasicCluster,
     BinaryOutputInterlock,
     ElectricalMeasurementCluster,
+    MeteringCluster,
     XiaomiCustomDevice,
 )
 
@@ -99,6 +100,7 @@ class Relay(XiaomiCustomDevice):
                     Scenes.cluster_id,
                     BinaryOutputInterlock,
                     Time.cluster_id,
+                    MeteringCluster,
                     ElectricalMeasurementCluster,
                     AnalogInputCluster,
                 ],


### PR DESCRIPTION
## Proposed change
Adds missing `MeteringCluster` to Aqara `lumi.relay.c2acn01`.

The `BasicCluster` catches the special Xiaomi attribute reports and passes them to the Metering cluster.
This cluster was missing before which caused errors (see linked issue below). The imported `MeteringCluster` is a `LocalDataCluster` that just "stores" the total energy consumption for the Aqara relay.

This PR fixes both the exception seen in the issue below and adds the missing total energy consumption sensor for this device.


## Additional information
Will address https://github.com/home-assistant/core/issues/100116 once merged into HA.
Confirmed working in that issue.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
