### PR TITLE
Add alternative IKEA Symfonisk Gen1 signature

### DIFF
--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -38,7 +38,13 @@ from zhaquirks.const import (
     TRIPLE_PRESS,
     TURN_ON,
 )
-from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, DoublingPowerConfig1CRCluster
+from zhaquirks.ikea import (
+    IKEA,
+    IKEA_CLUSTER_ID,
+    WWAH_CLUSTER_ID,
+    DoublingPowerConfig1CRCluster,
+    PowerConfig1CRCluster,
+)
 
 
 class IkeaSYMFONISK1(CustomDevice):
@@ -135,14 +141,14 @@ class IkeaSYMFONISK1(CustomDevice):
     }
 
 
-class IkeaSYMFONISK2(CustomDevice):
+class IkeaSYMFONISK2(IkeaSYMFONISK1):
     """Custom device representing IKEA of Sweden TRADFRI remote control."""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=6
         # device_version=1
-        # input_clusters=[0, 1, 3, 32, 4096 64636]
-        # output_clusters=[3, 4, 5, 6, 8, 25, 4096,]>
+        # input_clusters=[0, 1, 3, 32, 4096, 64636]
+        # output_clusters=[3, 4, 5, 6, 8, 25, 4096]>
         MODELS_INFO: [(IKEA, "SYMFONISK Sound Controller")],
         ENDPOINTS: {
             1: {
@@ -195,4 +201,64 @@ class IkeaSYMFONISK2(CustomDevice):
         }
     }
 
-    device_automation_triggers = IkeaSYMFONISK1.device_automation_triggers.copy()
+
+class IkeaSYMFONISK3(IkeaSYMFONISK1):
+    """Custom device representing IKEA of Sweden TRADFRI remote control."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=6
+        # input_clusters=[0, 1, 3, 32, 4096, 64599, 64636]
+        # output_clusters=[3, 4, 5, 6, 8, 25, 4096]>
+        MODELS_INFO: [(IKEA, "SYMFONISK Sound Controller")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                    WWAH_CLUSTER_ID,
+                    IKEA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfig1CRCluster,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                    WWAH_CLUSTER_ID,
+                    IKEA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }


### PR DESCRIPTION
## Proposed change
Adds an alternative signature for the IKEA Symfonisk Gen1 device.
This is a signature from 24.x firmware when newly paired.

It also cleans up the comments a bit and changes from the copying the device triggers to having all alternative classes inherit from `IkeaSYMFONISK1` (`device_automation_triggers` is still the same for all then).

Since 24.x firmware no longer requires power doubling, this quirk does not double the power. It uses the [`PowerConfig1CRCluster`](https://github.com/zigpy/zha-device-handlers/blob/3eb660a907829df0a7e52e5c8c45a11e88eaf02c/zhaquirks/ikea/__init__.py#L173-L180) cluster class to provide some information about battery quantity, size, and voltage.

## Additional information
Device diagnostics with signature originally provided in: https://github.com/zigpy/zha-device-handlers/pull/2773#issuecomment-1826910690

Note: We still need a proper long-term solution for quirks with the older signatures (that could still match this device if updated and not re-paired) regarding battery percentage doubling. Related:
- https://github.com/zigpy/zha-device-handlers/issues/2203
- https://github.com/zigpy/zha-device-handlers/pull/2773 (discussion)


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
