### PR TITLE
Fix pressure measurements for Aqara T1 weather sensor

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -77,6 +77,7 @@ import zhaquirks.xiaomi.aqara.motion_aq2b
 import zhaquirks.xiaomi.aqara.plug
 import zhaquirks.xiaomi.aqara.plug_eu
 import zhaquirks.xiaomi.aqara.roller_curtain_e1
+import zhaquirks.xiaomi.aqara.sensor_ht_agl02
 import zhaquirks.xiaomi.aqara.smoke
 import zhaquirks.xiaomi.aqara.switch_t1
 import zhaquirks.xiaomi.aqara.weather
@@ -1086,9 +1087,11 @@ async def test_xiaomi_p1_motion_sensor(zigpy_device_from_quirk, quirk):
 
 
 @pytest.mark.parametrize(
-    "raw_report, expected_results",
+    "quirk, cluster_name, raw_report, expected_results",
     (
-        [
+        (
+            zhaquirks.xiaomi.aqara.weather.Weather2,
+            "basic",
             "18200A01FF412501214F0B0421A84305214E020624010000000064299B096521BE1B662B138D01000A21900D",
             [
                 2459,  # temperature
@@ -1097,16 +1100,29 @@ async def test_xiaomi_p1_motion_sensor(zigpy_device_from_quirk, quirk):
                 28.9,  # battery voltage
                 54,  # battery percent * 2
             ],
-        ],
+        ),
+        (
+            zhaquirks.xiaomi.aqara.sensor_ht_agl02.LumiSensorHtAgl02,
+            "opple_cluster",
+            "1C5F11860AF700412D0121B60B0328170421A81305210B000624060000000008211D010A210"
+            "0000C200164292D09652904186629E903",
+            [
+                2349,  # temperature
+                6148,  # humidity
+                1001,  # pressure
+                30.0,  # battery voltage
+                127,  # battery percent * 2
+            ],
+        ),
     ),
 )
-async def test_xiaomi_weather(zigpy_device_from_quirk, raw_report, expected_results):
-    """Test Aqara weather sensor."""
+async def test_xiaomi_weather(
+    zigpy_device_from_quirk, quirk, cluster_name, raw_report, expected_results
+):
+    """Test Aqara weather sensors."""
     raw_report = bytes.fromhex(raw_report)
-
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.weather.Weather2)
-
-    basic_cluster = device.endpoints[1].basic
+    device = zigpy_device_from_quirk(quirk)
+    xiaomi_attr_cluster = getattr(device.endpoints[1], cluster_name)
 
     temperature_cluster = device.endpoints[1].temperature
     temperature_listener = ClusterListener(temperature_cluster)
@@ -1130,9 +1146,9 @@ async def test_xiaomi_weather(zigpy_device_from_quirk, raw_report, expected_resu
 
     device.handle_message(
         260,
-        basic_cluster.cluster_id,
-        basic_cluster.endpoint.endpoint_id,
-        basic_cluster.endpoint.endpoint_id,
+        xiaomi_attr_cluster.cluster_id,
+        xiaomi_attr_cluster.endpoint.endpoint_id,
+        xiaomi_attr_cluster.endpoint.endpoint_id,
         raw_report,
     )
 

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -65,6 +65,7 @@ POWER = "power"
 CONSUMPTION = "consumption"
 VOLTAGE = "voltage"
 PRESSURE_MEASUREMENT = "pressure_measurement"
+PRESSURE_MEASUREMENT_PRECISION = "pressure_measurement_precision"
 STATE = "state"
 TEMPERATURE = "temperature"
 TEMPERATURE_MEASUREMENT = "temperature_measurement"
@@ -277,7 +278,13 @@ class XiaomiCluster(CustomCluster):
         if PRESSURE_MEASUREMENT in attributes:
             self.endpoint.pressure.update_attribute(
                 PressureMeasurement.AttributeDefs.measured_value.id,
-                attributes[PRESSURE_MEASUREMENT] / 100,
+                attributes[PRESSURE_MEASUREMENT],
+            )
+
+        if PRESSURE_MEASUREMENT_PRECISION in attributes:
+            self.endpoint.pressure.update_attribute(
+                PressureMeasurement.AttributeDefs.measured_value.id,
+                attributes[PRESSURE_MEASUREMENT_PRECISION] / 100,
             )
 
         if POWER in attributes:
@@ -357,6 +364,8 @@ class XiaomiCluster(CustomCluster):
                     101: HUMIDITY_MEASUREMENT,
                     102: TVOC_MEASUREMENT
                     if self.endpoint.device.model == "lumi.airmonitor.acn01"
+                    else PRESSURE_MEASUREMENT_PRECISION
+                    if self.endpoint.device.model == "lumi.weather"
                     else PRESSURE_MEASUREMENT,
                 }
             )

