### PR TITLE
Add Tuya soil sensor variant `_TZE284_aao3yzhs` and `_TZE284_sgabhwa6`

### DIFF
--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -407,3 +407,78 @@ class TuyaSoilSensor(CustomDevice):
             }
         },
     }
+
+
+class SoilManufClusterVar02(TuyaMCUCluster):
+    """Tuya Manufacturer Cluster with Temperature and Humidity data points (variation 02)"""
+
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
+        5: DPToAttributeMapping(
+            TuyaTemperatureMeasurement.ep_attribute,
+            "measured_value",
+            converter=lambda x: x * 10,
+        ),
+        3: DPToAttributeMapping(
+            TuyaSoilMoisture.ep_attribute,
+            "measured_value",
+            converter=lambda x: x * 100,
+        ),
+        15: DPToAttributeMapping(
+            TuyaPowerConfigurationCluster2AAA.ep_attribute,
+            "battery_percentage_remaining",
+            converter=lambda x: x * 2,  # double reported percentage
+        ),
+    }
+
+    data_point_handlers = {
+        3: "_dp_2_attr_update",
+        5: "_dp_2_attr_update",
+        15: "_dp_2_attr_update",
+    }
+
+
+class TuyaSoilSensorVar02(CustomDevice):
+    """Tuya temp and humidity sensor (variation 05)."""
+
+    signature = {
+        # "profile_id": 260,
+        # "device_type": "0x0051",
+        # "in_clusters": ["0x0000","0x0004","0x0005","0xed00","0xef00"],
+        # "out_clusters": ["0x000a","0x0019"]
+        MODELS_INFO: [
+            ("_TZE284_aao3yzhs", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    0xED00,
+                    TemperatureHumidityManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        SKIP_CONFIGURATION: True,
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.TEMPERATURE_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    SoilManufClusterVar02,
+                    TuyaTemperatureMeasurement,
+                    TuyaSoilMoisture,
+                    TuyaPowerConfigurationCluster2AAA,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            }
+        },
+    }

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -410,7 +410,7 @@ class TuyaSoilSensor(CustomDevice):
 
 
 class SoilManufClusterVar02(TuyaMCUCluster):
-    """Tuya Manufacturer Cluster with Temperature and Humidity data points (variation 02)"""
+    """Tuya Manufacturer Cluster with Temperature and Humidity data points (variation 02)."""
 
     dp_to_attribute: dict[int, DPToAttributeMapping] = {
         5: DPToAttributeMapping(

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -447,6 +447,7 @@ class TuyaSoilSensorVar02(CustomDevice):
         # "out_clusters": ["0x000a","0x0019"]
         MODELS_INFO: [
             ("_TZE284_aao3yzhs", "TS0601"),
+            ("_TZE284_sgabhwa6", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Add support for TUYA TS0601 _TZE284_aao3yzhs

Also adds support for TS0601_TZE284_sgabhwa6.  @GeoffWy confirms suitability for TS0601_TZE284_sgabhwa6.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

Fixes: https://github.com/zigpy/zha-device-handlers/issues/3305
Fixes: https://github.com/zigpy/zha-device-handlers/issues/3266


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
