### PR TITLE
Add Philips effect cluster and enable it for Hue Go

### DIFF
--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -340,3 +340,25 @@ class PhilipsRwlRemoteCluster(PhilipsRemoteCluster):
         3: Button("down", DIM_DOWN),
         4: Button("off", TURN_OFF),
     }
+
+
+class PhilipsEffectCluster(CustomCluster):
+    """Philips effect cluster."""
+
+    cluster_id = 0xFC03
+    ep_attribute = "philips_effect"
+
+    class ServerCommandDefs(foundation.BaseCommandDefs):
+        """Server command definitions."""
+
+        set_effect: Final = foundation.ZCLCommandDef(
+            id=0x00,
+            schema={
+                "param1": t.uint8_t,
+                "param2": t.uint8_t,
+                "param3": t.uint8_t,
+                "param4": t.uint8_t,
+            },
+            direction=foundation.Direction.Client_to_Server,
+            is_manufacturer_specific=True,
+        )

--- a/zhaquirks/philips/hue_go.py
+++ b/zhaquirks/philips/hue_go.py
@@ -1,0 +1,11 @@
+"""Philips Hue Go device."""
+
+from zigpy.quirks.v2 import QuirkBuilder
+from zhaquirks.philips import PHILIPS, PhilipsEffectCluster
+
+(
+    QuirkBuilder(PHILIPS, "7602031P7")
+    .also_applies_to(PHILIPS, "7602031U7")
+    .replaces(PhilipsEffectCluster, endpoint_id=11)
+    .add_to_registry()
+)

--- a/zhaquirks/philips/hue_go.py
+++ b/zhaquirks/philips/hue_go.py
@@ -1,6 +1,7 @@
 """Philips Hue Go device."""
 
 from zigpy.quirks.v2 import QuirkBuilder
+
 from zhaquirks.philips import PHILIPS, PhilipsEffectCluster
 
 (


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Adds a new, manufacturer specific, Philips cluster that is used to set effects on certain Hue devices, such as Hue Go.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Fixes #2517.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
