### PR TITLE
Add manufacturer in signature to GLEDOPTO SoposhGU10 quirk

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -404,7 +404,6 @@ def test_signature(quirk: CustomDevice) -> None:
             zhaquirks.smartthings.tag_v4.SmartThingsTagV4,
             zhaquirks.smartthings.multi.SmartthingsMultiPurposeSensor,
             zhaquirks.netvox.z308e3ed.Z308E3ED,
-            zhaquirks.gledopto.soposhgu10.SoposhGU10,
         )
     ],
 )

--- a/zhaquirks/gledopto/soposhgu10.py
+++ b/zhaquirks/gledopto/soposhgu10.py
@@ -17,15 +17,18 @@ from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
+    MANUFACTURER,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.gledopto import GLEDOPTO
 
 
 class SoposhGU10(CustomDevice):
     """GLEDOPTO Soposh Dual White and color 5W GU10 300lm."""
 
     signature = {
+        MANUFACTURER: GLEDOPTO,
         ENDPOINTS: {
             11: {
                 PROFILE_ID: zll.PROFILE_ID,
@@ -47,7 +50,7 @@ class SoposhGU10(CustomDevice):
                 INPUT_CLUSTERS: [LightLink.cluster_id],
                 OUTPUT_CLUSTERS: [LightLink.cluster_id],
             },
-        }
+        },
     }
 
     replacement = {


### PR DESCRIPTION
## Proposed change
Adds the manufacturer name to the signature in GLEDOPTO SoposhGU10 quirk.

This PR is the first part to remove devices with exceptions from: 
- https://github.com/zigpy/zha-device-handlers/pull/2720


## Additional information
We don't have the original signature and it's also not in the [original PR](https://github.com/zigpy/zha-device-handlers/pull/60).
There are multiple model names in [Z2M's code](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/gledopto.ts) that could be possible for this.

But we might still miss some devices by using `MODELS_INFO`, thus this PR uses `MANUFACTURER` for now.
This narrows it down a bit at least, but ideally, we should get all model names that this quirk needs to be applied to.

---

There's some weirdness going on with the other GLEDOPTO quirk that was added in the linked PR above.
According to Z2M, it's an RGB-CCT device, yet the quirk removes all clusters except the one with the `COLOR_DIMMABLE_LIGHT` type: https://github.com/zigpy/zha-device-handlers/blob/22a1ac59813fe7f6cb6b501b63580f7c6a8e4dbe/zhaquirks/gledopto/gls007z.py#L84
I guess the `Color` cluster could expose other color modes, but the quirk should still change the `DEVICE_TYPE` in that case.

## Checklist
- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
