### PR TITLE
Quirk for Ikea TRETAKT Smart Plug

### DIFF
--- a/zhaquirks/ikea/tretaktplug.py
+++ b/zhaquirks/ikea/tretaktplug.py
@@ -1,4 +1,5 @@
 """Tretakt Plug Quirk."""
+
 from zigpy.profiles import zgp, zha, zll
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -24,6 +25,7 @@ from zhaquirks.const import (
 )
 from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, WWAH_CLUSTER_ID
 
+
 class TretaktPlug(CustomDevice):
     """Tretakt Smart plug."""
 
@@ -46,7 +48,7 @@ class TretaktPlug(CustomDevice):
                     LightLink.cluster_id,
                     WWAH_CLUSTER_ID,
                     IKEA_CLUSTER_ID,
-                    0xfc85,
+                    0xFC85,
                 ],
                 OUTPUT_CLUSTERS: [
                     Ota.cluster_id,

--- a/zhaquirks/ikea/tretaktplug.py
+++ b/zhaquirks/ikea/tretaktplug.py
@@ -1,0 +1,91 @@
+"""Tretakt Plug Quirk."""
+from zigpy.profiles import zgp, zha, zll
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    PollControl,
+    Scenes,
+)
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.ikea import IKEA, IKEA_CLUSTER_ID, WWAH_CLUSTER_ID
+
+class TretaktPlug(CustomDevice):
+    """Tretakt Smart plug."""
+
+    signature = {
+        MODELS_INFO: [(IKEA, "TRETAKT Smart plug")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=266
+            # device_version=0
+            # input_clusters=[0, 3, 4, 5, 6, 8, 4096, 64599, 64636, 64645] output_clusters=[25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                    WWAH_CLUSTER_ID,
+                    IKEA_CLUSTER_ID,
+                    0xfc85,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # device_version=0
+            # input_clusters=[33] output_clusters=[33]>
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }

--- a/zhaquirks/ikea/tretaktplug.py
+++ b/zhaquirks/ikea/tretaktplug.py
@@ -1,6 +1,6 @@
 """Tretakt Plug Quirk."""
 
-from zigpy.profiles import zgp, zha, zll
+from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -10,7 +10,6 @@ from zigpy.zcl.clusters.general import (
     LevelControl,
     OnOff,
     Ota,
-    PollControl,
     Scenes,
 )
 from zigpy.zcl.clusters.lightlink import LightLink


### PR DESCRIPTION
## Proposed change

The new Ikea plug exposes entities that are not correct and do not work, this quirk solves them by exposing only the parameters of a plug.

![image](https://github.com/zigpy/zha-device-handlers/assets/15717847/ef5e1ce1-be53-415f-8f5f-c1c4a60f1ba1)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
