### PR TITLE
Add support for new version of 1/2 gang MOES dimmer modules

### DIFF
--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -49,6 +49,7 @@ class TuyaSingleSwitchDimmer(TuyaDimmerSwitch):
             ("_TZE200_a0syesf5", "TS0601"),  # Added for Mercator IKUU SSWRM-ZB
             ("_TZE200_p0gzbqct", "TS0601"),
             ("_TZE200_w4cryh2i", "TS0601"),
+            ("_TZE204_dcnsggvz", "TS0601")
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0051
@@ -93,6 +94,7 @@ class TuyaDoubleSwitchDimmer(TuyaDimmerSwitch):
     signature = {
         MODELS_INFO: [
             ("_TZE200_e3oitdyu", "TS0601"),
+            ("_TZE204_bxoo2swd", "TS0601")
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0051

--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -49,7 +49,7 @@ class TuyaSingleSwitchDimmer(TuyaDimmerSwitch):
             ("_TZE200_a0syesf5", "TS0601"),  # Added for Mercator IKUU SSWRM-ZB
             ("_TZE200_p0gzbqct", "TS0601"),
             ("_TZE200_w4cryh2i", "TS0601"),
-            ("_TZE204_dcnsggvz", "TS0601")
+            ("_TZE204_dcnsggvz", "TS0601"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0051
@@ -94,7 +94,7 @@ class TuyaDoubleSwitchDimmer(TuyaDimmerSwitch):
     signature = {
         MODELS_INFO: [
             ("_TZE200_e3oitdyu", "TS0601"),
-            ("_TZE204_bxoo2swd", "TS0601")
+            ("_TZE204_bxoo2swd", "TS0601"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0051


### PR DESCRIPTION
## Proposed change
Add model info for new versions of 1 gang and 2 gang MOES zigbee dimmers to TuyaSingleSwitchDimmer and TuyaDoubleSwitchDimmer respectively.

## Additional information
1 gang dimmer: 
 - ZM-105-M
 - _TZE204_dcnsggvz

2 gang dimmer: 
 - ZM-105B-M
 - _TZE204_bxoo2swd

https://moeshouse.com/products/zigbee-smart-dimmer-switch-module-timer?variant=47134032691515

## Checklist
- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
