### PR TITLE
Add Tuya `TS011F` variation: Rylike RY-WS02Z 2ac wall socket AU

### DIFF
--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -1479,3 +1479,81 @@ class Plug_TZ3000_2AC(CustomDevice):
             },
         },
     }
+
+
+class Plug_TZ3000_2AC_var02(EnchantedDevice):
+    """Tuya 2 socket wall outlet."""
+
+    quirk_id = TUYA_PLUG_ONOFF
+
+    signature = {
+        MODEL: "TS011F",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    TuyaZBE000Cluster.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                    TuyaZBE000Cluster,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This adds a quirk to support `Rylike RY-WS02Z` which is a Tuya two outlet ac wall outlet AU model. Without the quirk both channels are linked together and no other features work.

Tested and working for the following features as well
- Power on restore mode
- Child Lock
- Backlight mode

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
<details>

<summary>Diagnostics</summary>

```json

  "data": {
    "ieee": "**REDACTED**",
    "nwk": 57063,
    "manufacturer": "_TZ3000_rgpqqmbj",
    "model": "TS011F",
    "name": "_TZ3000_rgpqqmbj TS011F",
    "quirk_applied": false,
    "quirk_class": "zigpy.device.Device",
    "quirk_id": null,
    "manufacturer_code": 4417,
    "power_source": "Mains",
    "lqi": 188,
    "rssi": -53,
    "last_seen": "2023-12-02T23:33:28",
    "available": true,
    "device_type": "Router",
    "signature": {
      "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.FullFunctionDevice|MainsPowered|RxOnWhenIdle|AllocateAddress: 142>, manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x010a",
          "input_clusters": [
            "0x0000",
            "0x0003",
            "0x0004",
            "0x0005",
            "0x0006",
            "0xe000",
            "0xe001"
          ],
          "output_clusters": [
            "0x000a",
            "0x0019"
          ]
        },
        "2": {
          "profile_id": "0x0104",  
          "device_type": "0x010a",
          "input_clusters": [
            "0x0004",
            "0x0005",
            "0x0006",
            "0xe001"
          ],
          "output_clusters": []
        },
        "242": {
          "profile_id": "0xa1e0",
          "device_type": "0x0061",
          "input_clusters": [],
          "output_clusters": [
            "0x0021"
          ]
        }
      },
      "manufacturer": "_TZ3000_rgpqqmbj",
      "model": "TS011F"
    },
    "active_coordinator": false,
    "entities": [
      {
        "entity_id": "button.tz3000_rgpqqmbj_ts011f_identify",
        "name": "_TZ3000_rgpqqmbj TS011F"
      },
      {
        "entity_id": "switch.tz3000_rgpqqmbj_ts011f_switch",
        "name": "_TZ3000_rgpqqmbj TS011F"
      },
      {
        "entity_id": "switch.tz3000_rgpqqmbj_ts011f_switch_2",
        "name": "_TZ3000_rgpqqmbj TS011F"
      }
    ],
    "neighbors": [],
    "routes": [],
    "endpoint_names": [
      {
        "name": "ON_OFF_PLUG_IN_UNIT"
      },
      {
        "name": "ON_OFF_PLUG_IN_UNIT"
      },
      {
        "name": "PROXY_BASIC"
      }
    ],
    "user_given_name": null,
    "device_reg_id": "1b239c0b1baba4236d87a13917d54fa1",
    "area_id": null,
    "cluster_details": {
      "1": {
        "device_type": {
          "name": "ON_OFF_PLUG_IN_UNIT",
          "id": 266
        },
        "profile_id": 260,
        "in_clusters": {
          "0x0003": {
            "endpoint_attribute": "identify",
            "attributes": {},
            "unsupported_attributes": {}
          },
          "0x0004": {
            "endpoint_attribute": "groups",
            "attributes": {},
            "unsupported_attributes": {}
          },
          "0x0005": {
            "endpoint_attribute": "scenes",
            "attributes": {},
            "unsupported_attributes": {}
          },
          "0x0006": {
            "endpoint_attribute": "on_off",
            "attributes": {
              "0x4002": {
                "attribute_name": "off_wait_time",
                "value": 0
              },
              "0x0000": {
                "attribute_name": "on_off",
                "value": 1
              },
              "0x4001": {
                "attribute_name": "on_time",
                "value": 0
              }
            },
            "unsupported_attributes": {
              "0x4000": {
                "attribute_name": "global_scene_control"
              },
              "0x4003": {
                "attribute_name": "start_up_on_off"
              },
              "0xfffe": {
                "attribute_name": "reporting_status"
              }
            }
          },
          "0xe000": {
            "endpoint_attribute": null,
            "attributes": {},
            "unsupported_attributes": {}
          },
          "0xe001": {
            "endpoint_attribute": null,
            "attributes": {},
            "unsupported_attributes": {}
          },
          "0x0000": {
            "endpoint_attribute": "basic",
            "attributes": {
              "0x0004": {
                "attribute_name": "manufacturer",
                "value": "_TZ3000_rgpqqmbj"
              },
              "0x0005": {
                "attribute_name": "model",
                "value": "TS011F"
              }
            },
            "unsupported_attributes": {}
          }
        },
        "out_clusters": {
          "0x0019": {
            "endpoint_attribute": "ota",
            "attributes": {},
            "unsupported_attributes": {}
          },
          "0x000a": {
            "endpoint_attribute": "time",
            "attributes": {},
            "unsupported_attributes": {
              "0x0007": {
                "attribute_name": "local_time"
              },
              "0x0006": {
                "attribute_name": "standard_time"
              }
            }
          }
        }
      },
      "2": {
        "device_type": {
          "name": "ON_OFF_PLUG_IN_UNIT",
          "id": 266
        },
        "profile_id": 260,
        "in_clusters": {
          "0x0004": {
            "endpoint_attribute": "groups",
            "attributes": {},
            "unsupported_attributes": {}
          },
          "0x0005": {
            "endpoint_attribute": "scenes",
            "attributes": {},
            "unsupported_attributes": {}
          },
          "0x0006": {
            "endpoint_attribute": "on_off",
            "attributes": {
              "0x4002": {
                "attribute_name": "off_wait_time",
                "value": 0
              },
              "0x0000": {
                "attribute_name": "on_off",
                "value": 1
              },
              "0x4001": {
                "attribute_name": "on_time",
                "value": 0
              }
            },
            "unsupported_attributes": {
              "0x4003": {
                "attribute_name": "start_up_on_off"
              }
            }
          },
          "0xe001": {
            "endpoint_attribute": null,
            "attributes": {},
            "unsupported_attributes": {}
          }
        },
        "out_clusters": {}
      },
      "242": {
        "device_type": {
          "name": "PROXY_BASIC",
          "id": 97
        },
        "profile_id": 41440,
        "in_clusters": {},
        "out_clusters": {
          "0x0021": {
            "endpoint_attribute": "green_power",
            "attributes": {},
            "unsupported_attributes": {}
          }
        }
      }
    }
  }

```

</details>
## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
