### PR TITLE
Add Bosch Radiator Thermostat 2 (RBSH-TRV0-ZB-EU) quirk

### DIFF
--- a/tests/test_bosch.py
+++ b/tests/test_bosch.py
@@ -2,14 +2,15 @@
 
 from unittest import mock
 
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.hvac import ControlSequenceOfOperation, Thermostat
+from zigpy.zcl.foundation import WriteAttributesStatusRecord
+
 import zhaquirks
 from zhaquirks.bosch.rbsh_trv0_zb_eu import (
     BoschOperatingMode,
     BoschThermostatCluster as BoschTrvThermostatCluster,
 )
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.hvac import ControlSequenceOfOperation, Thermostat
-from zigpy.zcl.foundation import WriteAttributesStatusRecord
 
 zhaquirks.setup()
 

--- a/tests/test_bosch.py
+++ b/tests/test_bosch.py
@@ -1,0 +1,188 @@
+"""Tests the Bosch thermostats quirk."""
+from unittest import mock
+
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.hvac import ControlSequenceOfOperation, Thermostat
+from zigpy.zcl.foundation import WriteAttributesStatusRecord
+
+import zhaquirks
+from zhaquirks.bosch.rbsh_trv0_zb_eu import (
+    BoschOperatingMode,
+    BoschThermostatCluster as BoschTrvThermostatCluster,
+)
+
+zhaquirks.setup()
+
+async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v2_quirk):
+    """Test the Radiator Thermostat II writes behaving correctly."""
+
+    device = zigpy_device_from_v2_quirk(manufacturer="BOSCH", model="RBSH-TRV0-ZB-EU")
+
+    bosch_thermostat_cluster = device.endpoints[1].thermostat
+
+    def mock_write(attributes, manufacturer=None):
+        records = [
+            WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+            for _ in attributes
+        ]
+        return [records, []]
+
+    # data is written to trv
+    patch_bosch_trv_write = mock.patch.object(
+        bosch_thermostat_cluster,
+        "_write_attributes",
+        mock.AsyncMock(side_effect=mock_write),
+    )
+
+    # check that system_mode ends-up writing operating_mode:
+    with patch_bosch_trv_write:
+        # - Heating operation
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {"ctrl_sequence_of_oper": ControlSequenceOfOperation.Heating_Only}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+
+        # -- Off
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {"system_mode": Thermostat.SystemMode.Off}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
+        assert bosch_thermostat_cluster._attr_cache[BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Pause
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+
+        # -- Heat
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {"system_mode": Thermostat.SystemMode.Heat}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Heat
+        assert bosch_thermostat_cluster._attr_cache[
+                       BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Manual
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+
+        # - Cooling operation
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {"ctrl_sequence_of_oper": ControlSequenceOfOperation.Cooling_Only}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+
+        # -- Off
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {"system_mode": Thermostat.SystemMode.Off}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
+        assert bosch_thermostat_cluster._attr_cache[BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Pause
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+
+        # -- Cool
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {"system_mode": Thermostat.SystemMode.Cool}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Cool
+        assert bosch_thermostat_cluster._attr_cache[
+                       BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Manual
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+
+
+async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_v2_quirk):
+    """Test the Room Thermostat II 230v system_mode writes behaving correctly."""
+
+    device = zigpy_device_from_v2_quirk(manufacturer="Bosch", model="RBSH-RTH0-ZB-EU")
+
+    bosch_thermostat_cluster = device.endpoints[1].thermostat
+
+    def mock_write(attributes, manufacturer=None):
+        records = [
+            WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+            for _ in attributes
+        ]
+        return [records, []]
+
+    # data is written to trv
+    patch_bosch_trv_write = mock.patch.object(
+        bosch_thermostat_cluster,
+        "_write_attributes",
+        mock.AsyncMock(side_effect=mock_write),
+    )
+
+    with patch_bosch_trv_write:
+        # check that system_mode ends-up writing operating_mode:
+
+        # - Heating operation
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {"ctrl_sequence_of_oper": ControlSequenceOfOperation.Heating_Only}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+
+        # -- Off
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {"system_mode": Thermostat.SystemMode.Off}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+
+        # -- Heat
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {"system_mode": Thermostat.SystemMode.Heat}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Heat
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+
+        # - Cooling operation
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {"ctrl_sequence_of_oper": ControlSequenceOfOperation.Cooling_Only}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+
+        # -- Off
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {"system_mode": Thermostat.SystemMode.Off}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+
+        # -- Cool
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {"system_mode": Thermostat.SystemMode.Cool}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Cool
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only

--- a/tests/test_bosch.py
+++ b/tests/test_bosch.py
@@ -1,4 +1,5 @@
 """Tests the Bosch thermostats quirk."""
+
 from unittest import mock
 
 from zigpy.zcl import foundation
@@ -15,7 +16,10 @@ from zhaquirks.bosch.rbsh_trv0_zb_eu import (
 
 zhaquirks.setup()
 
-async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v2_quirk):
+
+async def test_bosch_radiator_thermostat_II_write_attributes(
+    zigpy_device_from_v2_quirk,
+):
     """Test the Radiator Thermostat II writes behaving correctly."""
 
     device = zigpy_device_from_v2_quirk(manufacturer="BOSCH", model="RBSH-TRV0-ZB-EU")
@@ -24,8 +28,7 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
 
     def mock_write(attributes, manufacturer=None):
         records = [
-            WriteAttributesStatusRecord(foundation.Status.SUCCESS)
-            for _ in attributes
+            WriteAttributesStatusRecord(foundation.Status.SUCCESS) for _ in attributes
         ]
         return [records, []]
 
@@ -40,7 +43,9 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
     def mock_read(attributes, manufacturer=None):
         records = [
             foundation.ReadAttributeRecord(
-                attr, foundation.Status.SUCCESS, foundation.TypeValue(None, BoschOperatingMode.Manual)
+                attr,
+                foundation.Status.SUCCESS,
+                foundation.TypeValue(None, BoschOperatingMode.Manual),
             )
             for attr in attributes
         ]
@@ -54,18 +59,19 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
     )
 
     # check that system_mode ends-up writing operating_mode:
-    with (
-        patch_bosch_trv_write,
-        patch_bosch_trv_read
-    ):
+    with patch_bosch_trv_write, patch_bosch_trv_read:
         # - Heating operation
         success, fail = await bosch_thermostat_cluster.write_attributes(
             {"ctrl_sequence_of_oper": ControlSequenceOfOperation.Heating_Only}
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Heating_Only
+        )
 
         # -- Off (by-name)
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -73,10 +79,24 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
-        assert bosch_thermostat_cluster._attr_cache[BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Pause
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Off
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Pause
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Heating_Only
+        )
 
         # -- Heat (by-name)
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -84,12 +104,24 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Heat
-        assert bosch_thermostat_cluster._attr_cache[
-                       BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Manual
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Heat
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Manual
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Heating_Only
+        )
 
         # -- Off (by-id)
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -97,12 +129,24 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
-        assert bosch_thermostat_cluster._attr_cache[
-                   BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Pause
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Off
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Pause
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Heating_Only
+        )
 
         # -- Heat (by-id)
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -110,34 +154,66 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Heat
-        assert bosch_thermostat_cluster._attr_cache[
-                   BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Manual
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Heat
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Manual
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Heating_Only
+        )
 
         # -- operating_mode (by-id) changes system_mode
         success, fail = await bosch_thermostat_cluster.write_attributes(
-            {BoschTrvThermostatCluster.AttributeDefs.operating_mode.id: BoschOperatingMode.Pause}
+            {
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id: BoschOperatingMode.Pause
+            }
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
-        assert bosch_thermostat_cluster._attr_cache[
-                   BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Pause
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Off
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Pause
+        )
 
         # -- operating_mode (by-name) changes system_mode
         success, fail = await bosch_thermostat_cluster.write_attributes(
-            {BoschTrvThermostatCluster.AttributeDefs.operating_mode.name: BoschOperatingMode.Manual}
+            {
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.name: BoschOperatingMode.Manual
+            }
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Heat
-        assert bosch_thermostat_cluster._attr_cache[
-                   BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Manual
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Heat
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Manual
+        )
 
         # - Cooling operation
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -145,8 +221,12 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Cooling_Only
+        )
 
         # -- Off (by-name)
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -154,10 +234,24 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
-        assert bosch_thermostat_cluster._attr_cache[BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Pause
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Off
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Pause
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Cooling_Only
+        )
 
         # -- Cool (by-name)
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -165,12 +259,24 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Cool
-        assert bosch_thermostat_cluster._attr_cache[
-                       BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Manual
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Cool
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Manual
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Cooling_Only
+        )
 
         # -- Off (by-id)
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -178,10 +284,24 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
-        assert bosch_thermostat_cluster._attr_cache[BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Pause
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Off
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Pause
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Cooling_Only
+        )
 
         # -- Cool (by-id)
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -189,36 +309,69 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Cool
-        assert bosch_thermostat_cluster._attr_cache[
-                       BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Manual
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Cool
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Manual
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Cooling_Only
+        )
 
         # -- operating_mode (by-id) gets ignored when system_mode is written
         success, fail = await bosch_thermostat_cluster.write_attributes(
-            {Thermostat.AttributeDefs.system_mode.id: Thermostat.SystemMode.Off,
-             BoschTrvThermostatCluster.AttributeDefs.operating_mode.id: BoschOperatingMode.Manual}
+            {
+                Thermostat.AttributeDefs.system_mode.id: Thermostat.SystemMode.Off,
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id: BoschOperatingMode.Manual,
+            }
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
-        assert bosch_thermostat_cluster._attr_cache[
-                   BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Pause
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Off
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Pause
+        )
 
         # -- operating_mode (by-name) gets ignored when system_mode is written
         success, fail = await bosch_thermostat_cluster.write_attributes(
-            {Thermostat.AttributeDefs.system_mode.id: Thermostat.SystemMode.Cool,
-             BoschTrvThermostatCluster.AttributeDefs.operating_mode.name: BoschOperatingMode.Pause}
+            {
+                Thermostat.AttributeDefs.system_mode.id: Thermostat.SystemMode.Cool,
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.name: BoschOperatingMode.Pause,
+            }
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Cool
-        assert bosch_thermostat_cluster._attr_cache[
-                   BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Manual
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Cool
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Manual
+        )
+
 
 async def test_bosch_radiator_thermostat_II_read_attributes(zigpy_device_from_v2_quirk):
     """Test the Radiator Thermostat II reads behaving correctly."""
@@ -231,7 +384,9 @@ async def test_bosch_radiator_thermostat_II_read_attributes(zigpy_device_from_v2
     def mock_read(attributes, manufacturer=None):
         records = [
             foundation.ReadAttributeRecord(
-                attr, foundation.Status.SUCCESS, foundation.TypeValue(None, BoschOperatingMode.Pause)
+                attr,
+                foundation.Status.SUCCESS,
+                foundation.TypeValue(None, BoschOperatingMode.Pause),
             )
             for attr in attributes
         ]
@@ -262,7 +417,10 @@ async def test_bosch_radiator_thermostat_II_read_attributes(zigpy_device_from_v2
         assert not fail
         assert Thermostat.SystemMode.Off in success.values()
 
-async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_v2_quirk):
+
+async def test_bosch_room_thermostat_II_230v_write_attributes(
+    zigpy_device_from_v2_quirk,
+):
     """Test the Room Thermostat II 230v system_mode writes behaving correctly."""
 
     device = zigpy_device_from_v2_quirk(manufacturer="Bosch", model="RBSH-RTH0-ZB-EU")
@@ -271,8 +429,7 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_
 
     def mock_write(attributes, manufacturer=None):
         records = [
-            WriteAttributesStatusRecord(foundation.Status.SUCCESS)
-            for _ in attributes
+            WriteAttributesStatusRecord(foundation.Status.SUCCESS) for _ in attributes
         ]
         return [records, []]
 
@@ -292,8 +449,12 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Heating_Only
+        )
 
         # -- Off
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -301,9 +462,18 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Off
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Heating_Only
+        )
 
         # -- Heat
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -311,10 +481,18 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Heat
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Heat
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Heating_Only
+        )
 
         # - Cooling operation
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -322,8 +500,12 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Cooling_Only
+        )
 
         # -- Off
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -331,9 +513,18 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Off
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Cooling_Only
+        )
 
         # -- Cool
         success, fail = await bosch_thermostat_cluster.write_attributes(
@@ -341,12 +532,23 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_
         )
         assert success
         assert not fail
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Cool
-        assert bosch_thermostat_cluster._attr_cache[
-                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Cool
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Cooling_Only
+        )
 
-async def test_bosch_radiator_thermostat_II_user_interface_write_attributes(zigpy_device_from_v2_quirk):
+
+async def test_bosch_radiator_thermostat_II_user_interface_write_attributes(
+    zigpy_device_from_v2_quirk,
+):
     """Test the Radiator Thermostat II user-interface writes behaving correctly."""
 
     device = zigpy_device_from_v2_quirk(manufacturer="BOSCH", model="RBSH-TRV0-ZB-EU")
@@ -355,8 +557,7 @@ async def test_bosch_radiator_thermostat_II_user_interface_write_attributes(zigp
 
     def mock_write(attributes, manufacturer=None):
         records = [
-            WriteAttributesStatusRecord(foundation.Status.SUCCESS)
-            for _ in attributes
+            WriteAttributesStatusRecord(foundation.Status.SUCCESS) for _ in attributes
         ]
         return [records, []]
 
@@ -371,36 +572,60 @@ async def test_bosch_radiator_thermostat_II_user_interface_write_attributes(zigp
     with patch_bosch_trv_ui_write:
         # - orientation (by-id) normal
         success, fail = await bosch_thermostat_ui_cluster.write_attributes(
-            {BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id: BoschDisplayOrientation.Normal}
+            {
+                BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id: BoschDisplayOrientation.Normal
+            }
         )
         assert success
         assert not fail
-        assert bosch_thermostat_ui_cluster._attr_cache[
-                   BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id] == 0
+        assert (
+            bosch_thermostat_ui_cluster._attr_cache[
+                BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id
+            ]
+            == 0
+        )
 
         # - orientation (by-id) flipped
         success, fail = await bosch_thermostat_ui_cluster.write_attributes(
-            {BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id: BoschDisplayOrientation.Flipped}
+            {
+                BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id: BoschDisplayOrientation.Flipped
+            }
         )
         assert success
         assert not fail
-        assert bosch_thermostat_ui_cluster._attr_cache[
-                   BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id] == 1
+        assert (
+            bosch_thermostat_ui_cluster._attr_cache[
+                BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id
+            ]
+            == 1
+        )
 
         # - orientation (by-name) normal
         success, fail = await bosch_thermostat_ui_cluster.write_attributes(
-            {BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.name: BoschDisplayOrientation.Normal}
+            {
+                BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.name: BoschDisplayOrientation.Normal
+            }
         )
         assert success
         assert not fail
-        assert bosch_thermostat_ui_cluster._attr_cache[
-                   BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id] == 0
+        assert (
+            bosch_thermostat_ui_cluster._attr_cache[
+                BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id
+            ]
+            == 0
+        )
 
         # - orientation (by-name) flipped
         success, fail = await bosch_thermostat_ui_cluster.write_attributes(
-            {BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.name: BoschDisplayOrientation.Flipped}
+            {
+                BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.name: BoschDisplayOrientation.Flipped
+            }
         )
         assert success
         assert not fail
-        assert bosch_thermostat_ui_cluster._attr_cache[
-                   BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id] == 1
+        assert (
+            bosch_thermostat_ui_cluster._attr_cache[
+                BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id
+            ]
+            == 1
+        )

--- a/tests/test_bosch.py
+++ b/tests/test_bosch.py
@@ -7,8 +7,10 @@ from zigpy.zcl.foundation import WriteAttributesStatusRecord
 
 import zhaquirks
 from zhaquirks.bosch.rbsh_trv0_zb_eu import (
+    BoschDisplayOrientation,
     BoschOperatingMode,
     BoschThermostatCluster as BoschTrvThermostatCluster,
+    BoschUserInterfaceCluster as BoschTrvUserInterfaceCluster,
 )
 
 zhaquirks.setup()
@@ -45,9 +47,9 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         assert bosch_thermostat_cluster._attr_cache[
                    Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
 
-        # -- Off
+        # -- Off (by-name)
         success, fail = await bosch_thermostat_cluster.write_attributes(
-            {"system_mode": Thermostat.SystemMode.Off}
+            {Thermostat.AttributeDefs.system_mode.name: Thermostat.SystemMode.Off}
         )
         assert success
         assert not fail
@@ -56,9 +58,9 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         assert bosch_thermostat_cluster._attr_cache[
                    Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
 
-        # -- Heat
+        # -- Heat (by-name)
         success, fail = await bosch_thermostat_cluster.write_attributes(
-            {"system_mode": Thermostat.SystemMode.Heat}
+            {Thermostat.AttributeDefs.system_mode.name: Thermostat.SystemMode.Heat}
         )
         assert success
         assert not fail
@@ -69,6 +71,54 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         assert bosch_thermostat_cluster._attr_cache[
                    Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
 
+        # -- Off (by-id)
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {Thermostat.AttributeDefs.system_mode.id: Thermostat.SystemMode.Off}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
+        assert bosch_thermostat_cluster._attr_cache[
+                   BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Pause
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+
+        # -- Heat (by-id)
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {Thermostat.AttributeDefs.system_mode.id: Thermostat.SystemMode.Heat}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Heat
+        assert bosch_thermostat_cluster._attr_cache[
+                   BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Manual
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Heating_Only
+
+        # -- operating_mode (by-id) changes system_mode
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {BoschTrvThermostatCluster.AttributeDefs.operating_mode.id: BoschOperatingMode.Pause}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
+        assert bosch_thermostat_cluster._attr_cache[
+                   BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Pause
+
+        # -- operating_mode (by-name) changes system_mode
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {BoschTrvThermostatCluster.AttributeDefs.operating_mode.name: BoschOperatingMode.Manual}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Heat
+        assert bosch_thermostat_cluster._attr_cache[
+                   BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Manual
+
         # - Cooling operation
         success, fail = await bosch_thermostat_cluster.write_attributes(
             {"ctrl_sequence_of_oper": ControlSequenceOfOperation.Cooling_Only}
@@ -78,9 +128,9 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         assert bosch_thermostat_cluster._attr_cache[
                    Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
 
-        # -- Off
+        # -- Off (by-name)
         success, fail = await bosch_thermostat_cluster.write_attributes(
-            {"system_mode": Thermostat.SystemMode.Off}
+            {Thermostat.AttributeDefs.system_mode.name: Thermostat.SystemMode.Off}
         )
         assert success
         assert not fail
@@ -89,9 +139,9 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         assert bosch_thermostat_cluster._attr_cache[
                    Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
 
-        # -- Cool
+        # -- Cool (by-name)
         success, fail = await bosch_thermostat_cluster.write_attributes(
-            {"system_mode": Thermostat.SystemMode.Cool}
+            {Thermostat.AttributeDefs.system_mode.name: Thermostat.SystemMode.Cool}
         )
         assert success
         assert not fail
@@ -102,6 +152,53 @@ async def test_bosch_radiator_thermostat_II_write_attributes(zigpy_device_from_v
         assert bosch_thermostat_cluster._attr_cache[
                    Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
 
+        # -- Off (by-id)
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {Thermostat.AttributeDefs.system_mode.id: Thermostat.SystemMode.Off}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
+        assert bosch_thermostat_cluster._attr_cache[BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Pause
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+
+        # -- Cool (by-id)
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {Thermostat.AttributeDefs.system_mode.id: Thermostat.SystemMode.Cool}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Cool
+        assert bosch_thermostat_cluster._attr_cache[
+                       BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Manual
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+
+        # -- operating_mode (by-id) gets ignored when system_mode is written
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {Thermostat.AttributeDefs.system_mode.id: Thermostat.SystemMode.Off,
+             BoschTrvThermostatCluster.AttributeDefs.operating_mode.id: BoschOperatingMode.Manual}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Off
+        assert bosch_thermostat_cluster._attr_cache[
+                   BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Pause
+
+        # -- operating_mode (by-name) gets ignored when system_mode is written
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {Thermostat.AttributeDefs.system_mode.id: Thermostat.SystemMode.Cool,
+             BoschTrvThermostatCluster.AttributeDefs.operating_mode.name: BoschOperatingMode.Pause}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_cluster._attr_cache[
+                   Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Cool
+        assert bosch_thermostat_cluster._attr_cache[
+                   BoschTrvThermostatCluster.AttributeDefs.operating_mode.id] == BoschOperatingMode.Manual
 
 async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_v2_quirk):
     """Test the Room Thermostat II 230v system_mode writes behaving correctly."""
@@ -138,7 +235,7 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_
 
         # -- Off
         success, fail = await bosch_thermostat_cluster.write_attributes(
-            {"system_mode": Thermostat.SystemMode.Off}
+            {Thermostat.AttributeDefs.system_mode.name: Thermostat.SystemMode.Off}
         )
         assert success
         assert not fail
@@ -148,7 +245,7 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_
 
         # -- Heat
         success, fail = await bosch_thermostat_cluster.write_attributes(
-            {"system_mode": Thermostat.SystemMode.Heat}
+            {Thermostat.AttributeDefs.system_mode.name: Thermostat.SystemMode.Heat}
         )
         assert success
         assert not fail
@@ -168,7 +265,7 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_
 
         # -- Off
         success, fail = await bosch_thermostat_cluster.write_attributes(
-            {"system_mode": Thermostat.SystemMode.Off}
+            {Thermostat.AttributeDefs.system_mode.name: Thermostat.SystemMode.Off}
         )
         assert success
         assert not fail
@@ -178,7 +275,7 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_
 
         # -- Cool
         success, fail = await bosch_thermostat_cluster.write_attributes(
-            {"system_mode": Thermostat.SystemMode.Cool}
+            {Thermostat.AttributeDefs.system_mode.name: Thermostat.SystemMode.Cool}
         )
         assert success
         assert not fail
@@ -186,3 +283,62 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(zigpy_device_from_
                    Thermostat.AttributeDefs.system_mode.id] == Thermostat.SystemMode.Cool
         assert bosch_thermostat_cluster._attr_cache[
                    Thermostat.AttributeDefs.ctrl_sequence_of_oper.id] == ControlSequenceOfOperation.Cooling_Only
+
+async def test_bosch_radiator_thermostat_II_user_interface_write_attributes(zigpy_device_from_v2_quirk):
+    """Test the Radiator Thermostat II user-interface writes behaving correctly."""
+
+    device = zigpy_device_from_v2_quirk(manufacturer="BOSCH", model="RBSH-TRV0-ZB-EU")
+
+    bosch_thermostat_ui_cluster = device.endpoints[1].thermostat_ui
+
+    def mock_write(attributes, manufacturer=None):
+        records = [
+            WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+            for _ in attributes
+        ]
+        return [records, []]
+
+    # data is written to trv ui
+    patch_bosch_trv_ui_write = mock.patch.object(
+        bosch_thermostat_ui_cluster,
+        "_write_attributes",
+        mock.AsyncMock(side_effect=mock_write),
+    )
+
+    # check that display_orientation gets converted to supported value type:
+    with patch_bosch_trv_ui_write:
+        # - orientation (by-id) normal
+        success, fail = await bosch_thermostat_ui_cluster.write_attributes(
+            {BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id: BoschDisplayOrientation.Normal}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_ui_cluster._attr_cache[
+                   BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id] == 0
+
+        # - orientation (by-id) flipped
+        success, fail = await bosch_thermostat_ui_cluster.write_attributes(
+            {BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id: BoschDisplayOrientation.Flipped}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_ui_cluster._attr_cache[
+                   BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id] == 1
+
+        # - orientation (by-name) normal
+        success, fail = await bosch_thermostat_ui_cluster.write_attributes(
+            {BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.name: BoschDisplayOrientation.Normal}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_ui_cluster._attr_cache[
+                   BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id] == 0
+
+        # - orientation (by-name) flipped
+        success, fail = await bosch_thermostat_ui_cluster.write_attributes(
+            {BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.name: BoschDisplayOrientation.Flipped}
+        )
+        assert success
+        assert not fail
+        assert bosch_thermostat_ui_cluster._attr_cache[
+                   BoschTrvUserInterfaceCluster.AttributeDefs.display_orientation.id] == 1

--- a/tests/test_bosch.py
+++ b/tests/test_bosch.py
@@ -413,8 +413,10 @@ async def test_bosch_radiator_thermostat_II_write_attributes(
         )
 
 
-async def test_bosch_radiator_thermostat_II_read_attributes(zigpy_device_from_v2_quirk):
-    """Test the Radiator Thermostat II reads behaving correctly."""
+async def test_bosch_radiator_thermostat_II_read_attributes_paused(
+    zigpy_device_from_v2_quirk,
+):
+    """Test the Radiator Thermostat II reads behaving correctly when paused."""
 
     device = zigpy_device_from_v2_quirk(manufacturer="BOSCH", model="RBSH-TRV0-ZB-EU")
 
@@ -456,6 +458,110 @@ async def test_bosch_radiator_thermostat_II_read_attributes(zigpy_device_from_v2
         assert success
         assert not fail
         assert Thermostat.SystemMode.Off in success.values()
+
+
+async def test_bosch_radiator_thermostat_II_read_attributes_manual_heat(
+    zigpy_device_from_v2_quirk,
+):
+    """Test the Radiator Thermostat II reads behaving correctly when heat is enabled."""
+
+    device = zigpy_device_from_v2_quirk(manufacturer="BOSCH", model="RBSH-TRV0-ZB-EU")
+
+    bosch_thermostat_cluster = device.endpoints[1].thermostat
+
+    # fake read response for attributes: return BoschOperatingMode.Manual/ControlSequenceOfOperation.Heating_Only for all attributes
+    def mock_read(attributes, manufacturer=None):
+        records = [
+            foundation.ReadAttributeRecord(
+                attr,
+                foundation.Status.SUCCESS,
+                foundation.TypeValue(
+                    None,
+                    BoschOperatingMode.Manual
+                    if attr == BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+                    else ControlSequenceOfOperation.Heating_Only,
+                ),
+            )
+            for attr in attributes
+        ]
+        return (records,)
+
+    # data is read from trv
+    patch_bosch_trv_read = mock.patch.object(
+        bosch_thermostat_cluster,
+        "_read_attributes",
+        mock.AsyncMock(side_effect=mock_read),
+    )
+
+    # check that system_mode ends-up reading operating_mode and ControlSequenceOfOperation:
+    with patch_bosch_trv_read:
+        # - system_mode by id
+        success, fail = await bosch_thermostat_cluster.read_attributes(
+            [Thermostat.AttributeDefs.system_mode.id]
+        )
+        assert success
+        assert not fail
+        assert Thermostat.SystemMode.Heat in success.values()
+
+        # - system_mode by name
+        success, fail = await bosch_thermostat_cluster.read_attributes(
+            [Thermostat.AttributeDefs.system_mode.name]
+        )
+        assert success
+        assert not fail
+        assert Thermostat.SystemMode.Heat in success.values()
+
+
+async def test_bosch_radiator_thermostat_II_read_attributes_manual_cool(
+    zigpy_device_from_v2_quirk,
+):
+    """Test the Radiator Thermostat II reads behaving correctly when cooling is enabled."""
+
+    device = zigpy_device_from_v2_quirk(manufacturer="BOSCH", model="RBSH-TRV0-ZB-EU")
+
+    bosch_thermostat_cluster = device.endpoints[1].thermostat
+
+    # fake read response for attributes: return BoschOperatingMode.Manual/ControlSequenceOfOperation.Cooling_Only for all attributes
+    def mock_read(attributes, manufacturer=None):
+        records = [
+            foundation.ReadAttributeRecord(
+                attr,
+                foundation.Status.SUCCESS,
+                foundation.TypeValue(
+                    None,
+                    BoschOperatingMode.Manual
+                    if attr == BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+                    else ControlSequenceOfOperation.Cooling_Only,
+                ),
+            )
+            for attr in attributes
+        ]
+        return (records,)
+
+    # data is read from trv
+    patch_bosch_trv_read = mock.patch.object(
+        bosch_thermostat_cluster,
+        "_read_attributes",
+        mock.AsyncMock(side_effect=mock_read),
+    )
+
+    # check that system_mode ends-up reading operating_mode and ControlSequenceOfOperation:
+    with patch_bosch_trv_read:
+        # - system_mode by id
+        success, fail = await bosch_thermostat_cluster.read_attributes(
+            [Thermostat.AttributeDefs.system_mode.id]
+        )
+        assert success
+        assert not fail
+        assert Thermostat.SystemMode.Cool in success.values()
+
+        # - system_mode by name
+        success, fail = await bosch_thermostat_cluster.read_attributes(
+            [Thermostat.AttributeDefs.system_mode.name]
+        )
+        assert success
+        assert not fail
+        assert Thermostat.SystemMode.Cool in success.values()
 
 
 async def test_bosch_room_thermostat_II_230v_write_attributes(

--- a/tests/test_bosch.py
+++ b/tests/test_bosch.py
@@ -2,15 +2,14 @@
 
 from unittest import mock
 
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.hvac import ControlSequenceOfOperation, Thermostat
-from zigpy.zcl.foundation import WriteAttributesStatusRecord
-
 import zhaquirks
 from zhaquirks.bosch.rbsh_trv0_zb_eu import (
     BoschOperatingMode,
     BoschThermostatCluster as BoschTrvThermostatCluster,
 )
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.hvac import ControlSequenceOfOperation, Thermostat
+from zigpy.zcl.foundation import WriteAttributesStatusRecord
 
 zhaquirks.setup()
 
@@ -345,6 +344,27 @@ async def test_bosch_radiator_thermostat_II_write_attributes(
                 Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
             ]
             == ControlSequenceOfOperation.Cooling_Only
+        )
+
+        # -- operating_mode (by-id) in cooling mode
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id: BoschOperatingMode.Manual,
+            }
+        )
+        assert success
+        assert not fail
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                BoschTrvThermostatCluster.AttributeDefs.operating_mode.id
+            ]
+            == BoschOperatingMode.Manual
+        )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Cool
         )
 
         # -- operating_mode (by-id) gets ignored when system_mode is written

--- a/tests/test_bosch.py
+++ b/tests/test_bosch.py
@@ -2,15 +2,14 @@
 
 from unittest import mock
 
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.hvac import ControlSequenceOfOperation, Thermostat
-from zigpy.zcl.foundation import WriteAttributesStatusRecord
-
 import zhaquirks
 from zhaquirks.bosch.rbsh_trv0_zb_eu import (
     BoschOperatingMode,
     BoschThermostatCluster as BoschTrvThermostatCluster,
 )
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.hvac import ControlSequenceOfOperation, Thermostat
+from zigpy.zcl.foundation import WriteAttributesStatusRecord
 
 zhaquirks.setup()
 
@@ -451,9 +450,31 @@ async def test_bosch_radiator_thermostat_II_read_attributes_paused(
         assert not fail
         assert Thermostat.SystemMode.Off in success.values()
 
+        # - system_mode by id along other attributes
+        success, fail = await bosch_thermostat_cluster.read_attributes(
+            [
+                Thermostat.AttributeDefs.system_mode.id,
+                Thermostat.AttributeDefs.pi_heating_demand.id,
+            ]
+        )
+        assert success
+        assert not fail
+        assert Thermostat.SystemMode.Off in success.values()
+
         # - system_mode by name
         success, fail = await bosch_thermostat_cluster.read_attributes(
             [Thermostat.AttributeDefs.system_mode.name]
+        )
+        assert success
+        assert not fail
+        assert Thermostat.SystemMode.Off in success.values()
+
+        # - system_mode by name along other attributes
+        success, fail = await bosch_thermostat_cluster.read_attributes(
+            [
+                Thermostat.AttributeDefs.system_mode.name,
+                Thermostat.AttributeDefs.pi_heating_demand.name,
+            ]
         )
         assert success
         assert not fail

--- a/tests/test_bosch.py
+++ b/tests/test_bosch.py
@@ -2,15 +2,14 @@
 
 from unittest import mock
 
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.hvac import ControlSequenceOfOperation, Thermostat
-from zigpy.zcl.foundation import WriteAttributesStatusRecord
-
 import zhaquirks
 from zhaquirks.bosch.rbsh_trv0_zb_eu import (
     BoschOperatingMode,
     BoschThermostatCluster as BoschTrvThermostatCluster,
 )
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.hvac import ControlSequenceOfOperation, Thermostat
+from zigpy.zcl.foundation import WriteAttributesStatusRecord
 
 zhaquirks.setup()
 
@@ -58,9 +57,24 @@ async def test_bosch_radiator_thermostat_II_write_attributes(
 
     # check that system_mode ends-up writing operating_mode:
     with patch_bosch_trv_write, patch_bosch_trv_read:
-        # - Heating operation
+        # - Heating operation - by name
         success, fail = await bosch_thermostat_cluster.write_attributes(
             {"ctrl_sequence_of_oper": ControlSequenceOfOperation.Heating_Only}
+        )
+        assert success
+        assert not fail
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
+            ]
+            == ControlSequenceOfOperation.Heating_Only
+        )
+
+        # - Heating operation - by id
+        success, fail = await bosch_thermostat_cluster.write_attributes(
+            {
+                Thermostat.AttributeDefs.ctrl_sequence_of_oper.id: ControlSequenceOfOperation.Heating_Only
+            }
         )
         assert success
         assert not fail

--- a/tests/test_bosch.py
+++ b/tests/test_bosch.py
@@ -240,6 +240,12 @@ async def test_bosch_radiator_thermostat_II_write_attributes(
             ]
             == ControlSequenceOfOperation.Cooling_Only
         )
+        assert (
+            bosch_thermostat_cluster._attr_cache[
+                Thermostat.AttributeDefs.system_mode.id
+            ]
+            == Thermostat.SystemMode.Cool
+        )
 
         # -- Off (by-name)
         success, fail = await bosch_thermostat_cluster.write_attributes(

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -1,4 +1,4 @@
-        """Device handler for Bosch RBSH-RTH0-ZB-EU thermostat."""
+"""Device handler for Bosch RBSH-RTH0-ZB-EU thermostat."""
 
 from typing import Any, Final
 

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -4,7 +4,11 @@
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import add_to_registry_v2
 import zigpy.types as t
-from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
+from zigpy.zcl.clusters.hvac import (
+    ControlSequenceOfOperation,
+    Thermostat,
+    UserInterface,
+)
 from zigpy.zcl.foundation import ZCLAttributeDef
 
 """Bosch specific thermostat attribute ids."""
@@ -29,6 +33,8 @@ SCREEN_TIMEOUT_ATTR_ID = 0x403A
 # Display brightness (0 - 10).
 SCREEN_BRIGHTNESS_ATTR_ID = 0x403B
 
+# Control sequence of operation (heating/cooling)
+CTRL_SEQUENCE_OF_OPERATION_ID = 0x001B
 
 class BoschOperatingMode(t.enum8):
     """Bosh operating mode attribute values."""
@@ -43,6 +49,13 @@ class State(t.enum8):
 
     Off = 0x00
     On = 0x01
+
+
+class BoschControlSequenceOfOperation(t.enum8):
+    """Supported ControlSequenceOfOperation modes."""
+
+    Cooling = ControlSequenceOfOperation.Cooling_Only
+    Heating = ControlSequenceOfOperation.Heating_Only
 
 
 class BoschThermostatCluster(CustomCluster, Thermostat):
@@ -138,5 +151,11 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         max_value=10,
         step=1,
         translation_key="display_brightness",
+    )
+    .enum(
+        Thermostat.AttributeDefs.ctrl_sequence_of_oper.name,
+        BoschControlSequenceOfOperation,
+        BoschThermostatCluster.cluster_id,
+        translation_key="ctrl_sequence_of_oper",
     )
 )

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -69,29 +69,25 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
             id=OPERATING_MODE_ATTR_ID,
             type=BoschOperatingMode,
             is_manufacturer_specific=True,
-            name="operating_mode",
         )
 
         pi_heating_demand = ZCLAttributeDef(
             id=VALVE_POSITION_ATTR_ID,
             # Values range from 0-100
-            type=t.enum8,
+            type=t.uint8_t,
             is_manufacturer_specific=True,
-            name="pi_heating_demand",
         )
 
         window_open = ZCLAttributeDef(
             id=WINDOW_OPEN_ATTR_ID,
             type=State,
             is_manufacturer_specific=True,
-            name="window_open",
         )
 
         boost = ZCLAttributeDef(
             id=BOOST_ATTR_ID,
             type=State,
             is_manufacturer_specific=True,
-            name="boost",
         )
 
 
@@ -104,17 +100,15 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         display_on_time = ZCLAttributeDef(
             id=SCREEN_TIMEOUT_ATTR_ID,
             # Usable values range from 5-30
-            type=t.enum8,
+            type=t.uint8_t,
             is_manufacturer_specific=True,
-            name="display_on_time",
         )
 
         display_brightness = ZCLAttributeDef(
             id=SCREEN_BRIGHTNESS_ATTR_ID,
             # Values range from 0-10
-            type=t.enum8,
+            type=t.uint8_t,
             is_manufacturer_specific=True,
-            name="display_brightness",
         )
 
 
@@ -127,7 +121,6 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.AttributeDefs.operating_mode.name,
         BoschOperatingMode,
         BoschThermostatCluster.cluster_id,
-        translation_key="operating_mode",
         entity_platform=EntityPlatform.SENSOR,
         entity_type=EntityType.DIAGNOSTIC,
     )
@@ -135,13 +128,11 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     .switch(
         BoschThermostatCluster.AttributeDefs.boost.name,
         BoschThermostatCluster.cluster_id,
-        translation_key="boost",
     )
     # Window open switch: manually set or through an automation.
     .switch(
         BoschThermostatCluster.AttributeDefs.window_open.name,
         BoschThermostatCluster.cluster_id,
-        translation_key="window_open",
     )
     # Display time-out.
     .number(
@@ -150,7 +141,6 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         min_value=5,
         max_value=30,
         step=1,
-        translation_key="display_on_time",
     )
     # Display brightness.
     .number(
@@ -159,14 +149,12 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         min_value=0,
         max_value=10,
         step=1,
-        translation_key="display_brightness",
     )
     # Heating vs Cooling.
     .enum(
         Thermostat.AttributeDefs.ctrl_sequence_of_oper.name,
         BoschControlSequenceOfOperation,
         BoschThermostatCluster.cluster_id,
-        translation_key="ctrl_sequence_of_oper",
     )
     .add_to_registry()
 )

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -47,13 +47,6 @@ class BoschOperatingMode(t.enum8):
     Pause = 0x05
 
 
-class BoschPreset(t.enum8):
-    """Bosch thermostat preset."""
-
-    Normal = 0x00
-    Boost = 0x01
-
-
 class State(t.enum8):
     """Binary attribute (window open) value."""
 
@@ -86,7 +79,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
 
         boost = ZCLAttributeDef(
             id=t.uint16_t(BOOST_ATTR_ID),
-            type=BoschPreset,
+            type=State,
             is_manufacturer_specific=True,
         )
 
@@ -95,7 +88,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     """Bosch UserInterface cluster."""
 
     class AttributeDefs(UserInterface.AttributeDefs):
-        display_ontime = ZCLAttributeDef(
+        display_on_time = ZCLAttributeDef(
             id=t.uint16_t(SCREEN_TIMEOUT_ATTR_ID),
             # Usable values range from 5-30
             type=t.enum8,
@@ -124,29 +117,28 @@ class BoschThermostat(CustomDeviceV2):
         BoschThermostatCluster.AttributeDefs.operating_mode.name,
         BoschOperatingMode,
         BoschThermostatCluster.cluster_id,
-        translation_key="switch_mode",
+        translation_key="operating_mode",
     )
-    # Preset - normal/boost.
-    .enum(
+    # Fast heating/boost.
+    .switch(
         BoschThermostatCluster.AttributeDefs.boost.name,
-        BoschPreset,
         BoschThermostatCluster.cluster_id,
-        translation_key="preset",
+        translation_key="boost",
     )
     # Window open switch: manually set or through an automation.
     .switch(
         BoschThermostatCluster.AttributeDefs.window_open.name,
         BoschThermostatCluster.cluster_id,
-        translation_key="window_detection",
+        translation_key="window_open",
     )
     # Display time-out.
     .number(
-        BoschUserInterfaceCluster.AttributeDefs.display_ontime.name,
+        BoschUserInterfaceCluster.AttributeDefs.display_on_time.name,
         BoschUserInterfaceCluster.cluster_id,
         min_value=5,
         max_value=30,
         step=1,
-        translation_key="on_off_transition_time",
+        translation_key="display_on_time",
     )
     # Display brightness.
     .number(
@@ -155,6 +147,6 @@ class BoschThermostat(CustomDeviceV2):
         min_value=0,
         max_value=10,
         step=1,
-        translation_key="backlight_mode",
+        translation_key="display_brightness",
     )
 )

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -168,16 +168,5 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         translation_key="ctrl_sequence_of_oper",
         fallback_name="Control sequence",
     )
-    # Local temperature calibration.
-    .number(
-        Thermostat.AttributeDefs.local_temperature_calibration.name,
-        BoschThermostatCluster.cluster_id,
-        min_value=-5,
-        max_value=5,
-        step=0.1,
-        multiplier=0.1,
-        translation_key="local_temperature_calibration",
-        fallback_name="Local temperature offset",
-    )
     .add_to_registry()
 )

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -168,5 +168,16 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         translation_key="ctrl_sequence_of_oper",
         fallback_name="Control sequence",
     )
+    # Local temperature calibration.
+    .number(
+        Thermostat.AttributeDefs.local_temperature_calibration.name,
+        BoschThermostatCluster.cluster_id,
+        min_value=-5,
+        max_value=5,
+        step=0.1,
+        multiplier=0.1,
+        translation_key="local_temperature_calibration",
+        fallback_name="Local temperature offset",
+    )
     .add_to_registry()
 )

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -22,8 +22,8 @@ VALVE_POSITION_ATTR_ID = 0x4020
 # Window open switch (changes to a lower target temperature when on).
 WINDOW_OPEN_ATTR_ID = 0x4042
 
-# Boost preset mode.
-BOOST_ATTR_ID = 0x4043
+# Boost heating preset mode.
+BOOST_HEATING_ATTR_ID = 0x4043
 
 """Bosch specific user interface attribute ids."""
 
@@ -84,8 +84,8 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
             is_manufacturer_specific=True,
         )
 
-        boost = ZCLAttributeDef(
-            id=BOOST_ATTR_ID,
+        boost_heating = ZCLAttributeDef(
+            id=BOOST_HEATING_ATTR_ID,
             type=State,
             is_manufacturer_specific=True,
         )
@@ -126,7 +126,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     )
     # Fast heating/boost.
     .switch(
-        BoschThermostatCluster.AttributeDefs.boost.name,
+        BoschThermostatCluster.AttributeDefs.boost_heating.name,
         BoschThermostatCluster.cluster_id,
     )
     # Window open switch: manually set or through an automation.

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -65,26 +65,26 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         """Bosch thermostat manufacturer specific attributes."""
 
         operating_mode = ZCLAttributeDef(
-            id=t.uint16_t(OPERATING_MODE_ATTR_ID),
+            id=OPERATING_MODE_ATTR_ID,
             type=BoschOperatingMode,
             is_manufacturer_specific=True,
         )
 
         pi_heating_demand = ZCLAttributeDef(
-            id=t.uint16_t(VALVE_POSITION_ATTR_ID),
+            id=VALVE_POSITION_ATTR_ID,
             # Values range from 0-100
             type=t.enum8,
             is_manufacturer_specific=True,
         )
 
         window_open = ZCLAttributeDef(
-            id=t.uint16_t(WINDOW_OPEN_ATTR_ID),
+            id=WINDOW_OPEN_ATTR_ID,
             type=State,
             is_manufacturer_specific=True,
         )
 
         boost = ZCLAttributeDef(
-            id=t.uint16_t(BOOST_ATTR_ID),
+            id=BOOST_ATTR_ID,
             type=State,
             is_manufacturer_specific=True,
         )
@@ -97,14 +97,14 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         """Bosch user interface manufacturer specific attributes."""
 
         display_on_time = ZCLAttributeDef(
-            id=t.uint16_t(SCREEN_TIMEOUT_ATTR_ID),
+            id=SCREEN_TIMEOUT_ATTR_ID,
             # Usable values range from 5-30
             type=t.enum8,
             is_manufacturer_specific=True,
         )
 
         display_brightness = ZCLAttributeDef(
-            id=t.uint16_t(SCREEN_BRIGHTNESS_ATTR_ID),
+            id=SCREEN_BRIGHTNESS_ATTR_ID,
             # Values range from 0-10
             type=t.enum8,
             is_manufacturer_specific=True,

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -123,16 +123,22 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.cluster_id,
         entity_platform=EntityPlatform.SENSOR,
         entity_type=EntityType.DIAGNOSTIC,
+        translation_key="operating_mode",
+        fallback_name="Operating mode",
     )
     # Fast heating/boost.
     .switch(
         BoschThermostatCluster.AttributeDefs.boost_heating.name,
         BoschThermostatCluster.cluster_id,
+        translation_key="boost_heating",
+        fallback_name="Boost",
     )
     # Window open switch: manually set or through an automation.
     .switch(
         BoschThermostatCluster.AttributeDefs.window_open.name,
         BoschThermostatCluster.cluster_id,
+        translation_key="window_open",
+        fallback_name="Window open",
     )
     # Display time-out.
     .number(
@@ -141,6 +147,8 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         min_value=5,
         max_value=30,
         step=1,
+        translation_key="display_on_time",
+        fallback_name="Display on-time",
     )
     # Display brightness.
     .number(
@@ -149,12 +157,16 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         min_value=0,
         max_value=10,
         step=1,
+        translation_key="display_brightness",
+        fallback_name="Display brightness",
     )
     # Heating vs Cooling.
     .enum(
         Thermostat.AttributeDefs.ctrl_sequence_of_oper.name,
         BoschControlSequenceOfOperation,
         BoschThermostatCluster.cluster_id,
+        translation_key="ctrl_sequence_of_oper",
+        fallback_name="Control sequence",
     )
     .add_to_registry()
 )

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -1,0 +1,142 @@
+        """Device handler for Bosch RBSH-RTH0-ZB-EU thermostat."""
+
+from typing import Any, Final
+
+from zigpy.device import Device
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.registry import DeviceRegistry
+from zigpy.quirks.v2 import (
+    CustomDeviceV2,
+    add_to_registry_v2,
+)
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+import zigpy.types as t
+from zigpy.zcl import ClusterType
+from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef, ZCLCommandDef
+
+"""Bosch specific thermostat attribute ids."""
+OPERATING_MODE_ATTR_ID = 0x4007
+VALVE_POSITION_ATTR_ID = 0x4020
+WINDOW_OPEN_ATTR_ID = 0x4042
+BOOST_ATTR_ID = 0x4043
+
+"""Bosch specific user interface attribute ids."""
+SCREEN_TIMEOUT_ATTR_ID = 0x403a
+SCREEN_BRIGHTNESS_ATTR_ID = 0x403b
+
+"""Bosh operating mode attribute values."""
+class BoschOperatingMode(t.enum8):
+    Schedule = 0x00
+    Manual = 0x01
+    Pause = 0x05
+
+"""Bosch thermostat preset."""
+class BoschPreset(t.enum8):
+    Normal = 0x00
+    Boost = 0x01
+
+"""Binary attribute (window open) value."""
+class State(t.enum8):
+    Off = 0x00
+    On = 0x01
+
+class BoschThermostatCluster(CustomCluster, Thermostat):
+    """Bosch thermostat cluster."""
+
+    class AttributeDefs(Thermostat.AttributeDefs):
+        operating_mode = ZCLAttributeDef(
+            id=t.uint16_t(OPERATING_MODE_ATTR_ID),
+            type=BoschOperatingMode,
+            is_manufacturer_specific=True,
+        )
+
+        pi_heating_demand = ZCLAttributeDef(
+            id=t.uint16_t(VALVE_POSITION_ATTR_ID),
+            # Values range from 0-100
+            type=t.enum8,
+            is_manufacturer_specific=True,
+        )
+
+        window_open = ZCLAttributeDef(
+            id=t.uint16_t(WINDOW_OPEN_ATTR_ID),
+            type=State,
+            is_manufacturer_specific=True,
+        )
+
+        boost = ZCLAttributeDef(
+            id=t.uint16_t(BOOST_ATTR_ID),
+            type=BoschPreset,
+            is_manufacturer_specific=True,
+        )
+
+
+class BoschUserInterfaceCluster(CustomCluster, UserInterface):
+    """Bosch UserInterface cluster."""
+
+    class AttributeDefs(UserInterface.AttributeDefs):
+        display_ontime = ZCLAttributeDef(
+            id=t.uint16_t(SCREEN_TIMEOUT_ATTR_ID),
+            # Usable values range from 5-30
+            type=t.enum8,
+            is_manufacturer_specific=True,
+        )
+
+        display_brightness = ZCLAttributeDef(
+            id=t.uint16_t(SCREEN_BRIGHTNESS_ATTR_ID),
+            # Values range from 0-10
+            type=t.enum8,
+            is_manufacturer_specific=True,
+        )
+
+
+class BoschThermostat(CustomDeviceV2):
+    """Bosch thermostat custom device."""
+
+(
+    add_to_registry_v2(
+        "Bosch", "RBSH-RTH0-ZB-EU"
+    )
+    .device_class(BoschThermostat)
+    .replaces(BoschThermostatCluster)
+    .replaces(BoschUserInterfaceCluster)
+    # Operating mode: controlled automatically through Thermostat.system_mode (HAVC mode).
+    .enum(
+        BoschThermostatCluster.AttributeDefs.operating_mode.name,
+        BoschOperatingMode,
+        BoschThermostatCluster.cluster_id,
+        translation_key="switch_mode"
+    )
+    # Preset - normal/boost.
+    .enum(
+        BoschThermostatCluster.AttributeDefs.boost.name,
+        BoschPreset,
+        BoschThermostatCluster.cluster_id,
+        translation_key="preset"
+    )
+    # Window open switch: manually set or through an automation.
+    .switch(
+        BoschThermostatCluster.AttributeDefs.window_open.name,
+        BoschThermostatCluster.cluster_id,
+        translation_key="window_detection"
+    )
+    # Display time-out
+    .number(
+        BoschUserInterfaceCluster.AttributeDefs.display_ontime.name,
+        BoschUserInterfaceCluster.cluster_id,
+        min_value=5,
+        max_value=30,
+        step=1,
+        translation_key="on_off_transition_time"
+    )
+    # Display brightness
+    .number(
+        BoschUserInterfaceCluster.AttributeDefs.display_brightness.name,
+        BoschUserInterfaceCluster.cluster_id,
+        min_value=0,
+        max_value=10,
+        step=1,
+        translation_key="backlight_mode"
+    )
+)

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -152,6 +152,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         step=1,
         translation_key="display_brightness",
     )
+    # Heating vs Cooling.
     .enum(
         Thermostat.AttributeDefs.ctrl_sequence_of_oper.name,
         BoschControlSequenceOfOperation,

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -17,36 +17,46 @@ from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef, ZCLCommandDef
 
 """Bosch specific thermostat attribute ids."""
+
+# Mode of operation with values BoschOperatingMode.
 OPERATING_MODE_ATTR_ID = 0x4007
+
+# Valve position: 0% - 100%
 VALVE_POSITION_ATTR_ID = 0x4020
+
+# Window open switch (changes to a lower target temperature when on).
 WINDOW_OPEN_ATTR_ID = 0x4042
+
+# Boost preset mode.
 BOOST_ATTR_ID = 0x4043
 
 """Bosch specific user interface attribute ids."""
-SCREEN_TIMEOUT_ATTR_ID = 0x403A
-SCREEN_BRIGHTNESS_ATTR_ID = 0x403B
 
-"""Bosh operating mode attribute values."""
+# Display on-time (5s - 30s).
+SCREEN_TIMEOUT_ATTR_ID = 0x403A
+
+# Display brightness (0 - 10).
+SCREEN_BRIGHTNESS_ATTR_ID = 0x403B
 
 
 class BoschOperatingMode(t.enum8):
+    """Bosh operating mode attribute values."""
+
     Schedule = 0x00
     Manual = 0x01
     Pause = 0x05
 
 
-"""Bosch thermostat preset."""
-
-
 class BoschPreset(t.enum8):
+    """Bosch thermostat preset."""
+
     Normal = 0x00
     Boost = 0x01
 
 
-"""Binary attribute (window open) value."""
-
-
 class State(t.enum8):
+    """Binary attribute (window open) value."""
+
     Off = 0x00
     On = 0x01
 
@@ -129,7 +139,7 @@ class BoschThermostat(CustomDeviceV2):
         BoschThermostatCluster.cluster_id,
         translation_key="window_detection",
     )
-    # Display time-out
+    # Display time-out.
     .number(
         BoschUserInterfaceCluster.AttributeDefs.display_ontime.name,
         BoschUserInterfaceCluster.cluster_id,
@@ -138,7 +148,7 @@ class BoschThermostat(CustomDeviceV2):
         step=1,
         translation_key="on_off_transition_time",
     )
-    # Display brightness
+    # Display brightness.
     .number(
         BoschUserInterfaceCluster.AttributeDefs.display_brightness.name,
         BoschUserInterfaceCluster.cluster_id,

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -1,6 +1,5 @@
 """Device handler for Bosch RBSH-RTH0-ZB-EU thermostat."""
 
-
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import add_to_registry_v2
 from zigpy.quirks.v2.homeassistant import EntityPlatform, EntityType
@@ -36,6 +35,7 @@ SCREEN_BRIGHTNESS_ATTR_ID = 0x403B
 
 # Control sequence of operation (heating/cooling)
 CTRL_SEQUENCE_OF_OPERATION_ID = 0x001B
+
 
 class BoschOperatingMode(t.enum8):
     """Bosh operating mode attribute values."""

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -1,7 +1,7 @@
 """Device handler for Bosch RBSH-RTH0-ZB-EU thermostat."""
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import add_to_registry_v2
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import EntityPlatform, EntityType
 import zigpy.types as t
 from zigpy.zcl.clusters.hvac import (
@@ -119,7 +119,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
 
 
 (
-    add_to_registry_v2("Bosch", "RBSH-RTH0-ZB-EU")
+    QuirkBuilder("Bosch", "RBSH-RTH0-ZB-EU")
     .replaces(BoschThermostatCluster)
     .replaces(BoschUserInterfaceCluster)
     # Operating mode - read-only: controlled automatically through Thermostat.system_mode (HAVC mode).
@@ -168,4 +168,5 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.cluster_id,
         translation_key="ctrl_sequence_of_oper",
     )
+    .add_to_registry()
 )

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -1,20 +1,11 @@
 """Device handler for Bosch RBSH-RTH0-ZB-EU thermostat."""
 
-from typing import Any, Final
 
-from zigpy.device import Device
-from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.registry import DeviceRegistry
-from zigpy.quirks.v2 import (
-    CustomDeviceV2,
-    add_to_registry_v2,
-)
-from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+from zigpy.quirks.v2 import CustomDeviceV2, add_to_registry_v2
 import zigpy.types as t
-from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
-from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef, ZCLCommandDef
+from zigpy.zcl.foundation import ZCLAttributeDef
 
 """Bosch specific thermostat attribute ids."""
 
@@ -58,6 +49,8 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
     """Bosch thermostat cluster."""
 
     class AttributeDefs(Thermostat.AttributeDefs):
+        """Bosch thermostat manufacturer specific attributes."""
+
         operating_mode = ZCLAttributeDef(
             id=t.uint16_t(OPERATING_MODE_ATTR_ID),
             type=BoschOperatingMode,
@@ -88,6 +81,8 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     """Bosch UserInterface cluster."""
 
     class AttributeDefs(UserInterface.AttributeDefs):
+        """Bosch user interface manufacturer specific attributes."""
+
         display_on_time = ZCLAttributeDef(
             id=t.uint16_t(SCREEN_TIMEOUT_ATTR_ID),
             # Usable values range from 5-30

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -2,7 +2,7 @@
 
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import CustomDeviceV2, add_to_registry_v2
+from zigpy.quirks.v2 import add_to_registry_v2
 import zigpy.types as t
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.foundation import ZCLAttributeDef
@@ -98,13 +98,8 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         )
 
 
-class BoschThermostat(CustomDeviceV2):
-    """Bosch thermostat custom device."""
-
-
 (
     add_to_registry_v2("Bosch", "RBSH-RTH0-ZB-EU")
-    .device_class(BoschThermostat)
     .replaces(BoschThermostatCluster)
     .replaces(BoschUserInterfaceCluster)
     # Operating mode: controlled automatically through Thermostat.system_mode (HAVC mode).

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -23,24 +23,33 @@ WINDOW_OPEN_ATTR_ID = 0x4042
 BOOST_ATTR_ID = 0x4043
 
 """Bosch specific user interface attribute ids."""
-SCREEN_TIMEOUT_ATTR_ID = 0x403a
-SCREEN_BRIGHTNESS_ATTR_ID = 0x403b
+SCREEN_TIMEOUT_ATTR_ID = 0x403A
+SCREEN_BRIGHTNESS_ATTR_ID = 0x403B
 
 """Bosh operating mode attribute values."""
+
+
 class BoschOperatingMode(t.enum8):
     Schedule = 0x00
     Manual = 0x01
     Pause = 0x05
 
+
 """Bosch thermostat preset."""
+
+
 class BoschPreset(t.enum8):
     Normal = 0x00
     Boost = 0x01
 
+
 """Binary attribute (window open) value."""
+
+
 class State(t.enum8):
     Off = 0x00
     On = 0x01
+
 
 class BoschThermostatCluster(CustomCluster, Thermostat):
     """Bosch thermostat cluster."""
@@ -94,10 +103,9 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
 class BoschThermostat(CustomDeviceV2):
     """Bosch thermostat custom device."""
 
+
 (
-    add_to_registry_v2(
-        "Bosch", "RBSH-RTH0-ZB-EU"
-    )
+    add_to_registry_v2("Bosch", "RBSH-RTH0-ZB-EU")
     .device_class(BoschThermostat)
     .replaces(BoschThermostatCluster)
     .replaces(BoschUserInterfaceCluster)
@@ -106,20 +114,20 @@ class BoschThermostat(CustomDeviceV2):
         BoschThermostatCluster.AttributeDefs.operating_mode.name,
         BoschOperatingMode,
         BoschThermostatCluster.cluster_id,
-        translation_key="switch_mode"
+        translation_key="switch_mode",
     )
     # Preset - normal/boost.
     .enum(
         BoschThermostatCluster.AttributeDefs.boost.name,
         BoschPreset,
         BoschThermostatCluster.cluster_id,
-        translation_key="preset"
+        translation_key="preset",
     )
     # Window open switch: manually set or through an automation.
     .switch(
         BoschThermostatCluster.AttributeDefs.window_open.name,
         BoschThermostatCluster.cluster_id,
-        translation_key="window_detection"
+        translation_key="window_detection",
     )
     # Display time-out
     .number(
@@ -128,7 +136,7 @@ class BoschThermostat(CustomDeviceV2):
         min_value=5,
         max_value=30,
         step=1,
-        translation_key="on_off_transition_time"
+        translation_key="on_off_transition_time",
     )
     # Display brightness
     .number(
@@ -137,6 +145,6 @@ class BoschThermostat(CustomDeviceV2):
         min_value=0,
         max_value=10,
         step=1,
-        translation_key="backlight_mode"
+        translation_key="backlight_mode",
     )
 )

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -34,7 +34,7 @@ SCREEN_TIMEOUT_ATTR_ID = 0x403A
 SCREEN_BRIGHTNESS_ATTR_ID = 0x403B
 
 # Control sequence of operation (heating/cooling)
-CTRL_SEQUENCE_OF_OPERATION_ID = 0x001B
+CTRL_SEQUENCE_OF_OPERATION_ID = Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
 
 
 class BoschOperatingMode(t.enum8):

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -100,14 +100,14 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         display_on_time = ZCLAttributeDef(
             id=SCREEN_TIMEOUT_ATTR_ID,
             # Usable values range from 5-30
-            type=t.uint8_t,
+            type=t.enum8,
             is_manufacturer_specific=True,
         )
 
         display_brightness = ZCLAttributeDef(
             id=SCREEN_BRIGHTNESS_ATTR_ID,
             # Values range from 0-10
-            type=t.uint8_t,
+            type=t.enum8,
             is_manufacturer_specific=True,
         )
 

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -3,6 +3,7 @@
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import add_to_registry_v2
+from zigpy.quirks.v2.homeassistant import EntityPlatform, EntityType
 import zigpy.types as t
 from zigpy.zcl.clusters.hvac import (
     ControlSequenceOfOperation,
@@ -115,12 +116,14 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     add_to_registry_v2("Bosch", "RBSH-RTH0-ZB-EU")
     .replaces(BoschThermostatCluster)
     .replaces(BoschUserInterfaceCluster)
-    # Operating mode: controlled automatically through Thermostat.system_mode (HAVC mode).
+    # Operating mode - read-only: controlled automatically through Thermostat.system_mode (HAVC mode).
     .enum(
         BoschThermostatCluster.AttributeDefs.operating_mode.name,
         BoschOperatingMode,
         BoschThermostatCluster.cluster_id,
         translation_key="operating_mode",
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
     )
     # Fast heating/boost.
     .switch(

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -69,6 +69,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
             id=OPERATING_MODE_ATTR_ID,
             type=BoschOperatingMode,
             is_manufacturer_specific=True,
+            name="operating_mode",
         )
 
         pi_heating_demand = ZCLAttributeDef(
@@ -76,18 +77,21 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
             # Values range from 0-100
             type=t.enum8,
             is_manufacturer_specific=True,
+            name="pi_heating_demand",
         )
 
         window_open = ZCLAttributeDef(
             id=WINDOW_OPEN_ATTR_ID,
             type=State,
             is_manufacturer_specific=True,
+            name="window_open",
         )
 
         boost = ZCLAttributeDef(
             id=BOOST_ATTR_ID,
             type=State,
             is_manufacturer_specific=True,
+            name="boost",
         )
 
 
@@ -102,6 +106,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
             # Usable values range from 5-30
             type=t.enum8,
             is_manufacturer_specific=True,
+            name="display_on_time",
         )
 
         display_brightness = ZCLAttributeDef(
@@ -109,6 +114,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
             # Values range from 0-10
             type=t.enum8,
             is_manufacturer_specific=True,
+            name="display_brightness",
         )
 
 

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -114,6 +114,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
 
 (
     QuirkBuilder("Bosch", "RBSH-RTH0-ZB-EU")
+    .applies_to("Bosch", "RBSH-RTH0-BAT-ZB-EU")
     .replaces(BoschThermostatCluster)
     .replaces(BoschUserInterfaceCluster)
     # Operating mode - read-only: controlled automatically through Thermostat.system_mode (HAVC mode).

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -131,7 +131,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.AttributeDefs.boost_heating.name,
         BoschThermostatCluster.cluster_id,
         translation_key="boost_heating",
-        fallback_name="Boost",
+        fallback_name="Boost heating",
     )
     # Window open switch: manually set or through an automation.
     .switch(

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -1,0 +1,161 @@
+"""Device handler for Bosch RBSH-TRV0-ZB-EU thermostat."""
+
+from zigpy.profiles import zha
+import zigpy.types as t
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters import general, hvac, homeautomation
+
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Identify,
+    Ota,
+    PollControl,
+    Groups,
+    Time,
+    PowerConfiguration,
+    ZCLAttributeDef,
+)
+from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
+from zigpy.zcl.clusters.homeautomation import Diagnostic
+
+from zhaquirks import CustomCluster
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class BoschOperatingMode(t.enum8):
+    Schedule = 0x00
+    Manual = 0x01
+    Pause = 0x05
+
+
+class State(t.enum8):
+    Off = 0x00
+    On = 0x01
+
+
+class BoschDisplayOrientation(t.enum8):
+    Normal = 0x00
+    Flipped = 0x01
+
+
+class BoschDisplayedTemperature(t.enum8):
+    Target = 0x00
+    Measured = 0x01
+
+
+class BoschThermostatCluster(CustomCluster, Thermostat):
+    """Bosch thermostat cluster."""
+
+    class AttributeDefs(Thermostat.AttributeDefs):
+        operating_mode = ZCLAttributeDef(
+            id=t.uint16_t(0x4007),
+            type=BoschOperatingMode,
+            is_manufacturer_specific=True,
+        )
+
+        pi_heating_demand = ZCLAttributeDef(
+            id=t.uint16_t(0x4020),
+            # Values range from 0-100
+            type=t.enum8,
+            is_manufacturer_specific=True,
+        )
+
+        window_open = ZCLAttributeDef(
+            id=t.uint16_t(0x4042),
+            type=State,
+            is_manufacturer_specific=True,
+        )
+
+        boost = ZCLAttributeDef(
+            id=t.uint16_t(0x4043),
+            type=State,
+            is_manufacturer_specific=True,
+        )
+
+
+class BoschUserInterfaceCluster(CustomCluster, UserInterface):
+    """Bosch UserInterface cluster."""
+
+    class AttributeDefs(UserInterface.AttributeDefs):
+        display_orientation = ZCLAttributeDef(
+            id=t.uint16_t(0x400B),
+            type=BoschDisplayOrientation,
+            is_manufacturer_specific=True,
+        )
+
+        display_ontime = ZCLAttributeDef(
+            id=t.uint16_t(0x403A),
+            # Usable values range from 2-30
+            type=t.enum8,
+            is_manufacturer_specific=True,
+        )
+
+        display_brightness = ZCLAttributeDef(
+            id=t.uint16_t(0x403B),
+            # Values range from 0-10
+            type=t.enum8,
+            is_manufacturer_specific=True,
+        )
+
+        displayed_temperature = ZCLAttributeDef(
+            id=t.uint16_t(0x4039),
+            type=BoschDisplayedTemperature,
+            is_manufacturer_specific=True,
+        )
+
+
+class BoschThermostat(CustomDevice):
+    """Bosch thermostat custom device."""
+
+    signature = {
+        MODELS_INFO: [("BOSCH", "RBSH-TRV0-ZB-EU")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=769
+            # device_version=1
+            # input_clusters=[0, 1, 3, 4, 32, 513, 516, 2821]
+            # output_clusters=[10, 25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.THERMOSTAT,
+                INPUT_CLUSTERS: [
+                    general.Basic.cluster_id,
+                    general.PowerConfiguration.cluster_id,
+                    general.Identify.cluster_id,
+                    general.Groups.cluster_id,
+                    general.PollControl.cluster_id,
+                    hvac.Thermostat.cluster_id,
+                    hvac.UserInterface.cluster_id,
+                    homeautomation.Diagnostic.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [general.Ota.cluster_id,
+                                  general.Time.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [
+                    Basic,
+                    BoschThermostatCluster,
+                    BoschUserInterfaceCluster,
+                    Diagnostic,
+                    Groups,
+                    Identify,
+                    Ota,
+                    PollControl,
+                    PowerConfiguration,
+                    Time,
+                ],
+                OUTPUT_CLUSTERS: [Ota, Time],
+            },
+        },
+    }

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -1,22 +1,21 @@
 """Device handler for Bosch RBSH-TRV0-ZB-EU thermostat."""
 
 from zigpy.profiles import zha
-import zigpy.types as t
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters import general, hvac, homeautomation
-
+import zigpy.types as t
+from zigpy.zcl.clusters import general, homeautomation, hvac
 from zigpy.zcl.clusters.general import (
     Basic,
+    Groups,
     Identify,
     Ota,
     PollControl,
-    Groups,
-    Time,
     PowerConfiguration,
+    Time,
     ZCLAttributeDef,
 )
-from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.clusters.homeautomation import Diagnostic
+from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 
 from zhaquirks import CustomCluster
 from zhaquirks.const import (
@@ -134,8 +133,7 @@ class BoschThermostat(CustomDevice):
                     hvac.UserInterface.cluster_id,
                     homeautomation.Diagnostic.cluster_id,
                 ],
-                OUTPUT_CLUSTERS: [general.Ota.cluster_id,
-                                  general.Time.cluster_id],
+                OUTPUT_CLUSTERS: [general.Ota.cluster_id, general.Time.cluster_id],
             },
         },
     }

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -507,5 +507,16 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         translation_key="ctrl_sequence_of_oper",
         fallback_name="Control sequence",
     )
+    # Local temperature calibration.
+    .number(
+        Thermostat.AttributeDefs.local_temperature_calibration.name,
+        BoschThermostatCluster.cluster_id,
+        min_value=-5,
+        max_value=5,
+        step=0.1,
+        multiplier=0.1,
+        translation_key="local_temperature_calibration",
+        fallback_name="Local temperature offset",
+    )
     .add_to_registry()
 )

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -120,36 +120,25 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
             id=OPERATING_MODE_ATTR_ID,
             type=BoschOperatingMode,
             is_manufacturer_specific=True,
-            name="operating_mode",
         )
 
         pi_heating_demand = ZCLAttributeDef(
             id=VALVE_POSITION_ATTR_ID,
             # Values range from 0-100
-            type=t.enum8,
+            type=t.uint8_t,
             is_manufacturer_specific=True,
-            name="pi_heating_demand",
         )
 
         window_open = ZCLAttributeDef(
-            id=WINDOW_OPEN_ATTR_ID,
-            type=State,
-            is_manufacturer_specific=True,
-            name="window_open",
+            id=WINDOW_OPEN_ATTR_ID, type=State, is_manufacturer_specific=True
         )
 
         boost = ZCLAttributeDef(
-            id=BOOST_ATTR_ID,
-            type=State,
-            is_manufacturer_specific=True,
-            name="boost",
+            id=BOOST_ATTR_ID, type=State, is_manufacturer_specific=True
         )
 
         remote_temperature = ZCLAttributeDef(
-            id=REMOTE_TEMPERATURE_ATTR_ID,
-            type=t.int16s,
-            is_manufacturer_specific=True,
-            name="remote_temperature",
+            id=REMOTE_TEMPERATURE_ATTR_ID, type=t.int16s, is_manufacturer_specific=True
         )
 
     async def write_attributes(
@@ -351,30 +340,26 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
             # To be matched to BoschDisplayOrientation enum.
             type=t.uint8_t,
             is_manufacturer_specific=True,
-            name="display_orientation",
         )
 
         display_on_time = ZCLAttributeDef(
             id=SCREEN_TIMEOUT_ATTR_ID,
             # Usable values range from 5-30
-            type=t.enum8,
+            type=t.uint8_t,
             is_manufacturer_specific=True,
-            name="display_on_time",
         )
 
         display_brightness = ZCLAttributeDef(
             id=SCREEN_BRIGHTNESS_ATTR_ID,
             # Values range from 0-10
-            type=t.enum8,
+            type=t.uint8_t,
             is_manufacturer_specific=True,
-            name="display_brightness",
         )
 
         displayed_temperature = ZCLAttributeDef(
             id=DISPLAY_MODE_ATTR_ID,
             type=BoschDisplayedTemperature,
             is_manufacturer_specific=True,
-            name="displayed_temperature",
         )
 
     async def write_attributes(
@@ -418,7 +403,6 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.AttributeDefs.operating_mode.name,
         BoschOperatingMode,
         BoschThermostatCluster.cluster_id,
-        translation_key="operating_mode",
         entity_platform=EntityPlatform.SENSOR,
         entity_type=EntityType.DIAGNOSTIC,
     )
@@ -426,13 +410,11 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     .switch(
         BoschThermostatCluster.AttributeDefs.boost.name,
         BoschThermostatCluster.cluster_id,
-        translation_key="boost",
     )
     # Window open switch: manually set or through an automation.
     .switch(
         BoschThermostatCluster.AttributeDefs.window_open.name,
         BoschThermostatCluster.cluster_id,
-        translation_key="window_open",
     )
     # Remote temperature.
     .number(
@@ -443,21 +425,18 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         step=0.1,
         multiplier=100,
         device_class=NumberDeviceClass.TEMPERATURE,
-        # translation_key="remote_temperature"
     )
     # Display temperature.
     .enum(
         BoschUserInterfaceCluster.AttributeDefs.displayed_temperature.name,
         BoschDisplayedTemperature,
         BoschUserInterfaceCluster.cluster_id,
-        translation_key="displayed_temperature",
     )
     # Display orientation.
     .enum(
         BoschUserInterfaceCluster.AttributeDefs.display_orientation.name,
         BoschDisplayOrientation,
         BoschUserInterfaceCluster.cluster_id,
-        translation_key="display_orientation",
     )
     # Display time-out.
     .number(
@@ -466,7 +445,6 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         min_value=5,
         max_value=30,
         step=1,
-        translation_key="display_on_time",
     )
     # Display brightness.
     .number(
@@ -475,14 +453,12 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         min_value=0,
         max_value=10,
         step=1,
-        translation_key="display_brightness",
-        # Heating vs Cooling.
     )
+    # Heating vs Cooling.
     .enum(
         Thermostat.AttributeDefs.ctrl_sequence_of_oper.name,
         BoschControlSequenceOfOperation,
         BoschThermostatCluster.cluster_id,
-        translation_key="ctrl_sequence_of_oper",
     )
     .add_to_registry()
 )

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -48,6 +48,7 @@ SCREEN_BRIGHTNESS_ATTR_ID = 0x403B
 # Control sequence of operation (heating/cooling)
 CTRL_SEQUENCE_OF_OPERATION_ID = 0x001B
 
+
 class BoschOperatingMode(t.enum8):
     """Bosh operating mode attribute values."""
 
@@ -214,13 +215,20 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
 
             if new_system_mode_value == Thermostat.SystemMode.Heat:
                 """Heating or cooling? Depends on both operating_mode and ctrl_sequence_of_operation."""
-                ctrl_sequence_of_oper_attr = Thermostat.AttributeDefs.ctrl_sequence_of_oper
+                ctrl_sequence_of_oper_attr = (
+                    Thermostat.AttributeDefs.ctrl_sequence_of_oper
+                )
                 successful_r, failed_r = await super().read_attributes(
                     [ctrl_sequence_of_oper_attr.name], True, False, manufacturer
                 )
                 if ctrl_sequence_of_oper_attr.name in successful_r:
-                    ctrl_sequence_of_oper_value = successful_r.pop(ctrl_sequence_of_oper_attr.name)
-                    if ctrl_sequence_of_oper_value == BoschControlSequenceOfOperation.Cooling:
+                    ctrl_sequence_of_oper_value = successful_r.pop(
+                        ctrl_sequence_of_oper_attr.name
+                    )
+                    if (
+                        ctrl_sequence_of_oper_value
+                        == BoschControlSequenceOfOperation.Cooling
+                    ):
                         new_system_mode_value = Thermostat.SystemMode.Cool
 
             self._update_attribute(SYSTEM_MODE_ATTR.id, new_system_mode_value)
@@ -230,22 +238,33 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
 
             ctrl_sequence_of_oper_value = None
             if ctrl_sequence_of_oper_attr.id in attributes:
-                ctrl_sequence_of_oper_value = attributes.get(ctrl_sequence_of_oper_attr.id)
+                ctrl_sequence_of_oper_value = attributes.get(
+                    ctrl_sequence_of_oper_attr.id
+                )
             elif ctrl_sequence_of_oper_attr.name in attributes:
-                ctrl_sequence_of_oper_value = attributes.get(ctrl_sequence_of_oper_attr.name)
+                ctrl_sequence_of_oper_value = attributes.get(
+                    ctrl_sequence_of_oper_attr.name
+                )
 
             if ctrl_sequence_of_oper_value is not None:
                 successful_r, failed_r = await super().read_attributes(
                     [operating_mode_attr.name], True, False, manufacturer
                 )
                 if operating_mode_attr.name in successful_r:
-                    operating_mode_attr_value = successful_r.pop(operating_mode_attr.name)
+                    operating_mode_attr_value = successful_r.pop(
+                        operating_mode_attr.name
+                    )
                     if operating_mode_attr_value == BoschOperatingMode.Manual:
                         new_system_mode_value = Thermostat.SystemMode.Heat
-                        if ctrl_sequence_of_oper_value == BoschControlSequenceOfOperation.Cooling:
+                        if (
+                            ctrl_sequence_of_oper_value
+                            == BoschControlSequenceOfOperation.Cooling
+                        ):
                             new_system_mode_value = Thermostat.SystemMode.Cool
 
-                        self._update_attribute(SYSTEM_MODE_ATTR.id, new_system_mode_value)
+                        self._update_attribute(
+                            SYSTEM_MODE_ATTR.id, new_system_mode_value
+                        )
 
         """Write the remaining attributes to thermostat cluster."""
         if remaining_attributes:
@@ -283,7 +302,10 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
             ctrl_sequence_of_oper_attr = Thermostat.AttributeDefs.ctrl_sequence_of_oper
 
             successful_r, failed_r = await super().read_attributes(
-                [operating_mode_attr.name, ctrl_sequence_of_oper_attr.name], allow_cache, only_cache, manufacturer
+                [operating_mode_attr.name, ctrl_sequence_of_oper_attr.name],
+                allow_cache,
+                only_cache,
+                manufacturer,
             )
             if operating_mode_attr.name in successful_r:
                 operating_mode_value = successful_r.pop(operating_mode_attr.name)
@@ -293,8 +315,14 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
 
                 """Heating or cooling? Depends on both operating_mode and ctrl_sequence_of_operation."""
                 if ctrl_sequence_of_oper_attr.name in successful_r:
-                    ctrl_sequence_of_oper_value = successful_r.pop(ctrl_sequence_of_oper_attr.name)
-                    if ctrl_sequence_of_oper_value == BoschControlSequenceOfOperation.Cooling and system_mode_value == Thermostat.SystemMode.Heat:
+                    ctrl_sequence_of_oper_value = successful_r.pop(
+                        ctrl_sequence_of_oper_attr.name
+                    )
+                    if (
+                        ctrl_sequence_of_oper_value
+                        == BoschControlSequenceOfOperation.Cooling
+                        and system_mode_value == Thermostat.SystemMode.Heat
+                    ):
                         system_mode_value = Thermostat.SystemMode.Cool
 
                 successful_r[system_mode_attribute_id] = system_mode_value
@@ -448,8 +476,9 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         max_value=10,
         step=1,
         translation_key="display_brightness",
-    # Heating vs Cooling.
-    ).enum(
+        # Heating vs Cooling.
+    )
+    .enum(
         Thermostat.AttributeDefs.ctrl_sequence_of_oper.name,
         BoschControlSequenceOfOperation,
         BoschThermostatCluster.cluster_id,

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -92,9 +92,6 @@ OPERATING_MODE_TO_SYSTEM_MODE_MAP = {
     BoschOperatingMode.Schedule: Thermostat.SystemMode.Auto,
     BoschOperatingMode.Manual: Thermostat.SystemMode.Heat,
     BoschOperatingMode.Pause: Thermostat.SystemMode.Off,
-    "BoschOperatingMode.Schedule": Thermostat.SystemMode.Auto,
-    "BoschOperatingMode.Manual": Thermostat.SystemMode.Heat,
-    "BoschOperatingMode.Pause": Thermostat.SystemMode.Off,
 }
 
 """HA system mode to Bosch operating mode mapping."""
@@ -103,17 +100,12 @@ SYSTEM_MODE_TO_OPERATING_MODE_MAP = {
     Thermostat.SystemMode.Heat: BoschOperatingMode.Manual,
     Thermostat.SystemMode.Cool: BoschOperatingMode.Manual,
     Thermostat.SystemMode.Auto: BoschOperatingMode.Schedule,
-    "SystemMode.Off": BoschOperatingMode.Pause,
-    "SystemMode.Heat": BoschOperatingMode.Manual,
-    "SystemMode.Cool": BoschOperatingMode.Manual,
-    "SystemMode.Auto": BoschOperatingMode.Schedule,
 }
 
+"""Bosch display orientation enum to uint8_t mapping."""
 DISPLAY_ORIENTATION_ENUM_TO_INT_MAP = {
-    0x00: 0x00,
-    0x01: 0x01,
-    "BoschDisplayOrientation.Normal": 0x00,
-    "BoschDisplayOrientation.Flipped": 0x01,
+    BoschDisplayOrientation.Normal: 0x00,
+    BoschDisplayOrientation.Flipped: 0x01,
 }
 
 

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -17,55 +17,69 @@ from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef, ZCLCommandDef
 
 """Bosch specific thermostat attribute ids."""
+
+# Mode of operation with values BoschOperatingMode.
 OPERATING_MODE_ATTR_ID = 0x4007
+
+# Valve position: 0% - 100%
 VALVE_POSITION_ATTR_ID = 0x4020
+
+# Remote measured temperature.
 REMOTE_TEMPERATURE_ATTR_ID = 0x4040
+
+# Window open switch (changes to a lower target temperature when on).
 WINDOW_OPEN_ATTR_ID = 0x4042
+
+# Boost preset mode.
 BOOST_ATTR_ID = 0x4043
 
 """Bosch specific user interface attribute ids."""
-SCREEN_ORIENTATION_ATTR_ID = 0x400B
-DISPLAY_MODE_ATTR_ID = 0x4039
-SCREEN_TIMEOUT_ATTR_ID = 0x403A
-SCREEN_BRIGHTNESS_ATTR_ID = 0x403B
 
-"""Bosh operating mode attribute values."""
+# Display orientation with values BoschDisplayOrientation.
+SCREEN_ORIENTATION_ATTR_ID = 0x400B
+
+# Displayed temperature with values BoschDisplayedTemperature.
+DISPLAY_MODE_ATTR_ID = 0x4039
+
+# Display on-time (5s - 30s).
+SCREEN_TIMEOUT_ATTR_ID = 0x403A
+
+# Display brightness (0 - 10).
+SCREEN_BRIGHTNESS_ATTR_ID = 0x403B
 
 
 class BoschOperatingMode(t.enum8):
+    """Bosh operating mode attribute values."""
+
     Schedule = 0x00
     Manual = 0x01
     Pause = 0x05
 
 
-"""Bosch thermostat preset."""
-
-
 class BoschPreset(t.enum8):
+    """Bosch thermostat preset."""
+
     Normal = 0x00
     Boost = 0x01
 
 
-"""Binary attribute (window open) value."""
-
-
 class State(t.enum8):
+    """Binary attribute (window open) value."""
+
     Off = 0x00
     On = 0x01
 
 
-"""Bosch display orientation attribute values."""
-
-
 class BoschDisplayOrientation(t.enum8):
+    """Bosch display orientation attribute values."""
+
     Normal = 0x00
     Flipped = 0x01
 
 
-"""Bosch displayed temperature attribute values."""
-
-
 class BoschDisplayedTemperature(t.enum8):
+    """Bosch displayed temperature attribute values."""
+
     Target = 0x00
     Measured = 0x01
 
@@ -342,7 +356,7 @@ class BoschThermostat(CustomDeviceV2):
         BoschThermostatCluster.cluster_id,
         translation_key="window_detection",
     )
-    # Remote temperature
+    # Remote temperature.
     .number(
         BoschThermostatCluster.AttributeDefs.remote_temperature.name,
         BoschThermostatCluster.cluster_id,
@@ -360,14 +374,14 @@ class BoschThermostat(CustomDeviceV2):
         BoschUserInterfaceCluster.cluster_id,
         translation_key="device_temperature",
     )
-    # Display orientation
+    # Display orientation.
     .enum(
         BoschUserInterfaceCluster.AttributeDefs.display_orientation.name,
         BoschDisplayOrientation,
         BoschUserInterfaceCluster.cluster_id,
         translation_key="inverted",
     )
-    # Display time-out
+    # Display time-out.
     .number(
         BoschUserInterfaceCluster.AttributeDefs.display_ontime.name,
         BoschUserInterfaceCluster.cluster_id,
@@ -376,7 +390,7 @@ class BoschThermostat(CustomDeviceV2):
         step=1,
         translation_key="on_off_transition_time",
     )
-    # Display brightness
+    # Display brightness.
     .number(
         BoschUserInterfaceCluster.AttributeDefs.display_brightness.name,
         BoschUserInterfaceCluster.cluster_id,

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -56,13 +56,6 @@ class BoschOperatingMode(t.enum8):
     Pause = 0x05
 
 
-class BoschPreset(t.enum8):
-    """Bosch thermostat preset."""
-
-    Normal = 0x00
-    Boost = 0x01
-
-
 class State(t.enum8):
     """Binary attribute (window open) value."""
 
@@ -140,7 +133,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
 
         boost = ZCLAttributeDef(
             id=t.uint16_t(BOOST_ATTR_ID),
-            type=BoschPreset,
+            type=State,
             is_manufacturer_specific=True,
         )
 
@@ -276,7 +269,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
             is_manufacturer_specific=True,
         )
 
-        display_ontime = ZCLAttributeDef(
+        display_on_time = ZCLAttributeDef(
             id=t.uint16_t(SCREEN_TIMEOUT_ATTR_ID),
             # Usable values range from 5-30
             type=t.enum8,
@@ -341,20 +334,19 @@ class BoschThermostat(CustomDeviceV2):
         BoschThermostatCluster.AttributeDefs.operating_mode.name,
         BoschOperatingMode,
         BoschThermostatCluster.cluster_id,
-        translation_key="switch_mode",
+        translation_key="operating_mode",
     )
-    # Preset - normal/boost.
-    .enum(
+    # Fast heating/boost.
+    .switch(
         BoschThermostatCluster.AttributeDefs.boost.name,
-        BoschPreset,
         BoschThermostatCluster.cluster_id,
-        translation_key="preset",
+        translation_key="boost",
     )
     # Window open switch: manually set or through an automation.
     .switch(
         BoschThermostatCluster.AttributeDefs.window_open.name,
         BoschThermostatCluster.cluster_id,
-        translation_key="window_detection",
+        translation_key="window_open",
     )
     # Remote temperature.
     .number(
@@ -365,30 +357,30 @@ class BoschThermostat(CustomDeviceV2):
         step=0.1,
         multiplier=100,
         device_class=NumberDeviceClass.TEMPERATURE,
-        # translation_key="external_sensor"
+        # translation_key="remote_temperature"
     )
     # Display temperature.
     .enum(
         BoschUserInterfaceCluster.AttributeDefs.displayed_temperature.name,
         BoschDisplayedTemperature,
         BoschUserInterfaceCluster.cluster_id,
-        translation_key="device_temperature",
+        translation_key="displayed_temperature",
     )
     # Display orientation.
     .enum(
         BoschUserInterfaceCluster.AttributeDefs.display_orientation.name,
         BoschDisplayOrientation,
         BoschUserInterfaceCluster.cluster_id,
-        translation_key="inverted",
+        translation_key="display_orientation",
     )
     # Display time-out.
     .number(
-        BoschUserInterfaceCluster.AttributeDefs.display_ontime.name,
+        BoschUserInterfaceCluster.AttributeDefs.display_on_time.name,
         BoschUserInterfaceCluster.cluster_id,
         min_value=5,
         max_value=30,
         step=1,
-        translation_key="on_off_transition_time",
+        translation_key="display_on_time",
     )
     # Display brightness.
     .number(
@@ -397,6 +389,6 @@ class BoschThermostat(CustomDeviceV2):
         min_value=0,
         max_value=10,
         step=1,
-        translation_key="backlight_mode",
+        translation_key="display_brightness",
     )
 )

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -6,7 +6,11 @@ from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import add_to_registry_v2
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
-from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
+from zigpy.zcl.clusters.hvac import (
+    ControlSequenceOfOperation,
+    Thermostat,
+    UserInterface,
+)
 from zigpy.zcl.foundation import ZCLAttributeDef
 
 """Bosch specific thermostat attribute ids."""
@@ -40,6 +44,8 @@ SCREEN_TIMEOUT_ATTR_ID = 0x403A
 # Display brightness (0 - 10).
 SCREEN_BRIGHTNESS_ATTR_ID = 0x403B
 
+# Control sequence of operation (heating/cooling)
+CTRL_SEQUENCE_OF_OPERATION_ID = 0x001B
 
 class BoschOperatingMode(t.enum8):
     """Bosh operating mode attribute values."""
@@ -68,6 +74,13 @@ class BoschDisplayedTemperature(t.enum8):
 
     Target = 0x00
     Measured = 0x01
+
+
+class BoschControlSequenceOfOperation(t.enum8):
+    """Supported ControlSequenceOfOperation modes."""
+
+    Cooling = ControlSequenceOfOperation.Cooling_Only
+    Heating = ControlSequenceOfOperation.Heating_Only
 
 
 """HA thermostat attribute that needs special handling in the Bosch thermostat entity."""
@@ -385,5 +398,10 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         max_value=10,
         step=1,
         translation_key="display_brightness",
+    ).enum(
+        Thermostat.AttributeDefs.ctrl_sequence_of_oper.name,
+        BoschControlSequenceOfOperation,
+        BoschThermostatCluster.cluster_id,
+        translation_key="ctrl_sequence_of_oper",
     )
 )

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -28,8 +28,8 @@ REMOTE_TEMPERATURE_ATTR_ID = 0x4040
 # Window open switch (changes to a lower target temperature when on).
 WINDOW_OPEN_ATTR_ID = 0x4042
 
