### PR TITLE
Purge quirks when loading custom quirks

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -12,7 +12,11 @@ from typing import Any
 
 import zigpy.device
 import zigpy.endpoint
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import (
+    _DEVICE_REGISTRY as DEVICE_REGISTRY,
+    CustomCluster,
+    CustomDevice,
+)
 import zigpy.types as t
 from zigpy.util import ListenableMixin
 from zigpy.zcl import foundation
@@ -428,8 +432,12 @@ class NoReplyMixin:
         return rsp
 
 
-def setup(custom_quirks_path: str | None = None) -> None:
+def setup(custom_quirks_path: str | None = None, *, clear_existing: bool = True) -> None:
     """Register all quirks with zigpy, including optional custom quirks."""
+
+    if clear_existing:
+        DEVICE_REGISTRY._registry.clear()
+        DEVICE_REGISTRY._registry_v2.clear()
 
     # Import all quirks in the `zhaquirks` package first
     for _importer, modname, _ispkg in pkgutil.walk_packages(


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Currently, v1 and v2 quirks are loaded multiple times due to us using `importlib` when the integration is reloaded. For v2 quirks, this will cause a startup error. This PR purges the device registries when quirks are setup.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
