### PR TITLE
Add Tuya Royal Gardineer irrigation valve quirk

### DIFF
--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -26,6 +26,7 @@ from zhaquirks.tuya import (
     EnchantedDevice,
     TuyaLocalCluster,
     TuyaPowerConfigurationCluster4AA,
+    TuyaPowerConfigurationCluster2AAA
 )
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zhaquirks.tuya.mcu import (
@@ -566,5 +567,74 @@ class GiexIrrigationStatus(t.enum8):
         fallback_name="Status 2",
     )
     .skip_configuration()
+    .add_to_registry()
+)
+
+
+class RoyalGardineerWeatherDelay(t.enum8):
+    """Royal Gardineer Irrigation Valve weather delay enum."""
+
+    Disabled = 0x00
+    Delayed_24h = 0x01
+    Delayed_48h = 0x02
+    Delayed_72h = 0x03
+
+class RoyalGardineerTimerState(t.enum8):
+    """Royal Gardineer Irrigation Valve timer state enum."""
+
+    Disabled = 0x00
+    Active = 0x01
+    Enabled = 0x02
+
+(
+    TuyaQuirkBuilder("_TZE200_2wg5qrjy", "TS0601")
+    .tuya_onoff(dp_id=1)
+    #!!! should be TuyaPowerConfigurationCluster2AA, but it is broken at this time.
+    .tuya_battery(dp_id=7, power_cfg=TuyaPowerConfigurationCluster2AAA)
+    # Might need a convertor: x // 10
+    .tuya_metering(dp_id=5)
+    # Timer time left/remaining (raw value in seconds).
+    .tuya_number(
+        dp_id=11,
+        attribute_name="timer_time_left",
+        type=t.uint32_t,
+        min_value=1,
+        max_value=600,
+        step=1,
+        multiplier=1/60,
+        unit=UnitOfTime.MINUTES,
+        translation_key="timer_time_left",
+        fallback_name="Timer time left",
+    )
+    # Weather delay.
+    .tuya_enum(
+        dp_id=10,
+        attribute_name="weather_delay",
+        enum_class=RoyalGardineerWeatherDelay,
+        translation_key="weather_delay",
+        fallback_name="Weather delay",
+        initially_disabled=True,
+    )
+    # Timer state - read-only.
+    .tuya_enum(
+        dp_id=12,
+        attribute_name="timer_state",
+        enum_class=RoyalGardineerTimerState,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="timer_state",
+        fallback_name="Timer state",
+    )
+    # Last valve open duration - read-only (raw value in seconds).
+    .tuya_sensor(
+        dp_id=15,
+        attribute_name="last_valve_open_duration",
+        type=t.uint32_t,
+        divisor=60,
+        entity_type=EntityType.DIAGNOSTIC,
+        unit=UnitOfTime.MINUTES,
+        translation_key="last_valve_open_duration",
+        fallback_name="Last valve open duration",
+    )
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -2,6 +2,16 @@
 
 from datetime import datetime, timedelta, timezone
 
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import EntityPlatform, EntityType
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
+from zigpy.zcl.clusters.smartenergy import Metering
+
 from zhaquirks import DoublingPowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -25,15 +35,6 @@ from zhaquirks.tuya.mcu import (
     TuyaOnOff,
     TuyaPowerConfigurationCluster,
 )
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.quirks.v2 import EntityPlatform, EntityType
-from zigpy.quirks.v2.homeassistant import UnitOfTime
-from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
-import zigpy.types as t
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
-from zigpy.zcl.clusters.smartenergy import Metering
 
 
 class TuyaValveWaterConsumed(Metering, TuyaLocalCluster):

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -25,8 +25,8 @@ from zhaquirks.tuya import (
     TUYA_CLUSTER_ID,
     EnchantedDevice,
     TuyaLocalCluster,
+    TuyaPowerConfigurationCluster2AAA,
     TuyaPowerConfigurationCluster4AA,
-    TuyaPowerConfigurationCluster2AAA
 )
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zhaquirks.tuya.mcu import (
@@ -579,12 +579,14 @@ class RoyalGardineerWeatherDelay(t.enum8):
     Delayed_48h = 0x02
     Delayed_72h = 0x03
 
+
 class RoyalGardineerTimerState(t.enum8):
     """Royal Gardineer Irrigation Valve timer state enum."""
 
     Disabled = 0x00
     Active = 0x01
     Enabled = 0x02
+
 
 (
     TuyaQuirkBuilder("_TZE200_2wg5qrjy", "TS0601")
@@ -601,7 +603,7 @@ class RoyalGardineerTimerState(t.enum8):
         min_value=1,
         max_value=600,
         step=1,
-        multiplier=1/60,
+        multiplier=1 / 60,
         unit=UnitOfTime.MINUTES,
         translation_key="timer_time_left",
         fallback_name="Timer time left",

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -25,7 +25,6 @@ from zhaquirks.tuya import (
     TUYA_CLUSTER_ID,
     EnchantedDevice,
     TuyaLocalCluster,
-    TuyaPowerConfigurationCluster2AAA,
     TuyaPowerConfigurationCluster4AA,
 )
 from zhaquirks.tuya.builder import TuyaQuirkBuilder

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -25,6 +25,7 @@ from zhaquirks.tuya import (
     TUYA_CLUSTER_ID,
     EnchantedDevice,
     TuyaLocalCluster,
+    TuyaPowerConfigurationCluster2AA,
     TuyaPowerConfigurationCluster4AA,
 )
 from zhaquirks.tuya.builder import TuyaQuirkBuilder

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -2,16 +2,6 @@
 
 from datetime import datetime, timedelta, timezone
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.quirks.v2 import EntityPlatform, EntityType
-from zigpy.quirks.v2.homeassistant import UnitOfTime
-from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
-import zigpy.types as t
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
-from zigpy.zcl.clusters.smartenergy import Metering
-
 from zhaquirks import DoublingPowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -35,6 +25,15 @@ from zhaquirks.tuya.mcu import (
     TuyaOnOff,
     TuyaPowerConfigurationCluster,
 )
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import EntityPlatform, EntityType
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
+from zigpy.zcl.clusters.smartenergy import Metering
 
 
 class TuyaValveWaterConsumed(Metering, TuyaLocalCluster):
@@ -591,9 +590,9 @@ class RoyalGardineerTimerState(t.enum8):
 (
     TuyaQuirkBuilder("_TZE200_2wg5qrjy", "TS0601")
     .tuya_onoff(dp_id=1)
-    #!!! should be TuyaPowerConfigurationCluster2AA, but it is broken at this time.
+    # Should be TuyaPowerConfigurationCluster2AA, but it is broken at this time.
     .tuya_battery(dp_id=7, power_cfg=TuyaPowerConfigurationCluster2AAA)
-    # Might need a convertor: x // 10
+    # Might need a converter: x // 10
     .tuya_metering(dp_id=5)
     # Timer time left/remaining (raw value in seconds).
     .tuya_number(

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -592,7 +592,7 @@ class RoyalGardineerTimerState(t.enum8):
     TuyaQuirkBuilder("_TZE200_2wg5qrjy", "TS0601")
     .tuya_onoff(dp_id=1)
     # Should be TuyaPowerConfigurationCluster2AA, but it is broken at this time.
-    .tuya_battery(dp_id=7, power_cfg=TuyaPowerConfigurationCluster2AAA)
+    .tuya_battery(dp_id=7, power_cfg=TuyaPowerConfigurationCluster2AA)
     # Might need a converter: x // 10
     .tuya_metering(dp_id=5)
     # Timer time left/remaining (raw value in seconds).


### PR DESCRIPTION
## Proposed change
Quirk for supporting [Royal Gardineer](https://www.royal-gardineer.de/Bewaesserungsventil-ZX-7155-919.shtml) valve.
Similar to this [device](https://www.zigbee2mqtt.io/devices/ZVG1.html).

## Additional information
Exposes:

- open/close command
- battery remaining percentage
- water consumption
- timer time left
- timer state
- last open duration
- weather delay

Valve works on a timer only, with a default timer of 10 minutes. Before opening the valve, it is recommended to set the irrigation desired time in the "Timer time left" field. 

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
