### PR TITLE
Support Codecov v4 changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,5 @@ jobs:
       PRE_COMMIT_CACHE_PATH:  ~/.cache/pre-commit
       MINIMUM_COVERAGE_PERCENTAGE: 80
       PYTHON_MATRIX: "3.12"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### ~~DRAFT -- do not merge yet (needs below workflow PR merged first, CI will fail for now)~~

## Proposed change
Passes the `CODECOV_TOKEN` GH secret to the shared workflow.

## Additional information
Related PR:
- https://github.com/zigpy/workflows/pull/17

This PR is on a branch in the main repo, not on a fork, so the `CODECOV_TOKEN` secret is available and Codecov uses the upload variant with the token. See this [run with token](https://github.com/zigpy/zha-device-handlers/actions/runs/8639920207/job/23687068756?pr=3105).
For PRs created from a fork, Codecov recognized that and automatically switches to the tokenless upload. See this [run without token](https://github.com/zigpy/zha-device-handlers/actions/runs/8640013545/job/23687293771?pr=2721).