### PR TITLE
Add Avatto 2 ch dimmer `_TZE204_jtbgusdc` variant

### DIFF
--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -218,6 +218,7 @@ class TuyaDoubleSwitchDimmerGP(TuyaDimmerSwitch):
             ("_TZE200_gwkapsoq", "TS0601"),  # Loratap
             ("_TZE204_zenj4lxv", "TS0601"),
             ("_TZE204_o9gyszw2", "TS0601"),  # Avattto ZDMS16-2
+            ("_TZE204_jtbgusdc", "TS0601"),  # Avattto DMS16/ZDMS16
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0100

--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -154,8 +154,8 @@ class TuyaSingleSwitchDimmerGP(TuyaDimmerSwitch):
             ("_TZE200_y8yjulon", "TS0601"),
             ("_TZE204_n9ctkb6j", "TS0601"),  # BSEED
             ("_TZE204_vevc4c6g", "TS0601"),  # BSEED
-            ("_TZE204_5cuocqty", "TS0601"),  # Avattto ZDMS16-1
-            ("_TZE204_nqqylykc", "TS0601"),  # Avattto ZDMS16-1
+            ("_TZE204_5cuocqty", "TS0601"),  # Avatto ZDMS16-1
+            ("_TZE204_nqqylykc", "TS0601"),  # Avatto ZDMS16-1
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0100
@@ -217,8 +217,8 @@ class TuyaDoubleSwitchDimmerGP(TuyaDimmerSwitch):
             ("_TZE200_fjjbhx9d", "TS0601"),
             ("_TZE200_gwkapsoq", "TS0601"),  # Loratap
             ("_TZE204_zenj4lxv", "TS0601"),
-            ("_TZE204_o9gyszw2", "TS0601"),  # Avattto ZDMS16-2
-            ("_TZE204_jtbgusdc", "TS0601"),  # Avattto DMS16/ZDMS16
+            ("_TZE204_o9gyszw2", "TS0601"),  # Avatto ZDMS16-2
+            ("_TZE204_jtbgusdc", "TS0601"),  # Avatto DMS16/ZDMS16
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0100


### PR DESCRIPTION
## Proposed change

My new 2 channels relais was not detected.
I just used ch1 and ch2 as a switch.  I did not try to use the dimmer.


## Additional information


Model Number: DMS16/ZDMS16 (although I'm not sure it the description on the package is correct)
A 2 channel Zigbee dimmer module



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
