### PR TITLE
Add Tuya cover `_TZE200_1vxgqfba`

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -377,6 +377,7 @@ class TuyaMoesCover0601(TuyaWindowCover):
             ("_TZE200_nw1r9hp6", "TS0601"),
             ("_TZE200_gaj531w3", "TS0601"),
             ("_TZE200_icka1clh", "TS0601"),
+            ("_TZE200_1vxgqfba", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
  This modification add supports for Zemismart roller motor ZM25R1 (TZE200_1vxgqfba)


## Additional information
  It solves issue #2560
  Fix https://github.com/zigpy/zha-device-handlers/issues/2560  
  Modification consist on the addition of a new model into existent functions. No mayor change exist
  It was tested on my HA with a custom ZHA quirk and cover was recognized and works just fine.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
