### PR TITLE
Use AttributeDefs for quirks subclassed from TuyaMCUCluster and TuyaNewManufCluster

### DIFF
--- a/zhaquirks/tuya/ts0001_fingerbot.py
+++ b/zhaquirks/tuya/ts0001_fingerbot.py
@@ -41,18 +41,30 @@ class FingerBotReverse(t.enum8):
 class TuyaFingerbotCluster(TuyaMCUCluster):
     """Tuya Fingerbot cluster."""
 
-    attributes = TuyaMCUCluster.attributes.copy()
-    attributes.update(
-        {
-            101: ("mode", FingerBotMode),
-            102: ("down_movement", t.uint16_t),
-            103: ("sustain_time", t.uint16_t),
-            104: ("reverse", FingerBotReverse),
-            105: ("battery", t.uint16_t),
-            106: ("up_movement", t.uint16_t),
-            107: ("touch_control", t.Bool),
-        }
-    )
+    class AttributeDefs(TuyaMCUCluster.AttributeDefs):
+        """Attribute Definitions."""
+
+        mode = foundation.ZCLAttributeDef(
+            id=101, type=FingerBotMode, is_manufacturer_specific=True
+        )
+        down_movement = foundation.ZCLAttributeDef(
+            id=102, type=t.uint16_t, is_manufacturer_specific=True
+        )
+        sustain_time = foundation.ZCLAttributeDef(
+            id=103, type=t.uint16_t, is_manufacturer_specific=True
+        )
+        reverse = foundation.ZCLAttributeDef(
+            id=104, type=FingerBotReverse, is_manufacturer_specific=True
+        )
+        battery = foundation.ZCLAttributeDef(
+            id=105, type=t.uint16_t, is_manufacturer_specific=True
+        )
+        up_movement = foundation.ZCLAttributeDef(
+            id=106, type=t.uint16_t, is_manufacturer_specific=True
+        )
+        touch_control = foundation.ZCLAttributeDef(
+            id=107, type=t.Bool, is_manufacturer_specific=True
+        )
 
     async def command(
         self,

--- a/zhaquirks/tuya/ts0601_garage.py
+++ b/zhaquirks/tuya/ts0601_garage.py
@@ -3,6 +3,7 @@
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
 import zigpy.types as t
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Groups, Ota, Scenes, Time
 
 from zhaquirks.const import (
@@ -24,19 +25,30 @@ class TuyaGarageManufCluster(NoManufacturerCluster, TuyaMCUCluster):
 
     ep_attribute = TUYA_MANUFACTURER_GARAGE
 
-    attributes = TuyaMCUCluster.attributes.copy()
-    attributes.update(
-        {
-            # random attribute IDs
-            0xEF01: ("button", t.Bool, True),
-            0xEF02: ("dp_2", t.uint32_t, True),
-            0xEF03: ("contact_sensor", t.Bool, True),
-            0xEF04: ("dp_4", t.uint32_t, True),
-            0xEF05: ("dp_5", t.uint32_t, True),
-            0xEF0B: ("dp_11", t.Bool, True),
-            0xEF0C: ("dp_12", t.enum8, True),
-        }
-    )
+    class AttributeDefs(TuyaMCUCluster.AttributeDefs):
+        """Attribute Definitions."""
+
+        button = foundation.ZCLAttributeDef(
+            id=0xEF01, type=t.Bool, is_manufacturer_specific=True
+        )
+        dp_2 = foundation.ZCLAttributeDef(
+            id=0xEF02, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        contact_sensor = foundation.ZCLAttributeDef(
+            id=0xEF03, type=t.Bool, is_manufacturer_specific=True
+        )
+        dp_4 = foundation.ZCLAttributeDef(
+            id=0xEF04, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        dp_5 = foundation.ZCLAttributeDef(
+            id=0xEF05, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        dp_11 = foundation.ZCLAttributeDef(
+            id=0xEF0B, type=t.Bool, is_manufacturer_specific=True
+        )
+        dp_12 = foundation.ZCLAttributeDef(
+            id=0xEF0C, type=t.enum8, is_manufacturer_specific=True
+        )
 
     dp_to_attribute: dict[int, DPToAttributeMapping] = {
         # garage door trigger ¿on movement, on open, on closed?

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -79,12 +79,14 @@ class NeoBatteryLevel(t.enum8):
 class NeoMotionManufCluster(TuyaNewManufCluster):
     """Neo manufacturer cluster."""
 
-    attributes = TuyaNewManufCluster.attributes.copy()
-    attributes.update(
-        {
-            0xEF0D: ("dp_113", t.enum8, True),  # random attribute ID
-        }
-    )
+    class AttributeDefs(TuyaNewManufCluster.AttributeDefs):
+        """Attribute Definitions."""
+
+        dp_113 = foundation.ZCLAttributeDef(
+            id=0xEF0D,
+            type=t.enum8,
+            is_manufacturer_specific=True,
+        )  # random attribute ID
 
     dp_to_attribute: dict[int, DPToAttributeMapping] = {
         101: DPToAttributeMapping(
@@ -132,23 +134,42 @@ class MmwRadarManufCluster(TuyaMCUCluster):
     # no_one_brightness: no control
     # current_brightness: off
 
-    attributes = TuyaMCUCluster.attributes.copy()
-    attributes.update(
-        {
-            # random attribute IDs
-            0xEF02: ("dp_2", t.uint32_t, True),
-            0xEF03: ("dp_3", t.uint32_t, True),
-            0xEF04: ("dp_4", t.uint32_t, True),
-            0xEF06: ("dp_6", t.enum8, True),
-            0xEF65: ("dp_101", t.uint32_t, True),
-            0xEF66: ("dp_102", t.uint32_t, True),
-            0xEF67: ("dp_103", t.CharacterString, True),
-            0xEF69: ("dp_105", t.enum8, True),
-            0xEF6A: ("dp_106", t.enum8, True),
-            0xEF6B: ("dp_107", t.enum8, True),
-            0xEF6C: ("dp_108", t.uint32_t, True),
-        }
-    )
+    class AttributeDefs(TuyaMCUCluster.AttributeDefs):
+        """Attribute Definitions."""
+
+        dp_2 = foundation.ZCLAttributeDef(
+            id=0xEF02, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        dp_3 = foundation.ZCLAttributeDef(
+            id=0xEF03, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        dp_4 = foundation.ZCLAttributeDef(
+            id=0xEF04, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        dp_6 = foundation.ZCLAttributeDef(
+            id=0xEF06, type=t.enum8, is_manufacturer_specific=True
+        )
+        dp_101 = foundation.ZCLAttributeDef(
+            id=0xEF65, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        dp_102 = foundation.ZCLAttributeDef(
+            id=0xEF66, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        dp_103 = foundation.ZCLAttributeDef(
+            id=0xEF67, type=t.CharacterString, is_manufacturer_specific=True
+        )
+        dp_105 = foundation.ZCLAttributeDef(
+            id=0xEF69, type=t.enum8, is_manufacturer_specific=True
+        )
+        dp_106 = foundation.ZCLAttributeDef(
+            id=0xEF6A, type=t.enum8, is_manufacturer_specific=True
+        )
+        dp_107 = foundation.ZCLAttributeDef(
+            id=0xEF6B, type=t.enum8, is_manufacturer_specific=True
+        )
+        dp_108 = foundation.ZCLAttributeDef(
+            id=0xEF6C, type=t.uint32_t, is_manufacturer_specific=True
+        )
 
     dp_to_attribute: dict[int, DPToAttributeMapping] = {
         1: DPToAttributeMapping(

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -42,16 +42,24 @@ class TuyaValveWaterConsumed(Metering, TuyaLocalCluster):
 class TuyaValveManufCluster(TuyaMCUCluster):
     """On/Off Tuya cluster with extra device attributes."""
 
-    attributes = TuyaMCUCluster.attributes.copy()
-    attributes.update(
-        {
-            0xEF01: ("time_left", t.uint32_t, True),
-            0xEF02: ("state", t.enum8, True),
-            0xEF03: ("last_valve_open_duration", t.uint32_t, True),
-            0xEF04: ("dp_6", t.uint32_t, True),
-            0xEF05: ("valve_position", t.uint32_t, True),
-        }
-    )
+    class AttributeDefs(TuyaMCUCluster.AttributeDefs):
+        """Attribute Definitions."""
+
+        time_left = foundation.ZCLAttributeDef(
+            id=0xEF01, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        state = foundation.ZCLAttributeDef(
+            id=0xEF02, type=t.enum8, is_manufacturer_specific=True
+        )
+        last_valve_open_duration = foundation.ZCLAttributeDef(
+            id=0xEF03, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        dp_6 = foundation.ZCLAttributeDef(
+            id=0xEF04, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        valve_position = foundation.ZCLAttributeDef(
+            id=0xEF05, type=t.uint32_t, is_manufacturer_specific=True
+        )
 
     dp_to_attribute: dict[int, DPToAttributeMapping] = {
         1: DPToAttributeMapping(
@@ -183,15 +191,21 @@ class BasicTuyaValve(CustomDevice):
 class ParksideTuyaValveManufCluster(TuyaMCUCluster):
     """Manufacturer Specific Cluster for the _TZE200_htnnfasr water valve sold as PARKSIDE."""
 
-    attributes = TuyaMCUCluster.attributes.copy()
-    attributes.update(
-        {
-            0xEF11: ("timer_duration", t.uint32_t, True),
-            0xEF12: ("timer_time_left", t.uint32_t, True),
-            0xEF13: ("frost_lock", t.Bool, True),
-            0xEF14: ("frost_lock_reset", t.Bool, True),  # 0 resets frost lock
-        }
-    )
+    class AttributeDefs(TuyaMCUCluster.AttributeDefs):
+        """Attribute Definitions."""
+
+        timer_duration = foundation.ZCLAttributeDef(
+            id=0xEF11, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        timer_time_left = foundation.ZCLAttributeDef(
+            id=0xEF12, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        frost_lock = foundation.ZCLAttributeDef(
+            id=0xEF13, type=t.Bool, is_manufacturer_specific=True
+        )
+        frost_lock_reset = foundation.ZCLAttributeDef(
+            id=0xEF14, type=t.Bool, is_manufacturer_specific=True
+        )  # 0 resets frost lock
 
     dp_to_attribute: dict[int, DPToAttributeMapping] = {
         1: DPToAttributeMapping(
@@ -300,18 +314,30 @@ GIEX_DURATION_ATTR = 0xEF72  # Last irrigation duration
 class GiexValveManufCluster(TuyaMCUCluster):
     """GiEX valve manufacturer cluster."""
 
-    attributes = TuyaMCUCluster.attributes.copy()
-    attributes.update(
-        {
-            GIEX_MODE_ATTR: ("irrigation_mode", t.Bool, True),
-            GIEX_START_TIME_ATTR: ("irrigation_start_time", t.uint32_t, True),
-            GIEX_END_TIME_ATTR: ("irrigation_end_time", t.uint32_t, True),
-            GIEX_NUM_TIMES_ATTR: ("irrigation_num_times", t.uint32_t, True),
-            GIEX_TARGET_ATTR: ("irrigation_target", t.uint32_t, True),
-            GIEX_INTERVAL_ATTR: ("irrigation_interval", t.uint32_t, True),
-            GIEX_DURATION_ATTR: ("irrigation_duration", t.uint32_t, True),
-        }
-    )
+    class AttributeDefs(TuyaMCUCluster.AttributeDefs):
+        """Attribute Definitions."""
+
+        irrigation_mode = foundation.ZCLAttributeDef(
+            id=GIEX_MODE_ATTR, type=t.Bool, is_manufacturer_specific=True
+        )
+        irrigation_start_time = foundation.ZCLAttributeDef(
+            id=GIEX_START_TIME_ATTR, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        irrigation_end_time = foundation.ZCLAttributeDef(
+            id=GIEX_END_TIME_ATTR, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        irrigation_num_times = foundation.ZCLAttributeDef(
+            id=GIEX_NUM_TIMES_ATTR, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        irrigation_target = foundation.ZCLAttributeDef(
+            id=GIEX_TARGET_ATTR, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        irrigation_interval = foundation.ZCLAttributeDef(
+            id=GIEX_INTERVAL_ATTR, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        irrigation_duration = foundation.ZCLAttributeDef(
+            id=GIEX_DURATION_ATTR, type=t.uint32_t, is_manufacturer_specific=True
+        )
 
     dp_to_attribute: dict[int, DPToAttributeMapping] = {
         1: DPToAttributeMapping(


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Converts from attributes to AttributeDefs on quirks subclassed from TuyaMCUCluster and TuyaNewManufCluster.

Required by changes introduced in https://github.com/zigpy/zha-device-handlers/pull/3417

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
