### PR TITLE
Added Clipsal Dimmer and 2A Switch quirk and entities

### DIFF
--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -3,7 +3,6 @@
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
-from zigpy.zcl import ClusterType
 
 from zhaquirks.schneiderelectric import (
     SE_MANUF_NAME,
@@ -73,6 +72,7 @@ from zhaquirks.schneiderelectric import (
         cluster_id=SESpecific.cluster_id,
         endpoint_id=21,
         translation_key="switch_indication",
-        fallback_name="Switch Indication")
+        fallback_name="Switch Indication",
+    )
     .add_to_registry()
 )

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -9,9 +9,9 @@ from zhaquirks.schneiderelectric import (
     SE_MANUF_NAME,
     SEBallast,
     SEBasic,
+    SEControlMode,
     SEOnOff,
     SESpecific,
-    SEControlMode,
 )
 
 (
@@ -37,7 +37,8 @@ from zhaquirks.schneiderelectric import (
         device_class=NumberDeviceClass.DURATION,
         unit=UnitOfTime.SECONDS,
         fallback_name="On Time Reload",
-        translation_key="on_time_reload")
+        translation_key="on_time_reload",
+    )
     .number(
         attribute_name=SEBallast.AttributeDefs.min_level.name,
         cluster_id=SEBallast.cluster_id,
@@ -46,7 +47,8 @@ from zhaquirks.schneiderelectric import (
         max_value=254,
         step=1,
         fallback_name="Min Light Level",
-        translation_key="min_level")
+        translation_key="min_level",
+    )
     .number(
         attribute_name=SEBallast.AttributeDefs.max_level.name,
         cluster_id=SEBallast.cluster_id,
@@ -55,14 +57,16 @@ from zhaquirks.schneiderelectric import (
         max_value=254,
         step=1,
         fallback_name="Max Light Level",
-        translation_key="max_level")
+        translation_key="max_level",
+    )
     .enum(
         attribute_name=SEBallast.AttributeDefs.se_control_mode.name,
         enum_class=SEControlMode,
         cluster_id=SEBallast.cluster_id,
         endpoint_id=3,
         translation_key="control_mode",
-        fallback_name="Control Mode")
+        fallback_name="Control Mode",
+    )
     .add_to_registry()
 )
 
@@ -83,6 +87,7 @@ from zhaquirks.schneiderelectric import (
         unit=UnitOfTime.SECONDS,
         device_class=NumberDeviceClass.DURATION,
         fallback_name="On Time Reload",
-        translation_key="on_time_reload")
+        translation_key="on_time_reload",
+    )
     .add_to_registry()
 )

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -12,6 +12,7 @@ from zhaquirks.schneiderelectric import (
     SEControlMode,
     SEOnOff,
     SESpecific,
+    SESwitchIndication,
 )
 
 (
@@ -66,6 +67,13 @@ from zhaquirks.schneiderelectric import (
         translation_key="control_mode",
         fallback_name="Control Mode",
     )
+    .enum(
+        attribute_name=SESpecific.AttributeDefs.se_switch_indication.name,
+        enum_class=SESwitchIndication,
+        cluster_id=SESpecific.cluster_id,
+        endpoint_id=21,
+        translation_key="switch_indication",
+        fallback_name="Switch Indication")
     .add_to_registry()
 )
 
@@ -88,5 +96,12 @@ from zhaquirks.schneiderelectric import (
         fallback_name="On Time Reload",
         translation_key="on_time_reload",
     )
