### PR TITLE
Change to new Tuya `EnchantedDevice` import path

### DIFF
--- a/zhaquirks/lidl/ts011f_plug.py
+++ b/zhaquirks/lidl/ts011f_plug.py
@@ -21,7 +21,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya.mcu import EnchantedDevice
+from zhaquirks.tuya import EnchantedDevice
 from zhaquirks.tuya.ts011f_plug import Plug_3AC_4USB
 
 

--- a/zhaquirks/tuya/ts0001_fingerbot.py
+++ b/zhaquirks/tuya/ts0001_fingerbot.py
@@ -13,10 +13,9 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import TUYA_SEND_DATA
+from zhaquirks.tuya import TUYA_SEND_DATA, EnchantedDevice
 from zhaquirks.tuya.mcu import (
     DPToAttributeMapping,
-    EnchantedDevice,
     TuyaEnchantableCluster,
     TuyaMCUCluster,
     TuyaPowerConfigurationCluster,

--- a/zhaquirks/tuya/ts000f_switch.py
+++ b/zhaquirks/tuya/ts000f_switch.py
@@ -22,13 +22,13 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import (
+    EnchantedDevice,
     TuyaZB1888Cluster,
     TuyaZBE000Cluster,
     TuyaZBElectricalMeasurement,
     TuyaZBMeteringCluster,
     TuyaZBOnOffAttributeCluster,
 )
-from zhaquirks.tuya.mcu import EnchantedDevice
 
 
 class Tuya_1G_Wall_Switch_Metering(EnchantedDevice):

--- a/zhaquirks/tuya/ts000x.py
+++ b/zhaquirks/tuya/ts000x.py
@@ -22,13 +22,13 @@ from zhaquirks.const import (
 )
 from zhaquirks.quirk_ids import TUYA_PLUG_ONOFF
 from zhaquirks.tuya import (
+    EnchantedDevice,
     TuyaZBE000Cluster,
     TuyaZBElectricalMeasurement,
     TuyaZBExternalSwitchTypeCluster,
     TuyaZBMeteringCluster,
     TuyaZBOnOffAttributeCluster,
 )
-from zhaquirks.tuya.mcu import EnchantedDevice
 
 
 class Switch_1G_GPP(EnchantedDevice):

--- a/zhaquirks/tuya/ts001x.py
+++ b/zhaquirks/tuya/ts001x.py
@@ -12,12 +12,12 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import (
+    EnchantedDevice,
     TuyaSwitch,
     TuyaZBE000Cluster,
     TuyaZBExternalSwitchTypeCluster,
     TuyaZBOnOffAttributeCluster,
 )
-from zhaquirks.tuya.mcu import EnchantedDevice
 
 
 # NoNeutralSwitch family = without tuya cluster and Identify.

--- a/zhaquirks/tuya/ts0046.py
+++ b/zhaquirks/tuya/ts0046.py
@@ -23,11 +23,11 @@ from zhaquirks.const import (
     SHORT_PRESS,
 )
 from zhaquirks.tuya import (
+    EnchantedDevice,
     TuyaNoBindPowerConfigurationCluster,
     TuyaSmartRemoteOnOffCluster,
     TuyaZBE000Cluster,
 )
-from zhaquirks.tuya.mcu import EnchantedDevice
 
 
 class Tuya6ButtonTriggers:

--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -57,11 +57,11 @@ from zhaquirks.const import (
     TURN_ON,
 )
 from zhaquirks.tuya import (
+    EnchantedDevice,
     TuyaNoBindPowerConfigurationCluster,
     TuyaSmartRemoteOnOffCluster,
     TuyaZBExternalSwitchTypeCluster,
 )
-from zhaquirks.tuya.mcu import EnchantedDevice
 
 
 class TuyaSmartRemote004FROK(EnchantedDevice):

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -28,6 +28,7 @@ from zhaquirks.const import (
 )
 from zhaquirks.quirk_ids import TUYA_PLUG_ONOFF
 from zhaquirks.tuya import (
+    EnchantedDevice,
     TuyaNewManufCluster,
     TuyaZB1888Cluster,
     TuyaZBE000Cluster,
@@ -37,7 +38,6 @@ from zhaquirks.tuya import (
     TuyaZBMeteringClusterWithUnit,
     TuyaZBOnOffAttributeCluster,
 )
-from zhaquirks.tuya.mcu import EnchantedDevice
 
 
 class Plug(EnchantedDevice):

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -17,10 +17,9 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import TuyaLocalCluster
+from zhaquirks.tuya import EnchantedDevice, TuyaLocalCluster
 from zhaquirks.tuya.mcu import (
     DPToAttributeMapping,
-    EnchantedDevice,
     TuyaMCUCluster,
     TuyaOnOff,
     TuyaOnOffNM,


### PR DESCRIPTION
## Proposed change
This changes the imports for the `EnchantedDevice` class from the old path to the new path:
```diff
- from zhaquirks.tuya.mcu import EnchantedDevice
+ from zhaquirks.tuya import EnchantedDevice
```

## Additional information
This changes the imports to the new `EnchantedDevice` path as mentioned in this related PR:
- https://github.com/zigpy/zha-device-handlers/pull/2940

As mentioned in that PR, it's still impossible to import `EnchantedDevice` from `zhaquirks.tuya.mcu` in order to keep backwards compatibility with custom quirks that haven't updated.

But it only makes sense to update zha-quirks to import from the "correct"/new location already, hence this PR.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
