### PR TITLE
Some Tuya devices require a data_query package to awake and send data.

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -37,6 +37,7 @@ TUYA_CLUSTER_1888_ID = 0x1888
 TUYA_SET_DATA = 0x00
 TUYA_GET_DATA = 0x01
 TUYA_SET_DATA_RESPONSE = 0x02
+TUYA_QUERY_DATA = 0x03
 TUYA_SEND_DATA = 0x04
 TUYA_ACTIVE_STATUS_RPT = 0x06
 TUYA_SET_TIME = 0x24
@@ -1488,6 +1489,9 @@ class TuyaNewManufCluster(CustomCluster):
     ep_attribute: str = "tuya_manufacturer"
 
     server_commands = {
+        TUYA_QUERY_DATA: foundation.ZCLCommandDef(
+             "query_data", {}, False, is_manufacturer_specific=True
+        ),
         TUYA_SET_DATA: foundation.ZCLCommandDef(
             "set_data", {"data": TuyaCommand}, False, is_manufacturer_specific=True
         ),

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1490,7 +1490,7 @@ class TuyaNewManufCluster(CustomCluster):
 
     server_commands = {
         TUYA_QUERY_DATA: foundation.ZCLCommandDef(
-             "query_data", {}, False, is_manufacturer_specific=True
+            "query_data", {}, False, is_manufacturer_specific=True
         ),
         TUYA_SET_DATA: foundation.ZCLCommandDef(
             "set_data", {"data": TuyaCommand}, False, is_manufacturer_specific=True


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Some Tuya devices require a Tuya query_data packet to awake and send  data. 
As suggested by tjj, this adds this capability.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Will contribute to fix https://github.com/zigpy/zha-device-handlers/issues/2565

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works

I couldn't find an informative test for this. 
