### PR TITLE
Update pre-commit settings and fix lint issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,49 +1,18 @@
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
-
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.0.2
-    hooks:
-      - id: autoflake
-
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-      - id: black
-        args:
-          - --quiet
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies: 
-          - Flake8-pyproject==1.2.3
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.2.6
     hooks:
       - id: codespell
-        additional_dependencies:
-          - tomli
+        additional_dependencies: [tomli]
+        args: ["--toml", "pyproject.toml"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
+    rev: v1.9.0
     hooks:
       - id: mypy
   
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.261
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.2
     hooks:
       - id: ruff
-        args:
-          - --fix
+        args: ["--fix", "--exit-non-zero-on-fix", "--config", "pyproject.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "Apache License Version 2.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 dependencies = [
     "zigpy>=0.63.5",
 ]
@@ -28,29 +28,8 @@ testing = [
 [tool.setuptools-git-versioning]
 enabled = true
 
-[tool.isort]
-# https://github.com/timothycrosley/isort
-# https://github.com/timothycrosley/isort/wiki/isort-Settings
-# splits long import on multiple lines indented by 4 spaces
-profile = "black"
-# by default isort don't check module indexes
-not_skip = ["__init__.py"]
-# will group `import x` and `from x import` of the same module.
-force_sort_within_sections = true
-sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
-default_section = "THIRDPARTY"
-known_first_party = ["zhaquirks", "tests"]
-forced_separate = "tests"
-combine_as_imports = true
-use_parentheses = true
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-line_length = 88
-indent = "    "
-
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.12"
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_calls = true
@@ -94,108 +73,145 @@ asyncio_mode = "auto"
 testpaths = "tests"
 norecursedirs = ".git testing_config"
 
-[tool.flake8]
-exclude = [".venv", ".git", ".tox", "docs", "venv", "bin", "lib", "deps", "build"]
-# To work with Black
-max-line-length = 88
-ignore = [
-    "E501",  # E501: line too long
-    "W503",  # W503: Line break occurred before a binary operator
-    "E203",  # E203: Whitespace before ':'
-    "D202",  # D202 No blank lines allowed after function docstring
-]
-
-[tool.autoflake]
-in-place = true
-recursive = false
-expand-star-imports = false
-exclude = [".venv", ".git", ".tox", "docs", "venv", "bin", "lib", "deps", "build"]
-
-[tool.pydocstyle]
-ignore = [
-    "D202",
-    "D203",
-    "D213",
-]
-
-[tool.pyupgrade]
-py37plus = true
-
 [tool.codespell]
-exclude = "pyproject.toml"
-ignore-words-list = "hass,dout"
-skip = "./.*,test/*"
+skip = "Contributors.md"
+ignore-words-list = "hass, dout, potentiels"
 quiet-level = 2
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py312"
 
+[tool.ruff.lint]
 select = [
+    "B002", # Python does not support the unary prefix increment
     "B007", # Loop control variable {name} not used within loop body
     "B014", # Exception handler with duplicate exception
-    "C",  # complexity
-    "D",  # docstrings
-    "E",  # pycodestyle
-    "F",  # pyflakes/autoflake
+    "B023", # Function definition does not bind loop variable {name}
+    "B026", # Star-arg unpacking after a keyword argument is strongly discouraged
+    "B904", # Use raise from to specify exception cause
+    "C", # complexity
+    "COM818", # Trailing comma on bare tuple prohibited
+    "D", # docstrings
+    "DTZ003", # Use datetime.now(tz=) instead of datetime.utcnow()
+    "DTZ004", # Use datetime.fromtimestamp(ts, tz=) instead of datetime.utcfromtimestamp(ts)
+    "E", # pycodestyle
+    "F", # pyflakes/autoflake
+    "G", # flake8-logging-format
+    "I", # isort
     "ICN001", # import concentions; {name} should be imported as {asname}
-    "PGH004",  # Use specific rule codes when using noqa
+    "N804", # First argument of a class method should be named cls
+    "N805", # First argument of a method should be named self
+    "N815", # Variable {name} in class scope should not be mixedCase
+    "PERF101", # Do not cast an iterable to list before iterating over it
+    "PERF102", # When using only the {subset} of a dict use the {subset}() method
+    "PERF203", # try-except within a loop incurs performance overhead
+    "PGH004", # Use specific rule codes when using noqa
     "PLC0414", # Useless import alias. Import alias does not rename original package.
+    "PLC", # pylint
+    "PLE", # pylint
+    "PLR", # pylint
+    "PLW", # pylint
+    "Q000", # Double quotes found but single quotes preferred
+    "RUF006", # Store a reference to the return value of asyncio.create_task
+    "S102", # Use of exec detected
+    "S103", # bad-file-permissions
+    "S108", # hardcoded-temp-file
+    "S306", # suspicious-mktemp-usage
+    "S307", # suspicious-eval-usage
+    "S313", # suspicious-xmlc-element-tree-usage
+    "S314", # suspicious-xml-element-tree-usage
+    "S315", # suspicious-xml-expat-reader-usage
+    "S316", # suspicious-xml-expat-builder-usage
+    "S317", # suspicious-xml-sax-usage
+    "S318", # suspicious-xml-mini-dom-usage
+    "S319", # suspicious-xml-pull-dom-usage
+    "S320", # suspicious-xmle-tree-usage
+    "S601", # paramiko-call
+    "S602", # subprocess-popen-with-shell-equals-true
+    "S604", # call-with-shell-equals-true
+    "S608", # hardcoded-sql-expression
+    "S609", # unix-command-wildcard-injection
     "SIM105", # Use contextlib.suppress({exception}) instead of try-except-pass
+    "SIM114", # Combine if branches using logical or operator
     "SIM117", # Merge with-statements that use the same scope
     "SIM118", # Use {key} in {dict} instead of {key} in {dict}.keys()
     "SIM201", # Use {left} != {right} instead of not {left} == {right}
+    "SIM208", # Use {expr} instead of not (not {expr})
     "SIM212", # Use {a} if {a} else {b} instead of {b} if not {a} else {a}
     "SIM300", # Yoda conditions. Use 'age == 42' instead of '42 == age'.
     "SIM401", # Use get from dict with default instead of an if block
-    "T20",  # flake8-print
+    "T100", # Trace found: {name} used
+    "T20", # flake8-print
+    "TID251", # Banned imports
     "TRY004", # Prefer TypeError exception for invalid type
-    "RUF006", # Store a reference to the return value of asyncio.create_task
-    "UP",  # pyupgrade
-    "W",  # pycodestyle
+    "TRY302", # Remove exception handler; error is immediately re-raised
+    "UP", # pyupgrade
+    "W", # pycodestyle
 ]
 
 ignore = [
-    "D100",   # Missing docstring in public module
-    "D101",   # Missing docstring in public class
-    "D102",   # Missing docstring in public method
-    "D103",   # Missing docstring in public function
-    "D104",   # Missing docstring in public package
-    "D105",   # Missing docstring in magic method
-    "D106",   # Missing docstring in public nested class
-    "D107",   # Missing docstring in `__init__`
-    "D202",   # No blank lines allowed after function docstring
-    "D203",   # 1 blank line required before class docstring
-    "D205",   # 1 blank line required between summary line and description
-    "D213",   # Multi-line docstring summary should start at the second line
-    "D400",   # First line should end with a period
-    "D401",   # First line of docstring should be in imperative mood:
-    "D406",   # Section name should end with a newline
-    "D407",   # Section name underlining
-    "D415",   # First line should end with a period, question mark, or exclamation point
-    "E501",   # line too long
-              # the rules below this line should be corrected
-    "PGH004", # Use specific rule codes when using `noqa`
+    "D202", # No blank lines allowed after function docstring
+    "D203", # 1 blank line required before class docstring
+    "D213", # Multi-line docstring summary should start at the second line
+    "D406", # Section name should end with a newline
+    "D407", # Section name underlining
+    "E501", # line too long
+    "E731", # do not assign a lambda expression, use a def
+
+    # Ignore ignored, as the rule is now back in preview/nursery, which cannot
+    # be ignored anymore without warnings.
+    # https://github.com/astral-sh/ruff/issues/7491
+    # "PLC1901", # Lots of false positives
+
+    # False positives https://github.com/astral-sh/ruff/issues/5386
+    "PLC0208", # Use a sequence type instead of a `set` when iterating over values
+    "PLR0911", # Too many return statements ({returns} > {max_returns})
+    "PLR0912", # Too many branches ({branches} > {max_branches})
+    "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
+    "PLR0915", # Too many statements ({statements} > {max_statements})
+    "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
+    "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
+    "UP006", # keep type annotation style as is
+    "UP007", # keep type annotation style as is
+    # Ignored due to performance: https://github.com/charliermarsh/ruff/issues/2923
+    "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
+
+    # May conflict with the formatter, https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "COM812",
+    "COM819",
+    "ISC001",
+    "ISC002",
+
+    # Disabled because ruff does not understand type of __all__ generated by a function
+    "PLE0605",
 ]
 
-extend-exclude = [
-    "tests"
-]
-
-[tool.ruff.flake8-pytest-style]
+[tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
 
-[tool.ruff.pyupgrade]
-keep-runtime-typing = true
-
-[tool.ruff.isort]
-# will group `import x` and `from x import` of the same module.
+[tool.ruff.lint.isort]
 force-sort-within-sections = true
 known-first-party = [
     "zhaquirks",
     "tests",
 ]
-forced-separate = ["tests"]
 combine-as-imports = true
+split-on-trailing-comma = false
 
-[tool.ruff.mccabe]
-max-complexity = 25
+[tool.ruff.lint.per-file-ignores]
+
+# Allow for main entry & scripts to write to stdout
+"script/*" = ["T20"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 27

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ testing = [
 [tool.setuptools-git-versioning]
 enabled = true
 
+[tool.pylint]
+max-line-length = 120
+disable = ["C0103", "W0212"]
+
 [tool.mypy]
 python_version = "3.12"
 check_untyped_defs = true

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+"""setup."""
+
 import setuptools
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,8 @@ import zigpy.application
 import zigpy.device
 import zigpy.quirks
 import zigpy.types
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic
-import zigpy.zcl.foundation as foundation
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -72,7 +72,7 @@ class MockApp(zigpy.application.ControllerApplication):
         """Mock start_network."""
 
     async def permit_with_link_key(self, *args, **kwargs):
-        """Mock permit_with_link_key"""
+        """Mock permit_with_link_key."""
 
     async def write_network_info(self, *args, **kwargs):
         """Mock write_network_info."""

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -2,10 +2,9 @@
 import pytest
 from zigpy.zcl.clusters.general import DeviceTemperature
 
+from tests.common import ClusterListener
 import zhaquirks.develco.motion
 import zhaquirks.develco.power_plug
-
-from tests.common import ClusterListener
 
 zhaquirks.setup()
 

--- a/tests/test_ikea.py
+++ b/tests/test_ikea.py
@@ -7,10 +7,9 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, PowerConfiguration
 from zigpy.zcl.clusters.measurement import PM25
 
+from tests.common import ClusterListener
 import zhaquirks
 import zhaquirks.ikea.starkvind
-
-from tests.common import ClusterListener
 
 zhaquirks.setup()
 
@@ -87,7 +86,7 @@ def test_ikea_starkvind_v2(assert_signature_matches_quirk):
 
 
 async def test_pm25_cluster_read(zigpy_device_from_quirk):
-    """Test reading from PM25 cluster"""
+    """Test reading from PM25 cluster."""
 
     starkvind_device = zigpy_device_from_quirk(zhaquirks.ikea.starkvind.IkeaSTARKVIND)
     assert starkvind_device.model == "STARKVIND Air purifier"

--- a/tests/test_konke.py
+++ b/tests/test_konke.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 
+from tests.common import ZCL_IAS_MOTION_COMMAND, ClusterListener
 import zhaquirks
 from zhaquirks.const import (
     COMMAND_DOUBLE,
@@ -17,8 +18,6 @@ from zhaquirks.const import (
     ZONE_STATUS_CHANGE_COMMAND,
 )
 import zhaquirks.konke.motion
-
-from tests.common import ZCL_IAS_MOTION_COMMAND, ClusterListener
 
 zhaquirks.setup()
 

--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -1,4 +1,5 @@
 """Tests for Legrand."""
+
 import pytest
 
 import zhaquirks
@@ -29,6 +30,7 @@ async def test_legrand_battery(zigpy_device_from_quirk, voltage, bpr):
 
 
 def test_light_switch_with_neutral_signature(assert_signature_matches_quirk):
+    """Test signature."""
     signature = {
         "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=1, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4129, maximum_buffer_size=89, maximum_incoming_transfer_size=63, server_mask=10752, maximum_outgoing_transfer_size=63, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
         "endpoints": {

--- a/tests/test_linkind.py
+++ b/tests/test_linkind.py
@@ -1,9 +1,10 @@
+"""Test linkind."""
+
 import pytest
 from zigpy.zcl.clusters.security import IasZone
 
-import zhaquirks
-
 from tests.common import ClusterListener
+import zhaquirks
 
 zhaquirks.setup()
 

--- a/tests/test_orvibo.py
+++ b/tests/test_orvibo.py
@@ -5,11 +5,10 @@ from unittest import mock
 
 import pytest
 
+from tests.common import ZCL_IAS_MOTION_COMMAND, ClusterListener
 import zhaquirks
 from zhaquirks.const import OFF, ON, ZONE_STATUS_CHANGE_COMMAND
 import zhaquirks.orvibo.motion
-
-from tests.common import ZCL_IAS_MOTION_COMMAND, ClusterListener
 
 zhaquirks.setup()
 

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -1,4 +1,5 @@
 """General quirk tests."""
+
 from __future__ import annotations
 
 import collections
@@ -8,19 +9,19 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from zigpy import zcl
 import zigpy.device
 import zigpy.endpoint
 import zigpy.profiles
 import zigpy.quirks as zq
 from zigpy.quirks import CustomDevice
 import zigpy.types
-import zigpy.zcl as zcl
 import zigpy.zdo.types
 
 import zhaquirks
+from zhaquirks import const
 import zhaquirks.bosch.motion
 import zhaquirks.centralite.cl_3310S
-import zhaquirks.const as const
 from zhaquirks.const import (
     ARGS,
     COMMAND,
@@ -278,10 +279,8 @@ def test_dev_from_signature(
         assert ep.status == zigpy.endpoint.Status.ZDO_INIT
         assert ep.profile_id == ep_data[PROFILE_ID]
         assert ep.device_type == ep_data[DEVICE_TYPE]
-        assert [cluster_id for cluster_id in ep.in_clusters] == ep_data[INPUT_CLUSTERS]
-        assert [cluster_id for cluster_id in ep.out_clusters] == ep_data[
-            OUTPUT_CLUSTERS
-        ]
+        assert list(ep.in_clusters) == ep_data[INPUT_CLUSTERS]
+        assert list(ep.out_clusters) == ep_data[OUTPUT_CLUSTERS]
 
 
 @pytest.mark.parametrize(
@@ -309,7 +308,7 @@ def test_signature(quirk: CustomDevice) -> None:
     """Make sure signature look sane for all custom devices."""
 
     def _check_range(cluster: zcl.Cluster) -> bool:
-        for range in zcl.Cluster._registry_range.keys():
+        for range in zcl.Cluster._registry_range:
             if range[0] <= cluster <= range[1]:
                 return True
         return False
@@ -429,7 +428,7 @@ def test_quirk_importable(quirk: CustomDevice) -> None:
 
     path = f"{quirk.__module__}.{quirk.__name__}"
     assert all(
-        [m and m.isidentifier() for m in path.split(".")]
+        m and m.isidentifier() for m in path.split(".")
     ), f"{path} is not importable"
 
 
@@ -592,7 +591,7 @@ def test_migrated_lighting_automation_triggers(quirk: CustomDevice) -> None:
     if not hasattr(quirk, "device_automation_triggers"):
         return
 
-    for trigger, event in quirk.device_automation_triggers.items():
+    for event in quirk.device_automation_triggers.values():
         if COMMAND not in event:
             continue
 
@@ -696,7 +695,7 @@ def test_quirk_device_automation_triggers_unique(quirk):
             triggers_text = "\n".join(
                 [f" * {event} <- {trigger}" for trigger, event in triggers_and_events]
             )
-            fail_func(f"Triggers are not unique for {quirk}:\n{triggers_text}")  # noqa
+            fail_func(f"Triggers are not unique for {quirk}:\n{triggers_text}")
 
 
 @pytest.mark.parametrize(
@@ -717,7 +716,7 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
     base_cluster_attrs_name = {}
     base_cluster_attrs_id = {}
 
-    for name, cluster in zcl.clusters.CLUSTERS_BY_NAME.items():
+    for cluster in zcl.clusters.CLUSTERS_BY_NAME.values():
         assert cluster.ep_attribute not in base_cluster_attrs_name
         base_cluster_attrs_name[cluster.ep_attribute] = set(
             cluster.attributes_by_name.keys()
@@ -726,13 +725,15 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
             cluster.attributes_by_name.keys()
         )
 
-    for ep_id, ep_data in quirk.replacement[ENDPOINTS].items():
+    for ep_data in quirk.replacement[ENDPOINTS].values():
         for cluster in ep_data.get(INPUT_CLUSTERS, []) + ep_data.get(
             OUTPUT_CLUSTERS, []
         ):
-            if isinstance(cluster, int) or not issubclass(cluster, zcl.Cluster):
-                continue
-            elif cluster in ALL_ZIGPY_CLUSTERS:
+            if (
+                isinstance(cluster, int)
+                or not issubclass(cluster, zcl.Cluster)
+                or cluster in ALL_ZIGPY_CLUSTERS
+            ):
                 continue
 
             assert issubclass(cluster, zigpy.quirks.CustomCluster)
@@ -771,7 +772,7 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
                     zhaquirks.xiaomi.aqara.vibration_aq1.VibrationAQ1.MultistateInputCluster,
                 ):
                     pytest.fail(
-                        f"Cluster {cluster} with endpoint ID 0x{cluster.cluster_id:04X}"  # noqa
+                        f"Cluster {cluster} with endpoint ID 0x{cluster.cluster_id:04X}"
                         f" does not contain all named attributes: {missing_attrs}"
                     )
 
@@ -821,11 +822,11 @@ def test_no_duplicate_clusters(quirk: CustomDevice) -> None:
 
             if cluster_id in used_cluster_ids:
                 pytest.fail(
-                    f"Cluster ID 0x{cluster_id:04X} is used more than once in the"  # noqa
+                    f"Cluster ID 0x{cluster_id:04X} is used more than once in the"
                     f" replacement for endpoint {ep_id} in {quirk}"
                 )
             used_cluster_ids.add(cluster_id)
 
-    for ep_id, ep_data in quirk.replacement[ENDPOINTS].items():
+    for ep_id, ep_data in quirk.replacement[ENDPOINTS].items():  # noqa: B007
         check_for_duplicate_cluster_ids(ep_data.get(INPUT_CLUSTERS, []))
         check_for_duplicate_cluster_ids(ep_data.get(OUTPUT_CLUSTERS, []))

--- a/tests/test_schneider.py
+++ b/tests/test_schneider.py
@@ -3,9 +3,8 @@
 import pytest
 from zigpy.zcl.clusters.smartenergy import Metering
 
-import zhaquirks.schneider.outlet
-
 from tests.common import ClusterListener
+import zhaquirks.schneider.outlet
 
 zhaquirks.setup()
 

--- a/tests/test_schneiderelectric.py
+++ b/tests/test_schneiderelectric.py
@@ -1,18 +1,19 @@
 """Tests for Schneider Electric devices."""
+
 from unittest import mock
 
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 
+from tests.common import ClusterListener
 import zhaquirks.schneiderelectric.dimmers
 import zhaquirks.schneiderelectric.shutters
-
-from tests.common import ClusterListener
 
 zhaquirks.setup()
 
 
 def test_1gang_shutter_1_signature(assert_signature_matches_quirk):
+    """Test signature."""
     signature = {
         "node_descriptor": (
             "NodeDescriptor(logical_type=<LogicalType.Router: 1>, "
@@ -113,8 +114,10 @@ async def test_1gang_shutter_1_unpatched_cmd(zigpy_device_from_quirk):
 
 
 async def test_1gang_shutter_1_lift_percentage_updates(zigpy_device_from_quirk):
-    """Asserts that updates to the ``current_position_lift_percentage`` attribute
-    (e.g., by the device) invert the reported percentage value."""
+    """Asserts that updates to the ``current_position_lift_percentage`` attribute.
+
+    (e.g., by the device) invert the reported percentage value.
+    """
 
     device = zigpy_device_from_quirk(
         zhaquirks.schneiderelectric.shutters.OneGangShutter1
@@ -136,6 +139,7 @@ async def test_1gang_shutter_1_lift_percentage_updates(zigpy_device_from_quirk):
 
 
 def test_nh_rotary_dimmer_1_signature(assert_signature_matches_quirk):
+    """Test signature."""
     signature = {
         "node_descriptor": (
             "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, "

--- a/tests/test_sinope.py
+++ b/tests/test_sinope.py
@@ -4,9 +4,8 @@ import pytest
 from zigpy.zcl.clusters.general import DeviceTemperature
 from zigpy.zcl.clusters.measurement import FlowMeasurement
 
-import zhaquirks.sinope.switch
-
 from tests.common import ClusterListener
+import zhaquirks.sinope.switch
 
 zhaquirks.setup()
 

--- a/tests/test_thirdreality.py
+++ b/tests/test_thirdreality.py
@@ -4,10 +4,9 @@
 import pytest
 from zigpy.zcl.clusters.security import IasZone
 
+from tests.common import ClusterListener
 import zhaquirks
 import zhaquirks.thirdreality.night_light
-
-from tests.common import ClusterListener
 
 zhaquirks.setup()
 

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -11,6 +11,7 @@ import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import PowerConfiguration
 
+from tests.common import ClusterListener, MockDatetime, wait_for_zigpy_tasks
 import zhaquirks
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -25,18 +26,16 @@ from zhaquirks.const import (
 )
 from zhaquirks.tuya import Data, TuyaManufClusterAttributes, TuyaNewManufCluster
 import zhaquirks.tuya.sm0202_motion
-import zhaquirks.tuya.ts011f_plug
 import zhaquirks.tuya.ts0041
 import zhaquirks.tuya.ts0042
 import zhaquirks.tuya.ts0043
+import zhaquirks.tuya.ts011f_plug
 import zhaquirks.tuya.ts0501_fan_switch
 import zhaquirks.tuya.ts0601_electric_heating
 import zhaquirks.tuya.ts0601_motion
 import zhaquirks.tuya.ts0601_siren
 import zhaquirks.tuya.ts0601_trv
 import zhaquirks.tuya.ts0601_valve
-
-from tests.common import ClusterListener, MockDatetime, wait_for_zigpy_tasks
 
 zhaquirks.setup()
 

--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -5,9 +5,8 @@ from unittest import mock
 import pytest
 from zigpy.zcl import foundation
 
-import zhaquirks
-
 from tests.common import ClusterListener, wait_for_zigpy_tasks
+import zhaquirks
 
 zhaquirks.setup()
 

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 from zigpy.zcl import foundation
 
+from tests.common import ClusterListener, MockDatetime
 import zhaquirks
 from zhaquirks.tuya import TUYA_MCU_VERSION_RSP, TUYA_SET_TIME, TuyaDPType
 from zhaquirks.tuya.mcu import (
@@ -15,8 +16,6 @@ from zhaquirks.tuya.mcu import (
     TuyaClusterData,
     TuyaMCUCluster,
 )
-
-from tests.common import ClusterListener, MockDatetime
 
 zhaquirks.setup()
 

--- a/tests/test_tuya_rcbo.py
+++ b/tests/test_tuya_rcbo.py
@@ -5,9 +5,8 @@ from unittest import mock
 import pytest
 from zigpy.zcl import foundation
 
-import zhaquirks
-
 from tests.common import ClusterListener, wait_for_zigpy_tasks
+import zhaquirks
 
 zhaquirks.setup()
 

--- a/tests/test_tuya_valve.py
+++ b/tests/test_tuya_valve.py
@@ -5,9 +5,8 @@ from unittest import mock
 import pytest
 from zigpy.zcl import foundation
 
-import zhaquirks
-
 from tests.common import ClusterListener, wait_for_zigpy_tasks
+import zhaquirks
 
 zhaquirks.setup()
 

--- a/tests/test_xbee.py
+++ b/tests/test_xbee.py
@@ -6,6 +6,7 @@ import pytest
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import AnalogOutput, Basic, LevelControl, OnOff
 
+from tests.common import ClusterListener
 import zhaquirks
 from zhaquirks.xbee import (
     XBEE_AT_ENDPOINT,
@@ -18,8 +19,6 @@ from zhaquirks.xbee import (
 )
 from zhaquirks.xbee.xbee3_io import XBee3Sensor
 from zhaquirks.xbee.xbee_io import XBeeSensor
-
-from tests.common import ClusterListener
 
 zhaquirks.setup()
 

--- a/zhaquirks/adeo/color_controller.py
+++ b/zhaquirks/adeo/color_controller.py
@@ -1,5 +1,6 @@
 """Device handler for ADEO Lexman LXEK-5 (HR-C99C-Z-C045) & ZBEK-26 (HR-C99C-Z-C045-B) color controllers."""
-from typing import Any, List, Optional, Union
+
+from typing import Any, Optional, Union
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -79,7 +80,7 @@ class AdeoManufacturerCluster(EventableCluster):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]

--- a/zhaquirks/develco/open_close.py
+++ b/zhaquirks/develco/open_close.py
@@ -1,4 +1,5 @@
 """Door/Windows sensors."""
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
@@ -55,7 +56,7 @@ class DevelcoIASZone(CustomCluster, IasZone):
 
 
 class WISZB120(CustomDevice):
-    """Custom device representing door/windows sensors, with built-in temperature measuring"""
+    """Custom device representing door/windows sensors, with built-in temperature measuring."""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=49353 device_type=1 device_version=1
@@ -138,7 +139,7 @@ class WISZB120(CustomDevice):
 
 
 class WISZB121(CustomDevice):
-    """Custom device representing door/windows sensors, without built-in temperature measuring"""
+    """Custom device representing door/windows sensors, without built-in temperature measuring."""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=49353 device_type=1 device_version=1

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -1,4 +1,5 @@
 """Ikea module."""
+
 import logging
 
 from zigpy.quirks import CustomCluster
@@ -210,7 +211,7 @@ class DoublingPowerConfigClusterIKEA(CustomCluster, PowerConfiguration):
         return result
 
     def _is_firmware_new(self):
-        """Checks if new firmware is installed that does not require battery doubling."""
+        """Check if new firmware is installed that does not require battery doubling."""
         # get sw_build_id from attribute cache if available
         sw_build_id = self.endpoint.basic.get(Basic.AttributeDefs.sw_build_id.id, None)
 

--- a/zhaquirks/ikea/opencloseremote.py
+++ b/zhaquirks/ikea/opencloseremote.py
@@ -1,5 +1,6 @@
 """Device handler for IKEA of Sweden TRADFRI remote control."""
-from typing import Any, List, Optional, Union
+
+from typing import Any, Optional, Union
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -54,7 +55,7 @@ class IkeaWindowCovering(CustomCluster, WindowCovering):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]

--- a/zhaquirks/ikea/somrigsmartbtn.py
+++ b/zhaquirks/ikea/somrigsmartbtn.py
@@ -1,4 +1,5 @@
-"""Device handler for IKEA of Sweden SOMRIG shortcut button"""
+"""Device handler for IKEA of Sweden SOMRIG shortcut button."""
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -44,7 +45,7 @@ from zhaquirks.ikea import (
 
 
 class IkeaSomrigSmartButton(CustomDevice):
-    """Custom device representing IKEA SOMRIG shortcut button"""
+    """Custom device representing IKEA SOMRIG shortcut button."""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260, device_type=6

--- a/zhaquirks/inovelli/VZM36.py
+++ b/zhaquirks/inovelli/VZM36.py
@@ -36,7 +36,7 @@ WWAH_CLUSTER_ID = 64599
 
 
 class InovelliVZM36(CustomDevice):
-    """VZM36 Canopy Module"""
+    """VZM36 Canopy Module."""
 
     signature = {
         MODELS_INFO: [("Inovelli", "VZM36")],

--- a/zhaquirks/inovelli/__init__.py
+++ b/zhaquirks/inovelli/__init__.py
@@ -1,7 +1,7 @@
 """Module for Inovelli quirks implementations."""
 
 import logging
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
@@ -159,7 +159,7 @@ class InovelliCluster(CustomCluster):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]

--- a/zhaquirks/konke/__init__.py
+++ b/zhaquirks/konke/__init__.py
@@ -1,5 +1,6 @@
 """Konke sensors."""
-from typing import Any, List, Optional, Union
+
+from typing import Any, Optional, Union
 
 import zigpy.types as t
 from zigpy.zcl.clusters.general import OnOff
@@ -19,6 +20,8 @@ KONKE = "Konke"
 
 
 class KonkeButtonEvent(t.enum8):
+    """Konke button event."""
+
     Single = 0x80
     Double = 0x81
     Hold = 0x82
@@ -59,7 +62,7 @@ class KonkeOnOffCluster(CustomCluster):
     def handle_cluster_general_request(
         self,
         header: zigpy.zcl.foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]

--- a/zhaquirks/legrand/cable_outlet.py
+++ b/zhaquirks/legrand/cable_outlet.py
@@ -35,6 +35,8 @@ MANUFACTURER_SPECIFIC_CLUSTER_ID_2 = 0xFC40  # 64576
 
 
 class DeviceMode(t.enum16):
+    """Device mode."""
+
     PILOT_OFF = 0x0100
     PILOT_ON = 0x0200
 
@@ -47,6 +49,8 @@ class LegrandCluster(CustomCluster):
     ep_attribute = "legrand_cluster"
 
     class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
         device_mode = ZCLAttributeDef(
             id=0x0000,
             type=t.data16,  # DeviceMode
@@ -65,6 +69,8 @@ class LegrandCluster(CustomCluster):
 
 
 class PilotWireMode(t.enum8):
+    """Pilot wire mode."""
+
     COMFORT = 0x00
     COMFORT_MINUS_1 = 0x01
     COMFORT_MINUS_2 = 0x02
@@ -81,6 +87,8 @@ class LegrandCableOutletCluster(CustomCluster):
     ep_attribute = "cable_outlet_cluster"
 
     class ServerCommandDefs(BaseCommandDefs):
+        """Server command definitions."""
+
         set_pilot_wire_mode = ZCLCommandDef(
             id=0x00,
             schema={"mode": PilotWireMode},
@@ -90,6 +98,8 @@ class LegrandCableOutletCluster(CustomCluster):
 
 
 class Legrand064882CableOutlet(CustomDevice):
+    """Legrand 064882 Cable Outlet device."""
+
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=1
         # input_clusters=[0, 3, 4, 6, 5, 64513, 2820, 64576]

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -1,8 +1,9 @@
 """Module for Philips quirks implementations."""
+
 import asyncio
 import logging
 import time
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
@@ -166,7 +167,7 @@ class PhilipsRemoteCluster(CustomCluster):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]

--- a/zhaquirks/philips/rdm001.py
+++ b/zhaquirks/philips/rdm001.py
@@ -1,6 +1,7 @@
 """Signify RDM001 device."""
+
 import logging
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -96,7 +97,7 @@ class PhilipsRemoteCluster(CustomCluster):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]

--- a/zhaquirks/samjin/__init__.py
+++ b/zhaquirks/samjin/__init__.py
@@ -1,5 +1,6 @@
 """Module for Samjin quirks implementations."""
-from typing import Any, List, Optional, Union
+
+from typing import Any, Optional, Union
 
 from zigpy.quirks import CustomCluster
 from zigpy.types import Addressing
@@ -22,7 +23,7 @@ class SamjinIASCluster(CustomCluster, zigpy.zcl.clusters.security.IasZone):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[
             Union[Addressing.Group, Addressing.IEEE, Addressing.NWK]

--- a/zhaquirks/schneiderelectric/__init__.py
+++ b/zhaquirks/schneiderelectric/__init__.py
@@ -1,5 +1,7 @@
 """Quirks implementations for Schneider Electric devices."""
-from typing import Any, Coroutine, Final, Union
+
+from collections.abc import Coroutine
+from typing import Any, Final, Union
 
 from zigpy import types as t
 from zigpy.quirks import CustomCluster
@@ -16,6 +18,8 @@ class SEBasic(CustomCluster, Basic):
     """Schneider Electric manufacturer specific Basic cluster."""
 
     class AttributeDefs(Basic.AttributeDefs):
+        """Attribute definitions."""
+
         se_sw_build_id: Final = ZCLAttributeDef(
             id=0xE001,
             type=t.CharacterString,
@@ -62,6 +66,8 @@ class SEWindowCovering(CustomCluster, WindowCovering):
     """Schneider Electric manufacturer specific Window Covering cluster."""
 
     class AttributeDefs(WindowCovering.AttributeDefs):
+        """Attribute definitions."""
+
         unknown_attribute_65533: Final = ZCLAttributeDef(
             id=0xFFFD,
             type=t.uint16_t,
@@ -120,6 +126,7 @@ class SEWindowCovering(CustomCluster, WindowCovering):
         *args: Any,
         **kwargs: Any,
     ) -> Coroutine:
+        """Override the command method to invert the percent lift value."""
         command = self.server_commands[command_id]
 
         # Override default command to invert percent lift value.
@@ -152,6 +159,8 @@ class SESpecific(CustomCluster):
     cluster_id = 0xFF17
 
     class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
         led_indicator_signals: Final = ZCLAttributeDef(
             id=0x0000,
             type=SELedIndicatorSignals,

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -1,3 +1,5 @@
+"""Schneider Electric dimmers and switches quirks."""
+
 from typing import Final
 
 from zigpy.profiles import zgp, zha
@@ -30,7 +32,7 @@ from zhaquirks.schneiderelectric import SE_MANUF_ID, SE_MANUF_NAME, SEBasic, SES
 
 
 class ControlMode(t.enum8):
-    """Dimming mode for PUCK/DIMMER/* and NHROTARY/DIMMER/1"""
+    """Dimming mode for PUCK/DIMMER/* and NHROTARY/DIMMER/1."""
 
     Auto = 0
     RC = 1
@@ -39,9 +41,13 @@ class ControlMode(t.enum8):
 
 
 class SEBallast(CustomCluster, Ballast):
+    """Schneider Electric Ballast cluster."""
+
     manufacturer_id_override = SE_MANUF_ID
 
     class AttributeDefs(Ballast.AttributeDefs):
+        """Attribute definitions."""
+
         control_mode: Final = ZCLAttributeDef(
             id=0xE000, type=ControlMode, is_manufacturer_specific=True
         )
@@ -54,7 +60,7 @@ class SEBallast(CustomCluster, Ballast):
 
 
 class NHRotaryDimmer1(CustomDevice):
-    """NHROTARY/DIMMER/1 by Schneider Electric"""
+    """NHROTARY/DIMMER/1 by Schneider Electric."""
 
     signature = {
         MODELS_INFO: [

--- a/zhaquirks/sengled/e1e_g7f.py
+++ b/zhaquirks/sengled/e1e_g7f.py
@@ -1,5 +1,6 @@
 """Sengled E1E-G7F device."""
-from typing import Any, List, Optional, Union
+
+from typing import Any, Optional, Union
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -85,7 +86,7 @@ class SengledE1EG7FManufacturerSpecificCluster(CustomCluster):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]

--- a/zhaquirks/siglis/zigfred.py
+++ b/zhaquirks/siglis/zigfred.py
@@ -1,6 +1,7 @@
 """zigfred device handler."""
+
 import logging
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -93,7 +94,7 @@ class ZigfredCluster(CustomCluster):
             PRESS_TYPE: press_type,
         }
 
-        _LOGGER.info(f"Got button press on zigfred cluster: {action}")
+        _LOGGER.info("Got button press on zigfred cluster: %s", action)
 
         if button and press_type:
             self.listener_event(ZHA_SEND_EVENT, action, event_args)
@@ -101,7 +102,7 @@ class ZigfredCluster(CustomCluster):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -49,13 +49,13 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         Partial_lock = 0x02
 
     class PhaseControl(t.enum8):
-        """Phase control value, reverse / forward"""
+        """Phase control value, reverse / forward."""
 
         Forward = 0x00
         Reverse = 0x01
 
     class DoubleFull(t.enum8):
-        """Double click up set full intensity"""
+        """Double click up set full intensity."""
 
         Off = 0x00
         On = 0x01

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -103,7 +103,7 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         Heat = 0x04
 
     class PumpDuration(t.enum8):
-        """Pump protection duration period values"""
+        """Pump protection duration period values."""
 
         T5 = 0x05
         T10 = 0x0A

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -1,7 +1,8 @@
 """Device handler for Smartwings blinds."""
 from __future__ import annotations
 
-from typing import Any, Coroutine
+from collections.abc import Coroutine
+from typing import Any
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice

--- a/zhaquirks/sonoff/snzb01p.py
+++ b/zhaquirks/sonoff/snzb01p.py
@@ -1,4 +1,5 @@
-"""Sonoff Smart Button SNZB-01P"""
+"""Sonoff Smart Button SNZB-01P."""
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -33,7 +34,7 @@ SONOFF_CLUSTER_ID = 0xFC57
 
 
 class SonoffSmartButtonSNZB01P(CustomDevice):
-    """Sonoff smart button remote - model SNZB-01P"""
+    """Sonoff smart button remote - model SNZB-01P."""
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=0

--- a/zhaquirks/sonoff/snzb06p.py
+++ b/zhaquirks/sonoff/snzb06p.py
@@ -1,3 +1,5 @@
+"""Sonoff SNZB-06 - Zigbee presence sensor."""
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t

--- a/zhaquirks/terncy/__init__.py
+++ b/zhaquirks/terncy/__init__.py
@@ -1,7 +1,8 @@
 """Module for Terncy quirks."""
+
 from collections import deque
 import math
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
@@ -149,7 +150,7 @@ class TerncyRawCluster(CustomCluster):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]

--- a/zhaquirks/tuya/air/__init__.py
+++ b/zhaquirks/tuya/air/__init__.py
@@ -1,6 +1,6 @@
 """Tuya Air sensors."""
 
-from typing import Any, Dict
+from typing import Any
 
 import zigpy.types as t
 from zigpy.zcl.clusters.measurement import (
@@ -69,7 +69,7 @@ class TuyaAirQualityHumidity(RelativeHumidity, TuyaLocalCluster):
 
 
 class TuyaAirQualityPM25(PM25, TuyaLocalCluster):
-    """Tuya PM25 concentration measurement"""
+    """Tuya PM25 concentration measurement."""
 
 
 class TuyaAirQualityCO2(CarbonDioxideConcentration, TuyaLocalCluster):
@@ -83,7 +83,7 @@ class TuyaAirQualityFormaldehyde(FormaldehydeConcentration, TuyaLocalCluster):
 class TuyaCO2ManufCluster(TuyaNewManufCluster):
     """Tuya with Air quality data points."""
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         2: DPToAttributeMapping(
             TuyaAirQualityCO2.ep_attribute,
             "measured_value",

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -1,18 +1,23 @@
-"""Tuya MCU comunications."""
+"""Tuya MCU communications."""
+
+from collections.abc import Callable
 import dataclasses
 import datetime
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import LevelControl, OnOff
 
 from zhaquirks import Bus, DoublingPowerConfigurationCluster
+
+# add EnchantedDevice import for custom quirks backwards compatibility
 from zhaquirks.tuya import (
     TUYA_MCU_COMMAND,
     TUYA_MCU_VERSION_RSP,
     TUYA_SET_DATA,
     TUYA_SET_TIME,
+    EnchantedDevice,  # noqa: F401
     NoManufacturerCluster,
     PowerOnState,
     TuyaCommand,
@@ -22,9 +27,6 @@ from zhaquirks.tuya import (
     TuyaNewManufCluster,
     TuyaTimePayload,
 )
-
-# add EnchantedDevice import for custom quirks backwards compatibility
-from zhaquirks.tuya import EnchantedDevice  # noqa: F401
 
 # New manufacturer attributes
 ATTR_MCU_VERSION = 0xEF00
@@ -284,7 +286,7 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
 
     def get_dp_mapping(
         self, endpoint_id: int, attribute_name: str
-    ) -> Optional[Tuple[int, DPToAttributeMapping]]:
+    ) -> Optional[tuple[int, DPToAttributeMapping]]:
         """Search for the DP in dp_to_attribute."""
 
         result = {}
@@ -319,7 +321,7 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
         self.debug("handle_set_time_request payload: %s", payload)
         payload_rsp = TuyaTimePayload()
 
-        utc_now = datetime.datetime.utcnow()
+        utc_now = datetime.datetime.utcnow()  # noqa: DTZ003
         now = datetime.datetime.now()
 
         offset_time = datetime.datetime(self.set_time_offset, 1, 1)
@@ -406,7 +408,7 @@ class TuyaOnOffNM(NoManufacturerCluster, TuyaOnOff):
 class TuyaOnOffManufCluster(TuyaMCUCluster):
     """Tuya with On/Off data points."""
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         1: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
@@ -519,9 +521,9 @@ class MoesSwitchManufCluster(TuyaOnOffManufCluster):
         }
     )
 
-    dp_to_attribute: Dict[
-        int, DPToAttributeMapping
-    ] = TuyaOnOffManufCluster.dp_to_attribute.copy()
+    dp_to_attribute: dict[int, DPToAttributeMapping] = (
+        TuyaOnOffManufCluster.dp_to_attribute.copy()
+    )
     dp_to_attribute.update(
         {
             14: DPToAttributeMapping(
@@ -637,7 +639,7 @@ class TuyaInWallLevelControl(TuyaAttributesCluster, TuyaLevelControl):
 class TuyaLevelControlManufCluster(TuyaMCUCluster):
     """Tuya with Level Control data points."""
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         1: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",

--- a/zhaquirks/tuya/ts0001_fingerbot.py
+++ b/zhaquirks/tuya/ts0001_fingerbot.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Optional, Union
+"""Tuya Fingerbot device."""
+
+from typing import Any, Optional, Union
 
 from zigpy.profiles import zha
 import zigpy.types as t
@@ -23,17 +25,23 @@ from zhaquirks.tuya.mcu import (
 
 
 class FingerBotMode(t.enum8):
+    """FingerBot mode."""
+
     CLICK = 0x00
     SWITCH = 0x01
     PROGRAM = 0x02
 
 
 class FingerBotReverse(t.enum8):
+    """FingerBot reverse."""
+
     UP_ON = 0x00
     UP_OFF = 0x01
 
 
 class TuyaFingerbotCluster(TuyaMCUCluster):
+    """Tuya Fingerbot cluster."""
+
     attributes = TuyaMCUCluster.attributes.copy()
     attributes.update(
         {
@@ -67,7 +75,7 @@ class TuyaFingerbotCluster(TuyaMCUCluster):
             **kwargs,
         )
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         # Mode
         101: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
@@ -116,6 +124,8 @@ class OnOffEnchantable(TuyaEnchantableCluster, OnOff):
 
 
 class TuyaFingerbot(EnchantedDevice):
+    """Tuya finger bot device."""
+
     signature = {
         MODELS_INFO: [("_TZ3210_dse8ogfy", "TS0001"), ("_TZ3210_j4pdtz9v", "TS0001")],
         ENDPOINTS: {

--- a/zhaquirks/tuya/ts0210.py
+++ b/zhaquirks/tuya/ts0210.py
@@ -1,6 +1,6 @@
 """TS0210 vibration sensor."""
 
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -34,7 +34,7 @@ class VibrationCluster(LocalDataCluster, MotionOnEvent, IasZone):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: Tuple[TuyaManufCluster.Command],
+        args: tuple[TuyaManufCluster.Command],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
@@ -53,7 +53,8 @@ class TuyaVibration(CustomDevice):
         super().__init__(*args, **kwargs)
 
     signature = {
-        #   SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=1026, device_version=0, input_clusters=[0, 10, 1, 1280], output_clusters=[25])
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=1026, device_version=0,
+        # input_clusters=[0, 10, 1, 1280], output_clusters=[25])
         MODEL: "TS0210",
         ENDPOINTS: {
             1: {

--- a/zhaquirks/tuya/ts0211.py
+++ b/zhaquirks/tuya/ts0211.py
@@ -1,6 +1,6 @@
 """Tuya Doorbell."""
 
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -29,7 +29,7 @@ class IasZoneDoorbellCluster(CustomCluster, IasZone):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: Tuple[IasZone.ZoneStatus],
+        args: tuple[IasZone.ZoneStatus],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]

--- a/zhaquirks/tuya/ts0601_garage.py
+++ b/zhaquirks/tuya/ts0601_garage.py
@@ -1,5 +1,4 @@
 """Tuya based cover and blinds."""
-from typing import Dict
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
@@ -39,7 +38,7 @@ class TuyaGarageManufCluster(NoManufacturerCluster, TuyaMCUCluster):
         }
     )
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         # garage door trigger ¿on movement, on open, on closed?
         1: DPToAttributeMapping(
             TUYA_MANUFACTURER_GARAGE,

--- a/zhaquirks/tuya/ts0601_illuminance.py
+++ b/zhaquirks/tuya/ts0601_illuminance.py
@@ -1,7 +1,6 @@
 """Tuya illuminance sensors."""
 
 import math
-from typing import Dict
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
@@ -46,7 +45,7 @@ class TuyaIlluminanceMeasurement(IlluminanceMeasurement, TuyaLocalCluster):
 class TuyaIlluminanceCluster(TuyaMCUCluster):
     """Tuya Illuminance cluster."""
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         TUYA_BRIGHTNESS_LEVEL_DP: DPToAttributeMapping(
             TuyaIlluminanceMeasurement.ep_attribute,
             "manufacturer_brightness_level",

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -1,7 +1,7 @@
 """BlitzWolf IS-3/Tuya motion rechargeable occupancy sensor."""
 
 import math
-from typing import Dict, Optional, Tuple, Union
+from typing import Optional, Union
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
@@ -86,7 +86,7 @@ class NeoMotionManufCluster(TuyaNewManufCluster):
         }
     )
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         101: DPToAttributeMapping(
             TuyaOccupancySensing.ep_attribute,
             "occupancy",
@@ -150,7 +150,7 @@ class MmwRadarManufCluster(TuyaMCUCluster):
         }
     )
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         1: DPToAttributeMapping(
             TuyaOccupancySensing.ep_attribute,
             "occupancy",
@@ -242,7 +242,7 @@ class TuyaManufacturerClusterMotion(TuyaManufCluster):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: Tuple[TuyaManufCluster.Command],
+        args: tuple[TuyaManufCluster.Command],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]

--- a/zhaquirks/tuya/ts0601_rcbo.py
+++ b/zhaquirks/tuya/ts0601_rcbo.py
@@ -1,5 +1,6 @@
 """Tuya Din RCBO Circuit Breaker."""
-from typing import Any, Dict, Optional, Union
+
+from typing import Any, Optional, Union
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -335,7 +336,7 @@ class TuyaRCBOMetering(Metering, TuyaAttributesCluster):
 class TuyaRCBOManufCluster(TuyaMCUCluster):
     """Tuya with power measurement data points."""
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         TUYA_DP_STATE: DPToAttributeMapping(
             TuyaRCBOOnOff.ep_attribute,
             "on_off",
@@ -422,7 +423,11 @@ class TuyaRCBOManufCluster(TuyaMCUCluster):
                 x[5] | x[4] << 8,
                 x[6],
             ),
-            lambda rms_extreme_over_voltage, over_voltage_trip, ac_alarms_mask, rms_extreme_under_voltage, under_voltage_trip: VoltageParameters(
+            lambda rms_extreme_over_voltage,
+            over_voltage_trip,
+            ac_alarms_mask,
+            rms_extreme_under_voltage,
+            under_voltage_trip: VoltageParameters(
                 rms_extreme_over_voltage,
                 over_voltage_trip,
                 bool(ac_alarms_mask & 0x40),
@@ -439,7 +444,9 @@ class TuyaRCBOManufCluster(TuyaMCUCluster):
                 x[3],
                 AttributeWithMask(x[4] << 1, 1 << 1),
             ),
-            lambda ac_current_overload, over_current_trip, ac_alarms_mask: CurrentParameters(
+            lambda ac_current_overload,
+            over_current_trip,
+            ac_alarms_mask: CurrentParameters(
                 ac_current_overload, over_current_trip, bool(ac_alarms_mask & 0x02)
             ),
         ),
@@ -478,7 +485,7 @@ class TuyaRCBOManufCluster(TuyaMCUCluster):
         ),
     }
 
-    data_point_handlers: Dict[int, str] = {
+    data_point_handlers: dict[int, str] = {
         TUYA_DP_STATE: "_dp_2_attr_update",
         TUYA_DP_COUNTDOWN_TIMER: "_dp_2_attr_update",
         TUYA_DP_FAULT_CODE: "_dp_2_attr_update",

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -1,6 +1,6 @@
 """Tuya temp and humidity sensors."""
 
-from typing import Any, Dict
+from typing import Any
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -50,7 +50,7 @@ class TuyaRelativeHumidity(RelativeHumidity, TuyaLocalCluster):
 class TemperatureHumidityManufCluster(TuyaMCUCluster):
     """Tuya Manufacturer Cluster with Temperature and Humidity data points."""
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         1: DPToAttributeMapping(
             TuyaTemperatureMeasurement.ep_attribute,
             "measured_value",
@@ -78,7 +78,7 @@ class TemperatureHumidityManufCluster(TuyaMCUCluster):
 class TemperatureHumidityBatteryStatesManufCluster(TuyaMCUCluster):
     """Tuya Manufacturer Cluster with Temperature and Humidity data points. Battery states 25, 50 and 100%."""
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         1: TemperatureHumidityManufCluster.dp_to_attribute[1],
         2: TemperatureHumidityManufCluster.dp_to_attribute[2],
         3: DPToAttributeMapping(
@@ -291,7 +291,7 @@ class TuyaTempHumiditySensorVar04(CustomDevice):
 class SoilManufCluster(TuyaMCUCluster):
     """Tuya Manufacturer Cluster with Temperature and Humidity data points."""
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         5: DPToAttributeMapping(
             TuyaTemperatureMeasurement.ep_attribute,
             "measured_value",

--- a/zhaquirks/tuya/ts0601_siren.py
+++ b/zhaquirks/tuya/ts0601_siren.py
@@ -1,5 +1,6 @@
 """Map from manufacturer to standard clusters for the NEO Siren device."""
-from typing import Dict, Optional, Union
+
+from typing import Optional, Union
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
@@ -106,15 +107,18 @@ class TuyaManufClusterSiren(TuyaManufClusterAttributes):
         super()._update_attribute(attrid, value)
         if attrid == TUYA_TEMPERATURE_ATTR:
             self.endpoint.device.temperature_bus.listener_event(
-                "temperature_reported", value * 10  # decidegree to centidegree
+                "temperature_reported",
+                value * 10,  # decidegree to centidegree
             )
         elif attrid == TUYA_HUMIDITY_ATTR:
             self.endpoint.device.humidity_bus.listener_event(
-                "humidity_reported", value * 100  # whole percentage to 1/1000th
+                "humidity_reported",
+                value * 100,  # whole percentage to 1/1000th
             )
         elif attrid == TUYA_ALARM_ATTR:
             self.endpoint.device.switch_bus.listener_event(
-                "switch_event", value  # boolean 1=on / 0=off
+                "switch_event",
+                value,  # boolean 1=on / 0=off
             )
 
 
@@ -309,7 +313,7 @@ class TuyaMCUSiren(OnOff, TuyaAttributesCluster):
 class NeoSirenManufCluster(TuyaMCUCluster):
     """Tuya with NEO Siren data points."""
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         5: DPToAttributeMapping(
             TuyaMCUSiren.ep_attribute,
             "volume",

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1,4 +1,5 @@
 """Map from manufacturer to standard clusters for thermostatic valves."""
+
 import logging
 from typing import Optional, Union
 
@@ -525,13 +526,12 @@ class MoesThermostat(TuyaThermostatCluster):
                             )
                             / 100
                         )
+                elif attr == attribute:
+                    val = value
                 else:
-                    if attr == attribute:
-                        val = value
-                    else:
-                        val = self._attr_cache.get(
-                            self.attributes_by_name[attr].id, default
-                        )
+                    val = self._attr_cache.get(
+                        self.attributes_by_name[attr].id, default
+                    )
 
                 data.append(val)
             return {MOES_SCHEDULE_WORKDAY_ATTR: data}
@@ -548,13 +548,12 @@ class MoesThermostat(TuyaThermostatCluster):
                             )
                             / 100
                         )
+                elif attr == attribute:
+                    val = value
                 else:
-                    if attr == attribute:
-                        val = value
-                    else:
-                        val = self._attr_cache.get(
-                            self.attributes_by_name[attr].id, default
-                        )
+                    val = self._attr_cache.get(
+                        self.attributes_by_name[attr].id, default
+                    )
 
                 data.append(val)
             return {MOES_SCHEDULE_WEEKEND_ATTR: data}
@@ -567,10 +566,7 @@ class MoesThermostat(TuyaThermostatCluster):
         elif value == 1:
             prog_mode = self.ProgrammingOperationMode.Schedule_programming_mode
             occupancy = self.Occupancy.Occupied
-        elif value == 2:
-            prog_mode = self.ProgrammingOperationMode.Simple
-            occupancy = self.Occupancy.Occupied
-        elif value == 3:
+        elif value in (2, 3):
             prog_mode = self.ProgrammingOperationMode.Simple
             occupancy = self.Occupancy.Occupied
         elif value == 4:
@@ -942,7 +938,7 @@ class ZONNSMARTManufCluster(TuyaManufClusterAttributes):
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
-        global ZonnsmartManuClusterSelf
+        global ZonnsmartManuClusterSelf  # noqa: PLW0603
         ZonnsmartManuClusterSelf = self
 
     attributes = TuyaManufClusterAttributes.attributes.copy()

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -1,5 +1,4 @@
 """Collection of Tuya Valve devices e.g. water valves, gas valve etc."""
-from typing import Dict
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -54,7 +53,7 @@ class TuyaValveManufCluster(TuyaMCUCluster):
         }
     )
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         1: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
@@ -194,7 +193,7 @@ class ParksideTuyaValveManufCluster(TuyaMCUCluster):
         }
     )
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         1: DPToAttributeMapping(
             TuyaOnOff.ep_attribute,
             "on_off",
@@ -293,7 +292,7 @@ GIEX_MODE_ATTR = 0xEF01  # Mode [0] duration [1] capacity
 GIEX_START_TIME_ATTR = 0xEF65  # Last irrigation start time (GMT)
 GIEX_END_TIME_ATTR = 0xEF66  # Last irrigation end time (GMT)
 GIEX_NUM_TIMES_ATTR = 0xEF67  # Number of cycle irrigation times min=0 max=100
-GIEX_TARGET_ATTR = 0xEF68  # Irrigation target, duration in seconds or capacity in litres (depending on mode) min=0 max=3600
+GIEX_TARGET_ATTR = 0xEF68  # Irrigation target, duration in sec or capacity in litres (depending on mode) min=0 max=3600
 GIEX_INTERVAL_ATTR = 0xEF69  # Cycle irrigation interval in seconds min=0 max=3600
 GIEX_DURATION_ATTR = 0xEF72  # Last irrigation duration
 
@@ -314,7 +313,7 @@ class GiexValveManufCluster(TuyaMCUCluster):
         }
     )
 
-    dp_to_attribute: Dict[int, DPToAttributeMapping] = {
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
         1: DPToAttributeMapping(
             TuyaMCUCluster.ep_attribute,
             "irrigation_mode",

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -1,4 +1,5 @@
 """Device handler for loratap TS130F smart curtain switch."""
+
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
@@ -273,7 +274,7 @@ class TuyaTS130FTO(CustomDevice):
 
     signature = {
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0x0202, device_version=1, input_clusters=[0, 4, 5, 6, 10, 0x0102], output_clusters=[25]))
-        # This singnature is not correct is one copy of the first one and the cluster is not inline with the device.
+        # This signature is not correct is one copy of the first one and the cluster is not inline with the device.
         MODEL: "TS130F",
         ENDPOINTS: {
             1: {

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -1,6 +1,7 @@
 """Device handler for WAXMAN leakSMART."""
+
 # pylint: disable=W0102
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -78,7 +79,7 @@ class WAXMANApplianceEventAlerts(CustomCluster, ApplianceEventAlerts):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[
             Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]

--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -6,7 +6,7 @@ See xbee.md for additional information.
 import asyncio
 import enum
 import logging
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from zigpy.quirks import CustomDevice
 import zigpy.types as t
@@ -320,7 +320,7 @@ class XBeeRemoteATRequest(LocalDataCluster):
                 await self._command(options, name.encode("ascii"), data, *args),
                 timeout=REMOTE_AT_COMMAND_TIMEOUT,
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.warning("No response to %s command", name)
             raise
 
@@ -430,7 +430,7 @@ class XBeeRemoteATResponse(LocalDataCluster):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[t.AddrMode] = None,
     ):
@@ -484,7 +484,7 @@ class XBeeDigitalIOCluster(LocalDataCluster, BinaryInput):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[t.AddrMode] = None,
     ):
@@ -587,7 +587,7 @@ class XBeeSerialDataCluster(LocalDataCluster):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: List[Any],
+        args: list[Any],
         *,
         dst_addressing: Optional[t.AddrMode] = None,
     ):

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -1,14 +1,17 @@
 """Xiaomi common components for custom device handlers."""
+
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator
 import logging
 import math
-from typing import Any, Iterable, Iterator
+from typing import Any
 
 from zigpy import types as t
 import zigpy.device
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     AnalogInput,
     Basic,
@@ -26,7 +29,6 @@ from zigpy.zcl.clusters.measurement import (
 )
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zcl.clusters.smartenergy import Metering
-import zigpy.zcl.foundation as foundation
 import zigpy.zdo
 from zigpy.zdo.types import NodeDescriptor
 
@@ -162,10 +164,13 @@ class XiaomiCluster(CustomCluster):
             attr_val = t.LVBytes(val)
             attr_type = 0x41  # The data type should be "Octet String"
 
-            yield foundation.Attribute(
-                attrid=attr_id,
-                value=foundation.TypeValue(type=attr_type, value=attr_val),
-            ), final_data
+            yield (
+                foundation.Attribute(
+                    attrid=attr_id,
+                    value=foundation.TypeValue(type=attr_type, value=attr_val),
+                ),
+                final_data,
+            )
 
     def _interpret_attr_reports(
         self, data: bytes
@@ -511,7 +516,7 @@ class XiaomiPowerConfiguration(PowerConfiguration, LocalDataCluster):
 
 
 class XiaomiPowerConfigurationPercent(XiaomiPowerConfiguration):
-    """Power cluster which ignores Xiaomi voltage reports for calculating battery percentage
+    """Power cluster which ignores Xiaomi voltage reports for calculating battery percentage.
 
     Devices that use this cluster (E1 curtain driver/roller) already send the battery percentage on their own
     as a separate attribute, but additionally also send the battery voltage.

--- a/zhaquirks/xiaomi/aqara/feeder_acn001.py
+++ b/zhaquirks/xiaomi/aqara/feeder_acn001.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from zigpy import types
 from zigpy.profiles import zgp, zha
-import zigpy.types as types
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
@@ -16,7 +17,6 @@ from zigpy.zcl.clusters.general import (
     Scenes,
     Time,
 )
-import zigpy.zcl.foundation as foundation
 
 from zhaquirks.const import (
     DEVICE_TYPE,

--- a/zhaquirks/xiaomi/aqara/illumination.py
+++ b/zhaquirks/xiaomi/aqara/illumination.py
@@ -1,7 +1,7 @@
 """Quirk for Aqara illumination sensor."""
 
+from zigpy import types
 from zigpy.profiles import zha
-import zigpy.types as types
 from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement
 from zigpy.zdo.types import NodeDescriptor

--- a/zhaquirks/xiaomi/aqara/light_acn.py
+++ b/zhaquirks/xiaomi/aqara/light_acn.py
@@ -1,3 +1,5 @@
+"""Aqara light."""
+
 from zigpy import types as t
 from zigpy.profiles import zgp, zha
 from zigpy.zcl.clusters.general import (

--- a/zhaquirks/xiaomi/aqara/motion_ac01.py
+++ b/zhaquirks/xiaomi/aqara/motion_ac01.py
@@ -1,11 +1,12 @@
 """Quirk for aqara lumi.motion.ac01."""
+
 from __future__ import annotations
 
 from typing import Any
 
+from zigpy import types
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
-import zigpy.types as types
 from zigpy.zcl.clusters.general import Basic, DeviceTemperature, Identify, Ota
 from zigpy.zcl.clusters.measurement import OccupancySensing
 
@@ -60,10 +61,10 @@ class OppleCluster(XiaomiAqaraE1Cluster):
 
     def _update_attribute(self, attrid: int, value: Any) -> None:
         super()._update_attribute(attrid, value)
-        if attrid == PRESENCE or attrid == PRESENCE2:
+        if attrid in (PRESENCE, PRESENCE2):
             if value != 0xFF:
                 self.endpoint.occupancy.update_attribute(OCCUPANCY, value)
-        elif attrid == PRESENCE_EVENT or attrid == PRESENCE_EVENT2:
+        elif attrid in (PRESENCE_EVENT, PRESENCE_EVENT2):
             self.listener_event(ZHA_SEND_EVENT, AqaraPresenceEvents(value).name, {})
 
 

--- a/zhaquirks/xiaomi/aqara/motion_ac02.py
+++ b/zhaquirks/xiaomi/aqara/motion_ac02.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from zigpy import types
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
-import zigpy.types as types
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement, OccupancySensing
 

--- a/zhaquirks/xiaomi/aqara/motion_agl04.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl04.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from zigpy import types
 from zigpy.profiles import zha
-import zigpy.types as types
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.measurement import OccupancySensing
 

--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -1,7 +1,7 @@
 """Xiaomi aqara opple remote devices."""
 
+from zigpy import types
 from zigpy.profiles import zha
-import zigpy.types as types
 from zigpy.zcl.clusters.general import (
     Basic,
     Identify,

--- a/zhaquirks/xiaomi/aqara/plug_eu.py
+++ b/zhaquirks/xiaomi/aqara/plug_eu.py
@@ -1,8 +1,8 @@
 """Xiaomi Aqara EU plugs."""
 
 import zigpy
+from zigpy import types
 from zigpy.profiles import zgp, zha
-import zigpy.types as types
 from zigpy.zcl.clusters.general import (
     Alarms,
     AnalogInput,

--- a/zhaquirks/xiaomi/aqara/smoke.py
+++ b/zhaquirks/xiaomi/aqara/smoke.py
@@ -1,9 +1,9 @@
 """Quirk for LUMI lumi.sensor_smoke.acn03 smoke sensor."""
 from typing import Any
 
+from zigpy import types
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
-import zigpy.types as types
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zdo.types import NodeDescriptor

--- a/zhaquirks/xiaomi/aqara/switch_h1_single.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_single.py
@@ -1,4 +1,5 @@
 """Aqara H1 single rocker switch quirks. Also see opple_switch.py for similar double rocker switches."""
+
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -56,7 +57,7 @@ XIAOMI_COMMAND_HOLD = "1_hold"
 
 
 class AqaraH1SingleRockerBase(CustomDevice):
-    """Device automation triggers for the Aqara H1 Single Rocker Switches"""
+    """Device automation triggers for the Aqara H1 Single Rocker Switches."""
 
     device_automation_triggers = {
         (SHORT_PRESS, BUTTON): {

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -140,11 +140,12 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
 
 class ScheduleEvent:
-    """Schedule event object"""
+    """Schedule event object."""
 
     _is_next_day = False
 
     def __init__(self, value, is_next_day=False):
+        """Create ScheduleEvent object from bytes or string."""
         if isinstance(value, bytes):
             self._verify_buffer_len(value)
             self._time = self._read_time_from_buf(value)
@@ -177,8 +178,8 @@ class ScheduleEvent:
         return time
 
     @staticmethod
-    def _parse_time(str):
-        parts = str.split(":")
+    def _parse_time(string):
+        parts = string.split(":")
         if len(parts) != 2:
             raise ValueError("Time must contain ':' separator")
 
@@ -192,8 +193,8 @@ class ScheduleEvent:
         return struct.unpack_from(">H", buf, offset=4)[0] / 100
 
     @staticmethod
-    def _parse_temp(str):
-        return float(str)
+    def _parse_temp(string):
+        return float(string)
 
     @staticmethod
     def _validate_time(time):
@@ -221,18 +222,23 @@ class ScheduleEvent:
         struct.pack_into(">H", buf, 4, int(self._temp * 100))
 
     def is_next_day(self):
+        """Return if event is on the next day."""
         return self._is_next_day
 
     def set_next_day(self, is_next_day):
+        """Set if event is on the next day."""
         self._is_next_day = is_next_day
 
     def get_time(self):
+        """Return event time."""
         return self._time
 
     def __str__(self):
-        return f"{math.floor(self._time / 60)}:{f'{self._time % 60:0>2}'},{f'{self._temp:.1f}'}"  # noqa
+        """Return event as string."""
+        return f"{math.floor(self._time / 60)}:{f'{self._time % 60:0>2}'},{f'{self._temp:.1f}'}"
 
     def serialize(self):
+        """Serialize event to bytes."""
         result = bytearray(6)
         self._write_time_to_buf(result)
         self._write_temp_to_buf(result)
@@ -240,9 +246,10 @@ class ScheduleEvent:
 
 
 class ScheduleSettings(t.LVBytes):
-    """Schedule settings object"""
+    """Schedule settings object."""
 
     def __new__(cls, value):
+        """Create ScheduleSettings object from bytes or string."""
         day_selection = None
         events = [None] * 4
         if isinstance(value, bytes):
@@ -297,7 +304,7 @@ class ScheduleSettings(t.LVBytes):
         if len(days) != len(set(days)):
             raise ValueError("Duplicate day names present")
         for d in days:
-            if d not in DAYS_MAP.keys():
+            if d not in DAYS_MAP:
                 raise ValueError(
                     f"String: {d} is not a valid day name, valid names: mon, tue, wed, thu, fri, sat, sun"
                 )
@@ -309,8 +316,8 @@ class ScheduleSettings(t.LVBytes):
             byte = struct.unpack_from("c", value, offset=1)[0][0]
             if byte & 0x01:
                 raise ValueError("Incorrect day selected")
-            for i in DAYS_MAP:
-                if byte & DAYS_MAP[i]:
+            for i, v in DAYS_MAP.items():
+                if byte & v:
                     day_selection.append(i)
             ScheduleSettings._verify_day_selection_in_str(day_selection)
         elif isinstance(value, str):
@@ -351,6 +358,7 @@ class ScheduleSettings(t.LVBytes):
         return byte
 
     def __str__(self):
+        """Return ScheduleSettings as string."""
         day_selection = ScheduleSettings._read_day_selection(self)
         events = [None] * 4
         for i in range(4):

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -1,9 +1,9 @@
 """Xiaomi aqara smart motion sensor device."""
 import math
 
+from zigpy import types
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster
-import zigpy.types as types
 from zigpy.zcl.clusters.closures import DoorLock
 from zigpy.zcl.clusters.general import (
     Basic,

--- a/zhaquirks/xiaomi/mija/sensor_switch.py
+++ b/zhaquirks/xiaomi/mija/sensor_switch.py
@@ -95,13 +95,12 @@ class MijaButton(XiaomiQuickInitDevice):
                     self._timer_handle = self._loop.call_later(
                         self.hold_duration, self._hold_timeout
                     )
+                elif self._timer_handle:
+                    self._timer_handle.cancel()
+                    self._timer_handle = None
+                    click_type = COMMAND_SINGLE
                 else:
-                    if self._timer_handle:
-                        self._timer_handle.cancel()
-                        self._timer_handle = None
-                        click_type = COMMAND_SINGLE
-                    else:
-                        self.listener_event(ZHA_SEND_EVENT, COMMAND_RELEASE, [])
+                    self.listener_event(ZHA_SEND_EVENT, COMMAND_RELEASE, [])
 
             # Handle Multi Clicks
             elif attrid == 32768:

--- a/zhaquirks/zbeacon/__init__.py
+++ b/zhaquirks/zbeacon/__init__.py
@@ -1,0 +1,1 @@
+"""zbeacon module."""

--- a/zhaquirks/zbeacon/doorsensor.py
+++ b/zhaquirks/zbeacon/doorsensor.py
@@ -1,4 +1,4 @@
-"""Doorsensors"""
+"""Doorsensors."""
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -22,7 +22,8 @@ from zhaquirks.const import (
 
 
 class DS01DoorSensor(CustomDevice):
-    """One of the long rectangular Doorsensors working on 2xAAA
+    """One of the long rectangular Doorsensors working on 2xAAA.
+
     It doesn't correctly implement the PollControl Cluster.
     The device will send "PollControl:checkin()" on PollControl cluster,
         but doesn't respond when checkin_response is sent after that from the coordinator
@@ -35,7 +36,9 @@ class DS01DoorSensor(CustomDevice):
     signature = {
         MODELS_INFO: [("zbeacon", "DS01")],
         ENDPOINTS: {
-            # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=1026, device_version=0, input_clusters=[0, 3, 1, 1280, 32], output_clusters=[25])
+            # SizePrefixedSimpleDescriptor(
+            # endpoint=1, profile=260, device_type=1026, device_version=0,
+            # input_clusters=[0, 3, 1, 1280, 32], output_clusters=[25])
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.IAS_ZONE,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

This pull request includes changes to multiple files, primarily focusing on updating dependencies, improving code quality, and changing the Python version requirement. The most significant changes include updating the versions of dependencies in `.pre-commit-config.yaml`, changing the required Python version in `pyproject.toml`, and removing unnecessary methods and changing the formatting of code in several test files.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

Dependency updates:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L2-R18): Updated the versions of `codespell-project/codespell`, `pre-commit/mirrors-mypy`, and `astral-sh/ruff-pre-commit`. Removed dependencies `asottile/pyupgrade`, `PyCQA/autoflake`, `psf/black`, `pycqa/flake8`, `PyCQA/isort`, and `charliermarsh/ruff-pre-commit`.

Python version changes:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L15-R15): Changed the required Python version from 3.8 to 3.12.

Code quality improvements:

* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L75-R75): Improved the docstrings for `permit_with_link_key` and `write_network_info` methods.
* [`tests/test_develco.py`](diffhunk://#diff-d3ae996e23077acb060c6573715befc4f14d59e7851aab2d8284faaa8275cde4R5-L9): Moved import of `ClusterListener` to the top of the file for better code organization.
* [`tests/test_ikea.py`](diffhunk://#diff-844ebc381c538437f9b23a15f9a35b86dc261ab3ae7934844ec21ed7ad21e56dL90-R89): Improved the docstring for `test_pm25_cluster_read` method.
* [`tests/test_legrand.py`](diffhunk://#diff-48b3e2cffcb26ec8a99c155e5436926f0590c073cd4d90cc84e40b6e53c14ad5R33): Added a docstring for `test_light_switch_with_neutral_signature` method.
* [`tests/test_quirks.py`](diffhunk://#diff-1f260bb55ea8379ab0f57b273070f6c22f014ffcc6bd01744042a71c6f20c2ffR2): Refactored several test methods to improve code readability and efficiency. [[1]](diffhunk://#diff-1f260bb55ea8379ab0f57b273070f6c22f014ffcc6bd01744042a71c6f20c2ffR2) [[2]](diffhunk://#diff-1f260bb55ea8379ab0f57b273070f6c22f014ffcc6bd01744042a71c6f20c2ffR12-L23) [[3]](diffhunk://#diff-1f260bb55ea8379ab0f57b273070f6c22f014ffcc6bd01744042a71c6f20c2ffL281-R283) [[4]](diffhunk://#diff-1f260bb55ea8379ab0f57b273070f6c22f014ffcc6bd01744042a71c6f20c2ffL312-R311) [[5]](diffhunk://#diff-1f260bb55ea8379ab0f57b273070f6c22f014ffcc6bd01744042a71c6f20c2ffL432-R431) [[6]](diffhunk://#diff-1f260bb55ea8379ab0f57b273070f6c22f014ffcc6bd01744042a71c6f20c2ffL595-R594) [[7]](diffhunk://#diff-1f260bb55ea8379ab0f57b273070f6c22f014ffcc6bd01744042a71c6f20c2ffL699-R698) [[8]](diffhunk://#diff-1f260bb55ea8379ab0f57b273070f6c22f014ffcc6bd01744042a71c6f20c2ffL720-R719) [[9]](diffhunk://#diff-1f260bb55ea8379ab0f57b273070f6c22f014ffcc6bd01744042a71c6f20c2ffL729-R736)

Other changes:

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R1-R2): Added a docstring for the file.
* [`tests/test_linkind.py`](diffhunk://#diff-e94a6bdfba310681b0f7ad3afda4788dc2ab56e0e71144084290da68142f5722R1-R7): Added a docstring for the file.


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works