### PR TITLE
Add Moes Tuya valve controller `_TZE204_d0ypnbvn`, `_TZE200_d0ypnbvn`

### DIFF
--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -127,8 +127,10 @@ class TuyaSingleSwitch_GP(TuyaSwitch):
 
     signature = {
         MODELS_INFO: [
+            ("_TZE200_d0ypnbvn", "TS0601"),  # reported in #1335
             ("_TZE200_gbagoilo", "TS0601"),  # reported in #1634
             ("_TZE204_6fk3gewc", "TS0601"),
+            ("_TZE204_d0ypnbvn", "TS0601"),  # reported in #3220 & #3291
             ("_TZE204_ptaqh9tk", "TS0601"),  # reported in #2780
         ],
         ENDPOINTS: {


### PR DESCRIPTION
## Proposed change

This implement support for valve `_TZE204_d0ypnbvn`.


## Additional information

This device is also known as `_TZE200_d0ypnbvn`, I don't have it handy, but it should work for it.

I haven't added test as the code should already be covered as I only added a device to an existing definition.

Fixes #3291, fixes #3220, fixes #1335.

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
