### PR TITLE
Convert IKEA Styrbar quirks to v2 quirk

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -641,12 +641,6 @@ KNOWN_DUPLICATE_TRIGGERS = {
             (zhaquirks.aurora.aurora_dimmer.COLOR_DOWN, const.LEFT),
         ],
     ],
-    zhaquirks.ikea.fourbtnremote.IkeaTradfriRemoteV1: [
-        [
-            (const.LONG_RELEASE, const.DIM_UP),
-            (const.LONG_RELEASE, const.DIM_DOWN),
-        ]
-    ],
     zhaquirks.paulmann.fourbtnremote.PaulmannRemote4Btn: [
         [
             (const.LONG_RELEASE, const.BUTTON_1),
@@ -666,6 +660,7 @@ KNOWN_DUPLICATE_TRIGGERS = {
 }
 
 
+# XXX: Test does not handle v2 quirks
 @pytest.mark.parametrize(
     "quirk",
     [q for q in ALL_QUIRK_CLASSES if getattr(q, "device_automation_triggers", None)],

--- a/zhaquirks/ikea/fourbtnremote.py
+++ b/zhaquirks/ikea/fourbtnremote.py
@@ -1,16 +1,5 @@
 """Device handler for IKEA of Sweden TRADFRI remote control."""
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    PollControl,
-    PowerConfiguration,
-)
-from zigpy.zcl.clusters.lightlink import LightLink
+from zigpy.quirks.v2 import add_to_registry_v2
 
 from zhaquirks.const import (
     CLUSTER_ID,
@@ -23,214 +12,95 @@ from zhaquirks.const import (
     COMMAND_PRESS,
     COMMAND_STOP,
     COMMAND_STOP_ON_OFF,
-    DEVICE_TYPE,
     DIM_DOWN,
     DIM_UP,
     ENDPOINT_ID,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
     LEFT,
     LONG_PRESS,
     LONG_RELEASE,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
     PARAMS,
-    PROFILE_ID,
     RIGHT,
     SHORT_PRESS,
     TURN_OFF,
     TURN_ON,
 )
-from zhaquirks.ikea import (
-    IKEA,
-    IKEA_CLUSTER_ID,
-    WWAH_CLUSTER_ID,
-    DoublingPowerConfig2AAACluster,
-    ScenesCluster,
+from zhaquirks.ikea import IKEA, DoublingPowerConfig2AAACluster
+
+(
+    add_to_registry_v2(IKEA, "Remote Control N2")
+    .replaces(DoublingPowerConfig2AAACluster)  # will only double for old firmware
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, TURN_ON): {
+                COMMAND: COMMAND_ON,
+                CLUSTER_ID: 6,
+                ENDPOINT_ID: 1,
+            },
+            (LONG_PRESS, DIM_UP): {
+                COMMAND: COMMAND_MOVE_ON_OFF,
+                CLUSTER_ID: 8,
+                ENDPOINT_ID: 1,
+                PARAMS: {"move_mode": 0},
+            },
+            (LONG_RELEASE, DIM_UP): {
+                COMMAND: COMMAND_STOP_ON_OFF,
+                CLUSTER_ID: 8,
+                ENDPOINT_ID: 1,
+            },
+            (SHORT_PRESS, TURN_OFF): {
+                COMMAND: COMMAND_OFF,
+                CLUSTER_ID: 6,
+                ENDPOINT_ID: 1,
+            },
+            (LONG_PRESS, DIM_DOWN): {
+                COMMAND: COMMAND_MOVE,
+                CLUSTER_ID: 8,
+                ENDPOINT_ID: 1,
+                PARAMS: {"move_mode": 1},
+            },
+            (LONG_RELEASE, DIM_DOWN): {
+                COMMAND: COMMAND_STOP,
+                CLUSTER_ID: 8,
+                ENDPOINT_ID: 1,
+            },
+            (SHORT_PRESS, LEFT): {
+                COMMAND: COMMAND_PRESS,
+                CLUSTER_ID: 5,
+                ENDPOINT_ID: 1,
+                PARAMS: {
+                    "param1": 257,
+                    "param2": 13,
+                    "param3": 0,
+                },
+            },
+            (LONG_PRESS, LEFT): {
+                COMMAND: COMMAND_HOLD,
+                CLUSTER_ID: 5,
+                ENDPOINT_ID: 1,
+                PARAMS: {
+                    "param1": 3329,
+                    "param2": 0,
+                },
+            },
+            (SHORT_PRESS, RIGHT): {
+                COMMAND: COMMAND_PRESS,
+                CLUSTER_ID: 5,
+                ENDPOINT_ID: 1,
+                PARAMS: {
+                    "param1": 256,
+                    "param2": 13,
+                    "param3": 0,
+                },
+            },
+            (LONG_PRESS, RIGHT): {
+                COMMAND: COMMAND_HOLD,
+                CLUSTER_ID: 5,
+                ENDPOINT_ID: 1,
+                PARAMS: {
+                    "param1": 3328,
+                    "param2": 0,
+                },
+            },
+        }
+    )
 )
-
-
-class IkeaTradfriRemoteV1(CustomDevice):
-    """Custom device representing IKEA of Sweden TRADFRI remote control V1.0.024."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=820
-        # device_version=1
-        # input_clusters=[0, 1, 3, 32, 4096, 64599]
-        # output_clusters=[3, 6, 8, 25, 4096]>
-        MODELS_INFO: [(IKEA, "Remote Control N2")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    LightLink.cluster_id,
-                    WWAH_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    LightLink.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    DoublingPowerConfig2AAACluster,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    LightLink.cluster_id,
-                    WWAH_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    ScenesCluster,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    LightLink.cluster_id,
-                ],
-            }
-        }
-    }
-
-    device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 1},
-        (LONG_PRESS, DIM_UP): {
-            COMMAND: COMMAND_MOVE_ON_OFF,
-            CLUSTER_ID: 8,
-            ENDPOINT_ID: 1,
-            PARAMS: {"move_mode": 0},
-        },
-        (LONG_RELEASE, DIM_UP): {
-            COMMAND: COMMAND_STOP_ON_OFF,
-            CLUSTER_ID: 8,
-            ENDPOINT_ID: 1,
-        },
-        (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 1},
-        (LONG_PRESS, DIM_DOWN): {
-            COMMAND: COMMAND_MOVE,
-            CLUSTER_ID: 8,
-            ENDPOINT_ID: 1,
-            PARAMS: {"move_mode": 1},
-        },
-        (LONG_RELEASE, DIM_DOWN): {
-            COMMAND: COMMAND_STOP,
-            CLUSTER_ID: 8,
-            ENDPOINT_ID: 1,
-        },
-        (SHORT_PRESS, LEFT): {
-            COMMAND: COMMAND_PRESS,
-            CLUSTER_ID: 5,
-            ENDPOINT_ID: 1,
-            PARAMS: {
-                "param1": 257,
-                "param2": 13,
-                "param3": 0,
-            },
-        },
-        (LONG_PRESS, LEFT): {
-            COMMAND: COMMAND_HOLD,
-            CLUSTER_ID: 5,
-            ENDPOINT_ID: 1,
-            PARAMS: {
-                "param1": 3329,
-                "param2": 0,
-            },
-        },
-        (SHORT_PRESS, RIGHT): {
-            COMMAND: COMMAND_PRESS,
-            CLUSTER_ID: 5,
-            ENDPOINT_ID: 1,
-            PARAMS: {
-                "param1": 256,
-                "param2": 13,
-                "param3": 0,
-            },
-        },
-        (LONG_PRESS, RIGHT): {
-            COMMAND: COMMAND_HOLD,
-            CLUSTER_ID: 5,
-            ENDPOINT_ID: 1,
-            PARAMS: {
-                "param1": 3328,
-                "param2": 0,
-            },
-        },
-    }
-
-
-class IkeaTradfriRemoteV2(CustomDevice):
-    """Custom device representing IKEA of Sweden TRADFRI remote control Version 2.4.5."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=820
-        # device_version=1
-        # input_clusters=[0, 1, 3, 32, 4096, 64599, 64636]
-        # output_clusters=[3, 5, 6, 8, 25, 4096]>
-        MODELS_INFO: [(IKEA, "Remote Control N2")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    LightLink.cluster_id,
-                    WWAH_CLUSTER_ID,
-                    IKEA_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    ScenesCluster.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    LightLink.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    LightLink.cluster_id,
-                    WWAH_CLUSTER_ID,
-                    IKEA_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    ScenesCluster,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    LightLink.cluster_id,
-                ],
-            }
-        }
-    }
-
-    device_automation_triggers = IkeaTradfriRemoteV1.device_automation_triggers.copy()

