### PR TITLE
Use zigpy `AttributeDefs` for `PhilipsBasicCluster`

### DIFF
--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -4,13 +4,14 @@ import asyncio
 import itertools
 import logging
 import time
-from typing import Any, Optional, Union
+from typing import Any, Final, Optional, Union
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.clusters.measurement import OccupancySensing
+from zigpy.zcl.foundation import ZCLAttributeDef
 
 from zhaquirks.const import (
     ARGS,
@@ -59,10 +60,14 @@ class PhilipsOccupancySensing(CustomCluster):
 class PhilipsBasicCluster(CustomCluster, Basic):
     """Philips Basic cluster."""
 
-    attributes = Basic.attributes.copy()
-    attributes[0x0031] = ("philips", t.bitmap16, True)
+    class AttributeDefs(Basic.AttributeDefs):
+        """Attribute definitions."""
 
-    attr_config = {0x0031: 0x000B}
+        philips: Final = ZCLAttributeDef(
+            id=0x0031, type=t.bitmap16, is_manufacturer_specific=True
+        )
+
+    attr_config = {AttributeDefs.philips.id: 0x000B}
 
     async def bind(self):
         """Bind cluster."""

--- a/zhaquirks/philips/wall_switch.py
+++ b/zhaquirks/philips/wall_switch.py
@@ -3,7 +3,7 @@
 from typing import Final
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomDevice
 import zigpy.types as t
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -31,35 +31,31 @@ from zhaquirks.const import (
     SHORT_RELEASE,
     TURN_ON,
 )
-from zhaquirks.philips import PHILIPS, SIGNIFY, Button, PhilipsRemoteCluster, PressType
+from zhaquirks.philips import (
+    PHILIPS,
+    SIGNIFY,
+    Button,
+    PhilipsBasicCluster,
+    PhilipsRemoteCluster,
+    PressType,
+)
 
 DEVICE_SPECIFIC_UNKNOWN = 64512
 
 
-class PhilipsBasicCluster(CustomCluster, Basic):
-    """Philips Basic cluster."""
+class PhilipsWallSwitchBasicCluster(PhilipsBasicCluster):
+    """Philips wall switch Basic cluster."""
 
-    class AttributeDefs(Basic.AttributeDefs):
+    class AttributeDefs(PhilipsBasicCluster.AttributeDefs):
         """Attribute definitions."""
 
-        philips: Final = ZCLAttributeDef(
-            id=0x0031,
-            type=t.bitmap16,
-            is_manufacturer_specific=True,
-        )
         mode: Final = ZCLAttributeDef(
             id=0x0034,
             type=t.enum8,
             is_manufacturer_specific=True,
         )
 
-    attr_config = {AttributeDefs.philips.id: 0x000B, AttributeDefs.mode.id: 0x02}
-
-    async def bind(self):
-        """Bind cluster."""
-        result = await super().bind()
-        await self.write_attributes(self.attr_config, manufacturer=0x100B)
-        return result
+    attr_config = {**PhilipsBasicCluster.attr_config, AttributeDefs.mode.id: 0x02}
 
 
 class PhilipsWallSwitchRemoteCluster(PhilipsRemoteCluster):
@@ -122,7 +118,7 @@ class PhilipsWallSwitch(CustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
-                    PhilipsBasicCluster,
+                    PhilipsWallSwitchBasicCluster,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     PhilipsWallSwitchRemoteCluster,

--- a/zhaquirks/philips/wall_switch.py
+++ b/zhaquirks/philips/wall_switch.py
@@ -1,5 +1,7 @@
 """Signify wall switch devices (RDM001 and RDM004)."""
 
+from typing import Final
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
@@ -12,6 +14,7 @@ from zigpy.zcl.clusters.general import (
     Ota,
     PowerConfiguration,
 )
+from zigpy.zcl.foundation import ZCLAttributeDef
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -36,15 +39,21 @@ DEVICE_SPECIFIC_UNKNOWN = 64512
 class PhilipsBasicCluster(CustomCluster, Basic):
     """Philips Basic cluster."""
 
-    attributes = Basic.attributes.copy()
-    attributes.update(
-        {
-            0x0031: ("philips", t.bitmap16, True),
-            0x0034: ("mode", t.enum8, True),
-        }
-    )
+    class AttributeDefs(Basic.AttributeDefs):
+        """Attribute definitions."""
 
-    attr_config = {0x0031: 0x000B, 0x0034: 0x02}
+        philips: Final = ZCLAttributeDef(
+            id=0x0031,
+            type=t.bitmap16,
+            is_manufacturer_specific=True,
+        )
+        mode: Final = ZCLAttributeDef(
+            id=0x0034,
+            type=t.enum8,
+            is_manufacturer_specific=True,
+        )
+
+    attr_config = {AttributeDefs.philips.id: 0x000B, AttributeDefs.mode.id: 0x02}
 
     async def bind(self):
         """Bind cluster."""


### PR DESCRIPTION
### Untested
These changes are still untested.


## Proposed change
This converts the `PhilipsBasicCluster` used for Hue remotes to use the new-style zigpy `AttributeDefs`.
It also lets the `PhilipsWallSwitchBasicCluster` inherit from the global `PhilipsBasicCluster`, so we don't need to define the `"philips"` attribute twice.


## Additional information


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
