### PR TITLE
Add Tuya temp/humidity sensor `_TZE204_s139roas` variant

### DIFF
--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -18,6 +18,7 @@ from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkB
     .applies_to("_TZE200_znbl8dj5", "TS0601")
     .applies_to("_TZE200_qyflbnbj", "TS0601")
     .applies_to("_TZE200_zppcgbdj", "TS0601")
+    .applies_to("_TZE204_s139roas", "TS0601")
     .tuya_temperature(dp_id=1, scale=10)
     .tuya_humidity(dp_id=2)
     .tuya_battery(dp_id=4)


### PR DESCRIPTION
variant has e-ink screen and cr2430 battery. seems to work like the variant without screen. tested by copying to zha.custom_quirks_path

closes #3402

```python
"""Tuya temp and humidity sensors."""

from zhaquirks.tuya.builder import TuyaQuirkBuilder

(
    TuyaQuirkBuilder("_TZE204_s139roas", "TS0601")
    .tuya_temperature(dp_id=1, scale=10)
    .tuya_humidity(dp_id=2)
    .tuya_battery(dp_id=4)
    .skip_configuration()
    .add_to_registry()
)

```

## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
