### PR TITLE
Add Tuya soil sensor variant `_TZE204_myd45weu`

### DIFF
--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -372,6 +372,7 @@ class TuyaSoilSensor(CustomDevice):
             ("_TZE200_myd45weu", "TS0601"),
             ("_TZE200_ga1maeof", "TS0601"),
             ("_TZE200_9cqcpkgb", "TS0601"),
+            ("_TZE204_myd45weu", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
Add Tuya soil sensor variant _TZE204_myd45weu


## Additional information
Received a new version of a Tuya soil sensor currently not supported 


## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
