### PR TITLE
Add NodOn switch options for SIN-4-1-20, SIN-4-1-21, SIN-4-2-20

### DIFF
--- a/zhaquirks/nodon/switch.py
+++ b/zhaquirks/nodon/switch.py
@@ -61,7 +61,7 @@ class OnOffSIN4_2_20(OnOff, CustomCluster):
     QuirkBuilder(NODON, "SIN-4-1-20")
     .applies_to(NODON, "SIN-4-1-21")
     .applies_to(NODON, "SIN-4-1-20_PRO")
-    # .filter() TODO this should be applied to firmware 3.5.0+, but I didn't find a way to reliably detect it .
+    # .filter() TODO this should be applied to firmware 3.4.0+, but I didn't find a way to reliably detect it .
     #           Please let me know if you know how
     .replaces(OnOffSIN4_1_20)
     .enum(
@@ -93,7 +93,7 @@ class OnOffSIN4_2_20(OnOff, CustomCluster):
     .applies_to(NODON, "SIN-4-2-20_PRO")
     .removes(cluster_id=LevelControl.cluster_id, endpoint_id=1)
     .removes(cluster_id=LevelControl.cluster_id, endpoint_id=2)
-    # .filter() TODO this should be applied to firmware 3.5.0+, but I didn't find a way to reliably detect it .
+    # .filter() TODO this should be applied to firmware 3.4.0+, but I didn't find a way to reliably detect it .
     #           Please let me know if you know how
     .replaces(OnOffSIN4_2_20, endpoint_id=1)
     .replaces(OnOffSIN4_2_20, endpoint_id=2)

--- a/zhaquirks/nodon/switch.py
+++ b/zhaquirks/nodon/switch.py
@@ -30,6 +30,7 @@ class OnOffSIN4_1_20(OnOff, CustomCluster):
             id=0x1001,
             type=NodOnSwitchType,
             zcl_type=DataTypeId.enum8,  # need to explicitly set ZCL type
+            access="rw",
             is_manufacturer_specific=True,
         )
 
@@ -37,6 +38,7 @@ class OnOffSIN4_1_20(OnOff, CustomCluster):
         impulse_mode_duration = ZCLAttributeDef(
             id=0x0001,
             type=t.uint16_t,
+            access="rw",
             is_manufacturer_specific=True,
         )
 
@@ -52,6 +54,7 @@ class OnOffSIN4_2_20(OnOff, CustomCluster):
             id=0x1001,
             type=NodOnSwitchType,
             zcl_type=DataTypeId.enum8,  # need to explicitly set ZCL type
+            access="rw",
             is_manufacturer_specific=True,
         )
 

--- a/zhaquirks/nodon/switch.py
+++ b/zhaquirks/nodon/switch.py
@@ -20,12 +20,12 @@ class NodOnSwitchType(t.enum8):
 
 
 class OnOffSIN4_1_20(OnOff, CustomCluster):
-    """NodOn custom OnOff cluster for SIN-4-1-20 and alike"""
+    """NodOn custom OnOff cluster for SIN-4-1-20 and alike."""
 
     class AttributeDefs(OnOff.AttributeDefs):
         """Attribute definitions."""
 
-        """Select the switch type wire to the device. Available from version > V3.4.0"""
+        """Select the switch type wire to the device. Available from version > V3.4.0."""
         switch_type = ZCLAttributeDef(
             id=0x1001,
             type=NodOnSwitchType,
@@ -42,12 +42,12 @@ class OnOffSIN4_1_20(OnOff, CustomCluster):
 
 
 class OnOffSIN4_2_20(OnOff, CustomCluster):
-    """NodOn custom OnOff cluster for SIN-4-2-20 and alike"""
+    """NodOn custom OnOff cluster for SIN-4-2-20 and alike."""
 
     class AttributeDefs(OnOff.AttributeDefs):
         """Attribute definitions."""
 
-        """Select the switch type wire to the device. Available from version > V3.4.0"""
+        """Select the switch type wire to the device. Available from version > V3.4.0."""
         switch_type = ZCLAttributeDef(
             id=0x1001,
             type=NodOnSwitchType,

--- a/zhaquirks/nodon/switch.py
+++ b/zhaquirks/nodon/switch.py
@@ -1,8 +1,8 @@
 """NodOn on/off switch two channels."""
 
-from zha.units import UnitOfTime
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
 from zigpy.zcl.clusters.general import LevelControl, OnOff

--- a/zhaquirks/nodon/switch.py
+++ b/zhaquirks/nodon/switch.py
@@ -1,15 +1,15 @@
 """NodOn on/off switch two channels."""
 
+from zha.units import UnitOfTime
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
-from zigpy.zcl.clusters.general import LevelControl
-from zigpy.zcl.clusters.general import OnOff
-from zigpy.zcl.foundation import ZCLAttributeDef, DataTypeId
-from zha.units import UnitOfTime
+from zigpy.zcl.clusters.general import LevelControl, OnOff
+from zigpy.zcl.foundation import DataTypeId, ZCLAttributeDef
 
 NODON = "NodOn"
+
 
 class NodOnSwitchType(t.enum8):
     """NodOn switch type."""
@@ -29,7 +29,7 @@ class OnOffSIN4_1_20(OnOff, CustomCluster):
         switch_type = ZCLAttributeDef(
             id=0x1001,
             type=NodOnSwitchType,
-            zcl_type=DataTypeId.enum8, # need to explicitly set ZCL type
+            zcl_type=DataTypeId.enum8,  # need to explicitly set ZCL type
             is_manufacturer_specific=True,
         )
 
@@ -39,6 +39,7 @@ class OnOffSIN4_1_20(OnOff, CustomCluster):
             type=t.uint16_t,
             is_manufacturer_specific=True,
         )
+
 
 class OnOffSIN4_2_20(OnOff, CustomCluster):
     """NodOn custom OnOff cluster for SIN-4-2-20 and alike"""
@@ -50,9 +51,10 @@ class OnOffSIN4_2_20(OnOff, CustomCluster):
         switch_type = ZCLAttributeDef(
             id=0x1001,
             type=NodOnSwitchType,
-            zcl_type=DataTypeId.enum8, # need to explicitly set ZCL type
+            zcl_type=DataTypeId.enum8,  # need to explicitly set ZCL type
             is_manufacturer_specific=True,
         )
+
 
 (
     # quirk is similar to https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/nodon.ts#L100
@@ -79,8 +81,8 @@ class OnOffSIN4_2_20(OnOff, CustomCluster):
         unit=UnitOfTime.MILLISECONDS,
         device_class=NumberDeviceClass.DURATION,
         initially_disabled=True,
-        translation_key='impulse_mode_duration',
-        fallback_name='Impulse mode duration',
+        translation_key="impulse_mode_duration",
+        fallback_name="Impulse mode duration",
     )
     .add_to_registry()
 )

