### PR TITLE
Add signature for Aqara H1 double switch `lumi.switch.n2aeu1`

### DIFF
--- a/zhaquirks/xiaomi/aqara/opple_switch.py
+++ b/zhaquirks/xiaomi/aqara/opple_switch.py
@@ -141,7 +141,10 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
                     ElectricalMeasurementCluster,
                     OppleSwitchCluster,
                 ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
             },
             2: {
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -214,7 +217,9 @@ class XiaomiOpple2ButtonSwitchBase(XiaomiCustomDevice):
                 PROFILE_ID: zgp.PROFILE_ID,
                 DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
                 INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
             },
         },
     }
@@ -297,7 +302,10 @@ class XiaomiOpple2ButtonSwitch1(XiaomiOpple2ButtonSwitchBase):
                     MultistateInput.cluster_id,
                     OppleSwitchCluster.cluster_id,
                 ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
             },
             # input_clusters=[0, 3, 4, 5, 6, 18, 64704], output_clusters=[]
             2: {
@@ -363,7 +371,9 @@ class XiaomiOpple2ButtonSwitch1(XiaomiOpple2ButtonSwitchBase):
                 PROFILE_ID: zgp.PROFILE_ID,
                 DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
                 INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
             },
         },
     }

--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -24,7 +24,10 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.xiaomi import LUMI
-from zhaquirks.xiaomi.aqara.opple_switch import XiaomiOpple2ButtonSwitchBase
+from zhaquirks.xiaomi.aqara.opple_switch import (
+    OppleSwitchCluster,
+    XiaomiOpple2ButtonSwitchBase,
+)
 
 
 class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
@@ -91,7 +94,7 @@ class AqaraH1DoubleRockerSwitchNoNeutral(XiaomiOpple2ButtonSwitchBase):
                     Scenes.cluster_id,
                     OnOff.cluster_id,
                     MultistateInput.cluster_id,
-                    0xFCC0,
+                    OppleSwitchCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,
@@ -109,7 +112,7 @@ class AqaraH1DoubleRockerSwitchNoNeutral(XiaomiOpple2ButtonSwitchBase):
                     Scenes.cluster_id,
                     OnOff.cluster_id,
                     MultistateInput.cluster_id,
-                    0xFCC0,
+                    OppleSwitchCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [],
             },

--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -27,6 +27,7 @@ from zhaquirks.const import (
 from zhaquirks.xiaomi import LUMI
 from zhaquirks.xiaomi.aqara.opple_switch import (
     OppleSwitchCluster,
+    XiaomiOpple2ButtonSwitch1,
     XiaomiOpple2ButtonSwitchBase,
 )
 
@@ -74,6 +75,15 @@ class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
                 OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
             },
         },
