### PR TITLE
Add Tuya Giex GX02 water valve support

### DIFF
--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -385,6 +385,7 @@ class GiexValve(CustomDevice):
             ("_TZE200_sh1btabb", "TS0601"),
             ("_TZE200_a7sghmms", "TS0601"),
             ("_TZE204_7ytb3h8u", "TS0601"),
+            ("_TZE200_7ytb3h8u", "TS0601"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0051


### PR DESCRIPTION
## Proposed change
Bought here: aliexpress.com/item/1005006547328147.html


## Additional information
![image](https://github.com/zigpy/zha-device-handlers/assets/33869051/bf2c0f2e-8be4-4f03-87b5-4f292fd06dd6)
just adding another device into the same tuya valve quirk

Similar pull request: https://github.com/zigpy/zha-device-handlers/pull/3124#issue-2261665043
(Mainly why I bought that particular one)



## Checklist
<!--

-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
