### PR TITLE
Add ZLinky variant for firmware v14.0

### DIFF
--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -11,6 +11,7 @@ from zigpy.zcl.clusters.general import (
     Identify,
     Ota,
     PowerConfiguration,
+    Time,
 )
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement, MeterIdentification
 from zigpy.zcl.clusters.smartenergy import Metering
@@ -24,6 +25,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.lixee import LIXEE, ZLINKY_MANUFACTURER_CLUSTER_ID
+from zhaquirks.tuya import TuyaManufCluster
 
 
 class ZLinkyTICManufacturerCluster(CustomCluster):
@@ -200,9 +202,25 @@ class ZLinkyTIC(CustomDevice):
 
 
 class ZLinkyTICFWV12(ZLinkyTIC):
-    """ZLinky_TIC from LiXee with firmware v12.0+."""
+    """ZLinky_TIC from LiXee with firmware v12.0 & v13.0."""
 
     signature = deepcopy(ZLinkyTIC.signature)
 
-    # Insert PowerConfiguration cluster in signature for devices with firmware v12.0+
+    # Insert PowerConfiguration cluster in signature for devices with firmware v12.0 & v13.0
     signature[ENDPOINTS][1][INPUT_CLUSTERS].insert(1, PowerConfiguration.cluster_id)
+
+
+class ZLinkyTICFWV14(ZLinkyTICFWV12):
+    """ZLinky_TIC from LiXee with firmware v14.0+."""
+
+    signature = deepcopy(ZLinkyTICFWV12.signature)
+    replacement = deepcopy(ZLinkyTICFWV12.replacement)
+
+    # Insert Time configuration cluster in signature for devices with firmware v14.0+
+    signature[ENDPOINTS][1][INPUT_CLUSTERS].insert(1, Time.cluster_id)
+
+    # Insert Tuya cluster in signature for devices with firmware v14.0+
+    signature[ENDPOINTS][1][INPUT_CLUSTERS].insert(7, TuyaManufCluster.cluster_id)
+    signature[ENDPOINTS][1][OUTPUT_CLUSTERS].insert(1, TuyaManufCluster.cluster_id)
+
+    replacement[ENDPOINTS][1][INPUT_CLUSTERS].insert(1, Time.cluster_id)


### PR DESCRIPTION
## Proposed change

Add Signature for the [latest Firmware release](https://github.com/fairecasoimeme/Zlinky_TIC/releases/tag/v14.0) of the ZLinky_TIC

## Additional information

The latest firmware add new clusters which prevent it from being associated with the quirks and result in incorrect data being pushed in HA.

Fixes #3365 


## Checklist

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [X] Tests have been added to verify that the new code works
