### PR TITLE
Use ClusterListener in Tuya test example

### DIFF
--- a/tuya.md
+++ b/tuya.md
@@ -269,8 +269,7 @@ async def test_tuya():
     quirked = zigpy_device_from_v2_quirk(model, manuf)
     ep = quirked.endpoints[1]
 
-    assert ep.basic is not None
-    assert isinstance(ep.basic, Basic)
+    temperature_listener = ClusterListener(ep.temperature)
 
     assert ep.tuya_manufacturer is not None
     assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
@@ -281,8 +280,9 @@ async def test_tuya():
     status = ep.tuya_manufacturer.handle_get_data(data.data)
     assert status == foundation.Status.SUCCESS
 
+    assert len(temperature_listener.attribute_updates) == 1
     assert (
-        ep.temperature.get("measured_value")
+        temperature_listener.attribute_updates[0][1]
         == data.data.datapoints[0].data.payload * temp_scale
     )
 ```


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Change the example test in TuyaQuirkBuilder docs to use ClusterListener and remove the Basic cluster test.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
