### PR TITLE
Clean up Tuya Power Config

### DIFF
--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -13,7 +13,6 @@ from zigpy.zcl.clusters.general import Basic
 from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
 from zhaquirks.tuya.builder import (
-    TuyaPowerConfigurationCluster2AAA,
     TuyaQuirkBuilder,
     TuyaRelativeHumidity,
     TuyaSoilMoisture,
@@ -21,6 +20,7 @@ from zhaquirks.tuya.builder import (
     TuyaValveWaterConsumed,
 )
 from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaOnOffNM
+from zhaquirks.tuya.power_config import TuyaPowerConfigurationCluster2AAA
 
 from .async_mock import sentinel
 

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -919,6 +919,13 @@ class TuyaPowerConfigurationCluster3AA(TuyaPowerConfigurationCluster):
     }
 
 
+# Avoid breaking custom quirks, located here to avoid circular dependencies.
+from zhaquirks.tuya.power_config import (  # noqa: E402
+    TuyaPowerConfigurationCluster2AAA as TuyaPowerConfigurationCluster2AAA,  # noqa: PLC0414
+    TuyaPowerConfigurationCluster4AA as TuyaPowerConfigurationCluster4AA,  # noqa: PLC0414
+)
+
+
 class TuyaThermostat(CustomDevice):
     """Generic Tuya thermostat device."""
 

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -899,18 +899,8 @@ class TuyaPowerConfigurationCluster(PowerConfiguration, TuyaLocalCluster):
         self.update_attribute("battery_percentage_remaining", value * 2)
 
 
-class TuyaPowerConfigurationCluster2AAA(PowerConfiguration, TuyaLocalCluster):
-    """PowerConfiguration cluster for devices with 2 AAA."""
-
-    _CONSTANT_ATTRIBUTES = {
-        PowerConfiguration.AttributeDefs.battery_size.id: 4,
-        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
-        PowerConfiguration.AttributeDefs.battery_quantity.id: 2,
-    }
-
-
 class TuyaPowerConfigurationCluster2AA(TuyaPowerConfigurationCluster):
