### PR TITLE
Fix Sinope clusters blocking some attribute updates

### DIFF
--- a/tests/test_sinope.py
+++ b/tests/test_sinope.py
@@ -19,11 +19,19 @@ async def test_sinope_device_temp(zigpy_device_from_quirk, quirk):
     dev_temp_cluster = device.endpoints[1].device_temperature
     dev_temp_listener = ClusterListener(dev_temp_cluster)
     dev_temp_attr_id = DeviceTemperature.AttributeDefs.current_temperature.id
+    dev_temp_other_attr_id = DeviceTemperature.AttributeDefs.min_temp_experienced.id
 
+    # verify current temperature is multiplied by 100
     dev_temp_cluster.update_attribute(dev_temp_attr_id, 25)
     assert len(dev_temp_listener.attribute_updates) == 1
     assert dev_temp_listener.attribute_updates[0][0] == dev_temp_attr_id
     assert dev_temp_listener.attribute_updates[0][1] == 2500  # multiplied by 100
+
+    # verify other attributes are not modified
+    dev_temp_cluster.update_attribute(dev_temp_other_attr_id, 25)
+    assert len(dev_temp_listener.attribute_updates) == 2
+    assert dev_temp_listener.attribute_updates[1][0] == dev_temp_other_attr_id
+    assert dev_temp_listener.attribute_updates[1][1] == 25  # not modified
 
 
 @pytest.mark.parametrize("quirk", (zhaquirks.sinope.switch.SinopeTechnologiesValveG2,))
@@ -34,8 +42,19 @@ async def test_sinope_flow_measurement(zigpy_device_from_quirk, quirk):
     flow_measurement_cluster = device.endpoints[1].flow
     flow_measurement_listener = ClusterListener(flow_measurement_cluster)
     flow_measurement_attr_id = FlowMeasurement.AttributeDefs.measured_value.id
+    flow_measurement_other_attr_id = FlowMeasurement.AttributeDefs.min_measured_value.id
 
+    # verify measured value is divided by 10
     flow_measurement_cluster.update_attribute(flow_measurement_attr_id, 2500)
     assert len(flow_measurement_listener.attribute_updates) == 1
     assert flow_measurement_listener.attribute_updates[0][0] == flow_measurement_attr_id
     assert flow_measurement_listener.attribute_updates[0][1] == 250.0  # divided by 10
+
+    # verify other attributes are not modified
+    flow_measurement_cluster.update_attribute(flow_measurement_other_attr_id, 25)
+    assert len(flow_measurement_listener.attribute_updates) == 2
+    assert (
+        flow_measurement_listener.attribute_updates[1][0]
+        == flow_measurement_other_attr_id
+    )
+    assert flow_measurement_listener.attribute_updates[1][1] == 25  # not modified

--- a/zhaquirks/sinope/__init__.py
+++ b/zhaquirks/sinope/__init__.py
@@ -69,4 +69,5 @@ class CustomDeviceTemperatureCluster(CustomCluster, DeviceTemperature):
 
     def _update_attribute(self, attrid, value):
         if attrid == self.AttributeDefs.current_temperature.id:
-            super()._update_attribute(attrid, value * 100)
+            value = value * 100
+        super()._update_attribute(attrid, value)

--- a/zhaquirks/sinope/switch.py
+++ b/zhaquirks/sinope/switch.py
@@ -216,7 +216,8 @@ class CustomFlowMeasurementCluster(CustomCluster, FlowMeasurement):
 
     def _update_attribute(self, attrid, value):
         if attrid == self.AttributeDefs.measured_value.id:
-            super()._update_attribute(attrid, value / 10)
+            value = value / 10
+        super()._update_attribute(attrid, value)
 
 
 class SinopeTechnologiesSwitch(CustomDevice):


### PR DESCRIPTION
## Proposed change
This fixes an issue where other attributes on the custom Sinope clusters were not updating.
Tests are also added to verify this is working.


## Additional information
I'm not sure if other attributes are actually used though, but we should still fix it.


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
