### PR TITLE
Remove unnecessary default in IKEA fw check

### DIFF
--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -212,7 +212,7 @@ class DoublingPowerConfigClusterIKEA(CustomCluster, PowerConfiguration):
     def _is_firmware_new(self):
         """Checks if new firmware is installed that does not require battery doubling."""
         # get sw_build_id from attribute cache if available
-        sw_build_id = self.endpoint.basic.get(Basic.AttributeDefs.sw_build_id.id, None)
+        sw_build_id = self.endpoint.basic.get(Basic.AttributeDefs.sw_build_id.id)
 
         # sw_build_id is not cached or empty, so we consider it old firmware for now
         if not sw_build_id:


### PR DESCRIPTION
## Proposed change
Remove unnecessary default in IKEA firmware check.
zigpy already uses `None` as the default for getting cluster attribute values.


## Additional information
Small follow-up PR to:
- https://github.com/zigpy/zha-device-handlers/pull/2998
- https://github.com/zigpy/zha-device-handlers/pull/2948

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