--- a/zhaquirks/ikea/fourbtnremote.py
+++ b/zhaquirks/ikea/fourbtnremote.py
@@ -1,5 +1,6 @@
 """Device handler for IKEA of Sweden TRADFRI remote control."""
 from zigpy.quirks.v2 import add_to_registry_v2
+from zigpy.zcl import ClusterType
 
 from zhaquirks.const import (
     CLUSTER_ID,
@@ -24,11 +25,12 @@ from zhaquirks.const import (
     TURN_OFF,
     TURN_ON,
 )
-from zhaquirks.ikea import IKEA, DoublingPowerConfig2AAACluster
+from zhaquirks.ikea import IKEA, DoublingPowerConfig2AAACluster, ScenesCluster
 
 (
     add_to_registry_v2(IKEA, "Remote Control N2")
     .replaces(DoublingPowerConfig2AAACluster)  # will only double for old firmware
+    .replaces(ScenesCluster, cluster_type=ClusterType.Client)
     .device_automation_triggers(
         {
             (SHORT_PRESS, TURN_ON): {


### PR DESCRIPTION
## Proposed change
Converts existing IKEA Styrbar quirks to a v2 quirk.
This also adds support for new signatures of the Styrbar, as quirks v2 don't need to match by endpoint/clusters (signature) anymore.


## Additional information
The only downside I see is that we use `DoublingPowerConfig2AAACluster` for all versions of the remote, even if it's a "newer signature". I think we should at least change the default to not double for that first, before we merge this.
Related PR for that:
- https://github.com/zigpy/zha-device-handlers/pull/3176

Would supersede #3144 if we want to go this route.
The test `test_quirk_device_automation_triggers_unique` also still needs updating that should be done in a separate PR.
It doesn't deal properly with v2 quirks.

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
