### PR TITLE
Add Tuya air sensor `_TZE204_dwcarsat` variant

### DIFF
--- a/zhaquirks/tuya/air/ts0601_smart_air.py
+++ b/zhaquirks/tuya/air/ts0601_smart_air.py
@@ -34,6 +34,7 @@ class TuyaSmartAirSensor(CustomDevice):
         MODELS_INFO: [
             ("_TZE200_mja3fuja", "TS0601"),
             ("_TZE200_dwcarsat", "TS0601"),
+            ("_TZE204_dwcarsat", "TS0601"),
         ],
         ENDPOINTS: {
             1: {
@@ -84,6 +85,7 @@ class TuyaSmartAirSensorGPP(CustomDevice):
         MODELS_INFO: [
             ("_TZE200_mja3fuja", "TS0601"),
             ("_TZE200_dwcarsat", "TS0601"),
+            ("_TZE204_dwcarsat", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
  Simple fix for https://github.com/zigpy/zha-device-handlers/issues/3337 to add support for additional manufacturer signature info "_TZE204_dwcarsat" for model "TS0601" tuya smart air


## Additional information
  "Fixes [#3337](https://github.com/zigpy/zha-device-handlers/issues/3337)". 


## Checklist
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
