### PR TITLE
Add Sonoff SNZB-06P presence sensor support

### DIFF
--- a/tests/test_sonoff.py
+++ b/tests/test_sonoff.py
@@ -3,6 +3,7 @@
 
 import zhaquirks
 import zhaquirks.sonoff.snzb01p
+import zhaquirks.sonoff.snzb06p
 
 zhaquirks.setup()
 
@@ -27,4 +28,34 @@ def test_sonoff_snzb01p(assert_signature_matches_quirk):
 
     assert_signature_matches_quirk(
         zhaquirks.sonoff.snzb01p.SonoffSmartButtonSNZB01P, signature
+    )
+
+
+def test_sonoff_snzb06p(assert_signature_matches_quirk):
+    """Test 'Sonoff SNZB-06P presence sensor' signature is matched to its quirk."""
+
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.FullFunctionDevice|MainsPowered|RxOnWhenIdle|AllocateAddress: 142>, manufacturer_code=4742, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 260,
+                "device_type": "0x0107",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0003",
+                    "0x0406",
+                    "0x0500",
+                    "0xfc11",
+                    "0xfc57",
+                ],
+                "out_clusters": ["0x0003", "0x0019"],
+            }
+        },
+        "manufacturer": "SONOFF",
+        "model": "SNZB-06P",
+        "class": "sonoff.snzb06p.SonoffPresenceSensorSNZB06P",
+    }
+
+    assert_signature_matches_quirk(
+        zhaquirks.sonoff.snzb06p.SonoffPresenceSensorSNZB06P, signature
     )

--- a/tests/test_sonoff.py
+++ b/tests/test_sonoff.py
@@ -1,9 +1,16 @@
 """Tests for Sonoff quirks."""
 
+from unittest import mock
+
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import AnalogOutput, BinaryInput
+from zigpy.zcl.clusters.measurement import OccupancySensing
 
 import zhaquirks
 import zhaquirks.sonoff.snzb01p
 import zhaquirks.sonoff.snzb06p
+
+from tests.common import ClusterListener
 
 zhaquirks.setup()
 
@@ -59,3 +66,107 @@ def test_sonoff_snzb06p(assert_signature_matches_quirk):
     assert_signature_matches_quirk(
         zhaquirks.sonoff.snzb06p.SonoffPresenceSensorSNZB06P, signature
     )