-# Boost preset mode.
-BOOST_ATTR_ID = 0x4043
+# Boost heating preset mode.
+BOOST_HEATING_ATTR_ID = 0x4043
 
 """Bosch specific user interface attribute ids."""
 
@@ -133,8 +133,8 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
             id=WINDOW_OPEN_ATTR_ID, type=State, is_manufacturer_specific=True
         )
 
-        boost = ZCLAttributeDef(
-            id=BOOST_ATTR_ID, type=State, is_manufacturer_specific=True
+        boost_heating = ZCLAttributeDef(
+            id=BOOST_HEATING_ATTR_ID, type=State, is_manufacturer_specific=True
         )
 
         remote_temperature = ZCLAttributeDef(
@@ -408,7 +408,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     )
     # Fast heating/boost.
     .switch(
-        BoschThermostatCluster.AttributeDefs.boost.name,
+        BoschThermostatCluster.AttributeDefs.boost_heating.name,
         BoschThermostatCluster.cluster_id,
     )
     # Window open switch: manually set or through an automation.

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -1,20 +1,13 @@
 """Device handler for Bosch RBSH-TRV0-ZB-EU thermostat."""
 
-from typing import Any, Final
+from typing import Any
 
-from zigpy.device import Device
-from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.registry import DeviceRegistry
-from zigpy.quirks.v2 import (
-    CustomDeviceV2,
-    add_to_registry_v2,
-)
+from zigpy.quirks.v2 import CustomDeviceV2, add_to_registry_v2
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
-from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
-from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef, ZCLCommandDef
+from zigpy.zcl.foundation import ZCLAttributeDef
 
 """Bosch specific thermostat attribute ids."""
 
@@ -112,6 +105,8 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
     """Bosch thermostat cluster."""
 
     class AttributeDefs(Thermostat.AttributeDefs):
+        """Bosch thermostat manufacturer specific attributes."""
+
         operating_mode = ZCLAttributeDef(
             id=t.uint16_t(OPERATING_MODE_ATTR_ID),
             type=BoschOperatingMode,
@@ -146,7 +141,8 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
     async def write_attributes(
         self, attributes: dict[str | int, Any], manufacturer: int | None = None
     ) -> list:
-        """system_mode special handling:
+        """system_mode special handling.
+
         - turn off by setting operating_mode to Pause
         - turn on by setting operating_mode to Manual
         - add new system_mode value to the internal zigpy Cluster cache
@@ -161,7 +157,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
 
         """Check if SYSTEM_MODE_ATTR is being written (can be numeric or string):
             - do not write it to the device since it is not supported
-            - keep the value to be converted to the supported operating_mode 
+            - keep the value to be converted to the supported operating_mode
         """
         if SYSTEM_MODE_ATTR.id in attributes:
             remaining_attributes.pop(SYSTEM_MODE_ATTR.id)
@@ -171,7 +167,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
             system_mode_value = attributes.get(SYSTEM_MODE_ATTR.name)
 
         """Check if operating_mode_attr is being written (can be numeric or string).
-            - ignore incoming operating_mode when system_mode is also written  
+            - ignore incoming operating_mode when system_mode is also written
             - system_mode has priority and its value would be converted to operating_mode
             - add resulting system_mode to the internal zigpy Cluster cache
         """
@@ -216,7 +212,8 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         only_cache: bool = False,
         manufacturer: int | t.uint16_t | None = None,
     ):
-        """system_mode special handling:
+        """system_mode special handling.
+
         - read and convert operating_mode to system_mode.
         """
 
@@ -262,6 +259,8 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     """Bosch UserInterface cluster."""
 
     class AttributeDefs(UserInterface.AttributeDefs):
+        """Bosch user interface manufacturer specific attributes."""
+
         display_orientation = ZCLAttributeDef(
             id=t.uint16_t(SCREEN_ORIENTATION_ATTR_ID),
             # To be matched to BoschDisplayOrientation enum.
@@ -292,7 +291,8 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     async def write_attributes(
         self, attributes: dict[str | int, Any], manufacturer: int | None = None
     ) -> list:
-        """display_orientation special handling:
+        """display_orientation special handling.
+
         - convert from enum to uint8_t
         """
         display_orientation_attr = self.AttributeDefs.display_orientation

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -343,7 +343,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
 
         new_config_records = config_records.copy()
         [
-            new_config_records.pop(record)
+            new_config_records.remove(record)  # type: ignore
             for record in new_config_records
             if record.attrid == SYSTEM_MODE_ATTR.id
         ]
@@ -351,7 +351,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         return await super()._configure_reporting(
             new_config_records,
             *args,
-            manufacturer,
+            manufacturer=manufacturer,
             **kwargs,
         )
 

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -3,7 +3,7 @@
 from typing import Any, Final, Optional, Union
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2 import QuirkBuilder, ReportingConfig
 from zigpy.quirks.v2.homeassistant import EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
@@ -127,6 +127,11 @@ DISPLAY_ORIENTATION_ENUM_TO_INT_MAP = {
     BoschDisplayOrientation.Normal: 0x00,
     BoschDisplayOrientation.Flipped: 0x01,
 }
+
+"""Battery saving Reporting Configuration"""
+REPORT_CONFIG_BATTERY_SAVE = ReportingConfig(
+    min_interval=3600, max_interval=10800, reportable_change=1
+)
 
 
 class BoschThermostatCluster(CustomCluster, Thermostat):
@@ -466,6 +471,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.cluster_id,
         entity_platform=EntityPlatform.SENSOR,
         entity_type=EntityType.DIAGNOSTIC,
+        reporting_config=REPORT_CONFIG_BATTERY_SAVE,
         translation_key="operating_mode",
         fallback_name="Operating mode",
     )
