### PR TITLE
Add Aqara E1 2-gang switch `lumi.switch.b2lc04` support

### DIFF
--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -63,7 +63,7 @@ class AqaraH1DoubleRockerSwitchNoNeutral(XiaomiOpple2ButtonSwitchBase):
     """Aqara H1 Double Rocker Switch (no neutral)."""
 
     signature = {
-        MODELS_INFO: [(LUMI, "lumi.switch.l2aeu1")],
+        MODELS_INFO: [(LUMI, "lumi.switch.l2aeu1"), (LUMI, "lumi.switch.b2lc04")],
         ENDPOINTS: {
             # input_clusters=[0, 2, 3, 4, 5, 6, 18, 64704], output_clusters=[10, 25]
             1: {
@@ -142,7 +142,7 @@ class AqaraH1DoubleRockerSwitchNoNeutralAlt(XiaomiOpple2ButtonSwitchBase):
     """Aqara H1 Double Rocker Switch (no neutral) alternative signature."""
 
     signature = {
-        MODELS_INFO: [(LUMI, "lumi.switch.l2aeu1")],
+        MODELS_INFO: [(LUMI, "lumi.switch.l2aeu1"), (LUMI, "lumi.switch.b2lc04")],
         ENDPOINTS: {
             # input_clusters=[0, 2, 3, 4, 5, 6, 9], output_clusters=[10, 25]
             1: {


### PR DESCRIPTION
## Proposed change
Add Aqara E1 2-gang switch support (w/o neutral) for model: `QBKG39LM`

## Additional information
Supersedes https://github.com/zigpy/zha-device-handlers/pull/2912
Fixes https://github.com/zigpy/zha-device-handlers/issues/1810

Both signatures are from the issue linked above.

Currently untested. Custom quirk link to test should be: https://raw.githubusercontent.com/TheJulianJES/zha-device-handlers/tjj/aqara_e1_double_no_neutral_switch/zhaquirks/xiaomi/aqara/switch_h1_double.py

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
