### PR TITLE
Add a helper to create devices from v2 quirks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,8 @@ import zigpy.application
 import zigpy.device
 import zigpy.quirks
 import zigpy.types
-import zigpy.zcl.foundation as foundation
 from zigpy.zcl.clusters.general import Basic
+import zigpy.zcl.foundation as foundation
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -162,13 +162,13 @@ def zigpy_device_from_v2_quirk(MockAppController, ieee_mock):
     """Create zigpy device from Quirk's signature."""
 
     def _dev(
-            manufacturer: str,
-            model: str,
-            endpoint_ids: list[int] = [1],
-            ieee=None,
-            nwk=zigpy.types.NWK(0x1234),
-            apply_quirk=True
-        ):
+        manufacturer: str,
+        model: str,
+        endpoint_ids: list[int] = [1],
+        ieee=None,
+        nwk=zigpy.types.NWK(0x1234),
+        apply_quirk=True,
+    ):
         if ieee is None:
             ieee = ieee_mock
 


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR adds a helper for creating devices from v2 quirks. It will not create a complete copy of the device as we no longer have a signature (we don't have the info at all any more). I think what it creates gives us what we need to test what the quirk is actually meant to do. Definitely open to suggestions...


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
