### PR TITLE
Fix instantaneous demand on Schneider Wiser outlets

### DIFF
--- a/tests/test_schneider.py
+++ b/tests/test_schneider.py
@@ -1,0 +1,33 @@
+"""Tests for Schneider."""
+
+import pytest
+from zigpy.zcl.clusters.smartenergy import Metering
+
+import zhaquirks.schneider.outlet
+
+from tests.common import ClusterListener
+
+zhaquirks.setup()
+
+
+@pytest.mark.parametrize("quirk", (zhaquirks.schneider.outlet.SocketOutlet,))
+async def test_schneider_device_temp(zigpy_device_from_quirk, quirk):
+    """Test that instant demand is divided by 1000."""
+    device = zigpy_device_from_quirk(quirk)
+
+    metering_cluster = device.endpoints[6].smartenergy_metering
+    metering_listener = ClusterListener(metering_cluster)
+    instantaneous_demand_attr_id = Metering.AttributeDefs.instantaneous_demand.id
+    summation_delivered_attr_id = Metering.AttributeDefs.current_summ_delivered.id
+
+    # verify instant demand is divided by 1000
+    metering_cluster.update_attribute(instantaneous_demand_attr_id, 25000)
+    assert len(metering_listener.attribute_updates) == 1
+    assert metering_listener.attribute_updates[0][0] == instantaneous_demand_attr_id
+    assert metering_listener.attribute_updates[0][1] == 25  # divided by 1000
+
+    # verify other attributes are not modified
+    metering_cluster.update_attribute(summation_delivered_attr_id, 25)
+    assert len(metering_listener.attribute_updates) == 2
+    assert metering_listener.attribute_updates[1][0] == summation_delivered_attr_id
+    assert metering_listener.attribute_updates[1][1] == 25  # not modified

--- a/zhaquirks/schneider/__init__.py
+++ b/zhaquirks/schneider/__init__.py
@@ -1,1 +1,3 @@
 """Quirks for Schneider devices."""
+
+SCHNEIDER = "Schneider Electric"

--- a/zhaquirks/schneider/__init__.py
+++ b/zhaquirks/schneider/__init__.py
@@ -1,0 +1,1 @@
+"""Quirks for Schneider devices."""

--- a/zhaquirks/schneider/outlet.py
+++ b/zhaquirks/schneider/outlet.py
@@ -45,7 +45,7 @@ class SocketOutlet(CustomDevice):
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=9
             # device_version=0
