### PR TITLE
Let Sinopé thermostat and light quirks inherit from CustomDevice

### DIFF
--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -301,7 +301,7 @@ class SinopeTechnologieslight(CustomDevice):
     device_automation_triggers = LIGHT_DEVICE_TRIGGERS
 
 
-class SinopeDM2500ZB(SinopeTechnologieslight):
+class SinopeDM2500ZB(CustomDevice):
     """DM2500ZB, DM2500ZB-G2 Dimmers."""
 
     signature = {
@@ -366,7 +366,7 @@ class SinopeDM2500ZB(SinopeTechnologieslight):
     device_automation_triggers = LIGHT_DEVICE_TRIGGERS
 
 
-class SinopeDM2550ZB(SinopeTechnologieslight):
+class SinopeDM2550ZB(CustomDevice):
     """DM2550ZB, DM2550ZB-G2 Dimmers."""
 
     signature = {

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -402,7 +402,7 @@ class SinopeTechnologiesThermostat(CustomDevice):
     }
 
 
-class SinopeTH1400ZB(SinopeTechnologiesThermostat):
+class SinopeTH1400ZB(CustomDevice):
     """TH1400ZB thermostat."""
 
     signature = {
@@ -460,7 +460,7 @@ class SinopeTH1400ZB(SinopeTechnologiesThermostat):
     }
 
 
-class SinopeTH1300ZB(SinopeTechnologiesThermostat):
+class SinopeTH1300ZB(CustomDevice):
     """TH1300ZB thermostat."""
 
     signature = {
@@ -520,7 +520,7 @@ class SinopeTH1300ZB(SinopeTechnologiesThermostat):
     }
 
 
-class SinopeLineThermostats(SinopeTechnologiesThermostat):
+class SinopeLineThermostats(CustomDevice):
     """TH1123ZB, TH1124ZB, TH1500ZB and OTH3600-GA-ZB thermostats."""
 
     signature = {
@@ -585,7 +585,7 @@ class SinopeLineThermostats(SinopeTechnologiesThermostat):
     }
 
 
-class SinopeG2Thermostats(SinopeTechnologiesThermostat):
+class SinopeG2Thermostats(CustomDevice):
     """TH1123ZB-G2 and TH1124ZB-G2 thermostats."""
 
     signature = {
@@ -648,7 +648,7 @@ class SinopeG2Thermostats(SinopeTechnologiesThermostat):
     }
 
 
-class SinopeHPThermostats(SinopeTechnologiesThermostat):
+class SinopeHPThermostats(CustomDevice):
     """HP6000ZB-MA and HP6000ZB-GE thermostats."""
 
     signature = {

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -649,7 +649,7 @@ class SinopeG2Thermostats(CustomDevice):
 
 
 class SinopeHPThermostats(CustomDevice):
-    """HP6000ZB-MA and HP6000ZB-GE thermostats."""
+    """HP6000ZB-GE, HP6000ZB-HS and HP6000ZB-MA thermostats."""
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=775 device_version=1


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
- All devices class should inherit from CustomDevice.
- Small fix for SinopeHPThermostats for devices list

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
