### PR TITLE
Add test requiring new quirks to provide model info

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -391,6 +391,40 @@ def test_signature(quirk: CustomDevice) -> None:
             assert isinstance(node_desc, zigpy.zdo.types.NodeDescriptor)
 
 
+@pytest.mark.parametrize(
+    "quirk",
+    [
+        quirk_cls
+        for quirk_cls in ALL_QUIRK_CLASSES
+        if quirk_cls
+        not in (
+            # Some quirks do not yet have model info:
+            zhaquirks.xbee.xbee_io.XBeeSensor,
+            zhaquirks.xbee.xbee3_io.XBee3Sensor,
+            zhaquirks.xiaomi.aqara.opple_switch.XiaomiOpple2ButtonSwitchFace2,
+            zhaquirks.xiaomi.aqara.opple_switch.XiaomiOpple2ButtonSwitchFace1,
+            zhaquirks.tuya.ts0201.MoesTemperatureHumidtySensorWithScreen,
+            zhaquirks.smartthings.tag_v4.SmartThingsTagV4,
+            zhaquirks.smartthings.multi.SmartthingsMultiPurposeSensor,
+            zhaquirks.netvox.z308e3ed.Z308E3ED,
+            zhaquirks.gledopto.soposhgu10.SoposhGU10,
+        )
+    ],
+)
+def test_signature_model_info_given(quirk: CustomDevice) -> None:
+    """Verify that quirks have MODELS_INFO, MODEL or MANUFACTURER in their signature."""
+
+    if (
+        not quirk.signature.get(MODELS_INFO)
+        and not quirk.signature.get(MODEL)
+        and not quirk.signature.get(MANUFACTURER)
+    ):
+        pytest.fail(
+            f"Quirk {quirk} does not have MODELS_INFO, MODEL or MANUFACTURER in its signature. "
+            f"At least one of these is required."
+        )
+
+
 @pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)
 def test_quirk_importable(quirk: CustomDevice) -> None:
     """Ensure all quirks can be imported with a normal Python `import` statement."""


### PR DESCRIPTION
## Proposed change
This adds a test which fails when a quirk provides neither the preferred `MODELS_INFO` nor `MODEL` or `MANUFACTURER`.

Some quirks currently fail this and are excluded from the test for the time being.
**These should be fixed in another PR**. It might be hard to get all matching model/manufacturer names though.

## Additional information
- https://github.com/zigpy/zha-device-handlers/pull/2719 is somewhat related to this, as the SmartThings quirk currently seems to match with a Samjin device, even though that also provides a quirk.

### Collection of PRs/commit that were missing model info:
- https://github.com/zigpy/zha-device-handlers/pull/1672
- https://github.com/zigpy/zha-device-handlers/pull/1391
- https://github.com/zigpy/zha-device-handlers/pull/217/
- https://github.com/zigpy/zha-device-handlers/pull/60
- https://github.com/zigpy/zha-device-handlers/commit/9e48159ad7c6be99d9bf82c6457dc20cd34cfd51
- https://github.com/zigpy/zha-device-handlers/commit/999f3d8718b9e42dece44957633a562913376608
- XBee stuff (although that's somewhat special)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
