### PR TITLE
Bump codespell to v2.3.0 in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies: [tomli]


### PR DESCRIPTION
## Proposed change
Bump codespell to v2.3.0 in pre-commit config, as this was not included in https://github.com/zigpy/zha-device-handlers/pull/3257.


## Additional information
Needed for https://github.com/zigpy/zha-device-handlers/pull/2336.


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
