### PR TITLE
Fix Aqara T1 motion sensor `illuminance_reported` error

### DIFF
--- a/zhaquirks/xiaomi/aqara/motion_agl02.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl02.py
@@ -1,7 +1,7 @@
 """Xiaomi aqara T1 motion sensor device."""
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Identify, Ota
-from zigpy.zcl.clusters.measurement import OccupancySensing
+from zigpy.zcl.clusters.measurement import IlluminanceMeasurement, OccupancySensing
 
 from zhaquirks import Bus
 from zhaquirks.const import (
@@ -33,8 +33,13 @@ class XiaomiManufacturerCluster(XiaomiAqaraE1Cluster):
         super()._update_attribute(attrid, value)
         if attrid == 274:
             value = value - 65536
-            self.endpoint.illuminance.illuminance_reported(value)
-            self.endpoint.occupancy.update_attribute(0, 1)
+            self.endpoint.illuminance.update_attribute(
+                IlluminanceMeasurement.AttributeDefs.measured_value.id, value
+            )
+            self.endpoint.occupancy.update_attribute(
+                OccupancySensing.AttributeDefs.occupancy.id,
+                OccupancySensing.Occupancy.Occupied,
+            )
 
 
 class MotionT1(XiaomiCustomDevice):


### PR DESCRIPTION
## Proposed change
Fixes an issue where the removed `illuminance_reported` method was still called on the Xiaomi illuminance cluster for Aqara T1 motion sensors.

This was missed in https://github.com/zigpy/zha-device-handlers/pull/2528.

The code is now also tested (sharing the same test as Aqara P1 sensor).



## Additional information
Reported on Discord: https://discord.com/channels/330944238910963714/551843655682490399/1172244355034140732
~~Ideally, we also want/need a "Xiaomi attribute report" for this device, so we can add proper tests for it.~~
EDIT: I've expanded the existing Aqara P1 test to also cover this sensor for now.

The code also seems to be duplicated from the Aqara P1 motion sensor. Ideally, this should be improved (in the future):
https://github.com/zigpy/zha-device-handlers/blob/cbd0f037fbc3c5b696e499bdf13bf935bc8746ff/zhaquirks/xiaomi/aqara/motion_ac02.py#L46-L56

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
