### PR TITLE
Fix switch events for Aqara T2 relay

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1639,9 +1639,7 @@ async def test_xiaomi_e1_roller_commands_2(zigpy_device_from_quirk, command, val
     )
 
 
-@pytest.mark.parametrize(
-    "endpoint", [(1), (2)]
-)
+@pytest.mark.parametrize("endpoint", [(1), (2)])
 async def test_aqara_t2_relay(zigpy_device_from_quirk, endpoint):
     """Test Aqara T2 relay."""
 

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1640,45 +1640,19 @@ async def test_xiaomi_e1_roller_commands_2(zigpy_device_from_quirk, command, val
 
 
 @pytest.mark.parametrize(
-    "quirk",
-    (zhaquirks.xiaomi.aqara.switch_acn047.AqaraT2Relay,),
+    "endpoint", [(1), (2)]
 )
-async def test_aqara_t2_relay_endpoint_1(zigpy_device_from_quirk, quirk):
-    """Test Aqara T2 relay endpoint 1."""
+async def test_aqara_t2_relay(zigpy_device_from_quirk, endpoint):
+    """Test Aqara T2 relay."""
 
-    device = zigpy_device_from_quirk(quirk)
-    mi_cluster = device.endpoints[1].multistate_input
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.switch_acn047.AqaraT2Relay)
+    mi_cluster = device.endpoints[endpoint].multistate_input
     mi_listener = ClusterListener(mi_cluster)
 
     mi_cluster.update_attribute(MultistateInput.AttributeDefs.present_value.id, 1)
     assert len(mi_listener.attribute_updates) == 1
     assert mi_listener.attribute_updates[0][0] == 0
