### PR TITLE
Refactor Tuya spell implementation, add Tuya query data spell

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -1790,7 +1790,7 @@ def test_tuya_spell_devices_valid():
                 f"{quirk} has more than one cluster subclassing `TuyaEnchantableCluster` on endpoint 1"
             )
 
-        # an EnchantedDevice with TUYA_SPELL >= 2 must also have a cluster subclassing TuyaNewManufCluster on endpoint 1
+        # an EnchantedDevice with the data query spell must also have a cluster subclassing TuyaNewManufCluster
         if quirk.tuya_spell_data_query and not tuya_cluster_exists:
             pytest.fail(
                 f"{quirk} set Tuya data query spell but has no cluster subclassing `TuyaNewManufCluster` on endpoint 1"

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -17,6 +17,7 @@ from zigpy.zcl.clusters.general import (
     GreenPowerProxy,
     Groups,
     Identify,
+    OnOff,
     Ota,
     PowerConfiguration,
 )
@@ -42,6 +43,7 @@ from zhaquirks.tuya import (
     TuyaEnchantableCluster,
     TuyaManufClusterAttributes,
     TuyaNewManufCluster,
+    TuyaZBOnOffAttributeCluster,
 )
 import zhaquirks.tuya.sm0202_motion
 import zhaquirks.tuya.ts011f_plug
@@ -1610,7 +1612,44 @@ async def test_power_config_no_bind(zigpy_device_from_quirk, quirk):
         assert len(bind_mock.mock_calls) == 0
 
 
-ENCHANTED_QUIRKS = []
+class TuyaTestSpellDevice(EnchantedDevice):
+    """Tuya test spell device."""
+
+    tuya_spell_data_query = True  # enable additional data query spell
+
+    signature = {
+        MODELS_INFO: [("UjqjHq6ZErY23tgs", "zo9WD7q5dbvDj96y")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    OnOff.cluster_id,
+                    TuyaNewManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                    TuyaNewManufCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            }
+        }
+    }
+
+
+ENCHANTED_QUIRKS = [TuyaTestSpellDevice]
 for manufacturer in zigpy.quirks._DEVICE_REGISTRY._registry.values():
     for model_quirk_list in manufacturer.values():
         for quirk_entry in model_quirk_list:

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -1730,9 +1730,14 @@ def test_tuya_spell_devices_valid():
                 continue
             for cluster in endpoint[INPUT_CLUSTERS] + endpoint[OUTPUT_CLUSTERS]:
                 if not isinstance(cluster, int):
+                    # count all clusters which would apply the spell on bind()
                     if issubclass(cluster, TuyaEnchantableCluster):
                         enchanted_clusters += 1
-                    if issubclass(cluster, TuyaNewManufCluster):
+                    # check if there's a valid Tuya cluster where the id wasn't modified
+                    if (
+                        issubclass(cluster, TuyaNewManufCluster)
+                        and cluster.cluster_id == TuyaNewManufCluster.cluster_id
+                    ):
                         tuya_cluster_exists = True
 
         # an EnchantedDevice must have exactly one enchanted cluster on endpoint 1

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -9,7 +9,7 @@ from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
-from zigpy.zcl.clusters.general import LevelControl, OnOff, PowerConfiguration
+from zigpy.zcl.clusters.general import Basic, LevelControl, OnOff, PowerConfiguration
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.clusters.smartenergy import Metering
@@ -551,20 +551,52 @@ class TuyaEnchantableCluster(CustomCluster):
         """Bind cluster and start casting the spell if necessary."""
         # check if the device needs to have the spell cast
         # and since the cluster can be used on multiple endpoints, check that it's endpoint 1
-        if (
-            getattr(self.endpoint.device, "TUYA_SPELL", False)
-            and self.endpoint.endpoint_id == 1
-        ):
-            await self.spell()
+        if self.endpoint.endpoint_id == 1:
+            tuya_spell_level = getattr(self.endpoint.device, "TUYA_SPELL", 0)
+            # execute the 'attribute read spell' on all levels, and also the 'data query spell' on level 2 and up
+            if tuya_spell_level >= 1:
+                await self.spell_attribute_reads()
+            if tuya_spell_level >= 2:
+                await self.spell_data_query()
         return await super().bind()
 
-    async def spell(self):
-        """Cast spell, so the Tuya device works correctly."""
-        self.debug("Executing spell on Tuya device %s", self.endpoint.device.ieee)
+    async def spell_attribute_reads(self):
+        """Cast 'attribute read' spell, so the Tuya device works correctly."""
+        self.debug(
+            "Executing attribute read spell on Tuya device %s",
+            self.endpoint.device.ieee,
+        )
         attr_to_read = [4, 0, 1, 5, 7, 0xFFFE]
-        basic_cluster = self.endpoint.device.endpoints[1].in_clusters[0]
+        basic_cluster = self.endpoint.device.endpoints[1].in_clusters[Basic.cluster_id]
         await basic_cluster.read_attributes(attr_to_read)
