### PR TITLE
Add ZTH-02 Tuya `_TZE204_ksz749x8` temp/humidity sensor

### DIFF
--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -297,6 +297,7 @@ class TuyaTempHumiditySensorVar04(CustomDevice):
             ("_TZE200_utkemkbs", "TS0601"),
             ("_TZE204_utkemkbs", "TS0601"),
             ("_TZE204_yjjdcqsq", "TS0601"),
+            ("_TZE204_ksz749x8", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
Add support for `_TZE204_ksz749x8` as a temp/humidity sensor (ZTH-02). I bought one under the name `EMOS GoSmart EGS0102`.

<img width="669" alt="image" src="https://github.com/user-attachments/assets/2d56507f-ddab-406d-9733-5b544c7407d3">


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
