### PR TITLE
Add initial NodOn SIN-4-FP-21 (Adeo SIN-4-FP-21_EQU) quirk

### DIFF
--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -3,13 +3,7 @@
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import EntityType, QuirkBuilder
 import zigpy.types as t
-from zigpy.zcl.foundation import (
-    BaseAttributeDefs,
-    DataTypeId,
-    Direction,
-    ZCLAttributeDef,
-    ZCLCommandDef,
-)
+from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
 
 NODON = "NodOn"
 NODON_MANUFACTURER_ID = 4747

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -13,7 +13,6 @@ from zigpy.zcl.foundation import (
 )
 from zigpy.zdo.types import NodeDescriptor
 
-
 NODON = "NodOn"
 NODON_MANUFACTURER_ID = 4747
 NODON_PILOT_WIRE_CLUSTER_ID = 0xFC00  # 64512

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -5,7 +5,6 @@ from zigpy.quirks.v2 import EntityType, QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
-    BaseCommandDefs,
     DataTypeId,
     Direction,
     ZCLAttributeDef,
@@ -32,8 +31,8 @@ class NodOnPilotWireMode(t.enum8):
     ComfortMinus2 = 0x05
 
 
-class BasePilotWireCluster(CustomCluster):
-    """Base cluster to set Pilot Wire mode."""
+class NodOnPilotWireCluster(CustomCluster):
+    """NodOn manufacturer specific cluster to set Pilot Wire mode."""
 
     name: str = "PilotWireCluster"
     cluster_id: t.uint16_t = NODON_PILOT_WIRE_CLUSTER_ID
@@ -51,24 +50,8 @@ class BasePilotWireCluster(CustomCluster):
             is_manufacturer_specific=True,
         )
 
-    class ServerCommandDefs(BaseCommandDefs):
-        """Server command definitions."""
 
-        set_pilot_wire_mode = ZCLCommandDef(
-            id=0x00,
-            schema={"mode": NodOnPilotWireMode},
-            direction=Direction.Client_to_Server,
-            is_manufacturer_specific=True,
-        )
-
-
-class NodOnPilotWireCluster(BasePilotWireCluster):
-    """NodOn manufacturer specific cluster to set Pilot Wire mode."""
-
-    pass
-
-
-class AdeoPilotWireCluster(BasePilotWireCluster):
+class AdeoPilotWireCluster(NodOnPilotWireCluster):
     """Adeo manufacturer specific cluster to set Pilot Wire mode."""
 
     # Adeo SIN-4-FP-21_EQU has a weird setup where it reports 4727
@@ -86,7 +69,7 @@ nodon = (
         cluster_id=NodOnPilotWireCluster.cluster_id,
         entity_type=EntityType.STANDARD,
         translation_key="pilot_wire",
-        fallback_name="Pilot Wire",
+        fallback_name="Pilot wire",
     )
 )
 

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -53,7 +53,10 @@ class AdeoPilotWireCluster(NodOnPilotWireCluster):
     manufacturer_id_override: t.uint16_t = NODON_MANUFACTURER_ID
 
 
