### PR TITLE
Fix Tuya PowerConfiguration clusters on quirks without `battery_bus`

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -892,7 +892,9 @@ class TuyaPowerConfigurationCluster(PowerConfiguration, TuyaLocalCluster):
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
-        self.endpoint.device.battery_bus.add_listener(self)
+        # listening to battery_bus required for legacy and custom Tuya TRV quirks
+        if hasattr(self.endpoint.device, "battery_bus"):
+            self.endpoint.device.battery_bus.add_listener(self)
 
     def battery_change(self, value):
         """Change of reported battery percentage remaining."""


### PR DESCRIPTION
## Proposed change
This fixes an issue where you were unable to use `TuyaPowerConfigurationCluster2AA` and `TuyaPowerConfigurationCluster3AA` in modern quirks that do not create a `battery_bus` in `CustomDevice`.

`TuyaPowerConfigurationCluster2AAA` and `TuyaPowerConfigurationCluster4AA` are already able to be used without a `battery_bus` though.

This inconsistency is fixed by this PR, whilst keeping the legacy behavior for the Tuya TRV quirks.
This is done by checking if the `battery_bus` attribute exists before we start listening to it.


## Additional information

This change is required by https://github.com/zigpy/zha-device-handlers/pull/3505

### TODO

We need to fix two(?) Tuya TRV quirks (that are immensely broken in other ways too) in our repo to no longer emit events to the `battery_bus`. That's easy, but we cannot fix custom quirks:


### Custom quirks

The Tuya TRV quirks in this repo are incomplete and broken, so everyone uses custom quirks, e.g. from here: https://github.com/jacekk015/zha_quirks

Those quirks still depend on the `battery_bus` for these clusters, so we would break a lot of people's setups. The repo alone already has 145 stars at the moment. A lot of people that use custom quirks do not even have a GitHub account, so the real usage number is much higher.

As we can easily avoid breaking these custom quirks here, we do it. 
Generally though, custom quirks remain completely unsupported.


### Future

We'll need to redo all Tuya TRV quirks. Remove all global variables (that break when you have more than one device using the same quirk), remove virtual `OnOff` and `AnalogInput` clusters for user configuration, convert those quirks to expose quirks v2 entities, and more..
Hopefully, https://github.com/zigpy/zha-device-handlers/pull/1961 can be picked up again at some point. It was really close and would have at least supported some Tuya TRVs with a good basis.
However, we should use quirks v2 entities for that and not define them in ZHA. This is especially important for Tuya devices, as there are many variations and we want contributors to easily add support for slight variations, without needing to dig in multiple codebases.

If we have fixed our Tuya TRV quirks, we can also get rid of this workaround (and remove `Bus` entirely?).


cc @prairiesnpr (per #3550 and discussion)


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
