### PR TITLE
Fix energy and current divisors for Innr plugs, clean up

### DIFF
--- a/zhaquirks/innr/__init__.py
+++ b/zhaquirks/innr/__init__.py
@@ -8,7 +8,7 @@ INNR = "innr"
 class MeteringClusterInnr(CustomCluster, Metering):
     """Provide constant multiplier and divisor.
 
-    The device supplies the summation_formatting attribute correctly, but ZHA doesn't use it for kWh at the moment.
+    The device seems to supply the summation_formatting attribute correctly, but ZHA doesn't use it for kWh for now.
     """
 
     _CONSTANT_ATTRIBUTES = {

--- a/zhaquirks/innr/__init__.py
+++ b/zhaquirks/innr/__init__.py
@@ -1,1 +1,15 @@
 """Module for Innr quirks implementations."""
+from zigpy.quirks import CustomCluster
+from zigpy.zcl.clusters.smartenergy import Metering
+
+
+class MeteringClusterInnr(CustomCluster, Metering):
+    """Provide constant multiplier and divisor.
+
+    The device supplies the summation_formatting attribute correctly, but ZHA doesn't use it for kWh at the moment.
+    """
+
+    _CONSTANT_ATTRIBUTES = {
+        Metering.AttributeDefs.multiplier.id: 1,
+        Metering.AttributeDefs.divisor.id: 100,
+    }

--- a/zhaquirks/innr/__init__.py
+++ b/zhaquirks/innr/__init__.py
@@ -1,5 +1,6 @@
 """Module for Innr quirks implementations."""
 from zigpy.quirks import CustomCluster
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
 INNR = "innr"
@@ -14,4 +15,15 @@ class MeteringClusterInnr(CustomCluster, Metering):
     _CONSTANT_ATTRIBUTES = {
         Metering.AttributeDefs.multiplier.id: 1,
         Metering.AttributeDefs.divisor.id: 100,
+    }
+
+
+class ElectricalMeasurementClusterInnr(CustomCluster, ElectricalMeasurement):
+    """Fix multiplier and divisor for AC current."""
+
+    _CONSTANT_ATTRIBUTES = {
+        ElectricalMeasurement.AttributeDefs.ac_current_multiplier.id: 1,
+        ElectricalMeasurement.AttributeDefs.ac_current_divisor.id: 1000,
+        ElectricalMeasurement.AttributeDefs.ac_power_divisor.id: 1,
+        ElectricalMeasurement.AttributeDefs.ac_power_multiplier.id: 1,
     }

--- a/zhaquirks/innr/__init__.py
+++ b/zhaquirks/innr/__init__.py
@@ -19,7 +19,7 @@ class MeteringClusterInnr(CustomCluster, Metering):
 
 
 class ElectricalMeasurementClusterInnr(CustomCluster, ElectricalMeasurement):
-    """Fix multiplier and divisor for AC current."""
+    """Fix multiplier and divisor for AC current and power."""
 
     _CONSTANT_ATTRIBUTES = {
         ElectricalMeasurement.AttributeDefs.ac_current_multiplier.id: 1,

--- a/zhaquirks/innr/__init__.py
+++ b/zhaquirks/innr/__init__.py
@@ -2,6 +2,8 @@
 from zigpy.quirks import CustomCluster
 from zigpy.zcl.clusters.smartenergy import Metering
 
+INNR = "innr"
+
 
 class MeteringClusterInnr(CustomCluster, Metering):
     """Provide constant multiplier and divisor.

--- a/zhaquirks/innr/innr_sp120_plug.py
+++ b/zhaquirks/innr/innr_sp120_plug.py
@@ -23,15 +23,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.innr import INNR
-
-
-class MeteringCluster(CustomCluster, Metering):
-    """Fix multiplier and divisor."""
-
-    MULTIPLIER = 0x0301
-    DIVISOR = 0x0302
-    _CONSTANT_ATTRIBUTES = {MULTIPLIER: 1, DIVISOR: 100}
+from zhaquirks.innr import INNR, MeteringClusterInnr
 
 
 class ElectricalMeasurementCluster(CustomCluster, ElectricalMeasurement):
@@ -90,7 +82,7 @@ class SP120(CustomDevice):
                     Groups.cluster_id,
                     Identify.cluster_id,
                     LevelControl.cluster_id,
-                    MeteringCluster,
+                    MeteringClusterInnr,
                     OnOff.cluster_id,
                     Scenes.cluster_id,
                     Time.cluster_id,

--- a/zhaquirks/innr/innr_sp120_plug.py
+++ b/zhaquirks/innr/innr_sp120_plug.py
@@ -23,9 +23,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-MANUFACTURER = "innr"
-MODEL = "SP 120"
+from zhaquirks.innr import INNR
 
 
 class MeteringCluster(CustomCluster, Metering):
@@ -48,6 +46,7 @@ class SP120(CustomDevice):
     """Innr SP 120 smart plug."""
 
     signature = {
+        MODELS_INFO: [(INNR, "SP 120")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zll.PROFILE_ID,
@@ -78,7 +77,6 @@ class SP120(CustomDevice):
                 OUTPUT_CLUSTERS: [],
             },
         },
-        MODELS_INFO: [(MANUFACTURER, MODEL)],
     }
 
     replacement = {

--- a/zhaquirks/innr/innr_sp120_plug.py
+++ b/zhaquirks/innr/innr_sp120_plug.py
@@ -27,11 +27,12 @@ from zhaquirks.innr import INNR, MeteringClusterInnr
 
 
 class ElectricalMeasurementCluster(CustomCluster, ElectricalMeasurement):
-    """Fix multiplier and divisor."""
+    """Fix multiplier and divisor for AC current."""
 
-    MULTIPLIER = 0x0602
-    DIVISOR = 0x0603
-    _CONSTANT_ATTRIBUTES = {MULTIPLIER: 1, DIVISOR: 1000}
+    _CONSTANT_ATTRIBUTES = {
+        ElectricalMeasurement.AttributeDefs.ac_current_multiplier.id: 1,
+        ElectricalMeasurement.AttributeDefs.ac_current_divisor.id: 1000,
+    }
 
 
 class SP120(CustomDevice):

--- a/zhaquirks/innr/innr_sp120_plug.py
+++ b/zhaquirks/innr/innr_sp120_plug.py
@@ -1,6 +1,6 @@
 """Innr SP 120 plug."""
 from zigpy.profiles import zll
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -23,16 +23,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.innr import INNR, MeteringClusterInnr
-
-
-class ElectricalMeasurementCluster(CustomCluster, ElectricalMeasurement):
-    """Fix multiplier and divisor for AC current."""
-
-    _CONSTANT_ATTRIBUTES = {
-        ElectricalMeasurement.AttributeDefs.ac_current_multiplier.id: 1,
-        ElectricalMeasurement.AttributeDefs.ac_current_divisor.id: 1000,
-    }
+from zhaquirks.innr import INNR, ElectricalMeasurementClusterInnr, MeteringClusterInnr
 
 
 class SP120(CustomDevice):
@@ -79,7 +70,7 @@ class SP120(CustomDevice):
                 DEVICE_TYPE: zll.DeviceType.ON_OFF_PLUGIN_UNIT,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    ElectricalMeasurementCluster,
+                    ElectricalMeasurementClusterInnr,
                     Groups.cluster_id,
                     Identify.cluster_id,
                     LevelControl.cluster_id,

--- a/zhaquirks/innr/innr_sp234_plug.py
+++ b/zhaquirks/innr/innr_sp234_plug.py
@@ -23,9 +23,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-MANUFACTURER = "innr"
-MODEL = "SP 234"
+from zhaquirks.innr import INNR
 
 
 class ElectricalMeasurementCluster(CustomCluster, ElectricalMeasurement):
@@ -39,6 +37,7 @@ class SP234(CustomDevice):
     """Innr SP 234 smart plug."""
 
     signature = {
+        MODELS_INFO: [(INNR, "SP 234")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -69,7 +68,6 @@ class SP234(CustomDevice):
                 OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
             },
         },
-        MODELS_INFO: [(MANUFACTURER, MODEL)],
     }
 
     replacement = {

--- a/zhaquirks/innr/innr_sp234_plug.py
+++ b/zhaquirks/innr/innr_sp234_plug.py
@@ -23,7 +23,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.innr import INNR
+from zhaquirks.innr import INNR, MeteringClusterInnr
 
 
 class ElectricalMeasurementCluster(CustomCluster, ElectricalMeasurement):
@@ -80,7 +80,7 @@ class SP234(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     OnOff.cluster_id,
-                    Metering.cluster_id,
+                    MeteringClusterInnr,
                     ElectricalMeasurementCluster,
                     Diagnostic.cluster_id,
                     LightLink.cluster_id,

--- a/zhaquirks/innr/innr_sp234_plug.py
+++ b/zhaquirks/innr/innr_sp234_plug.py
@@ -1,6 +1,6 @@
 """Innr SP 234 plug."""
 from zigpy.profiles import zgp, zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
@@ -23,13 +23,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.innr import INNR, MeteringClusterInnr
-
-
-class ElectricalMeasurementCluster(CustomCluster, ElectricalMeasurement):
-    """Fix divisor for AC power."""
-
-    _CONSTANT_ATTRIBUTES = {ElectricalMeasurement.AttributeDefs.ac_power_divisor.id: 1}
+from zhaquirks.innr import INNR, ElectricalMeasurementClusterInnr, MeteringClusterInnr
 
 
 class SP234(CustomDevice):
@@ -81,7 +75,7 @@ class SP234(CustomDevice):
                     Scenes.cluster_id,
                     OnOff.cluster_id,
                     MeteringClusterInnr,
-                    ElectricalMeasurementCluster,
+                    ElectricalMeasurementClusterInnr,
                     Diagnostic.cluster_id,
                     LightLink.cluster_id,
                     0xFC57,

--- a/zhaquirks/innr/innr_sp234_plug.py
+++ b/zhaquirks/innr/innr_sp234_plug.py
@@ -29,8 +29,7 @@ from zhaquirks.innr import INNR
 class ElectricalMeasurementCluster(CustomCluster, ElectricalMeasurement):
     """Fix divisor."""
 
-    AC_POWER_DIVISOR = 0x0605
-    _CONSTANT_ATTRIBUTES = {AC_POWER_DIVISOR: 1}
+    _CONSTANT_ATTRIBUTES = {ElectricalMeasurement.AttributeDefs.ac_power_divisor.id: 1}
 
 
 class SP234(CustomDevice):

--- a/zhaquirks/innr/innr_sp234_plug.py
+++ b/zhaquirks/innr/innr_sp234_plug.py
@@ -27,7 +27,7 @@ from zhaquirks.innr import INNR, MeteringClusterInnr
 
 
 class ElectricalMeasurementCluster(CustomCluster, ElectricalMeasurement):
-    """Fix divisor."""
+    """Fix divisor for AC power."""
 
     _CONSTANT_ATTRIBUTES = {ElectricalMeasurement.AttributeDefs.ac_power_divisor.id: 1}
 

--- a/zhaquirks/innr/innr_sp240_plug.py
+++ b/zhaquirks/innr/innr_sp240_plug.py
@@ -1,0 +1,110 @@
+"""Quirk for innr SP 240."""
+
+from zigpy.profiles import zgp, zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.lightlink import LightLink
+from zigpy.zcl.clusters.smartenergy import Metering
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class MeteringCluster(CustomCluster, Metering):
+    """Fix multiplier and divisor.
+
+    The device supplies the summation_formatting attribute correctly, but ZHA doesn't use it for kWh at the moment.
+    """
+
+    _CONSTANT_ATTRIBUTES = {
+        Metering.AttributeDefs.multiplier.id: 1,
+        Metering.AttributeDefs.divisor.id: 100,
+    }
+
+
+class InnrSp240(CustomDevice):
+    """Innr SP 240 custom device implementation."""
+
+    signature = {
+        MODELS_INFO: [("innr", "SP 240")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    LightLink.cluster_id,
+                    0xE001,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    MeteringCluster,
+                    ElectricalMeasurement.cluster_id,
+                    LightLink.cluster_id,
+                    0xE001,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
+            },
+        },
+    }

--- a/zhaquirks/innr/innr_sp240_plug.py
+++ b/zhaquirks/innr/innr_sp240_plug.py
@@ -25,7 +25,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.innr import MeteringClusterInnr
+from zhaquirks.innr import INNR, MeteringClusterInnr
 
 
 class InnrCluster(CustomCluster):
@@ -38,7 +38,7 @@ class InnrSp240(CustomDevice):
     """Innr SP 240 custom device implementation."""
 
     signature = {
-        MODELS_INFO: [("innr", "SP 240")],
+        MODELS_INFO: [(INNR, "SP 240")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/innr/innr_sp240_plug.py
+++ b/zhaquirks/innr/innr_sp240_plug.py
@@ -40,6 +40,8 @@ class MeteringCluster(CustomCluster, Metering):
 
 
 class InnrCluster(CustomCluster):
+    """Innr manufacturer specific cluster."""
+
     cluster_id = 0xE001
 
 

--- a/zhaquirks/innr/innr_sp240_plug.py
+++ b/zhaquirks/innr/innr_sp240_plug.py
@@ -39,6 +39,10 @@ class MeteringCluster(CustomCluster, Metering):
     }
 
 
+class InnrCluster(CustomCluster):
+    cluster_id = 0xE001
+
+
 class InnrSp240(CustomDevice):
     """Innr SP 240 custom device implementation."""
 
@@ -58,7 +62,7 @@ class InnrSp240(CustomDevice):
                     Metering.cluster_id,
                     ElectricalMeasurement.cluster_id,
                     LightLink.cluster_id,
-                    0xE001,
+                    InnrCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,
@@ -91,7 +95,7 @@ class InnrSp240(CustomDevice):
                     MeteringCluster,
                     ElectricalMeasurement.cluster_id,
                     LightLink.cluster_id,
-                    0xE001,
+                    InnrCluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,

--- a/zhaquirks/innr/innr_sp240_plug.py
+++ b/zhaquirks/innr/innr_sp240_plug.py
@@ -25,18 +25,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
-
-class MeteringCluster(CustomCluster, Metering):
-    """Fix multiplier and divisor.
-
-    The device supplies the summation_formatting attribute correctly, but ZHA doesn't use it for kWh at the moment.
-    """
-
-    _CONSTANT_ATTRIBUTES = {
-        Metering.AttributeDefs.multiplier.id: 1,
-        Metering.AttributeDefs.divisor.id: 100,
-    }
+from zhaquirks.innr import MeteringClusterInnr
 
 
 class InnrCluster(CustomCluster):
@@ -94,7 +83,7 @@ class InnrSp240(CustomDevice):
                     Scenes.cluster_id,
                     OnOff.cluster_id,
                     LevelControl.cluster_id,
-                    MeteringCluster,
+                    MeteringClusterInnr,
                     ElectricalMeasurement.cluster_id,
                     LightLink.cluster_id,
                     InnrCluster,

--- a/zhaquirks/innr/innr_sp240_plug.py
+++ b/zhaquirks/innr/innr_sp240_plug.py
@@ -1,4 +1,4 @@
-"""Quirk for innr SP 240."""
+"""Innr SP 240 plug."""
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -34,8 +34,8 @@ class InnrCluster(CustomCluster):
     cluster_id = 0xE001
 
 
-class InnrSp240(CustomDevice):
-    """Innr SP 240 custom device implementation."""
+class SP240(CustomDevice):
+    """Innr SP 240  smart plug."""
 
     signature = {
         MODELS_INFO: [(INNR, "SP 240")],

--- a/zhaquirks/innr/rs228t.py
+++ b/zhaquirks/innr/rs228t.py
@@ -23,6 +23,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.innr import INNR
 
 
 class RS228T(CustomDevice):
@@ -33,7 +34,7 @@ class RS228T(CustomDevice):
         # device_version=1
         # input_clusters=[0, 3, 4, 5, 6, 8, 768, 4096]
         # output_clusters=[25]>
-        MODELS_INFO: [("innr", "RS 228 T")],
+        MODELS_INFO: [(INNR, "RS 228 T")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
## Proposed change
Adds a constant divisor attribute for the Innr SP240 plug for the `Metering` cluster.
It also fixes the divisors for other plugs and cleans everything up a bit.

## Additional information
Addresses https://github.com/zigpy/zha-device-handlers/issues/2781. The [comment in that issue](https://github.com/zigpy/zha-device-handlers/issues/2781#issuecomment-1830832448) is still relevant though.

Note: The SP-234 apparently has `ac_current_divisor` [set correctly to `1000` already](https://github.com/zigpy/zha-device-handlers/issues/2781#issuecomment-1831186468). We're doing that again in our EM cluster now.
The original quirk just set power divider to `1`. Apparently it was `10` before (reported by original quirk creator).
Z2M code comments mentions that `ac_current_divisor` wasn't present on some devices though, hence why we're always overriding it now.
EDIT: It seems like it's not present (correctly) on older firmware versions. Hence this PR adds it always.

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
