### PR TITLE
Sinope thermostat attribute update

### DIFF
--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -62,6 +62,20 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         Off = 0x00
         On = 0x01
 
+    class PumpStatus(t.uint8_t):
+        """Pump protection status."""
+
+        Off = 0x00
+        On = 0x01
+
+    class LimitStatus(t.uint8_t):
+        """Floor limit status values."""
+
+        Ok = 0x00
+        Low_reached = 0x01
+        Max_reached = 0x02
+        Max_air_reached = 0x03
+
     class SensorType(t.enum8):
         """temp_sensor_type values."""
 
@@ -88,6 +102,16 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         Cool = 0x03
         Heat = 0x04
 
+    class PumpDuration(t.enum8):
+        """Pump protection duration period values"""
+
+        T5 = 0x05
+        T10 = 0x0A
+        T15 = 0x0F
+        T20 = 0x14
+        T30 = 0x1E
+        T60 = 0x3C
+
     cluster_id = SINOPE_MANUFACTURER_CLUSTER_ID
     name = "Sinopé Technologies Manufacturer specific"
     ep_attribute = "sinope_manufacturer_specific"
@@ -111,14 +135,15 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         0x0109: ("floor_min_setpoint", t.int16s, True),
         0x010A: ("floor_max_setpoint", t.int16s, True),
         0x010B: ("floor_sensor_type_param", SensorType, True),
-        0x010C: ("floor_limit_status", t.uint8_t, True),
+        0x010C: ("floor_limit_status", LimitStatus, True),
         0x010D: ("room_temperature", t.int16s, True),
         0x0114: ("time_format", TimeFormat, True),
         0x0115: ("gfci_status", GfciStatus, True),
         0x0116: ("aux_mode", SystemMode, True),
         0x0118: ("aux_connected_load", t.uint16_t, True),
         0x0119: ("connected_load", t.uint16_t, True),
-        0x0128: ("pump_protection", t.uint8_t, True),
+        0x0128: ("pump_protection_status", PumpStatus, True),
+        0x012A: ("pump_protection_duration", PumpDuration, True),
         0x012B: ("current_setpoint", t.int16s, True),
         0x012D: ("report_local_temperature", t.int16s, True),
         0x0200: ("status", t.bitmap32, True),

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -189,7 +189,9 @@ class SinopeTechnologiesThermostatCluster(CustomCluster, Thermostat):
     )
 
 
-class SinopeTechnologiesElectricalMeasurementCluster(CustomCluster, ElectricalMeasurement):
+class SinopeTechnologiesElectricalMeasurementCluster(
+    CustomCluster, ElectricalMeasurement
+):
     """SinopeTechnologiesElectricalMeasurementCluster custom cluster."""
 
     attributes = ElectricalMeasurement.attributes.copy()

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -1,6 +1,6 @@
 """Module to handle quirks of the  Sinopé Technologies thermostat.
 
-manufacturer specific cluster implements attributes to control displaying
+Manufacturer specific cluster implements attributes to control displaying
 of outdoor temperature, setting occupancy on/off and setting device time.
 """
 
@@ -47,8 +47,8 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         """config_2nd_display values."""
 
         Auto = 0x00
-        Outside_temperature = 0x01
-        Setpoint = 0x02
+        Setpoint = 0x01
+        Outside_temperature = 0x02
 
     class FloorMode(t.enum8):
         """air_floor_mode values."""
@@ -80,11 +80,20 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         Ok = 0x00
         Error = 0x01
 
+    class SystemMode(t.enum8):
+        """system mode values."""
+
+        Off = 0x00
+        Auto = 0x01
+        Cool = 0x03
+        Heat = 0x04
+
     cluster_id = SINOPE_MANUFACTURER_CLUSTER_ID
     name = "Sinopé Technologies Manufacturer specific"
     ep_attribute = "sinope_manufacturer_specific"
     attributes = {
         0x0002: ("keypad_lockout", KeypadLock, True),
+        0x0003: ("firmware_number", t.uint16_t, True),
         0x0004: ("firmware_version", t.CharacterString, True),
         0x0010: ("outdoor_temp", t.int16s, True),
         0x0011: ("outdoor_temp_timeout", t.uint16_t, True),
@@ -101,15 +110,18 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         0x0108: ("air_max_limit", t.int16s, True),
         0x0109: ("floor_min_setpoint", t.int16s, True),
         0x010A: ("floor_max_setpoint", t.int16s, True),
-        0x010B: ("temp_sensor_type", SensorType, True),
+        0x010B: ("floor_sensor_type_param", SensorType, True),
         0x010C: ("floor_limit_status", t.uint8_t, True),
         0x010D: ("room_temperature", t.int16s, True),
         0x0114: ("time_format", TimeFormat, True),
         0x0115: ("gfci_status", GfciStatus, True),
+        0x0116: ("aux_mode", SystemMode, True),
         0x0118: ("aux_connected_load", t.uint16_t, True),
         0x0119: ("connected_load", t.uint16_t, True),
         0x0128: ("pump_protection", t.uint8_t, True),
+        0x012B: ("current_setpoint", t.int16s, True),
         0x012D: ("report_local_temperature", t.int16s, True),
+        0x0200: ("status", t.bitmap32, True),
         0xFFFD: ("cluster_revision", t.uint16_t, True),
     }
 
