### PR TITLE
Adds BSEED/Tuya dimmer switch variant `_TZE204_vevc4c6g`

### DIFF
--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -147,6 +147,7 @@ class TuyaSingleSwitchDimmerGP(TuyaDimmerSwitch):
 
     signature = {
         MODELS_INFO: [
+            ("_TZE204_vevc4c6g", "TS0601"),
             ("_TZE200_3p5ydos3", "TS0601"),
             ("_TZE200_ip2akl4w", "TS0601"),
             ("_TZE200_vucankjx", "TS0601"),  # Loratap

--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -147,12 +147,12 @@ class TuyaSingleSwitchDimmerGP(TuyaDimmerSwitch):
 
     signature = {
         MODELS_INFO: [
-            ("_TZE204_vevc4c6g", "TS0601"),
             ("_TZE200_3p5ydos3", "TS0601"),
             ("_TZE200_ip2akl4w", "TS0601"),
             ("_TZE200_vucankjx", "TS0601"),  # Loratap
             ("_TZE200_y8yjulon", "TS0601"),
-            ("_TZE204_n9ctkb6j", "TS0601"),  # For BSEED switch
+            ("_TZE204_n9ctkb6j", "TS0601"),  # BSEED
+            ("_TZE204_vevc4c6g", "TS0601"),  # BSEED
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0100


### PR DESCRIPTION
## Proposed change
Simple addition to the model info. I have this switch at home as well as the `_TZE200_3p5ydos3` they are the same practically.


## Additional information
Used at home and tested it.


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
