### PR TITLE
Convert Sinope light to new style AttributeDefs, add ZHA events

### DIFF
--- a/tests/test_sinope.py
+++ b/tests/test_sinope.py
@@ -195,7 +195,7 @@ async def test_sinope_light_switch_reporting(zigpy_device_from_quirk, quirk):
 
         await manu_cluster.bind()
         await manu_cluster.configure_reporting(
-            SinopeTechnologiesManufacturerCluster.AttributeDefs.action_report.id
+            SinopeTechnologiesManufacturerCluster.AttributeDefs.action_report.id,
             3600,
             10800,
             1,

--- a/tests/test_sinope.py
+++ b/tests/test_sinope.py
@@ -1,18 +1,18 @@
 """Tests for Sinope."""
 
 from unittest import mock
+
 import pytest
-from zhaquirks.sinope import SINOPE_MANUFACTURER_CLUSTER_ID
+from zigpy.device import Device
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import DeviceTemperature
 from zigpy.zcl.clusters.measurement import FlowMeasurement
-from zigpy.device import Device
-from zhaquirks.const import COMMAND_BUTTON_DOUBLE
-
-import zhaquirks.sinope.switch
-import zhaquirks.sinope.light
 
 from tests.common import ClusterListener
+from zhaquirks.const import COMMAND_BUTTON_DOUBLE
+from zhaquirks.sinope import SINOPE_MANUFACTURER_CLUSTER_ID
+import zhaquirks.sinope.light
+import zhaquirks.sinope.switch
 
 zhaquirks.setup()
 
@@ -65,9 +65,10 @@ async def test_sinope_flow_measurement(zigpy_device_from_quirk, quirk):
     )
     assert flow_measurement_listener.attribute_updates[1][1] == 25  # not modified
 
+
 @pytest.mark.parametrize("quirk", (zhaquirks.sinope.light.SinopeTechnologieslight,))
 async def test_sinope_light_switch(zigpy_device_from_quirk, quirk):
-    """Test that button presses are sent as events"""
+    """Test that button presses are sent as events."""
     device: Device = zigpy_device_from_quirk(quirk)
 
     data = b"\x1c\x9c\x11\x81\nT\x000\x04"  # off button double down
@@ -93,7 +94,7 @@ async def test_sinope_light_switch(zigpy_device_from_quirk, quirk):
 
 @pytest.mark.parametrize("quirk", (zhaquirks.sinope.light.SinopeTechnologieslight,))
 async def test_sinope_light_switch_reporting(zigpy_device_from_quirk, quirk):
-    """Test that button presses are sent as events"""
+    """Test that configuring reporting for action_report works."""
     device: Device = zigpy_device_from_quirk(quirk)
 
     manu_cluster = device.endpoints[1].in_clusters[SINOPE_MANUFACTURER_CLUSTER_ID]
@@ -106,11 +107,13 @@ async def test_sinope_light_switch_reporting(zigpy_device_from_quirk, quirk):
 
         await manu_cluster.bind()
         await manu_cluster.configure_reporting(
-            zhaquirks.sinope.light.SinopeTechnologiesManufacturerCluster.attributes_by_name['action_report'].id,
+            zhaquirks.sinope.light.SinopeTechnologiesManufacturerCluster.attributes_by_name[
+                "action_report"
+            ].id,
             3600,
             10800,
             1,
         )
 
-        assert len(request_mock.mock_calls) == 0
-        assert len(bind_mock.mock_calls) == 0
+        assert len(request_mock.mock_calls) == 1
+        assert len(bind_mock.mock_calls) == 1

--- a/tests/test_sinope.py
+++ b/tests/test_sinope.py
@@ -10,13 +10,14 @@ from zigpy.zcl.clusters.general import DeviceTemperature
 from zigpy.zcl.clusters.measurement import FlowMeasurement
 
 from tests.common import ClusterListener