-nodon = QuirkBuilder(NODON, "SIN-4-FP-21").replaces(NodOnPilotWireCluster)
+nodon = (
+    QuirkBuilder(NODON, "SIN-4-FP-21")
+    .replaces(NodOnPilotWireCluster)
+)  # fmt: skip
 
 adeo = (
     nodon.clone(omit_man_model_data=True)

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -14,20 +14,6 @@ from zigpy.zcl.foundation import (
 from zigpy.zdo.types import NodeDescriptor
 
 
-class NodOnPilotWireMode(t.enum8):
-    """Pilot wire mode."""
-
-    # Codes taken from
-    # https://github.com/Koenkk/zigbee-herdsman-converters/blob/0f4833340a20db3dae625a61c41d9be0a6f952be/src/converters/fromZigbee.ts#L5285.
-
-    Off = 0x00
-    Comfort = 0x01
-    Eco = 0x02
-    FrostProtection = 0x03
-    ComfortMinus1 = 0x04
-    ComfortMinus2 = 0x05
-
-
 NODON = "NodOn"
 NODON_MANUFACTURER_ID = 4747
 NODON_PILOT_WIRE_CLUSTER_ID = 0xFC00  # 64512
@@ -50,6 +36,20 @@ ADEO_NODE_DESCRIPTION_WITH_CORRECTED_MANUFACTURER_CODE = NodeDescriptor(
     maximum_outgoing_transfer_size=500,
     descriptor_capability_field=0,
 )
+
+
+class NodOnPilotWireMode(t.enum8):
+    """Pilot wire mode."""
+
+    # Codes taken from
+    # https://github.com/Koenkk/zigbee-herdsman-converters/blob/0f4833340a20db3dae625a61c41d9be0a6f952be/src/converters/fromZigbee.ts#L5285.
+
+    Off = 0x00
+    Comfort = 0x01
+    Eco = 0x02
+    FrostProtection = 0x03
+    ComfortMinus1 = 0x04
+    ComfortMinus2 = 0x05
 
 
 class BasePilotWireCluster(CustomCluster):

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -16,25 +16,7 @@ from zigpy.zdo.types import NodeDescriptor
 NODON = "NodOn"
 NODON_MANUFACTURER_ID = 4747
 NODON_PILOT_WIRE_CLUSTER_ID = 0xFC00  # 64512
-
 ADEO = "Adeo"
-ADEO_NODE_DESCRIPTION_WITH_CORRECTED_MANUFACTURER_CODE = NodeDescriptor(
-    # the values are from a real Adeo device
-    logical_type=1,
-    complex_descriptor_available=0,
-    user_descriptor_available=0,
-    reserved=0,
-    aps_flags=0,
-    frequency_band=8,
-    mac_capability_flags=142,
-    # manufacturer_code = 4727,
-    manufacturer_code=NODON_MANUFACTURER_ID,
-    maximum_buffer_size=82,
-    maximum_incoming_transfer_size=500,
-    server_mask=11264,
-    maximum_outgoing_transfer_size=500,
-    descriptor_capability_field=0,
-)
 
 
 class NodOnPilotWireMode(t.enum8):
@@ -93,10 +75,6 @@ class AdeoPilotWireCluster(BasePilotWireCluster):
     # Adeo SIN-4-FP-21_EQU has a weird setup where it reports 4727
     # manufacturer_code in node_descriptor(), but requires NodOn's (4747)
     # manufacturer_id to execute commands and get/set attributes.
-
-    # This seems to have no effect, but I'll still leave it here.
-    # Maybe it will get fixed in future releases. NodeDescriptor magic won't
-    # be necessary then.
     manufacturer_id_override: t.uint16_t = NODON_MANUFACTURER_ID
 
 
@@ -117,8 +95,6 @@ adeo = (
     nodon.clone(omit_man_model_data=True)
     .applies_to(ADEO, "SIN-4-FP-21_EQU")
     .replaces(AdeoPilotWireCluster)
-    # please read the comment in AdeoPilotWireCluster
-    .node_descriptor(ADEO_NODE_DESCRIPTION_WITH_CORRECTED_MANUFACTURER_CODE)
 )
 
 nodon.add_to_registry()

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -38,8 +38,7 @@ class NodOnPilotWireCluster(CustomCluster):
         pilot_wire_mode = ZCLAttributeDef(
             id=0x0000,
             type=NodOnPilotWireMode,
-            # I got the following error without setting zcl_type explicitly to int:
-            # Failed to write attribute pilot_wire_mode=<NodOnPilotWireMode.FrostProtection: 3>: <Status.INVALID_DATA_TYPE: 141>
+            # need to explicitly set ZCL type
             zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -56,14 +56,6 @@ class AdeoPilotWireCluster(NodOnPilotWireCluster):
 nodon = (
     QuirkBuilder(NODON, "SIN-4-FP-21")
     .replaces(NodOnPilotWireCluster)
-    .enum(
-        attribute_name=NodOnPilotWireCluster.AttributeDefs.pilot_wire_mode.name,
-        enum_class=NodOnPilotWireMode,
-        cluster_id=NodOnPilotWireCluster.cluster_id,
-        entity_type=EntityType.STANDARD,
-        translation_key="pilot_wire",
-        fallback_name="Pilot wire",
-    )
 )
 
 adeo = (

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -1,7 +1,7 @@
 """NodOn pilot wire heating module."""
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import EntityType, QuirkBuilder
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
 
@@ -53,10 +53,7 @@ class AdeoPilotWireCluster(NodOnPilotWireCluster):
     manufacturer_id_override: t.uint16_t = NODON_MANUFACTURER_ID
 
 
-nodon = (
-    QuirkBuilder(NODON, "SIN-4-FP-21")
-    .replaces(NodOnPilotWireCluster)
-)
+nodon = QuirkBuilder(NODON, "SIN-4-FP-21").replaces(NodOnPilotWireCluster)
 
 adeo = (
     nodon.clone(omit_man_model_data=True)

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -11,7 +11,6 @@ from zigpy.zcl.foundation import (
     ZCLAttributeDef,
     ZCLCommandDef,
 )
-from zigpy.zdo.types import NodeDescriptor
 
 NODON = "NodOn"
 NODON_MANUFACTURER_ID = 4747

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -1,0 +1,126 @@
+"""NodOn pilot wire heating module."""
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import EntityType, QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl.foundation import (
+    BaseAttributeDefs,
+    BaseCommandDefs,
+    DataTypeId,
+    Direction,
+    ZCLAttributeDef,
+    ZCLCommandDef,
+)
+from zigpy.zdo.types import NodeDescriptor
+
+
+class NodOnPilotWireMode(t.enum8):
+    """Pilot wire mode."""
+
+    # Codes taken from
+    # https://github.com/Koenkk/zigbee-herdsman-converters/blob/0f4833340a20db3dae625a61c41d9be0a6f952be/src/converters/fromZigbee.ts#L5285.
+
+    Off = 0x00
+    Comfort = 0x01
+    Eco = 0x02
+    FrostProtection = 0x03
+    ComfortMinus1 = 0x04
+    ComfortMinus2 = 0x05
+
+
+NODON = "NodOn"
+NODON_MANUFACTURER_ID = 4747
+NODON_PILOT_WIRE_CLUSTER_ID = 0xFC00  # 64512
+
+ADEO = "Adeo"
+ADEO_NODE_DESCRIPTION_WITH_CORRECTED_MANUFACTURER_CODE = NodeDescriptor(
+    # the values are from a real Adeo device
+    logical_type=1,
+    complex_descriptor_available=0,
+    user_descriptor_available=0,
+    reserved=0,
+    aps_flags=0,
+    frequency_band=8,
+    mac_capability_flags=142,
+    # manufacturer_code = 4727,
+    manufacturer_code=NODON_MANUFACTURER_ID,
+    maximum_buffer_size=82,
+    maximum_incoming_transfer_size=500,
+    server_mask=11264,
+    maximum_outgoing_transfer_size=500,
+    descriptor_capability_field=0,
+)
+
+
+class BasePilotWireCluster(CustomCluster):
+    """Base cluster to set Pilot Wire mode."""
+
+    name: str = "PilotWireCluster"
+    cluster_id: t.uint16_t = NODON_PILOT_WIRE_CLUSTER_ID
+    ep_attribute: str = "pilot_wire_cluster"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        pilot_wire_mode = ZCLAttributeDef(
+            id=0x0000,
+            type=NodOnPilotWireMode,
+            # I got the following error without setting zcl_type explicitly to int:
+            # Failed to write attribute pilot_wire_mode=<NodOnPilotWireMode.FrostProtection: 3>: <Status.INVALID_DATA_TYPE: 141>
+            zcl_type=DataTypeId.uint8,
+            is_manufacturer_specific=True,
+        )
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Server command definitions."""
+
+        set_pilot_wire_mode = ZCLCommandDef(
+            id=0x00,
+            schema={"mode": NodOnPilotWireMode},
+            direction=Direction.Client_to_Server,
+            is_manufacturer_specific=True,
+        )
+
+
+class NodOnPilotWireCluster(BasePilotWireCluster):
+    """NodOn manufacturer specific cluster to set Pilot Wire mode."""
+
+    pass
+
+
+class AdeoPilotWireCluster(BasePilotWireCluster):
+    """Adeo manufacturer specific cluster to set Pilot Wire mode."""
+
+    # Adeo SIN-4-FP-21_EQU has a weird setup where it reports 4727
+    # manufacturer_code in node_descriptor(), but requires NodOn's (4747)
+    # manufacturer_id to execute commands and get/set attributes.
+
+    # This seems to have no effect, but I'll still leave it here.
+    # Maybe it will get fixed in future releases. NodeDescriptor magic won't
+    # be necessary then.
+    manufacturer_id_override: t.uint16_t = NODON_MANUFACTURER_ID
+
+
+nodon = (
+    QuirkBuilder(NODON, "SIN-4-FP-21")
+    .replaces(NodOnPilotWireCluster)
+    .enum(
+        attribute_name=NodOnPilotWireCluster.AttributeDefs.pilot_wire_mode.name,
+        enum_class=NodOnPilotWireMode,
+        cluster_id=NodOnPilotWireCluster.cluster_id,
+        entity_type=EntityType.STANDARD,
+        translation_key="pilot_wire",
+        fallback_name="Pilot Wire",
+    )
+)
+
+adeo = (
+    nodon.clone(omit_man_model_data=True)
+    .applies_to(ADEO, "SIN-4-FP-21_EQU")
+    .replaces(AdeoPilotWireCluster)
+    # please read the comment in AdeoPilotWireCluster
+    .node_descriptor(ADEO_NODE_DESCRIPTION_WITH_CORRECTED_MANUFACTURER_CODE)
+)
+
+nodon.add_to_registry()
+adeo.add_to_registry()


### PR DESCRIPTION
## Proposed change
This PR adds a quirk for SIN-4-FP-21 (PilotWire). The device reports itself as a SmartPlug but it has special manufacturer-specific cluster which allows setting the following modes:
```
        Off = 0x00
        Comfort = 0x01
        Eco = 0x02
        FrostProtection = 0x03
        ComfortMinus1 = 0x04
        ComfortMinus2 = 0x05
```

## Additional information

> [!IMPORTANT]  
> The HA entity shown below is not yet implemented with this version.
> See this comment for more information: https://github.com/zigpy/zha-device-handlers/pull/3364#issuecomment-2502032896

The result look like this in Home Assitant:
<img width="680" alt="Screenshot 2024-09-22 at 22 16 55" src="https://github.com/user-attachments/assets/e84e001d-1046-499f-addb-954c8f36a867">

The PR also contains a solution for Adeo SIN-4-FP-21_EQU, which seems to be an exact clone of NodOn. However, it requires https://github.com/zigpy/zigpy/pull/1505 in HA to work. https://github.com/zigpy/zigpy/pull/1505 has not yet been released as part of HA as of writing.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
