### PR TITLE
Fix Tuya RoyalGardineer valve water consumed value

### DIFF
--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -4,6 +4,13 @@ from collections.abc import Callable
 from enum import Enum
 from typing import Any, Optional
 
+from zhaquirks.tuya import (
+    TUYA_CLUSTER_ID,
+    PowerConfiguration,
+    TuyaLocalCluster,
+    TuyaPowerConfigurationCluster2AAA,
+)
+from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster, TuyaOnOffNM
 from zigpy.quirks import _DEVICE_REGISTRY
 from zigpy.quirks.registry import DeviceRegistry
 from zigpy.quirks.v2 import QuirkBuilder, QuirksV2RegistryEntry
@@ -20,14 +27,6 @@ from zigpy.zcl.clusters.measurement import (
 )
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zcl.clusters.smartenergy import Metering
-
-from zhaquirks.tuya import (
-    TUYA_CLUSTER_ID,
-    PowerConfiguration,
-    TuyaLocalCluster,
-    TuyaPowerConfigurationCluster2AAA,
-)
-from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster, TuyaOnOffNM
 
 
 class TuyaIasContact(IasZone, TuyaLocalCluster):
@@ -144,13 +143,15 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_metering(
         self,
         dp_id: int,
+        converter: Optional[Callable[[Any], Any]] = None,
         metering_cfg: TuyaLocalCluster = TuyaValveWaterConsumed,
     ) -> QuirkBuilder:
         """Add a Tuya Metering Configuration."""
         self.tuya_dp(
             dp_id,
             metering_cfg.ep_attribute,
-            "current_summ_delivered",
+            attribute_name="current_summ_delivered",
+            converter=converter,
         )
         self.adds(metering_cfg)
         return self

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -4,13 +4,6 @@ from collections.abc import Callable
 from enum import Enum
 from typing import Any, Optional
 
-from zhaquirks.tuya import (
-    TUYA_CLUSTER_ID,
-    PowerConfiguration,
-    TuyaLocalCluster,
-    TuyaPowerConfigurationCluster2AAA,
-)
-from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster, TuyaOnOffNM
 from zigpy.quirks import _DEVICE_REGISTRY
 from zigpy.quirks.registry import DeviceRegistry
 from zigpy.quirks.v2 import QuirkBuilder, QuirksV2RegistryEntry
@@ -27,6 +20,14 @@ from zigpy.zcl.clusters.measurement import (
 )
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zcl.clusters.smartenergy import Metering
+
+from zhaquirks.tuya import (
+    TUYA_CLUSTER_ID,
+    PowerConfiguration,
+    TuyaLocalCluster,
+    TuyaPowerConfigurationCluster2AAA,
+)
+from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster, TuyaOnOffNM
 
 
 class TuyaIasContact(IasZone, TuyaLocalCluster):

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -144,15 +144,15 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_metering(
         self,
         dp_id: int,
-        converter: Optional[Callable[[Any], Any]] = None,
         metering_cfg: TuyaLocalCluster = TuyaValveWaterConsumed,
+        scale: float = 1,
     ) -> QuirkBuilder:
         """Add a Tuya Metering Configuration."""
         self.tuya_dp(
             dp_id,
             metering_cfg.ep_attribute,
             attribute_name="current_summ_delivered",
-            converter=converter,
+            converter=lambda x: x * scale,
         )
         self.adds(metering_cfg)
         return self

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -2,6 +2,16 @@
 
 from datetime import datetime, timedelta, timezone
 
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import EntityPlatform, EntityType
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
+from zigpy.zcl.clusters.smartenergy import Metering
+
 from zhaquirks import DoublingPowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -25,15 +35,6 @@ from zhaquirks.tuya.mcu import (
     TuyaOnOff,
     TuyaPowerConfigurationCluster,
 )
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.quirks.v2 import EntityPlatform, EntityType
-from zigpy.quirks.v2.homeassistant import UnitOfTime
-from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
-import zigpy.types as t
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
-from zigpy.zcl.clusters.smartenergy import Metering
 
 
 class TuyaValveWaterConsumed(Metering, TuyaLocalCluster):

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -594,7 +594,7 @@ class RoyalGardineerTimerState(t.enum8):
     .tuya_onoff(dp_id=1)
     .tuya_battery(dp_id=7, power_cfg=TuyaPowerConfigurationCluster2AA)
     # Water consumed (value comes in deciliters - convert it to liters)
-    .tuya_metering(dp_id=5, scale=1 / 10)
+    .tuya_metering(dp_id=5, scale=0.1)
     # Timer time left/remaining (raw value in seconds)
     .tuya_number(
         dp_id=11,

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -594,7 +594,7 @@ class RoyalGardineerTimerState(t.enum8):
     .tuya_onoff(dp_id=1)
     .tuya_battery(dp_id=7, power_cfg=TuyaPowerConfigurationCluster2AA)
     # Water consumed (value comes in deciliters - convert it to liters)
-    .tuya_metering(dp_id=5, converter=lambda x: x // 10)
+    .tuya_metering(dp_id=5, scale=1 / 10)
     # Timer time left/remaining (raw value in seconds)
     .tuya_number(
         dp_id=11,

--- a/zhaquirks/tuya/ts0601_valve.py
+++ b/zhaquirks/tuya/ts0601_valve.py
@@ -2,16 +2,6 @@
 
 from datetime import datetime, timedelta, timezone
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.quirks.v2 import EntityPlatform, EntityType
-from zigpy.quirks.v2.homeassistant import UnitOfTime
-from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
-import zigpy.types as t
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
-from zigpy.zcl.clusters.smartenergy import Metering
-
 from zhaquirks import DoublingPowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -35,6 +25,15 @@ from zhaquirks.tuya.mcu import (
     TuyaOnOff,
     TuyaPowerConfigurationCluster,
 )
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import EntityPlatform, EntityType
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
+from zigpy.zcl.clusters.smartenergy import Metering
 
 
 class TuyaValveWaterConsumed(Metering, TuyaLocalCluster):
@@ -593,8 +592,8 @@ class RoyalGardineerTimerState(t.enum8):
     TuyaQuirkBuilder("_TZE200_2wg5qrjy", "TS0601")
     .tuya_onoff(dp_id=1)
     .tuya_battery(dp_id=7, power_cfg=TuyaPowerConfigurationCluster2AA)
-    # Might need a converter: x // 10
-    .tuya_metering(dp_id=5)
+    # Water consumed (value comes in deciliters - convert it to liters)
+    .tuya_metering(dp_id=5, converter=lambda x: x // 10)
     # Timer time left/remaining (raw value in seconds)
     .tuya_number(
         dp_id=11,


### PR DESCRIPTION
## Proposed change
Converts RoyalGardineer valve water consumed value from deciliters to liters.

## Additional information
Changes TuyaQuirkBuilder.tuya_meterig API to allow custom value scale.

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
