### PR TITLE
Add Conecto TS0601 `_TZE200_zppcgbdj` temperature & humidity

### DIFF
--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -143,11 +143,8 @@ class TuyaTempHumiditySensor(CustomDevice):
     }
 
 
-class TuyaTempHumiditySensor_Conecto_Display(CustomDevice):
+class TuyaTempHumiditySensorVar02(CustomDevice):
     """Custom device representing tuya temp and humidity sensor with e-ink screen."""
-
-    # RelativeHumidity multiplier
-    # RH_MULTIPLIER = 100
 
     signature = {
         # <SimpleDescriptor endpoint=1, profile=260, device_type=81
@@ -155,7 +152,7 @@ class TuyaTempHumiditySensor_Conecto_Display(CustomDevice):
         # input_clusters=[4, 5, 61184, 0]
         # output_clusters=[25, 10]>
         MODELS_INFO: [
-            ("_TZE200_zppcgbdj", "TS0601"),
+            ("_TZE200_zppcgbdj", "TS0601"),  # Conecto TH
         ],
         ENDPOINTS: {
             1: {

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -142,6 +142,52 @@ class TuyaTempHumiditySensor(CustomDevice):
         },
     }
 
+class TuyaTempHumiditySensor_Conecto_Display(CustomDevice):
+    """Custom device representing tuya temp and humidity sensor with e-ink screen."""
+
+    # RelativeHumidity multiplier
+    # RH_MULTIPLIER = 100
+
+    signature = {
+        # <SimpleDescriptor endpoint=1, profile=260, device_type=81
+        # device_version=1
+        # input_clusters=[4, 5, 61184, 0]
+        # output_clusters=[25, 10]>
+        MODELS_INFO: [
+            ("_TZE200_zppcgbdj", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TemperatureHumidityManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        SKIP_CONFIGURATION: True,
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.TEMPERATURE_SENSOR,
+                INPUT_CLUSTERS: [
+                    TemperatureHumidityManufCluster,  # Single bus for temp, humidity, and battery
+                    TuyaTemperatureMeasurement,
+                    TuyaRelativeHumidity,
+                    TuyaPowerConfigurationCluster2AAA,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            }
+        },
+    }
+
 
 class TuyaTempHumiditySensor_Square(CustomDevice):
     """Custom device representing tuya temp and humidity sensor with e-ink screen."""

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -142,6 +142,7 @@ class TuyaTempHumiditySensor(CustomDevice):
         },
     }
 
+
 class TuyaTempHumiditySensor_Conecto_Display(CustomDevice):
     """Custom device representing tuya temp and humidity sensor with e-ink screen."""
 


### PR DESCRIPTION
The device is a rebranded Tuya temperature and humidity sensor, and the quirk is almost identical to one of the existing Tuya quirks (but with a different humidity multiplier). I am not sure if the device is also sold under other brand names, though I suppose that is quite likely. I figure it makes sense to put it in as a Tuya quirk.

## Proposed change

This pull request adds the quirk immediately after the most similar existing quirk. It is almost identical, though if follows the standard set by the rest of the file when it comes to humidity multiplier (commented line containing the default value of 100).

## Additional information

Fixes #3024 

I do not have the development environment available to run formatting or adding tests. Given that this is essentially a copy-paste of the quirk before it, and it works in manual testing, I hope that is OK.

## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
