### PR TITLE
Add quirk ID to Konke button quirks

### DIFF
--- a/zhaquirks/konke/button.py
+++ b/zhaquirks/konke/button.py
@@ -29,6 +29,7 @@ from zhaquirks.const import (
     SHORT_PRESS,
 )
 from zhaquirks.konke import KONKE, KonkeOnOffCluster
+from zhaquirks.quirk_ids import KONKE_BUTTON
 
 KONKE_CLUSTER_ID = 0xFCC0
 
@@ -37,6 +38,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class KonkeButtonRemote1(CustomDevice):
     """Konke 1-button remote device."""
+
+    quirk_id = KONKE_BUTTON
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=2
@@ -88,6 +91,8 @@ class KonkeButtonRemote1(CustomDevice):
 
 class KonkeButtonRemote2(CustomDevice):
     """Konke 1-button remote device 2nd variant."""
+
+    quirk_id = KONKE_BUTTON
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=2

--- a/zhaquirks/quirk_ids.py
+++ b/zhaquirks/quirk_ids.py
@@ -1,5 +1,8 @@
 """Quirk IDs used for matching quirked devices in ZHA."""
 
+# Konke
+KONKE_BUTTON = "konke.button_remote"  # remote with custom handling in cluster handler
+
 # Tuya
 TUYA_PLUG_ONOFF = "tuya.plug_on_off_attributes"  # plugs with configurable attributes on the OnOff cluster
 TUYA_PLUG_MANUFACTURER = "tuya.plug_manufacturer_attributes"  # plugs with configurable attributes on a custom cluster


### PR DESCRIPTION
## Proposed change
Adds a quirk ID to the Konke button quirks.
This is done, so the following ZHA code can be cleaned up / improved in a future PR: [`zha/core/cluster_handlers/general.py#L372-L379`](https://github.com/home-assistant/core/blob/b372a64057dcf88a373ff0b839c7fe61b1d4161d/homeassistant/components/zha/core/cluster_handlers/general.py#L372-L379)


## Additional information
This will also prevent issues where only quirks code is updated, but not the ZHA code (for these buttons), as it's not obvious that adding a new Konke button in quirks also requires a change in ZHA.

Using a quirk ID for all Konke button quirks prevents that.


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