+import zhaquirks
 from zhaquirks.const import COMMAND_BUTTON_DOUBLE, COMMAND_BUTTON_HOLD
 from zhaquirks.sinope import SINOPE_MANUFACTURER_CLUSTER_ID
 from zhaquirks.sinope.light import (
     SinopeTechnologieslight,
     SinopeTechnologiesManufacturerCluster,
 )
-import zhaquirks.sinope.switch
+from zhaquirks.sinope.switch import SinopeTechnologiesCalypso, SinopeTechnologiesValveG2
 
 zhaquirks.setup()
 
@@ -25,7 +26,7 @@ ButtonAction = SinopeTechnologiesManufacturerCluster.Action
 SINOPE_MANUFACTURER_ID = 4508  # 0x119C
 
 
-@pytest.mark.parametrize("quirk", (zhaquirks.sinope.switch.SinopeTechnologiesCalypso,))
+@pytest.mark.parametrize("quirk", (SinopeTechnologiesCalypso,))
 async def test_sinope_device_temp(zigpy_device_from_quirk, quirk):
     """Test that device temperature is multiplied."""
     device = zigpy_device_from_quirk(quirk)
@@ -48,7 +49,7 @@ async def test_sinope_device_temp(zigpy_device_from_quirk, quirk):
     assert dev_temp_listener.attribute_updates[1][1] == 25  # not modified
 
 
-@pytest.mark.parametrize("quirk", (zhaquirks.sinope.switch.SinopeTechnologiesValveG2,))
+@pytest.mark.parametrize("quirk", (SinopeTechnologiesValveG2,))
 async def test_sinope_flow_measurement(zigpy_device_from_quirk, quirk):
     """Test that flow measurement measured value is divided."""
     device = zigpy_device_from_quirk(quirk)
