### PR TITLE
Add quirk for Sonoff SWV Smart Water Valve

### DIFF
--- a/zhaquirks/sonoff/swv.py
+++ b/zhaquirks/sonoff/swv.py
@@ -1,0 +1,47 @@
+"""Sonoff SWV - Zigbee smart water valve."""
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import EntityPlatform, EntityType, QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+
+class ValveState(t.enum8):
+    """Water valve state."""
+
+    Normal = 0
+    Water_Shortage = 1
+    Water_Leakage = 2
+    Water_Shortage_And_Leakage = 3
+
+
+class EwelinkCluster(CustomCluster):
+    """Ewelink specific cluster."""
+
+    cluster_id = 0xFC11
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        water_valve_state = ZCLAttributeDef(
+            id=0x500C,
+            type=ValveState,
+        )
+
+    @property
+    def _is_manuf_specific(self):
+        return False
+
+
+(
+    QuirkBuilder("SONOFF", "SWV")
+    .replaces(EwelinkCluster)
+    .enum(
+        EwelinkCluster.AttributeDefs.water_valve_state.name,
+        ValveState,
+        EwelinkCluster.cluster_id,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/sonoff/swv.py
+++ b/zhaquirks/sonoff/swv.py
@@ -1,7 +1,10 @@
 """Sonoff SWV - Zigbee smart water valve."""
 
+import typing
+
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import EntityPlatform, EntityType, QuirkBuilder
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
@@ -9,10 +12,8 @@ from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 class ValveState(t.enum8):
     """Water valve state."""
 
-    Normal = 0
     Water_Shortage = 1
     Water_Leakage = 2
-    Water_Shortage_And_Leakage = 3
 
 
 class EwelinkCluster(CustomCluster):
@@ -23,25 +24,48 @@ class EwelinkCluster(CustomCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
 
-        water_valve_state = ZCLAttributeDef(
+        water_supply_state = ZCLAttributeDef(
             id=0x500C,
-            type=ValveState,
+            type=bool,
+        )
+
+        valve_leak_state = ZCLAttributeDef(
+            id=0x500C,
+            type=bool,
         )
 
     @property
     def _is_manuf_specific(self):
         return False
 
+    def get(self, key: int | str, default: typing.Any | None = None) -> typing.Any:
+        """Map binary sensors onto bits of shared attribute."""
+
+        value = super().get(key, default)
+        match key:
+            case self.AttributeDefs.water_supply_state.name:
+                return value & ValveState.Water_Shortage
+            case self.AttributeDefs.valve_leak_state.name:
+                return value & ValveState.Water_Leakage
+        raise ValueError(f"Unknown attribute {key}")
+
 
 (
     QuirkBuilder("SONOFF", "SWV")
     .replaces(EwelinkCluster)
-    .enum(
-        EwelinkCluster.AttributeDefs.water_valve_state.name,
-        ValveState,
+    .binary_sensor(
+        EwelinkCluster.AttributeDefs.water_supply_state.name,
         EwelinkCluster.cluster_id,
-        entity_platform=EntityPlatform.SENSOR,
-        entity_type=EntityType.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        translation_key="water_supply",
+        fallback_name="Water supply status",
+    )
+    .binary_sensor(
+        EwelinkCluster.AttributeDefs.valve_leak_state.name,
+        EwelinkCluster.cluster_id,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        translation_key="valve_leak",
+        fallback_name="Valve leak status",
     )
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Adds support for Sonoff SWV Smart Water Valve custom cluster, which exposes a new attribute called valve_status for querying if the valve is leaking or if the water supply to the valve has stopped.

Code should hopefully should be self explanatory, the only complication is the overridden `_is_manuf_specific()` property in `SonoffFC11Cluster` class. This is required, as if the device receives an attribute read or notify zigbee command which has manufacturer_specific = True set (default if cluster's ID is within manufacturer specific range which this is), it will return `UNSUPPORTED_ATTRIBUTE`.

This feature was requested as part of https://github.com/zigpy/zha-device-handlers/issues/3298

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
- zha pull request for Home Assistant Sensors: https://github.com/zigpy/zha/pull/189
- Home Assistant core pull request for language strings for sensor: https://github.com/home-assistant/core/pull/124989

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works