### PR TITLE
Add Sonoff SNZB-06P presence sensor support

### DIFF
--- a/zhaquirks/sonoff/snzb06p.py
+++ b/zhaquirks/sonoff/snzb06p.py
@@ -29,9 +29,8 @@ class IlluminationStatus(t.enum8):
 class SonoffFC11Cluster(CustomCluster):
     """Sonoff manufacture specific cluster that provides illuminance."""
 
-    name = "Sonoff Manufacture Specific Cluster at 0xFC11"
     cluster_id = SONOFF_CLUSTER_FC11_ID
-    ep_attribute = "sonoff_manufacturer_specific_FC11"
+    ep_attribute = "sonoff_manufacturer"
     attributes = {
         ATTR_SONOFF_ILLUMINATION_STATUS: ("last_illumination_state", IlluminationStatus)
     }

--- a/zhaquirks/sonoff/snzb06p.py
+++ b/zhaquirks/sonoff/snzb06p.py
@@ -1,0 +1,87 @@
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic, Identify, Ota
+from zigpy.zcl.clusters.measurement import OccupancySensing
+from zigpy.zcl.clusters.security import IasZone
+
+SONOFF_CLUSTER_FC11_ID = 0xFC11
+SONOFF_CLUSTER_FC57_ID = 0xFC57
+ATTR_SONOFF_ILLUMINATION_STATUS = 0x2001
+
+
+class IlluminationStatus(t.enum8):
+    """Last measureed state of illumination enum."""
+
+    Dark = 0x00
+    Light = 0x01
+
+
+class SonoffFC11Cluster(CustomCluster):
+    """Sonoff manufacture specific cluster that provides illuminance."""
+
+    name = "Sonoff Manufacture Specific Cluster at 0xFC11"
+    cluster_id = SONOFF_CLUSTER_FC11_ID
+    ep_attribute = "sonoff_manufacturer_specific_FC11"
+    attributes = {
+        ATTR_SONOFF_ILLUMINATION_STATUS: ("last_illumination_state", IlluminationStatus)
+    }
+
+
+class SonoffPresenceSenorSNZB06P(CustomDevice):
+    """Sonoff human presence senor - model SNZB-06P."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1, profile=260, device_type=263
+        # device_version=1
+        # input_clusters=[0, 3, 1030, 1280, 64599, 64529]
+        # output_clusters=[3, 25]>
+        MODELS_INFO: [
+            ("SONOFF", "SNZB-06P"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OccupancySensing.cluster_id,
+                    IasZone.cluster_id,
+                    SONOFF_CLUSTER_FC11_ID,
+                    SONOFF_CLUSTER_FC57_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OccupancySensing.cluster_id,
+                    SonoffFC11Cluster,
+                    SONOFF_CLUSTER_FC57_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }

--- a/zhaquirks/sonoff/snzb06p.py
+++ b/zhaquirks/sonoff/snzb06p.py
@@ -1,3 +1,10 @@
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic, Identify, Ota
+from zigpy.zcl.clusters.measurement import OccupancySensing
+from zigpy.zcl.clusters.security import IasZone
+
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -6,12 +13,6 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
-import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, Identify, Ota
-from zigpy.zcl.clusters.measurement import OccupancySensing
-from zigpy.zcl.clusters.security import IasZone
 
 SONOFF_CLUSTER_FC11_ID = 0xFC11
 SONOFF_CLUSTER_FC57_ID = 0xFC57


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Improving the support for the Sonoff SNZB-06P

Main changes by this quirk:
* remove redundant IaS Zone cluster as it doesn't provide anything useful that is not already provided from the Occupancy cluster and removes a second entity being created.
* Adds support for Sonoff specific cluster which has the illumination state (Light or Dark) when presence was last detected. 

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Thanks to @theorlangur  and their work on https://github.com/zigpy/zha-device-handlers/pull/2869.

When combined with https://github.com/home-assistant/core/pull/107379, solves https://github.com/zigpy/zha-device-handlers/issues/2702


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