@@ -89,7 +90,7 @@ def _get_packet_data(
     return t.SerializableBytes(hdr + cmd).serialize()
 
 
-@pytest.mark.parametrize("quirk", (zhaquirks.sinope.light.SinopeTechnologieslight,))
+@pytest.mark.parametrize("quirk", (SinopeTechnologieslight,))
 @pytest.mark.parametrize(
     "press_type,exp_event",
     (

--- a/tests/test_sinope.py
+++ b/tests/test_sinope.py
@@ -74,7 +74,7 @@ async def test_sinope_flow_measurement(zigpy_device_from_quirk, quirk):
     assert flow_measurement_listener.attribute_updates[1][1] == 25  # not modified
 
 
-def _get_xbee_packet_data(
+def _get_packet_data(
     command: foundation.GeneralCommand,
     attr: foundation.Attribute | None = None,
     dirc: foundation.Direction = foundation.Direction.Server_to_Client,
@@ -124,7 +124,7 @@ async def test_sinope_light_switch(
             value=press_type,
         ),
     )
-    data = _get_xbee_packet_data(foundation.GeneralCommand.Report_Attributes, attr)
+    data = _get_packet_data(foundation.GeneralCommand.Report_Attributes, attr)
     device.handle_message(260, cluster_id, endpoint_id, endpoint_id, data)
 
     if exp_event is None:
@@ -160,7 +160,7 @@ async def test_sinope_light_switch_non_action_report(zigpy_device_from_quirk, qu
     device.endpoints[endpoint_id].in_clusters[cluster_id].add_listener(cluster_listener)
 
     # read attributes general command
-    data = _get_xbee_packet_data(foundation.GeneralCommand.Read_Attributes)
+    data = _get_packet_data(foundation.GeneralCommand.Read_Attributes)
     device.handle_message(260, cluster_id, endpoint_id, endpoint_id, data)
     # no ZHA events emitted because we only handle Report_Attributes
     assert cluster_listener.zha_send_event.call_count == 0
@@ -172,7 +172,7 @@ async def test_sinope_light_switch_non_action_report(zigpy_device_from_quirk, qu
             type=t.int16s(0x29), value=t.int16s(50)
         ),  # 0x29 = t.int16s
     )
-    data = _get_xbee_packet_data(foundation.GeneralCommand.Report_Attributes, attr)
+    data = _get_packet_data(foundation.GeneralCommand.Report_Attributes, attr)
     device.handle_message(260, cluster_id, endpoint_id, endpoint_id, data)
     # ZHA event emitted because we pass non "action_report"
     # reports to the base class handler.

--- a/tests/test_sinope.py
+++ b/tests/test_sinope.py
@@ -95,7 +95,6 @@ async def test_sinope_light_switch(zigpy_device_from_quirk, quirk):
 async def test_sinope_light_switch_reporting(zigpy_device_from_quirk, quirk):
     """Test that button presses are sent as events"""
     device: Device = zigpy_device_from_quirk(quirk)
-    from pudb import set_trace; set_trace();
 
     manu_cluster = device.endpoints[1].in_clusters[SINOPE_MANUFACTURER_CLUSTER_ID]
 

--- a/tests/test_sinope.py
+++ b/tests/test_sinope.py
@@ -195,9 +195,7 @@ async def test_sinope_light_switch_reporting(zigpy_device_from_quirk, quirk):
 
         await manu_cluster.bind()
         await manu_cluster.configure_reporting(
-            SinopeTechnologiesManufacturerCluster.attributes_by_name[
-                "action_report"
-            ].id,
+            SinopeTechnologiesManufacturerCluster.AttributeDefs.action_report.id
             3600,
             10800,
             1,

--- a/zhaquirks/sinope/__init__.py
+++ b/zhaquirks/sinope/__init__.py
@@ -23,7 +23,7 @@ from zhaquirks.const import (
 
 SINOPE = "Sinope Technologies"
 SINOPE_MANUFACTURER_CLUSTER_ID = 0xFF01
-ATTRIBUTE_ACTION = "actionReport"
+ATTRIBUTE_ACTION = "action_report"
 
 LIGHT_DEVICE_TRIGGERS = {
     (SHORT_PRESS, TURN_ON): {

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -189,7 +189,7 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
 
         attr = args[0][0]
 
-        if attr.attrid != self.attributes_by_name["action_report"].id:
+        if attr.attrid != self.AttributeDefs.action_report.id:
             return super().handle_cluster_general_request(
                 hdr, args, dst_addressing=dst_addressing
             )

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -5,7 +5,7 @@ DM2550ZB-G2.
 """
 
 import logging
-from typing import Any, Optional, Union
+from typing import Any, Final, Optional, Union
 
 import zigpy.profiles.zha as zha_p
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -52,63 +52,110 @@ SINOPE_MANUFACTURER_CLUSTER_ID = 0xFF01
 _LOGGER = logging.getLogger(__name__)
 
 
+class KeypadLock(t.enum8):
+    """Keypad_lockout values."""
+
+    Unlocked = 0x00
+    Locked = 0x01
+    Partial_lock = 0x02
+
+
+class PhaseControl(t.enum8):
+    """Phase control value, reverse / forward."""
+
+    Forward = 0x00
+    Reverse = 0x01
+
+
+class DoubleFull(t.enum8):
+    """Double click up set full intensity."""
+
+    Off = 0x00
+    On = 0x01
+
+
+class ButtonAction(t.enum8):
+    """Action_report values."""
+
+    Single_on = 0x01
+    Single_release_on = 0x02
+    Long_on = 0x03
+    Double_on = 0x04
+    Single_off = 0x11
+    Single_release_off = 0x12
+    Long_off = 0x13
+    Double_off = 0x14
+
+
 class SinopeTechnologiesManufacturerCluster(CustomCluster):
     """SinopeTechnologiesManufacturerCluster manufacturer cluster."""
 
-    class KeypadLock(t.enum8):
-        """Keypad_lockout values."""
+    KeypadLock: Final = KeypadLock
+    PhaseControl: Final = PhaseControl
+    DoubleFull: Final = DoubleFull
+    Action: Final = ButtonAction
 
-        Unlocked = 0x00
-        Locked = 0x01
-        Partial_lock = 0x02
+    cluster_id: Final[t.uint16_t] = SINOPE_MANUFACTURER_CLUSTER_ID
+    name: Final = "SinopeTechnologiesManufacturerCluster"
+    ep_attribute: Final = "sinope_manufacturer_specific"
 
-    class PhaseControl(t.enum8):
-        """Phase control value, reverse / forward."""
+    class AttributeDefs(foundation.BaseAttributeDefs):
+        """Sinope Manufacturer Cluster Attributes."""
 
-        Forward = 0x00
-        Reverse = 0x01
-
-    class DoubleFull(t.enum8):
-        """Double click up set full intensity."""
-
-        Off = 0x00
-        On = 0x01
-
-    class Action(t.enum8):
-        """Action_report values."""
-
-        Single_on = 0x01
-        Single_release_on = 0x02
-        Long_on = 0x03
-        Double_on = 0x04
-        Single_off = 0x11
-        Single_release_off = 0x12
-        Long_off = 0x13
-        Double_off = 0x14
-
-    cluster_id = SINOPE_MANUFACTURER_CLUSTER_ID
-    name = "SinopeTechnologiesManufacturerCluster"
-    ep_attribute = "sinope_manufacturer_specific"
-    attributes = {
-        0x0002: ("keypad_lockout", KeypadLock, True),
-        0x0003: ("firmware_number", t.uint16_t, True),
-        0x0004: ("firmware_version", t.CharacterString, True),
-        0x0010: ("on_intensity", t.int16s, True),
-        0x0050: ("on_led_color", t.uint24_t, True),
-        0x0051: ("off_led_color", t.uint24_t, True),
-        0x0052: ("on_led_intensity", t.uint8_t, True),
-        0x0053: ("off_led_intensity", t.uint8_t, True),
-        0x0054: ("action_report", Action, True),
-        0x0055: ("min_intensity", t.uint16_t, True),
-        0x0056: ("phase_control", PhaseControl, True),
-        0x0058: ("double_up_full", DoubleFull, True),
-        0x0090: ("current_summation_delivered", t.uint32_t, True),
-        0x00A0: ("timer", t.uint32_t, True),
-        0x00A1: ("timer_countdown", t.uint32_t, True),
-        0x0119: ("connected_load", t.uint16_t, True),
-        0x0200: ("status", t.bitmap32, True),
-        0xFFFD: ("cluster_revision", t.uint16_t, True),
-    }
+        keypad_lockout: Final = foundation.ZCLAttributeDef(
+            id=0x0002, type=KeypadLock, access="rw", is_manufacturer_specific=True
+        )
+        firmware_number: Final = foundation.ZCLAttributeDef(
+            id=0x0003, type=t.uint16_t, access="r", is_manufacturer_specific=True
+        )
+        firmware_version: Final = foundation.ZCLAttributeDef(
+            id=0x0004, type=t.CharacterString, access="r", is_manufacturer_specific=True
+        )
+        on_intensity: Final = foundation.ZCLAttributeDef(
+            id=0x0010, type=t.int16s, access="rw", is_manufacturer_specific=True
+        )
+        on_led_color: Final = foundation.ZCLAttributeDef(
+            id=0x0050, type=t.uint24_t, access="rw", is_manufacturer_specific=True
+        )
+        off_led_color: Final = foundation.ZCLAttributeDef(
+            id=0x0051, type=t.uint24_t, access="rw", is_manufacturer_specific=True
+        )
+        on_led_intensity: Final = foundation.ZCLAttributeDef(
+            id=0x0052, type=t.uint8_t, access="rw", is_manufacturer_specific=True
+        )
+        off_led_intensity: Final = foundation.ZCLAttributeDef(
+            id=0x0053, type=t.uint8_t, access="rw", is_manufacturer_specific=True
+        )
+        action_report: Final = foundation.ZCLAttributeDef(
+            id=0x0054, type=ButtonAction, access="rp", is_manufacturer_specific=True
+        )
+        min_intensity: Final = foundation.ZCLAttributeDef(
+            id=0x0055, type=t.uint16_t, access="rw", is_manufacturer_specific=True
+        )
+        phase_control: Final = foundation.ZCLAttributeDef(
+            id=0x0056, type=PhaseControl, access="rw", is_manufacturer_specific=True
+        )
+        double_up_full: Final = foundation.ZCLAttributeDef(
+            id=0x0058, type=DoubleFull, access="rw", is_manufacturer_specific=True
+        )
+        current_summation_delivered: Final = foundation.ZCLAttributeDef(
+            id=0x0090, type=t.uint32_t, access="rp", is_manufacturer_specific=True
+        )
+        timer: Final = foundation.ZCLAttributeDef(
+            id=0x00A0, type=t.uint32_t, access="rw", is_manufacturer_specific=True
+        )
+        timer_countdown: Final = foundation.ZCLAttributeDef(
+            id=0x00A1, type=t.uint32_t, access="r", is_manufacturer_specific=True
+        )
+        connected_load: Final = foundation.ZCLAttributeDef(
+            id=0x0119, type=t.uint16_t, access="rw", is_manufacturer_specific=True
+        )
+        status: Final = foundation.ZCLAttributeDef(
+            id=0x0200, type=t.bitmap32, access="rp", is_manufacturer_specific=True
+        )
+        cluster_revision: Final = foundation.ZCLAttributeDef(
+            id=0xFFFD, type=t.uint16_t, access="r", is_manufacturer_specific=True
+        )
 
     server_commands = {
         0x54: foundation.ZCLCommandDef(
@@ -158,7 +205,7 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
             return
         self.listener_event(ZHA_SEND_EVENT, action, event_args)
 
-    def _get_command_from_action(self, action: Action) -> str | None:
+    def _get_command_from_action(self, action: ButtonAction) -> str | None:
         # const lookup = {2: 'up_single', 3: 'up_hold', 4: 'up_double',
         #             18: 'down_single', 19: 'down_hold', 20: 'down_double'};
         match action:

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -6,8 +6,7 @@ DM2550ZB-G2.
 
 import logging
 from typing import Any, Optional, Union
-from homeassistant.components.zha.core.cluster_handlers import AttrReportConfig
-from homeassistant.components.zha.core.const import REPORT_CONFIG_IMMEDIATE
+
 import zigpy.profiles.zha as zha_p
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
@@ -45,7 +44,7 @@ from zhaquirks.sinope import (
     ATTRIBUTE_ACTION,
     LIGHT_DEVICE_TRIGGERS,
     SINOPE,
-    CustomDeviceTemperatureCluster
+    CustomDeviceTemperatureCluster,
 )
 
 SINOPE_MANUFACTURER_CLUSTER_ID = 0xFF01
@@ -150,12 +149,12 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
             ATTRIBUTE_NAME: ATTRIBUTE_ACTION,
             VALUE: value.value,
         }
-        action = self.get_command_from_action(self.Action(value))
+        action = self._get_command_from_action(self.Action(value))
         if not action:
             return
         self.listener_event(ZHA_SEND_EVENT, action, event_args)
 
-    def get_command_from_action(self, action: Action) -> str | None:
+    def _get_command_from_action(self, action: Action) -> str | None:
         # const lookup = {2: 'up_single', 3: 'up_hold', 4: 'up_double',
         #             18: 'down_single', 19: 'down_hold', 20: 'down_double'};
         match action:

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -136,12 +136,16 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         )
 
         if hdr.command_id != foundation.GeneralCommand.Report_Attributes:
-            return
+            return super().handle_cluster_general_request(
+                hdr, args, dst_addressing=dst_addressing
+            )
 
         attr = args[0][0]
 
         if attr.attrid != self.attributes_by_name["action_report"].id:
-            return
+            return super().handle_cluster_general_request(
+                hdr, args, dst_addressing=dst_addressing
+            )
 
         value = attr.value.value
         event_args = {

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -44,10 +44,9 @@ from zhaquirks.sinope import (
     ATTRIBUTE_ACTION,
     LIGHT_DEVICE_TRIGGERS,
     SINOPE,
+    SINOPE_MANUFACTURER_CLUSTER_ID,
     CustomDeviceTemperatureCluster,
 )
-
-SINOPE_MANUFACTURER_CLUSTER_ID = 0xFF01
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -230,7 +230,7 @@ class SinopeTechnologieslight(CustomDevice):
                 DEVICE_TYPE: zha_p.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DeviceTemperature,
+                    DeviceTemperature.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
@@ -294,7 +294,7 @@ class SinopeDM2500ZB(SinopeTechnologieslight):
                 DEVICE_TYPE: zha_p.DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DeviceTemperature,
+                    DeviceTemperature.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
@@ -361,7 +361,7 @@ class SinopeDM2550ZB(SinopeTechnologieslight):
                 DEVICE_TYPE: zha_p.DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    DeviceTemperature,
+                    DeviceTemperature.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -152,9 +152,7 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         status: Final = foundation.ZCLAttributeDef(
             id=0x0200, type=t.bitmap32, access="rp", is_manufacturer_specific=True
         )
-        cluster_revision: Final = foundation.ZCLAttributeDef(
-            id=0xFFFD, type=t.uint16_t, access="r", is_manufacturer_specific=True
-        )
+        cluster_revision: Final = foundation.ZCL_CLUSTER_REVISION_ATTR
 
     server_commands = {
         0x54: foundation.ZCLCommandDef(

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -28,17 +28,13 @@ from zhaquirks import EventableCluster
 from zhaquirks.const import (
     ATTRIBUTE_ID,
     ATTRIBUTE_NAME,
-    COMMAND,
     COMMAND_BUTTON_DOUBLE,
     COMMAND_BUTTON_HOLD,
-    COMMAND_BUTTON_SINGLE,
-    COMMAND_ID,
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
-    PRESS_TYPE,
     PROFILE_ID,
     VALUE,
     ZHA_SEND_EVENT,
@@ -46,10 +42,10 @@ from zhaquirks.const import (
 from zhaquirks.sinope import (
     ATTRIBUTE_ACTION,
     LIGHT_DEVICE_TRIGGERS,
-    SINOPE,
-    SINOPE_MANUFACTURER_CLUSTER_ID,
-    CustomDeviceTemperatureCluster,
+    SINOPE
 )
+
+SINOPE_MANUFACTURER_CLUSTER_ID = 0xFF01
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -234,7 +230,7 @@ class SinopeTechnologieslight(CustomDevice):
                 DEVICE_TYPE: zha_p.DeviceType.ON_OFF_LIGHT,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    CustomDeviceTemperatureCluster,
+                    DeviceTemperature,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
@@ -298,7 +294,7 @@ class SinopeDM2500ZB(SinopeTechnologieslight):
                 DEVICE_TYPE: zha_p.DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    CustomDeviceTemperatureCluster,
+                    DeviceTemperature,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
@@ -365,7 +361,7 @@ class SinopeDM2550ZB(SinopeTechnologieslight):
                 DEVICE_TYPE: zha_p.DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    CustomDeviceTemperatureCluster,
+                    DeviceTemperature,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,


### PR DESCRIPTION
## Proposed change
Add ability for Sinope light switches to handle routing attribute reports on the manufacturer cluster attribute `action_report` as ZHA events.

## Additional information
Related PR zigpy/zha/pull/153 made it so that `action_report` doesn't need to be manually configured for reporting (as shown by @claudegel here: https://github.com/claudegel/sinope-zha?tab=readme-ov-file#a-create-the-reporting-).

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
