### PR TITLE
Fix Tuya issue with `LocalDataCluster._VALID_ATTRIBUTES`

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -69,7 +69,7 @@ class LocalDataCluster(CustomCluster):
     """
 
     _CONSTANT_ATTRIBUTES: dict[int, typing.Any] = {}
-    _VALID_ATTRIBUTES: list[int] = []
+    _VALID_ATTRIBUTES: set[int] = set()
 
     async def bind(self):
         """Prevent bind."""

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1534,7 +1534,7 @@ class TuyaNewManufCluster(CustomCluster):
             # mark mapped to attribute as valid if existing and if on a LocalDataCluster
             attr = cluster.attributes_by_name.get(dp_map.attribute_name)
             if attr and isinstance(cluster, LocalDataCluster):
-                cluster._VALID_ATTRIBUTES.append(attr.id)
+                cluster._VALID_ATTRIBUTES.add(attr.id)
 
     def handle_cluster_request(
         self,

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1534,6 +1534,10 @@ class TuyaNewManufCluster(CustomCluster):
             # mark mapped to attribute as valid if existing and if on a LocalDataCluster
             attr = cluster.attributes_by_name.get(dp_map.attribute_name)
             if attr and isinstance(cluster, LocalDataCluster):
+                # _VALID_ATTRIBUTES is only a class variable, but as want to modify it
+                # per instance here, we need to create an instance variable first
+                if "_VALID_ATTRIBUTES" not in cluster.__dict__:
+                    cluster._VALID_ATTRIBUTES = set()
                 cluster._VALID_ATTRIBUTES.add(attr.id)
 
     def handle_cluster_request(


### PR DESCRIPTION
## Proposed change

This PR makes multiple changes:

- This fixes an issue where Tuya datapoint mappings affected `LocalDataCluster._VALID_ATTRIBUTES` globally (for all clusters), as we never created an instance variable. So, attributes were basically marked as valid for all `LocalDataCluster`s, which we do not want.

  Normally, I'd expect `LocalDataCluster._VALID_ATTRIBUTES` to be used like `_CONSTANT_ATTRIBUTES` and have it be constant per class*. It'll  be used like that for Aqara plugs in the future, for example.
However, for Tuya devices, we automatically populate `_VALID_ATTRIBUTES` based on the datapoint mappings to virtual/local clusters. If there is a datapoint mapping to a virtual ZCL cluster, it's added to `_VALID_ATTRIBUTES` of that specific virtual cluster instance.
In that case, the previous code always modified the existing `_VALID_ATTRIBUTES` class variable in `LocalDataCluster`.

  Now, we make sure to first create an instance variable for `_VALID_ATTRIBUTES` if there isn't one for the cluster already**.

- This PR also adds a test confirming `_VALID_ATTRIBUTES` are populated as expected for a Tuya sensor using datapoint mappings to virtual/local ZCL clusters. (This is how I found the issue. Probably should have added this test in the initial PR..)

- This changes `LocalDataCluster._VALID_ATTRIBUTES` to be a `set`, instead of a `list`.

*: Another fix would be to just always create an instance variable in `LocalDataCluster` in `__init__`.
However, we'll likely rarely need that and I'd ideally like to keep the behavior similar to `_CONSTANT_ATTRIBUTES`.

**: We need to access `cluster.__dict__` to check if there's already an instance variable for that cluster instance. We **cannot** use `hasattr`/`getattr`, as that would return `True` and the class variable, which we should not modify.

## Additional information
Follow-up to:
- https://github.com/zigpy/zha-device-handlers/pull/3415

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
