### PR TITLE
Use new zigpy ZCL attribute data types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache License Version 2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy>=0.65.2",
+    "zigpy>=0.66.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.65.3
+zigpy>=0.66.0
 ruff==0.0.261

--- a/tests/test_danfoss.py
+++ b/tests/test_danfoss.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 from zigpy.quirks import CustomCluster
+import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.hvac import Thermostat
 from zigpy.zcl.foundation import WriteAttributesStatusRecord, ZCLAttributeDef
@@ -161,8 +162,8 @@ async def test_customized_standardcluster(zigpy_device_from_quirk):
     ) == [[4545, 345], [5433, 45355]]
 
     mock_attributes = {
-        656: ZCLAttributeDef(is_manufacturer_specific=True),
-        56454: ZCLAttributeDef(is_manufacturer_specific=False),
+        656: ZCLAttributeDef(type=t.uint8_t, is_manufacturer_specific=True),
+        56454: ZCLAttributeDef(type=t.uint8_t, is_manufacturer_specific=False),
     }
 
     danfoss_thermostat_cluster.attributes = mock_attributes

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -627,9 +627,9 @@ async def test_aqara_feeder_write_attrs(
 
     expected_attr_def = opple_cluster.find_attribute(0xFFF1)
     expected = foundation.Attribute(0xFFF1, foundation.TypeValue())
-    expected.value.type = foundation.DATA_TYPES.pytype_to_datatype_id(
+    expected.value.type = foundation.DataType.from_python_type(
         expected_attr_def.type
-    )
+    ).type_id
     expected.value.value = expected_attr_def.type(expected_bytes)
 
     await opple_cluster.write_attributes({attribute: value}, manufacturer=0x115F)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Make quirks (just unit tests) compatible with https://github.com/zigpy/zigpy/pull/1463. It's a relatively simple change that affects just how ZCL data types are looked up.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