-    """PowerConfiguration cluster for devices with 2 AA."""
+    """Legacy PowerConfiguration cluster for devices with 2 AA."""
 
     _CONSTANT_ATTRIBUTES = {
         PowerConfiguration.AttributeDefs.battery_size.id: 3,
@@ -920,22 +910,12 @@ class TuyaPowerConfigurationCluster2AA(TuyaPowerConfigurationCluster):
 
 
 class TuyaPowerConfigurationCluster3AA(TuyaPowerConfigurationCluster):
-    """PowerConfiguration cluster for devices with 3 AA."""
+    """Legacy PowerConfiguration cluster for devices with 3 AA."""
 
     _CONSTANT_ATTRIBUTES = {
         PowerConfiguration.AttributeDefs.battery_size.id: 3,
         PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
         PowerConfiguration.AttributeDefs.battery_quantity.id: 3,
-    }
-
-
-class TuyaPowerConfigurationCluster4AA(PowerConfiguration, TuyaLocalCluster):
-    """PowerConfiguration cluster for devices with 4 AA."""
-
-    _CONSTANT_ATTRIBUTES = {
-        PowerConfiguration.AttributeDefs.battery_size.id: 3,
-        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
-        PowerConfiguration.AttributeDefs.battery_quantity.id: 4,
     }
 
 

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -20,13 +20,9 @@ from zigpy.zcl.clusters.measurement import (
 )
 from zigpy.zcl.clusters.smartenergy import Metering
 
-from zhaquirks.tuya import (
-    TUYA_CLUSTER_ID,
-    PowerConfiguration,
-    TuyaLocalCluster,
-    TuyaPowerConfigurationCluster2AAA,
-)
+from zhaquirks.tuya import TUYA_CLUSTER_ID, PowerConfiguration, TuyaLocalCluster
 from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster, TuyaOnOffNM
+from zhaquirks.tuya.power_config import TuyaPowerConfigurationCluster2AAA
 
 
 class TuyaRelativeHumidity(RelativeHumidity, TuyaLocalCluster):

--- a/zhaquirks/tuya/power_config/__init__.py
+++ b/zhaquirks/tuya/power_config/__init__.py
@@ -1,0 +1,45 @@
+"""Tuya Power Configuration Clusters."""
+
+from zigpy.zcl.clusters.general import PowerConfiguration
+
+from zhaquirks.tuya import TuyaLocalCluster
+
+
+class TuyaPowerConfigurationCluster2AAA(PowerConfiguration, TuyaLocalCluster):
+    """PowerConfiguration cluster for devices with 2 AAA."""
+
+    _CONSTANT_ATTRIBUTES = {
+        PowerConfiguration.AttributeDefs.battery_size.id: 4,
+        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
+        PowerConfiguration.AttributeDefs.battery_quantity.id: 2,
+    }
+
+
+class TuyaPowerConfigurationCluster2AA(PowerConfiguration, TuyaLocalCluster):
+    """PowerConfiguration cluster for devices with 2 AA."""
+
+    _CONSTANT_ATTRIBUTES = {
+        PowerConfiguration.AttributeDefs.battery_size.id: 3,
+        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
+        PowerConfiguration.AttributeDefs.battery_quantity.id: 2,
+    }
+
+
+class TuyaPowerConfigurationCluster3AA(PowerConfiguration, TuyaLocalCluster):
+    """PowerConfiguration cluster for devices with 3 AA."""
+
+    _CONSTANT_ATTRIBUTES = {
+        PowerConfiguration.AttributeDefs.battery_size.id: 3,
+        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
+        PowerConfiguration.AttributeDefs.battery_quantity.id: 3,
+    }
+
+
+class TuyaPowerConfigurationCluster4AA(PowerConfiguration, TuyaLocalCluster):
+    """PowerConfiguration cluster for devices with 4 AA."""
+
+    _CONSTANT_ATTRIBUTES = {
+        PowerConfiguration.AttributeDefs.battery_size.id: 3,
+        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
+        PowerConfiguration.AttributeDefs.battery_quantity.id: 4,
+    }

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -5,7 +5,8 @@ from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
 
-from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkBuilder
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.power_config import TuyaPowerConfigurationCluster2AAA
 
 (
     TuyaQuirkBuilder("_TZE200_bjawzodf", "TS0601")

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -21,12 +21,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import (
-    TUYA_CLUSTER_ID,
-    EnchantedDevice,
-    TuyaLocalCluster,
-    TuyaPowerConfigurationCluster4AA,
-)
+from zhaquirks.tuya import TUYA_CLUSTER_ID, EnchantedDevice, TuyaLocalCluster
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zhaquirks.tuya.mcu import (
     DPToAttributeMapping,
@@ -34,6 +29,7 @@ from zhaquirks.tuya.mcu import (
     TuyaOnOff,
     TuyaPowerConfigurationCluster,
 )
+from zhaquirks.tuya.power_config import TuyaPowerConfigurationCluster4AA
 
 
 class TuyaValveWaterConsumed(Metering, TuyaLocalCluster):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Currently `TuyaPowerConfigurationCluster2AA` and `TuyaPowerConfigurationCluster3AA` clusters inherit from `TuyaPowerConfigurationCluster` which creates a battery bus. The other TuyaPowerConfiguration clusters are built off of `TuyaLocalCluster`. This causes confusion when building a quirk via TuyaQuirkBuilder since it will fail if either of the two legacy power clusters are used.

This PR moves the power config clusters to tuya.power_config, adds 2AA and 3AA, and marks the two legacy 2AA and 3AA as Legacy.

A follow-on PR should convert the ts0601_trv quirk to use the newer style, remove the legacy clusters, and remove the import and re-export of the 2AAA and 4AA clusters from tuya/__init__.py.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
