### PR TITLE
Add Legrand 064882 cable outlet support

### DIFF
--- a/zhaquirks/legrand/cable_outlet.py
+++ b/zhaquirks/legrand/cable_outlet.py
@@ -14,9 +14,9 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.foundation import (
-    Direction,
     BaseAttributeDefs,
     BaseCommandDefs,
+    Direction,
     ZCLAttributeDef,
     ZCLCommandDef,
 )

--- a/zhaquirks/legrand/cable_outlet.py
+++ b/zhaquirks/legrand/cable_outlet.py
@@ -1,17 +1,24 @@
 """Module for Legrand Cable Outlet (with pilot wire functionality)."""
 
 from zigpy.profiles import zgp, zha
-from zigpy.quirks import CustomDevice, CustomCluster
+from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
-from zigpy.zcl.foundation import Direction, BaseAttributeDefs, BaseCommandDefs, ZCLAttributeDef, ZCLCommandDef
 from zigpy.zcl.clusters.general import (
     Basic,
+    GreenPowerProxy,
     Groups,
     Identify,
     OnOff,
     Ota,
     Scenes,
-    GreenPowerProxy,
+)
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.foundation import (
+    Direction,
+    BaseAttributeDefs,
+    BaseCommandDefs,
+    ZCLAttributeDef,
+    ZCLCommandDef,
 )
 
 from zhaquirks.const import (
@@ -22,14 +29,15 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zhaquirks.legrand import LEGRAND, MANUFACTURER_SPECIFIC_CLUSTER_ID
 
-MANUFACTURER_SPECIFIC_CLUSTER_ID_2 = 0xFC40 # 64576
+MANUFACTURER_SPECIFIC_CLUSTER_ID_2 = 0xFC40  # 64576
+
 
 class DeviceMode(t.enum16):
     PILOT_OFF = 0x0100
     PILOT_ON = 0x0200
+
 
 class LegrandCluster(CustomCluster):
     """LegrandCluster."""
@@ -41,7 +49,7 @@ class LegrandCluster(CustomCluster):
     class AttributeDefs(BaseAttributeDefs):
         device_mode = ZCLAttributeDef(
             id=0x0000,
-            type=t.data16, # DeviceMode
+            type=t.data16,  # DeviceMode
             is_manufacturer_specific=True,
         )
         led_dark = ZCLAttributeDef(
@@ -63,6 +71,7 @@ class PilotWireMode(t.enum8):
     ECO = 0x03
     FROST_PROTECTION = 0x04
     OFF = 0x05
+
 
 class LegrandCableOutletCluster(CustomCluster):
     """Legrand second manufacturer-specific cluster."""
@@ -119,7 +128,6 @@ class Legrand064882CableOutlet(CustomDevice):
             },
         },
     }
-
 
     replacement = {
         ENDPOINTS: {

--- a/zhaquirks/legrand/cable_outlet.py
+++ b/zhaquirks/legrand/cable_outlet.py
@@ -1,0 +1,154 @@
+"""Module for Legrand Cable Outlet (with pilot wire functionality)."""
+
+from zigpy.profiles import zgp, zha
+from zigpy.quirks import CustomDevice, CustomCluster
+import zigpy.types as t
+from zigpy.zcl.foundation import Direction, BaseAttributeDefs, BaseCommandDefs, ZCLAttributeDef, ZCLCommandDef
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+    GreenPowerProxy,
+)
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zhaquirks.legrand import LEGRAND, MANUFACTURER_SPECIFIC_CLUSTER_ID
+
+MANUFACTURER_SPECIFIC_CLUSTER_ID_2 = 0xFC40 # 64576
+
+class DeviceMode(t.enum16):
+    PILOT_OFF = 0x0100
+    PILOT_ON = 0x0200
+
+class LegrandCluster(CustomCluster):
+    """LegrandCluster."""
+
+    cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID
+    name = "LegrandCluster"
+    ep_attribute = "legrand_cluster"
+
+    class AttributeDefs(BaseAttributeDefs):
+        device_mode = ZCLAttributeDef(
+            id=0x0000,
+            type=t.data16, # DeviceMode
+            is_manufacturer_specific=True,
+        )
+        led_dark = ZCLAttributeDef(
+            id=0x0001,
+            type=t.Bool,
+            is_manufacturer_specific=True,
+        )
+        led_on = ZCLAttributeDef(
+            id=0x0002,
+            type=t.Bool,
+            is_manufacturer_specific=True,
+        )
+
+
+class PilotWireMode(t.enum8):
+    COMFORT = 0x00
+    COMFORT_MINUS_1 = 0x01
+    COMFORT_MINUS_2 = 0x02
+    ECO = 0x03
+    FROST_PROTECTION = 0x04
+    OFF = 0x05
+
+class LegrandCableOutletCluster(CustomCluster):
+    """Legrand second manufacturer-specific cluster."""
+
+    cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID_2
+    name = "CableOutlet"
+    ep_attribute = "cable_outlet_cluster"
+
+    class ServerCommandDefs(BaseCommandDefs):
+        set_pilot_wire_mode = ZCLCommandDef(
+            id=0x00,
+            schema={"mode": PilotWireMode},
+            direction=Direction.Server_to_Client,
+            is_manufacturer_specific=True,
+        )
+
+
+class Legrand064882CableOutlet(CustomDevice):
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1
+        # input_clusters=[0, 3, 4, 6, 5, 64513, 2820, 64576]
+        # output_clusters=[6, 0, 64513, 5, 25]>
+        MODELS_INFO: [(f" {LEGRAND}", " Cable outlet")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    Scenes.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                    ElectricalMeasurement.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID_2,
+                ],
+                OUTPUT_CLUSTERS: [
+                    OnOff.cluster_id,
+                    Basic.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                    Scenes.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            #  <SimpleDescriptor endpoint=242 profile=41440 device_type=102
+            # input_clusters=[33]
+            # output_clusters=[33]>
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.COMBO_BASIC,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    Scenes.cluster_id,
+                    LegrandCluster,
+                    ElectricalMeasurement.cluster_id,
+                    LegrandCableOutletCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    OnOff.cluster_id,
+                    Basic.cluster_id,
+                    LegrandCluster,
+                    Scenes.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.COMBO_BASIC,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Add quirk to support Legrand 064882 cable outlet with pilot wire functionality.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Before being able to switch the pilot wire mode, you need to write `20` in `LegrandCluster` `device_mode` attribute, to enable pilote wire mode (`10` to disable it):
![Capture d’écran 2023-12-06 à 15 39 45](https://github.com/zigpy/zha-device-handlers/assets/397503/05d22fc7-5780-4c43-8a53-18bfe88f4db4)

Commands has to be send using `zha.issue_zigbee_cluster_command` service to change pilot wire mode.
Example:
```yaml
service: zha.issue_zigbee_cluster_command
data:
  cluster_type: in
  ieee: <device_ieee>
  endpoint_id: 1
  command: 0
  command_type: server
  cluster_id: 64576
  args:
    - 4
```
Check `PilotWireMode` enum for the possible values.

Fixes #789 


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
