### PR TITLE
Fix TuyaNewManufCluster `set_time` time synchronization

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1487,7 +1487,7 @@ class TuyaNewManufCluster(CustomCluster):
             "send_data", {"data": TuyaCommand}, False, is_manufacturer_specific=True
         ),
         TUYA_SET_TIME: foundation.ZCLCommandDef(
-            "set_time", {"time": TuyaTimePayload}, False, is_manufacturer_specific=True
+            "set_time", {"time": TuyaTimePayload}, False, is_manufacturer_specific=False
         ),
     }
 


### PR DESCRIPTION
## Proposed change
Changing set_time to be sent as is_manufacturer_specific=False. This is aligned with z2m behavior and fixes broken synchronization on Tyua thermostats.

## Additional information

**Symptoms:**
Avatto ZWT100 thermostat time synchronization is not working with HA using ZHA integration. When tested with z2m, synchronization works correctly. I compared both implementations and found that z2m is sending set_time command with is_manufacturer_specific=False, while ZHA is sending it with is_manufacturer_specific=True. With proposed change, Tuya time synchronization works correctly.

**zigpy.zcl log example:**

> 2024-12-29 02:23:10.058 DEBUG (MainThread) [zigpy.zcl] [0x5090:1:0xef00] Sending request header: ZCLHeader(frame_control=FrameControl<0x05>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, **is_manufacturer_specific=True**, direction=<Direction.Client_to_Server: 0>, disable_default_response=0, reserved=0, *is_cluster=True, *is_general=False), manufacturer=4417, tsn=7, command_id=36, *direction=<Direction.Client_to_Server: 0>)

**z2m log example:**

> [2024-12-21 20:12:06] [34mdebug[39m: 	zh:ember: ~~~> [ZCL to=0xa4c138753b223995:16528 apsFrame={"profileId":260,"clusterId":61184,"sourceEndpoint":1,"destinationEndpoint":1,"options":4416,"groupId":0,"sequence":0} header={"frameControl":{"reservedBits":0,"frameType":1,"direction":0,"disableDefaultResponse":false,**"manufacturerSpecific":false**},"transactionSequenceNumber":15,"commandIdentifier":36}]

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works - no new code, just fixing boolean
