### PR TITLE
Add Tuya air sensor `_TZE204_ogkdpgy2` variant

### DIFF
--- a/zhaquirks/tuya/air/ts0601_air_quality.py
+++ b/zhaquirks/tuya/air/ts0601_air_quality.py
@@ -152,6 +152,7 @@ class TuyaNDIRCO2SensorGPP(CustomDevice):
         # output_clusters=[25, 10])
         MODELS_INFO: [
             ("_TZE200_ogkdpgy2", "TS0601"),
+            ("_TZE204_ogkdpgy2", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
Add Tuya air sensor _TZE204_ogkdpgy2 variant

## Additional information
I just received a DCR-LCD Tuya CO2 monitor, and it turned up in Home Assistant as _TZE204_ogkdpgy2. Adding the modified file from this PR as a custom quirk file, the device works fine. Also, as can be deduced from [this post](https://github.com/Koenkk/zigbee2mqtt/issues/23205#issuecomment-2235297039), renaming the device works fine for several people, leading me to believe this PR is correct.

## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
