### PR TITLE
Add tuya smoke detector (TZE204_vawy74yh)

### DIFF
--- a/zhaquirks/tuya/ts0601_smoke.py
+++ b/zhaquirks/tuya/ts0601_smoke.py
@@ -84,6 +84,7 @@ class TuyaSmokeDetector0601(CustomDevice):
             ("_TZE200_rccxox8p", "TS0601"),
             ("_TZE200_vzekyi4c", "TS0601"),
             ("_TZE204_ntcy3xu1", "TS0601"),
+            ("_TZE204_vawy74yh", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
Get the smoke status of the MOES ZSS-HM-SSD01 smoke detector.

## Additional information
I don't know if other elements, such as battery status, could be recovered. This device seems fully compatible with z2M.

## Tests

The change permits to get smoke status into Home assistant :

  - Home assistant: 2024.10.3
  - Zigbee dongle: SkyConnect v1.0
  
  
![Capture d’écran du 2024-10-20 16-09-24](https://github.com/user-attachments/assets/9f11d46e-0aec-4109-86fb-dcf075751e3c)
![Capture d’écran du 2024-10-20 16-08-20](https://github.com/user-attachments/assets/dd9dd9d4-c887-4ddd-b99d-82f77832c448)
