### PR TITLE
IKEA STYRBAR V3

### DIFF
--- a/zhaquirks/ikea/fourbtnremote.py
+++ b/zhaquirks/ikea/fourbtnremote.py
@@ -1,8 +1,10 @@
 """Device handler for IKEA of Sweden TRADFRI remote control."""
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
+    Groups,
     Identify,
     LevelControl,
     OnOff,
@@ -223,6 +225,71 @@ class IkeaTradfriRemoteV2(CustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
+                    ScenesCluster,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        }
+    }
+
+    device_automation_triggers = IkeaTradfriRemoteV1.device_automation_triggers.copy()
+
+
+class IkeaTradfriRemoteV3(CustomDevice):
+    """Custom device representing IKEA of Sweden TRADFRI remote control Version 2.4.11."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=820
+        # device_version=1
+        # input_clusters=[0, 1, 3, 4, 32, 4096, 64636]
+        # output_clusters=[3, 4, 5, 6, 8, 25, 4096]>
+        MODELS_INFO: [(IKEA, "Remote Control N2")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                    IKEA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    ScenesCluster.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                    IKEA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
                     ScenesCluster,
                     OnOff.cluster_id,
                     LevelControl.cluster_id,


### PR DESCRIPTION
IKEA STYRBAR V3 for FW 2.4.11 firmware

## Proposed change
  Adding V3 for firmware 2.4.11 that adding real group binding.

DA for long press up and down release is broken for most version then the remote is sending the same stop command (atleast from the last production) = release up also for down.
If like getting it working the same logic as being used for open/close button must being implanted.

## Additional information
Fixes https://github.com/zigpy/zha-device-handlers/issues/3135

Tested in my production system plus 2 test  systems and also one user in the linked issue.

If binding the scene cluster is the "IKEA scene" working on most IKEA (C)WS lights out of the box with right and left buttons !!!

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
