### PR TITLE
Add Immax NEO Smart radiator valve `_TZE200_rufdtfyv`

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1527,7 +1527,8 @@ class MoesHY368_Type1(TuyaThermostat):
             ("_TZE200_cwnjrr72", "TS0601"),
             ("_TZE200_2atgpdho", "TS0601"),
             ("_TZE200_pvvbommb", "TS0601"),
-            ("_TZE200_4eeyebrt", "TS0601"),
+            ("_TZE200_4eeyebrt", "TS0601"),  # Immax NEO Smart (v1)
+            ("_TZE200_rufdtfyv", "TS0601"),  # Immax NEO Smart (v2)
             ("_TZE200_cpmgn2cf", "TS0601"),
             ("_TZE200_9sfg7gm0", "TS0601"),
             ("_TZE200_8whxpsiw", "TS0601"),


### PR DESCRIPTION
## Proposed change
This PR is to add support for an updated model of [Immax NEO Smart Thermostatic head](https://www.immax.eu/immax-neo-smart-thermostatic-head-zigbee-p13447/). The retailers keep selling it as a single model, but the updated one has different signature and doesn't work with ZHA yet. As far as I can tell it's the same hardware, just with updated firmware with 2 new configruation options in the menu on the device itself.


## Additional information
Here is how it now reports in HA after including the quirk:
![image](https://github.com/user-attachments/assets/9b9df516-dbb2-478d-b00a-8cb21e5de52d)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
