### PR TITLE
Add support for extra functions of Hue Tap Dial Switch (RDM002).

### DIFF
--- a/zhaquirks/philips/rdm002
+++ b/zhaquirks/philips/rdm002
@@ -28,7 +28,6 @@ from zhaquirks.const import (
     COMMAND,
     COMMAND_ID,
     DEVICE_TYPE,
-    DOUBLE_PRESS,
     ENDPOINTS,
     INPUT_CLUSTERS,
     LONG_PRESS,
@@ -37,12 +36,9 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PRESS_TYPE,
     PROFILE_ID,
-    QUADRUPLE_PRESS,
-    QUINTUPLE_PRESS,
     RIGHT,
     SHORT_PRESS,
     SHORT_RELEASE,
-    TRIPLE_PRESS,
     TURN_ON,
     ZHA_SEND_EVENT,
 )
@@ -93,12 +89,7 @@ class PhilipsRemoteCluster(CustomCluster):
             direction=foundation.Direction.Server_to_Client,
         )
     }
-    BUTTONS = {
-        1: "button_1",
-        2: "button_2",
-        3: "button_3",
-        4: "button_4",
-    }
+    BUTTONS = {1: "button_1", 2: "button_2", 3: "button_3", 4: "button_4"}
     PRESS_TYPES = {0: "press", 1: "hold", 2: "press_release", 3: "hold_release"}
 
     def handle_cluster_request(

--- a/zhaquirks/philips/rdm002
+++ b/zhaquirks/philips/rdm002
@@ -1,0 +1,151 @@
+"""Philips RDM002 device."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    PowerConfiguration,
+    Scenes,
+)
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    ARGS,
+    BUTTON,
+    COMMAND,
+    COMMAND_ID,
+    DIM_DOWN,
+    DIM_UP,
+    DOUBLE_PRESS,
+    LONG_PRESS,
+    LONG_RELEASE,
+    PRESS_TYPE,
+    QUADRUPLE_PRESS,
+    QUINTUPLE_PRESS,
+    SHORT_PRESS,
+    SHORT_RELEASE,
+    TRIPLE_PRESS,
+    TURN_OFF,
+    TURN_ON,
+    ZHA_SEND_EVENT,
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    BUTTON_4,
+)
+from zhaquirks.philips import (
+    SIGNIFY,
+    PhilipsBasicCluster,
+    PhilipsRemoteCluster,
+)
+
+DEVICE_SPECIFIC_UNKNOWN = 64512
+
+
+HUE_REMOTE_DEVICE_TRIGGERS = {
+    (SHORT_PRESS, BUTTON_1): {COMMAND: "on_press"},
+    (SHORT_PRESS, BUTTON_2): {COMMAND: "up_press"},
+    (SHORT_PRESS, BUTTON_3): {COMMAND: "down_press"},
+    (SHORT_PRESS, BUTTON_4): {COMMAND: "off_press"},
+    (LONG_PRESS, BUTTON_1): {COMMAND: "on_hold"},
+    (LONG_PRESS, BUTTON_2): {COMMAND: "up_hold"},
+    (LONG_PRESS, BUTTON_3): {COMMAND: "down_hold"},
+    (LONG_PRESS, BUTTON_4): {COMMAND: "off_hold"},
+    (DOUBLE_PRESS, BUTTON_1): {COMMAND: "on_double_press"},
+    (DOUBLE_PRESS, BUTTON_2): {COMMAND: "up_double_press"},
+    (DOUBLE_PRESS, BUTTON_3): {COMMAND: "down_double_press"},
+    (DOUBLE_PRESS, BUTTON_4): {COMMAND: "off_double_press"},
+    (TRIPLE_PRESS, BUTTON_1): {COMMAND: "on_triple_press"},
+    (TRIPLE_PRESS, BUTTON_2): {COMMAND: "up_triple_press"},
+    (TRIPLE_PRESS, BUTTON_3): {COMMAND: "down_triple_press"},
+    (TRIPLE_PRESS, BUTTON_4): {COMMAND: "off_triple_press"},
+    (QUADRUPLE_PRESS, BUTTON_1): {COMMAND: "on_quadruple_press"},
+    (QUADRUPLE_PRESS, BUTTON_2): {COMMAND: "up_quadruple_press"},
+    (QUADRUPLE_PRESS, BUTTON_3): {COMMAND: "down_quadruple_press"},
+    (QUADRUPLE_PRESS, BUTTON_4): {COMMAND: "off_quadruple_press"},
+    (QUINTUPLE_PRESS, BUTTON_1): {COMMAND: "on_quintuple_press"},
+    (QUINTUPLE_PRESS, BUTTON_2): {COMMAND: "up_quintuple_press"},
+    (QUINTUPLE_PRESS, BUTTON_3): {COMMAND: "down_quintuple_press"},
+    (QUINTUPLE_PRESS, BUTTON_4): {COMMAND: "off_quintuple_press"},
+    (SHORT_RELEASE, BUTTON_1): {COMMAND: "on_short_release"},
+    (SHORT_RELEASE, BUTTON_2): {COMMAND: "up_short_release"},
+    (SHORT_RELEASE, BUTTON_3): {COMMAND: "down_short_release"},
+    (SHORT_RELEASE, BUTTON_4): {COMMAND: "off_short_release"},
+    (LONG_RELEASE, BUTTON_1): {COMMAND: "on_long_release"},
+    (LONG_RELEASE, BUTTON_2): {COMMAND: "up_long_release"},
+    (LONG_RELEASE, BUTTON_3): {COMMAND: "down_long_release"},
+    (LONG_RELEASE, BUTTON_4): {COMMAND: "off_long_release"},
+}
+
+
+class RDM002(CustomDevice):
+    """Philips RDM002 device."""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=2096
+        #  device_version=1
+        #  input_clusters=[0, 1, 3, 64512, 4096]
+        #  output_clusters=[25, 0, 3, 4, 6, 8, 5, 4096]>
+        MODELS_INFO: [(SIGNIFY, "RDM002")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    DEVICE_SPECIFIC_UNKNOWN,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Scenes.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    PhilipsBasicCluster,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PhilipsRemoteCluster,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Scenes.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        }
+    }
+
+    device_automation_triggers = HUE_REMOTE_DEVICE_TRIGGERS

--- a/zhaquirks/philips/rdm002
+++ b/zhaquirks/philips/rdm002
@@ -1,6 +1,11 @@
 """Philips RDM002 device."""
+import logging
+from typing import Any, List, Optional, Union
+
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -14,81 +19,120 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lightlink import LightLink
 
 from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
     ARGS,
     BUTTON,
-    COMMAND,
-    COMMAND_ID,
-    DIM_DOWN,
-    DIM_UP,
-    DOUBLE_PRESS,
-    LONG_PRESS,
-    LONG_RELEASE,
-    PRESS_TYPE,
-    QUADRUPLE_PRESS,
-    QUINTUPLE_PRESS,
-    SHORT_PRESS,
-    SHORT_RELEASE,
-    TRIPLE_PRESS,
-    TURN_OFF,
-    TURN_ON,
-    ZHA_SEND_EVENT,
     BUTTON_1,
     BUTTON_2,
     BUTTON_3,
     BUTTON_4,
+    COMMAND,
+    COMMAND_ID,
+    DEVICE_TYPE,
+    DOUBLE_PRESS,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    LONG_PRESS,
+    LONG_RELEASE,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PRESS_TYPE,
+    PROFILE_ID,
+    QUADRUPLE_PRESS,
+    QUINTUPLE_PRESS,
+    RIGHT,
+    SHORT_PRESS,
+    SHORT_RELEASE,
+    TRIPLE_PRESS,
+    TURN_ON,
+    ZHA_SEND_EVENT,
 )
-from zhaquirks.philips import (
-    SIGNIFY,
-    PhilipsBasicCluster,
-    PhilipsRemoteCluster,
-)
+from zhaquirks.philips import PHILIPS, SIGNIFY
 
 DEVICE_SPECIFIC_UNKNOWN = 64512
+_LOGGER = logging.getLogger(__name__)
 
 
-HUE_REMOTE_DEVICE_TRIGGERS = {
-    (SHORT_PRESS, BUTTON_1): {COMMAND: "on_press"},
-    (SHORT_PRESS, BUTTON_2): {COMMAND: "up_press"},
-    (SHORT_PRESS, BUTTON_3): {COMMAND: "down_press"},
-    (SHORT_PRESS, BUTTON_4): {COMMAND: "off_press"},
-    (LONG_PRESS, BUTTON_1): {COMMAND: "on_hold"},
-    (LONG_PRESS, BUTTON_2): {COMMAND: "up_hold"},
-    (LONG_PRESS, BUTTON_3): {COMMAND: "down_hold"},
-    (LONG_PRESS, BUTTON_4): {COMMAND: "off_hold"},
-    (DOUBLE_PRESS, BUTTON_1): {COMMAND: "on_double_press"},
-    (DOUBLE_PRESS, BUTTON_2): {COMMAND: "up_double_press"},
-    (DOUBLE_PRESS, BUTTON_3): {COMMAND: "down_double_press"},
-    (DOUBLE_PRESS, BUTTON_4): {COMMAND: "off_double_press"},
-    (TRIPLE_PRESS, BUTTON_1): {COMMAND: "on_triple_press"},
-    (TRIPLE_PRESS, BUTTON_2): {COMMAND: "up_triple_press"},
-    (TRIPLE_PRESS, BUTTON_3): {COMMAND: "down_triple_press"},
-    (TRIPLE_PRESS, BUTTON_4): {COMMAND: "off_triple_press"},
-    (QUADRUPLE_PRESS, BUTTON_1): {COMMAND: "on_quadruple_press"},
-    (QUADRUPLE_PRESS, BUTTON_2): {COMMAND: "up_quadruple_press"},
-    (QUADRUPLE_PRESS, BUTTON_3): {COMMAND: "down_quadruple_press"},
-    (QUADRUPLE_PRESS, BUTTON_4): {COMMAND: "off_quadruple_press"},
-    (QUINTUPLE_PRESS, BUTTON_1): {COMMAND: "on_quintuple_press"},
-    (QUINTUPLE_PRESS, BUTTON_2): {COMMAND: "up_quintuple_press"},
-    (QUINTUPLE_PRESS, BUTTON_3): {COMMAND: "down_quintuple_press"},
-    (QUINTUPLE_PRESS, BUTTON_4): {COMMAND: "off_quintuple_press"},
-    (SHORT_RELEASE, BUTTON_1): {COMMAND: "on_short_release"},
-    (SHORT_RELEASE, BUTTON_2): {COMMAND: "up_short_release"},
-    (SHORT_RELEASE, BUTTON_3): {COMMAND: "down_short_release"},
-    (SHORT_RELEASE, BUTTON_4): {COMMAND: "off_short_release"},
-    (LONG_RELEASE, BUTTON_1): {COMMAND: "on_long_release"},
-    (LONG_RELEASE, BUTTON_2): {COMMAND: "up_long_release"},
-    (LONG_RELEASE, BUTTON_3): {COMMAND: "down_long_release"},
-    (LONG_RELEASE, BUTTON_4): {COMMAND: "off_long_release"},
-}
+class PhilipsBasicCluster(CustomCluster, Basic):
+    """Philips Basic cluster."""
+
+    attributes = Basic.attributes.copy()
+    attributes.update(
+        {
+            0x0031: ("philips", t.bitmap16, True),
+            0x0034: ("mode", t.enum8, True),
+        }
+    )
+
+    attr_config = {0x0031: 0x000B, 0x0034: 0x02}
+
+    async def bind(self):
+        """Bind cluster."""
+        result = await super().bind()
+        await self.write_attributes(self.attr_config, manufacturer=0x100B)
+        return result
 
 
-class RDM002(CustomDevice):
+class PhilipsRemoteCluster(CustomCluster):
+    """Philips remote cluster."""
+
+    cluster_id = 64512
+    name = "PhilipsRemoteCluster"
+    ep_attribute = "philips_remote_cluster"
+    client_commands = {
+        0x00: foundation.ZCLCommandDef(
+            "notification",
+            {
+                "param1": t.uint8_t,
+                "param2": t.uint24_t,
+                "param3": t.uint8_t,
+                "param4": t.uint8_t,
+                "param5": t.uint8_t,
+                "param6": t.uint8_t,
+            },
+            is_manufacturer_specific=True,
+            direction=foundation.Direction.Server_to_Client,
+        )
+    }
+    BUTTONS = {
+        1: "button_1",
+        2: "button_2",
+        3: "button_3",
+        4: "button_4",
+    }
+    PRESS_TYPES = {0: "press", 1: "hold", 2: "press_release", 3: "hold_release"}
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: List[Any],
+        *,
+        dst_addressing: Optional[
+            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
+        ] = None,
+    ):
+        """Handle the cluster command."""
+        _LOGGER.debug(
+            "PhilipsRemoteCluster - handle_cluster_request tsn: [%s] command id: %s - args: [%s]",
+            hdr.tsn,
+            hdr.command_id,
+            args,
+        )
+
+        button = self.BUTTONS.get(args[0], args[0])
+        press_type = self.PRESS_TYPES.get(args[2], args[2])
+
+        event_args = {
+            BUTTON: button,
+            PRESS_TYPE: press_type,
+            COMMAND_ID: hdr.command_id,
+            ARGS: args,
+        }
+
+        action = f"{button}_{press_type}"
+        self.listener_event(ZHA_SEND_EVENT, action, event_args)
+
+
+class TapDialSwitch(CustomDevice):
     """Philips RDM002 device."""
 
     signature = {
@@ -132,20 +176,33 @@ class RDM002(CustomDevice):
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     PhilipsRemoteCluster,
-                    LightLink.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Ota.cluster_id,
-                    Basic.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     OnOff.cluster_id,
                     LevelControl.cluster_id,
-                    Scenes.cluster_id,
-                    LightLink.cluster_id,
                 ],
             }
         }
     }
 
-    device_automation_triggers = HUE_REMOTE_DEVICE_TRIGGERS
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON_1): {COMMAND: "button_1_press"},
+        (SHORT_PRESS, BUTTON_2): {COMMAND: "button_2_press"},
+        (SHORT_PRESS, BUTTON_3): {COMMAND: "button_3_press"},
+        (SHORT_PRESS, BUTTON_4): {COMMAND: "button_4_press"},
+        (LONG_PRESS, BUTTON_1): {COMMAND: "button_1_hold"},
+        (LONG_PRESS, BUTTON_2): {COMMAND: "button_2_hold"},
+        (LONG_PRESS, BUTTON_3): {COMMAND: "button_3_hold"},
+        (LONG_PRESS, BUTTON_4): {COMMAND: "button_4_hold"},
+        (SHORT_RELEASE, BUTTON_1): {COMMAND: "button_1_short_release"},
+        (SHORT_RELEASE, BUTTON_2): {COMMAND: "button_2_short_release"},
+        (SHORT_RELEASE, BUTTON_3): {COMMAND: "button_3_short_release"},
+        (SHORT_RELEASE, BUTTON_4): {COMMAND: "button_4_short_release"},
+        (LONG_RELEASE, BUTTON_1): {COMMAND: "button_1_long_release"},
+        (LONG_RELEASE, BUTTON_2): {COMMAND: "button_2_long_release"},
+        (LONG_RELEASE, BUTTON_3): {COMMAND: "button_3_long_release"},
+        (LONG_RELEASE, BUTTON_4): {COMMAND: "button_4_long_release"},
+    }


### PR DESCRIPTION
Based on RWL022/RDM001, added support for button actions like in Z2M.

Added:
button_1_press, button_1_press_release, button_1_hold, button_1_hold_release
button_2_press, button_2_press_release, button_2_hold, button_2_hold_release
button_3_press, button_3_press_release, button_3_hold, button_3_hold_release
button_4_press, button_4_press_release, button_4_hold, button_4_hold_release

The dial functions were already supported without quirk.

## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
