### PR TITLE
Add Tuya Siren TS0601 `_TZE204_hcxvyxa5` variant

### DIFF
--- a/zhaquirks/tuya/ts0601_siren.py
+++ b/zhaquirks/tuya/ts0601_siren.py
@@ -356,6 +356,7 @@ class TuyaSirenGPP_NoSensors(CustomDevice):
         MODELS_INFO: [
             ("_TZE200_t1blo2bj", "TS0601"),
             ("_TZE204_t1blo2bj", "TS0601"),
+            ("_TZE204_hcxvyxa5", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

This PR adds siren TS0601 _TZE204_hcxvyxa5 into the existing quirk of `TuyaSirenGPP_NoSensors`, and fixes #3255 and fixes #3228.

I have confirmed locally that it enables the siren to be toggled like other similar sirens, and I am able to adjust melody and duration via "Manage zigbee device".

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
