### PR TITLE
Fix IKEA double battery percentage for old/new firmware

### DIFF
--- a/tests/test_ikea.py
+++ b/tests/test_ikea.py
@@ -196,3 +196,74 @@ async def test_double_power_config_firmware(zigpy_device_from_quirk, quirk):
         # check no reads were made when sw_build_id is known
         assert mock_task.call_count == 0
         assert request_mock.call_count == 0
+
+
+@pytest.mark.parametrize(
+    "firmware, pct_device, pct_correct, expected_pct_updates",
+    (
+        ("2.3.075", 50, 100, 1),
+        ("24.4.5", 50, 50, 2),
+    ),
+)
+async def test_double_power_config_firmware_2(
+    zigpy_device_from_quirk, firmware, pct_device, pct_correct, expected_pct_updates
+):
+    """Test battery percentage remaining is doubled for old firmware."""
+
+    device = zigpy_device_from_quirk(zhaquirks.ikea.fivebtnremote.IkeaTradfriRemote1)
+
+    basic_cluster = device.endpoints[1].basic
+    ClusterListener(basic_cluster)
+    sw_build_id = Basic.AttributeDefs.sw_build_id.id
+
+    power_cluster = device.endpoints[1].power
+    power_listener = ClusterListener(power_cluster)
+    battery_pct_id = PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
+
+    # fake read response for attributes: return plug_read argument for all attributes
+    def mock_read(attributes, manufacturer=None):
+        records = [
+            foundation.ReadAttributeRecord(
+                attr, foundation.Status.SUCCESS, foundation.TypeValue(None, firmware)
+            )
+            for attr in attributes
+        ]
+        return (records,)
+
+    p1 = mock.patch.object(power_cluster, "create_catching_task")
+    p2 = mock.patch.object(
+        basic_cluster, "_read_attributes", mock.AsyncMock(side_effect=mock_read)
+    )
+
+    with p1 as mock_task, p2 as request_mock:
+        # update battery percentage with no firmware in attr cache, check pct doubled for now
+        power_cluster.update_attribute(battery_pct_id, pct_device)
+        assert len(power_listener.attribute_updates) == 1
+        assert power_listener.attribute_updates[0] == (battery_pct_id, pct_device * 2)
+
+        # but also check that sw_build_id read is requested in the background for next update
+        assert mock_task.call_count == 1
+        await mock_task.call_args[0][0]  # await coroutine to read attribute
+        assert request_mock.call_count == 1  # verify request to read sw_build_id
+        assert request_mock.mock_calls[0][1][0][0] == sw_build_id
+
+        # battery pct might be updated again when the attribute read returned new firmware, check pct not doubled then
+        # if firmware turned out to be old or still unknown, do not update battery pct again, as we doubled it already
+        assert len(power_listener.attribute_updates) == expected_pct_updates
+        if expected_pct_updates > 2:
+            assert power_listener.attribute_updates[1] == (battery_pct_id, pct_correct)
+
+        # reset mocks for testing when sw_build_id is known next
+        mock_task.reset_mock()
+        request_mock.reset_mock()
+        power_listener = ClusterListener(power_cluster)
+
+        # update battery percentage with firmware in attr cache, check pct doubled if needed
+        basic_cluster.update_attribute(sw_build_id, firmware)
+        power_cluster.update_attribute(battery_pct_id, pct_device)
+        assert len(power_listener.attribute_updates) == 1
+        assert power_listener.attribute_updates[0] == (battery_pct_id, pct_correct)
+
+        # check no attribute reads were requested when sw_build_id is known
+        assert mock_task.call_count == 0
+        assert request_mock.call_count == 0

--- a/tests/test_ikea.py
+++ b/tests/test_ikea.py
@@ -2,11 +2,15 @@
 
 from unittest import mock
 
+import pytest
 from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import Basic, PowerConfiguration
 from zigpy.zcl.clusters.measurement import PM25
 
 import zhaquirks
 import zhaquirks.ikea.starkvind
+
+from tests.common import ClusterListener
 
 zhaquirks.setup()
 
@@ -122,3 +126,56 @@ async def test_pm25_cluster_read(zigpy_device_from_quirk):
         assert success
         assert 6 in success.values()
         assert not fail
