### PR TITLE
Add `translation_key` and `fallback_name` to Tuya tests

### DIFF
--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -67,25 +67,35 @@ async def test_tuya_quirkbuilder(device_mock):
         .tuya_switch(
             dp_id=6,
             attribute_name="test_onoff",
+            translation_key="test_onoff",
+            fallback_name="Test on/off",
         )
         .tuya_number(
             dp_id=7,
             attribute_name="test_number",
             type=t.uint16_t,
+            translation_key="test_number",
+            fallback_name="Test number",
         )
         .tuya_binary_sensor(
             dp_id=8,
             attribute_name="test_binary",
+            translation_key="test_binary",
+            fallback_name="Test binary",
         )
         .tuya_sensor(
             dp_id=9,
             attribute_name="test_sensor",
             type=t.uint8_t,
+            translation_key="test_sensor",
+            fallback_name="Test sensor",
         )
         .tuya_enum(
             dp_id=10,
             attribute_name="test_enum",
             enum_class=TestEnum,
+            translation_key="test_enum",
+            fallback_name="Test enum",
         )
         .tuya_humidity(dp_id=11)
         .add_to_registry()


### PR DESCRIPTION
## Proposed change
This adds `translation_key` and `fallback_name` to all v2 quirks in Tuya tests.


## Additional information
Will be required once we have zigpy bump merged with this PR:
- https://github.com/zigpy/zigpy/pull/1488


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
