### PR TITLE
Convert IKEA Starkvind fan speed attribute

### DIFF
--- a/zhaquirks/ikea/starkvind.py
+++ b/zhaquirks/ikea/starkvind.py
@@ -68,9 +68,9 @@ class IkeaAirpurifier(CustomCluster):
                 value is not None and value < 5500
             ):  # > 5500 = out of scale; if value is 65535 (0xFFFF), device is off
                 self.endpoint.device.pm25_bus.listener_event("update_state", value)
-        elif attrid == 0x0006:
-            if value > 9 and value < 51:
-                value = value / 5
+        elif attrid in (0x0006, 0x0007):
+            if value >= 10 and value <= 50:
+                value = value // 5
         super()._update_attribute(attrid, value)
 
     async def write_attributes(


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
IKEA Starkvind has two similar attributes: `fan_mode` and `fan_speed`.

`fan_mode` can take a value from 0-50 where 0 is off, 1 is auto and 10-50 are manual speed modes.
`fan_speed` can take a number from 10-50 or 0, where 0 is off and 10-50 is the fan speed. `fan_speed` is read-only.

If `fan_mode` is set to a manual mode that is not a multiple of 5 it is rounded to a multiple of 5, which can be seen by reading the `fan_speed` attribute. For this reason The current quirk scales that 10-50 range to a 2-10 range, eliminating the undefined and duplicate (rounded) values.

This patch applies the same downscaling to the `fan_speed` attribute, restoring the correspondence between `fan_mode` and `fan_speed` values.

Native values: Set `fan_mode` to 30 => `fan_speed` reads 30
Current state: Set `fan_mode` to 6 => `fan_speed` reads 30
With patch: Set `fan_mode` to 6 => `fan_speed` reads 6



## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
This will be followed up by a PR in home-assistant to eventually fix https://github.com/home-assistant/core/issues/97440.
Because home-assistant currently only uses the `fan_mode` and not the `fan_speed` attribute this does not depend on the corresponding home-assistant PR. Only the other way around.

I also changed the `<` and `>` to `<=` and `>=` to improve understandability of the code by mentioning the limit values and replaced `/` with `//` to prevent introducing floating point values.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