+    .enum(
+        attribute_name=SESpecific.AttributeDefs.se_switch_indication.name,
+        enum_class=SESwitchIndication,
+        cluster_id=SESpecific.cluster_id,
+        endpoint_id=21,
+        translation_key="switch_indication",
+        fallback_name="Switch Indication")
     .add_to_registry()
 )

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -15,7 +15,7 @@ from zhaquirks.schneiderelectric import (
 )
 
 (
-    # Note: UNIDIM and DIMMER have unique setttings in Ballast Cluster.
+    # Note: UNIDIM and DIMMER have unique settings in Ballast Cluster.
     QuirkBuilder(SE_MANUF_NAME, "NHROTARY/DIMMER/1")
     .applies_to(SE_MANUF_NAME, "NHROTARY/UNIDIM/1")
     .applies_to(SE_MANUF_NAME, "NHPB/DIMMER/1")

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -1,4 +1,4 @@
-"""Schneider Electric dimmers and switches quirks."""
+"""Schneider Electric dimmers quirks."""
 
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
@@ -66,35 +66,6 @@ from zhaquirks.schneiderelectric import (
         endpoint_id=3,
         translation_key="control_mode",
         fallback_name="Control Mode",
-    )
-    .enum(
-        attribute_name=SESpecific.AttributeDefs.se_switch_indication.name,
-        enum_class=SESwitchIndication,
-        cluster_id=SESpecific.cluster_id,
-        endpoint_id=21,
-        translation_key="switch_indication",
-        fallback_name="Switch Indication")
-    .add_to_registry()
-)
-
-(
-    QuirkBuilder(SE_MANUF_NAME, "NHPB/SWITCH/1")
-    .applies_to(SE_MANUF_NAME, "CH2AX/SWITCH/1")
-    .replaces(SEBasic, endpoint_id=1)
-    .replaces(SEOnOff, endpoint_id=1)
-    .replaces(SEBasic, endpoint_id=21)
-    .replaces(SESpecific, endpoint_id=21)
-    .number(
-        attribute_name=SEOnOff.AttributeDefs.se_on_time_reload.name,
-        cluster_id=SEOnOff.cluster_id,
-        endpoint_id=1,
-        min_value=0x0,
-        max_value=0xFFFFFFFF,
-        step=1,
-        unit=UnitOfTime.SECONDS,
-        device_class=NumberDeviceClass.DURATION,
-        fallback_name="On Time Reload",
-        translation_key="on_time_reload",
     )
     .enum(
         attribute_name=SESpecific.AttributeDefs.se_switch_indication.name,

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -1,6 +1,9 @@
 """Schneider Electric dimmers and switches quirks."""
 
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+from zigpy.zcl import ClusterType
 
 from zhaquirks.schneiderelectric import (
     SE_MANUF_NAME,
@@ -8,26 +11,78 @@ from zhaquirks.schneiderelectric import (
     SEBasic,
     SEOnOff,
     SESpecific,
+    SEControlMode,
 )
 
 (
+    # Note: UNIDIM and DIMMER have unique setttings in Ballast Cluster.
     QuirkBuilder(SE_MANUF_NAME, "NHROTARY/DIMMER/1")
     .applies_to(SE_MANUF_NAME, "NHROTARY/UNIDIM/1")
     .applies_to(SE_MANUF_NAME, "NHPB/DIMMER/1")
     .applies_to(SE_MANUF_NAME, "NHPB/UNIDIM/1")
+    .applies_to(SE_MANUF_NAME, "CH/DIMMER/1")
     .replaces(SEBasic, endpoint_id=3)
     .replaces(SEBallast, endpoint_id=3)
     .replaces(SEOnOff, endpoint_id=3)
     .replaces(SEBasic, endpoint_id=21)
+    .replaces(SEOnOff, endpoint_id=21, cluster_type=ClusterType.Client)
     .replaces(SESpecific, endpoint_id=21)
+    .number(
+        attribute_name=SEOnOff.AttributeDefs.se_on_time_reload.name,
+        cluster_id=SEOnOff.cluster_id,
+        endpoint_id=3,
+        min_value=0x0,
+        max_value=0xFFFFFFFF,
+        step=1,
+        device_class=NumberDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        fallback_name="On Time Reload",
+        translation_key="on_time_reload")
+    .number(
+        attribute_name=SEBallast.AttributeDefs.min_level.name,
+        cluster_id=SEBallast.cluster_id,
+        endpoint_id=3,
+        min_value=1,
+        max_value=254,
+        step=1,
+        fallback_name="Min Light Level",
+        translation_key="min_level")
+    .number(
+        attribute_name=SEBallast.AttributeDefs.max_level.name,
+        cluster_id=SEBallast.cluster_id,
+        endpoint_id=3,
+        min_value=1,
+        max_value=254,
+        step=1,
+        fallback_name="Max Light Level",
+        translation_key="max_level")
+    .enum(
+        attribute_name=SEBallast.AttributeDefs.se_control_mode.name,
+        enum_class=SEControlMode,
+        cluster_id=SEBallast.cluster_id,
+        endpoint_id=3,
+        translation_key="control_mode",
+        fallback_name="Control Mode")
     .add_to_registry()
 )
 
 (
     QuirkBuilder(SE_MANUF_NAME, "NHPB/SWITCH/1")
-    .replaces(SEBasic)
-    .replaces(SEOnOff)
+    .applies_to(SE_MANUF_NAME, "CH2AX/SWITCH/1")
+    .replaces(SEBasic, endpoint_id=1)
+    .replaces(SEOnOff, endpoint_id=1)
     .replaces(SEBasic, endpoint_id=21)
     .replaces(SESpecific, endpoint_id=21)
+    .number(
+        attribute_name=SEOnOff.AttributeDefs.se_on_time_reload.name,
+        cluster_id=SEOnOff.cluster_id,
+        endpoint_id=1,
+        min_value=0x0,
+        max_value=0xFFFFFFFF,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        device_class=NumberDeviceClass.DURATION,
+        fallback_name="On Time Reload",
+        translation_key="on_time_reload")
     .add_to_registry()
 )

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -25,7 +25,6 @@ from zhaquirks.schneiderelectric import (
     .replaces(SEBallast, endpoint_id=3)
     .replaces(SEOnOff, endpoint_id=3)
     .replaces(SEBasic, endpoint_id=21)
-    .replaces(SEOnOff, endpoint_id=21, cluster_type=ClusterType.Client)
     .replaces(SESpecific, endpoint_id=21)
     .number(
         attribute_name=SEOnOff.AttributeDefs.se_on_time_reload.name,

--- a/zhaquirks/schneiderelectric/switches.py
+++ b/zhaquirks/schneiderelectric/switches.py
@@ -3,7 +3,6 @@
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
-from zigpy.zcl import ClusterType
 
 from zhaquirks.schneiderelectric import (
     SE_MANUF_NAME,
@@ -38,6 +37,7 @@ from zhaquirks.schneiderelectric import (
         cluster_id=SESpecific.cluster_id,
         endpoint_id=21,
         translation_key="switch_indication",
-        fallback_name="Switch Indication")
+        fallback_name="Switch Indication",
+    )
     .add_to_registry()
 )

--- a/zhaquirks/schneiderelectric/switches.py
+++ b/zhaquirks/schneiderelectric/switches.py
@@ -1,0 +1,43 @@
+"""Schneider Electric switches quirks."""
+
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+from zigpy.zcl import ClusterType
+
+from zhaquirks.schneiderelectric import (
+    SE_MANUF_NAME,
+    SEBasic,
+    SEOnOff,
+    SESpecific,
+    SESwitchIndication,
+)
+
+(
+    QuirkBuilder(SE_MANUF_NAME, "NHPB/SWITCH/1")
+    .applies_to(SE_MANUF_NAME, "CH2AX/SWITCH/1")
+    .replaces(SEBasic, endpoint_id=1)
+    .replaces(SEOnOff, endpoint_id=1)
+    .replaces(SEBasic, endpoint_id=21)
+    .replaces(SESpecific, endpoint_id=21)
+    .number(
+        attribute_name=SEOnOff.AttributeDefs.se_on_time_reload.name,
+        cluster_id=SEOnOff.cluster_id,
+        endpoint_id=1,
+        min_value=0x0,
+        max_value=0xFFFFFFFF,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        device_class=NumberDeviceClass.DURATION,
+        fallback_name="On Time Reload",
+        translation_key="on_time_reload",
+    )
+    .enum(
+        attribute_name=SESpecific.AttributeDefs.se_switch_indication.name,
+        enum_class=SESwitchIndication,
+        cluster_id=SESpecific.cluster_id,
+        endpoint_id=21,
+        translation_key="switch_indication",
+        fallback_name="Switch Indication")
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
Added Clipsal (Australian branded Schneider Electric) push button dimmer and 2A relay.

## Additional information
I also added a missing entity to edit device attributes.

* Dimmer: Ballast Control Mode, Min Level, and Max Level.
* Dimmer and 2A: On Time Reload (Auto turn off after seconds)
* Dimmer and 2A: Switch Indication

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
