### PR TITLE
Add PM2.5 for Tuya Smart Air House keeper 

### DIFF
--- a/tests/test_tuya_air.py
+++ b/tests/test_tuya_air.py
@@ -8,6 +8,7 @@ import zigpy.profiles.zha
 import zhaquirks
 from zhaquirks.tuya import TuyaNewManufCluster
 from zhaquirks.tuya.air.ts0601_air_quality import TuyaCO2Sensor
+from zhaquirks.tuya.air.ts0601_smart_air import TuyaSmartAirSensor
 
 zhaquirks.setup()
 
@@ -68,4 +69,68 @@ def test_co2_sensor(air_quality_device, data, ep_attr, expected_value):
         zigpy.profiles.zha.PROFILE_ID, TuyaNewManufCluster.cluster_id, 1, 1, data
     )
     cluster = getattr(air_quality_device.endpoints[1], ep_attr)
+    assert cluster.get("measured_value") == expected_value
+
+
+@pytest.fixture
+def smart_air_quality_device(zigpy_device_from_quirk):
+    """Tuya Smart Air Quality Sensor."""
+    dev = zigpy_device_from_quirk(TuyaSmartAirSensor)
+    cluster = dev.endpoints[1].in_clusters[TuyaNewManufCluster.cluster_id]
+    with mock.patch.object(cluster, "send_default_rsp"):
+        yield dev
+
+
+@pytest.mark.parametrize(
+    "data, ep_attr, expected_value",
+    (
+        (
+            b"\t2\x01\x00\x02\x02\x02\x00\x04\x00\x00\x01r",
+            "carbon_dioxide_concentration",
+            370 * 1e-6,
+        ),
+        (
+            b"\t$\x01\x00\x00\x13\x02\x00\x04\x00\x00\x02\xd6",
+            "humidity",
+            7260,
+        ),
+        (
+            b"\t\x03\x01\x00\x01\x15\x02\x00\x04\x00\x00\x00\x01",
+            "voc_level",
+            1 * 1e-6,
+        ),
+        (
+            b"\t\x02\x01\x00\x01\x16\x02\x00\x04\x00\x00\x00\x02",
+            "formaldehyde_concentration",
+            2 * 1e-6,
+        ),
+        (
+            b"\t\x02\x01\x00\x00\x12\x02\x00\x04\x00\x00\x01 ",
+            "temperature",
+            2880,
+        ),
+        (
+            b"\t\x02\x01\x00\x00\x12\x02\x00\x04\x00\x00\xff\xfb",
+            "temperature",
+            -50,
+        ),
+        (
+            b"\t\x02\x01\x00\x00\x12\x02\x00\x04\x00\x00\xff\xef",
+            "temperature",
+            -170,
+        ),
+        (
+            b"\t\xa5\x02\x00\x01\x14\x02\x00\x04\x00\x00\x00\x01",
+            "pm25",
+            1,
+        ),
+    ),
+)
+def test_smart_air_sensor(smart_air_quality_device, data, ep_attr, expected_value):
+    """Test Tuya Smart Air Sensor."""
+
+    smart_air_quality_device.handle_message(
+        zigpy.profiles.zha.PROFILE_ID, TuyaNewManufCluster.cluster_id, 1, 1, data
+    )
+    cluster = getattr(smart_air_quality_device.endpoints[1], ep_attr)
     assert cluster.get("measured_value") == expected_value

--- a/zhaquirks/tuya/air/__init__.py
+++ b/zhaquirks/tuya/air/__init__.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 import zigpy.types as t
 from zigpy.zcl.clusters.measurement import (
+    PM25,
     CarbonDioxideConcentration,
     FormaldehydeConcentration,
     RelativeHumidity,
@@ -67,6 +68,10 @@ class TuyaAirQualityHumidity(RelativeHumidity, TuyaLocalCluster):
     """Tuya relative humidity measurement."""
 
 
+class TuyaAirQualityPM25(PM25, TuyaLocalCluster):
+    """Tuya PM25 concentration measurement"""
+
+
 class TuyaAirQualityCO2(CarbonDioxideConcentration, TuyaLocalCluster):
     """Tuya Carbon Dioxide concentration measurement."""
 
@@ -92,6 +97,9 @@ class TuyaCO2ManufCluster(TuyaNewManufCluster):
         19: DPToAttributeMapping(
             TuyaAirQualityHumidity.ep_attribute, "measured_value", lambda x: x * 10
         ),
+        20: DPToAttributeMapping(
+            TuyaAirQualityPM25.ep_attribute, "measured_value", lambda x: x
+        ),
         21: DPToAttributeMapping(
             TuyaAirQualityVOC.ep_attribute, "measured_value", lambda x: x * 1e-6
         ),
@@ -106,6 +114,7 @@ class TuyaCO2ManufCluster(TuyaNewManufCluster):
         2: "_dp_2_attr_update",
         18: "_dp_2_attr_update",
         19: "_dp_2_attr_update",
+        20: "_dp_2_attr_update",
         21: "_dp_2_attr_update",
         22: "_dp_2_attr_update",
     }

