### PR TITLE
Refactor Tuya `EnchantedDevice` to use custom configuration

### DIFF
--- a/tests/test_tuya_spells.py
+++ b/tests/test_tuya_spells.py
@@ -1,22 +1,12 @@
 """Tests for Tuya spells."""
 
-import itertools
 from unittest import mock
 
 import pytest
 import zigpy
 from zigpy.profiles import zha
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters import CLUSTERS_BY_ID
-from zigpy.zcl.clusters.general import (
-    Basic,
-    GreenPowerProxy,
-    Groups,
-    Identify,
-    OnOff,
-    Ota,
-)
-from zigpy.zcl.clusters.lightlink import LightLink
+from zigpy.zcl.clusters.general import Basic, OnOff
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -25,12 +15,10 @@ from zhaquirks.const import (
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    SKIP_CONFIGURATION,
 )
 from zhaquirks.tuya import (
     TUYA_QUERY_DATA,
     EnchantedDevice,
-    TuyaEnchantableCluster,
     TuyaNewManufCluster,
     TuyaZBOnOffAttributeCluster,
 )
@@ -88,18 +76,8 @@ for manufacturer in zigpy.quirks._DEVICE_REGISTRY._registry.values():
 del quirk_entry, model_quirk_list, manufacturer
 
 
-@mock.patch("zigpy.zcl.Cluster.bind", mock.AsyncMock())
 async def test_tuya_spell(zigpy_device_from_quirk):
-    """Test that enchanted Tuya devices have their spell applied when binding bindable cluster."""
-    non_bindable_cluster_ids = [
-        Basic.cluster_id,
-        Identify.cluster_id,
-        Groups.cluster_id,
-        Ota.cluster_id,
-        GreenPowerProxy.cluster_id,
-        LightLink.cluster_id,
-    ]
-
+    """Test that enchanted Tuya devices have their spells applied during configuration."""
     request_patch = mock.patch("zigpy.zcl.Cluster.request", mock.AsyncMock())
     with request_patch as request_mock:
         request_mock.return_value = (foundation.Status.SUCCESS, "done")
@@ -108,26 +86,9 @@ async def test_tuya_spell(zigpy_device_from_quirk):
             device = zigpy_device_from_quirk(quirk)
             assert isinstance(device, EnchantedDevice)
 
