### PR TITLE
Add Aqara Wall Outlet H2 EU

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2282,3 +2282,27 @@ async def test_lumi_magnet_sensor_aq2_bad_direction(zigpy_device_from_quirk, cap
 
     # Our matching logic should be forgiving
     assert listener.attribute_updates == [(0, t.Bool.true)]
+
+
+def test_plug_aeu001_metering_integration(zigpy_device_from_v2_quirk):
+    """Test Aqara lumi plug AEU001 Metering ignores decreases."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer=AQARA,
+        model="lumi.plug.aeu001",
+        endpoint_ids=[1, 2, 21],
+    )
+
+    metering_cluster = device.endpoints[1].smartenergy_metering
+    listener = ClusterListener(metering_cluster)
+    attr_id = Metering.AttributeDefs.current_summ_delivered.id
+
+    # 3 updates: initial, decrease (should be ignored), increase
+    metering_cluster.update_attribute(attr_id, 100)
+    assert listener.attribute_updates[-1] == (attr_id, 100)
+
+    metering_cluster.update_attribute(attr_id, 50)
+    assert listener.attribute_updates[-1] == (attr_id, 100)
+
+    metering_cluster.update_attribute(attr_id, 150)
+    assert listener.attribute_updates[-1] == (attr_id, 150)

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -391,15 +391,20 @@ class XiaomiCluster(CustomCluster):
                 {
                     100: TEMPERATURE_MEASUREMENT,
                     101: HUMIDITY_MEASUREMENT,
-                    102: TVOC_MEASUREMENT
-                    if self.endpoint.device.model == "lumi.airmonitor.acn01"
-                    else PRESSURE_MEASUREMENT_PRECISION
-                    if self.endpoint.device.model == "lumi.weather"
-                    else PRESSURE_MEASUREMENT,
+                    102: (
+                        TVOC_MEASUREMENT
+                        if self.endpoint.device.model == "lumi.airmonitor.acn01"
+                        else (
+                            PRESSURE_MEASUREMENT_PRECISION
+                            if self.endpoint.device.model == "lumi.weather"
+                            else PRESSURE_MEASUREMENT
+                        )
+                    ),
                 }
             )
         elif self.endpoint.device.model in [
             "lumi.plug",
+            "lumi.plug.aeu001",
             "lumi.plug.maus01",
             "lumi.plug.maeu01",
             "lumi.plug.mmeu01",

--- a/zhaquirks/xiaomi/aqara/plug_eu.py
+++ b/zhaquirks/xiaomi/aqara/plug_eu.py
@@ -410,15 +410,15 @@ class PlugAEU001MeteringCluster(MeteringCluster):
         attribute_name="button_lock",
         cluster_id=PlugAEU001Cluster.cluster_id,
         force_inverted=True,
-        translation_key="button_lock",
-        fallback_name="Button Lock",
+        translation_key="child_lock",
+        fallback_name="Child lock",
     )
     .enum(
         attribute_name="power_on_behavior",
         enum_class=AqaraPowerOutageMemoryEnum,
         cluster_id=PlugAEU001Cluster.cluster_id,
         translation_key="power_on_behavior",
-        fallback_name="Power On Behavior",
+        fallback_name="Power on behavior",
     )
     .number(
         attribute_name="overload_protection",
@@ -427,19 +427,19 @@ class PlugAEU001MeteringCluster(MeteringCluster):
         max_value=3840,
         unit=UnitOfPower.WATT,
         translation_key="overload_protection",
-        fallback_name="Overload Protection",
+        fallback_name="Overload protection",
     )
     .switch(
         attribute_name="led_indicator",
         cluster_id=PlugAEU001Cluster.cluster_id,
         translation_key="led_indicator",
-        fallback_name="LED Indicator",
+        fallback_name="LED indicator",
     )
     .switch(
         attribute_name="charging_protection",
         cluster_id=PlugAEU001Cluster.cluster_id,
         translation_key="charging_protection",
-        fallback_name="Charging Protection",
+        fallback_name="Charging protection",
     )
     .number(
         attribute_name="charging_limit",
@@ -449,7 +449,7 @@ class PlugAEU001MeteringCluster(MeteringCluster):
         step=0.1,
         unit=UnitOfPower.WATT,
         translation_key="charging_limit",
-        fallback_name="Charging Limit",
+        fallback_name="Charging limit",
     )
     .add_to_registry()
 )

--- a/zhaquirks/xiaomi/aqara/plug_eu.py
+++ b/zhaquirks/xiaomi/aqara/plug_eu.py
@@ -379,6 +379,7 @@ class PlugAEU001Cluster(XiaomiAqaraE1Cluster):
     QuirkBuilder("Aqara", "lumi.plug.aeu001")
     .friendly_name(model="Wall Outlet H2 EU", manufacturer="Aqara")
     .removes(TemperatureMeasurement.cluster_id)
+    .adds(DeviceTemperature)
     .removes(OnOff.cluster_id, endpoint_id=2)
     .replaces(BasicCluster)
     .replaces(MeteringCluster)

--- a/zhaquirks/xiaomi/aqara/plug_eu.py
+++ b/zhaquirks/xiaomi/aqara/plug_eu.py
@@ -2,6 +2,7 @@
 
 from enum import Enum
 import logging
+from typing import Final
 
 import zigpy
 from zigpy import types
@@ -24,6 +25,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -368,14 +370,30 @@ class AqaraPowerOutageMemoryEnum(types.uint8_t, Enum):
 class PlugAEU001Cluster(XiaomiAqaraE1Cluster):
     """Custom cluster for Aqara lumi plug AEU001."""
 
-    attributes = {
-        0x0200: ("button_lock", types.uint8_t, True),
-        0x0202: ("charging_protection", types.Bool, True),
-        0x0203: ("led_indicator", types.Bool, True),
-        0x0206: ("charging_limit", types.Single, True),
-        0x020B: ("overload_protection", types.Single, True),
-        0x0517: ("power_on_behavior", AqaraPowerOutageMemoryEnum, True),
-    }
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        button_lock: Final = ZCLAttributeDef(
+            id=0x0200, type=types.uint8_t, access="rw", is_manufacturer_specific=True
+        )
+        charging_protection: Final = ZCLAttributeDef(
+            id=0x0202, type=types.Bool, access="rw", is_manufacturer_specific=True
+        )
+        led_indicator: Final = ZCLAttributeDef(
+            id=0x0203, type=types.Bool, access="rw", is_manufacturer_specific=True
+        )
+        charging_limit: Final = ZCLAttributeDef(
+            id=0x0206, type=types.Single, access="rw", is_manufacturer_specific=True
+        )
+        overload_protection: Final = ZCLAttributeDef(
+            id=0x020B, type=types.Single, access="rw", is_manufacturer_specific=True
+        )
+        power_on_behavior: Final = ZCLAttributeDef(
+            id=0x0517,
+            type=AqaraPowerOutageMemoryEnum,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
 
 
 class PlugAEU001MeteringCluster(MeteringCluster):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR should add new configuration options and remove unused entities for Aqara Wall Outlet H2 EU (Aqara lumi.plug.aeu001) using the quirks v2 api.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
This is my first time writing a quirk and first time coding in Python, so please advise where improvements are possible.

Changes:
* removed temperature as it wasn't working as expected
* removed unknown/unused switch
* added Button lock
* added Charging Protection
* added option to configure LED indicator
* added Overload Protection
* added Power on behaviour

All the new configuration options have been tested on a device I own.

Related: #3265 #3187 

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
