### PR TITLE
Add Tuya cover TS0601 `_TZE200_9vpe3fl1` variant

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -174,6 +174,7 @@ class TuyaZemismartSmartCover0601_3(TuyaWindowCover):
             ("_TZE200_fzo2pocs", "TS0601"),
             ("_TZE200_iossyxra", "TS0601"),
             ("_TZE200_pw7mji0l", "TS0601"),
+            ("_TZE200_9vpe3fl1", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
Adds support for Zemismart Roller Shade Motor `_TZE200_9vpe3fl1` variant.

## Additional information
## Checklist
* [x]  The changes are tested and work correctly
* [ ]  `pre-commit` checks pass / the code has been formatted using Black
* [ ]  Tests have been added to verify that the new code works

