### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "David F. Mulcahey", email = "david.mulcahey@icloud.com"}
 ]
 readme = "README.md"
-license = {text = "Apache License Version 2.0"}
+license = {text = "Apache-2.0"}
 requires-python = ">=3.12"
 dependencies = [
     "zigpy>=0.70.0",


### PR DESCRIPTION
## Proposed change
Use official SPDX license identifier as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/Apache-2.0.html