### PR TITLE
Fix tests with zigpy 0.60

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,9 @@ class MockApp(zigpy.application.ControllerApplication):
     async def start_network(self, *args, **kwargs):
         """Mock start_network."""
 
+    async def permit_with_link_key(self, *args, **kwargs):
+        """Mock permit_with_link_key"""
+
     async def write_network_info(self, *args, **kwargs):
         """Mock write_network_info."""
 


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

In zigpy 0.60 the permit_with_link_key function became abstract, which means we now need to provide it on the concrete class.

This fixes error of the following kind:

```
    @pytest.fixture(name="MockAppController")
    def app_controller_mock():
        """App controller mock."""
        config = {"device": {"path": "/dev/ttyUSB0"}, "database": None}
        config = MockApp.SCHEMA(config)
>       app = MockApp(config)
E       TypeError: Can't instantiate abstract class MockApp with abstract method permit_with_link_key

tests/conftest.py:88: TypeError
```

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

Breaking change here:

https://github.com/zigpy/zigpy/commit/b0ffd5b624c3d1529f1aebd5a0548891572a2193#diff-066be728ff64be6f84d4f0ea83512608a64bead3804e27ef5bee4c73344f5287R1172


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
