### PR TITLE
Split Tuya IAS function into contact & smoke

### DIFF
--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -13,6 +13,8 @@ from zigpy.zcl.clusters.general import Basic
 from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
 from zhaquirks.tuya.builder import (
+    TuyaIASContact,
+    TuyaIASFire,
     TuyaPowerConfigurationCluster2AAA,
     TuyaQuirkBuilder,
     TuyaRelativeHumidity,
@@ -46,6 +48,41 @@ def real_device(MockAppController):
     return device
 
 
+@pytest.mark.parametrize(
+    "method_name,attr_name,exp_class",
+    [
+        ("tuya_battery", "power", TuyaPowerConfigurationCluster2AAA),
+        ("tuya_metering", "smartenergy_metering", TuyaValveWaterConsumed),
+        ("tuya_onoff", "on_off", TuyaOnOffNM),
+        ("tuya_soil_moisture", "soil_moisture", TuyaSoilMoisture),
+        ("tuya_temperature", "temperature", TuyaTemperatureMeasurement),
+        ("tuya_humidity", "humidity", TuyaRelativeHumidity),
+        ("tuya_smoke", "ias_zone", TuyaIASFire),
+        ("tuya_contact", "ias_zone", TuyaIASContact),
+    ],
+)
+async def test_convenience_methods(device_mock, method_name, attr_name, exp_class):
+    """Test TuyaQuirkBuilder convenience methods."""
+
+    registry = DeviceRegistry()
+
+    entry = TuyaQuirkBuilder(
+        device_mock.manufacturer, device_mock.model, registry=registry
+    )
+    entry = getattr(entry, method_name)(dp_id=1)
+    entry.skip_configuration().skip_configuration().add_to_registry()
+
+    quirked = registry.get_device(device_mock)
+    assert isinstance(quirked, CustomDeviceV2)
+    assert quirked in registry
+
+    ep = quirked.endpoints[1]
+
+    ep_attr = getattr(ep, attr_name)
+    assert ep_attr is not None
+    assert isinstance(ep_attr, exp_class)
+
+
 async def test_tuya_quirkbuilder(device_mock):
     """Test adding a v2 Tuya Quirk to the registry and getting back a quirked device."""
 
@@ -60,10 +97,7 @@ async def test_tuya_quirkbuilder(device_mock):
     entry = (
         TuyaQuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
         .tuya_battery(dp_id=1)
-        .tuya_metering(dp_id=2)
         .tuya_onoff(dp_id=3)
-        .tuya_soil_moisture(dp_id=4)
-        .tuya_temperature(dp_id=5)
         .tuya_switch(
             dp_id=6,
             attribute_name="test_onoff",
@@ -97,7 +131,7 @@ async def test_tuya_quirkbuilder(device_mock):
             translation_key="test_enum",
             fallback_name="Test enum",
         )
-        .tuya_humidity(dp_id=11)
+        .skip_configuration()
         .add_to_registry()
     )
 
@@ -125,24 +159,6 @@ async def test_tuya_quirkbuilder(device_mock):
     assert tuya_cluster.attributes_by_name["test_binary"].id == 0xEF08
     assert tuya_cluster.attributes_by_name["test_sensor"].id == 0xEF09
     assert tuya_cluster.attributes_by_name["test_enum"].id == 0xEF0A
-
-    assert ep.power is not None
-    assert isinstance(ep.power, TuyaPowerConfigurationCluster2AAA)
-
-    assert ep.smartenergy_metering is not None
-    assert isinstance(ep.smartenergy_metering, TuyaValveWaterConsumed)
-
-    assert ep.on_off is not None
-    assert isinstance(ep.on_off, TuyaOnOffNM)
-
-    assert ep.soil_moisture is not None
-    assert isinstance(ep.soil_moisture, TuyaSoilMoisture)
-
-    assert ep.temperature is not None
-    assert isinstance(ep.temperature, TuyaTemperatureMeasurement)
-
-    assert ep.humidity is not None
-    assert isinstance(ep.humidity, TuyaRelativeHumidity)
 
     with mock.patch.object(
         tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS

--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -70,7 +70,7 @@ async def test_convenience_methods(device_mock, method_name, attr_name, exp_clas
         device_mock.manufacturer, device_mock.model, registry=registry
     )
     entry = getattr(entry, method_name)(dp_id=1)
-    entry.skip_configuration().skip_configuration().add_to_registry()
+    entry.skip_configuration().add_to_registry()
 
     quirked = registry.get_device(device_mock)
     assert isinstance(quirked, CustomDeviceV2)

--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -13,8 +13,8 @@ from zigpy.zcl.clusters.general import Basic
 from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
 from zhaquirks.tuya.builder import (
-    TuyaIASContact,
-    TuyaIASFire,
+    TuyaIasContact,
+    TuyaIasFire,
     TuyaPowerConfigurationCluster2AAA,
     TuyaQuirkBuilder,
     TuyaRelativeHumidity,
@@ -57,8 +57,8 @@ def real_device(MockAppController):
         ("tuya_soil_moisture", "soil_moisture", TuyaSoilMoisture),
         ("tuya_temperature", "temperature", TuyaTemperatureMeasurement),
         ("tuya_humidity", "humidity", TuyaRelativeHumidity),
-        ("tuya_smoke", "ias_zone", TuyaIASFire),
-        ("tuya_contact", "ias_zone", TuyaIASContact),
+        ("tuya_smoke", "ias_zone", TuyaIasFire),
+        ("tuya_contact", "ias_zone", TuyaIasContact),
     ],
 )
 async def test_convenience_methods(device_mock, method_name, attr_name, exp_class):

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -30,8 +30,16 @@ from zhaquirks.tuya import (
 from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster, TuyaOnOffNM
 
 
+class TuyaIASContact(IasZone, TuyaLocalCluster):
+    """Tuya local IAS contact cluster."""
+
+    _CONSTANT_ATTRIBUTES = {
+        IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Contact_Switch
+    }
+
+
 class TuyaIASFire(IasZone, TuyaLocalCluster):
-    """Tuya local IAS cluster."""
+    """Tuya local IAS smoke/fire cluster."""
 
     _CONSTANT_ATTRIBUTES = {
         IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Fire_Sensor
@@ -99,6 +107,40 @@ class TuyaQuirkBuilder(QuirkBuilder):
         self.adds(power_cfg)
         return self
 
+    def tuya_contact(self, dp_id: int):
+        """Add a Tuya IAS contact sensor."""
+        self.tuya_ias(
+            dp_id=dp_id,
+            ias_cfg=TuyaIASContact,
+            converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 1 else 0,
+        )
+        return self
+
+    def tuya_smoke(self, dp_id: int):
+        """Add a Tuya IAS smoke/fire sensor."""
+        self.tuya_ias(
+            dp_id=dp_id,
+            ias_cfg=TuyaIASFire,
+            converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 0 else 0,
+        )
+        return self
+
+    def tuya_ias(
+        self,
+        dp_id: int,
+        ias_cfg: TuyaLocalCluster,
+        converter: Optional[Callable[[Any], Any]] = None,
+    ) -> QuirkBuilder:
+        """Add a Tuya IAS Configuration."""
+        self.tuya_dp(
+            dp_id,
+            ias_cfg.ep_attribute,
+            IasZone.AttributeDefs.zone_status.name,
+            converter=converter,
+        )
+        self.adds(ias_cfg)
+        return self
+
     def tuya_metering(
         self,
         dp_id: int,
@@ -111,21 +153,6 @@ class TuyaQuirkBuilder(QuirkBuilder):
             "current_summ_delivered",
         )
         self.adds(metering_cfg)
-        return self
-
-    def tuya_ias(
-        self,
-        dp_id: int,
-        ias_cfg: TuyaLocalCluster = TuyaIASFire,
-    ) -> QuirkBuilder:
-        """Add a Tuya IAS Configuration."""
-        self.tuya_dp(
-            dp_id,
-            ias_cfg.ep_attribute,
-            IasZone.AttributeDefs.zone_status.name,
-            converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 0 else 0,
-        )
-        self.adds(ias_cfg)
         return self
 
     def tuya_onoff(

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -30,7 +30,7 @@ from zhaquirks.tuya import (
 from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster, TuyaOnOffNM
 
 
-class TuyaIASContact(IasZone, TuyaLocalCluster):
+class TuyaIasContact(IasZone, TuyaLocalCluster):
     """Tuya local IAS contact cluster."""
 
     _CONSTANT_ATTRIBUTES = {
@@ -38,7 +38,7 @@ class TuyaIASContact(IasZone, TuyaLocalCluster):
     }
 
 
-class TuyaIASFire(IasZone, TuyaLocalCluster):
+class TuyaIasFire(IasZone, TuyaLocalCluster):
     """Tuya local IAS smoke/fire cluster."""
 
     _CONSTANT_ATTRIBUTES = {
@@ -111,7 +111,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         """Add a Tuya IAS contact sensor."""
         self.tuya_ias(
             dp_id=dp_id,
-            ias_cfg=TuyaIASContact,
+            ias_cfg=TuyaIasContact,
             converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x != 0 else 0,
         )
         return self
@@ -120,7 +120,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         """Add a Tuya IAS smoke/fire sensor."""
         self.tuya_ias(
             dp_id=dp_id,
-            ias_cfg=TuyaIASFire,
+            ias_cfg=TuyaIasFire,
             converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 0 else 0,
         )
         return self

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -112,7 +112,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         self.tuya_ias(
             dp_id=dp_id,
             ias_cfg=TuyaIASContact,
-            converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 1 else 0,
+            converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x != 0 else 0,
         )
         return self
 

--- a/zhaquirks/tuya/tuya_smoke.py
+++ b/zhaquirks/tuya/tuya_smoke.py
@@ -12,14 +12,14 @@ from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkB
     .applies_to("_TZE204_vawy74yh", "TS0601")
     .applies_to("_TZE284_0zaf1cr8", "TS0601")
     .applies_to("_TZ3210_up3pngle", "TS0205")
-    .tuya_ias(dp_id=1)
+    .tuya_smoke(dp_id=1)
     .skip_configuration()
     .add_to_registry()
 )
 
 (
     TuyaQuirkBuilder("_TZE204_ntcy3xu1", "TS0601")
-    .tuya_ias(dp_id=1)
+    .tuya_smoke(dp_id=1)
     .tuya_dp(
         dp_id=14,
         ep_attribute=TuyaPowerConfigurationCluster2AAA.ep_attribute,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Originally, we had tuya_ias with the intention of having one method to handle any IAS requirements. Looking at https://github.com/zigpy/zha-device-handlers/pull/3605, I think having separate convenience methods does make sense. Unfortunately, adding `tuya_contact` for contact sensors while retaining `tuya_ias` for Fire/smoke sensors would be confusing. This PR add `tuya_contact` and `tuya_smoke` and then modifies `tuya_ias` to accept a converter.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
