### PR TITLE
Add KeenHome smart vent `SV02-410-MP-1.2`

### DIFF
--- a/zhaquirks/keenhome/sv02612mp13.py
+++ b/zhaquirks/keenhome/sv02612mp13.py
@@ -42,6 +42,7 @@ class KeenHomeSmartVent(CustomDevice):
             ("Keen Home Inc", "SV01-410-MP-1.1"),
             ("Keen Home Inc", "SV01-410-MP-1.4"),
             ("Keen Home Inc", "SV01-410-MP-1.5"),
+            ("Keen Home Inc", "SV02-410-MP-1.2"),
             ("Keen Home Inc", "SV02-410-MP-1.3"),
             ("Keen Home Inc", "SV01-412-MP-1.0"),
             ("Keen Home Inc", "SV01-610-MP-1.0"),


### PR DESCRIPTION
Adding a missing signature for a KeenHome smart vent. It appears to behave exactly like the other KeenHome vents.

## Proposed change
Add a missing signature

## Checklist

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
