### PR TITLE
Add device triggers for Sonoff SNZB-01P smart button

### DIFF
--- a/tests/test_sonoff.py
+++ b/tests/test_sonoff.py
@@ -1,0 +1,30 @@
+"""Tests for Sonoff quirks."""
+
+
+import zhaquirks
+import zhaquirks.sonoff.snzb01p
+
+zhaquirks.setup()
+
+
+def test_sonoff_snzb01p(assert_signature_matches_quirk):
+    """Test 'Sonoff SNZB-01P smart button' signature is matched to its quirk."""
+
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4742, maximum_buffer_size=82, maximum_incoming_transfer_size=255, server_mask=11264, maximum_outgoing_transfer_size=255, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 260,
+                "device_type": "0x0000",
+                "in_clusters": ["0x0000", "0x0001", "0x0003", "0x0020", "0xfc57"],
+                "out_clusters": ["0x0003", "0x0006", "0x0019"],
+            }
+        },
+        "manufacturer": "eWeLink",
+        "model": "SNZB-01P",
+        "class": "sonoff.snzb01p.SonoffSmartButtonSNZB01P",
+    }
+
+    assert_signature_matches_quirk(
+        zhaquirks.sonoff.snzb01p.SonoffSmartButtonSNZB01P, signature
+    )

--- a/zhaquirks/sonoff/__init__.py
+++ b/zhaquirks/sonoff/__init__.py
@@ -1,1 +1,9 @@
 """Quirks for Sonoff devices."""
+from zigpy.quirks import CustomCluster
+
+SONOFF_CLUSTER_ID = 0xFC57
+
+
+class SonoffManufactureCluster(CustomCluster):
+    name = "Sonoff Manufacturer Specicific"
+    cluster_id = SONOFF_CLUSTER_ID

--- a/zhaquirks/sonoff/__init__.py
+++ b/zhaquirks/sonoff/__init__.py
@@ -1,9 +1,1 @@
 """Quirks for Sonoff devices."""
-from zigpy.quirks import CustomCluster
-
-SONOFF_CLUSTER_ID = 0xFC57
-
-
-class SonoffManufactureCluster(CustomCluster):
-    name = "Sonoff Manufacturer Specicific"
-    cluster_id = SONOFF_CLUSTER_ID

--- a/zhaquirks/sonoff/snzb01p.py
+++ b/zhaquirks/sonoff/snzb01p.py
@@ -28,7 +28,8 @@ from zhaquirks.const import (
     PROFILE_ID,
     SHORT_PRESS,
 )
-from zhaquirks.sonoff import SonoffManufactureCluster
+
+SONOFF_CLUSTER_ID = 0xFC57
 
 
 class SonoffSmartButtonSNZB01P(CustomDevice):
@@ -51,7 +52,7 @@ class SonoffSmartButtonSNZB01P(CustomDevice):
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     PollControl.cluster_id,
-                    SonoffManufactureCluster.cluster_id,
+                    SONOFF_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -72,7 +73,7 @@ class SonoffSmartButtonSNZB01P(CustomDevice):
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     PollControl.cluster_id,
-                    SonoffManufactureCluster.cluster_id,
+                    SONOFF_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,

--- a/zhaquirks/sonoff/snzb01p.py
+++ b/zhaquirks/sonoff/snzb01p.py
@@ -1,0 +1,90 @@
+"""Sonoff Smart Button SNZB-01P"""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Identify,
+    OnOff,
+    Ota,
+    PollControl,
+    PowerConfiguration,
+)
+
+from zhaquirks.const import (
+    BUTTON,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_TOGGLE,
+    DEVICE_TYPE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    LONG_PRESS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+)
+from zhaquirks.sonoff import SonoffManufactureCluster
+
+
+class SonoffSmartButtonSNZB01P(CustomDevice):
+    """Sonoff smart button remote - model SNZB-01P"""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=0
+        #  device_version=1
+        #  input_clusters=[0, 1, 3, 32, 64599]
+        #  output_clusters=[3, 6, 25]>
+        MODELS_INFO: [
+            ("eWeLink", "SNZB-01P"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    SonoffManufactureCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    SonoffManufactureCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, CLUSTER_ID: 6, ENDPOINT_ID: 1},
+        (DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 1},
+        (LONG_PRESS, BUTTON): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 1},
+    }


### PR DESCRIPTION
## Proposed change
This adds support for Sonoff smart button SNZB-01P. 
Basically provides 'normal' action triggers: short click, double click and a long press

Fixes #2686

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
