### PR TITLE
Fix Schneider SEBallast/WiringMode attribute id

### DIFF
--- a/zhaquirks/schneiderelectric/__init__.py
+++ b/zhaquirks/schneiderelectric/__init__.py
@@ -167,7 +167,7 @@ class SEBallast(CustomCluster, Ballast):
             id=0xE000, type=SEControlMode, is_manufacturer_specific=True
         )
         se_wiring_mode: Final = ZCLAttributeDef(
-            id=0xE002, type=SEWiringMode, is_manufacturer_specific=True
+            id=0xE001, type=SEWiringMode, is_manufacturer_specific=True
         )
         se_dimming_curve: Final = ZCLAttributeDef(
             id=0xE002, type=SEDimmingCurve, is_manufacturer_specific=True


### PR DESCRIPTION
## Proposed change
Typo in attribute ID.

From the spec:
![image](https://github.com/user-attachments/assets/9edad2ff-c2eb-44aa-8271-8ee70bad73e8)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
