### PR TITLE
Bump zigpy to 0.68.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache License Version 2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy>=0.66.0",
+    "zigpy>=0.68.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.66.0
+zigpy>=0.68.1
 ruff==0.0.261


### PR DESCRIPTION
## Proposed change
This bumps the zigpy requirement to [0.68.1](https://github.com/zigpy/zigpy/releases/tag/0.68.1).


## Additional information
Unblocks:
- https://github.com/zigpy/zha-device-handlers/pull/3417
- https://github.com/zigpy/zha-device-handlers/pull/3410


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