+
+
+async def test_sonoff_snzb06p_occupancy_timeout(zigpy_device_from_quirk):
+    """Test SNZB-06P occupancy timeout cluster."""
+
+    device = zigpy_device_from_quirk(
+        zhaquirks.sonoff.snzb06p.SonoffPresenceSensorSNZB06P
+    )
+    occupancy_timeout_cluster = device.endpoints[0x2].in_clusters[
+        AnalogOutput.cluster_id
+    ]
+    occupancy_sensing_cluster = device.endpoints[0x1].in_clusters[
+        OccupancySensing.cluster_id
+    ]
+
+    # Check mandatory attributes
+    succ, fail = await occupancy_timeout_cluster.read_attributes(
+        (
+            "max_present_value",
+            "min_present_value",
+            "resolution",
+            "application_type",
+            "engineering_units",
+        )
+    )
+    assert succ["max_present_value"] == 65535
+    assert succ["min_present_value"] == 15
+    assert succ["resolution"] == 1.0
+    assert succ["application_type"] == 0x000E0001
+    assert succ["engineering_units"] == 73
+
+    occ_timeout_write = mock.patch.object(
+        occupancy_timeout_cluster,
+        "_write_attributes",
+        mock.AsyncMock(
+            return_value=(
+                [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],
+            )
+        ),
+    )
+
+    occ_sensing_write = mock.patch.object(
+        occupancy_sensing_cluster,
+        "_write_attributes",
+        mock.AsyncMock(
+            return_value=(
+                [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],
+            )
+        ),
+    )
+
+    occupancy_sensing_listener = ClusterListener(occupancy_sensing_cluster)
+
+    # testing double-link nature of clusters (AnalogOutput exists just to provide
+    # means for configuring the setting
+    with occ_timeout_write, occ_sensing_write:
+        await occupancy_timeout_cluster.write_attributes({"present_value": 30})
+        assert len(occupancy_timeout_cluster._write_attributes.mock_calls) == 0
+        assert len(occupancy_sensing_cluster._write_attributes.mock_calls) == 1
+        occupancy_timeout_cluster._write_attributes.reset_mock()
+        occupancy_sensing_cluster._write_attributes.reset_mock()
+
+        assert occupancy_sensing_listener.attribute_updates[0] == (
+            zhaquirks.sonoff.snzb06p.ATTR_ULTRASONIC_O_TO_U_DELAY,
+            30,
+        )  # Opple system_mode
+
+        occupancy_sensing_cluster.update_attribute(
+            zhaquirks.sonoff.snzb06p.ATTR_ULTRASONIC_O_TO_U_DELAY, 15
+        )
+        success, fail = await occupancy_timeout_cluster.read_attributes(
+            ["present_value"]
+        )
+        assert success
+        assert 15 in success.values()
+        assert not fail
+
+
+async def test_sonoff_snzb06p_illuminance_level_sensing(zigpy_device_from_quirk):
+    """Test SNZB-06P artificial illuminance level sensing cluster."""
+
+    device = zigpy_device_from_quirk(
+        zhaquirks.sonoff.snzb06p.SonoffPresenceSensorSNZB06P
+    )
+    illuminance_cluster = device.endpoints[0x2].in_clusters[BinaryInput.cluster_id]
+    sonoff_cluster = device.endpoints[0x1].in_clusters[
+        zhaquirks.sonoff.snzb06p.SONOFF_CLUSTER_ID_2
+    ]
+
+    sonoff_cluster.update_attribute(
+        zhaquirks.sonoff.snzb06p.ATTR_SONOFF_ILLUMINATION_STATUS, 0
+    )
+    success, fail = await illuminance_cluster.read_attributes(["present_value"])
+    assert success
+    assert False in success.values()
+    assert not fail
+
+    sonoff_cluster.update_attribute(
+        zhaquirks.sonoff.snzb06p.ATTR_SONOFF_ILLUMINATION_STATUS, 1
+    )
+    success, fail = await illuminance_cluster.read_attributes(["present_value"])
+    assert success
+    assert True in success.values()
+    assert not fail

--- a/zhaquirks/sonoff/snzb06p.py
+++ b/zhaquirks/sonoff/snzb06p.py
@@ -69,7 +69,7 @@ class SonoffOccupancyTimeout(LocalDataCluster, AnalogOutput):
         return await super().write_attributes(attributes, manufacturer)
 
 
-class SonoffOccupancyCluster(OccupancySensing):
+class SonoffOccupancyCluster(CustomCluster, OccupancySensing):
     """AnalogOutput cluster for setting the timeout for occupancy state."""
 
     def _update_attribute(self, attrid, value):
@@ -94,14 +94,17 @@ class SonoffCluster(CustomCluster):
     cluster_id = SONOFF_CLUSTER_ID_2
     manufacturer_id_override = SONOFF_MANUFACTURER_ID
 
-    attributes = {
-        ATTR_SONOFF_ILLUMINATION_STATUS: ZCLAttributeDef(
-            type=IlluminationStatus,
-            access="r",
-            is_manufacturer_specific=True,
-            name="illuminantion",
-        ),
-    }
+    attributes = CustomCluster.attributes.copy()
+    attributes.update(
+        {
+            ATTR_SONOFF_ILLUMINATION_STATUS: ZCLAttributeDef(
+                type=IlluminationStatus,
+                access="r",
+                is_manufacturer_specific=True,
+                name="last_illuminantion_state",
+            ),  # ramdom attribute ID
+        }
+    )
 
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)

