### PR TITLE
Use new zigpy request kwarg format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache License Version 2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy>=0.66.0",
+    "zigpy>=0.68.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache License Version 2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy>=0.68.0",
+    "zigpy>=0.68.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.66.0
+zigpy>=0.68.1
 ruff==0.0.261

--- a/tests/test_smartwings.py
+++ b/tests/test_smartwings.py
@@ -23,9 +23,9 @@ async def test_smartwings_inverted_commands(zigpy_device_from_quirk, quirk):
     # close cover and check if the command is inverted
     await covering_cluster.command(close_command_id)
     assert len(device.request.mock_calls) == 1
-    assert device.request.mock_calls[0][1][5] == b"\x01\x01\x00"
+    assert device.request.mock_calls[0].kwargs["data"] == b"\x01\x01\x00"
 
     # open cover and check if the command is inverted
     await covering_cluster.command(open_command_id)
     assert len(device.request.mock_calls) == 2
-    assert device.request.mock_calls[1][1][5] == b"\x01\x02\x01"
+    assert device.request.mock_calls[1].kwargs["data"] == b"\x01\x02\x01"

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -301,22 +301,28 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
         rsp = await switch_cluster.command(0x0000)
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x00\x00\x01\x01\x01\x00\x01\x00",
+            cluster=0xEF00,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x01\x01\x00\x01\x00",
+            command_id=0x00,
+            timeout=5,
             expect_reply=True,
-            command_id=0,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp.status == 0
 
         rsp = await switch_cluster.command(0x0001)
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            61184,
-            2,
-            b"\x01\x02\x00\x00\x02\x01\x01\x00\x01\x01",
+            cluster=0xEF00,
+            sequence=2,
+            data=b"\x01\x02\x00\x00\x02\x01\x01\x00\x01\x01",
+            command_id=0x00,
+            timeout=5,
             expect_reply=True,
-            command_id=0,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp.status == 0
 
