### PR TITLE
Update ty0201 to TuyaLocalCluster

### DIFF
--- a/zhaquirks/tuya/ty0201.py
+++ b/zhaquirks/tuya/ty0201.py
@@ -1,11 +1,12 @@
 """Tuya TY0201 temperature and humidity sensor."""
 
 from zigpy.profiles import zha
-from zigpy.profiles.zha import DeviceType
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
-from zigpy.zcl.clusters.measurement import RelativeHumidity, TemperatureMeasurement
-
+from zigpy.zcl.clusters.general import Basic, Identify, Ota
+from zigpy.zcl.clusters.measurement import (
+    RelativeHumidity,
+    TemperatureMeasurement,
+)
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -13,50 +14,58 @@ from zhaquirks.const import (
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+   SKIP_CONFIGURATION,
 )
-from zhaquirks.tuya.air import TuyaAirQualityHumidity, TuyaAirQualityTemperature
+from zhaquirks.tuya import TuyaLocalCluster, TuyaPowerConfigurationCluster2AAA
 
+
+class TuyaTemperatureMeasurement(TemperatureMeasurement, TuyaLocalCluster):
+    """Tuya local TemperatureMeasurement cluster."""
+
+class TuyaRelativeHumidity(RelativeHumidity, TuyaLocalCluster):
+    """Tuya local RelativeHumidity cluster."""
 
 class TuyaTempHumiditySensor(CustomDevice):
-    """Temu/Aliexpress temperature and humidity sensor."""
+        """Tuya temp and humidity sensor."""
 
-    signature = {
-        #  <SimpleDescriptor endpoint=1, profile=260, device_type="0x0302"
-        #  input_clusters=["0x000", "0x0001", "0x0003", "0x0402", "0x0405"]
-        #  output_clusters=["0x0019"]>
-        MODELS_INFO: [("_TZ3000_bjawzodf", "TY0201"),
-                      ("_TZ3000_zl1kmjqx", "TY0201")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: DeviceType.TEMPERATURE_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    RelativeHumidity.cluster_id,
+        signature = {
+                # "profile_id": 260,
+                # "device_type": "0x0302",
+                # "in_cluster": ["0x0000","0x0001","0x0003","0x0402","0x0405"],
+                # "out_cluster": ["0x0019"]
+                MODELS_INFO: [
+                        ("_TZ3000_bjawzodf", "TY0201"),
                 ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
+                ENDPOINTS: {
+                        1: {
+                                PROFILE_ID: zha.PROFILE_ID,
+                                DEVICE_TYPE: zha.DeviceType.TEMPERATURE_SENSOR,
+                                INPUT_CLUSTERS: [
+                                        Basic.cluster_id,
+                                        Identify.cluster_id,
+                                        TuyaPowerConfigurationCluster2AAA.cluster_id,
+                                        RelativeHumidity.cluster_id,
+                                        TemperatureMeasurement.cluster_id,
+                                ],
+                                OUTPUT_CLUSTERS: [
+                                        Ota.cluster_id,
+                                ]
+                        }
+                },
+        }
 
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    TuyaAirQualityTemperature,
-                    TuyaAirQualityHumidity,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
+        replacement = {
+                SKIP_CONFIGURATION: True,
+                ENDPOINTS: {
+                        1: {
+                                INPUT_CLUSTERS: [
+                                        Basic.cluster_id,
+                                        Identify.cluster_id,
+                                        TuyaPowerConfigurationCluster2AAA,
+                                        TuyaTemperatureMeasurement,
+                                        TuyaRelativeHumidity,
+                                ],
+                                OUTPUT_CLUSTERS: [Ota.cluster_id],
+                        }
+                },
+        }


### PR DESCRIPTION
## Proposed change
I reviewed the ty0201.py and it didnt work on my TY0201 _TZ3000_bjawzodf.
So i reworked it to use the TuyaLocalCluster instead of TuyaAirQuality, which is way more stable.
Additonaly i added the TuyaPowerConfigurationCluster2AAA because the TY0201 _TZ3000_bjawzodf does get powered by 2x AAA Batteries.

## Additional information
This is a rework of #3201 and it fixes #2862,  fixes #2851 , fixes #2701 and fixes #3230 .

## Checklist
- [X] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
