### PR TITLE
Add Tuya single button switch  `TS004F` `_TZ3000_ja5osu5g`

### DIFF
--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -413,7 +413,7 @@ class TuyaSmartRemote004FSK_v2(TuyaSmartRemote004FSK):
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: DeviceType.ON_OFF_SWITCH,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,

--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -401,6 +401,86 @@ class TuyaSmartRemote004FSK(EnchantedDevice):
         (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
     }
 
+class TuyaSmartRemote004FSK_v2(EnchantedDevice):
+    """Tuya Smart (Single) Knob device."""
+
+    signature = {
+        # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=0, *allocate_address=True, *complex_descriptor_available=False, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False, *is_valid=True, *logical_type=<LogicalType.EndDevice: 2>, *user_descriptor_available=False)",
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=260, device_version=1, input_clusters=[0, 1, 3, 4, 6, 4096, 57345], output_clusters=[25, 10, 3, 4, 6, 8, 4096])
+        MODELS_INFO: [
+            ("_TZ3000_ja5osu5g", "TS004F"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: 0x0000,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LightLink.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    TuyaNoBindPowerConfigurationCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,  # Is needed for adding group then binding is not working.
+                    LightLink.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_ON, ENDPOINT_ID: 1, CLUSTER_ID: 6},
+        (DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1, CLUSTER_ID: 6},
+        (LONG_PRESS, BUTTON): {COMMAND: COMMAND_STEP, ENDPOINT_ID: 1, CLUSTER_ID: 8},
+        (LONG_RELEASE, BUTTON): {COMMAND: COMMAND_STOP, ENDPOINT_ID: 1, CLUSTER_ID: 8},
+        (ALT_SHORT_PRESS, BUTTON): {
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 8,
+            PARAMS: {
+                "transition_time": 1,
+                "options_mask": None,
+                "options_override": None,
+            },
+        },
+        (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
+    }
 
 class TuyaSmartRemote004F(EnchantedDevice):
     """Tuya 4-button New version remote device."""

--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -401,7 +401,7 @@ class TuyaSmartRemote004FSK(EnchantedDevice):
         (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
     }
 
-class TuyaSmartRemote004FSK_v2(EnchantedDevice):
+class TuyaSmartRemote004FSK_v2(TuyaSmartRemote004FSK):
     """Tuya Smart (Single) Knob device."""
 
     signature = {
@@ -413,7 +413,7 @@ class TuyaSmartRemote004FSK_v2(EnchantedDevice):
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: 0x0000,
+                DEVICE_TYPE: DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
@@ -434,52 +434,6 @@ class TuyaSmartRemote004FSK_v2(EnchantedDevice):
                 ],
             },
         },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    TuyaNoBindPowerConfigurationCluster,
-                    Identify.cluster_id,
-                    Groups.cluster_id,  # Is needed for adding group then binding is not working.
-                    LightLink.cluster_id,
-                    TuyaZBExternalSwitchTypeCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                    Time.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    TuyaSmartRemoteOnOffCluster,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                    LightLink.cluster_id,
-                ],
-            },
-        },
-    }
-
-    device_automation_triggers = {
-        (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_ON, ENDPOINT_ID: 1, CLUSTER_ID: 6},
-        (DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1, CLUSTER_ID: 6},
-        (LONG_PRESS, BUTTON): {COMMAND: COMMAND_STEP, ENDPOINT_ID: 1, CLUSTER_ID: 8},
-        (LONG_RELEASE, BUTTON): {COMMAND: COMMAND_STOP, ENDPOINT_ID: 1, CLUSTER_ID: 8},
-        (ALT_SHORT_PRESS, BUTTON): {
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 8,
-            PARAMS: {
-                "transition_time": 1,
-                "options_mask": None,
-                "options_override": None,
-            },
-        },
-        (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: SHORT_PRESS},
-        (LONG_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: LONG_PRESS},
-        (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
     }
 
 class TuyaSmartRemote004F(EnchantedDevice):


### PR DESCRIPTION
Existing signature before quirk:
```json
{
  "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4742, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0000",
      "input_clusters": [
        "0x0000",
        "0x0001",
        "0x0003",
        "0x0004",
        "0x0006",
        "0x1000",
        "0xe001"
      ],
      "output_clusters": [
        "0x0003",
        "0x0004",
        "0x0006",
        "0x0008",
        "0x000a",
        "0x0019",
        "0x1000"
      ]
    }
  },
  "manufacturer": "_TZ3000_ja5osu5g",
  "model": "TS004F",
  "class": "zigpy.device.Device"
}
```

Signature after quirk:
```json
{
  "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4742, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0820",
      "input_clusters": [
        "0x0000",
        "0x0001",
        "0x0003",
        "0x0004",
        "0x1000",
        "0xe001"
      ],
      "output_clusters": [
        "0x0003",
        "0x0004",
        "0x0006",
        "0x0008",
        "0x000a",
        "0x0019",
        "0x0300",
        "0x1000"
      ]
    }
  },
  "manufacturer": "_TZ3000_ja5osu5g",
  "model": "TS004F",
  "class": "ts004f.TuyaSmartRemote004FSK_v2"
}
```

Tested in HA, and HA correctly receives button presses now:
![image](https://github.com/zigpy/zha-device-handlers/assets/3992884/15e4f9c9-cfed-44d1-8fed-b15328803e7c)


Fixes https://github.com/zigpy/zha-device-handlers/discussions/2212

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
