### PR TITLE
Fix Nimly smart lock mains-powered capability

### DIFF
--- a/zhaquirks/nimly/__init__.py
+++ b/zhaquirks/nimly/__init__.py
@@ -1,0 +1,3 @@
+"""Nimly module."""
+
+NIMLY = "Onesti Products AS"

--- a/zhaquirks/nimly/lock.py
+++ b/zhaquirks/nimly/lock.py
@@ -1,0 +1,36 @@
+"""Device handler for Nimly Smart Locks."""
+
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zdo.types import NodeDescriptor
+
+from zhaquirks.nimly import NIMLY
+
+# clears the mains powered mac capability flag
+NIMLY_LOCK_NODE_DESCRIPTOR = NodeDescriptor(
+    logical_type=2,
+    complex_descriptor_available=0,
+    user_descriptor_available=0,
+    reserved=0,
+    aps_flags=0,
+    frequency_band=8,
+    manufacturer_code=4660,
+    maximum_buffer_size=108,
+    maximum_incoming_transfer_size=127,
+    server_mask=11264,
+    maximum_outgoing_transfer_size=127,
+    descriptor_capability_field=0,
+    mac_capability_flags=NodeDescriptor.MACCapabilityFlags.AllocateAddress
+    | NodeDescriptor.MACCapabilityFlags.RxOnWhenIdle,
+)
+
+
+(
+    QuirkBuilder(NIMLY, "NimlyPRO")
+    .also_applies_to(NIMLY, "NimlyCode")
+    .also_applies_to(NIMLY, "NimlyTouch")
+    .also_applies_to(NIMLY, "NimlyIn")
+    .also_applies_to(NIMLY, "EasyFingerTouch")
+    .also_applies_to(NIMLY, "EasyCodeTouch")
+    .node_descriptor(NIMLY_LOCK_NODE_DESCRIPTOR)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
Add nimly smart lock quirk
Clears the mains powered mac capability flag since lock is battery powered.

Note that after quirk is applied, ZHA reports that my lock has 20% remaining battery, but when I query PowerConfiguration/battery_percentage_remaining attribute it reports 41%.
Not sure where ZHA gets 20% from.

See picture below:
<img src="https://github.com/user-attachments/assets/84baf505-61c3-4f03-b67d-56a9830c856a" width="400">

## Additional information
Tested on NimlyPro model.

Ref
#3095
#2354

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
