### PR TITLE
Remove doubling of battery for symfonisk sound

### DIFF
--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -80,7 +80,7 @@ class IkeaSYMFONISK1(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfig1CRCluster,
+                    PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,


### PR DESCRIPTION

## Proposed change
<!--
  Explain your proposed change below.
-->
Sound controllers does not need doubling of battery percentage.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

Debug output of one of my sound controller, verified with another too.
[zha-810b434c4e1088344d3010f1e76eeb64-IKEA of Sweden SYMFONISK Sound Controller-e9fda80013051afd7cf7fd9a9982c3d7.json.txt](https://github.com/zigpy/zha-device-handlers/files/13467958/zha-810b434c4e1088344d3010f1e76eeb64-IKEA.of.Sweden.SYMFONISK.Sound.Controller-e9fda80013051afd7cf7fd9a9982c3d7.json.txt)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
