### PR TITLE
Fix Aqara high precision motion sensor not detecting motion

### DIFF
--- a/zhaquirks/xiaomi/aqara/motion_agl04.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl04.py
@@ -19,8 +19,8 @@ from zhaquirks.const import (
 )
 from zhaquirks.xiaomi import (
     DeviceTemperatureCluster,
-    LocalOccupancyCluster,
     MotionCluster,
+    OccupancyCluster,
     XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
     XiaomiPowerConfiguration,
@@ -98,7 +98,7 @@ class LumiLumiMotionAgl04(XiaomiCustomDevice):
                     XiaomiPowerConfiguration,
                     Identify.cluster_id,
                     DeviceTemperatureCluster,
-                    LocalOccupancyCluster,
+                    OccupancyCluster,
                     LocalMotionCluster,
                     OppleCluster,
                 ],


### PR DESCRIPTION
## Proposed change
Even though Aqara high precision motion sensors send false occupancy reports every hour (https://github.com/home-assistant/core/issues/114129), at least some firmware versions actually use the ZCL cluster for sending occupancy reports.

This PR changes the agl04 quirk to parse ZCL occupancy reports again. This fixes the issue of some of these devices not detecting motion at all.

## Additional information
This partly reverts https://github.com/zigpy/zha-device-handlers/pull/2779 (for the agl04 / high precision sensor). The T1 sensor fix is correct.
Addresses https://github.com/home-assistant/core/issues/115027

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