@@ -476,6 +482,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.cluster_id,
         entity_platform=EntityPlatform.SENSOR,
         entity_type=EntityType.DIAGNOSTIC,
+        reporting_config=REPORT_CONFIG_BATTERY_SAVE,
         translation_key="valve_adapt_status",
         fallback_name="Valve adaptation status",
     )
@@ -483,6 +490,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     .switch(
         BoschThermostatCluster.AttributeDefs.boost_heating.name,
         BoschThermostatCluster.cluster_id,
+        reporting_config=REPORT_CONFIG_BATTERY_SAVE,
         translation_key="boost_heating",
         fallback_name="Boost",
     )

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import add_to_registry_v2
+from zigpy.quirks.v2.homeassistant import EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
 from zigpy.zcl.clusters.hvac import (
@@ -383,12 +384,14 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     add_to_registry_v2("BOSCH", "RBSH-TRV0-ZB-EU")
     .replaces(BoschThermostatCluster)
     .replaces(BoschUserInterfaceCluster)
-    # Operating mode: controlled automatically through Thermostat.system_mode (HAVC mode).
+    # Operating mode - read-only: controlled automatically through Thermostat.system_mode (HAVC mode).
     .enum(
         BoschThermostatCluster.AttributeDefs.operating_mode.name,
         BoschOperatingMode,
         BoschThermostatCluster.cluster_id,
         translation_key="operating_mode",
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
     )
     # Fast heating/boost.
     .switch(

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import CustomDeviceV2, add_to_registry_v2
+from zigpy.quirks.v2 import add_to_registry_v2
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
@@ -320,13 +320,8 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         return await super().write_attributes(remaining_attributes, manufacturer)
 
 
-class BoschThermostat(CustomDeviceV2):
-    """Bosch thermostat custom device."""
-
-
 (
     add_to_registry_v2("BOSCH", "RBSH-TRV0-ZB-EU")
-    .device_class(BoschThermostat)
     .replaces(BoschThermostatCluster)
     .replaces(BoschUserInterfaceCluster)
     # Operating mode: controlled automatically through Thermostat.system_mode (HAVC mode).

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import add_to_registry_v2
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
@@ -410,7 +410,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
 
 
 (
-    add_to_registry_v2("BOSCH", "RBSH-TRV0-ZB-EU")
+    QuirkBuilder("BOSCH", "RBSH-TRV0-ZB-EU")
     .replaces(BoschThermostatCluster)
     .replaces(BoschUserInterfaceCluster)
     # Operating mode - read-only: controlled automatically through Thermostat.system_mode (HAVC mode).
@@ -484,4 +484,5 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.cluster_id,
         translation_key="ctrl_sequence_of_oper",
     )
+    .add_to_registry()
 )

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -482,6 +482,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
 
 (
     QuirkBuilder("BOSCH", "RBSH-TRV0-ZB-EU")
+    .applies_to("BOSCH", "RBSH-TRV1-ZB-EU")
     .replaces(BoschThermostatCluster)
     .replaces(BoschUserInterfaceCluster)
     # Operating mode - read-only: controlled automatically through Thermostat.system_mode (HAVC mode).
@@ -583,17 +584,6 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.cluster_id,
         translation_key="ctrl_sequence_of_oper",
         fallback_name="Control sequence",
-    )
-    # Local temperature calibration.
-    .number(
-        Thermostat.AttributeDefs.local_temperature_calibration.name,
-        BoschThermostatCluster.cluster_id,
-        min_value=-5,
-        max_value=5,
-        step=0.1,
-        multiplier=0.1,
-        translation_key="local_temperature_calibration",
-        fallback_name="Local temperature offset",
     )
     .add_to_registry()
 )

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -47,7 +47,7 @@ SCREEN_TIMEOUT_ATTR_ID = 0x403A
 SCREEN_BRIGHTNESS_ATTR_ID = 0x403B
 
 # Control sequence of operation (heating/cooling)
-CTRL_SEQUENCE_OF_OPERATION_ID = 0x001B
+CTRL_SEQUENCE_OF_OPERATION_ID = Thermostat.AttributeDefs.ctrl_sequence_of_oper.id
 
 
 class BoschOperatingMode(t.enum8):

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.hvac import (
     Thermostat,
     UserInterface,
 )
-from zigpy.zcl.foundation import Direction, ZCLAttributeDef, ZCLCommandDef
+from zigpy.zcl.foundation import DataTypeId, Direction, ZCLAttributeDef, ZCLCommandDef
 
 """Bosch specific thermostat attribute ids."""
 
@@ -423,8 +423,8 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
 
         display_orientation: Final = ZCLAttributeDef(
             id=SCREEN_ORIENTATION_ATTR_ID,
-            # To be matched to BoschDisplayOrientation enum.
-            type=t.uint8_t,
+            type=BoschDisplayOrientation,
+            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
 
@@ -447,37 +447,6 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
             type=BoschDisplayedTemperature,
             is_manufacturer_specific=True,
         )
-
-    async def write_attributes(
-        self, attributes: dict[str | int, Any], manufacturer: int | None = None
-    ) -> list:
-        """display_orientation special handling.
-
-        - convert from enum to uint8_t
-        """
-        display_orientation_attr = self.AttributeDefs.display_orientation
-
-        remaining_attributes = attributes.copy()
-        display_orientation_attribute_id = None
-
-        """Check if display_orientation is being written (can be numeric or string)."""
-        if display_orientation_attr.id in attributes:
-            display_orientation_attribute_id = display_orientation_attr.id
-        elif display_orientation_attr.name in attributes:
-            display_orientation_attribute_id = display_orientation_attr.name
-
-        if display_orientation_attribute_id is not None:
-            display_orientation_value = remaining_attributes.pop(
-                display_orientation_attribute_id
-            )
-            new_display_orientation_value = DISPLAY_ORIENTATION_ENUM_TO_INT_MAP[
-                display_orientation_value
-            ]
-            remaining_attributes[display_orientation_attribute_id] = (
-                new_display_orientation_value
-            )
-
-        return await super().write_attributes(remaining_attributes, manufacturer)
 
 
 (

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -435,16 +435,22 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.cluster_id,
         entity_platform=EntityPlatform.SENSOR,
         entity_type=EntityType.DIAGNOSTIC,
+        translation_key="operating_mode",
+        fallback_name="Operating mode",
     )
     # Fast heating/boost.
     .switch(
         BoschThermostatCluster.AttributeDefs.boost_heating.name,
         BoschThermostatCluster.cluster_id,
+        translation_key="boost_heating",
+        fallback_name="Boost",
     )
     # Window open switch: manually set or through an automation.
     .switch(
         BoschThermostatCluster.AttributeDefs.window_open.name,
         BoschThermostatCluster.cluster_id,
+        translation_key="window_open",
+        fallback_name="Window open",
     )
     # Remote temperature.
     .number(
@@ -455,18 +461,23 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         step=0.1,
         multiplier=100,
         device_class=NumberDeviceClass.TEMPERATURE,
+        fallback_name="Remote temperature",
     )
     # Display temperature.
     .enum(
         BoschUserInterfaceCluster.AttributeDefs.displayed_temperature.name,
         BoschDisplayedTemperature,
         BoschUserInterfaceCluster.cluster_id,
+        translation_key="displayed_temperature",
+        fallback_name="Displayed temperature",
     )
     # Display orientation.
     .enum(
         BoschUserInterfaceCluster.AttributeDefs.display_orientation.name,
         BoschDisplayOrientation,
         BoschUserInterfaceCluster.cluster_id,
+        translation_key="display_orientation",
+        fallback_name="Display orientation",
     )
     # Display time-out.
     .number(
@@ -475,6 +486,8 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         min_value=5,
         max_value=30,
         step=1,
+        translation_key="display_on_time",
+        fallback_name="Display on-time",
     )
     # Display brightness.
     .number(
@@ -483,12 +496,16 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         min_value=0,
         max_value=10,
         step=1,
+        translation_key="display_brightness",
+        fallback_name="Display brightness",
     )
     # Heating vs Cooling.
     .enum(
         Thermostat.AttributeDefs.ctrl_sequence_of_oper.name,
         BoschControlSequenceOfOperation,
         BoschThermostatCluster.cluster_id,
+        translation_key="ctrl_sequence_of_oper",
+        fallback_name="Control sequence",
     )
     .add_to_registry()
 )

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -334,7 +334,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
 
         if display_orientation_attribute_id is not None:
             display_orientation_value = remaining_attributes.pop(
-                display_orientation_attr.id
+                display_orientation_attribute_id
             )
             new_display_orientation_value = DISPLAY_ORIENTATION_ENUM_TO_INT_MAP[
                 display_orientation_value

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -508,6 +508,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     .command_button(
         BoschThermostatCluster.ServerCommandDefs.calibrate_valve.name,
         BoschThermostatCluster.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
         translation_key="calibrate_valve",
         fallback_name="Calibrate valve",
     )

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -119,6 +119,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
             id=OPERATING_MODE_ATTR_ID,
             type=BoschOperatingMode,
             is_manufacturer_specific=True,
+            name="operating_mode",
         )
 
         pi_heating_demand = ZCLAttributeDef(
@@ -126,24 +127,28 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
             # Values range from 0-100
             type=t.enum8,
             is_manufacturer_specific=True,
+            name="pi_heating_demand",
         )
 
         window_open = ZCLAttributeDef(
             id=WINDOW_OPEN_ATTR_ID,
             type=State,
             is_manufacturer_specific=True,
+            name="window_open",
         )
 
         boost = ZCLAttributeDef(
             id=BOOST_ATTR_ID,
             type=State,
             is_manufacturer_specific=True,
+            name="boost",
         )
 
         remote_temperature = ZCLAttributeDef(
             id=REMOTE_TEMPERATURE_ATTR_ID,
             type=t.int16s,
             is_manufacturer_specific=True,
+            name="remote_temperature",
         )
 
     async def write_attributes(
@@ -318,6 +323,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
             # To be matched to BoschDisplayOrientation enum.
             type=t.uint8_t,
             is_manufacturer_specific=True,
+            name="display_orientation",
         )
 
         display_on_time = ZCLAttributeDef(
@@ -325,6 +331,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
             # Usable values range from 5-30
             type=t.enum8,
             is_manufacturer_specific=True,
+            name="display_on_time",
         )
 
         display_brightness = ZCLAttributeDef(
@@ -332,12 +339,14 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
             # Values range from 0-10
             type=t.enum8,
             is_manufacturer_specific=True,
+            name="display_brightness",
         )
 
         displayed_temperature = ZCLAttributeDef(
             id=DISPLAY_MODE_ATTR_ID,
             type=BoschDisplayedTemperature,
             is_manufacturer_specific=True,
+            name="displayed_temperature",
         )
 
     async def write_attributes(

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.hvac import (
     Thermostat,
     UserInterface,
 )
-from zigpy.zcl.foundation import ZCLAttributeDef, ZCLCommandDef
+from zigpy.zcl.foundation import Direction, ZCLAttributeDef, ZCLCommandDef
 
 """Bosch specific thermostat attribute ids."""
 
@@ -128,9 +128,9 @@ DISPLAY_ORIENTATION_ENUM_TO_INT_MAP = {
     BoschDisplayOrientation.Flipped: 0x01,
 }
 
-"""Battery saving Reporting Configuration"""
-REPORT_CONFIG_BATTERY_SAVE = ReportingConfig(
-    min_interval=3600, max_interval=10800, reportable_change=1
+"""Bosch Attributes Reporting Configuration"""
+BOSCH_ATTR_REPORT_CONFIG = ReportingConfig(
+    min_interval=10, max_interval=10800, reportable_change=1
 )
 
 
@@ -175,7 +175,10 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         """Bosch thermostat manufacturer specific server commands."""
 
         calibrate_valve: Final = ZCLCommandDef(
-            id=CALIBRATE_VALVE_CMD_ID, schema={}, direction=False
+            id=CALIBRATE_VALVE_CMD_ID,
+            schema={},
+            direction=Direction.Client_to_Server,
+            is_manufacturer_specific=True,
         )
 
     async def write_attributes(
@@ -471,7 +474,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.cluster_id,
         entity_platform=EntityPlatform.SENSOR,
         entity_type=EntityType.DIAGNOSTIC,
-        reporting_config=REPORT_CONFIG_BATTERY_SAVE,
+        reporting_config=BOSCH_ATTR_REPORT_CONFIG,
         translation_key="operating_mode",
         fallback_name="Operating mode",
     )
@@ -482,7 +485,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.cluster_id,
         entity_platform=EntityPlatform.SENSOR,
         entity_type=EntityType.DIAGNOSTIC,
-        reporting_config=REPORT_CONFIG_BATTERY_SAVE,
+        reporting_config=BOSCH_ATTR_REPORT_CONFIG,
         translation_key="valve_adapt_status",
         fallback_name="Valve adaptation status",
     )
@@ -490,7 +493,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     .switch(
         BoschThermostatCluster.AttributeDefs.boost_heating.name,
         BoschThermostatCluster.cluster_id,
-        reporting_config=REPORT_CONFIG_BATTERY_SAVE,
+        reporting_config=BOSCH_ATTR_REPORT_CONFIG,
         translation_key="boost_heating",
         fallback_name="Boost",
     )

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -345,14 +345,14 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         display_on_time = ZCLAttributeDef(
             id=SCREEN_TIMEOUT_ATTR_ID,
             # Usable values range from 5-30
-            type=t.uint8_t,
+            type=t.enum8,
             is_manufacturer_specific=True,
         )
 
         display_brightness = ZCLAttributeDef(
             id=SCREEN_BRIGHTNESS_ATTR_ID,
             # Values range from 0-10
-            type=t.uint8_t,
+            type=t.enum8,
             is_manufacturer_specific=True,
         )
 

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -125,7 +125,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         pi_heating_demand = ZCLAttributeDef(
             id=VALVE_POSITION_ATTR_ID,
             # Values range from 0-100
-            type=t.uint8_t,
+            type=t.enum8,
             is_manufacturer_specific=True,
         )
 

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -459,7 +459,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         min_value=5,
         max_value=30,
         step=0.1,
-        multiplier=100,
+        multiplier=0.01,
         device_class=NumberDeviceClass.TEMPERATURE,
         fallback_name="Remote temperature",
     )

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -123,32 +123,32 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         """Bosch thermostat manufacturer specific attributes."""
 
         operating_mode = ZCLAttributeDef(
-            id=t.uint16_t(OPERATING_MODE_ATTR_ID),
+            id=OPERATING_MODE_ATTR_ID,
             type=BoschOperatingMode,
             is_manufacturer_specific=True,
         )
 
         pi_heating_demand = ZCLAttributeDef(
-            id=t.uint16_t(VALVE_POSITION_ATTR_ID),
+            id=VALVE_POSITION_ATTR_ID,
             # Values range from 0-100
             type=t.enum8,
             is_manufacturer_specific=True,
         )
 
         window_open = ZCLAttributeDef(
-            id=t.uint16_t(WINDOW_OPEN_ATTR_ID),
+            id=WINDOW_OPEN_ATTR_ID,
             type=State,
             is_manufacturer_specific=True,
         )
 
         boost = ZCLAttributeDef(
-            id=t.uint16_t(BOOST_ATTR_ID),
+            id=BOOST_ATTR_ID,
             type=State,
             is_manufacturer_specific=True,
         )
 
         remote_temperature = ZCLAttributeDef(
-            id=t.uint16_t(REMOTE_TEMPERATURE_ATTR_ID),
+            id=REMOTE_TEMPERATURE_ATTR_ID,
             type=t.int16s,
             is_manufacturer_specific=True,
         )
