### PR TITLE
Fix Tuya 3 gang switch TS0601 `_TZE200_vhy3iakz`

### DIFF
--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -84,7 +84,6 @@ class TuyaSingleSwitchTO(TuyaSwitch):
         MODELS_INFO: [
             ("_TZE200_amp6tsvy", "TS0601"),
             ("_TZE200_oisqyl4o", "TS0601"),
-            ("_TZE200_vhy3iakz", "TS0601"),  # ¿1 or 4 gangs?
             ("_TZ3000_uim07oem", "TS0601"),  # ¿1 or 4 gangs?
             ("_TZE200_wfxuhoea", "TS0601"),
             ("_TZE200_tviaymwx", "TS0601"),
@@ -314,6 +313,7 @@ class TuyaTripleSwitchTO(TuyaSwitch):
         MODELS_INFO: [
             # ("_TZE200_kyfqmmyl", "TS0601"),  ## candidate reported in #716
             ("_TZE200_tz32mtza", "TS0601"),
+            ("_TZE200_vhy3iakz", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
Mark the TS0601 _TZE200_vhy3iakz device as a 3 gang switch instead of a 1 gang switch.


## Additional information
I purchased a 3 gang "Tuya Smart ZigBee Push Switch" from [here](https://www.expert4house.com/en/smart-home/wi-fi-switches/tuya-smart-zigbee-push-switch#/40-size-3_gang). In HA the manufacturer is "_TZE200_vhy3iakz" and the model is "TS0601". It uses the ts0601_switch.TuyaSingleSwitchTO quirk, and so I was only able to control the first switch.

Multi gang quirks for tuya switches were added in [this PR](https://github.com/zigpy/zha-device-handlers/pull/1166), which notes that "For those devices whose number of gangs is not clear, they have been defined as 1-gang devices until someone report correct info" and "we have doubts about [the _TZE200_vhy3iakz] device".

I tried the changes by loading them as a custom quirk, and it works fine for me. I am now able to control all three switches remotely, and the status is updated properly in HA.


## Checklist
- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
