### PR TITLE
Add Aqara H1 Wireless Remote Double Rocker variant

### DIFF
--- a/zhaquirks/xiaomi/aqara/remote_h1.py
+++ b/zhaquirks/xiaomi/aqara/remote_h1.py
@@ -393,3 +393,88 @@ class RemoteH1DoubleRocker4(RemoteH1DoubleRocker1):
             },
         },
     }
+
+
+class RemoteH1DoubleRocker5(RemoteH1DoubleRocker1):
+    """Aqara H1 Wireless Remote Double Rocker Version WRS-R02, variant 5."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.remote.b28ac1")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    PowerConfiguration.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [Identify.cluster_id],
+                OUTPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+        },
+    }
+
+
+class RemoteH1DoubleRocker6(RemoteH1DoubleRocker1):
+    """Aqara H1 Wireless Remote Double Rocker Version WRS-R02, variant 6."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.remote.b28ac1")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [Identify.cluster_id],
+                OUTPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+            4: {},
+            5: {},
+            6: {},
+        },
+    }


### PR DESCRIPTION
## Proposed change

This is a variation for the Aqara H1 Double Rocker. 

Search led me here: https://github.com/zigpy/zha-device-handlers/issues/940#issuecomment-1001107154
and here https://gist.github.com/xuxiaoqiao/6ed8dcb950f26337218d0507733970a0#file-aqara_h1_remote-py

Unfortunately it didn't work because my device quirk somehow wasn't recognized properly.

By looking at the debug messages and tinkering a bit, I found that my device's `INPUT_CLUSTERS` are slightly different and a single line flip in **Variant 3** did the trick for me:

```diff
-                INPUT_CLUSTERS: [Basic.cluster_id, PowerConfiguration.cluster_id, Identify.cluster_id,], 
+                INPUT_CLUSTERS: [Basic.cluster_id, Identify.cluster_id, PowerConfiguration.cluster_id,], 
```

This has been working flawlessly for several months for me.

Sorry if this is not done properly, but I only have a limited understanding what is going on here 😅 

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
