### PR TITLE
Update IKEA Styrbar Remote to support long press releases for left and right buttons

### DIFF
--- a/zhaquirks/ikea/fourbtnremote.py
+++ b/zhaquirks/ikea/fourbtnremote.py
@@ -12,6 +12,7 @@ from zhaquirks.const import (
     COMMAND_OFF,
     COMMAND_ON,
     COMMAND_PRESS,
+    COMMAND_RELEASE,
     COMMAND_STOP,
     COMMAND_STOP_ON_OFF,
     DIM_DOWN,
@@ -85,6 +86,11 @@ from zhaquirks.ikea import IKEA, DoublingPowerConfig2AAACluster, ScenesCluster
                     "param2": 0,
                 },
             },
+            (LONG_RELEASE, LEFT): {
+                COMMAND: COMMAND_RELEASE,
+                CLUSTER_ID: 5,
+                ENDPOINT_ID: 1,
+            },
             (SHORT_PRESS, RIGHT): {
                 COMMAND: COMMAND_PRESS,
                 CLUSTER_ID: 5,
@@ -103,6 +109,11 @@ from zhaquirks.ikea import IKEA, DoublingPowerConfig2AAACluster, ScenesCluster
                     "param1": 3328,
                     "param2": 0,
                 },
+            },
+            (LONG_RELEASE, RIGHT): {
+                COMMAND: COMMAND_RELEASE,
+                CLUSTER_ID: 5,
+                ENDPOINT_ID: 1,
             },
         }
     )


### PR DESCRIPTION
## Proposed change
Add "released after long press" triggers for both Left and Right buttons on the IKEA Styrbar Remote quirk.

## Additional information
This change was trivial to make so this makes me wonder if there's some reason why this wasn't done on the earlier version of the quirk? This is new code base for me so maybe I've missed some reasoning here. However I've verified the changes to work on the Styrbar remote I have and I use them on my own automations.

## Checklist
- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
