### PR TITLE
Adapt v2 quirks to new zigpy API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache License Version 2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy>=0.63.5",
+    "zigpy>=0.65.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache License Version 2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy>=0.65.1",
+    "zigpy>=0.65.2",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.65.1
+zigpy>=0.65.2
 ruff==0.0.261

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.63.5
+zigpy>=0.65.1
 ruff==0.0.261

--- a/zhaquirks/ikea/fourbtnremote.py
+++ b/zhaquirks/ikea/fourbtnremote.py
@@ -1,6 +1,6 @@
 """Device handler for IKEA of Sweden TRADFRI remote control."""
 
-from zigpy.quirks.v2 import add_to_registry_v2
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl import ClusterType
 
 from zhaquirks.const import (
@@ -29,7 +29,7 @@ from zhaquirks.const import (
 from zhaquirks.ikea import IKEA, DoublingPowerConfig2AAACluster, ScenesCluster
 
 (
-    add_to_registry_v2(IKEA, "Remote Control N2")
+    QuirkBuilder(IKEA, "Remote Control N2")
     .replaces(DoublingPowerConfig2AAACluster)  # will only double for old firmware
     .replaces(ScenesCluster, cluster_type=ClusterType.Client)
     .device_automation_triggers(
@@ -106,4 +106,5 @@ from zhaquirks.ikea import IKEA, DoublingPowerConfig2AAACluster, ScenesCluster
             },
         }
     )
+    .add_to_registry()
 )

--- a/zhaquirks/ikea/plug.py
+++ b/zhaquirks/ikea/plug.py
@@ -1,13 +1,14 @@
 """IKEA plugs quirk."""
 
-from zigpy.quirks.v2 import add_to_registry_v2
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import LevelControl
 
 from zhaquirks.ikea import IKEA
 
 # remove LevelControl for plugs to not show config options in ZHA
 (
-    add_to_registry_v2(IKEA, "TRADFRI control outlet")
+    QuirkBuilder(IKEA, "TRADFRI control outlet")
     .also_applies_to(IKEA, "TRETAKT Smart plug")
     .removes(LevelControl.cluster_id)
+    .add_to_registry()
 )

--- a/zhaquirks/sonoff/button.py
+++ b/zhaquirks/sonoff/button.py
@@ -1,6 +1,6 @@
 """Device handler for Sonoff buttons."""
 
-from zigpy.quirks.v2 import add_to_registry_v2
+from zigpy.quirks.v2 import QuirkBuilder
 
 from zhaquirks.const import (
     BUTTON,
@@ -14,7 +14,7 @@ from zhaquirks.const import (
 )
 
 (
-    add_to_registry_v2("eWeLink", "WB01")
+    QuirkBuilder("eWeLink", "WB01")
     .also_applies_to("eWeLink", "SNZB-01P")
     .device_automation_triggers(
         {
@@ -23,4 +23,5 @@ from zhaquirks.const import (
             (LONG_PRESS, BUTTON): {COMMAND: COMMAND_OFF},
         }
     )
+    .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
The latest zigpy version changes the quirks v2 API to use `QuirkBuilder` instead of `add_to_registry_v2`.
A call to `quirkBuilder.add_to_registry()` at the end is also required now.

This PR adapts the three existing v2 quirks to the new API.
The zigpy requirement is also bumped to [0.65.2](https://github.com/zigpy/zigpy/releases/tag/0.65.1).


## Additional information
Related zigpy PR:
- https://github.com/zigpy/zigpy/pull/1420

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