+
+
+@pytest.mark.parametrize("quirk", (zhaquirks.ikea.fivebtnremote.IkeaTradfriRemote1,))
+async def test_double_power_config_firmware(zigpy_device_from_quirk, quirk):
+    """Test battery percentage remaining is doubled for old firmware."""
+
+    device = zigpy_device_from_quirk(quirk)
+
+    basic_cluster = device.endpoints[1].basic
+    ClusterListener(basic_cluster)
+    sw_build_id = Basic.AttributeDefs.sw_build_id.id
+
+    power_cluster = device.endpoints[1].power
+    power_listener = ClusterListener(power_cluster)
+    battery_percentage_id = (
+        PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
+    )
+
+    p1 = mock.patch.object(power_cluster, "create_catching_task")
+    p2 = mock.patch.object(basic_cluster.endpoint, "request", mock.AsyncMock())
+
+    with p1 as mock_task, p2 as request_mock:
+        request_mock.return_value = (foundation.Status.SUCCESS, "done")
+
+        # update battery percentage with no firmware in attr cache, check pct doubled
+        power_cluster.update_attribute(battery_percentage_id, 50)
+        assert power_listener.attribute_updates[0] == (battery_percentage_id, 100)
+
+        # but also check that sw_build_id read is requested in the background for next update
+        assert mock_task.call_count == 1
+        await mock_task.call_args[0][0]  # await coroutine to read attribute
+        assert request_mock.call_count == 1  # verify request to read sw_build_id
+        assert request_mock.mock_calls[0][1] == (0, 1, b"\x00\x01\x00\x00@")
+
+        # reset mocks for testing when sw_build_id is known next
+        mock_task.reset_mock()
+        request_mock.reset_mock()
+
+        # update battery percentage with old firmware in attr cache, check pct doubled
+        basic_cluster.update_attribute(sw_build_id, "2.3.075")
+        power_cluster.update_attribute(battery_percentage_id, 50)
+        assert power_listener.attribute_updates[1] == (battery_percentage_id, 100)
+        # check no reads were made when sw_build_id is known
+        assert mock_task.call_count == 0
+        assert request_mock.call_count == 0
+
+        # update battery percentage with new firmware in attr cache, check pct not doubled
+        basic_cluster.update_attribute(sw_build_id, "24.4.5")
+        power_cluster.update_attribute(battery_percentage_id, 50)
+        assert power_listener.attribute_updates[2] == (battery_percentage_id, 50)
+        # check no reads were made when sw_build_id is known
+        assert mock_task.call_count == 0
+        assert request_mock.call_count == 0

--- a/tests/test_ikea.py
+++ b/tests/test_ikea.py
@@ -128,6 +128,7 @@ async def test_pm25_cluster_read(zigpy_device_from_quirk):
         assert not fail
 
 