@@ -120,8 +132,8 @@ class SinopeTechnologiesThermostatCluster(CustomCluster, Thermostat):
     class Occupancy(t.enum8):
         """set_occupancy values."""
 
+        Home = 0x00
         Away = 0x01
-        Home = 0x02
 
     class Backlight(t.enum8):
         """backlight_auto_dim_param values."""
@@ -129,14 +141,38 @@ class SinopeTechnologiesThermostatCluster(CustomCluster, Thermostat):
         On_demand = 0x00
         Always_on = 0x01
 
+    class CycleOutput(t.uint16_t):
+        """main and aux cycle period values."""
+
+        Sec_15 = 0x000F
+        Min_5 = 0x012C
+        Min_10 = 0x0258
+        Min_15 = 0x0384
+        Min_20 = 0x04B0
+        Min_25 = 0x05DC
+        Min_30 = 0x0708
+
     attributes = Thermostat.attributes.copy()
     attributes.update(
         {
             0x0400: ("set_occupancy", Occupancy, True),
-            0x0401: ("main_cycle_output", t.uint16_t, True),
+            0x0401: ("main_cycle_output", CycleOutput, True),
             0x0402: ("backlight_auto_dim_param", Backlight, True),
-            0x0404: ("aux_cycle_output", t.uint16_t, True),
+            0x0404: ("aux_cycle_output", CycleOutput, True),
             0xFFFD: ("cluster_revision", t.uint16_t, True),
+        }
+    )
+
+
+class SinopeTechnologiesElectricalMeasurementCluster(CustomCluster, ElectricalMeasurement):
+    """SinopeTechnologiesElectricalMeasurementCluster custom cluster."""
+
+    attributes = ElectricalMeasurement.attributes.copy()
+    attributes.update(
+        {
+            0x0551: ("current_summation_delivered", t.uint32_t, True),
+            0x0552: ("aux_setpoint_min", t.uint32_t, True),
+            0x0553: ("aux_setpoint_max", t.uint32_t, True),
         }
     )
 
@@ -192,8 +228,8 @@ class SinopeTechnologiesThermostat(CustomDevice):
                     Scenes.cluster_id,
                     UserInterface.cluster_id,
                     TemperatureMeasurement.cluster_id,
-                    ElectricalMeasurement.cluster_id,
                     Diagnostic.cluster_id,
+                    SinopeTechnologiesElectricalMeasurementCluster,
                     SinopeTechnologiesThermostatCluster,
                     SinopeTechnologiesManufacturerCluster,
                 ],
@@ -310,8 +346,8 @@ class SinopeTH1300ZB(SinopeTechnologiesThermostat):
                     UserInterface.cluster_id,
                     TemperatureMeasurement.cluster_id,
                     Metering.cluster_id,
-                    ElectricalMeasurement.cluster_id,
                     Diagnostic.cluster_id,
+                    SinopeTechnologiesElectricalMeasurementCluster,
                     SinopeTechnologiesThermostatCluster,
                     SinopeTechnologiesManufacturerCluster,
                 ],
@@ -375,8 +411,8 @@ class SinopeLineThermostats(SinopeTechnologiesThermostat):
                     UserInterface.cluster_id,
                     TemperatureMeasurement.cluster_id,
                     Metering.cluster_id,
-                    ElectricalMeasurement.cluster_id,
                     Diagnostic.cluster_id,
+                    SinopeTechnologiesElectricalMeasurementCluster,
                     SinopeTechnologiesThermostatCluster,
                     SinopeTechnologiesManufacturerCluster,
                 ],
@@ -438,8 +474,8 @@ class SinopeG2Thermostats(SinopeTechnologiesThermostat):
                     UserInterface.cluster_id,
                     TemperatureMeasurement.cluster_id,
                     Metering.cluster_id,
-                    ElectricalMeasurement.cluster_id,
                     Diagnostic.cluster_id,
+                    SinopeTechnologiesElectricalMeasurementCluster,
                     SinopeTechnologiesThermostatCluster,
                     SinopeTechnologiesManufacturerCluster,
                 ],


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Added many manufacturer attributes and description of values supported. Pump protection, floor sensor, system mode,
Fix home / away value for thermostat set_occupancy attribute
Add cycle ouput values
Add SinopeTechnologiesElectricalMeasurementCluster for current_summation_delivered, aux_setpoint min and max


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Fix atribute values for config_2nd_display

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
