### PR TITLE
Improve support for sinope Calypso and Eco Mode

### DIFF
--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -88,6 +88,7 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         0x0055: ("min_intensity", t.uint16_t, True),
         0x0056: ("phase_control", PhaseControl, True),
         0x0058: ("double_up_full", DoubleFull, True),
+        0x0090: ("current_summation_delivered", t.uint32_t, True),
         0x00A0: ("timer", t.uint32_t, True),
         0x00A1: ("timer_countdown", t.uint32_t, True),
         0x0119: ("connected_load", t.uint16_t, True),

--- a/zhaquirks/sinope/sensor.py
+++ b/zhaquirks/sinope/sensor.py
@@ -39,8 +39,9 @@ class SinopeManufacturerCluster(CustomCluster):
     attributes = {
         0x0003: ("firmware_number", t.uint16_t, True),
         0x0004: ("firmware_version", t.CharacterString, True),
-        0x0032: ("min_measured_temperature", t.int16s, True),
-        0x0033: ("max_measured_temperature", t.int16s, True),
+        0x0032: ("min_temperature_limit", t.int16s, True),
+        0x0033: ("max_temperature_limit", t.int16s, True),
+        0x0034: ("device_status", t.bitmap8, True),
         0x0200: ("status", t.bitmap32, True),
         0xFFFD: ("cluster_revision", t.uint16_t, True),
     }

--- a/zhaquirks/sinope/sensor.py
+++ b/zhaquirks/sinope/sensor.py
@@ -39,6 +39,8 @@ class SinopeManufacturerCluster(CustomCluster):
     attributes = {
         0x0003: ("firmware_number", t.uint16_t, True),
         0x0004: ("firmware_version", t.CharacterString, True),
+        0x0032: ("min_measured_temperature", t.int16s, True),
+        0x0033: ("max_measured_temperature", t.int16s, True),
         0x0200: ("status", t.bitmap32, True),
         0xFFFD: ("cluster_revision", t.uint16_t, True),
     }

--- a/zhaquirks/sinope/switch.py
+++ b/zhaquirks/sinope/switch.py
@@ -97,14 +97,6 @@ class SinopeManufacturerCluster(CustomCluster):
         Active = 0x00
         Off = 0x01
 
-    class TankSize(t.enum8):
-        """tank_size values."""
-
-        Gal_40 = 0x01
-        Gal_50 = 0x02
-        Gal_60 = 0x03
-        Gal_80 = 0x04
-
     class FlowDuration(t.uint32_t):
         """Abnormal flow duration."""
 
@@ -127,12 +119,14 @@ class SinopeManufacturerCluster(CustomCluster):
         0x0003: ("firmware_number", t.uint16_t, True),
         0x0004: ("firmware_version", t.CharacterString, True),
         0x0010: ("outdoor_temp", t.int16s, True),
-        0x0013: ("tank_size", TankSize, True),
+        0x0013: ("unknown_attr_1", t.enum8, True),
         0x0060: ("connected_load", t.uint16_t, True),
         0x0070: ("current_load", t.bitmap8, True),
         0x0076: ("dr_config_water_temp_min", t.uint8_t, True),
         0x0077: ("dr_config_water_temp_time", t.uint8_t, True),
         0x0078: ("dr_wt_time_on", t.uint16_t, True),
+        0x007C: ("min_measured_temp", t.int16s, True),
+        0x007D: ("max_measured_temp", t.int16s, True),
         0x0090: ("current_summation_delivered", t.uint32_t, True),
         0x00A0: ("timer", t.uint32_t, True),
         0x00A1: ("timer_countdown", t.uint32_t, True),
@@ -145,7 +139,9 @@ class SinopeManufacturerCluster(CustomCluster):
         0x0251: ("emergency_power_source", EmergencyPower, True),
         0x0252: ("abnormal_flow_duration", FlowDuration, True),
         0x0253: ("abnormal_flow_action", AbnormalAction, True),
+        0x0280: ("max_measured_value", t.int16s, True),
         0x0283: ("cold_load_pickup_status", ColdStatus, True),
+        0x0284: ("cold_load_pickup_remaining_time", t.uint16_t, True),
         0xFFFD: ("cluster_revision", t.uint16_t, True),
     }
 
@@ -157,6 +153,7 @@ class CustomBasicCluster(CustomCluster, Basic):
         """Power source."""
 
         Unknown = 0x0000
+        DC_mains = 0x0001
         Battery = 0x0003
         DC_source = 0x0004
         ACUPS_01 = 0x0081
@@ -585,16 +582,8 @@ class SinopeTechnologiesCalypso(CustomDevice):
                     Time.cluster_id,
                     Ota.cluster_id,
                 ],
-            },
-            2: {
-                PROFILE_ID: zha_p.PROFILE_ID,
-                DEVICE_TYPE: zha_p.DeviceType.ON_OFF_OUTPUT,
-                INPUT_CLUSTERS: [
-                    TemperatureMeasurement.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
+            }
+        }
     }
 
 

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -126,6 +126,7 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         0x0071: ("eco_delta_setpoint", t.int8s, True),
         0x0072: ("eco_max_pi_heating_demand", t.uint8_t, True),
         0x0073: ("eco_safety_temperature_delta", t.uint8_t, True),
+        0x0101: ("unknown_attr_1", Array, True),
         0x0104: ("setpoint", t.int16s, True),
         0x0105: ("air_floor_mode", FloorMode, True),
         0x0106: ("aux_output_mode", AuxMode, True),

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -20,6 +20,7 @@ from zigpy.zcl.clusters.homeautomation import Diagnostic, ElectricalMeasurement
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
+from zigpy.zcl.foundation import Array
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -122,9 +123,9 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         0x0012: ("config_2nd_display", Display, True),
         0x0020: ("secs_since_2k", t.uint32_t, True),
         0x0070: ("current_load", t.bitmap8, True),
-        0x0071: ("eco_mode", t.int8s, True),
-        0x0072: ("eco_mode_1", t.uint8_t, True),
-        0x0073: ("eco_mode_2", t.uint8_t, True),
+        0x0071: ("eco_delta_setpoint", t.int8s, True),
+        0x0072: ("eco_max_pi_heating_demand", t.uint8_t, True),
+        0x0073: ("eco_safety_temperature_delta", t.uint8_t, True),
         0x0104: ("setpoint", t.int16s, True),
         0x0105: ("air_floor_mode", FloorMode, True),
         0x0106: ("aux_output_mode", AuxMode, True),
@@ -174,6 +175,7 @@ class SinopeTechnologiesThermostatCluster(CustomCluster, Thermostat):
         Min_20 = 0x04B0
         Min_25 = 0x05DC
         Min_30 = 0x0708
+        Off = 0xFFFF
 
     attributes = Thermostat.attributes.copy()
     attributes.update(


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
- Code cleanup for calypso controller.
- Add support for Eco Mode on thermostats, Eco Sinopé
- Add  many attributes for sensor and light in manufacturer cluster

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
