### PR TITLE
Add Python 3.13 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,6 @@ jobs:
       PYTHON_VERSION_DEFAULT: 3.12
       PRE_COMMIT_CACHE_PATH:  ~/.cache/pre-commit
       MINIMUM_COVERAGE_PERCENTAGE: 80
-      PYTHON_MATRIX: "3.12"
+      PYTHON_MATRIX: '"3.12", "3.13"'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Proposed change
Since this repo overrides the `PYTHON_MATRIX`, we didn't automatically get Python 3.13 CI with https://github.com/zigpy/workflows/pull/23.
So, this PR adds Python 3.13 to the GitHub CI by adding it to the overridden `PYTHON_MATRIX`.

