### PR TITLE
Add Tuya BSEED dimmer switch `_TZE204_n9ctkb6j`

### DIFF
--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -151,6 +151,7 @@ class TuyaSingleSwitchDimmerGP(TuyaDimmerSwitch):
             ("_TZE200_ip2akl4w", "TS0601"),
             ("_TZE200_vucankjx", "TS0601"),  # Loratap
             ("_TZE200_y8yjulon", "TS0601"),
+            ("_TZE204_n9ctkb6j", "TS0601"),  # For BSEED switch
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0100


### PR DESCRIPTION
## Proposed change
Added model info for new BSEED dimmer switch
This one https://www.bseed.com/collections/zigbee-series/products/bseed-eu-russia-new-zigbee-touch-wifi-light-dimmer-smart-switch 

## Additional information
Apparently there is a "new" model of this switch. It did pair just fine, but did not have any controls. After this change it did 🎉 
![image](https://github.com/zigpy/zha-device-handlers/assets/6860411/12d29f1b-ea1b-48bb-9ac1-753f3f8dd801)
I have exactly the same switch, guess its "old" model, TS0601 by _TZE200_3p5ydos3. Works just fine out of the box. And has a Quirk: ts0601_dimmer.TuyaSingleSwitchDimmerGP


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
