### PR TITLE
Add Tuya temperature sensor `_TZE204_yjjdcqsq`, fix battery reporting half

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -945,45 +945,33 @@ class TuyaPowerConfigurationCluster(PowerConfiguration, TuyaLocalCluster):
         self.update_attribute("battery_percentage_remaining", value * 2)
 
 
-class TuyaPowerConfigurationCluster2AAA(PowerConfiguration, TuyaLocalCluster):
+class TuyaPowerConfigurationCluster2AAA(TuyaPowerConfigurationCluster):
     """PowerConfiguration cluster for devices with 2 AAA."""
 
-    BATTERY_SIZES = 0x0031
-    BATTERY_QUANTITY = 0x0033
-    BATTERY_RATED_VOLTAGE = 0x0034
-
     _CONSTANT_ATTRIBUTES = {
-        BATTERY_SIZES: 4,
-        BATTERY_QUANTITY: 2,
-        BATTERY_RATED_VOLTAGE: 15,
+        PowerConfiguration.AttributeDefs.battery_size.id: 4,
+        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
+        PowerConfiguration.AttributeDefs.battery_quantity.id: 2,
     }
 
 
 class TuyaPowerConfigurationCluster2AA(TuyaPowerConfigurationCluster):
     """PowerConfiguration cluster for devices with 2 AA."""
 
-    BATTERY_SIZES = 0x0031
-    BATTERY_RATED_VOLTAGE = 0x0034
-    BATTERY_QUANTITY = 0x0033
-
     _CONSTANT_ATTRIBUTES = {
-        BATTERY_SIZES: 3,
-        BATTERY_RATED_VOLTAGE: 15,
-        BATTERY_QUANTITY: 2,
+        PowerConfiguration.AttributeDefs.battery_size.id: 3,
+        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
+        PowerConfiguration.AttributeDefs.battery_quantity.id: 2,
     }
 
 
 class TuyaPowerConfigurationCluster3AA(TuyaPowerConfigurationCluster):
     """PowerConfiguration cluster for devices with 3 AA."""
 
-    BATTERY_SIZES = 0x0031
-    BATTERY_RATED_VOLTAGE = 0x0034
-    BATTERY_QUANTITY = 0x0033
-
     _CONSTANT_ATTRIBUTES = {
-        BATTERY_SIZES: 3,
-        BATTERY_RATED_VOLTAGE: 15,
-        BATTERY_QUANTITY: 3,
+        PowerConfiguration.AttributeDefs.battery_size.id: 3,
+        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
+        PowerConfiguration.AttributeDefs.battery_quantity.id: 3,
     }
 
 

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -945,7 +945,7 @@ class TuyaPowerConfigurationCluster(PowerConfiguration, TuyaLocalCluster):
         self.update_attribute("battery_percentage_remaining", value * 2)
 
 
-class TuyaPowerConfigurationCluster2AAA(TuyaPowerConfigurationCluster):
+class TuyaPowerConfigurationCluster2AAA(PowerConfiguration, TuyaLocalCluster):
     """PowerConfiguration cluster for devices with 2 AAA."""
 
     _CONSTANT_ATTRIBUTES = {

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -95,6 +95,27 @@ class TemperatureHumidityBatteryStatesManufCluster(TuyaMCUCluster):
     }
 
 
+class TemperatureHumidityBatteryStatesManufClusterVar02(TuyaMCUCluster):
+    """Tuya Manufacturer Cluster with Temperature and Humidity data points. Battery states 20, 50 and 100%."""
+
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
+        1: TemperatureHumidityManufCluster.dp_to_attribute[1],
+        2: TemperatureHumidityManufCluster.dp_to_attribute[2],
+        3: DPToAttributeMapping(
+            TuyaPowerConfigurationCluster2AAA.ep_attribute,
+            "battery_percentage_remaining",
+            converter=lambda x: {0: 40, 1: 100, 2: 200}[x],  # double reported percentage
+            #for some reason values are halved somewhere downstream
+        ),
+    }
+
+    data_point_handlers = {
+        1: "_dp_2_attr_update",
+        2: "_dp_2_attr_update",
+        3: "_dp_2_attr_update",
+    }
+
+
 class TuyaTempHumiditySensor(CustomDevice):
     """Custom device representing tuya temp and humidity sensor with e-ink screen."""
 