--- a/zhaquirks/tuya/air/ts0601_smart_air.py
+++ b/zhaquirks/tuya/air/ts0601_smart_air.py
@@ -1,4 +1,4 @@
-"""Tuya Air Quality sensor."""
+"""Tuya Smart Air House keeper."""
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
@@ -16,26 +16,24 @@ from zhaquirks.tuya.air import (
     TuyaAirQualityCO2,
     TuyaAirQualityFormaldehyde,
     TuyaAirQualityHumidity,
+    TuyaAirQualityPM25,
     TuyaAirQualityTemperature,
     TuyaAirQualityVOC,
     TuyaCO2ManufCluster,
 )
 
 
-class TuyaCO2Sensor(CustomDevice):
-    """Tuya Air quality device."""
+class TuyaSmartAirSensor(CustomDevice):
+    """Tuya Smart air house keeper device."""
 
     signature = {
-        # NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.0: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)]
-        # device_version=1
+        # NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.FullFunctionDevice|MainsPowered|RxOnWhenIdle|AllocateAddress: 142>, manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=81, device_version=1,
-        # input_clusters=[0, 4, 5, 61184],
+        # input_clusters=[0, 4, 5, 1026, 1029, 1037, 1067, 1070, 61184],
         # output_clusters=[25, 10])
         MODELS_INFO: [
-            ("_TZE200_8ygsuhe1", "TS0601"),
-            ("_TZE200_ryfmq5rl", "TS0601"),
-            ("_TZE200_yvx5lh6k", "TS0601"),
-            ("_TZE200_c2fmom5z", "TS0601"),
+            ("_TZE200_mja3fuja", "TS0601"),
+            ("_TZE200_dwcarsat", "TS0601"),
         ],
         ENDPOINTS: {
             1: {
@@ -64,6 +62,7 @@ class TuyaCO2Sensor(CustomDevice):
                     TuyaAirQualityCO2,
                     TuyaAirQualityFormaldehyde,
                     TuyaAirQualityHumidity,
+                    TuyaAirQualityPM25,
                     TuyaAirQualityTemperature,
                     TuyaAirQualityVOC,
                 ],
@@ -73,20 +72,18 @@ class TuyaCO2Sensor(CustomDevice):
     }
 
 
-class TuyaCO2SensorGPP(CustomDevice):
+class TuyaSmartAirSensorGPP(CustomDevice):
     """Tuya Air quality device with GPP."""
 
     signature = {
         # NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.0: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)]
         # device_version=1
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=81, device_version=1,
-        # input_clusters=[0, 4, 5, 61184],
-        # output_clusters=[25, 10])
+        # input_clusters=[0, 4, 5, 1026, 1029, 1037, 1067, 1070, 61184],
+        # output_clusters=[10, 25])
         MODELS_INFO: [
-            ("_TZE200_8ygsuhe1", "TS0601"),
-            ("_TZE200_ryfmq5rl", "TS0601"),
-            ("_TZE200_yvx5lh6k", "TS0601"),
-            ("_TZE200_c2fmom5z", "TS0601"),
+            ("_TZE200_mja3fuja", "TS0601"),
+            ("_TZE200_dwcarsat", "TS0601"),
         ],
         ENDPOINTS: {
             1: {
@@ -124,67 +121,9 @@ class TuyaCO2SensorGPP(CustomDevice):
                     TuyaAirQualityCO2,
                     TuyaAirQualityFormaldehyde,
                     TuyaAirQualityHumidity,
+                    TuyaAirQualityPM25,
                     TuyaAirQualityTemperature,
                     TuyaAirQualityVOC,
-                ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        }
-    }
-
-
-class TuyaNDIRCO2SensorGPP(CustomDevice):
-    """Tuya NIDR CO2 sensor with GPP."""
-
-    signature = {
-        # NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)
-        # device_version=1
-        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=81, device_version=1,
-        # input_clusters=[0, 4, 5, 61184],
-        # output_clusters=[25, 10])
-        MODELS_INFO: [
-            ("_TZE200_ogkdpgy2", "TS0601"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    TuyaCO2ManufCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            },
-            242: {
-                # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
-                # input_clusters=[]
-                # output_clusters=[33]
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    TuyaCO2ManufCluster,
-                    TuyaAirQualityCO2,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Add capability to read PM25 values from Tuya Smart House keeper devices and split device into separate quirk.
This is my first pull request ever and also a first attempt at python so any guidance is appreciated.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
also synced the supported models with those supported by Zigbee2MQTT

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