+    }
+
+
+class AqaraH1DoubleRockerSwitchWithNeutralAlt(XiaomiOpple2ButtonSwitchBase):
+    """Aqara H1 Double Rocker Switch (with neutral) alternative signature."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.switch.n2aeu1")],
+        ENDPOINTS: XiaomiOpple2ButtonSwitch1.signature[ENDPOINTS],
     }
 
 

--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -13,8 +13,6 @@ from zigpy.zcl.clusters.general import (
     Scenes,
     Time,
 )
-from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
-from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -28,6 +26,7 @@ from zhaquirks.xiaomi import LUMI
 from zhaquirks.xiaomi.aqara.opple_switch import (
     OppleSwitchCluster,
     XiaomiOpple2ButtonSwitch1,
+    XiaomiOpple2ButtonSwitch4,
     XiaomiOpple2ButtonSwitchBase,
 )
 
@@ -37,44 +36,7 @@ class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
 
     signature = {
         MODELS_INFO: [(LUMI, "lumi.switch.n2aeu1")],
-        ENDPOINTS: {
-            # input_clusters=[0, 2, 3, 4, 5, 6, 9, 1794, 2820], output_clusters=[10, 25]
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    DeviceTemperature.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    Alarms.cluster_id,
-                    Metering.cluster_id,
-                    ElectricalMeasurement.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            },
-            # input_clusters=[0, 3, 4, 5, 6], output_clusters=[]
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
+        ENDPOINTS: XiaomiOpple2ButtonSwitch1.signature[ENDPOINTS],
     }
 
 
@@ -83,7 +45,7 @@ class AqaraH1DoubleRockerSwitchWithNeutralAlt(XiaomiOpple2ButtonSwitchBase):
 
     signature = {
         MODELS_INFO: [(LUMI, "lumi.switch.n2aeu1")],
-        ENDPOINTS: XiaomiOpple2ButtonSwitch1.signature[ENDPOINTS],
+        ENDPOINTS: XiaomiOpple2ButtonSwitch4.signature[ENDPOINTS],
     }
 
 

--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -13,6 +13,7 @@ from zigpy.zcl.clusters.general import (
     Scenes,
     Time,
 )
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.const import (
@@ -49,7 +50,7 @@ class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
                     OnOff.cluster_id,
                     Alarms.cluster_id,
                     Metering.cluster_id,
-                    0x0B04,
+                    ElectricalMeasurement.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },

--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -33,7 +33,7 @@ class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
     signature = {
         MODELS_INFO: [(LUMI, "lumi.switch.n2aeu1")],
         ENDPOINTS: {
-            # input_clusters=[0, 2, 3, 4, 5, 6, 18, 64704], output_clusters=[10, 25]
+            # input_clusters=[0, 2, 3, 4, 5, 6, 9, 1794, 2820], output_clusters=[10, 25]
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
@@ -50,7 +50,7 @@ class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
-            # input_clusters=[0, 3, 4, 5, 6, 18, 64704], output_clusters=[]
+            # input_clusters=[0, 3, 4, 5, 6], output_clusters=[]
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
@@ -79,6 +79,7 @@ class AqaraH1DoubleRockerSwitchNoNeutral(XiaomiOpple2ButtonSwitchBase):
     signature = {
         MODELS_INFO: [(LUMI, "lumi.switch.l2aeu1")],
         ENDPOINTS: {
+            # input_clusters=[0, 2, 3, 4, 5, 6, 18, 64704], output_clusters=[10, 25]
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
@@ -97,6 +98,7 @@ class AqaraH1DoubleRockerSwitchNoNeutral(XiaomiOpple2ButtonSwitchBase):
                     Ota.cluster_id,
                 ],
             },
+            # input_clusters=[0, 3, 4, 5, 6, 18, 64704], output_clusters=[]
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
@@ -111,6 +113,7 @@ class AqaraH1DoubleRockerSwitchNoNeutral(XiaomiOpple2ButtonSwitchBase):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # input_clusters=[18], output_clusters=[]
             41: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
@@ -119,6 +122,7 @@ class AqaraH1DoubleRockerSwitchNoNeutral(XiaomiOpple2ButtonSwitchBase):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # input_clusters=[18], output_clusters=[]
             42: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
@@ -127,6 +131,7 @@ class AqaraH1DoubleRockerSwitchNoNeutral(XiaomiOpple2ButtonSwitchBase):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # input_clusters=[18], output_clusters=[]
             51: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
@@ -153,6 +158,7 @@ class AqaraH1DoubleRockerSwitchNoNeutralAlt(XiaomiOpple2ButtonSwitchBase):
     signature = {
         MODELS_INFO: [(LUMI, "lumi.switch.l2aeu1")],
         ENDPOINTS: {
+            # input_clusters=[0, 2, 3, 4, 5, 6, 9], output_clusters=[10, 25]
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
@@ -170,6 +176,7 @@ class AqaraH1DoubleRockerSwitchNoNeutralAlt(XiaomiOpple2ButtonSwitchBase):
                     Ota.cluster_id,
                 ],
             },
+            # input_clusters=[0, 3, 4, 5, 6], output_clusters=[]
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,

--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -33,7 +33,7 @@ class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
     signature = {
         MODELS_INFO: [(LUMI, "lumi.switch.n2aeu1")],
         ENDPOINTS: {
-            #  input_clusters=[0, 2, 3, 4, 5, 6, 18, 64704], output_clusters=[10, 25]
+            # input_clusters=[0, 2, 3, 4, 5, 6, 18, 64704], output_clusters=[10, 25]
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
@@ -50,7 +50,7 @@ class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
-            #  input_clusters=[0, 3, 4, 5, 6, 18, 64704], output_clusters=[]
+            # input_clusters=[0, 3, 4, 5, 6, 18, 64704], output_clusters=[]
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,


### PR DESCRIPTION
## Proposed change
Adds an alternative signature for the Aqara H1 double rocker switch (with neutral) `lumi.switch.n2aeu1`.

The following small changes are also done:
- existing "cluster id comments" are fixed and new ones are added
- raw cluster ids are replaced by `cluster.cluster_id`
- some commas to the end of lists in `signature` are added to be consistent with the other Opple/H1 switch quirks

### Why use part of the signature from `opple_switch.py` instead of just adding new model info there?

The `opple_switch.py` file contains signatures strictly from the US `lumi.switch.b2naus01` switch now.
The `switch_h1_double.py` file contains signatures for H1 double switches, but now also bases two quirks off the signatures in `opple_switch.py` and only changes the `MODELS_INFO` in its `signature`.

To avoid the confusion that was caused around this in the past, I've opted to do it this way to keep the US switch vs EU H1 quirks somewhat separate.
All H1 quirks are now either in `switch_h1_double.py` or `switch_h1_single.py`. In the past, they were split in a very non-intuitive way.

## Additional information
- This is a continuation of #2825
- It fixes a regression (no quirk matched) from: https://github.com/zigpy/zha-device-handlers/pull/2784
- Supersedes #2806
- Also part of: https://github.com/zigpy/zha-device-handlers/issues/2520


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
