### PR TITLE
Add Tuya dimmable LED controller `_TZ3210_agjx0pxt` variation

### DIFF
--- a/zhaquirks/tuya/ts0501bs.py
+++ b/zhaquirks/tuya/ts0501bs.py
@@ -37,6 +37,7 @@ class DimmableLedController(CustomDevice):
             ("_TZ3210_i680rtja", "TS0501B"),
             ("_TZ3210_dxroobu3", "TS0501B"),
             ("_TZ3210_dbilpfqk", "TS0501B"),
+            ("_TZ3210_agjx0pxt", "TS0501B"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=257


### PR DESCRIPTION
## Proposed change
Added new model info for this type of LED dimmer, tested via custom quirk and working



## Additional information
Dimmer purchased recently from AliBaba supplier, as standard ZHA sets up as a RGBW Led Controller however device is a single colour LED controller

Fixes https://github.com/zigpy/zha-device-handlers/issues/2556

## Checklist

- [X] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
