### PR TITLE
Add Tuya TS0601 temp sensor variants, enable data query spell

### DIFF
--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -20,11 +20,11 @@ from zhaquirks.const import (
     PROFILE_ID,
     SKIP_CONFIGURATION,
 )
-from zhaquirks.tuya import TuyaLocalCluster, TuyaPowerConfigurationCluster2AAA
+from zhaquirks.tuya import TuyaLocalCluster, TuyaPowerConfigurationCluster2AAA, EnchantedDevice, TuyaEnchantableCluster
 from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster
 
 
-class TuyaTemperatureMeasurement(TemperatureMeasurement, TuyaLocalCluster):
+class TuyaTemperatureMeasurement(TuyaEnchantableCluster, TemperatureMeasurement, TuyaLocalCluster):
     """Tuya local TemperatureMeasurement cluster."""
 
 
@@ -238,9 +238,11 @@ class TuyaTempHumiditySensorVar03(CustomDevice):
     }
 
 
-class TuyaTempHumiditySensorVar04(CustomDevice):
+class TuyaTempHumiditySensorVar04(EnchantedDevice):
     """Tuya temp and humidity sensor (variation 04)."""
 
+    tuya_spell_data_query = True
+    
     signature = {
         # "profile_id": 260,
         # "device_type": "0x0051",
@@ -265,7 +267,7 @@ class TuyaTempHumiditySensorVar04(CustomDevice):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TemperatureHumidityManufCluster.cluster_id,
+                    TemperatureHumidityBatteryStatesManufCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
             }

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -275,7 +275,6 @@ class TuyaTempHumiditySensorVar04(EnchantedDevice):
     }
 
     replacement = {
-        SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
                 DEVICE_TYPE: zha.DeviceType.TEMPERATURE_SENSOR,

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -20,7 +20,12 @@ from zhaquirks.const import (
     PROFILE_ID,
     SKIP_CONFIGURATION,
 )
-from zhaquirks.tuya import TuyaLocalCluster, TuyaPowerConfigurationCluster2AAA, EnchantedDevice, TuyaEnchantableCluster
+from zhaquirks.tuya import (
+    EnchantedDevice,
+    TuyaEnchantableCluster,
+    TuyaLocalCluster,
+    TuyaPowerConfigurationCluster2AAA,
+)
 from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster
 
 
@@ -242,7 +247,7 @@ class TuyaTempHumiditySensorVar04(EnchantedDevice):
     """Tuya temp and humidity sensor (variation 04)."""
 
     tuya_spell_data_query = True
-    
+
     signature = {
         # "profile_id": 260,
         # "device_type": "0x0051",

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -252,6 +252,10 @@ class TuyaTempHumiditySensorVar04(CustomDevice):
             ("_TZE204_yjjdcqsq", "TS0601"),
             ("_TZE200_utkemkbs", "TS0601"),
             ("_TZE204_utkemkbs", "TS0601"),
+            ("_TZE204_9yapgbuv", "TS0601"),
+            ("_TZE204_upagmta9", "TS0601"),
+            ("_TZE200_upagmta9", "TS0601"),
+            ("_TZE200_cirvgep4", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Added:
```
            ("_TZE204_9yapgbuv", "TS0601"),
            ("_TZE204_upagmta9", "TS0601"),
            ("_TZE200_upagmta9", "TS0601"),
            ("_TZE200_cirvgep4", "TS0601"),
```
According to Z2M those are equivalents.
DP are compatible
https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts#L724

Sensors quirk are requested:
https://github.com/zigpy/zha-device-handlers/issues/2694
https://github.com/zigpy/zha-device-handlers/issues/2854

[edit]
Added EnchantedDevice to Device
Added TuyaEnchantableCluster to Temp cluster
Added tuya_spell_data_query = True to Device
as needed by
https://github.com/zigpy/zha-device-handlers/issues/2694#issuecomment-1916001737