### PR TITLE
Add manufacturer cluster for Sonoff SNZB-02D

### DIFF
--- a/tests/test_sonoff.py
+++ b/tests/test_sonoff.py
@@ -1,0 +1,35 @@
+"""Tests for Sonoff quirks."""
+
+
+import zhaquirks
+
+zhaquirks.setup()
+
+def test_sonoff_snzb02d(assert_signature_matches_quirk):
+    """Test 'Sonoff LCD Smart Temperature Humidity Sensor' signature is matched to its quirk."""
+
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4742, maximum_buffer_size=82, maximum_incoming_transfer_size=255, server_mask=11264, maximum_outgoing_transfer_size=255, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 260,
+                "device_type": "0x0302",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0001",
+                    "0x0003",
+                    "0x0020",
+                    "0x0402",
+                    "0x0405",
+                    "0xfc11",
+                    "0xfc57",
+                ],
+                "out_clusters": ["0x0019"],
+            }
+        },
+        "manufacturer": "SONOFF",
+        "model": "SNZB-02D",
+        "class": "zigpy.device.Device",
+    }
+
+    assert_signature_matches_quirk(zhaquirks.sonoff.snzb02d.SonoffSNZB02D, signature)

--- a/zhaquirks/sonoff/__init__.py
+++ b/zhaquirks/sonoff/__init__.py
@@ -1,1 +1,78 @@
 """Quirks for Sonoff devices."""
+from __future__ import annotations
+
+from typing import Any, Final
+
+from zigpy.quirks import CustomCluster
+import zigpy.types as t
+from zigpy.types.basic import enum_factory
+from zigpy.zcl.foundation import (
+    BaseAttributeDefs,
+    Direction,
+    GeneralCommand,
+    ZCLAttributeDef,
+    ZCLHeader,
+)
+
+WWAH_CLUSTER_ID = 0xFC57
+
+
+class DisplayUnit(enum_factory(t.uint16_t)):
+    Celsius = 0
+    Fahrenheit = 1
+
+
+class SonoffClusterFC11(CustomCluster):
+    """Sonoff custom cluster."""
+
+    DisplayUnit: Final = DisplayUnit
+
+    cluster_id = 0xFC11
+    name = "SonoffClusterFC11"
+
+    class AttributeDefs(BaseAttributeDefs):
+        high_temperature_threshold: Final = ZCLAttributeDef(
+            id=0x0003, type=t.int16s, access="rwp", is_manufacturer_specific=True
+        )
+        low_temperature_threshold: Final = ZCLAttributeDef(
+            id=0x0004, type=t.int16s, access="rwp", is_manufacturer_specific=True
+        )
+        low_humidity_threshold: Final = ZCLAttributeDef(
+            id=0x0005, type=t.uint16_t, access="rwp", is_manufacturer_specific=True
+        )
+        high_humidity_threshold: Final = ZCLAttributeDef(
+            id=0x0006, type=t.uint16_t, access="rwp", is_manufacturer_specific=True
+        )
+        display_unit: Final = ZCLAttributeDef(
+            id=0x0007, type=DisplayUnit, access="rwp", is_manufacturer_specific=True
+        )
+        unknown_fffd: Final = ZCLAttributeDef(
+            id=0xFFFD, type=t.uint16_t, access="rwp", is_manufacturer_specific=True
+        )
+
+    def _create_request(
+        self,
+        *,
+        general: bool,
+        command_id: GeneralCommand | int,
+        schema: dict | t.Struct,
+        manufacturer: int | None = None,
+        tsn: int | None = None,
+        disable_default_response: bool,
+        direction: Direction,
+        # Schema args and kwargs
+        args: tuple[Any, ...],
+        kwargs: Any,
+    ) -> tuple[ZCLHeader, bytes]:
+        """Override all request to disable manufacturer."""
+        return super()._create_request(
+            general=general,
+            command_id=command_id,
+            schema=schema,
+            manufacturer=ZCLHeader.NO_MANUFACTURER_ID,
+            tsn=tsn,
+            disable_default_response=disable_default_response,
+            direction=direction,
+            args=args,
+            kwargs=kwargs,
+        )

--- a/zhaquirks/sonoff/snzb02d.py
+++ b/zhaquirks/sonoff/snzb02d.py
@@ -1,12 +1,8 @@
 """Module for Philips quirks implementations."""
 from __future__ import annotations
 
-from typing import Any, Final
-
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
-import zigpy.types as t
-from zigpy.types.basic import enum_factory
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
     Identify,
@@ -15,13 +11,6 @@ from zigpy.zcl.clusters.general import (
     PowerConfiguration,
 )
 from zigpy.zcl.clusters.measurement import RelativeHumidity, TemperatureMeasurement
-from zigpy.zcl.foundation import (
-    BaseAttributeDefs,
-    Direction,
-    GeneralCommand,
-    ZCLAttributeDef,
-    ZCLHeader,
-)
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -32,68 +21,9 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 
+from . import SonoffClusterFC11
+
 WWAH_CLUSTER_ID = 0xFC57