@@ -321,28 +321,28 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         """Bosch user interface manufacturer specific attributes."""
 
         display_orientation = ZCLAttributeDef(
-            id=t.uint16_t(SCREEN_ORIENTATION_ATTR_ID),
+            id=SCREEN_ORIENTATION_ATTR_ID,
             # To be matched to BoschDisplayOrientation enum.
             type=t.uint8_t,
             is_manufacturer_specific=True,
         )
 
         display_on_time = ZCLAttributeDef(
-            id=t.uint16_t(SCREEN_TIMEOUT_ATTR_ID),
+            id=SCREEN_TIMEOUT_ATTR_ID,
             # Usable values range from 5-30
             type=t.enum8,
             is_manufacturer_specific=True,
         )
 
         display_brightness = ZCLAttributeDef(
-            id=t.uint16_t(SCREEN_BRIGHTNESS_ATTR_ID),
+            id=SCREEN_BRIGHTNESS_ATTR_ID,
             # Values range from 0-10
             type=t.enum8,
             is_manufacturer_specific=True,
         )
 
         displayed_temperature = ZCLAttributeDef(
-            id=t.uint16_t(DISPLAY_MODE_ATTR_ID),
+            id=DISPLAY_MODE_ATTR_ID,
             type=BoschDisplayedTemperature,
             is_manufacturer_specific=True,
         )

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -122,12 +122,6 @@ SYSTEM_MODE_TO_OPERATING_MODE_MAP = {
     Thermostat.SystemMode.Auto: BoschOperatingMode.Schedule,
 }
 
