### PR TITLE
Add Tuya contact and illuminance sensor `_TZE200_pay2byax`

### DIFF
--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -1,5 +1,10 @@
 """Tuya temp and humidity sensors."""
 
+from zigpy.quirks.v2.homeassistant import EntityType
+from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
+import zigpy.types as t
+
 from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkBuilder
 
 (
@@ -68,6 +73,28 @@ from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkB
     .tuya_temperature(dp_id=5)
     .tuya_battery(dp_id=15)
     .tuya_soil_moisture(dp_id=3)
+    .skip_configuration()
+    .add_to_registry()
+)
+
+(
+    TuyaQuirkBuilder("_TZE200_pay2byax", "TS0601") # Cusam ZG-102ZL
+    .applies_to("_TZE200_n8dljorx",  "TS0601")
+    .tuya_sensor(
+        dp_id=101,
+        attribute_name="measured_value",
+        type=t.uint16_t,
+        fallback_name="Illuminance",
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        state_class=SensorStateClass.MEASUREMENT
+    )
+    .tuya_binary_sensor(
+        dp_id=1,
+        attribute_name="zone_status",
+        device_class=BinarySensorDeviceClass.OPENING,
+        fallback_name="Opening",
+        entity_type=EntityType.STANDARD,
+    )
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -95,6 +95,7 @@ from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkB
         fallback_name="Opening",
         entity_type=EntityType.STANDARD,
     )
+    .tuya_battery(dp_id=2)
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -78,15 +78,15 @@ from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkB
 )
 
 (
-    TuyaQuirkBuilder("_TZE200_pay2byax", "TS0601") # Cusam ZG-102ZL
-    .applies_to("_TZE200_n8dljorx",  "TS0601")
+    TuyaQuirkBuilder("_TZE200_pay2byax", "TS0601")  # Cusam ZG-102ZL
+    .applies_to("_TZE200_n8dljorx", "TS0601")
     .tuya_sensor(
         dp_id=101,
         attribute_name="measured_value",
         type=t.uint16_t,
         fallback_name="Illuminance",
         device_class=SensorDeviceClass.ILLUMINANCE,
-        state_class=SensorStateClass.MEASUREMENT
+        state_class=SensorStateClass.MEASUREMENT,
     )
     .tuya_binary_sensor(
         dp_id=1,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

This is a custom V2 quirk that I cobbled together and wanted to share. It works in HA, except for battery sensor, which seems to be dysfunctional i think. The dp_id for the battery is 2 btw. 

Maybe someone wants to take this over and implement it correctly. 

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
