### PR TITLE
Fix battery reporting half on some Nimly locks

### DIFF
--- a/zhaquirks/nimly/lock.py
+++ b/zhaquirks/nimly/lock.py
@@ -3,6 +3,7 @@
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zdo.types import NodeDescriptor
 
+from zhaquirks import DoublingPowerConfigurationCluster
 from zhaquirks.nimly import NIMLY
 
 # clears the mains powered mac capability flag
@@ -25,12 +26,18 @@ NIMLY_LOCK_NODE_DESCRIPTOR = NodeDescriptor(
 
 
 (
+    QuirkBuilder(NIMLY, "EasyFingerTouch")
+    .also_applies_to(NIMLY, "EasyCodeTouch")
+    .node_descriptor(NIMLY_LOCK_NODE_DESCRIPTOR)
+    .add_to_registry()
+)
+
+(
     QuirkBuilder(NIMLY, "NimlyPRO")
     .also_applies_to(NIMLY, "NimlyCode")
     .also_applies_to(NIMLY, "NimlyTouch")
     .also_applies_to(NIMLY, "NimlyIn")
-    .also_applies_to(NIMLY, "EasyFingerTouch")
-    .also_applies_to(NIMLY, "EasyCodeTouch")
     .node_descriptor(NIMLY_LOCK_NODE_DESCRIPTOR)
+    .replaces(DoublingPowerConfigurationCluster, endpoint_id=11)
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Add `DoublingPowerConfigurationCluster` for some nimly locks.
Following the previous PR #3457.

According to this conversation over at Z2M, only Nimly new locks require this fix, not their old EasyTouch/EasyFinger locks: https://github.com/Koenkk/zigbee-herdsman-converters/pull/6940.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