-            # input_clusters=[0, 3, 4, 5, 6, 1794, 1800, 2820, 2821, 64516] output_clusters=[5, 25, 32]>
+            # input_clusters=[0, 3, 4, 5, 6, 1794, 1800, 2820, 2821, 64516] output_clusters=[25]>
             6: {
                 PROFILE_ID: 0x0104,
                 DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,

--- a/zhaquirks/schneider/outlet.py
+++ b/zhaquirks/schneider/outlet.py
@@ -1,5 +1,5 @@
 """Schneider Electric (Wiser) Outlet Quirks."""
-from zigpy.profiles import zha
+from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -21,33 +21,32 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.schneider import SCHNEIDER
 
 
 class MeteringCluster(CustomCluster, Metering):
-    """Fix the Instantaneous Demand value x1000"""
-
-    INSTANTANEOUS_DEMAND = 0x0400
+    """Custom Metering cluster to fix instantaneous demand value multiplied by 1000."""
 
     def _update_attribute(self, attrid, value):
-        if attrid == self.INSTANTANEOUS_DEMAND:
-            value = value / 1000.0
+        if attrid == self.AttributeDefs.instantaneous_demand.id:
+            value = value / 1000
         super()._update_attribute(attrid, value)
 
 
 class SocketOutlet(CustomDevice):
-    """Schneider Electric Socket outlet WDE002182,WDE002172."""
+    """Schneider Electric Socket outlet WDE002182, WDE002172."""
 
     signature = {
         MODELS_INFO: [
-            ("Schneider Electric", "SOCKET/OUTLET/1"),
-            ("Schneider Electric", "SOCKET/OUTLET/2"),
+            (SCHNEIDER, "SOCKET/OUTLET/1"),
+            (SCHNEIDER, "SOCKET/OUTLET/2"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=9
             # device_version=0
             # input_clusters=[0, 3, 4, 5, 6, 1794, 1800, 2820, 2821, 64516] output_clusters=[25]>
             6: {
-                PROFILE_ID: 0x0104,
+                PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
@@ -61,13 +60,17 @@ class SocketOutlet(CustomDevice):
                     Diagnostic.cluster_id,
                     0xFC04,
                 ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
             },
             242: {
-                PROFILE_ID: 41440,
-                DEVICE_TYPE: 97,
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
                 INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
             },
         },
     }
@@ -75,7 +78,7 @@ class SocketOutlet(CustomDevice):
     replacement = {
         ENDPOINTS: {
             6: {
-                PROFILE_ID: 0x0104,
+                PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
@@ -89,13 +92,17 @@ class SocketOutlet(CustomDevice):
                     Diagnostic.cluster_id,
                     0xFC04,
                 ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
             },
             242: {
-                PROFILE_ID: 41440,
-                DEVICE_TYPE: 97,
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
                 INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
             },
         },
     }

--- a/zhaquirks/schneider/outlet.py
+++ b/zhaquirks/schneider/outlet.py
@@ -1,0 +1,101 @@
+"""Schneider Electric (Wiser) Outlet Quirks."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+)
+from zigpy.zcl.clusters.homeautomation import Diagnostic, ElectricalMeasurement
+from zigpy.zcl.clusters.smartenergy import DeviceManagement, Metering
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+
+class MeteringCluster(CustomCluster, Metering):
+    """Fix the Instantaneous Demand value x1000"""
+
+    INSTANTANEOUS_DEMAND = 0x0400
+
+    def _update_attribute(self, attrid, value):
+        if attrid == self.INSTANTANEOUS_DEMAND:
+            value = value / 1000.0
+        super()._update_attribute(attrid, value)
+
+
+class SocketOutlet(CustomDevice):
+    """Schneider Electric Socket outlet WDE002182,WDE002172."""
+
+    signature = {
+        MODELS_INFO: [
+            ("Schneider Electric", "SOCKET/OUTLET/1"),
+            ("Schneider Electric", "SOCKET/OUTLET/2"),
+        ],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=9
+            # device_version=0
+            # input_clusters=[0, 3, 4, 5, 6, 1794, 1800, 2820, 2821, 64516] output_clusters=[5, 25, 32]>
+            6: {
+                PROFILE_ID: 0x0104,
+                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    Metering.cluster_id,
+                    DeviceManagement.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    0xFC04,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            6: {
+                PROFILE_ID: 0x0104,
+                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MeteringCluster,
+                    DeviceManagement.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    Diagnostic.cluster_id,
+                    0xFC04,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }


### PR DESCRIPTION
Based on the code supplied by krlssn in comment https://github.com/zigpy/zha-device-handlers/issues/1889#issuecomment-1337368444

I'm VERY new to the whole Python world so I feel totally lost when it comes to writing tests and honestly not capable of doing so currently. I'm currently trying to get a dev env setup with Python 3.12 but I get weird errors regarding building wheels and whatnot. I'll see if I can get that running...

## Proposed change
- Add quirks for Schneider Wiser outlets and how metering is calculated

## Additional information
- PR is based on the code attached to this comment: https://github.com/zigpy/zha-device-handlers/issues/1889#issuecomment-1337368444
- I added the `<SimpleDescriptor...>` based on log information obtained via HA. I also attempted to verify other information by comparing to my 2-way Wiser outlet.
- I have attached the info I got from HA so someone can look and confirm: [Wiser-2way.json](https://github.com/zigpy/zha-device-handlers/files/13665503/Wiser-2way.json)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