-            # fail if SKIP_CONFIGURATION is set, as that will cause ZHA to not call bind()
-            if getattr(device, SKIP_CONFIGURATION, False):
-                pytest.fail(
-                    f"Enchanted quirk {quirk} has SKIP_CONFIGURATION set. "
-                    f"This is not allowed for enchanted devices."
-                )
-
-            for cluster in itertools.chain(
-                device.endpoints[1].in_clusters.values(),
-                device.endpoints[1].out_clusters.values(),
-            ):
-                # emulate ZHA calling bind() on most default clusters with an unchanged ep_attribute
-                if (
-                    not isinstance(cluster, int)
-                    and cluster.cluster_id not in non_bindable_cluster_ids
-                    and cluster.cluster_id in CLUSTERS_BY_ID
-                    and CLUSTERS_BY_ID[cluster.cluster_id].ep_attribute
-                    == cluster.ep_attribute
-                ):
-                    await cluster.bind()
+            # call apply_custom_configuration() on each EnchantedDevice
+            # ZHA does this during device configuration normally
+            await device.apply_custom_configuration()
 
             # the number of Tuya spells that are allowed to be cast, so the sum of enabled Tuya spells
             enabled_tuya_spells_num = (
@@ -139,20 +100,8 @@ async def test_tuya_spell(zigpy_device_from_quirk):
             if enabled_tuya_spells_num == 0:
                 continue
 
-            # check that exactly a Tuya spell was cast
-            if len(request_mock.mock_calls) == 0:
-                pytest.fail(
-                    f"Enchanted quirk {quirk} did not cast a Tuya spell. "
-                    f"One bindable cluster subclassing `TuyaEnchantableCluster` on endpoint 1 needs to be implemented. "
-                    f"Also check that enchanted bindable clusters do not modify their `ep_attribute`, "
-                    f"as ZHA will not call bind() in that case."
-                )
-            # check that no more than one call was made for each enabled spell
-            elif len(request_mock.mock_calls) > enabled_tuya_spells_num:
-                pytest.fail(
-                    f"Enchanted quirk {quirk} cast more than one Tuya spell. "
-                    f"Make sure to only implement one cluster subclassing `TuyaEnchantableCluster` on endpoint 1."
-                )
+            # verify request was called the correct number of times
+            assert request_mock.call_count == enabled_tuya_spells_num
 
             # used to check list of mock calls below
             messages = 0
@@ -176,7 +125,7 @@ async def test_tuya_spell(zigpy_device_from_quirk):
 
 
 def test_tuya_spell_devices_valid():
-    """Test that all enchanted Tuya devices implement at least one enchanted cluster."""
+    """Test that all enchanted Tuya devices have at least one spell enabled."""
 
     for quirk in ENCHANTED_QUIRKS:
         # check that at least one Tuya spell is enabled for an EnchantedDevice
@@ -185,40 +134,4 @@ def test_tuya_spell_devices_valid():
                 f"Enchanted quirk {quirk} does not have any Tuya spells enabled. "
                 f"Enable at least one Tuya spell by setting `TUYA_SPELL_READ_ATTRIBUTES` or `TUYA_SPELL_DATA_QUERY` "
                 f"or inherit CustomDevice rather than EnchantedDevice."
-            )
-
-        enchanted_clusters = 0  # number of clusters subclassing TuyaEnchantableCluster
-        tuya_cluster_exists = False  # cluster subclassing TuyaNewManufCluster existing
-
-        # iterate over all clusters in the replacement
-        for endpoint_id, endpoint in quirk.replacement[ENDPOINTS].items():
-            if endpoint_id != 1:  # spell is only activated on endpoint 1 for now
-                continue
-            for cluster in endpoint[INPUT_CLUSTERS] + endpoint[OUTPUT_CLUSTERS]:
-                if not isinstance(cluster, int):
-                    # count all clusters which would apply the spell on bind()
-                    if issubclass(cluster, TuyaEnchantableCluster):
-                        enchanted_clusters += 1
-                    # check if there's a valid Tuya cluster where the id wasn't modified
-                    if (
-                        issubclass(cluster, TuyaNewManufCluster)
-                        and cluster.cluster_id == TuyaNewManufCluster.cluster_id
-                    ):
-                        tuya_cluster_exists = True
-
-        # an EnchantedDevice must have exactly one enchanted cluster on endpoint 1
-        if enchanted_clusters == 0:
-            pytest.fail(
-                f"{quirk} does not have a cluster subclassing `TuyaEnchantableCluster` on endpoint 1 "
-                f"as required by the Tuya spell."
-            )
-        elif enchanted_clusters > 1:
-            pytest.fail(
-                f"{quirk} has more than one cluster subclassing `TuyaEnchantableCluster` on endpoint 1"
-            )
-
-        # an EnchantedDevice with the data query spell must also have a cluster subclassing TuyaNewManufCluster
-        if quirk.tuya_spell_data_query and not tuya_cluster_exists:
-            pytest.fail(
-                f"{quirk} set Tuya data query spell but has no cluster subclassing `TuyaNewManufCluster` on endpoint 1"
             )

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -530,80 +530,47 @@ class TuyaManufClusterAttributes(TuyaManufCluster):
 
 
 class EnchantedDevice(CustomDevice):
-    """Class for Tuya devices which need to be unlocked by casting a 'spell'. This happens during binding.
+    """Class for Tuya devices which need to be unlocked by casting a 'spell'.
 