@@ -322,6 +343,52 @@ class TuyaTempHumiditySensorVar04(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     TemperatureHumidityBatteryStatesManufCluster,
+                    TuyaTemperatureMeasurement,
+                    TuyaRelativeHumidity,
+                    TuyaPowerConfigurationCluster2AAA,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            }
+        },
+    }
+
+
+class TuyaTempHumiditySensorVar05(CustomDevice):
+    """Tuya temp and humidity sensor (variation 05)."""
+
+    signature = {
+        # "profile_id": 260,
+        # "device_type": "0x0051",
+        # "in_clusters": ["0x0000","0x0004","0x0005","0xef00"],
+        # "out_clusters": ["0x000a","0x0019"]
+        MODELS_INFO: [
+            ("_TZE204_yjjdcqsq", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TemperatureHumidityManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        SKIP_CONFIGURATION: True,
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.TEMPERATURE_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TemperatureHumidityBatteryStatesManufClusterVar02,
                     TuyaTemperatureMeasurement,
                     TuyaRelativeHumidity,
                     TuyaPowerConfigurationCluster2AAA,

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -84,7 +84,7 @@ class TemperatureHumidityBatteryStatesManufCluster(TuyaMCUCluster):
         3: DPToAttributeMapping(
             TuyaPowerConfigurationCluster2AAA.ep_attribute,
             "battery_percentage_remaining",
-            converter=lambda x: {0: 25, 1: 50, 2: 100}[x],  # double reported percentage
+            converter=lambda x: {0: 50, 1: 100, 2: 200}[x],
         ),
     }
 

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -95,29 +95,6 @@ class TemperatureHumidityBatteryStatesManufCluster(TuyaMCUCluster):
     }
 
 
-class TemperatureHumidityBatteryStatesManufClusterVar02(TuyaMCUCluster):
-    """Tuya Manufacturer Cluster with Temperature and Humidity data points. Battery states 20, 50 and 100%."""
-
-    dp_to_attribute: dict[int, DPToAttributeMapping] = {
-        1: TemperatureHumidityManufCluster.dp_to_attribute[1],
-        2: TemperatureHumidityManufCluster.dp_to_attribute[2],
-        3: DPToAttributeMapping(
-            TuyaPowerConfigurationCluster2AAA.ep_attribute,
-            "battery_percentage_remaining",
-            converter=lambda x: {0: 40, 1: 100, 2: 200}[
-                x
-            ],  # double reported percentage
-            # for some reason values are halved somewhere downstream
-        ),
-    }
-
-    data_point_handlers = {
-        1: "_dp_2_attr_update",
-        2: "_dp_2_attr_update",
-        3: "_dp_2_attr_update",
-    }
-
-
 class TuyaTempHumiditySensor(CustomDevice):
     """Custom device representing tuya temp and humidity sensor with e-ink screen."""
 
@@ -319,51 +296,6 @@ class TuyaTempHumiditySensorVar04(CustomDevice):
             ("_TZE204_yjjdcqsq", "TS0601"),
             ("_TZE200_utkemkbs", "TS0601"),
             ("_TZE204_utkemkbs", "TS0601"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    TemperatureHumidityManufCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        SKIP_CONFIGURATION: True,
-        ENDPOINTS: {
-            1: {
-                DEVICE_TYPE: zha.DeviceType.TEMPERATURE_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    TemperatureHumidityBatteryStatesManufCluster,
-                    TuyaTemperatureMeasurement,
-                    TuyaRelativeHumidity,
-                    TuyaPowerConfigurationCluster2AAA,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id, Time.cluster_id],
-            }
-        },
-    }
-
-
-class TuyaTempHumiditySensorVar05(CustomDevice):
-    """Tuya temp and humidity sensor (variation 05)."""
-
-    signature = {
-        # "profile_id": 260,
-        # "device_type": "0x0051",
-        # "in_clusters": ["0x0000","0x0004","0x0005","0xef00"],
-        # "out_clusters": ["0x000a","0x0019"]
-        MODELS_INFO: [
             ("_TZE204_yjjdcqsq", "TS0601"),
         ],
         ENDPOINTS: {
@@ -390,7 +322,7 @@ class TuyaTempHumiditySensorVar05(CustomDevice):
                     Basic.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
-                    TemperatureHumidityBatteryStatesManufClusterVar02,
+                    TemperatureHumidityBatteryStatesManufCluster,
                     TuyaTemperatureMeasurement,
                     TuyaRelativeHumidity,
                     TuyaPowerConfigurationCluster2AAA,

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -104,8 +104,10 @@ class TemperatureHumidityBatteryStatesManufClusterVar02(TuyaMCUCluster):
         3: DPToAttributeMapping(
             TuyaPowerConfigurationCluster2AAA.ep_attribute,
             "battery_percentage_remaining",
-            converter=lambda x: {0: 40, 1: 100, 2: 200}[x],  # double reported percentage
-            #for some reason values are halved somewhere downstream
+            converter=lambda x: {0: 40, 1: 100, 2: 200}[
+                x
+            ],  # double reported percentage
+            # for some reason values are halved somewhere downstream
         ),
     }
 


### PR DESCRIPTION
Add quirk for  Temperature/humidity sensor model "_TZE204_yjjdcqsq", "TS0601".  

## Proposed change
<!--
-->
 Add quirk for  Temperature/humidity sensor model "_TZE204_yjjdcqsq", "TS0601".  This is added as class TuyaTempHumiditySensorVar05(CustomDevice)Var02, and references TemperatureHumidityBatteryStatesManufClusterVar02. The only difference from the original is that TemperatureHumidityBatteryStatesManufClusterVar02 has double the values for battery states, otherwise the sensor appears in HA with half the battery remaining %. It seems very likely that the original TemperatureHumidityBatteryStatesManufCluster should also have the same correction, but I don't have those sensors to test.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
