### PR TITLE
Rename `PhilipsRdm001RemoteCluster` to `PhilipsWallSwitchRemoteCluster`

### DIFF
--- a/zhaquirks/philips/wall_switch.py
+++ b/zhaquirks/philips/wall_switch.py
@@ -53,8 +53,8 @@ class PhilipsBasicCluster(CustomCluster, Basic):
         return result
 
 
-class PhilipsRdm001RemoteCluster(PhilipsRemoteCluster):
-    """Philips RDM001 remote cluster."""
+class PhilipsWallSwitchRemoteCluster(PhilipsRemoteCluster):
+    """Philips wall switch remote cluster."""
 
     BUTTONS = {
         1: Button(LEFT, TURN_ON),
@@ -116,7 +116,7 @@ class PhilipsWallSwitch(CustomDevice):
                     PhilipsBasicCluster,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
-                    PhilipsRdm001RemoteCluster,
+                    PhilipsWallSwitchRemoteCluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Ota.cluster_id,
@@ -130,5 +130,5 @@ class PhilipsWallSwitch(CustomDevice):
     }
 
     device_automation_triggers = (
-        PhilipsRdm001RemoteCluster.generate_device_automation_triggers()
+        PhilipsWallSwitchRemoteCluster.generate_device_automation_triggers()
     )


### PR DESCRIPTION
## Proposed change
Rename `PhilipsRdm001RemoteCluster` to `PhilipsWallSwitchRemoteCluster`, as the quirk is for both RDM001 and RDM004 devices now.


## Additional information
Small follow-up to https://github.com/zigpy/zha-device-handlers/commit/700d83bb9378a52223fb62a28792dd4cab87aca1 (https://github.com/zigpy/zha-device-handlers/pull/3075).


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
