### PR TITLE
Add Tuya TRV Moes HY368 variation

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1534,6 +1534,7 @@ class MoesHY368_Type1(TuyaThermostat):
             ("_TZE200_8whxpsiw", "TS0601"),
             ("_TZE200_8thwkzxl", "TS0601"),  # Tervix Pro Line EVA 2
             ("_TZE200_xby0s3ta", "TS0601"),  # Sandy Beach HY367
+            ("_TZE200_znlqjmih", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
Adds new variation `_TZE200_znlqjmih` of the Moes HY368 TRV.
The clusters seem to be the exact same as the other/older variations of the same TRV.

## Additional information
Signature as reported in ZHA
```json
{
  "node_descriptor": {
    "logical_type": 2,
    "complex_descriptor_available": 0,
    "user_descriptor_available": 0,
    "reserved": 0,
    "aps_flags": 0,
    "frequency_band": 8,
    "mac_capability_flags": 128,
    "manufacturer_code": 4098,
    "maximum_buffer_size": 82,
    "maximum_incoming_transfer_size": 82,
    "server_mask": 11264,
    "maximum_outgoing_transfer_size": 82,
    "descriptor_capability_field": 0
  },
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0051",
      "input_clusters": [
        "0x0000",
        "0x0004",
        "0x0005",
        "0xef00"
      ],
      "output_clusters": [
        "0x000a",
        "0x0019"
      ]
    }
  },
  "manufacturer": "_TZE200_znlqjmih",
  "model": "TS0601",
  "class": "zigpy.device.Device"
}
```


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
