### PR TITLE
Add Tuya IR blaster `_TZ3290_rlkmy85q4pzoxobl` variant

### DIFF
--- a/zhaquirks/tuya/ts1201.py
+++ b/zhaquirks/tuya/ts1201.py
@@ -506,6 +506,7 @@ class ZosungIRBlaster_ZS06(ZosungIRBlaster):
             ("_TZ3290_7v1k4vufotpowp9z", "TS1201"),
             ("_TZ3290_acv1iuslxi3shaaj", "TS1201"),
             ("_TZ3290_gnl5a6a5xvql7c2a", "TS1201"),
+            ("_TZ3290_rlkmy85q4pzoxobl", "TS1201"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
This code adds support for a currently unsupported variant of a Zosung ZS06 Tuya TS1201 IR blaster.


## Additional information


## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