-
-
-class DisplayUnit(enum_factory(t.uint16_t)):
-    Celsius = 0
-    Fahrenheit = 1
-
-
-class SonoffClusterFC11(CustomCluster):
-    """Sonoff custom cluster."""
-
-    DisplayUnit: Final = DisplayUnit
-
-    cluster_id = 0xFC11
-    name = "SonoffClusterFC11"
-
-    class AttributeDefs(BaseAttributeDefs):
-        high_temperature_threshold: Final = ZCLAttributeDef(
-            id=0x0003, type=t.int16s, access="rwp", is_manufacturer_specific=True
-        )
-        low_temperature_threshold: Final = ZCLAttributeDef(
-            id=0x0004, type=t.int16s, access="rwp", is_manufacturer_specific=True
-        )
-        low_humidity_threshold: Final = ZCLAttributeDef(
-            id=0x0005, type=t.uint16_t, access="rwp", is_manufacturer_specific=True
-        )
-        high_humidity_threshold: Final = ZCLAttributeDef(
-            id=0x0006, type=t.uint16_t, access="rwp", is_manufacturer_specific=True
-        )
-        display_unit: Final = ZCLAttributeDef(
-            id=0x0007, type=DisplayUnit, access="rwp", is_manufacturer_specific=True
-        )
-        unknown_fffd: Final = ZCLAttributeDef(
-            id=0xFFFD, type=t.uint16_t, access="rwp", is_manufacturer_specific=True
-        )
-
-    def _create_request(
-        self,
-        *,
-        general: bool,
-        command_id: GeneralCommand | int,
-        schema: dict | t.Struct,
-        manufacturer: int | None = None,
-        tsn: int | None = None,
-        disable_default_response: bool,
-        direction: Direction,
-        # Schema args and kwargs
-        args: tuple[Any, ...],
-        kwargs: Any,
-    ) -> tuple[ZCLHeader, bytes]:
-        """Override all request to disable manufacturer."""
-        return super()._create_request(
-            general=general,
-            command_id=command_id,
-            schema=schema,
-            manufacturer=ZCLHeader.NO_MANUFACTURER_ID,
-            tsn=tsn,
-            disable_default_response=disable_default_response,
-            direction=direction,
-            args=args,
-            kwargs=kwargs,
-        )
 
 
 class SonoffSNZB02D(CustomDevice):

--- a/zhaquirks/sonoff/snzb02d.py
+++ b/zhaquirks/sonoff/snzb02d.py
@@ -1,0 +1,147 @@
+"""Module for Philips quirks implementations."""
+from __future__ import annotations
+
+from typing import Any, Final
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.types.basic import enum_factory
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Identify,
+    Ota,
+    PollControl,
+    PowerConfiguration,
+)
+from zigpy.zcl.clusters.measurement import RelativeHumidity, TemperatureMeasurement
+from zigpy.zcl.foundation import (
+    BaseAttributeDefs,
+    Direction,
+    GeneralCommand,
+    ZCLAttributeDef,
+    ZCLHeader,
+)
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+WWAH_CLUSTER_ID = 0xFC57
+
+
+class DisplayUnit(enum_factory(t.uint16_t)):
+    Celsius = 0
+    Fahrenheit = 1
+
+
+class SonoffClusterFC11(CustomCluster):
+    """Sonoff custom cluster."""
+
+    DisplayUnit: Final = DisplayUnit
+
+    cluster_id = 0xFC11
+    name = "SonoffClusterFC11"
+
+    class AttributeDefs(BaseAttributeDefs):
+        high_temperature_threshold: Final = ZCLAttributeDef(
+            id=0x0003, type=t.int16s, access="rwp", is_manufacturer_specific=True
+        )
+        low_temperature_threshold: Final = ZCLAttributeDef(
+            id=0x0004, type=t.int16s, access="rwp", is_manufacturer_specific=True
+        )
+        low_humidity_threshold: Final = ZCLAttributeDef(
+            id=0x0005, type=t.uint16_t, access="rwp", is_manufacturer_specific=True
+        )
+        high_humidity_threshold: Final = ZCLAttributeDef(
+            id=0x0006, type=t.uint16_t, access="rwp", is_manufacturer_specific=True
+        )
+        display_unit: Final = ZCLAttributeDef(
+            id=0x0007, type=DisplayUnit, access="rwp", is_manufacturer_specific=True
+        )
+        unknown_fffd: Final = ZCLAttributeDef(
+            id=0xFFFD, type=t.uint16_t, access="rwp", is_manufacturer_specific=True
+        )
+
+    def _create_request(
+        self,
+        *,
+        general: bool,
+        command_id: GeneralCommand | int,
+        schema: dict | t.Struct,
+        manufacturer: int | None = None,
+        tsn: int | None = None,
+        disable_default_response: bool,
+        direction: Direction,
+        # Schema args and kwargs
+        args: tuple[Any, ...],
+        kwargs: Any,
+    ) -> tuple[ZCLHeader, bytes]:
+        """Override all request to disable manufacturer."""
+        return super()._create_request(
+            general=general,
+            command_id=command_id,
+            schema=schema,
+            manufacturer=ZCLHeader.NO_MANUFACTURER_ID,
+            tsn=tsn,
+            disable_default_response=disable_default_response,
+            direction=direction,
+            args=args,
+            kwargs=kwargs,
+        )
+
+
+class SonoffSNZB02D(CustomDevice):
+    """Sonoff LCD Smart Temperature Humidity Sensor - model SNZB-02D"""
+
+    signature = {
+        MODELS_INFO: [
+            ("SONOFF", "SNZB-02D"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.TEMPERATURE_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    RelativeHumidity.cluster_id,
+                    SonoffClusterFC11.cluster_id,
+                    WWAH_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.TEMPERATURE_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    RelativeHumidity.cluster_id,
+                    SonoffClusterFC11,
+                    WWAH_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            }
+        },
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Add description of sonoff custom cluster controlling the display information on the temperature meter.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

The devices requires manufacture code to not be set when reading/writing attributes. Unsetting this is currently not easily done without overriding core functions in zigpy. Here it's done by overriding the creation of request.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
