### PR TITLE
Update tests for zigpy TSN changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache License Version 2.0"}
 requires-python = ">=3.8"
 dependencies = [
-    "zigpy>=0.56.0",
+    "zigpy>=0.60.3",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_kof.py
+++ b/tests/test_kof.py
@@ -34,7 +34,7 @@ async def test_kof_no_reply():
         client_commands = {}
 
     ep = mock.AsyncMock()
-    ep.device.application.get_sequence = mock.MagicMock(return_value=4)
+    ep.device.get_sequence = mock.MagicMock(return_value=4)
 
     cluster = TestCluster(ep)
 

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -245,8 +245,8 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
-            2,
-            b"\x01\x02\x00\x00\x01\x01\x01\x00\x01\x00",
+            1,
+            b"\x01\x01\x00\x00\x01\x01\x01\x00\x01\x00",
             expect_reply=True,
             command_id=0,
         )
@@ -256,8 +256,8 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
-            4,
-            b"\x01\x04\x00\x00\x03\x01\x01\x00\x01\x01",
+            2,
+            b"\x01\x02\x00\x00\x02\x01\x01\x00\x01\x01",
             expect_reply=True,
             command_id=0,
         )
@@ -1242,8 +1242,8 @@ async def test_moes(zigpy_device_from_quirk, quirk):
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
-            21,
-            b"\x01\x15\x24\x00\x08\x00\x00\x1C\x20\x00\x00\x0E\x10",
+            1,
+            b"\x01\x01\x24\x00\x08\x00\x00\x1C\x20\x00\x00\x0E\x10",
             expect_reply=False,
             command_id=0x0024,
         )

--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -36,8 +36,8 @@ async def test_command(zigpy_device_from_quirk, quirk):
 
         m1.assert_called_with(
             61184,
-            2,
-            b"\x01\x02\x00\x00\x01\x07\x01\x00\x01\x01",
+            1,
+            b"\x01\x01\x00\x00\x01\x07\x01\x00\x01\x01",
             expect_reply=True,
             command_id=0,
         )
@@ -48,8 +48,8 @@ async def test_command(zigpy_device_from_quirk, quirk):
 
         m1.assert_called_with(
             61184,
-            4,
-            b"\x01\x04\x00\x00\x03\x02\x02\x00\x04\x00\x00\x03r",
+            2,
+            b"\x01\x02\x00\x00\x02\x02\x02\x00\x04\x00\x00\x03r",
             expect_reply=True,
             command_id=0,
         )
@@ -60,8 +60,8 @@ async def test_command(zigpy_device_from_quirk, quirk):
 
         m1.assert_called_with(
             61184,
-            6,
-            b"\x01\x06\x00\x00\x05\x01\x01\x00\x01\x01",
+            3,
+            b"\x01\x03\x00\x00\x03\x01\x01\x00\x01\x01",
             expect_reply=True,
             command_id=0,
         )
@@ -73,8 +73,8 @@ async def test_command(zigpy_device_from_quirk, quirk):
         # Should not trigger switch as it is already on
         m1.assert_called_with(
             61184,
-            8,
-            b"\x01\x08\x00\x00\x07\x02\x02\x00\x04\x00\x00\x01\xea",
+            4,
+            b"\x01\x04\x00\x00\x04\x02\x02\x00\x04\x00\x00\x01\xea",
             expect_reply=True,
             command_id=0,
         )
@@ -86,8 +86,8 @@ async def test_command(zigpy_device_from_quirk, quirk):
         # Should switch off without dimming
         m1.assert_called_with(
             61184,
-            10,
-            b"\x01\x0a\x00\x00\x09\x01\x01\x00\x01\x00",
+            5,
+            b"\x01\x05\x00\x00\x05\x01\x01\x00\x01\x00",
             expect_reply=True,
             command_id=0,
         )
