### PR TITLE
Add battery level for frient Entry Sensor and Entry Sensor Pro

### DIFF
--- a/zhaquirks/develco/open_close.py
+++ b/zhaquirks/develco/open_close.py
@@ -18,7 +18,6 @@ from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -27,15 +26,15 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-
 from zhaquirks.develco import DEVELCO, FRIENT
 
 
 class DevelcoPowerConfiguration(PowerConfigurationCluster):
     """Power configuration cluster."""
 
-    MIN_VOLTS = 2.5  # old 2.1
-    MAX_VOLTS = 3.0  # old 3.2
+    MIN_VOLTS = 2.5 #advised voltage to replace batteries
+    MAX_VOLTS = 3.0
+
 
 class DevelcoIASZone(CustomCluster, IasZone):
     """IAS Zone."""
@@ -56,7 +55,7 @@ class DevelcoIASZone(CustomCluster, IasZone):
 
 
 class WISZB120(CustomDevice):
-    """Custom device representing door/windows sensors."""
+    """Custom device representing door/windows sensors, with built-in temperature measuring"""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=49353 device_type=1 device_version=1
@@ -65,7 +64,7 @@ class WISZB120(CustomDevice):
         # input_clusters=[0, 1, 3, 15, 32, 1280] output_clusters=[10, 25]>
         # <SimpleDescriptor endpoint=38 profile=260 device_type=770 device_version=0
         # input_clusters=[0, 3, 1026] output_clusters=[3]>
-        MODELS_INFO: [(DEVELCO, "WISZB-120"),(FRIENT, "WISZB-120")],
+        MODELS_INFO: [(DEVELCO, "WISZB-120"), (FRIENT, "WISZB-120")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: 0xC0C9,
@@ -139,16 +138,14 @@ class WISZB120(CustomDevice):
 
 
 class WISZB121(CustomDevice):
-    """Custom device representing door/windows sensors."""
+    """Custom device representing door/windows sensors, without built-in temperature measuring"""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=49353 device_type=1 device_version=1
         # input_clusters=[3, 5, 6] output_clusters=[]>
         # <SimpleDescriptor endpoint=35 profile=260 device_type=1026 device_version=0
         # input_clusters=[0, 1, 3, 15, 32, 1280] output_clusters=[10, 25]>
-        # <SimpleDescriptor endpoint=38 profile=260 device_type=770 device_version=0
-        # input_clusters=[0, 3, 1026] output_clusters=[3]>
-        MODELS_INFO: [(DEVELCO, "WISZB-121"),(FRIENT, "WISZB-121")],
+        MODELS_INFO: [(DEVELCO, "WISZB-121"), (FRIENT, "WISZB-121")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: 0xC0C9,

--- a/zhaquirks/develco/open_close.py
+++ b/zhaquirks/develco/open_close.py
@@ -17,6 +17,8 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
+from zhaquirks import PowerConfigurationCluster
+
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -25,8 +27,15 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.develco import DEVELCO, DevelcoPowerConfiguration
 
+from zhaquirks.develco import DEVELCO, FRIENT
+
+
+class DevelcoPowerConfiguration(PowerConfigurationCluster):
+    """Power configuration cluster."""
+
+    MIN_VOLTS = 2.5  # old 2.1
+    MAX_VOLTS = 3.0  # old 3.2
 
 class DevelcoIASZone(CustomCluster, IasZone):
     """IAS Zone."""
@@ -56,7 +65,7 @@ class WISZB120(CustomDevice):
         # input_clusters=[0, 1, 3, 15, 32, 1280] output_clusters=[10, 25]>
         # <SimpleDescriptor endpoint=38 profile=260 device_type=770 device_version=0
         # input_clusters=[0, 3, 1026] output_clusters=[3]>
-        MODELS_INFO: [(DEVELCO, "WISZB-120")],
+        MODELS_INFO: [(DEVELCO, "WISZB-120"),(FRIENT, "WISZB-120")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: 0xC0C9,
@@ -127,3 +136,67 @@ class WISZB120(CustomDevice):
             },
         }
     }
+
+
+class WISZB121(CustomDevice):
+    """Custom device representing door/windows sensors."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=49353 device_type=1 device_version=1
+        # input_clusters=[3, 5, 6] output_clusters=[]>
+        # <SimpleDescriptor endpoint=35 profile=260 device_type=1026 device_version=0
+        # input_clusters=[0, 1, 3, 15, 32, 1280] output_clusters=[10, 25]>
+        # <SimpleDescriptor endpoint=38 profile=260 device_type=770 device_version=0
+        # input_clusters=[0, 3, 1026] output_clusters=[3]>
+        MODELS_INFO: [(DEVELCO, "WISZB-121"),(FRIENT, "WISZB-121")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: 0xC0C9,
+                DEVICE_TYPE: 1,
+                INPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            35: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    BinaryInput.cluster_id,
+                    PollControl.cluster_id,
+                    IasZone.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            35: {
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DevelcoPowerConfiguration,
+                    Identify.cluster_id,
+                    BinaryInput.cluster_id,
+                    PollControl.cluster_id,
+                    DevelcoIASZone,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+        }
+    }
+    

--- a/zhaquirks/develco/open_close.py
+++ b/zhaquirks/develco/open_close.py
@@ -32,7 +32,7 @@ from zhaquirks.develco import DEVELCO, FRIENT
 class DevelcoPowerConfiguration(PowerConfigurationCluster):
     """Power configuration cluster."""
 
-    MIN_VOLTS = 2.5 #advised voltage to replace batteries
+    MIN_VOLTS = 2.5  # advised voltage to replace batteries, device will blink red when this state hits.
     MAX_VOLTS = 3.0
 
 

--- a/zhaquirks/develco/open_close.py
+++ b/zhaquirks/develco/open_close.py
@@ -196,4 +196,3 @@ class WISZB121(CustomDevice):
             },
         }
     }
-    


### PR DESCRIPTION
Added battery level support for frient Entry Sensor and Entry Sensor Pro.

## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
