### PR TITLE
Update Schneider quirks using spec docs

### DIFF
--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -1,10 +1,8 @@
 """Schneider Electric dimmers and switches quirks."""
 
-from typing import Final
 
 from zigpy.profiles import zgp, zha
-from zigpy.quirks import CustomCluster, CustomDevice
-import zigpy.types as t
+from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -18,7 +16,6 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.lighting import Ballast
-from zigpy.zcl.foundation import ZCLAttributeDef
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -28,35 +25,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.schneiderelectric import SE_MANUF_ID, SE_MANUF_NAME, SEBasic, SESpecific
-
-
-class ControlMode(t.enum8):
-    """Dimming mode for PUCK/DIMMER/* and NHROTARY/DIMMER/1."""
-
-    Auto = 0
-    RC = 1
-    RL = 2
-    RL_LED = 3
-
-
-class SEBallast(CustomCluster, Ballast):
-    """Schneider Electric Ballast cluster."""
-
-    manufacturer_id_override = SE_MANUF_ID
-
-    class AttributeDefs(Ballast.AttributeDefs):
-        """Attribute definitions."""
-
-        control_mode: Final = ZCLAttributeDef(
-            id=0xE000, type=ControlMode, is_manufacturer_specific=True
-        )
-        unknown_attribute_e001: Final = ZCLAttributeDef(
-            id=0xE002, type=t.enum8, is_manufacturer_specific=True
-        )
-        unknown_attribute_e002: Final = ZCLAttributeDef(
-            id=0xE002, type=t.enum8, is_manufacturer_specific=True
-        )
+from zhaquirks.schneiderelectric import SE_MANUF_NAME, SEBallast, SEBasic, SESpecific
 
 
 class NHRotaryDimmer1(CustomDevice):


### PR DESCRIPTION
## Proposed change

This is a start of using the leaked Schneider Electric specification docs posted by @uvNikita in #1705, linked here again for convenience: https://drive.google.com/file/d/1rM9iVhAB-AlWwWhvpEtcReSpEATi7aVH/view

So far I have looked at the light related specs and updated the attributes with the information for the specs docs.  More improvements could probably be made by incorporating info from the other device types too, but I only have light-related devices in my home (dimmers, switches, etc) so I can't test any other changes right now.

The comments have a number of grammar issues etc, but I copied them verbatim from the spec, so if there are any ambiguous statements, your guess is as good as mine!

## Additional information

This PR renames some python variables/constant names to match the spec.  I doubt that anything is using these in code already; if so, this could be a breaking change.  I suppose @cspurk is the only person I know of that might be using this?


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
