### PR TITLE
Remove Hue tamper entity `translation_key`

### DIFF
--- a/zhaquirks/philips/soc001.py
+++ b/zhaquirks/philips/soc001.py
@@ -51,7 +51,6 @@ class PhilipsContactCluster(CustomCluster):
         endpoint_id=2,
         device_class=BinarySensorDeviceClass.TAMPER,
         entity_type=EntityType.DIAGNOSTIC,
-        translation_key="tamper",
         fallback_name="Tamper",
     )
     .add_to_registry()


### PR DESCRIPTION
## Proposed change
Remove `translation_key` from Hue contact sensor tamper entity.
With future ZHA versions, no translation key will cause HA to use the name of the device class.


## Additional information
Requires to properly work (but can be merged before):
- https://github.com/zigpy/zha/pull/251

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
