### PR TITLE
Migrate Schneider dimmer quirks to v2, add missing models

### DIFF
--- a/tests/test_schneiderelectric.py
+++ b/tests/test_schneiderelectric.py
@@ -6,7 +6,6 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 
 from tests.common import ClusterListener
-import zhaquirks.schneiderelectric.dimmers
 import zhaquirks.schneiderelectric.shutters
 
 zhaquirks.setup()
@@ -136,62 +135,3 @@ async def test_1gang_shutter_1_lift_percentage_updates(zigpy_device_from_quirk):
         23,  # 100 - 77
     )
     assert len(cluster_listener.cluster_commands) == 0
-
-
-def test_nh_rotary_dimmer_1_signature(assert_signature_matches_quirk):
-    """Test signature."""
-    signature = {
-        "node_descriptor": (
-            "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, "
-            "user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, "
-            "mac_capability_flags=<MACCapabilityFlags.FullFunctionDevice|MainsPowered|RxOnWhenIdle|"
-            "AllocateAddress: 142>, manufacturer_code=4190, maximum_buffer_size=82, maximum_incoming_transfer_size=82, "
-            "server_mask=11264, maximum_outgoing_transfer_size=82, "
-            "descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, "
-            "*is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, "
-            "*is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, "
-            "*is_security_capable=False)"
-        ),
-        "endpoints": {
-            "3": {
-                "profile_id": 0x0104,
-                "device_type": "0x0101",
-                "in_clusters": [
-                    "0x0000",
-                    "0x0003",
-                    "0x0004",
-                    "0x0005",
-                    "0x0006",
-                    "0x0008",
-                    "0x0301",
-                    "0x0b05",
-                ],
-                "out_clusters": ["0x0019"],
-            },
-            "21": {
-                "profile_id": 0x0104,
-                "device_type": "0x0104",
-                "in_clusters": ["0x0000", "0x0003", "0x0b05", "0xff17"],
-                "out_clusters": [
-                    "0x0003",
-                    "0x0004",
-                    "0x0005",
-                    "0x0006",
-                    "0x0008",
-                    "0x0102",
-                ],
-            },
-            "242": {
-                "profile_id": 0xA1E0,
-                "device_type": "0x0061",
-                "in_clusters": [],
-                "out_clusters": ["0x0021"],
-            },
-        },
-        "manufacturer": "Schneider Electric",
-        "model": "NHROTARY/DIMMER/1",
-        "class": "zigpy.device.Device",
-    }
-    assert_signature_matches_quirk(
-        zhaquirks.schneiderelectric.dimmers.NHRotaryDimmer1, signature
-    )

--- a/zhaquirks/schneiderelectric/__init__.py
+++ b/zhaquirks/schneiderelectric/__init__.py
@@ -167,10 +167,10 @@ class SEBallast(CustomCluster, Ballast):
             id=0xE000, type=SEControlMode, is_manufacturer_specific=True
         )
         se_wiring_mode: Final = ZCLAttributeDef(
-            id=0xE002, type=t.enum8, is_manufacturer_specific=True
+            id=0xE002, type=SEWiringMode, is_manufacturer_specific=True
         )
         se_dimming_curve: Final = ZCLAttributeDef(
-            id=0xE002, type=t.enum8, is_manufacturer_specific=True
+            id=0xE002, type=SEDimmingCurve, is_manufacturer_specific=True
         )
 
 

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -19,7 +19,7 @@ from zhaquirks.schneiderelectric import (
     .replaces(SEBallast, endpoint_id=3)
     .replaces(SEOnOff, endpoint_id=3)
     .replaces(SEBasic, endpoint_id=21)
-    .adds(SESpecific, endpoint_id=21)
+    .replaces(SESpecific, endpoint_id=21)
     .add_to_registry()
 )
 
@@ -28,6 +28,6 @@ from zhaquirks.schneiderelectric import (
     .replaces(SEBasic)
     .replaces(SEOnOff)
     .replaces(SEBasic, endpoint_id=21)
-    .adds(SESpecific, endpoint_id=21)
+    .replaces(SESpecific, endpoint_id=21)
     .add_to_registry()
 )

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -1,129 +1,33 @@
 """Schneider Electric dimmers and switches quirks."""
 
-from zigpy.profiles import zgp, zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.closures import WindowCovering
-from zigpy.zcl.clusters.general import (
-    Basic,
-    GreenPowerProxy,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    Scenes,
+from zigpy.quirks.v2 import QuirkBuilder
+
+from zhaquirks.schneiderelectric import (
+    SE_MANUF_NAME,
+    SEBallast,
+    SEBasic,
+    SEOnOff,
+    SESpecific,
 )
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.lighting import Ballast
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
+(
+    QuirkBuilder(SE_MANUF_NAME, "NHROTARY/DIMMER/1")
+    .applies_to(SE_MANUF_NAME, "NHROTARY/UNIDIM/1")
+    .applies_to(SE_MANUF_NAME, "NHPB/DIMMER/1")
+    .applies_to(SE_MANUF_NAME, "NHPB/UNIDIM/1")
+    .replaces(SEBasic, endpoint_id=3)
+    .replaces(SEBallast, endpoint_id=3)
+    .replaces(SEOnOff, endpoint_id=3)
+    .replaces(SEBasic, endpoint_id=21)
+    .adds(SESpecific, endpoint_id=21)
+    .add_to_registry()
 )
-from zhaquirks.schneiderelectric import SE_MANUF_NAME, SEBallast, SEBasic, SESpecific
 
-
-class NHRotaryDimmer1(CustomDevice):
-    """NHROTARY/DIMMER/1 by Schneider Electric."""
-
-    signature = {
-        MODELS_INFO: [
-            (SE_MANUF_NAME, "NHROTARY/DIMMER/1"),
-        ],
-        ENDPOINTS: {
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ballast.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-            21: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Diagnostic.cluster_id,
-                    SESpecific.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    WindowCovering.cluster_id,
-                ],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [
-                    GreenPowerProxy.cluster_id,
-                ],
-            },
-        },
-    }
-    replacement = {
-        ENDPOINTS: {
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
-                INPUT_CLUSTERS: [
-                    SEBasic,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    SEBallast,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-            21: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    SEBasic,
-                    Identify.cluster_id,
-                    Diagnostic.cluster_id,
-                    SESpecific,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    WindowCovering.cluster_id,
-                ],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [
-                    GreenPowerProxy.cluster_id,
-                ],
-            },
-        }
-    }
+(
+    QuirkBuilder(SE_MANUF_NAME, "NHPB/SWITCH/1")
+    .replaces(SEBasic)
+    .replaces(SEOnOff)
+    .replaces(SEBasic, endpoint_id=21)
+    .adds(SESpecific, endpoint_id=21)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
I migrated quirks to v2 and added models other models from the spec.
Looking through the spec docs, they all seem to have equivalent functionality.
The original quirk was missing SEOnOff cluster, so I added it too.

## Additional information
Specs:
[ZB Spec - Push-button Dimmer - 110422.pdf](https://github.com/user-attachments/files/17831848/ZB.Spec.-.Push-button.Dimmer.-.110422.pdf)
[ZB Spec - Rotary Dimmer - 110422.pdf](https://github.com/user-attachments/files/17831849/ZB.Spec.-.Rotary.Dimmer.-.110422.pdf)
[ZB Spec - Relay Switch 10A - 110422.pdf](https://github.com/user-attachments/files/17832116/ZB.Spec.-.Relay.Switch.10A.-.110422.pdf)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
