### PR TITLE
Add Aqara E1 2-gang switch support (w/o neutral) `QBKG39LM`

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -22,3 +22,4 @@
 - [Michael Thingnes](https://github.com/thimic)
 - [Piotr Mis](https://github.com/piomis)
 - [Julien Rivaud](https://github.com/FrnchFrgg)
+- [Matthew Simpson](https://github.com/typhoon2099)

--- a/zhaquirks/xiaomi/aqara/b2lc04.py
+++ b/zhaquirks/xiaomi/aqara/b2lc04.py
@@ -1,0 +1,175 @@
+"""Xiaomi aqara double key wall switch devices."""
+
+from zigpy import types as t
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import (
+    AnalogInput,
+    Basic,
+    BinaryOutput,
+    DeviceTemperature,
+    Groups,
+    Identify,
+    MultistateInput,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+    Alarms,
+)
+
+from zhaquirks import Bus, EventableCluster
+from zhaquirks.const import (
+    ARGS,
+    ATTRIBUTE_ID,
+    ATTRIBUTE_NAME,
+    BUTTON_1,
+    BUTTON_2,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_ATTRIBUTE_UPDATED,
+    DEVICE_TYPE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+    SKIP_CONFIGURATION,
+    VALUE,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    AnalogInputCluster,
+    BasicCluster,
+    OnOffCluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
+)
+from zhaquirks.xiaomi.aqara.opple_switch import (
+    OppleSwitchCluster,
+)
+
+ATTRIBUTE_PRESENT_VALUE = "present_value"
+
+
+class B2lc04(XiaomiCustomDevice):
+    """Aqara double key switch device."""
+
+    class WallSwitchMultistateInputCluster(EventableCluster, MultistateInput):
+        """WallSwitchMultistateInputCluster: fire events corresponding to press type."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.power_bus = Bus()
+        super().__init__(*args, **kwargs)
+
+    # Signature
+    #  "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4447, maximum_buffer_size=127, maximum_incoming_transfer_size=100, server_mask=11264, maximum_outgoing_transfer_size=100, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
+    signature = {
+        #  "manufacturer": "LUMI",
+        #  "model": "lumi.switch.b2lc04",
+        MODELS_INFO: [(LUMI, "lumi.switch.b2lc04")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DeviceTemperature.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    Alarms.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: 0xA1E0,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [0x0021],
+            },
+        },
+    }
+
+    replacement = {
+        SKIP_CONFIGURATION: True,
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DeviceTemperature.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    Alarms.cluster_id,
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            41: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    WallSwitchMultistateInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            42: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    WallSwitchMultistateInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            51: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    WallSwitchMultistateInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: 0xA1E0,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [0x0021],
+            },
+        },
+    }


### PR DESCRIPTION
## Proposed change

Add a Quirk for Xiaomi Aqara B2LC04. This has been discussed on #1810 and now I'm trying to get the changes added instead of keeping a custom quirk lying around that someone can make use of.


## Additional information

I'm unsure on testing and whether or not I've duplicated code (I have a feeling I have as this is originally based on something, but I honestly can't remember where I got the base file from.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
