### PR TITLE
Fix Linkind motion sensor detection

### DIFF
--- a/tests/test_linkind.py
+++ b/tests/test_linkind.py
@@ -1,0 +1,38 @@
+import pytest
+from zigpy.zcl.clusters.security import IasZone
+
+import zhaquirks
+
+from tests.common import ClusterListener
+
+zhaquirks.setup()
+
+
+@pytest.mark.parametrize("quirk", (zhaquirks.linkind.motion.LinkindD0003,))
+async def test_linkind_motion_ignore_alarm_2(zigpy_device_from_quirk, quirk):
+    """Test that the quirk for the Linkind motion sensor ignores the IasZone Alarm_2 bit."""
+    device = zigpy_device_from_quirk(quirk)
+
+    ias_zone_cluster = device.endpoints[1].ias_zone
+    ias_zone_listener = ClusterListener(ias_zone_cluster)
+    ias_zone_status_attr_id = IasZone.AttributeDefs.zone_status.id
+
+    # ZHA calls update_attribute on the IasZone cluster when it receives a status_change_notification
+    ias_zone_cluster.update_attribute(
+        ias_zone_status_attr_id, IasZone.ZoneStatus.Alarm_2
+    )
+
+    # verify Alarm_2 bit was set to 0
+    assert len(ias_zone_listener.attribute_updates) == 1
+    assert ias_zone_listener.attribute_updates[0][0] == ias_zone_status_attr_id
+    assert ias_zone_listener.attribute_updates[0][1] == 0
+
+    # call again with Alarm_1
+    ias_zone_cluster.update_attribute(
+        ias_zone_status_attr_id, IasZone.ZoneStatus.Alarm_1
+    )
+
+    # verify Alarm_1 was not ignored
+    assert len(ias_zone_listener.attribute_updates) == 2
+    assert ias_zone_listener.attribute_updates[1][0] == ias_zone_status_attr_id
+    assert ias_zone_listener.attribute_updates[1][1] == IasZone.ZoneStatus.Alarm_1


### PR DESCRIPTION
## Proposed change

Fixes the issue where Linkind motion sensors get reset after 60 seconds (during continuous motion).
Also fixes the issue where brightness triggers the motion entity.

### Explanation

According to the OP in #1291, the Linkind motion sensor uses three bits for the IasZone `zone_status`:
- `Alarm_1` for detected motion
- `Alarm_2` for detected brightness
- `tamper` for detected tamper

ZHA currently creates a binary sensor for motion, but turns it on if either `Alarm_1` or  `Alarm_2` is set to `1`.
As we want to ignore the brightness bit for the motion sensor entity, this PR modifies the quirk to always ignore the `Alarm_2` bit on this motion sensor, so only `Alarm_1` (motion) is considered for the motion sensor entity.

A test to verify the added code works was also added.

### Previous quirk with timeout to reset

#2130 added a quirk which reset the motion sensor after a timeout (expecting continuous reports every 60 seconds).
This caused issues for some users at least (perhaps different firmware versions?).
Z2M does not use a timeout to reset the sensor, so we likely also shouldn't.

---

In #2225, @jasongabler removed the added quirk entirely and the motion sensors started working again. (Maybe old versions do not use the `Alarm_2` bit for brightness at all?)
If you're around, can you try this version of the quirk to see if it (still) works for you?
@LAHA2 Please also confirm if this works.

@1jk, @jfrux, @dmackenzie123, @TheRealSimon42 were the ones that had issues with the motion sensor getting stuck.
If you can, please also try if this quirk version (still) works for you.

### Install as a custom quirk:

To install this as a custom quirk, download the the [`motion.py`](https://raw.githubusercontent.com/TheJulianJES/zha-device-handlers/tjj/linkind_revert_motion_sensor_timeout/zhaquirks/linkind/motion.py) file.
Then, add [this](https://github.com/zigpy/zha-device-handlers/discussions/693#discussioncomment-857274) to your HA `configuration.yaml`. Copy the downloaded `.py` file in the (newly) created `custom_zha_quirks` directory and restart HA.



## Additional information
Fixes #2225, fixes #1291

Partly reverts #2130 / commit 7f5c50635da36d83cd436b3125edbd3307ed7ca8.

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
