### PR TITLE
Implement contact attribute and skip on/off configuration for Philips SOC001

### DIFF
--- a/zhaquirks/philips/soc001.py
+++ b/zhaquirks/philips/soc001.py
@@ -73,7 +73,6 @@ class PhilipsContactCluster(CustomCluster):
         endpoint_id=2,
         device_class=BinarySensorDeviceClass.OPENING,
         EntityType=EntityType.STANDARD,
-        translation_key="contact",
         fallback_name="Contact",
     )
     .binary_sensor(
@@ -82,7 +81,6 @@ class PhilipsContactCluster(CustomCluster):
         endpoint_id=2,
         device_class=BinarySensorDeviceClass.TAMPER,
         entity_type=EntityType.DIAGNOSTIC,
-        translation_key="tamper",
         fallback_name="Tamper",
     )
     .add_to_registry()

--- a/zhaquirks/philips/soc001.py
+++ b/zhaquirks/philips/soc001.py
@@ -72,7 +72,7 @@ class PhilipsContactCluster(CustomCluster):
         PhilipsContactCluster.cluster_id,
         endpoint_id=2,
         device_class=BinarySensorDeviceClass.OPENING,
-        EntityType=EntityType.STANDARD,
+        entity_type=EntityType.STANDARD,
         fallback_name="Contact",
     )
     .binary_sensor(

--- a/zhaquirks/philips/soc001.py
+++ b/zhaquirks/philips/soc001.py
@@ -2,8 +2,25 @@
 
 from zigpy import types
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import BinarySensorDeviceClass, EntityType, QuirkBuilder
+from zigpy.quirks.v2 import (
+    BinarySensorDeviceClass,
+    EntityType,
+    QuirkBuilder,
+    ClusterType,
+)
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+from zigpy.zcl.clusters.general import OnOff
+
+
+class PhilipsOnOffCluster(CustomCluster, OnOff):
+    """Philips OnOff cluster for contact sensor."""
+
+    """Prevents the creation of the on_off entity."""
+
+    cluster_id = 6  # 0x0006
+    name = "Philips OnOff cluster"
+    ep_attribute = "philips_onoff_cluster"
+    SKIP_CONFIGURATION = True
 
 
 class PhilipsContactCluster(CustomCluster):
@@ -44,7 +61,21 @@ class PhilipsContactCluster(CustomCluster):
     #  input_clusters=[0, 1, 3, 64518]
     #  output_clusters=[0, 3, 6, 25]>
     QuirkBuilder("Signify Netherlands B.V.", "SOC001")
+    .replaces(
+        PhilipsOnOffCluster,
+        cluster_type=ClusterType.Client,
+        endpoint_id=2,
+    )
     .replaces(PhilipsContactCluster, endpoint_id=2)
+    .binary_sensor(
+        "contact",
+        PhilipsContactCluster.cluster_id,
+        endpoint_id=2,
+        device_class=BinarySensorDeviceClass.OPENING,
+        EntityType=EntityType.STANDARD,
+        translation_key="contact",
+        fallback_name="Contact",
+    )
     .binary_sensor(
         "tamper",
         PhilipsContactCluster.cluster_id,

--- a/zhaquirks/philips/soc001.py
+++ b/zhaquirks/philips/soc001.py
@@ -4,12 +4,12 @@ from zigpy import types
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import (
     BinarySensorDeviceClass,
+    ClusterType,
     EntityType,
     QuirkBuilder,
-    ClusterType,
 )
-from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 from zigpy.zcl.clusters.general import OnOff
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 
 class PhilipsOnOffCluster(CustomCluster, OnOff):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Implement manufacturer specific contact attribute and skip on/off configuration for SOC001.
Since the on/off attribute does not support reporting configuration, network failure or shutdown will leave Home Assistant unaware of the new sensor state. Demonstrated here : https://github.com/zigpy/zha-device-handlers/pull/3432#issuecomment-2423011662

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Confirm binding works on the custom on/off. Tested between a light and this sensor.
Breaking change for previous installations by disabling the on/off entity creation.
Fixes https://github.com/zigpy/zha-device-handlers/issues/3314

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