--- a/zhaquirks/sonoff/snzb06p.py
+++ b/zhaquirks/sonoff/snzb06p.py
@@ -1,4 +1,6 @@
 """Sonoff Smart Button SNZB-06P"""
+import copy
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
@@ -94,14 +96,14 @@ class SonoffCluster(CustomCluster):
     cluster_id = SONOFF_CLUSTER_ID_2
     manufacturer_id_override = SONOFF_MANUFACTURER_ID
 
-    attributes = CustomCluster.attributes.copy()
+    attributes = copy.deepcopy(CustomCluster.attributes)
     attributes.update(
         {
             ATTR_SONOFF_ILLUMINATION_STATUS: ZCLAttributeDef(
                 type=IlluminationStatus,
                 access="r",
                 is_manufacturer_specific=True,
-                name="last_illuminantion_state",
+                name="last_illumination_state",
             ),  # ramdom attribute ID
         }
     )

--- a/zhaquirks/sonoff/snzb06p.py
+++ b/zhaquirks/sonoff/snzb06p.py
@@ -1,0 +1,95 @@
+"""Sonoff Smart Button SNZB-06P"""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic, Identify, Ota
+from zigpy.zcl.clusters.measurement import OccupancySensing
+from zigpy.zcl.clusters.security import IasZone
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+SONOFF_CLUSTER_ID = 0xFC57
+SONOFF_MANUFACTURER_ID = 0x1286
+
+
+class IlluminationStatus(t.uint8_t):
+    """Last captured state of illumination."""
+
+    Dark = 0x00
+    Light = 0x01
+
+
+class SonoffCluster(CustomCluster):
+    """Sonoff manufacture specific cluster that provides illuminance"""
+
+    cluster_id = 0xFC11
+    manufacturer_id_override = SONOFF_MANUFACTURER_ID
+
+    attributes = {
+        0x2001: ZCLAttributeDef(
+            type=IlluminationStatus,
+            access="r",
+            is_manufacturer_specific=True,
+            name="illuminantion",
+        ),
+    }
+
+
+class SonoffPresenceSensorSNZB06P(CustomDevice):
+    """Sonoff presence sensor - model SNZB-06P"""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=0
+        #  device_version=1
+        #  input_clusters=[0, 3, 32, 64599]
+        #  output_clusters=[3, 25]>
+        MODELS_INFO: [
+            ("SONOFF", "SNZB-06P"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OccupancySensing.cluster_id,
+                    IasZone.cluster_id,
+                    SonoffCluster.cluster_id,
+                    SONOFF_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OccupancySensing.cluster_id,
+                    SonoffCluster,
+                    SONOFF_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }

--- a/zhaquirks/sonoff/snzb06p.py
+++ b/zhaquirks/sonoff/snzb06p.py
@@ -1,5 +1,4 @@
 """Sonoff Smart Button SNZB-06P"""
-import copy
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -7,7 +6,6 @@ import zigpy.types as t
 from zigpy.zcl.clusters.general import AnalogOutput, Basic, BinaryInput, Identify, Ota
 from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
-from zigpy.zcl.foundation import ZCLAttributeDef
 
 from zhaquirks import Bus, LocalDataCluster
 from zhaquirks.const import (
@@ -96,14 +94,13 @@ class SonoffCluster(CustomCluster):
     cluster_id = SONOFF_CLUSTER_ID_2
     manufacturer_id_override = SONOFF_MANUFACTURER_ID
 
-    attributes = copy.deepcopy(CustomCluster.attributes)
+    attributes = CustomCluster.attributes.copy()
     attributes.update(
         {
-            ATTR_SONOFF_ILLUMINATION_STATUS: ZCLAttributeDef(
-                type=IlluminationStatus,
-                access="r",
-                is_manufacturer_specific=True,
-                name="last_illumination_state",
+            ATTR_SONOFF_ILLUMINATION_STATUS: (
+                "last_illumination_state",
+                IlluminationStatus,
+                True,
             ),  # ramdom attribute ID
         }
     )

--- a/zhaquirks/sonoff/snzb06p.py
+++ b/zhaquirks/sonoff/snzb06p.py
@@ -2,11 +2,12 @@
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, Identify, Ota
+from zigpy.zcl.clusters.general import AnalogOutput, Basic, BinaryInput, Identify, Ota
 from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zcl.foundation import ZCLAttributeDef
 
+from zhaquirks import Bus, LocalDataCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -17,7 +18,67 @@ from zhaquirks.const import (
 )
 
 SONOFF_CLUSTER_ID = 0xFC57
+SONOFF_CLUSTER_ID_2 = 0xFC11
 SONOFF_MANUFACTURER_ID = 0x1286
+ATTR_SONOFF_ILLUMINATION_STATUS = 0x2001
+ATTR_PRESENT_VALUE = 0x0055
+ATTR_ULTRASONIC_O_TO_U_DELAY = 0x0020
+
+
+class SonoffOccupancyTimeout(LocalDataCluster, AnalogOutput):
+    """AnalogOutput cluster for setting the timeout for occupancy state."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.occupancy_timeout_bus.add_listener(self)
+        self._update_attribute(
+            self.attributes_by_name["description"].id, "Occupancy timeout"
+        )
+        self._update_attribute(self.attributes_by_name["max_present_value"].id, 65535)
+        self._update_attribute(self.attributes_by_name["min_present_value"].id, 15)
+        self._update_attribute(self.attributes_by_name["resolution"].id, 1)
+        self._update_attribute(
+            self.attributes_by_name["application_type"].id, 0x000E0001
+        )  # Type=time
+        self._update_attribute(
+            self.attributes_by_name["engineering_units"].id, 73
+        )  # Units=seconds
+
+    def set_value(self, value):
+        """Set new occupancy timeout value."""
+        self._update_attribute(self.attributes_by_name["present_value"].id, value)
+
+    def get_value(self):
+        """Get current occupancy timeout value."""
+        return self._attr_cache.get(self.attributes_by_name["present_value"].id)
+
+    async def write_attributes(self, attributes, manufacturer=None):
+        """Modify value before passing it to the set_data tuya command."""
+        for attrid, value in attributes.items():
+            if isinstance(attrid, str):
+                attrid = self.attributes_by_name[attrid].id
+            if attrid not in self.attributes:
+                self.error("%d is not a valid attribute id", attrid)
+                continue
+            if attrid == ATTR_PRESENT_VALUE:
+                await self.endpoint.device.endpoints[1].occupancy.write_attributes(
+                    {ATTR_ULTRASONIC_O_TO_U_DELAY: value}, manufacturer=None
+                )
+
+        return await super().write_attributes(attributes, manufacturer)
+
+
+class SonoffOccupancyCluster(OccupancySensing):
+    """AnalogOutput cluster for setting the timeout for occupancy state."""
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == ATTR_ULTRASONIC_O_TO_U_DELAY:
+            self.endpoint.device.occupancy_timeout_bus.listener_event(
+                "set_value",
+                value,
+            )
 
 
 class IlluminationStatus(t.uint8_t):
@@ -30,11 +91,11 @@ class IlluminationStatus(t.uint8_t):
 class SonoffCluster(CustomCluster):
     """Sonoff manufacture specific cluster that provides illuminance"""
 
-    cluster_id = 0xFC11
+    cluster_id = SONOFF_CLUSTER_ID_2
     manufacturer_id_override = SONOFF_MANUFACTURER_ID
 
     attributes = {
-        0x2001: ZCLAttributeDef(
+        ATTR_SONOFF_ILLUMINATION_STATUS: ZCLAttributeDef(
             type=IlluminationStatus,
             access="r",
             is_manufacturer_specific=True,
@@ -42,14 +103,52 @@ class SonoffCluster(CustomCluster):
         ),
     }
 
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == ATTR_SONOFF_ILLUMINATION_STATUS:
+            self.endpoint.device.illumination_bus.listener_event(
+                "set_value",
+                value,
+            )
+
+
+class SonoffIlluminanceLevelSensing(LocalDataCluster, BinaryInput):
+    """Sonoff emulated illuminance level sensing cluster to provide access to FC11/2001."""
+
+    name = "Last Illumination State"
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.illumination_bus.add_listener(self)
+        self._update_attribute(
+            self.attributes_by_name["description"].id, "Last illumination state"
+        )
+        self._update_attribute(self.attributes_by_name["active_text"].id, "Bright")
+        self._update_attribute(self.attributes_by_name["inactive_text"].id, "Dark")
+        # self._update_attribute(self.attributes_by_name["application_type"].id, 0x00ff0002)#Type=other
+
+    def set_value(self, value):
+        """Set new illumination status value."""
+        self._update_attribute(
+            self.attributes_by_name["present_value"].id,
+            value == IlluminationStatus.Light,
+        )
+
 
 class SonoffPresenceSensorSNZB06P(CustomDevice):
     """Sonoff presence sensor - model SNZB-06P"""
 
+    def __init__(self, *args, **kwargs):
+        """Init device."""
+        self.occupancy_timeout_bus = Bus()
+        self.illumination_bus = Bus()
+        super().__init__(*args, **kwargs)
+
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=0
         #  device_version=1
-        #  input_clusters=[0, 3, 32, 64599]
+        #  input_clusters=[0, 3, 1030, 1280, 64529, 64599]
         #  output_clusters=[3, 25]>
         MODELS_INFO: [
             ("SONOFF", "SNZB-06P"),
@@ -82,7 +181,7 @@ class SonoffPresenceSensorSNZB06P(CustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    OccupancySensing.cluster_id,
+                    SonoffOccupancyCluster,
                     SonoffCluster,
                     SONOFF_CLUSTER_ID,
                 ],
@@ -90,6 +189,15 @@ class SonoffPresenceSensorSNZB06P(CustomDevice):
                     Identify.cluster_id,
                     Ota.cluster_id,
                 ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COMBINED_INTERFACE,
+                INPUT_CLUSTERS: [
+                    SonoffOccupancyTimeout,
+                    SonoffIlluminanceLevelSensing,
+                ],
+                OUTPUT_CLUSTERS: [],
             },
         },
     }


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
I was working on a quirk for SNZB-06P, but got stuck.
Decided to make a PR, although right now it's not at the state I'd like it to be. Maybe I'll get some pointers here


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
When finished, fixes #2702

What I would like is to do is:
* remove motion entity (it's non-functional) (done)
* add access to occupancy timeout (done, kinda, via virtual AnalogOutput cluster on the virtual endpoint, but it works)
* add access (read-only) to the latest captured illuminance state (dark/bright)
* add access to a sensitivity setting (in case of this device controlled by the "ultrasonic_u_to_o_threshold" standard Zigbee attribute and allows values 1,2,3 - Low,Medium, High)

Access to occupancy timeout seems to work but looks kinda hacky. Is there a better way? We're talking about a standard attribute "ultrasonic_o_to_u_delay" for OccupancySensing cluster with a manufacturer-specific limitations (minimum value that may be set is 15)

A read-only access to the last captured illuminance state was made by creating a BinaryInput-derived cluster. It created a 'binary input' entity in HA and it shows the right thing, but I wanted to provide an adequate name for it and didn't find a proper way.

How to describe a sensitivity in the quirk so that ZHA would "automagically" create an enum-based selector entity for it?

Current state looks like on the screenshot:
![Screenshot_20231228-155404](https://github.com/zigpy/zha-device-handlers/assets/19556862/cbeccac8-74fa-42d6-a9d4-df8087e7a108)

'Binary input' is supposed to be 'Last illuminance state', but I haven't found a way to specify that in the quirk so that it would be taken over to HA's entity.

I'm opened for suggestions of better ways to do any of it.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
