### PR TITLE
Add Philips Hue smart button `RDM003` variant

### DIFF
--- a/zhaquirks/philips/rom001.py
+++ b/zhaquirks/philips/rom001.py
@@ -65,7 +65,7 @@ class PhilipsROM001(CustomDevice):
         #  device_version=1
         #  input_clusters=[0, 1, 3, 64512, 4096]
         #  output_clusters=[25, 0, 3, 4, 6, 8, 5, 4096]>
-        MODELS_INFO: [(PHILIPS, "ROM001"), (SIGNIFY, "ROM001")],
+        MODELS_INFO: [(PHILIPS, "ROM001"), (SIGNIFY, "ROM001"), (SIGNIFY, "RDM003")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
## Proposed change
Adding the RDM003 to supported devices for ROM001


## Additional information
This fix has been requested a few times on the Home Assistant side, and I have been running with this change for 1year+.
All RDM003 matches all features of the ROM001, and looks the same so keeping it all in one file.


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
