### PR TITLE
Add another signature for Aqara H1 double switch `lumi.switch.n2aeu1`

### DIFF
--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -26,13 +26,14 @@ from zhaquirks.xiaomi import LUMI
 from zhaquirks.xiaomi.aqara.opple_switch import (
     OppleSwitchCluster,
     XiaomiOpple2ButtonSwitch1,
+    XiaomiOpple2ButtonSwitch3,
     XiaomiOpple2ButtonSwitch4,
     XiaomiOpple2ButtonSwitchBase,
 )
 
 
-class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
-    """Aqara H1 Double Rocker Switch (with neutral)."""
+class AqaraH1DoubleRockerSwitchWithNeutral1(XiaomiOpple2ButtonSwitchBase):
+    """Aqara H1 Double Rocker Switch (with neutral). Based on signature 1."""
 
     signature = {
         MODELS_INFO: [(LUMI, "lumi.switch.n2aeu1")],
@@ -40,8 +41,17 @@ class AqaraH1DoubleRockerSwitchWithNeutral(XiaomiOpple2ButtonSwitchBase):
     }
 
 
-class AqaraH1DoubleRockerSwitchWithNeutralAlt(XiaomiOpple2ButtonSwitchBase):
-    """Aqara H1 Double Rocker Switch (with neutral) alternative signature."""
+class AqaraH1DoubleRockerSwitchWithNeutral3(XiaomiOpple2ButtonSwitchBase):
+    """Aqara H1 Double Rocker Switch (with neutral). Based on signature 3."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.switch.n2aeu1")],
+        ENDPOINTS: XiaomiOpple2ButtonSwitch3.signature[ENDPOINTS],
+    }
+
+
+class AqaraH1DoubleRockerSwitchWithNeutral4(XiaomiOpple2ButtonSwitchBase):
+    """Aqara H1 Double Rocker Switch (with neutral). Based on signature 4."""
 
     signature = {
         MODELS_INFO: [(LUMI, "lumi.switch.n2aeu1")],


### PR DESCRIPTION
## Proposed change
Adds another signature for the Aqara EU double wall-switches.
This is based on the `opple_switch.py` / `XiaomiOpple2ButtonSwitch3` signature.


## Additional information
Follow-up to:
- https://github.com/zigpy/zha-device-handlers/pull/2826
- https://github.com/zigpy/zha-device-handlers/pull/2825
- https://github.com/zigpy/zha-device-handlers/pull/2784

Reason why the new model info isn't just added to `opple_switch.py` quirks is explained here: https://github.com/zigpy/zha-device-handlers/pull/2826#issue-2034155192
(So basically to avoid confusion and separate the different devices types better.)

Signature reported here: https://github.com/zigpy/zha-device-handlers/pull/2826#discussion_r1436610959 (cc @ehoogend)

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
