### PR TITLE
Add Moes/Tuya cover `_TZE200_icka1clh`

### DIFF
--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -3,7 +3,7 @@ from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601
 
 
 def test_ts601_moes_signature(assert_signature_matches_quirk):
-    """Test TS0121 remote signature is matched to its quirk."""
+    """Test TS0121 cover signature is matched to its quirk."""
     signature = {
         "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
         "endpoints": {

--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -1,0 +1,21 @@
+"""Test units for Tuya covers."""
+from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601
+
+
+def test_ts601_moes_signature(assert_signature_matches_quirk):
+    """Test TS0121 remote signature is matched to its quirk."""
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 0x0104,
+                "device_type": "0x0051",
+                "in_clusters": ["0x0000", "0x0004", "0x0005", "0xef00"],
+                "out_clusters": ["0x000a", "0x0019"],
+            }
+        },
+        "manufacturer": "_TZE200_icka1clh",
+        "model": "TS0601",
+        "class": "zigpy.device.Device",
+    }
+    assert_signature_matches_quirk(TuyaMoesCover0601, signature)

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -1,4 +1,5 @@
 """Tuya based cover and blinds."""
+
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
 
@@ -374,6 +375,7 @@ class TuyaMoesCover0601(TuyaWindowCover):
             ("_TZE200_bv1jcqqu", "TS0601"),
             ("_TZE200_nw1r9hp6", "TS0601"),
             ("_TZE200_gaj531w3", "TS0601"),
+            ("_TZE200_icka1clh", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
adds Moes/Tuya _TZE200_icka1clh cover


## Checklist

I have tested this on my Home assistant instance using a custom quirk.

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
