### PR TITLE
Aqara P1 contact sensor: fix typo in attributes

### DIFF
--- a/zhaquirks/xiaomi/aqara/magnet_ac01.py
+++ b/zhaquirks/xiaomi/aqara/magnet_ac01.py
@@ -28,9 +28,9 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     class DetectionDistance(t.enum8):
         """Detection distance."""
 
-        TenMilimeters = 0x01
-        TwentyMilimeters = 0x02
-        ThirtyMilimeters = 0x03
+        TenMillimeters = 0x01
+        TwentyMillimeters = 0x02
+        ThirtyMillimeters = 0x03
 
     attributes = {
         0x010C: ("detection_distance", t.uint8_t, True),


### PR DESCRIPTION
## Proposed change

A `l` was missing in `millimeters` attributes of the new Aqara P1 contact sensor quirk.


## Additional information

The typo was introduced in #2822.


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