@@ -426,11 +432,14 @@ async def test_tuya_send_attribute(zigpy_device_from_quirk, quirk):
     ) as m1:
         (status,) = await tuya_cluster.write_attributes({617: 179})
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x00\x00\x01i\x02\x00\x04\x00\x00\x00\xb3",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01i\x02\x00\x04\x00\x00\x00\xb3",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -492,21 +501,27 @@ async def test_siren_send_attribute(zigpy_device_from_quirk, quirk):
     ) as m1:
         _, status = await switch_cluster.command(0x0000)
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x00\x00\x01h\x01\x00\x01\x00",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01h\x01\x00\x01\x00",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == foundation.Status.SUCCESS
 
         _, status = await switch_cluster.command(0x0001)
         m1.assert_called_with(
-            61184,
-            2,
-            b"\x01\x02\x00\x00\x02h\x01\x00\x01\x01",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=2,
+            data=b"\x01\x02\x00\x00\x02h\x01\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -578,11 +593,14 @@ async def test_zonnsmart_send_attribute(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x00\x00\x01\x10\x02\x00\x04\x00\x00\x00\xfa",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x10\x02\x00\x04\x00\x00\x00\xfa",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -594,11 +612,14 @@ async def test_zonnsmart_send_attribute(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            2,
-            b"\x01\x02\x00\x00\x02\x02\x04\x00\x01\x01",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=2,
+            data=b"\x01\x02\x00\x00\x02\x02\x04\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -610,11 +631,14 @@ async def test_zonnsmart_send_attribute(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            3,
-            b"\x01\x03\x00\x00\x03\x0a\x01\x00\x01\x01",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=3,
+            data=b"\x01\x03\x00\x00\x03\x0a\x01\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -626,11 +650,14 @@ async def test_zonnsmart_send_attribute(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            4,
-            b"\x01\x04\x00\x00\x04\x6b\x01\x00\x01\x01",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=4,
+            data=b"\x01\x04\x00\x00\x04\x6b\x01\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -707,11 +734,14 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x00\x00\x01\x02\x02\x00\x04\x00\x00\x00\xfa",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x02\x02\x00\x04\x00\x00\x00\xfa",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -723,11 +753,14 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            2,
-            b"\x01\x02\x00\x00\x02\x04\x04\x00\x01\x00",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=2,
+            data=b"\x01\x02\x00\x00\x02\x04\x04\x00\x01\x00",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -739,11 +772,14 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            3,
-            b"\x01\x03\x00\x00\x03\x04\x04\x00\x01\x02",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=3,
+            data=b"\x01\x03\x00\x00\x03\x04\x04\x00\x01\x02",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -755,11 +791,14 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            4,
-            b"\x01\x04\x00\x00\x04\x04\x04\x00\x01\x01",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=4,
+            data=b"\x01\x04\x00\x00\x04\x04\x04\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -770,11 +809,14 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
         tuya_cluster.handle_message(hdr, args)
         _, status = await thermostat_cluster.command(0x0000, 0x00, 20)
         m1.assert_called_with(
-            61184,
-            5,
-            b"\x01\x05\x00\x00\x05\x02\x02\x00\x04\x00\x00\x00F",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=5,
+            data=b"\x01\x05\x00\x00\x05\x02\x02\x00\x04\x00\x00\x00F",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -983,11 +1025,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x00\x00\x01\x02\x02\x00\x04\x00\x00\x00\xfa",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x02\x02\x00\x04\x00\x00\x00\xfa",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -999,11 +1044,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            2,
-            b"\x01\x02\x00\x00\x02\x04\x04\x00\x01\x00",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=2,
+            data=b"\x01\x02\x00\x00\x02\x04\x04\x00\x01\x00",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1015,11 +1063,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            3,
-            b"\x01\x03\x00\x00\x03\x04\x04\x00\x01\x02",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=3,
+            data=b"\x01\x03\x00\x00\x03\x04\x04\x00\x01\x02",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1030,11 +1081,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
         tuya_cluster.handle_message(hdr, args)
         _, status = await thermostat_cluster.command(0x0000, 0x00, 20)
         m1.assert_called_with(
-            61184,
-            4,
-            b"\x01\x04\x00\x00\x04\x02\x02\x00\x04\x00\x00\x00F",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=4,
+            data=b"\x01\x04\x00\x00\x04\x02\x02\x00\x04\x00\x00\x00F",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -1046,11 +1100,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            5,
-            b"\x01\x05\x00\x00\x05\x68\x00\x00\x03\x00\x14\x02",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=5,
+            data=b"\x01\x05\x00\x00\x05\x68\x00\x00\x03\x00\x14\x02",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1062,11 +1119,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            6,
-            b"\x01\x06\x00\x00\x06\x04\x04\x00\x01\x00",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=6,
+            data=b"\x01\x06\x00\x00\x06\x04\x04\x00\x01\x00",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1079,11 +1139,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            7,
-            b"\x01\x07\x00\x00\x07\x04\x04\x00\x01\x02",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=7,
+            data=b"\x01\x07\x00\x00\x07\x04\x04\x00\x01\x02",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1095,11 +1158,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            8,
-            b"\x01\x08\x00\x00\x08\x04\x04\x00\x01\x01",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=8,
+            data=b"\x01\x08\x00\x00\x08\x04\x04\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1111,11 +1177,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            9,
-            b"\x01\x09\x00\x00\x09\x04\x04\x00\x01\x04",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=9,
+            data=b"\x01\x09\x00\x00\x09\x04\x04\x00\x01\x04",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1127,11 +1196,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            10,
-            b"\x01\x0a\x00\x00\x0a\x70\x00\x00\x12\x06\x00\x11\x08\x00\x0f\x0b\x1e\x0f\x0c\x1e\x0f\x11\x1e\x14\x16\x00\x0f",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=10,
+            data=b"\x01\x0a\x00\x00\x0a\x70\x00\x00\x12\x06\x00\x11\x08\x00\x0f\x0b\x1e\x0f\x0c\x1e\x0f\x11\x1e\x14\x16\x00\x0f",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1143,11 +1215,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            11,
-            b"\x01\x0b\x00\x00\x0b\x70\x00\x00\x12\x06\x2d\x14\x08\x00\x0f\x0b\x1e\x0f\x0c\x1e\x0f\x11\x1e\x14\x16\x00\x0f",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=11,
+            data=b"\x01\x0b\x00\x00\x0b\x70\x00\x00\x12\x06\x2d\x14\x08\x00\x0f\x0b\x1e\x0f\x0c\x1e\x0f\x11\x1e\x14\x16\x00\x0f",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1159,11 +1234,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            12,
-            b"\x01\x0c\x00\x00\x0c\x70\x00\x00\x12\x05\x00\x14\x08\x00\x0f\x0b\x1e\x0f\x0c\x1e\x0f\x11\x1e\x14\x16\x00\x0f",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=12,
+            data=b"\x01\x0c\x00\x00\x0c\x70\x00\x00\x12\x05\x00\x14\x08\x00\x0f\x0b\x1e\x0f\x0c\x1e\x0f\x11\x1e\x14\x16\x00\x0f",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1175,11 +1253,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            13,
-            b"\x01\x0d\x00\x00\x0d\x71\x00\x00\x12\x06\x00\x11\x08\x00\x0f\x0b\x1e\x0f\x0c\x1e\x0f\x11\x1e\x14\x16\x00\x0f",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=13,
+            data=b"\x01\x0d\x00\x00\x0d\x71\x00\x00\x12\x06\x00\x11\x08\x00\x0f\x0b\x1e\x0f\x0c\x1e\x0f\x11\x1e\x14\x16\x00\x0f",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1191,11 +1272,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            14,
-            b"\x01\x0e\x00\x00\x0e\x71\x00\x00\x12\x06\x2d\x14\x08\x00\x0f\x0b\x1e\x0f\x0c\x1e\x0f\x11\x1e\x14\x16\x00\x0f",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=14,
+            data=b"\x01\x0e\x00\x00\x0e\x71\x00\x00\x12\x06\x2d\x14\x08\x00\x0f\x0b\x1e\x0f\x0c\x1e\x0f\x11\x1e\x14\x16\x00\x0f",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1207,11 +1291,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            15,
-            b"\x01\x0f\x00\x00\x0f\x71\x00\x00\x12\x05\x00\x14\x08\x00\x0f\x0b\x1e\x0f\x0c\x1e\x0f\x11\x1e\x14\x16\x00\x0f",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=15,
+            data=b"\x01\x0f\x00\x00\x0f\x71\x00\x00\x12\x05\x00\x14\x08\x00\x0f\x0b\x1e\x0f\x0c\x1e\x0f\x11\x1e\x14\x16\x00\x0f",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1223,11 +1310,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            16,
-            b"\x01\x10\x00\x00\x10\x04\x04\x00\x01\x06",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=16,
+            data=b"\x01\x10\x00\x00\x10\x04\x04\x00\x01\x06",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1239,11 +1329,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            17,
-            b"\x01\x11\x00\x00\x11\x74\x01\x00\x01\x00",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=17,
+            data=b"\x01\x11\x00\x00\x11\x74\x01\x00\x01\x00",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1251,32 +1344,41 @@ async def test_moes(zigpy_device_from_quirk, quirk):
 
         _, status = await onoff_cluster.command(0x0000)
         m1.assert_called_with(
-            61184,
-            18,
-            b"\x01\x12\x00\x00\x12\x68\x00\x00\x03\x00\x10\x05",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=18,
+            data=b"\x01\x12\x00\x00\x12\x68\x00\x00\x03\x00\x10\x05",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == foundation.Status.SUCCESS
 
         _, status = await onoff_cluster.command(0x0001)
 
         m1.assert_called_with(
-            61184,
-            19,
-            b"\x01\x13\x00\x00\x13\x68\x00\x00\x03\x01\x10\x05",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=19,
+            data=b"\x01\x13\x00\x00\x13\x68\x00\x00\x03\x01\x10\x05",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == foundation.Status.SUCCESS
 
         _, status = await onoff_cluster.command(0x0002)
         m1.assert_called_with(
-            61184,
-            20,
-            b"\x01\x14\x00\x00\x14\x68\x00\x00\x03\x00\x10\x05",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=20,
+            data=b"\x01\x14\x00\x00\x14\x68\x00\x00\x03\x00\x10\x05",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -1298,11 +1400,14 @@ async def test_moes(zigpy_device_from_quirk, quirk):
         tuya_cluster.handle_message(hdr, args)
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x24\x00\x08\x00\x00\x1c\x20\x00\x00\x0e\x10",
+            cluster=0xEF00,
+            sequence=1,
+            data=b"\x01\x01\x24\x00\x08\x00\x00\x1c\x20\x00\x00\x0e\x10",
+            command_id=0x24,
+            timeout=5,
             expect_reply=False,
-            command_id=0x0024,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         datetime.datetime = origdatetime
 
@@ -1349,11 +1454,14 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x00\x00\x01\x10\x02\x00\x04\x00\x00\x00\x19",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x10\x02\x00\x04\x00\x00\x00\x19",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1365,11 +1473,14 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            2,
-            b"\x01\x02\x00\x00\x02\x01\x01\x00\x01\x00",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=2,
+            data=b"\x01\x02\x00\x00\x02\x01\x01\x00\x01\x00",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1381,11 +1492,14 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
             }
         )
         m1.assert_called_with(
-            61184,
-            3,
-            b"\x01\x03\x00\x00\x03\x01\x01\x00\x01\x01",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=3,
+            data=b"\x01\x03\x00\x00\x03\x01\x01\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1396,11 +1510,14 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
         tuya_cluster.handle_message(hdr, args)
         _, status = await thermostat_cluster.command(0x0000, 0x00, 20)
         m1.assert_called_with(
-            61184,
-            4,
-            b"\x01\x04\x00\x00\x04\x10\x02\x00\x04\x00\x00\x00\x17",
-            expect_reply=False,
+            cluster=0xEF00,
+            sequence=4,
+            data=b"\x01\x04\x00\x00\x04\x10\x02\x00\x04\x00\x00\x00\x17",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -1617,11 +1734,9 @@ async def test_fan_switch_writes_attributes(zigpy_device_from_quirk, quirk):
         await fan_cluster.bind()
 
         assert len(m1.mock_calls) == 1
-        assert m1.mock_calls[0][1] == (
-            514,
-            1,
-            b"\x00\x01\x02\x01\x000\x00",
-        )
+        assert m1.mock_calls[0].kwargs["cluster"] == 514
+        assert m1.mock_calls[0].kwargs["sequence"] == 1
+        assert m1.mock_calls[0].kwargs["data"] == b"\x00\x01\x02\x01\x000\x00"
 
 
 async def test_sm0202_motion_sensor_signature(assert_signature_matches_quirk):
@@ -1749,11 +1864,14 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
         rsp = await ts1201_control_cluster.command(0x0001, on_off=True)
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            control_cluster_id,
-            1,
-            b"\x01\x01\x00" + b'{"study":0}',
-            expect_reply=True,
+            cluster=control_cluster_id,
+            sequence=1,
+            data=b"\x01\x01\x00" + b'{"study":0}',
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp == foundation.Status.SUCCESS
 
@@ -1764,13 +1882,18 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
         ts1201_transmit_cluster.handle_message(hdr, args)
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            transmit_cluster_id,
-            3,
-            b"\x01\x03\x02\x01\x00"
-            + struct.pack("<L", position)
-            + struct.pack("<B", part_max_length),
-            expect_reply=True,
+            cluster=transmit_cluster_id,
+            sequence=3,
+            data=(
+                b"\x01\x03\x02\x01\x00"
+                + struct.pack("<L", position)
+                + struct.pack("<B", part_max_length)
+            ),
             command_id=2,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert (
             ts1201_transmit_listener.cluster_commands[0][2].command.name
@@ -1794,13 +1917,18 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
         ts1201_transmit_cluster.handle_message(hdr, args)
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            transmit_cluster_id,
-            4,
-            b"\x01\x04\x02\x01\x00"
-            + struct.pack("<L", position)
-            + struct.pack("<B", part_max_length),
-            expect_reply=False,
+            cluster=transmit_cluster_id,
+            sequence=4,
+            data=(
+                b"\x01\x04\x02\x01\x00"
+                + struct.pack("<L", position)
+                + struct.pack("<B", part_max_length)
+            ),
             command_id=2,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert (
             ts1201_transmit_listener.cluster_commands[1][2].command.name
@@ -1821,11 +1949,14 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
         ts1201_transmit_cluster.handle_message(hdr, args)
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            transmit_cluster_id,
-            5,
-            b"\x01\x05\x04\x00\x01\x00\x00\x00",
-            expect_reply=False,
+            cluster=transmit_cluster_id,
+            sequence=5,
+            data=b"\x01\x05\x04\x00\x01\x00\x00\x00",
             command_id=4,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert (
             ts1201_transmit_listener.cluster_commands[2][2].command.name
@@ -1846,11 +1977,14 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
         ts1201_transmit_cluster.handle_message(hdr, args)
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            control_cluster_id,
-            6,
-            b'\x01\x06\x00{"study":1}',
-            expect_reply=True,
+            cluster=control_cluster_id,
+            sequence=6,
+            data=b'\x01\x06\x00{"study":1}',
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert (
             ts1201_transmit_listener.cluster_commands[3][2].command.name
@@ -1874,15 +2008,20 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
         await wait_for_zigpy_tasks()
         # IR send must call ir transmit command id 0x00
         m1.assert_called_with(
-            transmit_cluster_id,
-            7,
-            b"\x01\x07\x00\x01\x00"
-            + struct.pack("<I", ir_msg_length)
-            + b"\x00\x00\x00\x00"
-            + struct.pack("<H", control_cluster_id)
-            + b"\x01\x02\x00\x00",
-            expect_reply=False,
+            cluster=transmit_cluster_id,
+            sequence=7,
+            data=(
+                b"\x01\x07\x00\x01\x00"
+                + struct.pack("<I", ir_msg_length)
+                + b"\x00\x00\x00\x00"
+                + struct.pack("<H", control_cluster_id)
+                + b"\x01\x02\x00\x00"
+            ),
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
 
         # simulate receive_ir_frame_00
@@ -1892,12 +2031,17 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
         ts1201_transmit_cluster.handle_message(hdr, args)
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            transmit_cluster_id,
-            9,
-            b"\x01\x09\x02\x01\x00\x00\x00\x00\x00"
-            + struct.pack("<B", part_max_length),
-            expect_reply=True,
+            cluster=transmit_cluster_id,
+            sequence=9,
+            data=(
+                b"\x01\x09\x02\x01\x00\x00\x00\x00\x00"
+                + struct.pack("<B", part_max_length)
+            ),
             command_id=2,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert (
             ts1201_transmit_listener.cluster_commands[4][2].command.name
@@ -1945,11 +2089,14 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
         ts1201_transmit_cluster.handle_message(hdr, args)
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            transmit_cluster_id,
-            11,
-            b"\x01\x0b\x05\x01\x00\x00\x00",
-            expect_reply=False,
+            cluster=transmit_cluster_id,
+            sequence=11,
+            data=b"\x01\x0b\x05\x01\x00\x00\x00",
             command_id=5,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert (
             ts1201_transmit_listener.cluster_commands[7][2].command.name
@@ -1962,11 +2109,14 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
         )
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            control_cluster_id,
-            12,
-            b"\x01\x0c\x00\x00\x01\x02\x03\x04",
-            expect_reply=True,
+            cluster=control_cluster_id,
+            sequence=12,
+            data=b"\x01\x0c\x00\x00\x01\x02\x03\x04",
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp == foundation.Status.SUCCESS
 

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -309,6 +309,7 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp.status == 0
 
@@ -323,6 +324,7 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp.status == 0
 
@@ -440,6 +442,7 @@ async def test_tuya_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -509,6 +512,7 @@ async def test_siren_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -522,6 +526,7 @@ async def test_siren_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -601,6 +606,7 @@ async def test_zonnsmart_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -620,6 +626,7 @@ async def test_zonnsmart_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -639,6 +646,7 @@ async def test_zonnsmart_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -658,6 +666,7 @@ async def test_zonnsmart_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -742,6 +751,7 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -761,6 +771,7 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -780,6 +791,7 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -799,6 +811,7 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -817,6 +830,7 @@ async def test_valve_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -1033,6 +1047,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1052,6 +1067,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1071,6 +1087,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1089,6 +1106,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -1108,6 +1126,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1127,6 +1146,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1147,6 +1167,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1166,6 +1187,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1185,6 +1207,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1204,6 +1227,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1223,6 +1247,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1242,6 +1267,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1261,6 +1287,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1280,6 +1307,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1299,6 +1327,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1318,6 +1347,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1337,6 +1367,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1352,6 +1383,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -1366,6 +1398,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -1379,6 +1412,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -1408,6 +1442,7 @@ async def test_moes(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         datetime.datetime = origdatetime
 
@@ -1462,6 +1497,7 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1481,6 +1517,7 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1500,6 +1537,7 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -1518,6 +1556,7 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == foundation.Status.SUCCESS
 
@@ -1872,6 +1911,7 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp == foundation.Status.SUCCESS
 
@@ -1894,6 +1934,7 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert (
             ts1201_transmit_listener.cluster_commands[0][2].command.name
@@ -1929,6 +1970,7 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert (
             ts1201_transmit_listener.cluster_commands[1][2].command.name
@@ -1957,6 +1999,7 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert (
             ts1201_transmit_listener.cluster_commands[2][2].command.name
@@ -1985,6 +2028,7 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert (
             ts1201_transmit_listener.cluster_commands[3][2].command.name
@@ -2022,6 +2066,7 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
 
         # simulate receive_ir_frame_00
@@ -2042,6 +2087,7 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert (
             ts1201_transmit_listener.cluster_commands[4][2].command.name
@@ -2097,6 +2143,7 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert (
             ts1201_transmit_listener.cluster_commands[7][2].command.name
@@ -2117,6 +2164,7 @@ async def test_ts1201_ir_blaster(zigpy_device_from_quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp == foundation.Status.SUCCESS
 

--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+import zigpy.types as t
 from zigpy.zcl import foundation
 
 from tests.common import ClusterListener, wait_for_zigpy_tasks
@@ -42,6 +43,7 @@ async def test_command(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -57,6 +59,7 @@ async def test_command(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -72,6 +75,7 @@ async def test_command(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -88,6 +92,7 @@ async def test_command(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -104,6 +109,7 @@ async def test_command(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -120,6 +126,7 @@ async def test_command(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         m1.assert_called_with(
             cluster=61184,
@@ -130,6 +137,7 @@ async def test_command(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -162,6 +170,7 @@ async def test_write_attr(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)

--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -34,11 +34,14 @@ async def test_command(zigpy_device_from_quirk, quirk):
         await wait_for_zigpy_tasks()
 
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x00\x00\x01\x07\x01\x00\x01\x01",
-            expect_reply=True,
+            cluster=61184,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x07\x01\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -46,11 +49,14 @@ async def test_command(zigpy_device_from_quirk, quirk):
         await wait_for_zigpy_tasks()
 
         m1.assert_called_with(
-            61184,
-            2,
-            b"\x01\x02\x00\x00\x02\x02\x02\x00\x04\x00\x00\x03r",
-            expect_reply=True,
+            cluster=61184,
+            sequence=2,
+            data=b"\x01\x02\x00\x00\x02\x02\x02\x00\x04\x00\x00\x03r",
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -58,11 +64,14 @@ async def test_command(zigpy_device_from_quirk, quirk):
         await wait_for_zigpy_tasks()
 
         m1.assert_called_with(
-            61184,
-            3,
-            b"\x01\x03\x00\x00\x03\x01\x01\x00\x01\x01",
-            expect_reply=True,
+            cluster=61184,
+            sequence=3,
+            data=b"\x01\x03\x00\x00\x03\x01\x01\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -71,11 +80,14 @@ async def test_command(zigpy_device_from_quirk, quirk):
 
         # Should not trigger switch as it is already on
         m1.assert_called_with(
-            61184,
-            4,
-            b"\x01\x04\x00\x00\x04\x02\x02\x00\x04\x00\x00\x01\xea",
-            expect_reply=True,
+            cluster=61184,
+            sequence=4,
+            data=b"\x01\x04\x00\x00\x04\x02\x02\x00\x04\x00\x00\x01\xea",
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -84,11 +96,14 @@ async def test_command(zigpy_device_from_quirk, quirk):
 
         # Should switch off without dimming
         m1.assert_called_with(
-            61184,
-            5,
-            b"\x01\x05\x00\x00\x05\x01\x01\x00\x01\x00",
-            expect_reply=True,
+            cluster=61184,
+            sequence=5,
+            data=b"\x01\x05\x00\x00\x05\x01\x01\x00\x01\x00",
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -97,18 +112,24 @@ async def test_command(zigpy_device_from_quirk, quirk):
 
         # Should switch on and then switch to level
         m1.assert_any_call(
-            61184,
-            6,
-            b"\x01\x06\x00\x00\x06\x01\x01\x00\x01\x01",
-            expect_reply=True,
+            cluster=61184,
+            sequence=6,
+            data=b"\x01\x06\x00\x00\x06\x01\x01\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         m1.assert_called_with(
-            61184,
-            7,
-            b"\x01\x07\x00\x00\x07\x02\x02\x00\x04\x00\x00\x00b",
-            expect_reply=True,
+            cluster=61184,
+            sequence=7,
+            data=b"\x01\x07\x00\x00\x07\x02\x02\x00\x04\x00\x00\x00b",
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -133,11 +154,14 @@ async def test_write_attr(zigpy_device_from_quirk, quirk):
         )
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x00\x00\x01\x03\x02\x00\x04\x00\x00\x00b",
-            expect_reply=False,
+            cluster=61184,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x03\x02\x00\x04\x00\x00\x00b",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)

--- a/tests/test_tuya_rcbo.py
+++ b/tests/test_tuya_rcbo.py
@@ -30,11 +30,14 @@ async def test_command_rcbo(zigpy_device_from_quirk):
 
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x00\x00\x01\x01\x01\x00\x01\x01",
-            expect_reply=True,
+            cluster=61184,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x01\x01\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -43,11 +46,14 @@ async def test_command_rcbo(zigpy_device_from_quirk):
 
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            61184,
-            2,
-            b"\x01\x02\x00\x00\x02t\x01\x00\x01\x01",
-            expect_reply=True,
+            cluster=61184,
+            sequence=2,
+            data=b"\x01\x02\x00\x00\x02t\x01\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -56,11 +62,14 @@ async def test_command_rcbo(zigpy_device_from_quirk):
 
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            61184,
-            3,
-            b"\x01\x03\x00\x00\x03s\x01\x00\x01\x01",
-            expect_reply=True,
+            cluster=61184,
+            sequence=3,
+            data=b"\x01\x03\x00\x00\x03s\x01\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -305,11 +314,14 @@ async def test_write_attr_rcbo(
         (status,) = await target_cluster.write_attributes(attributes)
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            61184,
-            frame[1],
-            frame,
-            expect_reply=False,
+            cluster=61184,
+            sequence=frame[1],
+            data=frame,
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)

--- a/tests/test_tuya_rcbo.py
+++ b/tests/test_tuya_rcbo.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+import zigpy.types as t
 from zigpy.zcl import foundation
 
 from tests.common import ClusterListener, wait_for_zigpy_tasks
@@ -38,6 +39,7 @@ async def test_command_rcbo(zigpy_device_from_quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -54,6 +56,7 @@ async def test_command_rcbo(zigpy_device_from_quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -70,6 +73,7 @@ async def test_command_rcbo(zigpy_device_from_quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -322,6 +326,7 @@ async def test_write_attr_rcbo(
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)

--- a/tests/test_tuya_valve.py
+++ b/tests/test_tuya_valve.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+import zigpy.types as t
 from zigpy.zcl import foundation
 
 from tests.common import ClusterListener, wait_for_zigpy_tasks
@@ -38,6 +39,7 @@ async def test_command_psbzs(zigpy_device_from_quirk, quirk):
             expect_reply=True,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -67,6 +69,7 @@ async def test_write_attr_psbzs(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -87,6 +90,7 @@ async def test_write_attr_psbzs(zigpy_device_from_quirk, quirk):
             expect_reply=False,
             use_ieee=False,
             ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)

--- a/tests/test_tuya_valve.py
+++ b/tests/test_tuya_valve.py
@@ -30,11 +30,14 @@ async def test_command_psbzs(zigpy_device_from_quirk, quirk):
 
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x00\x00\x01\x01\x01\x00\x01\x01",
-            expect_reply=True,
+            cluster=61184,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x01\x01\x00\x01\x01",
             command_id=0,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert rsp.status == foundation.Status.SUCCESS
 
@@ -56,11 +59,14 @@ async def test_write_attr_psbzs(zigpy_device_from_quirk, quirk):
         )
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            61184,
-            1,
-            b"\x01\x01\x00\x00\x01\x05\x02\x00\x04\x00\x00\x00\x0f",
-            expect_reply=False,
+            cluster=61184,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x05\x02\x00\x04\x00\x00\x00\x0f",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
@@ -73,11 +79,14 @@ async def test_write_attr_psbzs(zigpy_device_from_quirk, quirk):
         )
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
-            61184,
-            2,
-            b"\x01\x02\x00\x00\x02m\x01\x00\x01\x00",
-            expect_reply=False,
+            cluster=61184,
+            sequence=2,
+            data=b"\x01\x02\x00\x00\x02m\x01\x00\x01\x00",
             command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
         )
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -511,20 +511,19 @@ async def test_xiaomi_eu_plug_binding(zigpy_device_from_quirk, quirk):
         assert len(request_mock.mock_calls) == 1
         assert mock_task.call_count == 1
 
-        assert request_mock.mock_calls[0][1] == (
-            4,
-            1,
-            b"\x01\x01\x03\x00\x00",
-        )
+        assert request_mock.mock_calls[0]
+        assert request_mock.mock_calls[0].kwargs["cluster"] == 4
+        assert request_mock.mock_calls[0].kwargs["sequence"] == 1
+        assert request_mock.mock_calls[0].kwargs["data"] == b"\x01\x01\x03\x00\x00"
 
         # Await call writing OppleMode attribute
         await mock_task.call_args[0][0]
 
         assert len(request_mock.mock_calls) == 2
-        assert request_mock.mock_calls[1][1] == (
-            64704,
-            2,
-            b"\x04_\x11\x02\x02\t\x00 \x01",
+        assert request_mock.mock_calls[1].kwargs["cluster"] == 64704
+        assert request_mock.mock_calls[1].kwargs["sequence"] == 2
+        assert (
+            request_mock.mock_calls[1].kwargs["data"] == b"\x04_\x11\x02\x02\t\x00 \x01"
         )
 
 

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -76,7 +76,7 @@ class LocalDataCluster(CustomCluster):
         """Prevent remote configure reporting."""
         return (foundation.ConfigureReportingResponse.deserialize(b"\x00")[0],)
 
-    async def read_attributes_raw(self, attributes, manufacturer=None):
+    async def read_attributes_raw(self, attributes, manufacturer=None, **kwargs):
         """Prevent remote reads."""
         records = [
             foundation.ReadAttributeRecord(
@@ -93,7 +93,7 @@ class LocalDataCluster(CustomCluster):
                 record.status = foundation.Status.SUCCESS
         return (records,)
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=None, **kwargs):
         """Prevent remote writes."""
         for attrid, value in attributes.items():
             if isinstance(attrid, str):

--- a/zhaquirks/eurotronic/__init__.py
+++ b/zhaquirks/eurotronic/__init__.py
@@ -72,7 +72,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
         _LOGGER.debug("update attribute %04x to %s... [ ok ]", attrid, value)
         super()._update_attribute(attrid, value)
 
-    async def read_attributes_raw(self, attributes, manufacturer=None):
+    async def read_attributes_raw(self, attributes, manufacturer=None, **kwargs):
         """Override wrong attribute reports from the thermostat."""
         success = []
         error = []
@@ -95,7 +95,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
             _LOGGER.debug("intercepting OCC_HS")
 
             values = await super().read_attributes_raw(
-                [CURRENT_TEMP_SETPOINT_ATTR], manufacturer=MANUFACTURER
+                [CURRENT_TEMP_SETPOINT_ATTR], manufacturer=MANUFACTURER, **kwargs
             )
 
             if len(values) == 2:
@@ -122,7 +122,9 @@ class ThermostatCluster(CustomCluster, Thermostat):
         )
 
         if attributes:
-            values = await super().read_attributes_raw(attributes, manufacturer)
+            values = await super().read_attributes_raw(
+                attributes, manufacturer, **kwargs
+            )
 
             success.extend(values[0])
 
@@ -131,7 +133,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
         return success, error
 
-    def write_attributes(self, attributes, manufacturer=None):
+    def write_attributes(self, attributes, manufacturer=None, **kwargs):
         """Override wrong writes to thermostat attributes."""
         if "system_mode" in attributes:
             host_flags = self._attr_cache.get(HOST_FLAGS_ATTR, 1)
@@ -146,4 +148,4 @@ class ThermostatCluster(CustomCluster, Thermostat):
                     {"host_flags": host_flags | CLR_OFF_MODE_FLAG}, MANUFACTURER
                 )
 
-        return super().write_attributes(attributes, manufacturer)
+        return super().write_attributes(attributes, manufacturer, **kwargs)

--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -248,7 +248,7 @@ class XBeePWM(LocalDataCluster, AnalogOutput):
 
     _ep_id_2_pwm = {0xDA: "M0", 0xDB: "M1"}
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=None, **kwargs):
         """Intercept present_value attribute write."""
         attr_id = None
         if ATTR_PRESENT_VALUE in attributes:
@@ -263,15 +263,15 @@ class XBeePWM(LocalDataCluster, AnalogOutput):
             at_command = ENDPOINT_TO_AT.get(self._endpoint.endpoint_id)
             await self._endpoint.device.remote_at(at_command, PIN_ANALOG_OUTPUT)
 
-        return await super().write_attributes(attributes, manufacturer)
+        return await super().write_attributes(attributes, manufacturer, **kwargs)
 
-    async def read_attributes_raw(self, attributes, manufacturer=None):
+    async def read_attributes_raw(self, attributes, manufacturer=None, **kwargs):
         """Intercept present_value attribute read."""
         if ATTR_PRESENT_VALUE in attributes or "present_value" in attributes:
             at_command = self._ep_id_2_pwm.get(self._endpoint.endpoint_id)
             result = await self._endpoint.device.remote_at(at_command)
             self._update_attribute(ATTR_PRESENT_VALUE, float(result))
-        return await super().read_attributes_raw(attributes, manufacturer)
+        return await super().read_attributes_raw(attributes, manufacturer, **kwargs)
 
 
 class XBeeRemoteATRequest(LocalDataCluster):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Once https://github.com/zigpy/zigpy/pull/1481 is merged, unit tests in this repo will start failing. This PR fixes them and ensures that we will have an easier time fixing them in the future, once we add new kwargs to the `request` method.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
