### PR TITLE
Clean up Develco unit test

### DIFF
--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -12,17 +12,14 @@ zhaquirks.setup()
 
 @pytest.mark.parametrize("quirk", (zhaquirks.develco.power_plug.SPLZB131,))
 async def test_develco_plug_device_temp_multiplier(zigpy_device_from_quirk, quirk):
-    """Test device temperature multiplication."""
-
+    """Test that device temperature is multiplied."""
     device = zigpy_device_from_quirk(quirk)
 
     dev_temp_cluster = device.endpoints[2].device_temperature
     dev_temp_listener = ClusterListener(dev_temp_cluster)
+    dev_temp_attr_id = DeviceTemperature.AttributeDefs.current_temperature.id
 
-    dev_temp_attr_id = DeviceTemperature.attributes_by_name["current_temperature"].id
-
-    # turn off heating
-    dev_temp_cluster._update_attribute(dev_temp_attr_id, 25)
+    dev_temp_cluster.update_attribute(dev_temp_attr_id, 25)
     assert len(dev_temp_listener.attribute_updates) == 1
     assert dev_temp_listener.attribute_updates[0][0] == dev_temp_attr_id
     assert dev_temp_listener.attribute_updates[0][1] == 2500  # multiplied by 100


### PR DESCRIPTION
## Proposed change
This slightly cleans up the Develco unit test for device temperature multiplication.
I noticed the wrong comment "turn off heating" recently which was copied from somewhere else.
The test now also uses zigpy new-style `AttributeDefs` (instead of `attributes_by_name`).

It's generally very similar to the added test for Sinope devices in: https://github.com/zigpy/zha-device-handlers/pull/2759
(except the endpoint)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
