### PR TITLE
Remove LevelControl cluster for IKEA INSPELNING plugs

### DIFF
--- a/zhaquirks/ikea/plug.py
+++ b/zhaquirks/ikea/plug.py
@@ -9,6 +9,7 @@ from zhaquirks.ikea import IKEA
 (
     QuirkBuilder(IKEA, "TRADFRI control outlet")
     .also_applies_to(IKEA, "TRETAKT Smart plug")
+    .also_applies_to(IKEA, "INSPELNING Smart plug")
     .removes(LevelControl.cluster_id)
     .add_to_registry()
 )


### PR DESCRIPTION
The new smart plug suffers from the same issue like all IKEA plugs, unnecessary level controls in the configuration panel:
<img width="508" alt="inspelning" src="https://github.com/user-attachments/assets/c2ab9352-e0a9-44f3-9d5d-88d00926d05c">

## Proposed change
<!--
  Explain your proposed change below.
-->
Expanded Quirk to be applied to new plug as well.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