-"""Bosch display orientation enum to uint8_t mapping."""
-DISPLAY_ORIENTATION_ENUM_TO_INT_MAP = {
-    BoschDisplayOrientation.Normal: 0x00,
-    BoschDisplayOrientation.Flipped: 0x01,
-}
-
 """Bosch Attributes Reporting Configuration"""
 BOSCH_ATTR_REPORT_CONFIG = ReportingConfig(
     min_interval=10, max_interval=10800, reportable_change=1

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.hvac import (
     Thermostat,
     UserInterface,
 )
-from zigpy.zcl.foundation import DataTypeId, Direction, ZCLAttributeDef, ZCLCommandDef
+from zigpy.zcl.foundation import DataTypeId, ZCLAttributeDef, ZCLCommandDef
 
 """Bosch specific thermostat attribute ids."""
 

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -481,7 +481,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
         BoschThermostatCluster.cluster_id,
         reporting_config=BOSCH_ATTR_REPORT_CONFIG,
         translation_key="boost_heating",
-        fallback_name="Boost",
+        fallback_name="Boost heating",
     )
     # Window open switch: manually set or through an automation.
     .switch(

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -156,7 +156,8 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         pi_heating_demand: Final = ZCLAttributeDef(
             id=VALVE_POSITION_ATTR_ID,
             # Values range from 0-100
-            type=t.enum8,
+            type=t.uint8_t,
+            zcl_type=DataTypeId.enum8,
             is_manufacturer_specific=True,
         )
 

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -185,7 +185,6 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         calibrate_valve: Final = ZCLCommandDef(
             id=CALIBRATE_VALVE_CMD_ID,
             schema={},
-            direction=Direction.Client_to_Server,
             is_manufacturer_specific=True,
         )
 

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -128,6 +128,19 @@ BOSCH_ATTR_REPORT_CONFIG = ReportingConfig(
 )
 
 
+def get_attribute_id_or_name(
+    attribute: ZCLAttributeDef, attributes: dict[str | int, Any] | list[int | str]
+) -> int | str | None:
+    """Return the attribute id/name when the id/name of the attribute is in the attributes list or None otherwise."""
+
+    if attribute.id in attributes:
+        return attribute.id
+    elif attribute.name in attributes:
+        return attribute.name
+    else:
+        return None
+
+
 class BoschThermostatCluster(CustomCluster, Thermostat):
     """Bosch thermostat cluster."""
 
@@ -196,24 +209,21 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
             - do not write it to the device since it is not supported
             - keep the value to be converted to the supported operating_mode
         """
-        if SYSTEM_MODE_ATTR.id in attributes:
-            remaining_attributes.pop(SYSTEM_MODE_ATTR.id)
-            system_mode_value = attributes.get(SYSTEM_MODE_ATTR.id)
-        elif SYSTEM_MODE_ATTR.name in attributes:
-            remaining_attributes.pop(SYSTEM_MODE_ATTR.name)
-            system_mode_value = attributes.get(SYSTEM_MODE_ATTR.name)
+        system_mode_attribute_id = get_attribute_id_or_name(
+            SYSTEM_MODE_ATTR, attributes
+        )
+        if system_mode_attribute_id is not None:
+            remaining_attributes.pop(system_mode_attribute_id)
+            system_mode_value = attributes.get(system_mode_attribute_id)
 
         """Check if operating_mode_attr is being written (can be numeric or string).
             - ignore incoming operating_mode when system_mode is also written
             - system_mode has priority and its value would be converted to operating_mode
             - add resulting system_mode to the internal zigpy Cluster cache
         """
-        operating_mode_attribute_id = None
-        if operating_mode_attr.id in attributes:
-            operating_mode_attribute_id = operating_mode_attr.id
-        elif operating_mode_attr.name in attributes:
-            operating_mode_attribute_id = operating_mode_attr.name
-
+        operating_mode_attribute_id = get_attribute_id_or_name(
+            operating_mode_attr, attributes
+        )
         if operating_mode_attribute_id is not None:
             if system_mode_value is not None:
                 operating_mode_value = remaining_attributes.pop(
@@ -259,35 +269,32 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
             """Sync system_mode with ctrl_sequence_of_oper."""
             ctrl_sequence_of_oper_attr = Thermostat.AttributeDefs.ctrl_sequence_of_oper
 
-            ctrl_sequence_of_oper_value = None
-            if ctrl_sequence_of_oper_attr.id in attributes:
+            ctrl_sequence_of_oper_attribute_id = get_attribute_id_or_name(
+                ctrl_sequence_of_oper_attr, attributes
+            )
+            if ctrl_sequence_of_oper_attribute_id is not None:
                 ctrl_sequence_of_oper_value = attributes.get(
-                    ctrl_sequence_of_oper_attr.id
+                    ctrl_sequence_of_oper_attribute_id
                 )
-            elif ctrl_sequence_of_oper_attr.name in attributes:
-                ctrl_sequence_of_oper_value = attributes.get(
-                    ctrl_sequence_of_oper_attr.name
-                )
-
-            if ctrl_sequence_of_oper_value is not None:
-                successful_r, failed_r = await super().read_attributes(
-                    [operating_mode_attr.name], True, False, manufacturer
-                )
-                if operating_mode_attr.name in successful_r:
-                    operating_mode_attr_value = successful_r.pop(
-                        operating_mode_attr.name
+                if ctrl_sequence_of_oper_value is not None:
+                    successful_r, failed_r = await super().read_attributes(
+                        [operating_mode_attr.name], True, False, manufacturer
                     )
-                    if operating_mode_attr_value == BoschOperatingMode.Manual:
-                        new_system_mode_value = Thermostat.SystemMode.Heat
-                        if (
-                            ctrl_sequence_of_oper_value
-                            == BoschControlSequenceOfOperation.Cooling
-                        ):
-                            new_system_mode_value = Thermostat.SystemMode.Cool
-
-                        self._update_attribute(
-                            SYSTEM_MODE_ATTR.id, new_system_mode_value
+                    if operating_mode_attr.name in successful_r:
+                        operating_mode_attr_value = successful_r.pop(
+                            operating_mode_attr.name
                         )
+                        if operating_mode_attr_value == BoschOperatingMode.Manual:
+                            new_system_mode_value = Thermostat.SystemMode.Heat
+                            if (
+                                ctrl_sequence_of_oper_value
+                                == BoschControlSequenceOfOperation.Cooling
+                            ):
+                                new_system_mode_value = Thermostat.SystemMode.Cool
+
+                            self._update_attribute(
+                                SYSTEM_MODE_ATTR.id, new_system_mode_value
+                            )
 
         """Write the remaining attributes to thermostat cluster."""
         if remaining_attributes:
@@ -310,16 +317,14 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
 
         successful_r, failed_r = {}, {}
         remaining_attributes = attributes.copy()
-        system_mode_attribute_id = None
 
         """Check if SYSTEM_MODE_ATTR is being read (can be numeric or string)."""
-        if SYSTEM_MODE_ATTR.id in attributes:
-            system_mode_attribute_id = SYSTEM_MODE_ATTR.id
-        elif SYSTEM_MODE_ATTR.name in attributes:
-            system_mode_attribute_id = SYSTEM_MODE_ATTR.name
-
-        """Read operating_mode instead and convert it to system_mode."""
+        system_mode_attribute_id = get_attribute_id_or_name(
+            SYSTEM_MODE_ATTR, attributes
+        )
         if system_mode_attribute_id is not None:
+            """Read operating_mode instead and convert it to system_mode."""
+
             remaining_attributes.remove(system_mode_attribute_id)
 
             ctrl_sequence_of_oper_attr = Thermostat.AttributeDefs.ctrl_sequence_of_oper


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The quirk provides Bosch specific thermostat and interface clusters, which add additional attributes and expose some common attributes on different addresses. 

Fixes https://github.com/zigpy/zha-device-handlers/issues/2476

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Following features are supported:

Operating modes:
 - Schedule or Auto
 - Manual
 - Pause

System modes:
- Heat
- Cool

Bosch-specific:
- Display orientation
- Display brightness
- Display on-time
- Displayed temperature (measured/target)
- Valve calibration state
- Trigger valve calibration
- External temperature calibration
- Manual temperature calibration from -5..5 degrees

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works

Credits go mostly to @mrrstux who has done the bulk of the work!
