### PR TITLE
Add version 3 of Ikea Frytur Blinds firmware 0x24040011

### DIFF
--- a/zhaquirks/ikea/blinds.py
+++ b/zhaquirks/ikea/blinds.py
@@ -112,3 +112,59 @@ class IkeaTradfriRollerBlinds2(CustomDevice):
     }
 
     replacement = IkeaTradfriRollerBlinds.replacement
+
+class IkeaTradfriRollerBlinds3(CustomDevice):
+    """Custom device representing IKEA of Sweden TRADFRI Fyrtur blinds."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=514
+        # device_version=1
+        # input_clusters=[0, 1, 3, 4, 5, 32, 258, 4096, 64636]
+        # output_clusters=[3, 25, 4096]>
+        MODELS_INFO: [
+            (IKEA, "FYRTUR block-out roller blind"),
+            (IKEA, "KADRILJ roller blind"),
+            (IKEA, "TREDANSEN block-out cellul blind"),
+            (IKEA, "PRAKTLYSING cellular blind"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    PollControl.cluster_id,
+                    WindowCovering.cluster_id,
+                    LightLink.cluster_id,
+                    IKEA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id, LightLink.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DoublingPowerConfigClusterIKEA,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    PollControl.cluster_id,
+                    WindowCovering.cluster_id,
+                    LightLink.cluster_id,
+                    IKEA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id,Ota.cluster_id, LightLink.cluster_id],
+            }
+        }
+    }
+


### PR DESCRIPTION
## Proposed change

Since with firmware 0x24040011, IKEA introduced a new output cluster 3. (see https://github.com/zigpy/zha-device-handlers/issues/2418).   This quirk adds the additional output clusters.  I have tested and thanks to https://github.com/zigpy/zha-device-handlers/pull/2948, battery issues appear to also be resolved.



## Additional information
I haven't tested a new factory blind getting gets this or a later firmware update, getting this quirk and reports 2x the battery, but see https://github.com/zigpy/zha-device-handlers/issues/2418 for possible resolutions.  My testing on devices with the firmware show correct battery and restore a minor annoyance where the shade being fully open will "drift" every so often leaving the shade slightly open.

## Checklist

- [X] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
