### PR TITLE
Sinope G2 light and dimmer support

### DIFF
--- a/zhaquirks/sinope/__init__.py
+++ b/zhaquirks/sinope/__init__.py
@@ -19,6 +19,7 @@ from zhaquirks.const import (
 
 SINOPE = "Sinope Technologies"
 ATTRIBUTE_ACTION = "actionReport"
+CURTEMP = 0x0000
 
 LIGHT_DEVICE_TRIGGERS = {
     (SHORT_PRESS, TURN_ON): {

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -1,7 +1,7 @@
-"""Module to handle quirks of the  Sinopé Technologies light SW2500ZB, dimmer DM2500ZB and DM2550ZB.
+"""Module to handle quirks of the Sinopé Technologies light.
 
-Manufacturer specific cluster implements attributes to control displaying
-setting occupancy on/off.
+Supported devices SW2500ZB, SW2500ZB-G2 dimmer DM2500ZB, DM2500ZB-G2, DM2550ZB,
+DM2550ZB-G2.
 """
 
 import zigpy.profiles.zha as zha_p
@@ -33,6 +33,8 @@ from zhaquirks.const import (
 from zhaquirks.sinope import LIGHT_DEVICE_TRIGGERS, SINOPE
 
 SINOPE_MANUFACTURER_CLUSTER_ID = 0xFF01
+ATTRIBUTE_ACTION = "actionReport"
+CURTEMP = 0x0000
 
 
 class SinopeTechnologiesManufacturerCluster(CustomCluster):
@@ -43,6 +45,19 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
 
         Unlocked = 0x00
         Locked = 0x01
+        Partial_lock = 0x02
+
+    class PhaseControl(t.enum8):
+        """Phase control value, reverse / forward"""
+
+        Forward = 0x00
+        Reverse = 0x01
+
+    class DoubleFull(t.enum8):
+        """Double click up set full intensity"""
+
+        Off = 0x00
+        On = 0x01
 
     class Action(t.enum8):
         """action_report values."""
@@ -61,22 +76,35 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
     ep_attribute = "sinope_manufacturer_specific"
     attributes = {
         0x0002: ("keypad_lockout", KeypadLock, True),
+        0x0003: ("firmware_number", t.uint16_t, True),
         0x0004: ("firmware_version", t.CharacterString, True),
+        0x0010: ("on_intensity", t.int16s, True),
         0x0050: ("on_led_color", t.uint24_t, True),
         0x0051: ("off_led_color", t.uint24_t, True),
         0x0052: ("on_led_intensity", t.uint8_t, True),
         0x0053: ("off_led_intensity", t.uint8_t, True),
         0x0054: ("action_report", Action, True),
         0x0055: ("min_intensity", t.uint16_t, True),
+        0x0056: ("phase_control", PhaseControl, True),
+        0x0058: ("double_up_full", DoubleFull, True),
         0x00A0: ("timer", t.uint32_t, True),
+        0x00A1: ("timer_countdown", t.uint32_t, True),
         0x0119: ("connected_load", t.uint16_t, True),
-        0x0200: ("unknown", t.bitmap32, True),
+        0x0200: ("status", t.bitmap32, True),
         0xFFFD: ("cluster_revision", t.uint16_t, True),
     }
 
 
 class LightManufacturerCluster(EventableCluster, SinopeTechnologiesManufacturerCluster):
     """LightManufacturerCluster: fire events corresponding to press type."""
+
+
+class CustomDeviceTemperatureCluster(CustomCluster, DeviceTemperature):
+    """Custom DeviceTemperature Cluster."""
+
+    def _update_attribute(self, attrid, value):
+        if attrid == CURTEMP:
+            super()._update_attribute(attrid, value*100)
 
 
 class SinopeTechnologieslight(CustomDevice):
@@ -86,7 +114,10 @@ class SinopeTechnologieslight(CustomDevice):
         # <SimpleDescriptor endpoint=1 profile=260 device_type=259
         # device_version=0 input_clusters=[0, 2, 3, 4, 5, 6, 1794, 2821, 65281]
         # output_clusters=[3, 4, 25]>
-        MODELS_INFO: [(SINOPE, "SW2500ZB")],
+        MODELS_INFO: [
+            (SINOPE, "SW2500ZB"),
+            (SINOPE, "SW2500ZB-G2"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha_p.PROFILE_ID,
@@ -118,7 +149,7 @@ class SinopeTechnologieslight(CustomDevice):
                 DEVICE_TYPE: zha_p.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DeviceTemperature.cluster_id,
+                    CustomDeviceTemperatureCluster,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
@@ -140,13 +171,16 @@ class SinopeTechnologieslight(CustomDevice):
 
 
 class SinopeDM2500ZB(SinopeTechnologieslight):
-    """DM2500ZB Dimmer."""
+    """DM2500ZB, DM2500ZB-G2 Dimmers."""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=260 device_version=1
         # input_clusters=[0, 2, 3, 4, 5, 6, 8, 1794, 2821, 65281]
         # output_clusters=[3, 4, 25]>
-        MODELS_INFO: [(SINOPE, "DM2500ZB")],
+        MODELS_INFO: [
+            (SINOPE, "DM2500ZB"),
+            (SINOPE, "DM2500ZB-G2"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha_p.PROFILE_ID,
@@ -179,7 +213,7 @@ class SinopeDM2500ZB(SinopeTechnologieslight):
                 DEVICE_TYPE: zha_p.DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DeviceTemperature.cluster_id,
+                    CustomDeviceTemperatureCluster,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
@@ -202,13 +236,16 @@ class SinopeDM2500ZB(SinopeTechnologieslight):
 
 
 class SinopeDM2550ZB(SinopeTechnologieslight):
-    """DM2550ZB Dimmer."""
+    """DM2550ZB, DM2550ZB-G2 Dimmers."""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=260 device_version=1
         # input_clusters=[0, 2, 3, 4, 5, 6, 8, 1794, 2820, 2821, 65281]
         # output_clusters=[3, 4, 10, 25]>
-        MODELS_INFO: [(SINOPE, "DM2550ZB")],
+        MODELS_INFO: [
+            (SINOPE, "DM2550ZB"),
+            (SINOPE, "DM2550ZB-G2"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha_p.PROFILE_ID,
@@ -243,7 +280,7 @@ class SinopeDM2550ZB(SinopeTechnologieslight):
                 DEVICE_TYPE: zha_p.DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DeviceTemperature.cluster_id,
+                    CustomDeviceTemperatureCluster,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -30,11 +30,9 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.sinope import LIGHT_DEVICE_TRIGGERS, SINOPE
+from zhaquirks.sinope import LIGHT_DEVICE_TRIGGERS, SINOPE, ATTRIBUTE_ACTION, CURTEMP
 
 SINOPE_MANUFACTURER_CLUSTER_ID = 0xFF01
-ATTRIBUTE_ACTION = "actionReport"
-CURTEMP = 0x0000
 
 
 class SinopeTechnologiesManufacturerCluster(CustomCluster):

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -104,7 +104,7 @@ class CustomDeviceTemperatureCluster(CustomCluster, DeviceTemperature):
 
     def _update_attribute(self, attrid, value):
         if attrid == CURTEMP:
-            super()._update_attribute(attrid, value*100)
+            super()._update_attribute(attrid, value * 100)
 
 
 class SinopeTechnologieslight(CustomDevice):


### PR DESCRIPTION
Add many manufacturer cluster attributes for the new G2 Sinopé light and dimmer support

## Proposed change
<!--
  Explain your proposed change below.
-->
The new G2 light and dimmer add new fonctionality like doubleup full which open at 100% intensity and keep current dimmer value in memory. It add also support for the DM2550ZB phase control

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
This PR also fix device temperature that was incorrectly reported as celsius instead of celsius*100

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ x] The changes are tested and work correctly
- [ x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
