### PR TITLE
Add Aqara FP1E presence sensor v2 quirk

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1761,8 +1761,8 @@ def test_aqara_acn014_signature_match(assert_signature_matches_quirk):
 @pytest.mark.parametrize(
     "occupancy_value, expected_occ_status, motion_value, expected_motion_status",
     [
-        (1, OccupancySensing.Occupancy.Occupied, 2, 0),
-        (0, OccupancySensing.Occupancy.Unoccupied, 3, IasZone.ZoneStatus.Alarm_1),
+        (0, OccupancySensing.Occupancy.Unoccupied, 2, 0),
+        (1, OccupancySensing.Occupancy.Occupied, 3, IasZone.ZoneStatus.Alarm_1),
     ],
 )
 async def test_aqara_fp1e_sensor(

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1756,3 +1756,50 @@ def test_aqara_acn014_signature_match(assert_signature_matches_quirk):
     assert_signature_matches_quirk(
         zhaquirks.xiaomi.aqara.light_acn.LumiLightAcn014, signature
     )
+
+
+@pytest.mark.parametrize(
+    "occupancy_value, expected_occ_status, motion_value, expected_motion_status",
+    [
+        (1, OccupancySensing.Occupancy.Occupied, 2, 0),
+        (0, OccupancySensing.Occupancy.Unoccupied, 3, IasZone.ZoneStatus.Alarm_1),
+    ],
+)
+async def test_aqara_fp1e_sensor(
+    zigpy_device_from_v2_quirk,
+    occupancy_value,
+    expected_occ_status,
+    motion_value,
+    expected_motion_status,
+):
+    """Test Aqara FP1E sensor."""
+    quirk = zigpy_device_from_v2_quirk("aqara", "lumi.sensor_occupy.agl1")
+
+    opple_cluster = quirk.endpoints[1].opple_cluster
+    ias_cluster = quirk.endpoints[1].ias_zone
+    occupancy_cluster = quirk.endpoints[1].occupancy
+
+    opple_listener = ClusterListener(opple_cluster)
+    ias_listener = ClusterListener(ias_cluster)
+    occupancy_listener = ClusterListener(occupancy_cluster)
+
+    # update custom occupancy attribute id
+    opple_cluster.update_attribute(0x0142, occupancy_value)
+    assert len(opple_listener.attribute_updates) == 1
+
+    # confirm occupancy cluster is updated
+    assert len(occupancy_listener.attribute_updates) == 1
+    assert (
+        occupancy_listener.attribute_updates[0][0]
+        == OccupancySensing.AttributeDefs.occupancy.id
+    )
+    assert occupancy_listener.attribute_updates[0][1] == expected_occ_status
+
+    # update custom motion attribute id
+    opple_cluster.update_attribute(0x0160, motion_value)
+    assert len(opple_listener.attribute_updates) == 2
+
+    # confirm ias cluster is updated
+    assert len(ias_listener.attribute_updates) == 1
+    assert ias_listener.attribute_updates[0][0] == IasZone.AttributeDefs.zone_status.id
+    assert ias_listener.attribute_updates[0][1] == expected_motion_status

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1763,6 +1763,7 @@ def test_aqara_acn014_signature_match(assert_signature_matches_quirk):
     [
         (0, OccupancySensing.Occupancy.Unoccupied, 2, 0),
         (1, OccupancySensing.Occupancy.Occupied, 3, IasZone.ZoneStatus.Alarm_1),
+        (1, OccupancySensing.Occupancy.Occupied, 4, 0),
     ],
 )
 async def test_aqara_fp1e_sensor(

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -15,7 +15,7 @@ from zigpy.quirks.v2 import (
 from zigpy.zcl.clusters.general import DeviceTemperature
 from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
-from zigpy.zcl.foundation import ZCLAttributeDef
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 from zhaquirks.xiaomi import XiaomiAqaraE1Cluster
 
@@ -54,8 +54,8 @@ class AqaraMotion(types.enum8):
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Aqara manufacturer cluster for the FP1E presence sensor."""
 
-    class AttributeDefs(XiaomiAqaraE1Cluster.AttributeDefs):
-        """Aqara occupancy sensor manufacturer specific attributes."""
+    class AttributeDefs(BaseAttributeDefs):
+        """Manufacturer specific attributes."""
 
         approach_distance = ZCLAttributeDef(
             id=APPROACH_DISTANCE_ATTR_ID,

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from zigpy import types
@@ -29,8 +28,6 @@ RESTART_DEVICE_ATTR_ID = 0x00E8  # BOOL Trigger device restart
 
 RESET_NO_PRESENCE_STATUS_WRITE_VALUE = 1
 RESTART_DEVICE_WRITE_VALUE = 0
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class AqaraMotionSensitivity(types.enum8):

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from zigpy import types
 from zigpy.quirks.v2 import (
-    QuirkBuilder,
     NumberDeviceClass,
+    QuirkBuilder,
     SensorDeviceClass,
     SensorStateClass,
 )
-from zigpy.quirks.v2.homeassistant import EntityType, UnitOfLength
-import zigpy.types as types
 from zigpy.zcl.clusters.general import DeviceTemperature
 from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -20,35 +20,32 @@ from zhaquirks import LocalDataCluster
 from zhaquirks.xiaomi import XiaomiAqaraE1Cluster
 
 
-class AqaraMotionSensitivity(types.enum8):
-    """Aqara motion sensitivity."""
-
-    Low = 0x01
-    Medium = 0x02
-    High = 0x03
-
-
 class AqaraMotion(types.enum8):
-    """Aqara motion."""
-
-    Unknown_0 = 0x00
-    Unknown_1 = 0x01
     Idle = 0x02
     Moving = 0x03
     Still = 0x04
 
 
+class AqaraMotionSensitivity(types.enum8):
+    Low = 0x01
+    Medium = 0x02
+    High = 0x03
+
+
+class AqaraOccupancy(types.enum8):
+    Unoccupied = 0x00
+    Occupied = 0x01
+
+
 class IasZoneLocal(LocalDataCluster, IasZone):
     """Virtual cluster for IasZone."""
 
-    # required to make sure ZHA creates sensors when initially pairing
     _VALID_ATTRIBUTES = {IasZone.AttributeDefs.zone_status.id}
 
 
 class OccupancySensingLocal(LocalDataCluster, OccupancySensing):
     """Virtual cluster for OccupancySensing."""
 
-    # required to make sure ZHA creates sensors when initially pairing
     _VALID_ATTRIBUTES = {OccupancySensing.AttributeDefs.occupancy.id}
 
 
@@ -66,10 +63,10 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             is_manufacturer_specific=True,
         )
 
-        # Detected motion (0x02 = no movement, 0x03 = large movement, 0x04 = small movement)
+        # Detected motion
         motion = ZCLAttributeDef(
             id=0x0160,
-            type=types.uint8_t,
+            type=AqaraMotion,
             access="rp",
             is_manufacturer_specific=True,
         )
@@ -82,18 +79,18 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             is_manufacturer_specific=True,
         )
 
-        # The configurable detection sensitivity (0x01 = low, 0x02 = medium, 0x03 = high, default 0x03 = high)
+        # The configurable detection sensitivity
         motion_sensitivity = ZCLAttributeDef(
             id=0x010C,
-            type=types.uint8_t,
+            type=AqaraMotionSensitivity,
             access="rw",
             is_manufacturer_specific=True,
         )
 
-        # Occupancy detected (0x0 = absence, 0x01 = presence)
+        # Occupancy detected
         occupancy = ZCLAttributeDef(
             id=0x0142,
-            type=types.uint8_t,
+            type=AqaraOccupancy,
             access="rp",
             is_manufacturer_specific=True,
         )
@@ -119,14 +116,14 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         if attrid == self.AttributeDefs.occupancy.id:
             self.endpoint.occupancy.update_attribute(
                 OccupancySensing.AttributeDefs.occupancy.id,
-                OccupancySensing.Occupancy(value),
+                OccupancySensing.Occupancy.Occupied
+                if value == AqaraOccupancy.Occupied
+                else OccupancySensing.Occupancy.Unoccupied,
             )
         elif attrid == self.AttributeDefs.motion.id:
             self.endpoint.ias_zone.update_attribute(
                 IasZone.AttributeDefs.zone_status.id,
-                IasZone.ZoneStatus(
-                    IasZone.ZoneStatus.Alarm_1 if value == AqaraMotion.Moving else 0
-                ),
+                IasZone.ZoneStatus.Alarm_1 if value == AqaraMotion.Moving else 0,
             )
 
 

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -21,18 +21,24 @@ from zhaquirks.xiaomi import XiaomiAqaraE1Cluster
 
 
 class AqaraMotion(types.enum8):
+    """Aqara motion attribute values."""
+
     Idle = 0x02
     Moving = 0x03
     Still = 0x04
 
 
 class AqaraMotionSensitivity(types.enum8):
+    """Aqara motion sensitivity attribute values."""
+
     Low = 0x01
     Medium = 0x02
     High = 0x03
 
 
 class AqaraOccupancy(types.enum8):
+    """Aqara occupancy attribute values."""
+
     Unoccupied = 0x00
     Occupied = 0x01
 
@@ -87,7 +93,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             is_manufacturer_specific=True,
         )
 
-        # Occupancy detected
+        # Detected occupancy
         occupancy = ZCLAttributeDef(
             id=0x0142,
             type=AqaraOccupancy,

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -98,7 +98,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             is_manufacturer_specific=True,
         )
 
-        # Trigger AI spatial learning (write 1 to tigger)
+        # Trigger AI spatial learning (write 1)
         reset_no_presence_status = ZCLAttributeDef(
             id=0x0157,
             type=types.uint8_t,
@@ -106,7 +106,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             is_manufacturer_specific=True,
         )
 
-        # Trigger device restart (write 0 to tigger)
+        # Trigger device restart (write 0)
         restart_device = ZCLAttributeDef(
             id=0x00E8,
             type=types.Bool,

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -142,9 +142,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     .friendly_name(model="Presence Sensor FP1E", manufacturer="Aqara")
     .adds(DeviceTemperature)
     .adds(OccupancySensingLocal)
-    .adds(
-        IasZoneLocal,
-    )
+    .adds(IasZoneLocal)
     .replaces(OppleCluster)
     .number(
         OppleCluster.AttributeDefs.approach_distance.name,

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -47,6 +47,7 @@ class AqaraOccupancy(types.enum8):
 class IasZoneLocal(LocalDataCluster, IasZone):
     """Virtual cluster for IasZone."""
 
+    _CONSTANT_ATTRIBUTES = {IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Motion_Sensor}
     _VALID_ATTRIBUTES = {IasZone.AttributeDefs.zone_status.id}
 
 
@@ -141,9 +142,6 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     .adds(OccupancySensingLocal)
     .adds(
         IasZoneLocal,
-        constant_attributes={
-            IasZone.AttributeDefs.zone_type: IasZone.ZoneType.Motion_Sensor
-        },
     )
     .replaces(OppleCluster)
     .number(

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -47,7 +47,9 @@ class AqaraOccupancy(types.enum8):
 class IasZoneLocal(LocalDataCluster, IasZone):
     """Virtual cluster for IasZone."""
 
-    _CONSTANT_ATTRIBUTES = {IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Motion_Sensor}
+    _CONSTANT_ATTRIBUTES = {
+        IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Motion_Sensor
+    }
     _VALID_ATTRIBUTES = {IasZone.AttributeDefs.zone_status.id}
 
 

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -16,18 +16,8 @@ from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
+from zhaquirks import LocalDataCluster
 from zhaquirks.xiaomi import XiaomiAqaraE1Cluster
-
-APPROACH_DISTANCE_ATTR_ID = 0x015B  # UINT32 The configurable maximum detection distance in millimeters (default 600 = 6 meters).
-MOTION_ATTR_ID = 0x0160  # UINT8 Detected motion (0x02 = no movement, 0x03 = large movement, 0x04 = small movement)
-MOTION_DISTANCE_ATTR_ID = 0x015F  # UINT32 Distance to the detected motion (mm)
-MOTION_SENSITIVITY_ATTR_ID = 0x010C  # UINT8 The configurable detection sensitivity (0x01 = low, 0x02 = medium, 0x03 = high, default 0x03 = High)
-OCCUPANCY_ATTR_ID = 0x0142  # UINT8 Occupancy detected 0x0 = absence, 0x01 = presence
-RESET_NO_PRESENCE_STATUS_ATTR_ID = 0x0157  # UINT8 Trigger AI spatial learning
-RESTART_DEVICE_ATTR_ID = 0x00E8  # BOOL Trigger device restart
-
-RESET_NO_PRESENCE_STATUS_WRITE_VALUE = 1
-RESTART_DEVICE_WRITE_VALUE = 0
 
 
 class AqaraMotionSensitivity(types.enum8):
@@ -48,56 +38,77 @@ class AqaraMotion(types.enum8):
     Still = 0x04
 
 
+class IasZoneLocal(LocalDataCluster, IasZone):
+    """Virtual cluster for IasZone."""
+
+    # required to make sure ZHA creates sensors when initially pairing
+    _VALID_ATTRIBUTES = {IasZone.AttributeDefs.zone_status.id}
+
+
+class OccupancySensingLocal(LocalDataCluster, OccupancySensing):
+    """Virtual cluster for OccupancySensing."""
+
+    # required to make sure ZHA creates sensors when initially pairing
+    _VALID_ATTRIBUTES = {OccupancySensing.AttributeDefs.occupancy.id}
+
+
 class OppleCluster(XiaomiAqaraE1Cluster):
-    """Aqara manufacturer cluster for the FP1E presence sensor."""
+    """Aqara manufacturer cluster for the presence sensor FP1E."""
 
     class AttributeDefs(BaseAttributeDefs):
         """Manufacturer specific attributes."""
 
+        # The configurable maximum detection distance in millimeters (default 600 = 6 meters).
         approach_distance = ZCLAttributeDef(
-            id=APPROACH_DISTANCE_ATTR_ID,
+            id=0x015B,
             type=types.uint32_t,
             access="rw",
             is_manufacturer_specific=True,
         )
 
+        # Detected motion (0x02 = no movement, 0x03 = large movement, 0x04 = small movement)
         motion = ZCLAttributeDef(
-            id=MOTION_ATTR_ID,
+            id=0x0160,
             type=types.uint8_t,
             access="rp",
             is_manufacturer_specific=True,
         )
 
+        # Distance to the detected motion in millimeters
         motion_distance = ZCLAttributeDef(
-            id=MOTION_DISTANCE_ATTR_ID,
+            id=0x015F,
             type=types.uint32_t,
             access="rp",
             is_manufacturer_specific=True,
         )
 
+        # The configurable detection sensitivity (0x01 = low, 0x02 = medium, 0x03 = high, default 0x03 = high)
         motion_sensitivity = ZCLAttributeDef(
-            id=MOTION_SENSITIVITY_ATTR_ID,
+            id=0x010C,
             type=types.uint8_t,
             access="rw",
             is_manufacturer_specific=True,
         )
 
+        # Occupancy detected (0x0 = absence, 0x01 = presence)
         occupancy = ZCLAttributeDef(
-            id=OCCUPANCY_ATTR_ID,
+            id=0x0142,
             type=types.uint8_t,
             access="rp",
             is_manufacturer_specific=True,
         )
 
+        # Trigger AI spatial learning (write 1 to tigger)
         reset_no_presence_status = ZCLAttributeDef(
-            id=RESET_NO_PRESENCE_STATUS_ATTR_ID,
+            id=0x0157,
             type=types.uint8_t,
             access="w",
             is_manufacturer_specific=True,
         )
 
+        # Trigger device restart (write 0 to tigger)
         restart_device = ZCLAttributeDef(
-            id=RESTART_DEVICE_ATTR_ID,
+            id=0x00E8,
             type=types.Bool,
             access="w",
             is_manufacturer_specific=True,
@@ -105,12 +116,12 @@ class OppleCluster(XiaomiAqaraE1Cluster):
 
     def _update_attribute(self, attrid: int, value: Any) -> None:
         super()._update_attribute(attrid, value)
-        if attrid == OCCUPANCY_ATTR_ID:
+        if attrid == self.AttributeDefs.occupancy.id:
             self.endpoint.occupancy.update_attribute(
                 OccupancySensing.AttributeDefs.occupancy.id,
                 OccupancySensing.Occupancy(value),
             )
-        elif attrid == MOTION_ATTR_ID:
+        elif attrid == self.AttributeDefs.motion.id:
             self.endpoint.ias_zone.update_attribute(
                 IasZone.AttributeDefs.zone_status.id,
                 IasZone.ZoneStatus(
@@ -123,9 +134,9 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     QuirkBuilder("aqara", "lumi.sensor_occupy.agl1")
     .friendly_name(model="Presence Sensor FP1E", manufacturer="Aqara")
     .adds(DeviceTemperature)
-    .adds(OccupancySensing)
+    .adds(OccupancySensingLocal)
     .adds(
-        IasZone,
+        IasZoneLocal,
         constant_attributes={
             IasZone.AttributeDefs.zone_type: IasZone.ZoneType.Motion_Sensor
         },
@@ -162,14 +173,14 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     )
     .write_attr_button(
         OppleCluster.AttributeDefs.reset_no_presence_status.name,
-        RESET_NO_PRESENCE_STATUS_WRITE_VALUE,
+        1,
         OppleCluster.cluster_id,
         translation_key="reset_no_presence_status",
         fallback_name="Presence status reset",
     )
     .write_attr_button(
         OppleCluster.AttributeDefs.restart_device.name,
-        RESTART_DEVICE_WRITE_VALUE,
+        0,
         OppleCluster.cluster_id,
         # entity_type=EntityType.DIAGNOSTIC,
         translation_key="restart_device",

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -11,6 +11,7 @@ from zigpy.quirks.v2 import (
     SensorDeviceClass,
     SensorStateClass,
 )
+from zigpy.quirks.v2.homeassistant import EntityType, UnitOfLength
 from zigpy.zcl.clusters.general import DeviceTemperature
 from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
@@ -151,7 +152,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         min_value=0,
         max_value=6,
         step=0.1,
-        # unit=UnitOfLength.METERS,
+        unit=UnitOfLength.METERS,
         multiplier=0.01,
         device_class=NumberDeviceClass.DISTANCE,
         translation_key="approach_distance",
@@ -160,7 +161,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     .sensor(
         OppleCluster.AttributeDefs.motion_distance.name,
         OppleCluster.cluster_id,
-        # unit=UnitOfLength.METERS,
+        unit=UnitOfLength.METERS,
         multiplier=0.01,
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -185,7 +186,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         OppleCluster.AttributeDefs.restart_device.name,
         0,
         OppleCluster.cluster_id,
-        # entity_type=EntityType.DIAGNOSTIC,
+        entity_type=EntityType.DIAGNOSTIC,
         translation_key="restart_device",
         fallback_name="Restart device",
     )

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -139,7 +139,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
 
 (
     QuirkBuilder("aqara", "lumi.sensor_occupy.agl1")
-    .friendly_name(model="Presence Sensor FP1E", manufacturer="Aqara")
+    .friendly_name(manufacturer="Aqara", model="Presence Sensor FP1E")
     .adds(DeviceTemperature)
     .adds(OccupancySensingLocal)
     .adds(IasZoneLocal)

--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -1,0 +1,183 @@
+"""Quirk for aqara lumi.sensor_occupy.agl1."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from zigpy.quirks.v2 import (
+    QuirkBuilder,
+    NumberDeviceClass,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from zigpy.quirks.v2.homeassistant import EntityType, UnitOfLength
+import zigpy.types as types
+from zigpy.zcl.clusters.general import DeviceTemperature
+from zigpy.zcl.clusters.measurement import OccupancySensing
+from zigpy.zcl.clusters.security import IasZone
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+from zhaquirks.xiaomi import XiaomiAqaraE1Cluster
+
+APPROACH_DISTANCE_ATTR_ID = 0x015B  # UINT32 The configurable maximum detection distance in millimeters (default 600 = 6 meters).
+MOTION_ATTR_ID = 0x0160  # UINT8 Detected motion (0x02 = no movement, 0x03 = large movement, 0x04 = small movement)
+MOTION_DISTANCE_ATTR_ID = 0x015F  # UINT32 Distance to the detected motion (mm)
+MOTION_SENSITIVITY_ATTR_ID = 0x010C  # UINT8 The configurable detection sensitivity (0x01 = low, 0x02 = medium, 0x03 = high, default 0x03 = High)
+OCCUPANCY_ATTR_ID = 0x0142  # UINT8 Occupancy detected 0x0 = absence, 0x01 = presence
+RESET_NO_PRESENCE_STATUS_ATTR_ID = 0x0157  # UINT8 Trigger AI spatial learning
+RESTART_DEVICE_ATTR_ID = 0x00E8  # BOOL Trigger device restart
+
+RESET_NO_PRESENCE_STATUS_WRITE_VALUE = 1
+RESTART_DEVICE_WRITE_VALUE = 0
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AqaraMotionSensitivity(types.enum8):
+    """Aqara motion sensitivity."""
+
+    Low = 0x01
+    Medium = 0x02
+    High = 0x03
+
+
+class AqaraMotion(types.enum8):
+    """Aqara motion."""
+
+    Unknown_0 = 0x00
+    Unknown_1 = 0x01
+    Idle = 0x02
+    Moving = 0x03
+    Still = 0x04
+
+
+class OppleCluster(XiaomiAqaraE1Cluster):
+    """Aqara manufacturer cluster for the FP1E presence sensor."""
+
+    class AttributeDefs(XiaomiAqaraE1Cluster.AttributeDefs):
+        """Aqara occupancy sensor manufacturer specific attributes."""
+
+        approach_distance = ZCLAttributeDef(
+            id=APPROACH_DISTANCE_ATTR_ID,
+            type=types.uint32_t,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+
+        motion = ZCLAttributeDef(
+            id=MOTION_ATTR_ID,
+            type=types.uint8_t,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+
+        motion_distance = ZCLAttributeDef(
+            id=MOTION_DISTANCE_ATTR_ID,
+            type=types.uint32_t,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+
+        motion_sensitivity = ZCLAttributeDef(
+            id=MOTION_SENSITIVITY_ATTR_ID,
+            type=types.uint8_t,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+
+        occupancy = ZCLAttributeDef(
+            id=OCCUPANCY_ATTR_ID,
+            type=types.uint8_t,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+
+        reset_no_presence_status = ZCLAttributeDef(
+            id=RESET_NO_PRESENCE_STATUS_ATTR_ID,
+            type=types.uint8_t,
+            access="w",
+            is_manufacturer_specific=True,
+        )
+
+        restart_device = ZCLAttributeDef(
+            id=RESTART_DEVICE_ATTR_ID,
+            type=types.Bool,
+            access="w",
+            is_manufacturer_specific=True,
+        )
+
+    def _update_attribute(self, attrid: int, value: Any) -> None:
+        super()._update_attribute(attrid, value)
+        if attrid == OCCUPANCY_ATTR_ID:
+            self.endpoint.occupancy.update_attribute(
+                OccupancySensing.AttributeDefs.occupancy.id,
+                OccupancySensing.Occupancy(value),
+            )
+        elif attrid == MOTION_ATTR_ID:
+            self.endpoint.ias_zone.update_attribute(
+                IasZone.AttributeDefs.zone_status.id,
+                IasZone.ZoneStatus(
+                    IasZone.ZoneStatus.Alarm_1 if value == AqaraMotion.Moving else 0
+                ),
+            )
+
+
+(
+    QuirkBuilder("aqara", "lumi.sensor_occupy.agl1")
+    .friendly_name(model="Presence Sensor FP1E", manufacturer="Aqara")
+    .adds(DeviceTemperature)
+    .adds(OccupancySensing)
+    .adds(
+        IasZone,
+        constant_attributes={
+            IasZone.AttributeDefs.zone_type: IasZone.ZoneType.Motion_Sensor
+        },
+    )
+    .replaces(OppleCluster)
+    .number(
+        OppleCluster.AttributeDefs.approach_distance.name,
+        OppleCluster.cluster_id,
+        min_value=0,
+        max_value=6,
+        step=0.1,
+        # unit=UnitOfLength.METERS,
+        multiplier=0.01,
+        device_class=NumberDeviceClass.DISTANCE,
+        translation_key="approach_distance",
+        fallback_name="Approach distance",
+    )
+    .sensor(
+        OppleCluster.AttributeDefs.motion_distance.name,
+        OppleCluster.cluster_id,
+        # unit=UnitOfLength.METERS,
+        multiplier=0.01,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="motion_distance",
+        fallback_name="Motion distance",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.motion_sensitivity.name,
+        AqaraMotionSensitivity,
+        OppleCluster.cluster_id,
+        translation_key="motion_sensitivity",
+        fallback_name="Motion sensitivity",
+    )
+    .write_attr_button(
+        OppleCluster.AttributeDefs.reset_no_presence_status.name,
+        RESET_NO_PRESENCE_STATUS_WRITE_VALUE,
+        OppleCluster.cluster_id,
+        translation_key="reset_no_presence_status",
+        fallback_name="Presence status reset",
+    )
+    .write_attr_button(
+        OppleCluster.AttributeDefs.restart_device.name,
+        RESTART_DEVICE_WRITE_VALUE,
+        OppleCluster.cluster_id,
+        # entity_type=EntityType.DIAGNOSTIC,
+        translation_key="restart_device",
+        fallback_name="Restart device",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This quirk adds support for the Aqara FP1E presence sensor, exposing its motion and occupancy sensors in addition to its  configuration parameters.

Fixes https://github.com/zigpy/zha-device-handlers/issues/3294 and is written using the quirks v2 format.

![image](https://github.com/user-attachments/assets/07e1b493-89c8-4f5a-92f0-ad40cfbb2ab0)



## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

There are two issues that we'd ideally want to fix before merging this PR.

- https://github.com/zigpy/zha/issues/290
   - _Currently unable to specify the unit for the distance sensors_
   - **PR raised:** https://github.com/zigpy/zha/pull/307
- https://github.com/zigpy/zha/issues/291
   - _I'd like to make the _Restart device_ button a diagnostic rather than config function_
   - **PR raised:** https://github.com/zigpy/zha/pull/308

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
