### PR TITLE
Add `zcl_type` for Aqara FP1E sensor attributes

### DIFF
--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -15,7 +15,7 @@ from zigpy.quirks.v2.homeassistant import EntityType, UnitOfLength
 from zigpy.zcl.clusters.general import DeviceTemperature
 from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
-from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
 
 from zhaquirks import LocalDataCluster
 from zhaquirks.xiaomi import XiaomiAqaraE1Cluster
@@ -77,6 +77,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         motion = ZCLAttributeDef(
             id=0x0160,
             type=AqaraMotion,
+            zcl_type=DataTypeId.uint8,
             access="rp",
             is_manufacturer_specific=True,
         )
@@ -93,6 +94,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         motion_sensitivity = ZCLAttributeDef(
             id=0x010C,
             type=AqaraMotionSensitivity,
+            zcl_type=DataTypeId.uint8,
             access="rw",
             is_manufacturer_specific=True,
         )
@@ -101,6 +103,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         occupancy = ZCLAttributeDef(
             id=0x0142,
             type=AqaraOccupancy,
+            zcl_type=DataTypeId.uint8,
             access="rp",
             is_manufacturer_specific=True,
         )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Addresses the bug raised https://github.com/zigpy/zha-device-handlers/issues/3597

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

Following investigation of the errors documented in https://github.com/zigpy/zha-device-handlers/issues/3597 and feedback from @TheJulianJES in https://github.com/zigpy/zha-device-handlers/issues/3597#issuecomment-2526306000 I've explicitly defined zcl_type for attributes documented using enums and validated that writes to the attribute now complete successfully without introducing further issues.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