--- a/zhaquirks/xiaomi/aqara/sensor_ht_agl02.py
+++ b/zhaquirks/xiaomi/aqara/sensor_ht_agl02.py
@@ -28,6 +28,23 @@ from zhaquirks.xiaomi import (
 )
 
 
+class PressureMeasurementT1Cluster(PressureMeasurementCluster):
+    """Pressure measurement cluster that multiplies Xiaomi attribute reports again."""
+
+    # Note: For normal attribute reports, zigpy does not call update_attribute().
+    # Instead, _update_attribute() is called directly.
+    # But Xiaomi attribute reports call update_attribute() first, so we override it.
+    def update_attribute(self, attrid, value):
+        """Override update_attribute to multiply pressure values by 100.
+
+        The pressure values in the Xiaomi attribute reports are divided by 100 in xiaomi/__init__.py.
+        However, this sensor sends pressure values that are already in hPa, so we need to undo that division.
+        """
+        if attrid == self.AttributeDefs.measured_value.id:
+            value = value * 100
+        super().update_attribute(attrid, value)
+
+
 class LumiSensorHtAgl02(XiaomiCustomDevice):
     """Lumi lumi.sensor_ht.agl02 custom device implementation."""
 
@@ -65,7 +82,7 @@ class LumiSensorHtAgl02(XiaomiCustomDevice):
                     XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     TemperatureMeasurementCluster,
-                    PressureMeasurementCluster,
+                    PressureMeasurementT1Cluster,
                     RelativeHumidityCluster,
                     XiaomiAqaraE1Cluster,
                 ],

--- a/zhaquirks/xiaomi/aqara/sensor_ht_agl02.py
+++ b/zhaquirks/xiaomi/aqara/sensor_ht_agl02.py
@@ -28,23 +28,6 @@ from zhaquirks.xiaomi import (
 )
 
 
-class PressureMeasurementT1Cluster(PressureMeasurementCluster):
-    """Pressure measurement cluster that multiplies Xiaomi attribute reports again."""
-
-    # Note: For normal attribute reports, zigpy does not call update_attribute().
-    # Instead, _update_attribute() is called directly.
-    # But Xiaomi attribute reports call update_attribute() first, so we override it.
-    def update_attribute(self, attrid, value):
-        """Override update_attribute to multiply pressure values by 100.
-
-        The pressure values in the Xiaomi attribute reports are divided by 100 in xiaomi/__init__.py.
-        However, this sensor sends pressure values that are already in hPa, so we need to undo that division.
-        """
-        if attrid == self.AttributeDefs.measured_value.id:
-            value = value * 100
-        super().update_attribute(attrid, value)
-
-
 class LumiSensorHtAgl02(XiaomiCustomDevice):
     """Lumi lumi.sensor_ht.agl02 custom device implementation."""
 
@@ -82,7 +65,7 @@ class LumiSensorHtAgl02(XiaomiCustomDevice):
                     XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     TemperatureMeasurementCluster,
