### PR TITLE
Fix duplicate opening sensor for `_TZE200_pay2byax`

### DIFF
--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -1,7 +1,5 @@
 """Tuya temp and humidity sensors."""
 
-from zigpy.quirks.v2.homeassistant import EntityType
-from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
 
@@ -90,13 +88,7 @@ from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkB
         device_class=SensorDeviceClass.ILLUMINANCE,
         state_class=SensorStateClass.MEASUREMENT,
     )
-    .tuya_binary_sensor(
-        dp_id=1,
-        attribute_name="zone_status",
-        device_class=BinarySensorDeviceClass.OPENING,
-        fallback_name="Opening",
-        entity_type=EntityType.STANDARD,
-    )
+    .tuya_contact(dp_id=1)
     .tuya_battery(dp_id=2)
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
![image](https://github.com/user-attachments/assets/c4cbe289-4d99-4229-8662-f36354168453)

This should fix the issue with duplicate opening sensor for Tuya _TZE200_pay2byax.  

Tested only as a custom quirk, not the end result as only my production machine has a zigbee radio.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


```python
"""Tuya temp and humidity sensors."""
from zigpy.quirks import DEVICE_REGISTRY
from zigpy.quirks.v2 import QuirkBuilder
from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
import zigpy.types as t
from zigpy.zcl.clusters.security import IasZone, ZoneType

from zhaquirks.tuya import TuyaLocalCluster
from zhaquirks.tuya.builder import TuyaQuirkBuilder

del DEVICE_REGISTRY._registry_v2[("_TZE200_pay2byax", "TS0601")]
del DEVICE_REGISTRY._registry_v2[("_TZE200_n8dljorx",  "TS0601")]

class TuyaIASContact(TuyaLocalCluster, IasZone):
    """Custom IasZone cluster that represents the Open/Closed sensor."""

    _CONSTANT_ATTRIBUTES = {
        IasZone.AttributeDefs.zone_type.id: ZoneType.Contact_Switch,
    }

class CustomTuyaQuirkBuilder(TuyaQuirkBuilder):
        
    def tuya_contact(
        self,
        dp_id: int,
        ias_cfg:  TuyaLocalCluster = TuyaIASContact,
    ) -> QuirkBuilder:
        """Add a Tuya contact switch configuration."""
        self.tuya_dp(
            dp_id,
            ias_cfg.ep_attribute,
            IasZone.AttributeDefs.zone_status.name,
        )
        self.adds(ias_cfg)
        return self

(
    CustomTuyaQuirkBuilder("_TZE200_pay2byax", "TS0601")
    .applies_to("_TZE200_n8dljorx",  "TS0601")
    .tuya_sensor(
        dp_id=101,
        attribute_name="measured_value",
        type=t.uint16_t,
        fallback_name="Illuminance",
        device_class=SensorDeviceClass.ILLUMINANCE,
        state_class=SensorStateClass.MEASUREMENT,
    )
    .tuya_contact(dp_id=1)
    .tuya_battery(dp_id=2)
    .skip_configuration()
    .add_to_registry()
)

```

Fixes: https://github.com/home-assistant/core/issues/132669

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
