### PR TITLE
Add Tuya smoke sensor variant `_TZE200_rccxox8p`

### DIFF
--- a/zhaquirks/tuya/ts0601_smoke.py
+++ b/zhaquirks/tuya/ts0601_smoke.py
@@ -80,9 +80,9 @@ class TuyaSmokeDetector0601(CustomDevice):
             ("_TZE200_dq1mfjug", "TS0601"),
             ("_TZE200_m9skfctm", "TS0601"),
             ("_TZE200_ntcy3xu1", "TS0601"),
+            ("_TZE200_rccxox8p", "TS0601"),
             ("_TZE200_vzekyi4c", "TS0601"),
             ("_TZE204_ntcy3xu1", "TS0601"),
-            ("_TZE200_rccxox8p", "TS0601"),
         ],
         ENDPOINTS: {
             1: {

--- a/zhaquirks/tuya/ts0601_smoke.py
+++ b/zhaquirks/tuya/ts0601_smoke.py
@@ -82,6 +82,7 @@ class TuyaSmokeDetector0601(CustomDevice):
             ("_TZE200_ntcy3xu1", "TS0601"),
             ("_TZE200_vzekyi4c", "TS0601"),
             ("_TZE204_ntcy3xu1", "TS0601"),
+            ("_TZE200_rccxox8p", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Added support for Tuya Smoke Detector TS0601 _TZE200_rccxox8p model

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
A freshly ordered smoke detector came with a new model name _TZE200_rccxox8p, previously the same kind devices was with model name _TZE200_m9skfctm.

( https://a.aliexpress.com/_EQZYANb )

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works