### PR TITLE
Bump zigpy to 0.70.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache License Version 2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy>=0.68.1",
+    "zigpy>=0.70.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.69
+zigpy>=0.70
 ruff==0.0.261


### PR DESCRIPTION
## Proposed change
Bump zigpy to 0.70.0. This adds a stricter validation for `translation_key` and `fallback_name` in v2 quirks.
The repo has already been updated to be compatible with these changes in previous PRs.


## Additional information
zigpy 0.70.0 release notes: https://github.com/zigpy/zigpy/releases/tag/0.70.0

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