@@ -99,15 +99,15 @@ async def test_command(zigpy_device_from_quirk, quirk):
         # Should switch on and then switch to level
         m1.assert_any_call(
             61184,
-            13,
-            b"\x01\r\x00\x00\x0b\x01\x01\x00\x01\x01",
+            6,
+            b"\x01\x06\x00\x00\x06\x01\x01\x00\x01\x01",
             expect_reply=True,
             command_id=0,
         )
         m1.assert_called_with(
             61184,
-            14,
-            b"\x01\x0e\x00\x00\x0c\x02\x02\x00\x04\x00\x00\x00\x62",
+            7,
+            b"\x01\x07\x00\x00\x07\x02\x02\x00\x04\x00\x00\x00b",
             expect_reply=True,
             command_id=0,
         )
@@ -135,8 +135,8 @@ async def test_write_attr(zigpy_device_from_quirk, quirk):
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
-            2,
-            b"\x01\x02\x00\x00\x01\x03\x02\x00\x04\x00\x00\x00b",
+            1,
+            b"\x01\x01\x00\x00\x01\x03\x02\x00\x04\x00\x00\x00b",
             expect_reply=False,
             command_id=0,
         )

--- a/tests/test_tuya_rcbo.py
+++ b/tests/test_tuya_rcbo.py
@@ -32,8 +32,8 @@ async def test_command_rcbo(zigpy_device_from_quirk):
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
-            2,
-            b"\x01\x02\x00\x00\x01\x01\x01\x00\x01\x01",
+            1,
+            b"\x01\x01\x00\x00\x01\x01\x01\x00\x01\x01",
             expect_reply=True,
             command_id=0,
         )
@@ -45,8 +45,8 @@ async def test_command_rcbo(zigpy_device_from_quirk):
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
-            4,
-            b"\x01\x04\x00\x00\x03t\x01\x00\x01\x01",
+            2,
+            b"\x01\x02\x00\x00\x02t\x01\x00\x01\x01",
             expect_reply=True,
             command_id=0,
         )
@@ -58,8 +58,8 @@ async def test_command_rcbo(zigpy_device_from_quirk):
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
-            6,
-            b"\x01\x06\x00\x00\x05s\x01\x00\x01\x01",
+            3,
+            b"\x01\x03\x00\x00\x03s\x01\x00\x01\x01",
             expect_reply=True,
             command_id=0,
         )
