### PR TITLE
Fix Sinope device triggers

### DIFF
--- a/tests/test_sinope.py
+++ b/tests/test_sinope.py
@@ -247,7 +247,6 @@ async def test_sinope_light_device_triggers_def(zigpy_device_from_quirk, quirk):
     device: Device = zigpy_device_from_quirk(quirk)
 
     for config in device.device_automation_triggers.values():
-        # from pudb import set_trace; set_trace();
         val = config.get("args", {}).get("value")
         if val is not None:
             assert type(val) is int, type(val)

--- a/tests/test_sinope.py
+++ b/tests/test_sinope.py
@@ -239,3 +239,15 @@ async def test_sinope_light_switch_reporting(zigpy_device_from_quirk, quirk):
 
         assert len(request_mock.mock_calls) == 1
         assert len(bind_mock.mock_calls) == 1
+
+
+@pytest.mark.parametrize("quirk", (SinopeTechnologieslight,))
+async def test_sinope_light_device_triggers_def(zigpy_device_from_quirk, quirk):
+    """Test that configuring reporting for action_report works."""
+    device: Device = zigpy_device_from_quirk(quirk)
+
+    for config in device.device_automation_triggers.values():
+        # from pudb import set_trace; set_trace();
+        val = config.get("args", {}).get("value")
+        if val is not None:
+            assert type(val) is int, type(val)

--- a/tests/test_sinope.py
+++ b/tests/test_sinope.py
@@ -243,7 +243,11 @@ async def test_sinope_light_switch_reporting(zigpy_device_from_quirk, quirk):
 
 @pytest.mark.parametrize("quirk", (SinopeTechnologieslight,))
 async def test_sinope_light_device_triggers_def(zigpy_device_from_quirk, quirk):
-    """Test that configuring reporting for action_report works."""
+    """Test device automation triggers.
+
+    Make sure that values are actual ints and not instances of an enum class.
+    """
+
     device: Device = zigpy_device_from_quirk(quirk)
 
     for config in device.device_automation_triggers.values():

--- a/zhaquirks/sinope/__init__.py
+++ b/zhaquirks/sinope/__init__.py
@@ -52,7 +52,7 @@ LIGHT_DEVICE_TRIGGERS = {
             ATTRIBUTE_ID: 84,
             ATTRIBUTE_NAME: ATTRIBUTE_ACTION,
             BUTTON: TURN_ON,
-            VALUE: ButtonAction.Pressed_on,
+            VALUE: int(ButtonAction.Pressed_on),
         },
     },
     (SHORT_PRESS, TURN_OFF): {
@@ -63,7 +63,7 @@ LIGHT_DEVICE_TRIGGERS = {
             ATTRIBUTE_ID: 84,
             ATTRIBUTE_NAME: ATTRIBUTE_ACTION,
             BUTTON: TURN_OFF,
-            VALUE: ButtonAction.Pressed_off,
+            VALUE: int(ButtonAction.Pressed_off),
         },
     },
     (SHORT_RELEASE, TURN_ON): {
@@ -74,7 +74,7 @@ LIGHT_DEVICE_TRIGGERS = {
             ATTRIBUTE_ID: 84,
             ATTRIBUTE_NAME: ATTRIBUTE_ACTION,
             BUTTON: TURN_ON,
-            VALUE: ButtonAction.Released_on,
+            VALUE: int(ButtonAction.Released_on),
         },
     },
     (SHORT_RELEASE, TURN_OFF): {
@@ -85,7 +85,7 @@ LIGHT_DEVICE_TRIGGERS = {
             ATTRIBUTE_ID: 84,
             ATTRIBUTE_NAME: ATTRIBUTE_ACTION,
             BUTTON: TURN_OFF,
-            VALUE: ButtonAction.Released_off,
+            VALUE: int(ButtonAction.Released_off),
         },
     },
     (DOUBLE_PRESS, TURN_ON): {
@@ -96,7 +96,7 @@ LIGHT_DEVICE_TRIGGERS = {
             ATTRIBUTE_ID: 84,
             ATTRIBUTE_NAME: ATTRIBUTE_ACTION,
             BUTTON: TURN_ON,
-            VALUE: ButtonAction.Double_on,
+            VALUE: int(ButtonAction.Double_on),
         },
     },
     (DOUBLE_PRESS, TURN_OFF): {
@@ -107,7 +107,7 @@ LIGHT_DEVICE_TRIGGERS = {
             ATTRIBUTE_ID: 84,
             ATTRIBUTE_NAME: ATTRIBUTE_ACTION,
             BUTTON: TURN_OFF,
-            VALUE: ButtonAction.Double_off,
+            VALUE: int(ButtonAction.Double_off),
         },
     },
     (LONG_PRESS, TURN_ON): {
@@ -118,7 +118,7 @@ LIGHT_DEVICE_TRIGGERS = {
             ATTRIBUTE_ID: 84,
             ATTRIBUTE_NAME: ATTRIBUTE_ACTION,
             BUTTON: TURN_ON,
-            VALUE: ButtonAction.Long_on,
+            VALUE: int(ButtonAction.Long_on),
         },
     },
     (LONG_PRESS, TURN_OFF): {
@@ -129,7 +129,7 @@ LIGHT_DEVICE_TRIGGERS = {
             ATTRIBUTE_ID: 84,
             ATTRIBUTE_NAME: ATTRIBUTE_ACTION,
             BUTTON: TURN_OFF,
-            VALUE: ButtonAction.Long_off,
+            VALUE: int(ButtonAction.Long_off),
         },
     },
 }


### PR DESCRIPTION
## Proposed change
Fixes device automation triggers for the Sinope light quirk. The current definition of the automation triggers
uses the `ButtonAction` enum in the `value` field, which throws an error from Voluptuous when passed into HA's `async_attach_trigger`.

## Additional information
Not a breaking change and doesn't require anything else to be merged into HA Core.

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
