### PR TITLE
Add Tuya `_TZE204_ztqnh5cg` presence and illumination variant

### DIFF
--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -399,6 +399,7 @@ class MmwRadarMotionGPP(CustomDevice):
             ("_TZE200_sfiy5tfs", "TS0601"),
             ("_TZE200_mrf6vtua", "TS0601"),
             ("_TZE204_qasjif9e", "TS0601"),
+            ("_TZE204_ztqnh5cg", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change

Fix #3225

## Additional information

Zigbee 24G variant of this device:
![image](https://github.com/user-attachments/assets/fc8b3a03-b1dc-4f56-8c70-e55f696b3740)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
