### PR TITLE
Add Philips Hue wall switch `RDM004` variant

### DIFF
--- a/zhaquirks/philips/wall_switch.py
+++ b/zhaquirks/philips/wall_switch.py
@@ -40,8 +40,6 @@ from zhaquirks.philips import (
     PressType,
 )
 
-DEVICE_SPECIFIC_UNKNOWN = 64512
-
 
 class PhilipsWallSwitchBasicCluster(PhilipsBasicCluster):
     """Philips wall switch Basic cluster."""
@@ -99,7 +97,7 @@ class PhilipsWallSwitch(CustomDevice):
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
-                    DEVICE_SPECIFIC_UNKNOWN,
+                    PhilipsWallSwitchRemoteCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -132,6 +130,61 @@ class PhilipsWallSwitch(CustomDevice):
                 ],
             }
         }
+    }
+
+    device_automation_triggers = (
+        PhilipsWallSwitchRemoteCluster.generate_device_automation_triggers()
+    )
+
+
+class PhilipsWallSwitchRDM004(CustomDevice):
+    """Philips RDM004 variant."""
+
+    signature = {
+        MODELS_INFO: [(SIGNIFY, "RDM004")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PhilipsWallSwitchRemoteCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    PhilipsWallSwitchBasicCluster,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PhilipsWallSwitchRemoteCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+        },
     }
 
     device_automation_triggers = (


### PR DESCRIPTION
## Proposed change
Adds an additional quirk variant for the Philips Hue wall switch `RDM004` based on the signature provided in #3539.

## Additional information
Fixes https://github.com/zigpy/zha-device-handlers/issues/3539

This would have been a perfect candidate for a v2 quirk, but we'd need to convert all Philips Hue remote related tests and other Hue remote quirks to be v2 then, as mixed v1/v2 tests are a bit annoying.
We should still do this in the future.

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
