### PR TITLE
Convert Aqara E1 TRV quirk to v2

### DIFF
--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -38,7 +38,7 @@ SCHEDULE_SETTINGS = 0x0276
 SENSOR = 0x027E
 BATTERY_PERCENTAGE = 0x040A
 
-#EXTERNAL SENSOR CALIBRATION
+# EXTERNAL SENSOR CALIBRATION
 SENSOR_TEMP = 0x1392  # Fake address to pass external sensor temperature
 SENSOR_ATTR = 0xFFF2
 SENSOR_ATTR_NAME = "sensor_attr"
@@ -383,7 +383,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
             SCHEDULE_SETTINGS: ("schedule_settings", ScheduleSettings, True),
             SENSOR: ("sensor", t.uint8_t, True),
             BATTERY_PERCENTAGE: ("battery_percentage", t.uint8_t, True),
-            #EXTERNAL SENSOR
+            # EXTERNAL SENSOR
             SENSOR_TEMP: ("sensor_temp", t.uint32_t, True),
             SENSOR_ATTR: (SENSOR_ATTR_NAME, t.LVBytes, True),
         }

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -383,6 +383,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
             SCHEDULE_SETTINGS: ("schedule_settings", ScheduleSettings, True),
             SENSOR: ("sensor", t.uint8_t, True),
             BATTERY_PERCENTAGE: ("battery_percentage", t.uint8_t, True),
+
             #EXTERNAL SENSOR
             SENSOR_TEMP: ("sensor_temp", t.uint32_t, True),
             SENSOR_ATTR: (SENSOR_ATTR_NAME, t.LVBytes, True),
@@ -393,6 +394,11 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         self.debug("Updating attribute on Xiaomi cluster %s with %s", attrid, value)
         if attrid == BATTERY_PERCENTAGE:
             self.endpoint.power.battery_percent_reported(value)
+        
+        elif attrid == SENSOR_TEMP: 
+            #EXTERNAL SENSOR
+            pass
+        
         elif attrid == SYSTEM_MODE:
             # update ZCL system_mode attribute (e.g. on attribute reports)
             self.endpoint.thermostat.update_attribute(

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -383,7 +383,6 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
             SCHEDULE_SETTINGS: ("schedule_settings", ScheduleSettings, True),
             SENSOR: ("sensor", t.uint8_t, True),
             BATTERY_PERCENTAGE: ("battery_percentage", t.uint8_t, True),
-
             # EXTERNAL SENSOR
             SENSOR_TEMP: ("sensor_temp", t.uint32_t, True),
             SENSOR_ATTR: (SENSOR_ATTR_NAME, t.LVBytes, True),
@@ -394,11 +393,11 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         self.debug("Updating attribute on Xiaomi cluster %s with %s", attrid, value)
         if attrid == BATTERY_PERCENTAGE:
             self.endpoint.power.battery_percent_reported(value)
-        
-        elif attrid == SENSOR_TEMP: 
+
+        elif attrid == SENSOR_TEMP:
             # EXTERNAL SENSOR
             pass
-        
+
         elif attrid == SYSTEM_MODE:
             # update ZCL system_mode attribute (e.g. on attribute reports)
             self.endpoint.thermostat.update_attribute(

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -38,6 +38,11 @@ SCHEDULE_SETTINGS = 0x0276
 SENSOR = 0x027E
 BATTERY_PERCENTAGE = 0x040A
 
+#EXTERNAL SENSOR CALIBRATION
+SENSOR_TEMP = 0x1392  # Fake address to pass external sensor temperature
+SENSOR_ATTR = 0xFFF2
+SENSOR_ATTR_NAME = "sensor_attr"
+
 XIAOMI_CLUSTER_ID = 0xFCC0
 
 DAYS_MAP = {
@@ -378,6 +383,9 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
             SCHEDULE_SETTINGS: ("schedule_settings", ScheduleSettings, True),
             SENSOR: ("sensor", t.uint8_t, True),
             BATTERY_PERCENTAGE: ("battery_percentage", t.uint8_t, True),
+            #EXTERNAL SENSOR
+            SENSOR_TEMP: ("sensor_temp", t.uint32_t, True),
+            SENSOR_ATTR: (SENSOR_ATTR_NAME, t.LVBytes, True),
         }
     )
 
@@ -404,6 +412,12 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         attribute_value=1,
         cluster_id=AqaraThermostatSpecificCluster.cluster_id,
         translation_key="calibrate",
+    )
+    .number(
+        attribute_name="sensor_temp",
+        attribute_value=1,
+        cluster_id=AqaraThermostatSpecificCluster.cluster_id,
+        translation_key="sensor_temp",
     )
     .add_to_registry()
 )

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -1,34 +1,20 @@
 """Aqara E1 Radiator Thermostat Quirk."""
 
 from __future__ import annotations