-    assert mi_listener.attribute_updates[0][1] == "switch_1"
-
-    mi_cluster.update_attribute(MultistateInput.AttributeDefs.state_text.id, "foo")
-    assert len(mi_listener.attribute_updates) == 2
-    assert (
-        mi_listener.attribute_updates[1][0]
-        == MultistateInput.AttributeDefs.state_text.id
-    )
-    assert mi_listener.attribute_updates[1][1] == "foo"
-
-
-@pytest.mark.parametrize(
-    "quirk",
-    (zhaquirks.xiaomi.aqara.switch_acn047.AqaraT2Relay,),
-)
-async def test_aqara_t2_relay_endpoint_2(zigpy_device_from_quirk, quirk):
-    """Test Aqara T2 relay endpoint 2."""
-
-    device = zigpy_device_from_quirk(quirk)
-    mi_cluster = device.endpoints[2].multistate_input
-    mi_listener = ClusterListener(mi_cluster)
-
-    mi_cluster.update_attribute(MultistateInput.AttributeDefs.present_value.id, 1)
-    assert len(mi_listener.attribute_updates) == 1
-    assert mi_listener.attribute_updates[0][0] == 0
-    assert mi_listener.attribute_updates[0][1] == "switch_2"
+    assert mi_listener.attribute_updates[0][1] == "switch_" + endpoint
 
     mi_cluster.update_attribute(MultistateInput.AttributeDefs.state_text.id, "foo")
     assert len(mi_listener.attribute_updates) == 2

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1610,31 +1610,6 @@ async def test_xiaomi_e1_roller_commands_1(zigpy_device_from_quirk, command, val
 
 
 @pytest.mark.parametrize(
-    "quirk",
-    (zhaquirks.xiaomi.aqara.switch_acn047.AqaraT2Relay,),
-)
-async def test_aqara_t2_relay(zigpy_device_from_quirk, quirk):
-    """Test Aqara T2 relay."""
-
-    device = zigpy_device_from_quirk(quirk)
-    mi_cluster = device.endpoints[1].multistate_input
-    mi_listener = ClusterListener(mi_cluster)
-
-    mi_cluster.update_attribute(MultistateInput.AttributeDefs.present_value.id, 1)
-    assert len(mi_listener.attribute_updates) == 1
-    assert mi_listener.attribute_updates[0][0] == 0
-    assert mi_listener.attribute_updates[0][1] == "single"
-
-    mi_cluster.update_attribute(MultistateInput.AttributeDefs.state_text.id, "foo")
-    assert len(mi_listener.attribute_updates) == 2
-    assert (
-        mi_listener.attribute_updates[1][0]
-        == MultistateInput.AttributeDefs.state_text.id
-    )
-    assert mi_listener.attribute_updates[1][1] == "foo"
-
-
-@pytest.mark.parametrize(
     "command, value",
     [
         (WindowCovering.ServerCommandDefs.go_to_lift_percentage.id, 60),
@@ -1662,6 +1637,56 @@ async def test_xiaomi_e1_roller_commands_2(zigpy_device_from_quirk, command, val
     assert (
         analog_cluster._write_attributes.call_args[0][0][0].value.value == 100 - value
     )
+
+
+@pytest.mark.parametrize(
+    "quirk",
+    (zhaquirks.xiaomi.aqara.switch_acn047.AqaraT2Relay,),
+)
+async def test_aqara_t2_relay_endpoint_1(zigpy_device_from_quirk, quirk):
+    """Test Aqara T2 relay endpoint 1."""
+
+    device = zigpy_device_from_quirk(quirk)
+    mi_cluster = device.endpoints[1].multistate_input
+    mi_listener = ClusterListener(mi_cluster)
+
+    mi_cluster.update_attribute(MultistateInput.AttributeDefs.present_value.id, 1)
+    assert len(mi_listener.attribute_updates) == 1
+    assert mi_listener.attribute_updates[0][0] == 0
+    assert mi_listener.attribute_updates[0][1] == "switch_1"
+
+    mi_cluster.update_attribute(MultistateInput.AttributeDefs.state_text.id, "foo")
+    assert len(mi_listener.attribute_updates) == 2
+    assert (
+        mi_listener.attribute_updates[1][0]
+        == MultistateInput.AttributeDefs.state_text.id
+    )
+    assert mi_listener.attribute_updates[1][1] == "foo"
+
+
+@pytest.mark.parametrize(
+    "quirk",
+    (zhaquirks.xiaomi.aqara.switch_acn047.AqaraT2Relay,),
+)
+async def test_aqara_t2_relay_endpoint_2(zigpy_device_from_quirk, quirk):
+    """Test Aqara T2 relay endpoint 2."""
+
+    device = zigpy_device_from_quirk(quirk)
+    mi_cluster = device.endpoints[2].multistate_input
+    mi_listener = ClusterListener(mi_cluster)
+
+    mi_cluster.update_attribute(MultistateInput.AttributeDefs.present_value.id, 1)
+    assert len(mi_listener.attribute_updates) == 1
+    assert mi_listener.attribute_updates[0][0] == 0
+    assert mi_listener.attribute_updates[0][1] == "switch_2"
+
+    mi_cluster.update_attribute(MultistateInput.AttributeDefs.state_text.id, "foo")
+    assert len(mi_listener.attribute_updates) == 2
+    assert (
+        mi_listener.attribute_updates[1][0]
+        == MultistateInput.AttributeDefs.state_text.id
+    )
+    assert mi_listener.attribute_updates[1][1] == "foo"
 
 
 def test_aqara_acn003_signature_match(assert_signature_matches_quirk):

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1652,7 +1652,7 @@ async def test_aqara_t2_relay(zigpy_device_from_quirk, endpoint):
     mi_cluster.update_attribute(MultistateInput.AttributeDefs.present_value.id, 1)
     assert len(mi_listener.attribute_updates) == 1
     assert mi_listener.attribute_updates[0][0] == 0
-    assert mi_listener.attribute_updates[0][1] == "switch_" + endpoint
+    assert mi_listener.attribute_updates[0][1] == "switch_" + str(endpoint)
 
     mi_cluster.update_attribute(MultistateInput.AttributeDefs.state_text.id, "foo")
     assert len(mi_listener.attribute_updates) == 2

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -32,6 +32,8 @@ from zigpy.zcl.clusters.smartenergy import Metering
 
 import zhaquirks
 from zhaquirks.const import (
+    BUTTON_1,
+    BUTTON_2,
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
@@ -43,8 +45,6 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     ZONE_STATUS_CHANGE_COMMAND,
-    BUTTON_1,
-    BUTTON_2,
 )
 from zhaquirks.xiaomi import (
     LUMI,

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -43,6 +43,8 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     ZONE_STATUS_CHANGE_COMMAND,
+    BUTTON_1,
+    BUTTON_2,
 )
 from zhaquirks.xiaomi import (
     LUMI,
@@ -1647,10 +1649,12 @@ async def test_aqara_t2_relay(zigpy_device_from_quirk, endpoint):
     mi_cluster = device.endpoints[endpoint].multistate_input
     mi_listener = ClusterListener(mi_cluster)
 
+    buttons = {1: BUTTON_1, 2: BUTTON_2}
+
     mi_cluster.update_attribute(MultistateInput.AttributeDefs.present_value.id, 1)
     assert len(mi_listener.attribute_updates) == 1
     assert mi_listener.attribute_updates[0][0] == 0
-    assert mi_listener.attribute_updates[0][1] == f"switch_{endpoint}"
+    assert mi_listener.attribute_updates[0][1] == buttons[endpoint]
 
     mi_cluster.update_attribute(MultistateInput.AttributeDefs.state_text.id, "foo")
     assert len(mi_listener.attribute_updates) == 2

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1652,7 +1652,7 @@ async def test_aqara_t2_relay(zigpy_device_from_quirk, endpoint):
     mi_cluster.update_attribute(MultistateInput.AttributeDefs.present_value.id, 1)
     assert len(mi_listener.attribute_updates) == 1
     assert mi_listener.attribute_updates[0][0] == 0
-    assert mi_listener.attribute_updates[0][1] == "switch_" + str(endpoint)
+    assert mi_listener.attribute_updates[0][1] == f"switch_{endpoint}"
 
     mi_cluster.update_attribute(MultistateInput.AttributeDefs.state_text.id, "foo")
     assert len(mi_listener.attribute_updates) == 2

--- a/zhaquirks/xiaomi/aqara/switch_acn047.py
+++ b/zhaquirks/xiaomi/aqara/switch_acn047.py
@@ -19,6 +19,8 @@ from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.const import (
     ATTR_ID,
+    BUTTON_1,
+    BUTTON_2,
     COMMAND,
     DEVICE_TYPE,
     ENDPOINT_ID,
@@ -31,8 +33,6 @@ from zhaquirks.const import (
     SHORT_PRESS,
     VALUE,
     ZHA_SEND_EVENT,
-    BUTTON_1,
-    BUTTON_2,
 )
 from zhaquirks.xiaomi import (
     AnalogInputCluster,

--- a/zhaquirks/xiaomi/aqara/switch_acn047.py
+++ b/zhaquirks/xiaomi/aqara/switch_acn047.py
@@ -21,6 +21,7 @@ from zhaquirks.const import (
     ATTR_ID,
     COMMAND,
     DEVICE_TYPE,
+    ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
@@ -30,7 +31,6 @@ from zhaquirks.const import (
     SHORT_PRESS,
     VALUE,
     ZHA_SEND_EVENT,
-    ENDPOINT_ID,
 )
 from zhaquirks.xiaomi import (
     AnalogInputCluster,
@@ -207,6 +207,12 @@ class AqaraT2Relay(XiaomiCustomDevice):
     }
 
     device_automation_triggers = {
-        (SHORT_PRESS, PRESS_TYPES.get(1)): {ENDPOINT_ID: 1, COMMAND: PRESS_TYPES.get(1)},
-        (SHORT_PRESS, PRESS_TYPES.get(2)): {ENDPOINT_ID: 2, COMMAND: PRESS_TYPES.get(2)},
+        (SHORT_PRESS, PRESS_TYPES.get(1)): {
+            ENDPOINT_ID: 1,
+            COMMAND: PRESS_TYPES.get(1),
+        },
+        (SHORT_PRESS, PRESS_TYPES.get(2)): {
+            ENDPOINT_ID: 2,
+            COMMAND: PRESS_TYPES.get(2),
+        },
     }

--- a/zhaquirks/xiaomi/aqara/switch_acn047.py
+++ b/zhaquirks/xiaomi/aqara/switch_acn047.py
@@ -30,6 +30,7 @@ from zhaquirks.const import (
     SHORT_PRESS,
     VALUE,
     ZHA_SEND_EVENT,
+    ENDPOINT_ID,
 )
 from zhaquirks.xiaomi import (
     AnalogInputCluster,
@@ -40,8 +41,7 @@ from zhaquirks.xiaomi import (
     XiaomiCustomDevice,
 )
 
-PRESS_TYPES = {1: "single"}
-SINGLE = "single"
+PRESS_TYPES = {1: "switch_1", 2: "switch_2"}
 STATUS_TYPE_ATTR = 0x0055  # decimal = 85
 
 
@@ -54,14 +54,15 @@ class MultistateInputCluster(CustomCluster, MultistateInput):
         super().__init__(*args, **kwargs)
 
     def _update_attribute(self, attrid, value):
-        if attrid == STATUS_TYPE_ATTR:
-            self._current_state = PRESS_TYPES.get(value)
+        if attrid == STATUS_TYPE_ATTR and value == 1:
+            self._current_state = PRESS_TYPES.get(self.endpoint.endpoint_id)
             event_args = {
                 PRESS_TYPE: self._current_state,
                 ATTR_ID: attrid,
                 VALUE: value,
+                ENDPOINT_ID: self.endpoint.endpoint_id,
             }
-            self.listener_event(ZHA_SEND_EVENT, self, self._current_state, event_args)
+            self.listener_event(ZHA_SEND_EVENT, self._current_state, event_args)
             super()._update_attribute(0, self._current_state)
         else:
             super()._update_attribute(attrid, value)
@@ -206,5 +207,6 @@ class AqaraT2Relay(XiaomiCustomDevice):
     }
 
     device_automation_triggers = {
-        (SHORT_PRESS, SHORT_PRESS): {COMMAND: SINGLE},
+        (SHORT_PRESS, PRESS_TYPES.get(1)): {ENDPOINT_ID: 1, COMMAND: PRESS_TYPES.get(1)},
+        (SHORT_PRESS, PRESS_TYPES.get(2)): {ENDPOINT_ID: 2, COMMAND: PRESS_TYPES.get(2)},
     }

--- a/zhaquirks/xiaomi/aqara/switch_acn047.py
+++ b/zhaquirks/xiaomi/aqara/switch_acn047.py
@@ -209,10 +209,10 @@ class AqaraT2Relay(XiaomiCustomDevice):
     device_automation_triggers = {
         (SHORT_PRESS, PRESS_TYPES[1]): {
             ENDPOINT_ID: 1,
-            COMMAND: PRESS_TYPES[1]),
+            COMMAND: PRESS_TYPES[1],
         },
         (SHORT_PRESS, PRESS_TYPES[2]): {
             ENDPOINT_ID: 2,
-            COMMAND: PRESS_TYPES[2]),
+            COMMAND: PRESS_TYPES[2],
         },
     }

--- a/zhaquirks/xiaomi/aqara/switch_acn047.py
+++ b/zhaquirks/xiaomi/aqara/switch_acn047.py
@@ -207,12 +207,12 @@ class AqaraT2Relay(XiaomiCustomDevice):
     }
 
     device_automation_triggers = {
-        (SHORT_PRESS, PRESS_TYPES.get(1)): {
+        (SHORT_PRESS, PRESS_TYPES[1]): {
             ENDPOINT_ID: 1,
-            COMMAND: PRESS_TYPES.get(1),
+            COMMAND: PRESS_TYPES[1]),
         },
-        (SHORT_PRESS, PRESS_TYPES.get(2)): {
+        (SHORT_PRESS, PRESS_TYPES[2]): {
             ENDPOINT_ID: 2,
-            COMMAND: PRESS_TYPES.get(2),
+            COMMAND: PRESS_TYPES[2]),
         },
     }

--- a/zhaquirks/xiaomi/aqara/switch_acn047.py
+++ b/zhaquirks/xiaomi/aqara/switch_acn047.py
@@ -31,6 +31,8 @@ from zhaquirks.const import (
     SHORT_PRESS,
     VALUE,
     ZHA_SEND_EVENT,
+    BUTTON_1,
+    BUTTON_2,
 )
 from zhaquirks.xiaomi import (
     AnalogInputCluster,
@@ -41,7 +43,7 @@ from zhaquirks.xiaomi import (
     XiaomiCustomDevice,
 )
 
-PRESS_TYPES = {1: "switch_1", 2: "switch_2"}
+PRESS_TYPES = {1: BUTTON_1, 2: BUTTON_2}
 STATUS_TYPE_ATTR = 0x0055  # decimal = 85
 
 


### PR DESCRIPTION
## Proposed change

1. Fixed event sending, it has 4 args passed in but could only take 3 so the event was not fired.
2. There is an event for each endpoint(1 and 2) when the S1-COM and S2-COM pins are shorted but the original implementation did not separate the events so both S1 and S2 was emitting the same event.

Fixes my issue (partially): #2934

![image](https://github.com/zigpy/zha-device-handlers/assets/1564933/48de447d-00df-4751-9142-b48772e660bc)
![image](https://github.com/zigpy/zha-device-handlers/assets/1564933/8a7d9d6d-d4fe-4a9f-9e32-1cea4e3ddb40)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
