### PR TITLE
Add Tuya TS0203 `TZ3000_6zvw8ham` contact sensor

### DIFF
--- a/zhaquirks/tuya/ts0203.py
+++ b/zhaquirks/tuya/ts0203.py
@@ -1,0 +1,21 @@
+"""Tuya Contact Sensor."""
+
+from zigpy.quirks.v2 import ClusterType, add_to_registry_v2
+from zigpy.zcl.clusters.general import Identify
+
+from zhaquirks.tuya import TuyaPowerConfigurationCluster2AAA
+
+(
+    add_to_registry_v2("_TZ3000_6zvw8ham", "TS0203")
+    .skip_configuration()
+    .removes(Identify.cluster_id)
+    .replaces(TuyaPowerConfigurationCluster2AAA)
+    .removes(0x0003, cluster_type=ClusterType.Client)
+    .removes(0x0004, cluster_type=ClusterType.Client)
+    .removes(0x0005, cluster_type=ClusterType.Client)
+    .removes(0x0006, cluster_type=ClusterType.Client)
+    .removes(0x0008, cluster_type=ClusterType.Client)
+    .removes(0x000a, cluster_type=ClusterType.Client)
+    .removes(0x0019, cluster_type=ClusterType.Client)
+    .removes(0x1000, cluster_type=ClusterType.Client)
+)


### PR DESCRIPTION
It's powered by  2 AAA/HR03 batteries.

The device presents too many clusters that it actually doesnt support.

According the Tuya Dev Platform the device has 2 datapoints:

* doorcontact_state of type Boolean
* battery_percentage of type Integer (0-100, step=1)

I wasn't able to read the datapoints with a TuyaMCUCluster (with or without NoManufacturerCluster addition).

The device seems to work fine with just the IasZone cluster though.

The battery reading seems to not work reliably.

Device signature without quirk:

```json
{
  "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0402",
      "input_clusters": [
        "0x0000",
        "0x0001",
        "0x0003",
        "0x0500"
      ],
      "output_clusters": [
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006",
        "0x0008",
        "0x000a",
        "0x0019",
        "0x1000"
      ]
    }
  },
  "manufacturer": "_TZ3000_6zvw8ham",
  "model": "TS0203",
  "class": "zigpy.device.Device"
}
```

Device signature with quirk:

```
{
  "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0402",
      "input_clusters": [
        "0x0000",
        "0x0001",
        "0x0500"
      ],
      "output_clusters": []
    }
  },
  "manufacturer": "_TZ3000_6zvw8ham",
  "model": "TS0203",
  "class": "zigpy.quirks.v2.CustomDeviceV2"
}
```

## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
