### PR TITLE
Support power/energy for more Aqara (H1) switches, add devices

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -401,8 +401,6 @@ def test_signature(quirk: CustomDevice) -> None:
             # Some quirks do not yet have model info:
             zhaquirks.xbee.xbee_io.XBeeSensor,
             zhaquirks.xbee.xbee3_io.XBee3Sensor,
-            zhaquirks.xiaomi.aqara.opple_switch.XiaomiOpple2ButtonSwitchFace2,
-            zhaquirks.xiaomi.aqara.opple_switch.XiaomiOpple2ButtonSwitchFace1,
             zhaquirks.tuya.ts0201.MoesTemperatureHumidtySensorWithScreen,
             zhaquirks.smartthings.tag_v4.SmartThingsTagV4,
             zhaquirks.smartthings.multi.SmartthingsMultiPurposeSensor,

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -542,10 +542,6 @@ class DeviceTemperatureCluster(LocalDataCluster, DeviceTemperature):
     """Device Temperature Cluster."""
 
 
-class XiaomiMeteringCluster(LocalDataCluster, Metering):
-    """Xiaomi Metering Cluster."""
-
-
 class TemperatureMeasurementCluster(CustomCluster, TemperatureMeasurement):
     """Temperature cluster that filters out invalid temperature readings."""
 

--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -50,7 +50,12 @@ from zhaquirks.const import (
     VALUE,
     ZHA_SEND_EVENT,
 )
-from zhaquirks.xiaomi import LUMI, BasicCluster, XiaomiCustomDevice
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    XiaomiAqaraE1Cluster,
+    XiaomiCustomDevice,
+)
 
 PRESS_TYPES = {0: "hold", 1: "single", 2: "double", 3: "triple", 255: "release"}
 STATUS_TYPE_ATTR = 0x0055  # decimal = 85
@@ -91,7 +96,6 @@ COMMAND_6_TRIPLE = "6_triple"
 COMMAND_6_HOLD = "6_hold"
 COMMAND_6_RELEASE = "6_release"
 
-OPPLE_CLUSTER_ID = 0xFCC0
 OPPLE_MFG_CODE = 0x115F
 
 
@@ -129,11 +133,9 @@ class MultistateInputCluster(CustomCluster, MultistateInput):
             super()._update_attribute(0, action)
 
 
-class OppleCluster(CustomCluster):
+class OppleCluster(XiaomiAqaraE1Cluster):
     """Opple cluster."""
 
-    ep_attribute = "opple_cluster"
-    cluster_id = OPPLE_CLUSTER_ID
     attributes = {
         0x0009: ("mode", types.uint8_t, True),
     }

