### PR TITLE
Fix Aqara motion sensor erroneous motion events

### DIFF
--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -11,6 +11,7 @@ from zigpy import types as t
 import zigpy.device
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.typing import AddressingMode
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     AnalogInput,
@@ -541,6 +542,19 @@ class MotionCluster(LocalDataCluster, MotionOnEvent):
 
     _CONSTANT_ATTRIBUTES = {IasZone.AttributeDefs.zone_type.id: MOTION_TYPE}
     reset_s: int = 70
+
+
+class LocalOccupancyCluster(LocalDataCluster, OccupancyCluster):
+    """Local occupancy cluster that ignores messages from device."""
+
+    def handle_cluster_general_request(
+        self,
+        hdr: zigpy.zcl.foundation.ZCLHeader,
+        args: list,
+        *,
+        dst_addressing: AddressingMode | None = None,
+    ) -> None:
+        """Ignore occupancy attribute reports on this cluster, as they're invalid and sent by the sensor every hour."""
 
 
 class DeviceTemperatureCluster(LocalDataCluster, DeviceTemperature):

--- a/zhaquirks/xiaomi/aqara/motion_agl02.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl02.py
@@ -59,6 +59,12 @@ class LocalOccupancyCluster(LocalDataCluster, OccupancyCluster):
         """Ignore occupancy attribute reports on this cluster, as they're invalid and sent by the sensor every hour."""
 
 
+class LocalMotionCluster(MotionCluster):
+    """Local motion cluster."""
+
+    reset_s: int = 60
+
+
 class MotionT1(XiaomiCustomDevice):
     """Xiaomi motion sensor device."""
 
@@ -96,7 +102,7 @@ class MotionT1(XiaomiCustomDevice):
                     XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     LocalOccupancyCluster,
-                    MotionCluster,
+                    LocalMotionCluster,
                     IlluminanceMeasurementCluster,
                     XiaomiManufacturerCluster,
                 ],

--- a/zhaquirks/xiaomi/aqara/motion_agl02.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl02.py
@@ -1,13 +1,11 @@
 """Xiaomi aqara T1 motion sensor device."""
 from __future__ import annotations
 
-import zigpy
 from zigpy.profiles import zha
-from zigpy.typing import AddressingMode
 from zigpy.zcl.clusters.general import Identify, Ota
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement, OccupancySensing
 
-from zhaquirks import Bus, LocalDataCluster
+from zhaquirks import Bus
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -20,8 +18,8 @@ from zhaquirks.xiaomi import (
     LUMI,
     BasicCluster,
     IlluminanceMeasurementCluster,
+    LocalOccupancyCluster,
     MotionCluster,
-    OccupancyCluster,
     XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
     XiaomiPowerConfiguration,
@@ -44,19 +42,6 @@ class XiaomiManufacturerCluster(XiaomiAqaraE1Cluster):
                 OccupancySensing.AttributeDefs.occupancy.id,
                 OccupancySensing.Occupancy.Occupied,
             )
-
-
-class LocalOccupancyCluster(LocalDataCluster, OccupancyCluster):
-    """Local occupancy cluster."""
-
-    def handle_cluster_general_request(
-        self,
-        hdr: zigpy.zcl.foundation.ZCLHeader,
-        args: list,
-        *,
-        dst_addressing: AddressingMode | None = None,
-    ) -> None:
-        """Ignore occupancy attribute reports on this cluster, as they're invalid and sent by the sensor every hour."""
 
 
 class LocalMotionCluster(MotionCluster):

--- a/zhaquirks/xiaomi/aqara/motion_agl02.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl02.py
@@ -1,5 +1,9 @@
 """Xiaomi aqara T1 motion sensor device."""
+from __future__ import annotations
+
+import zigpy
 from zigpy.profiles import zha
+from zigpy.typing import AddressingMode
 from zigpy.zcl.clusters.general import Identify, Ota
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement, OccupancySensing
 
@@ -44,6 +48,15 @@ class XiaomiManufacturerCluster(XiaomiAqaraE1Cluster):
 
 class LocalOccupancyCluster(LocalDataCluster, OccupancyCluster):
     """Local occupancy cluster."""
+
+    def handle_cluster_general_request(
+        self,
+        hdr: zigpy.zcl.foundation.ZCLHeader,
+        args: list,
+        *,
+        dst_addressing: AddressingMode | None = None,
+    ) -> None:
+        """Ignore occupancy attribute reports on this cluster, as they're invalid and sent by the sensor every hour."""
 
 
 class MotionT1(XiaomiCustomDevice):

--- a/zhaquirks/xiaomi/aqara/motion_agl02.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl02.py
@@ -44,12 +44,6 @@ class XiaomiManufacturerCluster(XiaomiAqaraE1Cluster):
             )
 
 
-class LocalMotionCluster(MotionCluster):
-    """Local motion cluster."""
-
-    reset_s: int = 60
-
-
 class MotionT1(XiaomiCustomDevice):
     """Xiaomi motion sensor device."""
 
@@ -87,7 +81,7 @@ class MotionT1(XiaomiCustomDevice):
                     XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     LocalOccupancyCluster,
-                    LocalMotionCluster,
+                    MotionCluster,
                     IlluminanceMeasurementCluster,
                     XiaomiManufacturerCluster,
                 ],

--- a/zhaquirks/xiaomi/aqara/motion_agl02.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl02.py
@@ -3,7 +3,7 @@ from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Identify, Ota
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement, OccupancySensing
 
-from zhaquirks import Bus
+from zhaquirks import Bus, LocalDataCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -42,6 +42,10 @@ class XiaomiManufacturerCluster(XiaomiAqaraE1Cluster):
             )
 
 
+class LocalOccupancyCluster(LocalDataCluster, OccupancyCluster):
+    """Local occupancy cluster."""
+
+
 class MotionT1(XiaomiCustomDevice):
     """Xiaomi motion sensor device."""
 
@@ -78,7 +82,7 @@ class MotionT1(XiaomiCustomDevice):
                     BasicCluster,
                     XiaomiPowerConfiguration,
                     Identify.cluster_id,
-                    OccupancyCluster,
+                    LocalOccupancyCluster,
                     MotionCluster,
                     IlluminanceMeasurementCluster,
                     XiaomiManufacturerCluster,

--- a/zhaquirks/xiaomi/aqara/motion_agl04.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl04.py
@@ -19,8 +19,8 @@ from zhaquirks.const import (
 )
 from zhaquirks.xiaomi import (
     DeviceTemperatureCluster,
+    LocalOccupancyCluster,
     MotionCluster,
-    OccupancyCluster,
     XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
     XiaomiPowerConfiguration,
@@ -98,7 +98,7 @@ class LumiLumiMotionAgl04(XiaomiCustomDevice):
                     XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     DeviceTemperatureCluster,
-                    OccupancyCluster,
+                    LocalOccupancyCluster,
                     LocalMotionCluster,
                     OppleCluster,
                 ],


### PR DESCRIPTION
## Proposed change
The Aqara T1 motion sensor sends false attribute reports about every hour or so on the `Occupancy` cluster. Just using a `LocalDataCluster` doesn't ignore them, so we override `handle_cluster_general_request`.
The same fix is also applied for the Aqara "high-precision" agl04 motion sensor.

This was reported via Discord.

## Additional information
We should also consider using a `LocalMotionCluster` for this sensor in the future (like the P1 quirk already does).
A 60 second timeout also works for this sensor.

Ideally, we should also figure out if this is needed for the "high-precision" agl04 motion sensor.
-> yes, see https://github.com/home-assistant/core/issues/114129

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
