### PR TITLE
Add Philips Hue wall switch `RDM004` variant

### DIFF
--- a/tests/test_philips.py
+++ b/tests/test_philips.py
@@ -32,11 +32,11 @@ from zhaquirks.const import (
 )
 import zhaquirks.philips
 from zhaquirks.philips import Button, ButtonPressQueue, PhilipsRemoteCluster, PressType
-from zhaquirks.philips.rdm001 import PhilipsRDM001
 from zhaquirks.philips.rdm002 import PhilipsRDM002
 from zhaquirks.philips.rom001 import PhilipsROM001
 from zhaquirks.philips.rwl022 import PhilipsRWL022
 from zhaquirks.philips.rwlfirstgen import PhilipsRWLFirstGen, PhilipsRWLFirstGen2
+from zhaquirks.philips.wall_switch import PhilipsWallSwitch
 
 zhaquirks.setup()
 
@@ -95,7 +95,7 @@ zhaquirks.setup()
             },
         ),
         (
-            [PhilipsRDM001],
+            [PhilipsWallSwitch],
             {
                 (SHORT_PRESS, TURN_ON): {COMMAND: "left_press"},
                 (LONG_PRESS, TURN_ON): {COMMAND: "left_hold"},
@@ -331,7 +331,7 @@ class ManuallyFiredButtonPressQueue:
     "dev, ep, button, events",
     (
         (
-            PhilipsRDM001,
+            PhilipsWallSwitch,
             1,
             "left",
             ["press", "short_release"],
@@ -415,7 +415,7 @@ def test_PhilipsRemoteCluster_short_press(
             "on",
         ),
         (
-            PhilipsRDM001,
+            PhilipsWallSwitch,
             1,
             "left",
         ),
@@ -490,7 +490,7 @@ def test_PhilipsRemoteCluster_multi_press(
 @pytest.mark.parametrize(
     "dev, ep",
     (
-        (PhilipsRDM001, 1),
+        (PhilipsWallSwitch, 1),
         (PhilipsROM001, 1),
         (PhilipsRWLFirstGen, 2),
         (PhilipsRWLFirstGen2, 2),
@@ -516,7 +516,7 @@ def test_PhilipsRemoteCluster_ignore_unknown_buttons(zigpy_device_from_quirk, de
     (
         (PhilipsROM001, 1, "on", "hold", "long_release", "hold_release"),
         (
-            PhilipsRDM001,
+            PhilipsWallSwitch,
             1,
             "left",
             "hold",

--- a/zhaquirks/philips/wall_switch.py
+++ b/zhaquirks/philips/wall_switch.py
@@ -1,4 +1,4 @@
-"""Signify wall switch devices (at the moment RDM001 and RDM004)."""
+"""Signify wall switch devices (RDM001 and RDM004)."""
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -83,7 +83,7 @@ class PhilipsWallSwitch(CustomDevice):
         MODELS_INFO: [
             (PHILIPS, "RDM001"),
             (SIGNIFY, "RDM001"),
-            (PHILIPS, "RDM004"),
+            (PHILIPS, "RDM004"),  # likely not needed
             (SIGNIFY, "RDM004"),
         ],
         ENDPOINTS: {

--- a/zhaquirks/philips/wall_switch.py
+++ b/zhaquirks/philips/wall_switch.py
@@ -1,4 +1,4 @@
-"""Signify RDM001 device."""
+"""Signify wall switch devices (at the moment RDM001 and RDM004)."""
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -72,15 +72,20 @@ class PhilipsRdm001RemoteCluster(PhilipsRemoteCluster):
     ]
 
 
-class PhilipsRDM001(CustomDevice):
-    """Philips RDM001 device."""
+class PhilipsWallSwitch(CustomDevice):
+    """Philips RDM001 or RDM004 device."""
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=2080
         #  device_version=1
         #  input_clusters=[0, 1, 3, 64512]
         #  output_clusters=[3, 4, 6, 8, 25]>
-        MODELS_INFO: [(PHILIPS, "RDM001"), (SIGNIFY, "RDM001")],
+        MODELS_INFO: [
+            (PHILIPS, "RDM001"),
+            (SIGNIFY, "RDM001"),
+            (PHILIPS, "RDM004"),
+            (SIGNIFY, "RDM004"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
## Proposed change

This PR adds support for a newer revision of the [wall switch from philips](https://www.philips-hue.com/en-us/p/hue-philips-hue-wall-switch-module-2-pack/046677571245) (identifier RDM004). This change is based on a few posts that I found that add support for this newer version via a custom quirk that is just a copy of the old version with a changed `MODEL_INFO` field in the signature [\[1\]](https://github.com/zigpy/zha-device-handlers/issues/2764)[\[2\]](https://community.home-assistant.io/t/how-to-configure-the-philips-hue-wall-module-to-use-push-button-momentary-type-wall-switches-zha/451125/24) 

So far, I have not tested this change on my home assistant setup, but this is the next step on my agenda for today :).

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Fixes https://github.com/zigpy/zha-device-handlers/issues/2764


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