--- a/zhaquirks/xiaomi/aqara/opple_switch.py
+++ b/zhaquirks/xiaomi/aqara/opple_switch.py
@@ -127,16 +127,16 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    DeviceTemperatureCluster,  # 2
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOffCluster,  # 6
-                    Alarms.cluster_id,  # 9
-                    MultistateInputCluster,  # 18
-                    MeteringCluster,  # 0x0702
-                    ElectricalMeasurementCluster,  # 0x0B04
-                    OppleSwitchCluster,  # 0xFCC0 / 64704
+                    DeviceTemperatureCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    Alarms.cluster_id,
+                    MultistateInputCluster,
+                    MeteringCluster,
+                    ElectricalMeasurementCluster,
+                    OppleSwitchCluster,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
@@ -144,12 +144,12 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOffCluster,  # 6
-                    MultistateInputCluster,  # 18
-                    OppleSwitchCluster,  # 0xFCC0 / 64704
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    OppleSwitchCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -158,7 +158,7 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    AnalogInputCluster,  # 12
+                    AnalogInputCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -167,7 +167,7 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    AnalogInput.cluster_id,  # 12
+                    AnalogInput.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -176,7 +176,7 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    MultistateInputCluster,  # 18
+                    MultistateInputCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -185,7 +185,7 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    MultistateInputCluster,  # 18
+                    MultistateInputCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -194,7 +194,7 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    MultistateInputCluster,  # 18
+                    MultistateInputCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -203,7 +203,7 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    MultistateInputCluster,  # 18
+                    MultistateInputCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -287,14 +287,14 @@ class XiaomiOpple2ButtonSwitchFace1(XiaomiOpple2ButtonSwitchBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    DeviceTemperatureCluster.cluster_id,  # 2
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    MultistateInputCluster.cluster_id,  # 18
-                    OppleSwitchCluster.cluster_id,  # 0xFCC0 / 64704
+                    Basic.cluster_id,
+                    DeviceTemperatureCluster.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInputCluster.cluster_id,
+                    OppleSwitchCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
@@ -303,13 +303,13 @@ class XiaomiOpple2ButtonSwitchFace1(XiaomiOpple2ButtonSwitchBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    MultistateInputCluster.cluster_id,  # 18
-                    OppleSwitchCluster.cluster_id,  # 0xFCC0 / 64704
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInputCluster.cluster_id,
+                    OppleSwitchCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -318,7 +318,7 @@ class XiaomiOpple2ButtonSwitchFace1(XiaomiOpple2ButtonSwitchBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    AnalogInput.cluster_id,  # 12
+                    AnalogInput.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -327,7 +327,7 @@ class XiaomiOpple2ButtonSwitchFace1(XiaomiOpple2ButtonSwitchBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    AnalogInput.cluster_id,  # 12
+                    AnalogInput.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -336,7 +336,7 @@ class XiaomiOpple2ButtonSwitchFace1(XiaomiOpple2ButtonSwitchBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,  # 18
+                    MultistateInputCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -345,7 +345,7 @@ class XiaomiOpple2ButtonSwitchFace1(XiaomiOpple2ButtonSwitchBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,  # 18
+                    MultistateInputCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -354,7 +354,7 @@ class XiaomiOpple2ButtonSwitchFace1(XiaomiOpple2ButtonSwitchBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,  # 18
+                    MultistateInputCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
             },

--- a/zhaquirks/xiaomi/aqara/opple_switch.py
+++ b/zhaquirks/xiaomi/aqara/opple_switch.py
@@ -42,11 +42,13 @@ from zhaquirks.const import (
 )
 from zhaquirks.xiaomi import (
     LUMI,
+    AnalogInputCluster,
     BasicCluster,
     DeviceTemperatureCluster,
+    ElectricalMeasurementCluster,
+    MeteringCluster,
     OnOffCluster,
     XiaomiCustomDevice,
-    XiaomiMeteringCluster,
 )
 
 from .opple_remote import MultistateInputCluster, OppleCluster
@@ -87,7 +89,6 @@ class OppleSwitchCluster(OppleCluster):
     """Xiaomi mfg cluster implementation."""
 
     attributes = copy.deepcopy(OppleCluster.attributes)
-
     attributes.update(
         {
             0x0002: ("power_outage_count", t.uint8_t, True),
@@ -133,7 +134,8 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
                     OnOffCluster,  # 6
                     Alarms.cluster_id,  # 9
                     MultistateInputCluster,  # 18
-                    XiaomiMeteringCluster,  # 0x0702
+                    MeteringCluster,  # 0x0702
+                    ElectricalMeasurementCluster,  # 0x0B04
                     OppleSwitchCluster,  # 0xFCC0 / 64704
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
@@ -156,7 +158,7 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    AnalogInput.cluster_id,  # 12
+                    AnalogInputCluster,  # 12
                 ],
                 OUTPUT_CLUSTERS: [],
             },
@@ -386,7 +388,7 @@ class XiaomiOpple2ButtonSwitchFace2(XiaomiOpple2ButtonSwitchBase):
                     Scenes.cluster_id,  # 5
                     OnOff.cluster_id,  # 6
                     Alarms.cluster_id,  # 9
-                    XiaomiMeteringCluster.cluster_id,  # 0x0702
+                    MeteringCluster.cluster_id,  # 0x0702
                     0x0B04,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],

--- a/zhaquirks/xiaomi/aqara/opple_switch.py
+++ b/zhaquirks/xiaomi/aqara/opple_switch.py
@@ -277,8 +277,6 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
 class XiaomiOpple2ButtonSwitchFace1(XiaomiOpple2ButtonSwitchBase):
     """Xiaomi Opple 2 Button Switch. Face 1."""
 
-    device_automation_triggers = XiaomiOpple2ButtonSwitchBase.device_automation_triggers
-
     signature = {
         MODELS_INFO: [(LUMI, "lumi.switch.b2naus01")],
         ENDPOINTS: {

--- a/zhaquirks/xiaomi/aqara/opple_switch.py
+++ b/zhaquirks/xiaomi/aqara/opple_switch.py
@@ -33,6 +33,7 @@ from zhaquirks.const import (
     ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
+    MODELS_INFO,
     OUTPUT_CLUSTERS,
     PRESS_TYPE,
     PROFILE_ID,
@@ -40,6 +41,7 @@ from zhaquirks.const import (
     ZHA_SEND_EVENT,
 )
 from zhaquirks.xiaomi import (
+    LUMI,
     BasicCluster,
     DeviceTemperatureCluster,
     OnOffCluster,
@@ -276,6 +278,7 @@ class XiaomiOpple2ButtonSwitchFace1(XiaomiOpple2ButtonSwitchBase):
     device_automation_triggers = XiaomiOpple2ButtonSwitchBase.device_automation_triggers
 
     signature = {
+        MODELS_INFO: [(LUMI, "lumi.switch.b2naus01")],
         ENDPOINTS: {
             # input_clusters=[0, 2, 3, 4, 5, 6, 18, 64704], output_clusters=[10, 25]
             1: {
@@ -369,6 +372,7 @@ class XiaomiOpple2ButtonSwitchFace2(XiaomiOpple2ButtonSwitchBase):
     device_automation_triggers = XiaomiOpple2ButtonSwitchBase.device_automation_triggers
 
     signature = {
+        MODELS_INFO: [(LUMI, "lumi.switch.n2aeu1")],
         ENDPOINTS: {
             #  input_clusters=[0, 2, 3, 4, 5, 6, 18, 64704], output_clusters=[10, 25]
             1: {

--- a/zhaquirks/xiaomi/aqara/opple_switch.py
+++ b/zhaquirks/xiaomi/aqara/opple_switch.py
@@ -1,4 +1,4 @@
-"""Xiaomi aqara single key wall switch devices."""
+"""Xiaomi Aqara wall switch devices. Also see switch_h1_single.py for similar H1 single rocker switches."""
 import copy
 from enum import Enum
 
@@ -353,54 +353,6 @@ class XiaomiOpple2ButtonSwitchFace1(XiaomiOpple2ButtonSwitchBase):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
                     MultistateInputCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
-    }
-
-
-class XiaomiOpple2ButtonSwitchFace2(XiaomiOpple2ButtonSwitchBase):
-    """Xiaomi Opple 2 Button Switch. Face 2."""
-
-    device_automation_triggers = XiaomiOpple2ButtonSwitchBase.device_automation_triggers
-
-    signature = {
-        MODELS_INFO: [(LUMI, "lumi.switch.n2aeu1")],
-        ENDPOINTS: {
-            #  input_clusters=[0, 2, 3, 4, 5, 6, 18, 64704], output_clusters=[10, 25]
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    DeviceTemperatureCluster.cluster_id,  # 2
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    Alarms.cluster_id,  # 9
-                    MeteringCluster.cluster_id,  # 0x0702
-                    0x0B04,
-                ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            },
-            #  input_clusters=[0, 3, 4, 5, 6, 18, 64704], output_clusters=[]
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
                 ],
                 OUTPUT_CLUSTERS: [],
             },

--- a/zhaquirks/xiaomi/aqara/opple_switch.py
+++ b/zhaquirks/xiaomi/aqara/opple_switch.py
@@ -1,4 +1,4 @@
-"""Xiaomi Aqara wall switch devices. Also see switch_h1_single.py for similar H1 single rocker switches."""
+"""Xiaomi Aqara wall switch devices. Also see switch_h1 files similar H1 rocker switches."""
 import copy
 from enum import Enum
 

--- a/zhaquirks/xiaomi/aqara/switch_h1.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1.py
@@ -83,7 +83,7 @@ class AqaraH1SingleRockerSwitchWithNeutral(AqaraH1SingleRockerBase):
     """Aqara H1 Single Rocker Switch (with neutral) (inherits above class for device automation triggers)."""
 
     signature = {
-        MODELS_INFO: [("LUMI", "lumi.switch.n1aeu1")],
+        MODELS_INFO: [(LUMI, "lumi.switch.n1aeu1")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/xiaomi/aqara/switch_h1.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1.py
@@ -2,10 +2,13 @@ from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Alarms,
+    AnalogInput,
     Basic,
+    DeviceTemperature,
     GreenPowerProxy,
     Groups,
     Identify,
+    MultistateInput,
     OnOff,
     Ota,
     Scenes,
@@ -36,10 +39,12 @@ from zhaquirks.const import (
 )
 from zhaquirks.xiaomi import (
     LUMI,
+    AnalogInputCluster,
     BasicCluster,
     DeviceTemperatureCluster,
+    ElectricalMeasurementCluster,
+    MeteringCluster,
     OnOffCluster,
-    XiaomiMeteringCluster,
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 from zhaquirks.xiaomi.aqara.opple_switch import OppleSwitchCluster
@@ -75,7 +80,124 @@ class AqaraH1SingleRockerBase(CustomDevice):
 
 
 class AqaraH1SingleRockerSwitchWithNeutral(AqaraH1SingleRockerBase):
-    """Aqara H1 Single Rocker Switch (with neutral)."""
+    """Aqara H1 Single Rocker Switch (with neutral) (inherits above class for device automation triggers)."""
+
+    signature = {
+        MODELS_INFO: [("LUMI", "lumi.switch.n1aeu1")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DeviceTemperature.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    OppleSwitchCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    AnalogInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            31: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    AnalogInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            41: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    MultistateInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    DeviceTemperature.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MeteringCluster,
+                    ElectricalMeasurementCluster,
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    AnalogInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            31: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    AnalogInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            41: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MultistateInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
+            },
+        },
+    }
+
+
+class AqaraH1SingleRockerSwitchWithNeutralAlt(AqaraH1SingleRockerSwitchWithNeutral):
+    """Aqara H1 Single Rocker Switch (with neutral) signature 2 (inherits above class for replacement + triggers)."""
 
     signature = {
         MODELS_INFO: [(LUMI, "lumi.switch.n1aeu1")],
@@ -85,48 +207,14 @@ class AqaraH1SingleRockerSwitchWithNeutral(AqaraH1SingleRockerBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    DeviceTemperatureCluster.cluster_id,  # 2
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    Alarms.cluster_id,  # 9
-                    XiaomiMeteringCluster.cluster_id,  # 0x0702
-                    0x0B04,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Time.cluster_id,  # 0x000a
-                    Ota.cluster_id,  # 0x0019
-                ],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [
-                    GreenPowerProxy.cluster_id,  # 0x0021
-                ],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,  # 0
-                    DeviceTemperatureCluster.cluster_id,  # 2
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOffCluster,  # 6
-                    Alarms.cluster_id,  # 9
-                    MultistateInputCluster,  # 18
-                    XiaomiMeteringCluster.cluster_id,  # 0x0702
-                    OppleSwitchCluster,  # 0xFCC0 / 64704
+                    Basic.cluster_id,
+                    DeviceTemperatureCluster.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    Alarms.cluster_id,
+                    MeteringCluster.cluster_id,
                     0x0B04,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -134,26 +222,20 @@ class AqaraH1SingleRockerSwitchWithNeutral(AqaraH1SingleRockerBase):
                     Ota.cluster_id,
                 ],
             },
-            41: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
-                INPUT_CLUSTERS: [
-                    MultistateInputCluster,  # 18
-                ],
-                OUTPUT_CLUSTERS: [],
-            },
             242: {
                 PROFILE_ID: zgp.PROFILE_ID,
                 DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
                 INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
             },
         },
     }
 
 
 class AqaraH1SingleRockerSwitchNoNeutral(AqaraH1SingleRockerBase):
-    """Aqara H1 Single Rocker Switch (no neutral)."""
+    """Aqara H1 Single Rocker Switch (no neutral) (inherits class for device triggers)."""
 
     signature = {
         MODELS_INFO: [(LUMI, "lumi.switch.l1aeu1")],
@@ -163,17 +245,17 @@ class AqaraH1SingleRockerSwitchNoNeutral(AqaraH1SingleRockerBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    DeviceTemperatureCluster.cluster_id,  # 2
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    Alarms.cluster_id,  # 9
+                    Basic.cluster_id,
+                    DeviceTemperatureCluster.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    Alarms.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
-                    Time.cluster_id,  # 0x000a
-                    Ota.cluster_id,  # 0x0019
+                    Time.cluster_id,
+                    Ota.cluster_id,
                 ],
             },
             242: {
@@ -181,7 +263,7 @@ class AqaraH1SingleRockerSwitchNoNeutral(AqaraH1SingleRockerBase):
                 DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
                 INPUT_CLUSTERS: [],
                 OUTPUT_CLUSTERS: [
-                    GreenPowerProxy.cluster_id,  # 0x0021
+                    GreenPowerProxy.cluster_id,
                 ],
             },
         },
@@ -193,15 +275,15 @@ class AqaraH1SingleRockerSwitchNoNeutral(AqaraH1SingleRockerBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
-                    BasicCluster,  # 0
-                    DeviceTemperatureCluster.cluster_id,  # 2
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOffCluster,  # 6
-                    Alarms.cluster_id,  # 9
-                    MultistateInputCluster,  # 18
-                    OppleSwitchCluster,  # 0xFCC0 / 64704
+                    BasicCluster,
+                    DeviceTemperatureCluster.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    Alarms.cluster_id,
+                    MultistateInputCluster,
+                    OppleSwitchCluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,
@@ -212,7 +294,7 @@ class AqaraH1SingleRockerSwitchNoNeutral(AqaraH1SingleRockerBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
-                    MultistateInputCluster,  # 18
+                    MultistateInputCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
             },

--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -1,0 +1,70 @@
+"""Aqara H1 double rocker switch quirks. Also see opple_switch.py for similar double rocker switches."""
+from zigpy.profiles import zgp, zha
+from zigpy.zcl.clusters.general import (
+    Alarms,
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import LUMI, DeviceTemperatureCluster, MeteringCluster
+from zhaquirks.xiaomi.aqara.opple_switch import XiaomiOpple2ButtonSwitchBase
+
+
+class XiaomiOpple2ButtonSwitchFace2(XiaomiOpple2ButtonSwitchBase):
+    """Xiaomi Opple 2 Button Switch. Face 2."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.switch.n2aeu1")],
+        ENDPOINTS: {
+            #  input_clusters=[0, 2, 3, 4, 5, 6, 18, 64704], output_clusters=[10, 25]
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,  # 0
+                    DeviceTemperatureCluster.cluster_id,  # 2
+                    Identify.cluster_id,  # 3
+                    Groups.cluster_id,  # 4
+                    Scenes.cluster_id,  # 5
+                    OnOff.cluster_id,  # 6
+                    Alarms.cluster_id,  # 9
+                    MeteringCluster.cluster_id,  # 0x0702
+                    0x0B04,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            #  input_clusters=[0, 3, 4, 5, 6, 18, 64704], output_clusters=[]
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,  # 0
+                    Identify.cluster_id,  # 3
+                    Groups.cluster_id,  # 4
+                    Scenes.cluster_id,  # 5
+                    OnOff.cluster_id,  # 6
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }

--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -24,8 +24,8 @@ from zhaquirks.xiaomi import LUMI, DeviceTemperatureCluster, MeteringCluster
 from zhaquirks.xiaomi.aqara.opple_switch import XiaomiOpple2ButtonSwitchBase
 
 
-class XiaomiOpple2ButtonSwitchFace2(XiaomiOpple2ButtonSwitchBase):
-    """Xiaomi Opple 2 Button Switch. Face 2."""
+class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
+    """Aqara H1 Double Rocker Switch (with neutral)."""
 
     signature = {
         MODELS_INFO: [(LUMI, "lumi.switch.n2aeu1")],

--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -35,14 +35,14 @@ class XiaomiOpple2ButtonSwitchFace2(XiaomiOpple2ButtonSwitchBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    DeviceTemperatureCluster.cluster_id,  # 2
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
-                    Alarms.cluster_id,  # 9
-                    MeteringCluster.cluster_id,  # 0x0702
+                    Basic.cluster_id,
+                    DeviceTemperatureCluster.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    Alarms.cluster_id,
+                    MeteringCluster.cluster_id,
                     0x0B04,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
@@ -52,11 +52,11 @@ class XiaomiOpple2ButtonSwitchFace2(XiaomiOpple2ButtonSwitchBase):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    Scenes.cluster_id,  # 5
-                    OnOff.cluster_id,  # 6
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
             },

--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -3,6 +3,7 @@ from zigpy.profiles import zgp, zha
 from zigpy.zcl.clusters.general import (
     Alarms,
     Basic,
+    DeviceTemperature,
     GreenPowerProxy,
     Groups,
     Identify,
@@ -11,6 +12,7 @@ from zigpy.zcl.clusters.general import (
     Scenes,
     Time,
 )
+from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -20,7 +22,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.xiaomi import LUMI, DeviceTemperatureCluster, MeteringCluster
+from zhaquirks.xiaomi import LUMI
 from zhaquirks.xiaomi.aqara.opple_switch import XiaomiOpple2ButtonSwitchBase
 
 
@@ -36,13 +38,13 @@ class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DeviceTemperatureCluster.cluster_id,
+                    DeviceTemperature.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     OnOff.cluster_id,
                     Alarms.cluster_id,
-                    MeteringCluster.cluster_id,
+                    Metering.cluster_id,
                     0x0B04,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],

--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -7,6 +7,7 @@ from zigpy.zcl.clusters.general import (
     GreenPowerProxy,
     Groups,
     Identify,
+    MultistateInput,
     OnOff,
     Ota,
     Scenes,
@@ -67,6 +68,127 @@ class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
                 DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
                 INPUT_CLUSTERS: [],
                 OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+
+class AqaraH1DoubleRockerSwitchNoNeutral(XiaomiOpple2ButtonSwitchBase):
+    """Aqara H1 Double Rocker Switch (no neutral)."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.switch.l2aeu1")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DeviceTemperature.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    0xFCC0,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    0xFCC0,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            41: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    MultistateInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            42: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    MultistateInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            51: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    MultistateInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
+            },
+        },
+    }
+
+
+class AqaraH1DoubleRockerSwitchNoNeutralAlt(XiaomiOpple2ButtonSwitchBase):
+    """Aqara H1 Double Rocker Switch (no neutral) alternative signature."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.switch.l2aeu1")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DeviceTemperature.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    Alarms.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
             },
         },
     }

--- a/zhaquirks/xiaomi/aqara/switch_h1_single.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_single.py
@@ -1,3 +1,4 @@
+"""Aqara H1 single rocker switch quirks. Also see opple_switch.py for similar double rocker switches."""
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (


### PR DESCRIPTION
## Proposed change
This should address multiple issues scattered throughout the repo.
- power/energy support is added for more Aqara switches
- the redundant `XiaomiMeteringCluster` is removed
- an alternative signature for `lumi.switch.n1aeu1` is added
- `MODELS_INFO` for `lumi.switch.b2naus01`, `lumi.switch.n2aeu1` (`XiaomiOpple2ButtonSwitchFace1`, `XiaomiOpple2ButtonSwitchFace2`) is added
- comments with clusters IDs are removed in some places

## Additional information
The diff is on the bigger side, but looking through the individual commits should make it clear that those "larger changes" are mostly due to refactoring. This PR isn't actually "that big".

Related:
- https://github.com/zigpy/zha-device-handlers/issues/2270
- https://github.com/zigpy/zha-device-handlers/issues/2520
- https://github.com/zigpy/zha-device-handlers/issues/2736
- https://github.com/zigpy/zha-device-handlers/issues/1369
- https://github.com/zigpy/zha-device-handlers/issues/1134
- (probably more)

I'm aware that the quirk for `lumi.switch.n1aeu1` changes the `DEVIEC_TYPE`, but this was done for all Aqara switches. The existing quirks and custom quirks seem to do this as well, so it only makes sense to do it here as well.

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