-    To make sure the spell is cast, the device needs to implement a subclass of `TuyaEnchantableCluster`.
-    For more information, see the documentation of `TuyaEnchantableCluster`.
+    The spell is applied during device configuration.
     """
 
     # These values can be overridden from a quirk to enable (or disable) additional Tuya spells:
     tuya_spell_read_attributes: bool = True  # spell reading attributes on Basic cluster
     tuya_spell_data_query: bool = False  # additional spell needed for some devices
 
+    async def apply_custom_configuration(self, *args, **kwargs):
+        """Hooks device configuration to apply custom configuration."""
+        # cast Tuya spell
+        if self.tuya_spell_read_attributes:
+            await self.spell_attribute_reads()
+        if self.tuya_spell_data_query:
+            await self.spell_data_query()
 
-class TuyaEnchantableCluster(CustomCluster):
-    """Tuya cluster that casts a magic spell if `TUYA_SPELL` is set.
-
-    Preferably, make the device inherit from `EnchantedDevice` and use a subclass of this class in the replacement.
-
-    This will only work for clusters that ZHA calls bind() on.
-    At the moment, ZHA does NOT do this for:
-    - Basic cluster
-    - Identify cluster
-    - Groups cluster
-    - OTA cluster
-    - GreenPowerProxy cluster
-    - LightLink cluster
-    - non-registered manufacturer specific clusters
-    - clusters which would be bound, but that changed their ep_attribute
-
-    Make sure to add a subclass of TuyaEnchantableCluster to the quirk replacement. Tests will fail if this is not done.
-    Classes like TuyaOnOff, TuyaZBOnOffAttributeCluster, TuyaNoBindPowerConfigurationCluster inherit from this class.
-    """
-
-    async def bind(self):
-        """Bind cluster and start casting the spell if necessary."""
-        device = self.endpoint.device
-
-        # check if the device is an EnchantedDevice
-        # and since the cluster can be used on multiple endpoints, check that it's endpoint 1
-        if isinstance(device, EnchantedDevice) and self.endpoint.endpoint_id == 1:
-            if device.tuya_spell_read_attributes:
-                await self.spell_attribute_reads()
-            if device.tuya_spell_data_query:
-                await self.spell_data_query()
-
-        return await super().bind()
+        # also apply custom configuration to clusters if defined
+        await super().apply_custom_configuration(*args, **kwargs)
 
     async def spell_attribute_reads(self):
         """Cast 'attribute read' spell, so the Tuya device works correctly."""
         self.debug(
             "Executing attribute read spell on Tuya device %s",
-            self.endpoint.device.ieee,
+            self.ieee,
         )
         attr_to_read = [4, 0, 1, 5, 7, 0xFFFE]
-        basic_cluster = self.endpoint.device.endpoints[1].in_clusters[Basic.cluster_id]
+        basic_cluster = self.endpoints[1].in_clusters[Basic.cluster_id]
         await basic_cluster.read_attributes(attr_to_read)
-        self.debug(
-            "Executed attribute read spell on Tuya device %s", self.endpoint.device.ieee
-        )
+        self.debug("Executed attribute read spell on Tuya device %s", self.ieee)
 
     async def spell_data_query(self):
         """Cast 'data query' spell, also required for some Tuya devices to send data."""
-        self.debug(
-            "Executing data query spell on Tuya device %s", self.endpoint.device.ieee
-        )
+        self.debug("Executing data query spell on Tuya device %s", self.ieee)
         # tests verify that a device with an enabled 'data query spell' has a TuyaNewManufCluster (subclass)
-        tuya_cluster = self.endpoint.device.endpoints[1].in_clusters[
-            TuyaNewManufCluster.cluster_id
-        ]
+        tuya_cluster = self.endpoints[1].in_clusters[TuyaNewManufCluster.cluster_id]
         await tuya_cluster.command(TUYA_QUERY_DATA)
-        self.debug(
-            "Executed data query spell on Tuya device %s", self.endpoint.device.ieee
-        )
+        self.debug("Executed data query spell on Tuya device %s", self.ieee)
 
 
-class TuyaOnOff(TuyaEnchantableCluster, OnOff):
+class TuyaOnOff(CustomCluster, OnOff):
     """Tuya On/Off cluster for On/Off device."""
 
     def __init__(self, *args, **kwargs):
@@ -907,11 +874,8 @@ class TuyaLocalCluster(LocalDataCluster):
         return self._update_attribute(attr.id, value)
 
 
-class _TuyaNoBindPowerConfigurationCluster(CustomCluster, PowerConfiguration):
-    """PowerConfiguration cluster that prevents setting up binding/attribute reports in order to stop battery drain.
-
-    Note: Use the `TuyaNoBindPowerConfigurationCluster` class instead of this one.
-    """
+class TuyaNoBindPowerConfigurationCluster(CustomCluster, PowerConfiguration):
+    """PowerConfiguration cluster that prevents setting up binding/attribute reports in order to stop battery drain."""
 
     async def bind(self):
         """Prevent bind."""
@@ -920,16 +884,6 @@ class _TuyaNoBindPowerConfigurationCluster(CustomCluster, PowerConfiguration):
     async def _configure_reporting(self, *args, **kwargs):  # pylint: disable=W0221
         """Prevent remote configure reporting."""
         return (foundation.ConfigureReportingResponse.deserialize(b"\x00")[0],)
-
-
-# these classes are needed, so the execution order of bind() is still correct
-class TuyaNoBindPowerConfigurationCluster(
-    TuyaEnchantableCluster, _TuyaNoBindPowerConfigurationCluster
-):
-    """PowerConfiguration cluster that prevents setting up binding/attribute reports in order to stop battery drain.
-
-    This class is also enchantable, so it will cast the Tuya spell if the device inherits from `EnchantedDevice`.
-    """
 
 
 class TuyaPowerConfigurationCluster(PowerConfiguration, TuyaLocalCluster):
@@ -1010,7 +964,7 @@ class PowerOnState(t.enum8):
     LastState = 0x02
 
 
-class TuyaZBOnOffAttributeCluster(TuyaEnchantableCluster, OnOff):
+class TuyaZBOnOffAttributeCluster(CustomCluster, OnOff):
     """Tuya Zigbee On Off cluster with extra attributes."""
 
     attributes = OnOff.attributes.copy()

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -22,7 +22,6 @@ from zhaquirks.tuya import (
     PowerOnState,
     TuyaCommand,
     TuyaDatapointData,
-    TuyaEnchantableCluster,
     TuyaLocalCluster,
     TuyaNewManufCluster,
     TuyaTimePayload,
@@ -358,7 +357,7 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
         return foundation.Status.SUCCESS
 
 
-class TuyaOnOff(TuyaEnchantableCluster, OnOff, TuyaLocalCluster):
+class TuyaOnOff(OnOff, TuyaLocalCluster):
     """Tuya MCU OnOff cluster."""
 
     async def command(

--- a/zhaquirks/tuya/ts0001_fingerbot.py
+++ b/zhaquirks/tuya/ts0001_fingerbot.py
@@ -3,6 +3,7 @@
 from typing import Any, Optional, Union
 
 from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota, Time
@@ -18,7 +19,6 @@ from zhaquirks.const import (
 from zhaquirks.tuya import TUYA_SEND_DATA, EnchantedDevice
 from zhaquirks.tuya.mcu import (
     DPToAttributeMapping,
-    TuyaEnchantableCluster,
     TuyaMCUCluster,
     TuyaPowerConfigurationCluster,
 )
@@ -119,7 +119,7 @@ class TuyaFingerbotCluster(TuyaMCUCluster):
     }
 
 
-class OnOffEnchantable(TuyaEnchantableCluster, OnOff):
+class OnOffEnchantable(CustomCluster, OnOff):
     """Enchantable OnOff cluster."""
 
 

--- a/zhaquirks/tuya/ts0001_fingerbot.py
+++ b/zhaquirks/tuya/ts0001_fingerbot.py
@@ -3,7 +3,6 @@
 from typing import Any, Optional, Union
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, OnOff, Ota, Time
@@ -119,10 +118,6 @@ class TuyaFingerbotCluster(TuyaMCUCluster):
     }
 
 
-class OnOffEnchantable(CustomCluster, OnOff):
-    """Enchantable OnOff cluster."""
-
-
 class TuyaFingerbot(EnchantedDevice):
     """Tuya finger bot device."""
 
@@ -134,7 +129,7 @@ class TuyaFingerbot(EnchantedDevice):
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    OnOffEnchantable.cluster_id,
+                    OnOff.cluster_id,
                     TuyaFingerbotCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
@@ -153,7 +148,7 @@ class TuyaFingerbot(EnchantedDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     TuyaPowerConfigurationCluster,
-                    OnOffEnchantable,
+                    OnOff.cluster_id,
                     TuyaFingerbotCluster,
                 ],
                 OUTPUT_CLUSTERS: [


### PR DESCRIPTION
## Proposed change
This PR refactors the Tuya spell code in `EnchantedDevice` to use the `apply_custom_configuration` hook in `BaseCustomDevice` (introduced in recent zha/zigpy versions).

This allows us to remove the workarounds of "enchantable" clusters where `bind()` was hijacked and called the Tuya spells.
With this PR, we can call the Tuya spell code way easier (and slightly earlier).

A bunch of now irrelevant documentation and tests are also removed. The tests can likely be reduced a bit more in future PRs, as we no longer need to test that every device/quirk correctly casts the spell, but it also doesn't hurt anything.
So, if we want to change the "spell tests" further, I'd push that to a future PR.

## Additional information
Requires:
- https://github.com/zigpy/zha/pull/231
- https://github.com/zigpy/zha/pull/239 (kind of)


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
