### PR TITLE
Change Tuya switch TS000x device type

### DIFF
--- a/zhaquirks/tuya/ts000x.py
+++ b/zhaquirks/tuya/ts000x.py
@@ -855,7 +855,7 @@ class Switch_4G_GPP(EnchantedDevice):
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
@@ -869,7 +869,7 @@ class Switch_4G_GPP(EnchantedDevice):
             },
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     Groups.cluster_id,
                     Scenes.cluster_id,
@@ -880,7 +880,7 @@ class Switch_4G_GPP(EnchantedDevice):
             },
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     Groups.cluster_id,
                     Scenes.cluster_id,
@@ -891,7 +891,7 @@ class Switch_4G_GPP(EnchantedDevice):
             },
             4: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     Groups.cluster_id,
                     Scenes.cluster_id,


### PR DESCRIPTION
## Proposed change
Change device type of Switch_4G_GPP to be an actual switch, as the device consists of potential-free relais. Also the type switch is substitutable with other types using HA helpers, but not (or not easily) vice versa.

It would probably make sense to change this for other similar switches as well, but as I don't own any others, I don't want to change stuff blindy, potentially introducing unnecessary errors/misbehaviour.

I found no related tests to this device, so I didn't do anything in this regard as well, as I've got not enough time to read through your testframework (yet) :/

## Checklist
- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