-        self.debug("Executed spell on Tuya device %s", self.endpoint.device.ieee)
+        self.debug(
+            "Executed attribute read spell on Tuya device %s", self.endpoint.device.ieee
+        )
+
+    async def spell_data_query(self):
+        """Cast 'data query' spell, also required for some Tuya devices to send data."""
+        # check if the device has a Tuya cluster with the Tuya query data command,
+        # but we should still make sure a quirk doesn't call this on a device that doesn't have it
+        if (
+            TuyaNewManufCluster.cluster_id
+            not in self.endpoint.device.endpoints[1].in_clusters
+        ):
+            self.debug(
+                "Tuya device %s has no TuyaNewManufCluster/TuyaMCUCluster, skipping data query spell",
+                self.endpoint.device.ieee,
+            )
+            return
+
+        self.debug(
+            "Executing data query spell on Tuya device %s", self.endpoint.device.ieee
+        )
+        tuya_cluster = self.endpoint.device.endpoints[1].in_clusters[
+            TuyaNewManufCluster.cluster_id
+        ]
+        await tuya_cluster.command(TUYA_QUERY_DATA)
+        self.debug(
+            "Executed data query spell on Tuya device %s", self.endpoint.device.ieee
+        )
 
 
 class TuyaOnOff(TuyaEnchantableCluster, OnOff):

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -729,4 +729,6 @@ class EnchantedDevice(CustomDevice):
     For more information, see the documentation of `TuyaEnchantableCluster`.
     """
 
-    TUYA_SPELL = True
+    # Tuya spell level:
+    # 1 is the 'read attribute spell', 2 also adds the 'query data spell'
+    TUYA_SPELL: int = 1

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -3,7 +3,6 @@ import dataclasses
 import datetime
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
-from zigpy.quirks import CustomDevice
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import LevelControl, OnOff
@@ -23,6 +22,9 @@ from zhaquirks.tuya import (
     TuyaNewManufCluster,
     TuyaTimePayload,
 )
+
+# add EnchantedDevice import for custom quirks backwards compatibility
+from zhaquirks.tuya import EnchantedDevice  # noqa: F401
 
 # New manufacturer attributes
 ATTR_MCU_VERSION = 0xEF00
@@ -720,15 +722,3 @@ class TuyaLevelControlManufCluster(TuyaMCUCluster):
         17: "_dp_2_attr_update",
         18: "_dp_2_attr_update",
     }
-
-
-class EnchantedDevice(CustomDevice):
-    """Class for Tuya devices which need to be unlocked by casting a 'spell'. This happens during binding.
-
-    To make sure the spell is cast, the device needs to implement a subclass of `TuyaEnchantableCluster`.
-    For more information, see the documentation of `TuyaEnchantableCluster`.
-    """
-
-    # Tuya spell level:
-    # 1 is the 'read attribute spell', 2 also adds the 'query data spell'
-    TUYA_SPELL: int = 1


### PR DESCRIPTION
## Proposed change
This refactors the (internal) Tuya spell implementation. Custom quirks are unaffected*.

The new Tuya query data spell is also added, it can be enabled like this for an `EnchantedDevice`:
```python
class TuyaDevice(EnchantedDevice):
    """Tuya device that needs both spells."""

    tuya_spell_data_query = True  # enable new data query spell
```

### Enable/disable Tuya spells:

The default "read attributes" Tuya spell is still enabled by default when inheriting `EnchantedDevice`, but it can be disabled by setting `tuya_spell_read_attributes` to `False` (although you probably don't want to do this).

Like shown in the example above, the new Tuya "data query" spell has to be enabled by setting `tuya_spell_data_query = True` in an `EnchantedDevice`.


### Moving `EnchantedDevice` class:

The `EnchantedDevice` class is also moved from `tuya.mcu` to just `tuya`, as all other "spell stuff" is there, and not every device that requires the spell is an MCU device (and it's also done to avoid circular imports).
To not break all custom Tuya quirks, I've added an import to `zhaquirks/tuya/mcu/__init__.py` for backwards compatibility.

Note: To keep the diff smaller, I have not changed all zhaquirks imports to the new path yet.
However, I already have that commit ready to go for a second PR after this is merged.
I can also add it to this PR if wanted.

*: Custom quirks should also switch to the new path for importing `EnchantedDevice` sooner or later.
I think we should keep it around for a long-ish time though, because I doubt anyone will update their custom quirks.

### Tests:

The tests were also modified to account for the new behavior.
I've also needed to add a "test quirk" to the Tuya tests, as no quirk using the new Tuya data query spell is merged yet.
This "test quirk" is used to make sure the code is actually tested (and thus to keep code coverage).
Theoretically, this could be removed when #2927 is merged.

I'll probably still refactor the Tuya spell tests out of `test_tuya.py` into something like `test_tuya_spell.py` in a future PR.

### First approach:

In my first commit, you can see my initial approach which used a "spell level" to define how many spells should be cast.
I've decided for another approach in case a "lower level spell" ever needs to be disabled (but requiring a higher one).
It's also a bit cleaner in general IMO.

## Additional information
Unblocks:
- https://github.com/zigpy/zha-device-handlers/pull/2927 (cc @tschiex)

Related follow-up PRs:
- https://github.com/zigpy/zha-device-handlers/pull/2941 (refactor Tuya spell tests)
- https://github.com/zigpy/zha-device-handlers/pull/2942 (change import path)

## Checklist

- [x] The changes are tested and work correctly (only via unit tests)
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
