### PR TITLE
Purge quirks on reload

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import zigpy.device
 import zigpy.endpoint
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import DEVICE_REGISTRY, CustomCluster, CustomDevice
 import zigpy.types as t
 from zigpy.util import ListenableMixin
 from zigpy.zcl import foundation
@@ -431,6 +431,9 @@ class NoReplyMixin:
 
 def setup(custom_quirks_path: str | None = None) -> None:
     """Register all quirks with zigpy, including optional custom quirks."""
+
+    if custom_quirks_path is not None:
+        DEVICE_REGISTRY.purge_custom_quirks(custom_quirks_path)
 
     # Import all quirks in the `zhaquirks` package first
     for _importer, modname, _ispkg in pkgutil.walk_packages(


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Purge custom quirks (V1 and V2) when ZHA is reloaded. This uses the new interface in zigpy: https://github.com/zigpy/zigpy/pull/1451

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
