### PR TITLE
Fix Tuya BlitzWolf motion sensor

### DIFF
--- a/tests/test_tuya_motion.py
+++ b/tests/test_tuya_motion.py
@@ -3,6 +3,7 @@
 import pytest
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.measurement import OccupancySensing
+from zigpy.zcl.clusters.security import IasZone
 
 from tests.common import ClusterListener
 import zhaquirks
@@ -32,12 +33,10 @@ zhaquirks.setup()
         ("_TZE200_ztc6ggyl", "TS0601", ZCL_TUYA_MOTION),
         ("_TZE204_ztc6ggyl", "TS0601", ZCL_TUYA_MOTION),
         ("_TZE204_ztqnh5cg", "TS0601", ZCL_TUYA_MOTION),
-        ("_TYST11_i5j6ifxj", "5j6ifxj", ZCL_TUYA_MOTION_V3),
-        ("_TYST11_7hfcudw5", "hfcudw5", ZCL_TUYA_MOTION_V3),
     ],
 )
-async def test_tuya_motion_quirk(zigpy_device_from_v2_quirk, model, manuf, occ_msg):
-    """Test Tuya Motion Quirks."""
+async def test_tuya_motion_quirk_occ(zigpy_device_from_v2_quirk, model, manuf, occ_msg):
+    """Test Tuya Motion Quirks using Occupancy cluster."""
     quirked_device = zigpy_device_from_v2_quirk(model, manuf)
     ep = quirked_device.endpoints[1]
 
@@ -62,3 +61,35 @@ async def test_tuya_motion_quirk(zigpy_device_from_v2_quirk, model, manuf, occ_m
         occupancy_listener.attribute_updates[0][1]
         == OccupancySensing.Occupancy.Occupied
     )
+
+
+@pytest.mark.parametrize(
+    "model,manuf,occ_msg",
+    [
+        ("_TYST11_i5j6ifxj", "5j6ifxj", ZCL_TUYA_MOTION_V3),
+        ("_TYST11_7hfcudw5", "hfcudw5", ZCL_TUYA_MOTION_V3),
+    ],
+)
+async def test_tuya_motion_quirk_ias(zigpy_device_from_v2_quirk, model, manuf, occ_msg):
+    """Test Tuya Motion Quirks using IasZone cluster."""
+    quirked_device = zigpy_device_from_v2_quirk(model, manuf)
+    ep = quirked_device.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+
+    assert ep.ias_zone is not None
+    assert isinstance(ep.ias_zone, IasZone)
+
+    ias_zone_listener = ClusterListener(ep.ias_zone)
+
+    hdr, data = ep.tuya_manufacturer.deserialize(occ_msg)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+
+    assert status == foundation.Status.SUCCESS
+
+    zcl_zone_status_id = IasZone.AttributeDefs.zone_status.id
+
+    assert len(ias_zone_listener.attribute_updates) == 1
+    assert ias_zone_listener.attribute_updates[0][0] == zcl_zone_status_id
+    assert ias_zone_listener.attribute_updates[0][1] == IasZone.ZoneStatus.Alarm_1

--- a/tests/test_tuya_motion.py
+++ b/tests/test_tuya_motion.py
@@ -1,5 +1,7 @@
 """Tests for Tuya quirks."""
 
+import asyncio
+
 import pytest
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.measurement import OccupancySensing
@@ -70,6 +72,7 @@ async def test_tuya_motion_quirk_occ(zigpy_device_from_v2_quirk, model, manuf, o
         ("_TYST11_7hfcudw5", "hfcudw5", ZCL_TUYA_MOTION_V3),
     ],
 )
+@pytest.mark.asyncio
 async def test_tuya_motion_quirk_ias(zigpy_device_from_v2_quirk, model, manuf, occ_msg):
     """Test Tuya Motion Quirks using IasZone cluster."""
     quirked_device = zigpy_device_from_v2_quirk(model, manuf)
@@ -81,6 +84,9 @@ async def test_tuya_motion_quirk_ias(zigpy_device_from_v2_quirk, model, manuf, o
     assert ep.ias_zone is not None
     assert isinstance(ep.ias_zone, IasZone)
 
+    # lower reset_s of IasZone cluster
+    ep.ias_zone.reset_s = 0
+
     ias_zone_listener = ClusterListener(ep.ias_zone)
 
     hdr, data = ep.tuya_manufacturer.deserialize(occ_msg)
@@ -90,6 +96,14 @@ async def test_tuya_motion_quirk_ias(zigpy_device_from_v2_quirk, model, manuf, o
 
     zcl_zone_status_id = IasZone.AttributeDefs.zone_status.id
 
+    # check that the zone status is set to alarm_1
     assert len(ias_zone_listener.attribute_updates) == 1
     assert ias_zone_listener.attribute_updates[0][0] == zcl_zone_status_id
     assert ias_zone_listener.attribute_updates[0][1] == IasZone.ZoneStatus.Alarm_1
+
+    await asyncio.sleep(0.01)
+
+    # check that the zone status is reset automatically
+    assert len(ias_zone_listener.attribute_updates) == 2
+    assert ias_zone_listener.attribute_updates[1][0] == zcl_zone_status_id
+    assert ias_zone_listener.attribute_updates[1][1] == 0

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -46,14 +46,6 @@ class TuyaIasFire(IasZone, TuyaLocalCluster):
     }
 
 
-class TuyaIasMotion(IasZone, TuyaLocalCluster):
-    """Tuya local IAS motion cluster."""
-
-    _CONSTANT_ATTRIBUTES = {
-        IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Motion_Sensor
-    }
-
-
 class TuyaRelativeHumidity(RelativeHumidity, TuyaLocalCluster):
     """Tuya local RelativeHumidity cluster."""
 
@@ -130,15 +122,6 @@ class TuyaQuirkBuilder(QuirkBuilder):
             dp_id=dp_id,
             ias_cfg=TuyaIasFire,
             converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 0 else 0,
-        )
-        return self
-
-    def tuya_motion(self, dp_id: int):
-        """Add a Tuya IAS motion sensor."""
-        self.tuya_ias(
-            dp_id=dp_id,
-            ias_cfg=TuyaIasMotion,
-            converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 2 else 0,
         )
         return self
 

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -46,6 +46,14 @@ class TuyaIasFire(IasZone, TuyaLocalCluster):
     }
 
 