--- a/zhaquirks/nodon/switch.py
+++ b/zhaquirks/nodon/switch.py
@@ -34,7 +34,7 @@ class OnOffSIN4_1_20(OnOff, CustomCluster):
             is_manufacturer_specific=True,
         )
 
-        """ Set the impulse duration in milliseconds (set value to 0 to deactivate the impulse mode). """
+        """Set the impulse duration in milliseconds (set value to 0 to deactivate the impulse mode). """
         impulse_mode_duration = ZCLAttributeDef(
             id=0x0001,
             type=t.uint16_t,
@@ -64,8 +64,6 @@ class OnOffSIN4_2_20(OnOff, CustomCluster):
     QuirkBuilder(NODON, "SIN-4-1-20")
     .applies_to(NODON, "SIN-4-1-21")
     .applies_to(NODON, "SIN-4-1-20_PRO")
-    # .filter() TODO this should be applied to firmware 3.4.0+, but I didn't find a way to reliably detect it .
-    #           Please let me know if you know how
     .replaces(OnOffSIN4_1_20)
     .enum(
         attribute_name=OnOffSIN4_1_20.AttributeDefs.switch_type.name,
@@ -96,8 +94,6 @@ class OnOffSIN4_2_20(OnOff, CustomCluster):
     .applies_to(NODON, "SIN-4-2-20_PRO")
     .removes(cluster_id=LevelControl.cluster_id, endpoint_id=1)
     .removes(cluster_id=LevelControl.cluster_id, endpoint_id=2)
-    # .filter() TODO this should be applied to firmware 3.4.0+, but I didn't find a way to reliably detect it .
-    #           Please let me know if you know how
     .replaces(OnOffSIN4_2_20, endpoint_id=1)
     .replaces(OnOffSIN4_2_20, endpoint_id=2)
     .enum(

--- a/zhaquirks/nodon/switch.py
+++ b/zhaquirks/nodon/switch.py
@@ -1,9 +1,45 @@
 """NodOn on/off switch two channels."""
 
+from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+import zigpy.types as t
 from zigpy.zcl.clusters.general import LevelControl
+from zigpy.zcl.clusters.general import OnOff
+from zigpy.zcl.foundation import ZCLAttributeDef
+from zha.units import UnitOfTime
 
 NODON = "NodOn"
+
+class NodOnOnOff(OnOff, CustomCluster):
+    """NodOn custom OnOff cluster"""
+
+    class AttributeDefs(OnOff.AttributeDefs):
+        """ Set the impulse duration in milliseconds (set value to 0 to deactivate the impulse mode). """
+        impulse_mode_duration = ZCLAttributeDef(
+            id=0x0001,
+            type=t.uint16_t,
+            is_manufacturer_specific=True,
+        )
+
+(
+    # quirk is similar to https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/nodon.ts#L100
+    QuirkBuilder(NODON, "SIN-4-1-20")
+    .replaces(NodOnOnOff)
+    .number(
+        attribute_name=NodOnOnOff.AttributeDefs.impulse_mode_duration.name,
+        cluster_id=NodOnOnOff.cluster_id,
+        min_value=0,
+        max_value=10000,
+        step=1,
+        unit=UnitOfTime.MILLISECONDS,
+        device_class=NumberDeviceClass.DURATION,
+        initially_disabled=True,
+        translation_key='impulse_mode_duration',
+        fallback_name='Impulse mode duration',
+    )
+    .add_to_registry()
+)
 
 (
     # this quirk is a v2 version of 7397b6a


### PR DESCRIPTION
## Proposed change
This PR adds the following configuration options for NodOn switches:

SIN-4-1-20, SIN-4-1-21, SIN-4-1-20_PRO
- switch_type (Bistable, Monostable, AutoDetect) 
   This setting is only available with firmware 3.4.0 and older. It allows one to manually configure SwitchType. In principle, NodOn switches auto-detect Toggle vs. Momentary mode. However, the auto-detection mechanism is not always reliable, and this option allows one to override it.

- impulse_mode_duration
  These switches have pulse mode, i.e., they turn off after a configured number of milliseconds. This setting allows one to configure it. 0 (the default value) means deactivation of the impulse mode.

SIN-4-2-20
- switch type (Bistable, Monostable, AutoDetect) 
  Same as above. For both endpoints.

## Additional information
The logic is a port of https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/nodon.ts#L100

This is how it looks in UI:
<img width="339" alt="Screenshot 2024-11-29 at 23 22 38" src="https://github.com/user-attachments/assets/3400a8e0-3731-45ba-ad4b-52bb63b9dce3">

All UI entities are initially disabled.

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