-from zigpy.zcl import ClusterType
 
 from functools import reduce
-from zigpy.quirks.v2 import QuirkBuilder
 import math
 import struct
 from typing import Any
 
-from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, Identify, Ota, Time
+from zigpy.zcl import ClusterType
+from zigpy.zcl.clusters.general import Ota
 from zigpy.zcl.clusters.hvac import Thermostat
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-from zhaquirks.xiaomi import (
-    LUMI,
-    XiaomiAqaraE1Cluster,
-    XiaomiCustomDevice,
-    XiaomiPowerConfiguration,
-)
+from zhaquirks.xiaomi import LUMI, XiaomiAqaraE1Cluster, XiaomiPowerConfiguration
 
 ZCL_SYSTEM_MODE = Thermostat.attributes_by_name["system_mode"].id
 

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -1,8 +1,10 @@
 """Aqara E1 Radiator Thermostat Quirk."""
 
 from __future__ import annotations
+from zigpy.zcl import ClusterType
 
 from functools import reduce
+from zigpy.quirks.v2 import QuirkBuilder
 import math
 import struct
 from typing import Any
@@ -35,6 +37,7 @@ XIAOMI_SYSTEM_MODE_MAP = {
     1: Thermostat.SystemMode.Heat,
 }
 
+CALIBRATE = 0x0270
 SYSTEM_MODE = 0x0271
 PRESET = 0x0272
 WINDOW_DETECTION = 0x0273
@@ -375,6 +378,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
     attributes = XiaomiAqaraE1Cluster.attributes.copy()
     attributes.update(
         {
+            CALIBRATE: ("calibrate", t.uint8_t, True),
             SYSTEM_MODE: ("system_mode", t.uint8_t, True),
             PRESET: ("preset", t.uint8_t, True),
             WINDOW_DETECTION: ("window_detection", t.uint8_t, True),
@@ -403,53 +407,16 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         super()._update_attribute(attrid, value)
 
 
-class AGL001(XiaomiCustomDevice):
-    """Aqara E1 Radiator Thermostat (AGL001) Device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=769
-        # device_version=1
-        # input_clusters=[0, 1, 3, 513, 64704]
-        # output_clusters=[3, 513, 64704]>
-        MODELS_INFO: [(LUMI, "lumi.airrtc.agl001")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.THERMOSTAT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Thermostat.cluster_id,
-                    Time.cluster_id,
-                    XiaomiPowerConfiguration.cluster_id,
-                    AqaraThermostatSpecificCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Thermostat.cluster_id,
-                    AqaraThermostatSpecificCluster.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    ThermostatCluster,
-                    Time.cluster_id,
-                    XiaomiPowerConfiguration,
-                    AqaraThermostatSpecificCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    ThermostatCluster,
-                    AqaraThermostatSpecificCluster,
-                    Ota.cluster_id,
-                ],
-            }
-        }
-    }
+(
+    QuirkBuilder(LUMI, "lumi.airrtc.agl001")
+    .replaces(XiaomiPowerConfiguration)
+    .replaces(AqaraThermostatSpecificCluster)
+    .adds(Ota, endpoint_id=1, cluster_type=ClusterType.Client)
+    .write_attr_button(
+        attribute_name="calibrate",
+        attribute_value=1,
+        cluster_id=AqaraThermostatSpecificCluster.cluster_id,
+        translation_key="calibrate",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -409,6 +409,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
 
 (
     QuirkBuilder(LUMI, "lumi.airrtc.agl001")
+    .replaces(ThermostatCluster)
     .replaces(XiaomiPowerConfiguration)
     .replaces(AqaraThermostatSpecificCluster)
     .adds(Ota, endpoint_id=1, cluster_type=ClusterType.Client)


### PR DESCRIPTION
## Proposed change
<!--
in order to add missing functionality I vas forced to convert quirk from v1 to v2
-->


## Additional information
<!--
It add also add missing calibration functionality to Aquara q1 TRV
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