@@ -211,27 +211,27 @@ async def test_report_values_rcbo(zigpy_device_from_quirk, frame, cluster, attri
     (
         (
             [],
-            b"\x01\x02\x00\x00\x01\x09\x02\x00\x04\x00\x00\x02\x58",
+            b"\x01\x01\x00\x00\x01\t\x02\x00\x04\x00\x00\x02X",
             "on_off",
             {"countdown_timer": 600},
         ),
-        ([], b"\x01\x02\x00\x00\x01\x1d\x01\x00\x01\x01", "on_off", {"child_lock": 1}),
+        ([], b"\x01\x01\x00\x00\x01\x1d\x01\x00\x01\x01", "on_off", {"child_lock": 1}),
         (
             [],
-            b"\x01\x02\x00\x00\x01\x1b\x04\x00\x01\x01",
+            b"\x01\x01\x00\x00\x01\x1b\x04\x00\x01\x01",
             "on_off",
             {"power_on_state": 1},
         ),
-        ([], b"\x01\x02\x00\x00\x01t\x01\x00\x01\x00", "on_off", {"trip": 0}),
+        ([], b"\x01\x01\x00\x00\x01t\x01\x00\x01\x00", "on_off", {"trip": 0}),
         (
             [],
-            b"\x01\x06\x00\x00\x03p\x00\x00\x03\x5a\x00\x00",
+            b"\x01\x03\x00\x00\x03p\x00\x00\x03Z\x00\x00",
             "device_temperature",
             {"high_temp_thres": 90, "over_temp_trip": 0, "dev_temp_alarm_mask": 0},
         ),
         (
             [],
-            b"\x01\x0e\x00\x00\x07m\x00\x00\x08\x01\x00\x00\x01\x2c\x00\x00\x00",
+            b"\x01\x07\x00\x00\x07m\x00\x00\x08\x01\x00\x00\x01,\x00\x00\x00",
             "electrical_measurement",
             {
                 "self_test_auto_days": 1,
@@ -245,7 +245,7 @@ async def test_report_values_rcbo(zigpy_device_from_quirk, frame, cluster, attri
         ),
         (
             [],
-            b'\x01\x0a\x00\x00\x06n\x00\x00\x08\x0b"\x00\x00\x01\xf4\x00\x00',
+            b'\x01\x04\x00\x00\x06n\x00\x00\x08\x0b"\x00\x00\x01\xf4\x00\x00',
             "electrical_measurement",
             {
                 "rms_extreme_over_voltage": 2850,
@@ -260,7 +260,7 @@ async def test_report_values_rcbo(zigpy_device_from_quirk, frame, cluster, attri
                 b'\x09\x0e\x01\x02\x03n\x00\x00\x08\x0b"\x00\x00\x01\xf4\x00\x00',
                 b"\x09\x0f\x01\x02\x03o\x00\x00\x05\x01\x86\xa0\x00\x00",
             ],
-            b"\x01\x08\x00\x00\x04o\x00\x00\x05\x01\x5f\x90\x01\x01",
+            b"\x01\x04\x00\x00\x04o\x00\x00\x05\x01_\x90\x01\x01",
             "electrical_measurement",
             {
                 "ac_current_overload": 90000,
@@ -273,7 +273,7 @@ async def test_report_values_rcbo(zigpy_device_from_quirk, frame, cluster, attri
                 b'\x09\x0e\x01\x02\x03n\x00\x00\x08\x0b"\x00\x00\x01\xf4\x00\x00',
                 b"\x09\x0f\x01\x02\x03o\x00\x00\x05\x01\x86\xa0\x00\x01",
             ],
-            b"\x01\x02\x00\x00\x01o\x00\x00\x05\x01\x86\xa0\x00\x01",
+            b"\x01\x01\x00\x00\x01o\x00\x00\x05\x01\x86\xa0\x00\x01",
             "electrical_measurement",
             {
                 "ac_current_overload": 100000,
@@ -281,7 +281,7 @@ async def test_report_values_rcbo(zigpy_device_from_quirk, frame, cluster, attri
         ),
         (
             [],
-            b"\x01\x04\x00\x00\x02l\x00\x00\x03\x14\xb4\x01",
+            b"\x01\x02\x00\x00\x02l\x00\x00\x03\x14\xb4\x01",
             "smartenergy_metering",
             {"cost_parameters": 5300, "cost_parameters_enabled": 1},
         ),

--- a/tests/test_tuya_valve.py
+++ b/tests/test_tuya_valve.py
@@ -32,8 +32,8 @@ async def test_command_psbzs(zigpy_device_from_quirk, quirk):
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
-            2,
-            b"\x01\x02\x00\x00\x01\x01\x01\x00\x01\x01",
+            1,
+            b"\x01\x01\x00\x00\x01\x01\x01\x00\x01\x01",
             expect_reply=True,
             command_id=0,
         )
@@ -58,8 +58,8 @@ async def test_write_attr_psbzs(zigpy_device_from_quirk, quirk):
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
-            2,
-            b"\x01\x02\x00\x00\x01\x05\x02\x00\x04\x00\x00\x00\x0f",
+            1,
+            b"\x01\x01\x00\x00\x01\x05\x02\x00\x04\x00\x00\x00\x0f",
             expect_reply=False,
             command_id=0,
         )
@@ -75,8 +75,8 @@ async def test_write_attr_psbzs(zigpy_device_from_quirk, quirk):
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
             61184,
-            4,
-            b"\x01\x04\x00\x00\x03\x6d\x01\x00\x01\x00",
+            2,
+            b"\x01\x02\x00\x00\x02m\x01\x00\x01\x00",
             expect_reply=False,
             command_id=0,
         )


### PR DESCRIPTION
## Proposed change
This updates zha-quirks tests to account for the [per-device TSNs](https://github.com/zigpy/zigpy/pull/1309) in zigpy [0.60.3](https://github.com/zigpy/zigpy/releases/tag/0.60.3) and later.
The tests do not pass without this change when using zigpy 0.60.3 or later.

The minimum required zigpy version is also bumped to 0.60.3, although only the tests "need" this.

## Additional information
cc @puddly 


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
