### PR TITLE
Replace NodOn SIN-4-2-20 quirk with v2 quirk

### DIFF
--- a/zhaquirks/nodon/switch.py
+++ b/zhaquirks/nodon/switch.py
@@ -1,134 +1,14 @@
 """NodOn on/off switch two channels."""
 
-from zigpy.profiles import zgp, zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    GreenPowerProxy,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    OnOffConfiguration,
-    Ota,
-    Scenes,
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.general import LevelControl
+
+NODON = "NodOn"
+
+(
+    # this quirk is a v2 version of 7397b6a
+    QuirkBuilder(NODON, "SIN-4-2-20")
+    .removes(cluster_id=LevelControl.cluster_id, endpoint_id=1)
+    .removes(cluster_id=LevelControl.cluster_id, endpoint_id=2)
+    .add_to_registry()
 )
-from zigpy.zcl.clusters.lightlink import LightLink
-
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-
-WWAH_CLUSTER_ID = 0xFC57
-
-
-class NodOnSIN4220(CustomDevice):
-    """NodOn on/off switch two channels."""
-
-    signature = {
-        MODELS_INFO: [("NodOn", "SIN-4-2-20")],
-        ENDPOINTS: {
-            # <SimpleDescriptor endpoint=1 profile=260 device_type=256
-            # input_clusters=[0, 3, 4, 5, 6, 7, 8, 4096, 64599]
-            # output_clusters=[3, 6, 25]>
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    OnOffConfiguration.cluster_id,
-                    LevelControl.cluster_id,
-                    LightLink.cluster_id,
-                    WWAH_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    Ota.cluster_id,
-                ],
-            },
-            # <SimpleDescriptor endpoint=1 profile=260 device_type=256
-            # input_clusters=[0, 3, 4, 5, 6, 7, 8]
-            # output_clusters=[3, 6]>
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    OnOffConfiguration.cluster_id,
-                    LevelControl.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                ],
-            },
-            # <SimpleDescriptor endpoint=242 profile=41440 device_type=102
-            # input_clusters=[33]
-            # output_clusters=[33]
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.COMBO_BASIC,
-                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
-    }
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    OnOffConfiguration.cluster_id,
-                    LightLink.cluster_id,
-                    WWAH_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    Ota.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    OnOffConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                ],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.COMBO_BASIC,
-                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
-    }


### PR DESCRIPTION
## Proposed change
This PR replaces the existing quirk for NodOn SIN-4-2-20 ([7397b6a](https://github.com/zigpy/zha-device-handlers/commit/7397b6a2ebc335d2cbea9d5fc98acde1c47e904a)), which removes the LevelControl cluster for endpoints 1 and 2. The modern NodOns don't expose the LevelControl cluster (at least the one I own). This quirk would likely be relevant for SIN-4-2-20 which has not updated firmware for quite a while.


## Additional information
No user-visible changes are expected. Just a more compact code using QuirkBuilder


## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