+class TuyaIasMotion(IasZone, TuyaLocalCluster):
+    """Tuya local IAS motion cluster."""
+
+    _CONSTANT_ATTRIBUTES = {
+        IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Motion_Sensor
+    }
+
+
 class TuyaRelativeHumidity(RelativeHumidity, TuyaLocalCluster):
     """Tuya local RelativeHumidity cluster."""
 
@@ -122,6 +130,15 @@ class TuyaQuirkBuilder(QuirkBuilder):
             dp_id=dp_id,
             ias_cfg=TuyaIasFire,
             converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 0 else 0,
+        )
+        return self
+
+    def tuya_motion(self, dp_id: int):
+        """Add a Tuya IAS motion sensor."""
+        self.tuya_ias(
+            dp_id=dp_id,
+            ias_cfg=TuyaIasMotion,
+            converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 2 else 0,
         )
         return self
 

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -1,12 +1,15 @@
 """BlitzWolf IS-3/Tuya motion rechargeable occupancy sensor."""
 
+import asyncio
 import math
+from typing import Any
 
 from zigpy.quirks.v2 import EntityType
 from zigpy.quirks.v2.homeassistant import UnitOfLength, UnitOfTime
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement, OccupancySensing
+from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks.tuya import TuyaLocalCluster
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
@@ -18,6 +21,37 @@ class TuyaIlluminanceCluster(IlluminanceMeasurement, TuyaLocalCluster):
 
 class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
     """Tuya local OccupancySensing cluster."""
+
+
+class TuyaMotionWithReset(IasZone, TuyaLocalCluster):
+    """Tuya local IAS motion cluster with reset."""
+
+    reset_s: int = 15
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self._loop = asyncio.get_running_loop()
+        self._timer_handle = None
+
+    def _turn_off(self) -> None:
+        """Reset IAS zone status."""
+        self._timer_handle = None
+        self.debug("%s - Resetting Tuya motion sensor", self.endpoint.device.ieee)
+        self._update_attribute(IasZone.AttributeDefs.zone_status.id, 0)
+
+    def _update_attribute(self, attrid: int | t.uint16_t, value: Any) -> None:
+        """Catch zone status updates and potentially schedule reset."""
+        if (
+            attrid == IasZone.AttributeDefs.zone_status.id
+            and value == IasZone.ZoneStatus.Alarm_1
+        ):
+            self.debug("%s - Received Tuya motion event", self.endpoint.device.ieee)
+            if self._timer_handle:
+                self._timer_handle.cancel()
+            self._timer_handle = self._loop.call_later(self.reset_s, self._turn_off)
+
+        super()._update_attribute(attrid, value)
 
 
 base_tuya_motion = (
@@ -170,6 +204,11 @@ base_tuya_motion = (
     TuyaQuirkBuilder("_TYST11_i5j6ifxj", "5j6ifxj")
     .applies_to("_TYST11_7hfcudw5", "hfcudw5")
     .tuya_motion(dp_id=3)
+    .tuya_ias(
+        dp_id=3,
+        ias_cfg=TuyaMotionWithReset,
+        converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 2 else 0,
+    )
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -26,6 +26,9 @@ class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
 class TuyaMotionWithReset(IasZone, TuyaLocalCluster):
     """Tuya local IAS motion cluster with reset."""
 
+    _CONSTANT_ATTRIBUTES = {
+        IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Motion_Sensor
+    }
     reset_s: int = 15
 
     def __init__(self, *args, **kwargs):

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -169,13 +169,7 @@ base_tuya_motion = (
 (
     TuyaQuirkBuilder("_TYST11_i5j6ifxj", "5j6ifxj")
     .applies_to("_TYST11_7hfcudw5", "hfcudw5")
-    .tuya_dp(
-        dp_id=3,
-        ep_attribute=TuyaOccupancySensing.ep_attribute,
-        attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
-        converter=lambda x: x == 2,
-    )
-    .adds(TuyaOccupancySensing)
+    .tuya_motion(dp_id=3)
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -203,7 +203,6 @@ base_tuya_motion = (
 (
     TuyaQuirkBuilder("_TYST11_i5j6ifxj", "5j6ifxj")
     .applies_to("_TYST11_7hfcudw5", "hfcudw5")
-    .tuya_motion(dp_id=3)
     .tuya_ias(
         dp_id=3,
         ias_cfg=TuyaMotionWithReset,


### PR DESCRIPTION
## Proposed change
This reverts the BlitzWolf motion sensors to use the `IasZone` cluster instead of using the `OccupancySensing` cluster.
This change was made to keep existing entities working. The missing auto-reset delay was also reintroduced.

cc @prairiesnpr


## Additional information
Small follow-up to https://github.com/zigpy/zha-device-handlers/pull/3612

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
