### PR TITLE
Add support for Aqara Ceiling Light T1M (acn032)

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1756,3 +1756,52 @@ def test_aqara_acn014_signature_match(assert_signature_matches_quirk):
     assert_signature_matches_quirk(
         zhaquirks.xiaomi.aqara.light_acn.LumiLightAcn014, signature
     )
+
+
+def test_aqara_acn032_signature_match(assert_signature_matches_quirk):
+    """Test signature."""
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.FullFunctionDevice|MainsPowered|RxOnWhenIdle|AllocateAddress: 142>, manufacturer_code=4447, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 0x0104,
+                "device_type": "0x0102",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0003",
+                    "0x0004",
+                    "0x0005",
+                    "0x0006",
+                    "0x0008",
+                    "0x0300",
+                    "0xfcc0"
+                ],
+                "out_clusters": [
+                    "0x000a",
+                    "0x0019"
+                ]
+            },
+            "2": {
+                "profile_id": 0x0104,
+                "device_type": "0x0102",
+                "in_clusters": [
+                    "0x0003",
+                    "0x0004",
+                    "0x0005",
+                    "0x0006",
+                    "0x0008",
+                    "0x0300",
+                    "0xfcc0"
+                ],
+                "out_clusters": []
+            }
+        },
+        "manufacturer": "Aqara",
+        "model": "lumi.light.acn032",
+        "class": "aqara_light.LumiLightAcn032"
+    }
+
+    assert_signature_matches_quirk(
+        zhaquirks.xiaomi.aqara.light_acn.LumiLightAcn032, signature
+    )
+


### PR DESCRIPTION
## Proposed change

This quirk adds support for power on behavior configuration to Aqara Light T1M (ceiling light with RGB ring).
This device identifies itself as lumi.light.acn032.


## Additional information

Resolves #3066 


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [X] Tests have been added to verify that the new code works
