### PR TITLE
Update Tuya RCBO quirk power factor calculation for home-assistant/core#107641

### DIFF
--- a/tests/test_tuya_rcbo.py
+++ b/tests/test_tuya_rcbo.py
@@ -346,11 +346,11 @@ async def test_power_factor(zigpy_device_from_quirk):
         b"\x09\x07\x01\x02\x03g\x00\x00\x0c\x00\x09\xbf\x00\x09\xbf\x00\x00\x00\x00\x00\x00"
     )
     tuya_cluster.handle_message(hdr, args)  # active_power
-    assert tuya_listener.attribute_updates == [(0x050B, 2495), (0x0510, 1000)]
+    assert tuya_listener.attribute_updates == [(0x050B, 2495), (0x0510, 100)]
 
     tuya_listener.attribute_updates = []
     hdr, args = tuya_cluster.deserialize(
         b"\x09\x08\x01\x02\x03g\x00\x00\x0c\x00\x06\x4b\x00\x06\x4b\x00\x00\x00\x00\x00\x00"
     )
     tuya_cluster.handle_message(hdr, args)  # active_power
-    assert tuya_listener.attribute_updates == [(0x050B, 1611), (0x0510, 987)]
+    assert tuya_listener.attribute_updates == [(0x050B, 1611), (0x0510, 99)]

--- a/zhaquirks/tuya/ts0601_rcbo.py
+++ b/zhaquirks/tuya/ts0601_rcbo.py
@@ -251,7 +251,7 @@ class TuyaRCBOElectricalMeasurement(ElectricalMeasurement, TuyaAttributesCluster
                 power_factor = value / apparent_power * 100
                 if power_factor > 100:
                     power_factor = 100
-                super().update_attribute("power_factor", int(power_factor))
+                super().update_attribute("power_factor", int(round(power_factor)))
 
 
 class TuyaRCBODeviceTemperature(DeviceTemperature, TuyaAttributesCluster):

--- a/zhaquirks/tuya/ts0601_rcbo.py
+++ b/zhaquirks/tuya/ts0601_rcbo.py
@@ -248,9 +248,9 @@ class TuyaRCBOElectricalMeasurement(ElectricalMeasurement, TuyaAttributesCluster
         if attr_name == "active_power":
             apparent_power = self.get("apparent_power")
             if apparent_power:
-                power_factor = value / apparent_power * 1000
-                if power_factor > 1000:
-                    power_factor = 1000
+                power_factor = value / apparent_power * 100
+                if power_factor > 100:
+                    power_factor = 100
                 super().update_attribute("power_factor", int(power_factor))
 
 

--- a/zhaquirks/tuya/ts0601_rcbo.py
+++ b/zhaquirks/tuya/ts0601_rcbo.py
@@ -251,7 +251,7 @@ class TuyaRCBOElectricalMeasurement(ElectricalMeasurement, TuyaAttributesCluster
                 power_factor = value / apparent_power * 100
                 if power_factor > 100:
                     power_factor = 100
-                super().update_attribute("power_factor", int(round(power_factor)))
+                super().update_attribute("power_factor", round(power_factor))
 
 
 class TuyaRCBODeviceTemperature(DeviceTemperature, TuyaAttributesCluster):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Amend power_factor calculation to respect Zigbee cluster specification - required for release of zha fix:

https://github.com/home-assistant/core/pull/107641

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

This updates the power factor calculation to multiply by 100 rather than 1000, this is because the ElectricalMeasurement attribute is supposed to expose values between -100 and 100 (see the pre-requisite PR 107641 for details).

The current code exposes values between 0 and 1000, which is subsequently divided by 10 due to the behaviour of the zha cluster sensor corrected in https://github.com/home-assistant/core/pull/107641

If released without https://github.com/home-assistant/core/pull/107641 the value reported will be an order of magnitude too low.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