+@mock.patch("zigpy.zcl.Cluster.bind", mock.AsyncMock())
 @pytest.mark.parametrize(
     "firmware, pct_device, pct_correct, expected_pct_updates",
     (
@@ -197,3 +198,8 @@ async def test_double_power_config_firmware(
         # check no attribute reads were requested when sw_build_id is known
         assert mock_task.call_count == 0
         assert request_mock.call_count == 0
+
+        # make sure a call to bind() always reads sw_build_id (e.g. on join or to refresh when repaired/reconfigured)
+        await power_cluster.bind()
+        assert request_mock.call_count == 1
+        assert request_mock.mock_calls[0][1][0][0] == sw_build_id

--- a/tests/test_ikea.py
+++ b/tests/test_ikea.py
@@ -144,21 +144,36 @@ async def test_double_power_config_firmware(zigpy_device_from_quirk, quirk):
         PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
     )
 
+    # fake read response for attributes: return "24.0.0" for all attributes
+    def mock_read(attributes, manufacturer=None):
+        records = [
+            foundation.ReadAttributeRecord(
+                attr, foundation.Status.SUCCESS, foundation.TypeValue(None, "24.0.0")
+            )
+            for attr in attributes
+        ]
+        return (records,)
+
     p1 = mock.patch.object(power_cluster, "create_catching_task")
-    p2 = mock.patch.object(basic_cluster.endpoint, "request", mock.AsyncMock())
+    p2 = mock.patch.object(
+        basic_cluster, "_read_attributes", mock.AsyncMock(side_effect=mock_read)
+    )
 
     with p1 as mock_task, p2 as request_mock:
-        request_mock.return_value = (foundation.Status.SUCCESS, "done")
-
-        # update battery percentage with no firmware in attr cache, check pct doubled
+        # update battery percentage with no firmware in attr cache, check pct doubled for now
         power_cluster.update_attribute(battery_percentage_id, 50)
+        assert len(power_listener.attribute_updates) == 1
         assert power_listener.attribute_updates[0] == (battery_percentage_id, 100)
 
         # but also check that sw_build_id read is requested in the background for next update
         assert mock_task.call_count == 1
         await mock_task.call_args[0][0]  # await coroutine to read attribute
         assert request_mock.call_count == 1  # verify request to read sw_build_id
-        assert request_mock.mock_calls[0][1] == (0, 1, b"\x00\x01\x00\x00@")
+        assert request_mock.mock_calls[0][1][0][0] == sw_build_id
+
+        # battery pct was updated again because the attribute read returned new firmware, check pct not doubled now
+        assert len(power_listener.attribute_updates) == 2
+        assert power_listener.attribute_updates[1] == (battery_percentage_id, 50)
 
         # reset mocks for testing when sw_build_id is known next
         mock_task.reset_mock()
@@ -167,7 +182,8 @@ async def test_double_power_config_firmware(zigpy_device_from_quirk, quirk):
         # update battery percentage with old firmware in attr cache, check pct doubled
         basic_cluster.update_attribute(sw_build_id, "2.3.075")
         power_cluster.update_attribute(battery_percentage_id, 50)
-        assert power_listener.attribute_updates[1] == (battery_percentage_id, 100)
+        assert len(power_listener.attribute_updates) == 3
+        assert power_listener.attribute_updates[2] == (battery_percentage_id, 100)
         # check no reads were made when sw_build_id is known
         assert mock_task.call_count == 0
         assert request_mock.call_count == 0
@@ -175,7 +191,8 @@ async def test_double_power_config_firmware(zigpy_device_from_quirk, quirk):
         # update battery percentage with new firmware in attr cache, check pct not doubled
         basic_cluster.update_attribute(sw_build_id, "24.4.5")
         power_cluster.update_attribute(battery_percentage_id, 50)
-        assert power_listener.attribute_updates[2] == (battery_percentage_id, 50)
+        assert len(power_listener.attribute_updates) == 4
+        assert power_listener.attribute_updates[3] == (battery_percentage_id, 50)
         # check no reads were made when sw_build_id is known
         assert mock_task.call_count == 0
         assert request_mock.call_count == 0

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -200,6 +200,12 @@ class DoublingPowerConfigClusterIKEA(CustomCluster, PowerConfiguration):
     This implementation doubles battery pct remaining for IKEA devices with old firmware.
     """
 
+    async def bind(self):
+        """Bind cluster and read the sw_build_id for later use."""
+        result = await super().bind()
+        await self.endpoint.basic.read_attributes([Basic.AttributeDefs.sw_build_id.id])
+        return result
+
     def _is_firmware_old(self):
         """Checks if firmware is old or unknown."""
         # get sw_build_id from attribute cache if available

--- a/zhaquirks/ikea/blinds.py
+++ b/zhaquirks/ikea/blinds.py
@@ -13,7 +13,6 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from zhaquirks import DoublingPowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -22,7 +21,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, DoublingPowerConfigClusterIKEA
 
 
 class IkeaTradfriRollerBlinds(CustomDevice):
@@ -66,7 +65,7 @@ class IkeaTradfriRollerBlinds(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfigurationCluster,
+                    DoublingPowerConfigClusterIKEA,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,

--- a/zhaquirks/ikea/fivebtnremote.py
+++ b/zhaquirks/ikea/fivebtnremote.py
@@ -16,7 +16,6 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from zhaquirks import DoublingPowerConfigurationCluster
 from zhaquirks.const import (
     CLUSTER_ID,
     COMMAND,
@@ -98,7 +97,7 @@ class IkeaTradfriRemote1(CustomDevice):
                 DEVICE_TYPE: zll.DeviceType.SCENE_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DoublingPowerConfigurationCluster,
+                    DoublingPowerConfig1CRCluster,
                     Identify.cluster_id,
                     Alarms.cluster_id,
                     Diagnostic.cluster_id,


### PR DESCRIPTION
## Proposed change
This fixes the issue of some battery-powered IKEA devices having double the percentage reported.
The "double battery pct" cluster is still used on some devices which can have new or old firmware (where doubling may or may not be needed depending on the installed firmware version).

The fix would be simple if ZHA/zigpy cached the `sw_build_id` attribute when pairing/reconfiguring a device.
But that doesn't happen. So, we need to read the attribute once to cache it while the device is awake.
(That would also be required if we want to use `sw_build_id` with quirks v2, because we can't magically read an attribute of battery-powered devices that are already paired and asleep.)

The diff might look huge at first (but ignore the tests) and the fix is mostly somewhat simple actually.
-> Start by looking at `_update_attribute()`

## The "fix"

The "fix" works as follows:
- a battery percentage report comes in from the device
   - check `sw_build_id` attribute value from cache like:
      - if the value is known (e.g. `24.0.0`), we split on `.` and check the first part, here: 24
      - when the value is 24 or greater, we do not double the percentage.
      - when the value is below 24, we double the percentage.
      - if the value is not known, double the percentage AND start a task to try and read `sw_build_id` in the background
- if a task was started because of `sw_build_id` being unknown AND the read is successful:
   - and if the task returned that new firmware is installed (>= 24), we update the attribute cache again to correct the wrong doubled value and replace it with the correct one
   - and if the task returned that old firmware is installed, we do not do anything, as the value is already correct because we doubled it by default

Note: If the attribute read for `sw_build_id` is successful (or it's already known), no (further) read calls will ever be made.

EDIT: For (new) pairings or reconfigurations, `sw_build_id` is now also read on pairing/`bind()`.

## Additional information

### Note part 1 / TODO:

~~I did not yet test if an IKEA device responds to attribute reads when it sends an attribute report with the remaining battery percentage. I assume it would, as it should be "awake" at that point, but I still have to test this.
(So far, I only wrote the unit tests to test this behavior.)~~

~~If, for some reason, it does not wake up to receive message in that case, I'd move the logic to read the `sw_build_id` attribute once (until it's in cache) to happen when a button is pressed (for a remote).
Because then, a remote is definitely ready to receive commands for a short period.~~

Seems to work as expected. A button push during longer inactivity of the remote also triggers an attribute report, thus causing us to read `sw_build_id` while the device is awake.

### Note part 2:

Or, if we do not want this "read schedule logic" at all (for now), we can also just check the `sw_build_id` from attribute cache and if it's unknown, not schedule a read call.

This might cause weird behavior though if a user who previously manually read `sw_build_id` and has correct percentages then removes and re-pairs the device, only now to have doubled percentages (because `sw_build_id` isn't in the attribute cache).
(That's fixed by scheduling the read at that point.)

### Note part 3 (EDIT):

We're now also reading `sw_build_id` during pairing/reconfiguration, so during `bind()`.
This will not automatically fix the issue for existing users who currently have doubled percentages, but it will fix it if the device is paired again or reconfigured.
I'm hoping that the "task to schedule a read" will still work to fix existing installations automatically.
If it doesn't work, the "making users reconfigure their device to read `sw_build_id` and fix the issue"-approach is also fine I guess.

~~(I'm waiting for an attribute report from the IKEA remote for now to see if it also receives commands for a short period then.)~~

### Initial approach

My initial approach did not re-update the attribute cache after a successful attribute read if the initial doubling was wrong.
The successful attribute read only updated the attribute cache, so only next time the device sends something, the percentage would be right. You can still see this approach in my initial commit.

---

cc @dmulcahey just to know if this approach/PR would be somewhat okay. I know it might not be ideal to have to read attributes in the background, but it's only done once (if successful) and we need the `sw_build_id` sooner or later anyway.

A similar-ish approach with the background tasks is used for some Tuya devices and EU Xiaomi plugs (although not for firmware checking).

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
