### PR TITLE
Bump zigpy to 0.63.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache License Version 2.0"}
 requires-python = ">=3.8"
 dependencies = [
-    "zigpy>=0.63.4",
+    "zigpy>=0.63.5",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache License Version 2.0"}
 requires-python = ">=3.8"
 dependencies = [
-    "zigpy>=0.63.3",
+    "zigpy>=0.63.4",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache License Version 2.0"}
 requires-python = ">=3.8"
 dependencies = [
-    "zigpy>=0.63.1",
+    "zigpy>=0.63.3",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache License Version 2.0"}
 requires-python = ">=3.8"
 dependencies = [
-    "zigpy>=0.62.0",
+    "zigpy>=0.63.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.53
+zigpy>=0.63.1
 ruff==0.0.261

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.63.1
+zigpy>=0.63.3
 ruff==0.0.261

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.63.4
+zigpy>=0.63.5
 ruff==0.0.261

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.63.3
+zigpy>=0.63.4
 ruff==0.0.261

--- a/tests/test_inovelli_blue.py
+++ b/tests/test_inovelli_blue.py
@@ -1,5 +1,6 @@
 """Tests for inovelli blue series manufacturer cluster."""
 from unittest import mock
+from unittest.mock import MagicMock
 
 import zhaquirks
 from zhaquirks.inovelli.VZM31SN import InovelliVZM31SNv11
@@ -17,6 +18,7 @@ def test_mfg_cluster_events(zigpy_device_from_quirk):
         zha_send_event = mock.MagicMock()
 
     device = zigpy_device_from_quirk(InovelliVZM31SNv11)
+    device._packet_debouncer.filter = MagicMock(return_value=False)
     cluster_listener = Listener()
     device.endpoints[endpoint_id].out_clusters[cluster_id].add_listener(
         cluster_listener

--- a/tests/test_tuya_air.py
+++ b/tests/test_tuya_air.py
@@ -1,6 +1,7 @@
 """Test Tuya Air quality sensor."""
 
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 import zigpy.profiles.zha
@@ -17,6 +18,7 @@ zhaquirks.setup()
 def air_quality_device(zigpy_device_from_quirk):
     """Tuya Air Quality Sensor."""
     dev = zigpy_device_from_quirk(TuyaCO2Sensor)
+    dev._packet_debouncer.filter = MagicMock(return_value=False)
     cluster = dev.endpoints[1].in_clusters[TuyaNewManufCluster.cluster_id]
     with mock.patch.object(cluster, "send_default_rsp"):
         yield dev
@@ -76,6 +78,7 @@ def test_co2_sensor(air_quality_device, data, ep_attr, expected_value):
 def smart_air_quality_device(zigpy_device_from_quirk):
     """Tuya Smart Air Quality Sensor."""
     dev = zigpy_device_from_quirk(TuyaSmartAirSensor)
+    dev._packet_debouncer.filter = MagicMock(return_value=False)
     cluster = dev.endpoints[1].in_clusters[TuyaNewManufCluster.cluster_id]
     with mock.patch.object(cluster, "send_default_rsp"):
         yield dev


### PR DESCRIPTION
## Proposed change
Bump zigpy to [0.63.5](https://github.com/zigpy/zigpy/releases/tag/0.63.5)
Full diff: https://github.com/zigpy/zigpy/compare/0.62.0...0.63.5

Tests affected by the [packet debouncing](https://github.com/zigpy/zigpy/pull/1338) added in zigpy [0.63.0](https://github.com/zigpy/zigpy/releases/tag/0.63.0) were also updated to disable the debouncer like zigpy does too.

## Additional information

This allows us to rebase this PR and add the `KeepAlive` cluster:
- https://github.com/zigpy/zha-device-handlers/pull/3003

## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
