### PR TITLE
Convert Tuya motion quirks to v2, add `_TZE200_ya4ft0w4`

### DIFF
--- a/tests/test_tuya_motion.py
+++ b/tests/test_tuya_motion.py
@@ -11,29 +11,32 @@ from zhaquirks.tuya.mcu import TuyaMCUCluster
 
 ZCL_TUYA_MOTION = b"\tL\x01\x00\x05\x01\x01\x00\x01\x01"  # DP 1
 ZCL_TUYA_MOTION_V2 = b"\tL\x01\x00\x05\x65\x01\x00\x01\x01"  # DP 101
+ZCL_TUYA_MOTION_V3 = b"\tL\x01\x00\x05\x03\x04\x00\x01\x02"  # DP 3, enum
 
 
 zhaquirks.setup()
 
 
 @pytest.mark.parametrize(
-    "model,manuf,occ_dp",
+    "model,manuf,occ_msg",
     [
-        ("_TZE200_ya4ft0w4", "TS0601", 1),
-        ("_TZE200_7hfcudw5", "TS0601", 101),
-        ("_TZE200_ppuj1vem", "TS0601", 101),
-        ("_TZE200_ar0slwnd", "TS0601", 1),
-        ("_TZE200_mrf6vtua", "TS0601", 1),
-        ("_TZE200_sfiy5tfs", "TS0601", 1),
-        ("_TZE204_sooucan5", "TS0601", 1),
-        ("_TZE200_wukb7rhc", "TS0601", 1),
-        ("_TZE204_qasjif9e", "TS0601", 1),
-        ("_TZE200_ztc6ggyl", "TS0601", 1),
-        ("_TZE204_ztc6ggyl", "TS0601", 1),
-        ("_TZE204_ztqnh5cg", "TS0601", 1),
+        ("_TZE200_ya4ft0w4", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE200_7hfcudw5", "TS0601", ZCL_TUYA_MOTION_V2),
+        ("_TZE200_ppuj1vem", "TS0601", ZCL_TUYA_MOTION_V2),
+        ("_TZE200_ar0slwnd", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE200_mrf6vtua", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE200_sfiy5tfs", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE204_sooucan5", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE200_wukb7rhc", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE204_qasjif9e", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE200_ztc6ggyl", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE204_ztc6ggyl", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE204_ztqnh5cg", "TS0601", ZCL_TUYA_MOTION),
+        ("_TYST11_i5j6ifxj", "5j6ifxj", ZCL_TUYA_MOTION_V3),
+        ("_TYST11_7hfcudw5", "hfcudw5", ZCL_TUYA_MOTION_V3),
     ],
 )
-async def test_tuya_motion_quirk(zigpy_device_from_v2_quirk, model, manuf, occ_dp):
+async def test_tuya_motion_quirk(zigpy_device_from_v2_quirk, model, manuf, occ_msg):
     """Test Tuya Motion Quirks."""
     quirked_device = zigpy_device_from_v2_quirk(model, manuf)
     ep = quirked_device.endpoints[1]
@@ -46,9 +49,7 @@ async def test_tuya_motion_quirk(zigpy_device_from_v2_quirk, model, manuf, occ_d
 
     occupancy_listener = ClusterListener(ep.occupancy)
 
-    hdr, data = ep.tuya_manufacturer.deserialize(
-        ZCL_TUYA_MOTION if occ_dp == 1 else ZCL_TUYA_MOTION_V2
-    )
+    hdr, data = ep.tuya_manufacturer.deserialize(occ_msg)
     status = ep.tuya_manufacturer.handle_get_data(data.data)
 
     assert status == foundation.Status.SUCCESS

--- a/tests/test_tuya_motion.py
+++ b/tests/test_tuya_motion.py
@@ -1,0 +1,63 @@
+"""Tests for Tuya quirks."""
+
+import pytest
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.measurement import OccupancySensing
+
+from tests.common import ClusterListener
+import zhaquirks
+import zhaquirks.tuya
+from zhaquirks.tuya.mcu import TuyaMCUCluster
+
+ZCL_TUYA_MOTION = b"\tL\x01\x00\x05\x01\x01\x00\x01\x01"  # DP 1
+ZCL_TUYA_MOTION_V2 = b"\tL\x01\x00\x05\x65\x01\x00\x01\x01"  # DP 101
+
+
+zhaquirks.setup()
+
+
+@pytest.mark.parametrize(
+    "model,manuf,occ_dp",
+    [
+        ("_TZE200_ya4ft0w4", "TS0601", 1),
+        ("_TZE200_7hfcudw5", "TS0601", 101),
+        ("_TZE200_ppuj1vem", "TS0601", 101),
+        ("_TZE200_ar0slwnd", "TS0601", 1),
+        ("_TZE200_mrf6vtua", "TS0601", 1),
+        ("_TZE200_sfiy5tfs", "TS0601", 1),
+        ("_TZE204_sooucan5", "TS0601", 1),
+        ("_TZE200_wukb7rhc", "TS0601", 1),
+        ("_TZE204_qasjif9e", "TS0601", 1),
+        ("_TZE200_ztc6ggyl", "TS0601", 1),
+        ("_TZE204_ztc6ggyl", "TS0601", 1),
+        ("_TZE204_ztqnh5cg", "TS0601", 1),
+    ],
+)
+async def test_tuya_motion_quirk(zigpy_device_from_v2_quirk, model, manuf, occ_dp):
+    """Test Tuya Motion Quirks."""
+    quirked_device = zigpy_device_from_v2_quirk(model, manuf)
+    ep = quirked_device.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+
+    assert ep.occupancy is not None
+    assert isinstance(ep.occupancy, OccupancySensing)
+
+    occupancy_listener = ClusterListener(ep.occupancy)
+
+    hdr, data = ep.tuya_manufacturer.deserialize(
+        ZCL_TUYA_MOTION if occ_dp == 1 else ZCL_TUYA_MOTION_V2
+    )
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+
+    assert status == foundation.Status.SUCCESS
+
+    zcl_occupancy_id = OccupancySensing.AttributeDefs.occupancy.id
+
+    assert len(occupancy_listener.attribute_updates) == 1
+    assert occupancy_listener.attribute_updates[0][0] == zcl_occupancy_id
+    assert (
+        occupancy_listener.attribute_updates[0][1]
+        == OccupancySensing.Occupancy.Occupied
+    )

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -128,7 +128,7 @@ base_tuya_motion = (
         dp_id=101,
         ep_attribute=TuyaOccupancySensing.ep_attribute,
         attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
-        converter=lambda x: True if x == 1 else False,
+        converter=lambda x: x == 1,
     )
     .adds(TuyaOccupancySensing)
     .tuya_temperature(dp_id=104, scale=10)
@@ -152,7 +152,7 @@ base_tuya_motion = (
         dp_id=1,
         ep_attribute=TuyaOccupancySensing.ep_attribute,
         attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
-        converter=lambda x: True if x == 1 else False,
+        converter=lambda x: x == 1,
     )
     # 103?
     .tuya_dp(
@@ -173,7 +173,7 @@ base_tuya_motion = (
         dp_id=3,
         ep_attribute=TuyaOccupancySensing.ep_attribute,
         attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
-        converter=lambda x: True if x == 2 else False,
+        converter=lambda x: x == 2,
     )
     .adds(TuyaOccupancySensing)
     .skip_configuration()

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -1,473 +1,224 @@
 """BlitzWolf IS-3/Tuya motion rechargeable occupancy sensor."""
 
 import math
-from typing import Optional, Union
 
-from zigpy.profiles import zgp, zha
-from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import EntityType
+from zigpy.quirks.v2.homeassistant import UnitOfLength, UnitOfTime
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import (
-    AnalogInput,
-    Basic,
-    GreenPowerProxy,
-    Groups,
-    Identify,
-    Ota,
-    Scenes,
-    Time,
-)
-from zigpy.zcl.clusters.measurement import (
-    IlluminanceMeasurement,
-    OccupancySensing,
-    RelativeHumidity,
-    TemperatureMeasurement,
-)
-from zigpy.zcl.clusters.security import IasZone
+from zigpy.zcl.clusters.measurement import IlluminanceMeasurement, OccupancySensing
 
-from zhaquirks import Bus, LocalDataCluster, MotionOnEvent
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    MOTION_EVENT,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-from zhaquirks.tuya import (
-    DPToAttributeMapping,
-    TuyaLocalCluster,
-    TuyaManufCluster,
-    TuyaNewManufCluster,
-)
-from zhaquirks.tuya.mcu import TuyaMCUCluster
+from zhaquirks.tuya import TuyaLocalCluster
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
-ZONE_TYPE = 0x0001
+
+class TuyaIlluminanceCluster(IlluminanceMeasurement, TuyaLocalCluster):
+    """Tuya Illuminance cluster."""
 
 
 class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
     """Tuya local OccupancySensing cluster."""
 
 
-class TuyaAnalogInput(AnalogInput, TuyaLocalCluster):
-    """Tuya local AnalogInput cluster."""
+(
+    TuyaQuirkBuilder("_TZE200_ya4ft0w4", "TS0601")
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=TuyaOccupancySensing.ep_attribute,
+        attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
+        converter=lambda x: True if x in (1, 2) else False,
+    )
+    .adds(TuyaOccupancySensing)
+    .tuya_number(
+        dp_id=2,
+        attribute_name="move_sensitivity",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=10,
+        step=1,
+        translation_key="move_sensitivity",
+        fallback_name="Motion sensitivity",
+    )
+    .tuya_number(
+        dp_id=3,
+        attribute_name="detection_distance_min",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.DISTANCE,
+        unit=UnitOfLength.METERS,
+        min_value=0,
+        max_value=8.25,
+        step=0.75,
+        translation_key="detection_distance_min",
+        fallback_name="Minimum range",
+    )
+    .tuya_number(
+        dp_id=4,
+        attribute_name="detection_distance_max",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.DISTANCE,
+        unit=UnitOfLength.METERS,
+        min_value=0.75,
+        max_value=9.0,
+        step=0.75,
+        translation_key="detection_distance_max",
+        fallback_name="Maximum range",
+    )
+    .tuya_sensor(
+        dp_id=9,
+        attribute_name="distance",
+        type=t.uint16_t,
+        divisor=10,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.DISTANCE,
+        unit=UnitOfLength.METERS,
+        entity_type=EntityType.STANDARD,
+        translation_key="distance",
+        fallback_name="Target distance",
+    )
+    .tuya_switch(
+        dp_id=101,
+        attribute_name="find_switch",
+        entity_type=EntityType.STANDARD,
+        translation_key="find_switch",
+        fallback_name="Distance switch",
+    )
+    .tuya_number(
+        dp_id=102,
+        attribute_name="presence_sensitivity",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=10,
+        step=1,
+        translation_key="presence_sensitivity",
+        fallback_name="Presence sensitivity",
+    )
+    .tuya_dp(
+        dp_id=103,
+        ep_attribute=TuyaIlluminanceCluster.ep_attribute,
+        attribute_name=TuyaIlluminanceCluster.AttributeDefs.measured_value.name,
+    )
+    .adds(TuyaIlluminanceCluster)
+    .tuya_number(
+        dp_id=105,
+        attribute_name="presence_timeout",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        min_value=1,
+        max_value=15000,
+        step=1,
+        translation_key="presence_timeout",
+        fallback_name="Fade time",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)
 
+# Neo motion, NAS-PD07 occupancy sensor
+(
+    TuyaQuirkBuilder("_TZE200_7hfcudw5", "TS0601")
+    .applies_to("_TZE200_ppuj1vem", "TS0601")
+    .tuya_dp(
+        dp_id=101,
+        ep_attribute=TuyaOccupancySensing.ep_attribute,
+        attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
+        converter=lambda x: True if x == 1 else False,
+    )
+    .adds(TuyaOccupancySensing)
+    .tuya_temperature(dp_id=104, scale=10)
+    .tuya_humidity(dp_id=105)
+    .skip_configuration()
+    .add_to_registry()
+)
 
-class TuyaIlluminanceMeasurement(IlluminanceMeasurement, TuyaLocalCluster):
-    """Tuya local IlluminanceMeasurement cluster."""
-
-
-class TuyaTemperatureMeasurement(TemperatureMeasurement, TuyaLocalCluster):
-    """Tuya local TemperatureMeasurement cluster."""
-
-
-class TuyaRelativeHumidity(RelativeHumidity, TuyaLocalCluster):
-    """Tuya local RelativeHumidity cluster."""
-
-
-class NeoBatteryLevel(t.enum8):
-    """NEO battery level enum."""
-
-    BATTERY_FULL = 0x00
-    BATTERY_HIGH = 0x01
-    BATTERY_MEDIUM = 0x02
-    BATTERY_LOW = 0x03
-    USB_POWER = 0x04
-
-
-class NeoMotionManufCluster(TuyaNewManufCluster):
-    """Neo manufacturer cluster."""
-
-    class AttributeDefs(TuyaNewManufCluster.AttributeDefs):
-        """Attribute Definitions."""
-
-        dp_113 = foundation.ZCLAttributeDef(
-            id=0xEF0D,
-            type=t.enum8,
-            is_manufacturer_specific=True,
-        )  # random attribute ID
-
-    dp_to_attribute: dict[int, DPToAttributeMapping] = {
-        101: DPToAttributeMapping(
-            TuyaOccupancySensing.ep_attribute,
-            "occupancy",
-        ),
-        104: DPToAttributeMapping(
-            TuyaTemperatureMeasurement.ep_attribute,
-            "measured_value",
-            lambda x: x * 10,
-        ),
-        105: DPToAttributeMapping(
-            TuyaRelativeHumidity.ep_attribute,
-            "measured_value",
-            lambda x: x * 100,
-        ),
-        113: DPToAttributeMapping(
-            TuyaNewManufCluster.ep_attribute,
-            "dp_113",
-        ),
-    }
-
-    data_point_handlers = {
-        101: "_dp_2_attr_update",
-        104: "_dp_2_attr_update",
-        105: "_dp_2_attr_update",
-        113: "_dp_2_attr_update",
-    }
-
-
-class MmwRadarManufCluster(TuyaMCUCluster):
-    """Neo manufacturer cluster."""
-
-    # # Possible DPs and values
-    # presence_state: presence
-    # target distance: 1.61m
-    # illuminance: 250lux
-    # sensitivity: 9
-    # minimum_detection_distance: 0.00m
-    # maximum_detection_distance: 4.05m
-    # dp_detection_delay: 0.1
-    # dp_fading_time: 5.0
-    # ¿illuminance?: 255lux
-    # presence_brightness: no control
-    # no_one_brightness: no control
-    # current_brightness: off
-
-    class AttributeDefs(TuyaMCUCluster.AttributeDefs):
-        """Attribute Definitions."""
-
-        dp_2 = foundation.ZCLAttributeDef(
-            id=0xEF02, type=t.uint32_t, is_manufacturer_specific=True
-        )
-        dp_3 = foundation.ZCLAttributeDef(
-            id=0xEF03, type=t.uint32_t, is_manufacturer_specific=True
-        )
-        dp_4 = foundation.ZCLAttributeDef(
-            id=0xEF04, type=t.uint32_t, is_manufacturer_specific=True
-        )
-        dp_6 = foundation.ZCLAttributeDef(
-            id=0xEF06, type=t.enum8, is_manufacturer_specific=True
-        )
-        dp_101 = foundation.ZCLAttributeDef(
-            id=0xEF65, type=t.uint32_t, is_manufacturer_specific=True
-        )
-        dp_102 = foundation.ZCLAttributeDef(
-            id=0xEF66, type=t.uint32_t, is_manufacturer_specific=True
-        )
-        dp_103 = foundation.ZCLAttributeDef(
-            id=0xEF67, type=t.CharacterString, is_manufacturer_specific=True
-        )
-        dp_105 = foundation.ZCLAttributeDef(
-            id=0xEF69, type=t.enum8, is_manufacturer_specific=True
-        )
-        dp_106 = foundation.ZCLAttributeDef(
-            id=0xEF6A, type=t.enum8, is_manufacturer_specific=True
-        )
-        dp_107 = foundation.ZCLAttributeDef(
-            id=0xEF6B, type=t.enum8, is_manufacturer_specific=True
-        )
-        dp_108 = foundation.ZCLAttributeDef(
-            id=0xEF6C, type=t.uint32_t, is_manufacturer_specific=True
-        )
-
-    dp_to_attribute: dict[int, DPToAttributeMapping] = {
-        1: DPToAttributeMapping(
-            TuyaOccupancySensing.ep_attribute,
-            "occupancy",
-        ),
-        2: DPToAttributeMapping(
-            TuyaMCUCluster.ep_attribute,
-            "dp_2",
-        ),
-        3: DPToAttributeMapping(
-            TuyaMCUCluster.ep_attribute,
-            "dp_3",
-        ),
-        4: DPToAttributeMapping(
-            TuyaMCUCluster.ep_attribute,
-            "dp_4",
-        ),
-        6: DPToAttributeMapping(
-            TuyaMCUCluster.ep_attribute,
-            "dp_6",
-        ),
-        9: DPToAttributeMapping(
-            TuyaAnalogInput.ep_attribute,
-            "present_value",
-            lambda x: x / 100,
-        ),
-        101: DPToAttributeMapping(
-            TuyaMCUCluster.ep_attribute,
-            "dp_101",
-        ),
-        102: DPToAttributeMapping(
-            TuyaMCUCluster.ep_attribute,
-            "dp_102",
-        ),
-        103: DPToAttributeMapping(
-            TuyaMCUCluster.ep_attribute,
-            "dp_103",
-        ),
-        104: DPToAttributeMapping(
-            TuyaIlluminanceMeasurement.ep_attribute,
-            "measured_value",
-            lambda x: 10000 * math.log10(x) + 1 if x != 0 else 0,
-        ),
-        105: DPToAttributeMapping(
-            TuyaMCUCluster.ep_attribute,
-            "dp_105",
-        ),
-        106: DPToAttributeMapping(
-            TuyaMCUCluster.ep_attribute,
-            "dp_106",
-        ),
-        107: DPToAttributeMapping(
-            TuyaMCUCluster.ep_attribute,
-            "dp_107",
-        ),
-        108: DPToAttributeMapping(
-            TuyaMCUCluster.ep_attribute,
-            "dp_108",
-        ),
-    }
-
-    data_point_handlers = {
-        1: "_dp_2_attr_update",
-        2: "_dp_2_attr_update",
-        3: "_dp_2_attr_update",
-        4: "_dp_2_attr_update",
-        6: "_dp_2_attr_update",
-        9: "_dp_2_attr_update",
-        101: "_dp_2_attr_update",
-        102: "_dp_2_attr_update",
-        103: "_dp_2_attr_update",
-        104: "_dp_2_attr_update",
-        105: "_dp_2_attr_update",
-        106: "_dp_2_attr_update",
-        107: "_dp_2_attr_update",
-        108: "_dp_2_attr_update",
-    }
-
-
-class MotionCluster(LocalDataCluster, MotionOnEvent):
-    """Tuya Motion Sensor."""
-
-    _CONSTANT_ATTRIBUTES = {ZONE_TYPE: IasZone.ZoneType.Motion_Sensor}
-    reset_s = 15
-
-
-class TuyaManufacturerClusterMotion(TuyaManufCluster):
-    """Manufacturer Specific Cluster of the Motion device."""
-
-    def handle_cluster_request(
-        self,
-        hdr: foundation.ZCLHeader,
-        args: tuple[TuyaManufCluster.Command],
-        *,
-        dst_addressing: Optional[
-            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        ] = None,
-    ) -> None:
-        """Handle cluster request."""
-        tuya_cmd = args[0]
-        self.debug("handle_cluster_request--> hdr: %s, args: %s", hdr, args)
-        if hdr.command_id == 0x0001 and tuya_cmd.command_id == 1027:
-            self.endpoint.device.motion_bus.listener_event(MOTION_EVENT)
-
-
-class TuyaMotion(CustomDevice):
-    """BW-IS3 occupancy sensor."""
-
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.motion_bus = Bus()
-        super().__init__(*args, **kwargs)
-
-    signature = {
-        #  endpoint=1 profile=260 device_type=0 device_version=0 input_clusters=[0, 3]
-        #  output_clusters=[3, 25]>
-        MODELS_INFO: [("_TYST11_i5j6ifxj", "5j6ifxj"), ("_TYST11_7hfcudw5", "hfcudw5")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
-                INPUT_CLUSTERS: [Basic.cluster_id, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    MotionCluster,
-                    TuyaManufacturerClusterMotion,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        }
-    }
-
-
-class NeoMotion(CustomDevice):
-    """NAS-PD07 occupancy sensor."""
-
-    signature = {
-        #  endpoint=1 profile=260 device_type=81 device_version=0 input_clusters=[0, 4, 5, 61184]
-        #  output_clusters=[10, 25]>
-        MODELS_INFO: [
-            ("_TZE200_7hfcudw5", "TS0601"),
-            ("_TZE200_ppuj1vem", "TS0601"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    NeoMotionManufCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    NeoMotionManufCluster,
-                    TuyaOccupancySensing,
-                    TuyaTemperatureMeasurement,
-                    TuyaRelativeHumidity,
-                ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            }
-        }
-    }
-
-
-class MmwRadarMotion(CustomDevice):
-    """Millimeter wave occupancy sensor."""
-
-    signature = {
-        #  endpoint=1, profile=260, device_type=81, device_version=1,
-        #  input_clusters=[0, 4, 5, 61184], output_clusters=[25, 10]
-        MODELS_INFO: [
-            ("_TZE200_ar0slwnd", "TS0601"),
-            ("_TZE200_sfiy5tfs", "TS0601"),
-            ("_TZE200_mrf6vtua", "TS0601"),
-            ("_TZE200_ztc6ggyl", "TS0601"),
-            ("_TZE204_ztc6ggyl", "TS0601"),
-            ("_TZE200_wukb7rhc", "TS0601"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    TuyaNewManufCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    MmwRadarManufCluster,
-                    TuyaOccupancySensing,
-                    TuyaAnalogInput,
-                    TuyaIlluminanceMeasurement,
-                ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            },
-        }
-    }
-
-
-class MmwRadarMotionGPP(CustomDevice):
-    """Millimeter wave occupancy sensor."""
-
-    signature = {
-        #  endpoint=1, profile=260, device_type=81, device_version=1,
-        #  input_clusters=[4, 5, 61184, 0], output_clusters=[25, 10])
-        MODELS_INFO: [
-            ("_TZE200_ar0slwnd", "TS0601"),
-            ("_TZE200_sfiy5tfs", "TS0601"),
-            ("_TZE200_mrf6vtua", "TS0601"),
-            ("_TZE204_qasjif9e", "TS0601"),
-            ("_TZE204_ztqnh5cg", "TS0601"),
-            ("_TZE204_sooucan5", "TS0601"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    TuyaNewManufCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            },
-            242: {
-                # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
-                # input_clusters=[]
-                # output_clusters=[33]
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    MmwRadarManufCluster,
-                    TuyaOccupancySensing,
-                    TuyaAnalogInput,
-                    TuyaIlluminanceMeasurement,
-                ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        }
-    }
+(
+    TuyaQuirkBuilder("_TZE200_ar0slwnd", "TS0601")
+    .applies_to("_TZE200_mrf6vtua", "TS0601")
+    .applies_to("_TZE200_sfiy5tfs", "TS0601")
+    .applies_to("_TZE204_sooucan5", "TS0601")
+    .applies_to("_TZE200_wukb7rhc", "TS0601")
+    .applies_to("_TZE204_qasjif9e", "TS0601")
+    .applies_to("_TZE200_ztc6ggyl", "TS0601")
+    .applies_to("_TZE204_ztc6ggyl", "TS0601")
+    .applies_to("_TZE204_ztqnh5cg", "TS0601")
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=TuyaOccupancySensing.ep_attribute,
+        attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
+        converter=lambda x: True if x == 1 else False,
+    )
+    .adds(TuyaOccupancySensing)
+    .tuya_number(
+        dp_id=2,
+        attribute_name="move_sensitivity",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=10,
+        step=1,
+        translation_key="move_sensitivity",
+        fallback_name="Motion sensitivity",
+    )
+    .tuya_number(
+        dp_id=3,
+        attribute_name="detection_distance_min",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.DISTANCE,
+        unit=UnitOfLength.METERS,
+        min_value=0,
+        max_value=8.25,
+        step=0.75,
+        translation_key="detection_distance_min",
+        fallback_name="Minimum range",
+    )
+    .tuya_number(
+        dp_id=4,
+        attribute_name="detection_distance_max",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.DISTANCE,
+        unit=UnitOfLength.METERS,
+        min_value=0.75,
+        max_value=9.0,
+        step=0.75,
+        translation_key="detection_distance_max",
+        fallback_name="Maximum range",
+    )
+    .tuya_sensor(
+        dp_id=9,
+        attribute_name="distance",
+        type=t.uint16_t,
+        divisor=100,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.DISTANCE,
+        unit=UnitOfLength.METERS,
+        entity_type=EntityType.STANDARD,
+        translation_key="distance",
+        fallback_name="Target distance",
+    )
+    .tuya_switch(
+        dp_id=101,
+        attribute_name="find_switch",
+        entity_type=EntityType.STANDARD,
+        translation_key="find_switch",
+        fallback_name="Distance switch",
+    )
+    .tuya_number(
+        dp_id=102,
+        attribute_name="presence_sensitivity",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=10,
+        step=1,
+        translation_key="presence_sensitivity",
+        fallback_name="Presence sensitivity",
+    )
+    # 103?
+    .tuya_dp(
+        dp_id=104,
+        ep_attribute=TuyaIlluminanceCluster.ep_attribute,
+        attribute_name=TuyaIlluminanceCluster.AttributeDefs.measured_value.name,
+        converter=lambda x: 10000 * math.log10(x) + 1 if x != 0 else 0,
+    )
+    .adds(TuyaIlluminanceCluster)
+    # 106?
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -20,14 +20,8 @@ class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
     """Tuya local OccupancySensing cluster."""
 
 
-(
-    TuyaQuirkBuilder("_TZE200_ya4ft0w4", "TS0601")
-    .tuya_dp(
-        dp_id=1,
-        ep_attribute=TuyaOccupancySensing.ep_attribute,
-        attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
-        converter=lambda x: True if x in (1, 2) else False,
-    )
+base_tuya_motion = (
+    TuyaQuirkBuilder()
     .adds(TuyaOccupancySensing)
     .tuya_number(
         dp_id=2,
@@ -92,12 +86,25 @@ class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
         translation_key="presence_sensitivity",
         fallback_name="Presence sensitivity",
     )
+    .adds(TuyaIlluminanceCluster)
+    .skip_configuration()
+)
+
+(
+    base_tuya_motion.clone()
+    .applies_to("_TZE200_ya4ft0w4", "TS0601")
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=TuyaOccupancySensing.ep_attribute,
+        attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
+        converter=lambda x: True if x in (1, 2) else False,
+    )
     .tuya_dp(
         dp_id=103,
         ep_attribute=TuyaIlluminanceCluster.ep_attribute,
         attribute_name=TuyaIlluminanceCluster.AttributeDefs.measured_value.name,
+        converter=lambda x: 10000 * math.log10(x) + 1 if x != 0 else 0,
     )
-    .adds(TuyaIlluminanceCluster)
     .tuya_number(
         dp_id=105,
         attribute_name="presence_timeout",
@@ -110,7 +117,6 @@ class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
         translation_key="presence_timeout",
         fallback_name="Fade time",
     )
-    .skip_configuration()
     .add_to_registry()
 )
 
@@ -132,7 +138,8 @@ class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
 )
 
 (
-    TuyaQuirkBuilder("_TZE200_ar0slwnd", "TS0601")
+    base_tuya_motion.clone()
+    .applies_to("_TZE200_ar0slwnd", "TS0601")
     .applies_to("_TZE200_mrf6vtua", "TS0601")
     .applies_to("_TZE200_sfiy5tfs", "TS0601")
     .applies_to("_TZE204_sooucan5", "TS0601")
@@ -147,70 +154,6 @@ class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
         attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
         converter=lambda x: True if x == 1 else False,
     )
-    .adds(TuyaOccupancySensing)
-    .tuya_number(
-        dp_id=2,
-        attribute_name="move_sensitivity",
-        type=t.uint16_t,
-        min_value=0,
-        max_value=10,
-        step=1,
-        translation_key="move_sensitivity",
-        fallback_name="Motion sensitivity",
-    )
-    .tuya_number(
-        dp_id=3,
-        attribute_name="detection_distance_min",
-        type=t.uint16_t,
-        device_class=SensorDeviceClass.DISTANCE,
-        unit=UnitOfLength.METERS,
-        min_value=0,
-        max_value=8.25,
-        step=0.75,
-        translation_key="detection_distance_min",
-        fallback_name="Minimum range",
-    )
-    .tuya_number(
-        dp_id=4,
-        attribute_name="detection_distance_max",
-        type=t.uint16_t,
-        device_class=SensorDeviceClass.DISTANCE,
-        unit=UnitOfLength.METERS,
-        min_value=0.75,
-        max_value=9.0,
-        step=0.75,
-        translation_key="detection_distance_max",
-        fallback_name="Maximum range",
-    )
-    .tuya_sensor(
-        dp_id=9,
-        attribute_name="distance",
-        type=t.uint16_t,
-        divisor=100,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.DISTANCE,
-        unit=UnitOfLength.METERS,
-        entity_type=EntityType.STANDARD,
-        translation_key="distance",
-        fallback_name="Target distance",
-    )
-    .tuya_switch(
-        dp_id=101,
-        attribute_name="find_switch",
-        entity_type=EntityType.STANDARD,
-        translation_key="find_switch",
-        fallback_name="Distance switch",
-    )
-    .tuya_number(
-        dp_id=102,
-        attribute_name="presence_sensitivity",
-        type=t.uint16_t,
-        min_value=0,
-        max_value=10,
-        step=1,
-        translation_key="presence_sensitivity",
-        fallback_name="Presence sensitivity",
-    )
     # 103?
     .tuya_dp(
         dp_id=104,
@@ -218,7 +161,6 @@ class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
         attribute_name=TuyaIlluminanceCluster.AttributeDefs.measured_value.name,
         converter=lambda x: 10000 * math.log10(x) + 1 if x != 0 else 0,
     )
-    .adds(TuyaIlluminanceCluster)
     # 106?
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -164,3 +164,18 @@ base_tuya_motion = (
     # 106?
     .add_to_registry()
 )
+
+
+(
+    TuyaQuirkBuilder("_TYST11_i5j6ifxj", "5j6ifxj")
+    .applies_to("_TYST11_7hfcudw5", "hfcudw5")
+    .tuya_dp(
+        dp_id=3,
+        ep_attribute=TuyaOccupancySensing.ep_attribute,
+        attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
+        converter=lambda x: True if x == 2 else False,
+    )
+    .adds(TuyaOccupancySensing)
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Adds _TZE200_ya4ft0w4, converts rest of motion to v2 quirks

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Closes: https://github.com/zigpy/zha-device-handlers/issues/3584
Closes: https://github.com/zigpy/zha-device-handlers/issues/3359

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