-                    PressureMeasurementT1Cluster,
+                    PressureMeasurementCluster,
                     RelativeHumidityCluster,
                     XiaomiAqaraE1Cluster,
                 ],


### PR DESCRIPTION
## Proposed change
This fixes the pressure measurements for the Aqara T1 weather sensor.


As seen in the screenshot below, the values were correct most of the time. The correct values were sent through the ZCL clusters. However, the Xiaomi "heartbeat" messages with Xiaomi attribute reports are slightly different for this T1 sensor variant compared to the old one.
The old sensor sent values which need to be divided by 100. We're currently doing that in the main Xiaomi ``__init__.py`` file for all pressure measurements, before calling the respective `update_attribute` method.

#### Initial fix

To fix this, I initially overrode `update_attribute` in the T1 sensor class and multiplied the value by 100 again.
This does not mess with the ZCL attribute reports, as zigpy directly calls `_update_attribute` for those.

#### Alternative fix (used now)

I've then looked at fixing this in the Xiaomi file and added antoher  "attribute name" for "precision pressure" (old sensor) and used the "(normal) pressure" for the T1 sensor (and probably future Aqara pressure sensors).

IMO, this alternative approach is better. Diff from the switch from old to new approach: https://github.com/zigpy/zha-device-handlers/commit/e0f6bd416556e067fa8b4f848e496021992505bf

### Test

This PR also adds a test for parsing the Xiaomi attribute reports for the Aqara T1 sensor, so both the old and new sensors are covered now.
In the future, we should now be able to more easily change the approach for parsing Xiaomi attribute reports depending on the quirk for example.

### More precision: `scaled_value`

The sensor also sends a more precise value for pressure (which is what Z2M uses) using the standard ZCL `scaled_value` attribute. ZHA is not set up for this though and only reads `measured_value`.
Logs of the ZCL attribute reports sent (in case this is implemented in the future):
```python
2023-11-08 00:49:33.401 DEBUG (MainThread) [zigpy.zcl] [0xDC49:1:0x0403] Received ZCL frame: b"\x18~\n\x00\x00)\xe9\x03\x14\x00(\xff\x10\x00)\x1b'"
2023-11-08 00:49:33.402 DEBUG (MainThread) [zigpy.zcl] [0xDC49:1:0x0403] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl(frame_type=<FrameType.GLOBAL_COMMAND: 0>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 1>, disable_default_response=1, reserved=0, *is_cluster=False, *is_general=True), tsn=126, command_id=10, *direction=<Direction.Client_to_Server: 1>)
2023-11-08 00:49:33.402 DEBUG (MainThread) [zigpy.zcl] [0xDC49:1:0x0403] Decoded ZCL frame: PressureMeasurementT1Cluster:Report_Attributes(attribute_reports=[Attribute(attrid=0x0000, value=TypeValue(type=int16s, value=1001)), Attribute(attrid=0x0014, value=TypeValue(type=int8s, value=-1)), Attribute(attrid=0x0010, value=TypeValue(type=int16s, value=10011))])
2023-11-08 00:49:33.403 DEBUG (MainThread) [zigpy.zcl] [0xDC49:1:0x0403] Received command 0x0A (TSN 126): Report_Attributes(attribute_reports=[Attribute(attrid=0x0000, value=TypeValue(type=int16s, value=1001)), Attribute(attrid=0x0014, value=TypeValue(type=int8s, value=-1)), Attribute(attrid=0x0010, value=TypeValue(type=int16s, value=10011))])
2023-11-08 00:49:33.403 DEBUG (MainThread) [zigpy.zcl] [0xDC49:1:0x0403] Attribute report received: measured_value=1001, scale=-1, scaled_value=10011
```


## Additional information
Screenshot of the issue (notice the drops to 10 hPa in the reporting):

![Bildschirmfoto 2023-11-08 um 00 20 47](https://github.com/zigpy/zha-device-handlers/assets/6409465/1444c018-bd20-46a0-983c-b424211fd6fc)

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
