### PR TITLE
Add Tuya TS130F `_TZ3000_qqdbccb3` curtain roller

### DIFF
--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -196,6 +196,7 @@ class TuyaZemismartWNEC1ETS130F(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
+                    Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     TuyaWithBacklightOnOffCluster,

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -168,7 +168,6 @@ class TuyaZemismartWNEC1ETS130F(CustomDevice):
     """Tuya ZemiSmart smart curtain roller shutter. WN-EC1E version."""
 
     signature = {
-        # SizePrefixedSimpleDescriptor(endpoint=1, profile=104, device_type=0x0202, device_version=1, input_clusters=[0x0000, 0x0003, 0x0004, 0x0005, 0x0102], output_clusters=[0x0019]))
         MODEL: "TS130F",
         ENDPOINTS: {
             1: {

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -164,6 +164,52 @@ class TuyaZemismartTS130F(CustomDevice):
     }
 
 
+class TuyaZemismartWNEC1ETS130F(CustomDevice):
+    """Tuya ZemiSmart smart curtain roller shutter. WN-EC1E version."""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=104, device_type=0x0202, device_version=1, input_clusters=[0x0000, 0x0003, 0x0004, 0x0005, 0x0102], output_clusters=[0x0019]))
+        MODEL: "TS130F",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    WindowCovering.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaWithBacklightOnOffCluster,
+                    TuyaCoveringCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+
 class TuyaTS130FTOGP(CustomDevice):
     """Tuya Oxt smart curtain roller shutter."""
 


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

This PR includes a new signature for the Zemismart curtain switch with reference WN2-EC1E because the current one doesn't work for this device.

Basically is a new signature for the device already present but this one has a different signature.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

![signal-2024-09-22-172942_002](https://github.com/user-attachments/assets/b54dcbcc-213b-43e8-a36a-8c685df46ffa)

![signal-2024-09-22-172942_003](https://github.com/user-attachments/assets/67a0f96d-f2f4-42a4-bbac-4e973f2a3d30)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
