### PR TITLE
Revert TuyaClusterData attr_value to int type only

### DIFF
--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -65,7 +65,7 @@ class TuyaClusterData(t.Struct):
     endpoint_id: int
     cluster_name: str
     cluster_attr: str
-    attr_value: int | str  # Maybe also others types?
+    attr_value: int  # Maybe also others types?
     expect_reply: bool
     manufacturer: int
 


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Fixes: https://github.com/zigpy/zha-device-handlers/issues/3520

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

This should allow any valid zigpy type, but we should revert for now and address in a later PR. 

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
