### PR TITLE
Add Enchanted Device method to TuyaQuirkBuilder

### DIFF
--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -227,8 +227,6 @@ async def test_tuya_spell(device_mock, read_attr_spell, data_query_spell):
     with request_patch as request_mock:
         request_mock.return_value = (foundation.Status.SUCCESS, "done")
 
-        # assert isinstance(quirked, EnchantedDeviceV2)
-
         # call apply_custom_configuration() on each EnchantedDevice
         # ZHA does this during device configuration normally
         await quirked.apply_custom_configuration()

--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -12,6 +12,7 @@ from zigpy.zcl.clusters.general import Basic
 
 from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
+from zhaquirks.tuya import TUYA_QUERY_DATA
 from zhaquirks.tuya.builder import (
     TuyaIasContact,
     TuyaIasFire,
@@ -187,3 +188,75 @@ async def test_tuya_quirkbuilder(device_mock):
 
     assert tuya_listener.attribute_updates[0][0] == 0xEF0A
     assert tuya_listener.attribute_updates[0][1] == TestEnum.B
+
+
+@pytest.mark.parametrize(
+    "read_attr_spell,data_query_spell",
+    [
+        (True, False),
+        (False, True),
+        (True, True),
+        (False, False),
+    ],
+)
+async def test_tuya_spell(device_mock, read_attr_spell, data_query_spell):
+    """Test that enchanted Tuya devices have their spells applied during configuration."""
+    registry = DeviceRegistry()
+
+    entry = (
+        TuyaQuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+        .tuya_battery(dp_id=1)
+        .tuya_onoff(dp_id=3)
+        .tuya_enchantment(
+            read_attr_spell=read_attr_spell, data_query_spell=data_query_spell
+        )
+        .skip_configuration()
+        .add_to_registry()
+    )
+
+    # coverage for overridden __eq__ method
+    assert entry.adds_metadata[0] != entry.adds_metadata[1]
+    assert entry.adds_metadata[0] != entry
+
+    quirked = registry.get_device(device_mock)
+
+    assert isinstance(quirked, CustomDeviceV2)
+    assert quirked in registry
+
+    request_patch = mock.patch("zigpy.zcl.Cluster.request", mock.AsyncMock())
+    with request_patch as request_mock:
+        request_mock.return_value = (foundation.Status.SUCCESS, "done")
+
+        # assert isinstance(quirked, EnchantedDeviceV2)
+
+        # call apply_custom_configuration() on each EnchantedDevice
+        # ZHA does this during device configuration normally
+        await quirked.apply_custom_configuration()
+
+        # the number of Tuya spells that are allowed to be cast, so the sum of enabled Tuya spells
+        enabled_tuya_spells_num = (
+            quirked.tuya_spell_read_attributes + quirked.tuya_spell_data_query
+        )
+
+        # verify request was called the correct number of times
+        assert request_mock.call_count == enabled_tuya_spells_num
+
+        # used to check list of mock calls below
+        messages = 0
+
+        # check 'attribute read spell' was cast correctly (if enabled)
+        if quirked.tuya_spell_read_attributes:
+            assert (
+                request_mock.mock_calls[messages][1][1]
+                == foundation.GeneralCommand.Read_Attributes
+            )
+            assert request_mock.mock_calls[messages][1][3] == [4, 0, 1, 5, 7, 65534]
+            messages += 1
+
+        # check 'query data spell' was cast correctly (if enabled)
+        if quirked.tuya_spell_data_query:
+            assert not request_mock.mock_calls[messages][1][0]
+            assert request_mock.mock_calls[messages][1][1] == TUYA_QUERY_DATA
+            messages += 1
+
+        request_mock.reset_mock()

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -7,7 +7,7 @@ import enum
 import logging
 from typing import Any, Optional, Union
 
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import BaseCustomDevice, CustomCluster, CustomDevice
 import zigpy.types as t
 from zigpy.zcl import BaseAttributeDefs, foundation
 from zigpy.zcl.clusters.closures import WindowCovering
@@ -529,7 +529,7 @@ class TuyaManufClusterAttributes(TuyaManufCluster):
         return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
 
-class EnchantedDevice(CustomDevice):
+class BaseEnchantedDevice(BaseCustomDevice):
     """Class for Tuya devices which need to be unlocked by casting a 'spell'.
 
     The spell is applied during device configuration.
@@ -568,6 +568,10 @@ class EnchantedDevice(CustomDevice):
         tuya_cluster = self.endpoints[1].in_clusters[TuyaNewManufCluster.cluster_id]
         await tuya_cluster.command(TUYA_QUERY_DATA)
         self.debug("Executed data query spell on Tuya device %s", self.ieee)
+
+
+class EnchantedDevice(CustomDevice, BaseEnchantedDevice):
+    """Enchanted device class for v1 quirks."""
 
 
 class TuyaOnOff(CustomCluster, OnOff):

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -6,13 +6,14 @@ from typing import Any, Optional
 
 from zigpy.quirks import _DEVICE_REGISTRY
 from zigpy.quirks.registry import DeviceRegistry
-from zigpy.quirks.v2 import QuirkBuilder, QuirksV2RegistryEntry
+from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder, QuirksV2RegistryEntry
 from zigpy.quirks.v2.homeassistant import EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
 from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.clusters.measurement import (
     RelativeHumidity,
     SoilMoisture,
@@ -23,8 +24,10 @@ from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.tuya import (
     TUYA_CLUSTER_ID,
+    TUYA_QUERY_DATA,
     PowerConfiguration,
     TuyaLocalCluster,
+    TuyaNewManufCluster,
     TuyaPowerConfigurationCluster2AAA,
 )
 from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster, TuyaOnOffNM
@@ -519,6 +522,64 @@ class TuyaQuirkBuilder(QuirkBuilder):
             translation_key=translation_key,
             fallback_name=fallback_name,
         )
+
+        return self
+
+    def tuya_enchantment(
+        self, read_attr_spell: bool = True, data_query_spell: bool = False
+    ) -> QuirkBuilder:
+        """Set the Tuya enchantment spells."""
+
+        class EnchantedDeviceV2(CustomDeviceV2):
+            """Class for Tuya devices which need to be unlocked by casting a 'spell'.
+
+            The spell is applied during device configuration.
+            """
+
+            # These values can be overridden from a quirk to enable (or disable) additional Tuya spells:
+            tuya_spell_read_attributes: bool = (
+                True  # spell reading attributes on Basic cluster
+            )
+            tuya_spell_data_query: bool = (
+                False  # additional spell needed for some devices
+            )
+
+            async def apply_custom_configuration(self, *args, **kwargs):
+                """Hooks device configuration to apply custom configuration."""
+                # cast Tuya spell
+                if self.tuya_spell_read_attributes:
+                    await self.spell_attribute_reads()
+                if self.tuya_spell_data_query:
+                    await self.spell_data_query()
+
+                # also apply custom configuration to clusters if defined
+                await super().apply_custom_configuration(*args, **kwargs)
+
+            async def spell_attribute_reads(self):
+                """Cast 'attribute read' spell, so the Tuya device works correctly."""
+                self.debug(
+                    "Executing attribute read spell on Tuya device %s",
+                    self.ieee,
+                )
+                attr_to_read = [4, 0, 1, 5, 7, 0xFFFE]
+                basic_cluster = self.endpoints[1].in_clusters[Basic.cluster_id]
+                await basic_cluster.read_attributes(attr_to_read)
+                self.debug("Executed attribute read spell on Tuya device %s", self.ieee)
+
+            async def spell_data_query(self):
+                """Cast 'data query' spell, also required for some Tuya devices to send data."""
+                self.debug("Executing data query spell on Tuya device %s", self.ieee)
+                # tests verify that a device with an enabled 'data query spell' has a TuyaNewManufCluster (subclass)
+                tuya_cluster = self.endpoints[1].in_clusters[
+                    TuyaNewManufCluster.cluster_id
+                ]
+                await tuya_cluster.command(TUYA_QUERY_DATA)
+                self.debug("Executed data query spell on Tuya device %s", self.ieee)
+
+        EnchantedDeviceV2.tuya_spell_read_attributes = read_attr_spell
+        EnchantedDeviceV2.tuya_spell_data_query = data_query_spell
+
+        self.device_class(EnchantedDeviceV2)
 
         return self
 

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -13,7 +13,6 @@ from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.clusters.measurement import (
     RelativeHumidity,
     SoilMoisture,
@@ -24,10 +23,9 @@ from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.tuya import (
     TUYA_CLUSTER_ID,
-    TUYA_QUERY_DATA,
+    BaseEnchantedDevice,
     PowerConfiguration,
     TuyaLocalCluster,
-    TuyaNewManufCluster,
     TuyaPowerConfigurationCluster2AAA,
 )
 from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster, TuyaOnOffNM
@@ -530,51 +528,8 @@ class TuyaQuirkBuilder(QuirkBuilder):
     ) -> QuirkBuilder:
         """Set the Tuya enchantment spells."""
 
-        class EnchantedDeviceV2(CustomDeviceV2):
-            """Class for Tuya devices which need to be unlocked by casting a 'spell'.
-
-            The spell is applied during device configuration.
-            """
-
-            # These values can be overridden from a quirk to enable (or disable) additional Tuya spells:
-            tuya_spell_read_attributes: bool = (
-                True  # spell reading attributes on Basic cluster
-            )
-            tuya_spell_data_query: bool = (
-                False  # additional spell needed for some devices
-            )
-
-            async def apply_custom_configuration(self, *args, **kwargs):
-                """Hooks device configuration to apply custom configuration."""
-                # cast Tuya spell
-                if self.tuya_spell_read_attributes:
-                    await self.spell_attribute_reads()
-                if self.tuya_spell_data_query:
-                    await self.spell_data_query()
-
-                # also apply custom configuration to clusters if defined
-                await super().apply_custom_configuration(*args, **kwargs)
-
-            async def spell_attribute_reads(self):
-                """Cast 'attribute read' spell, so the Tuya device works correctly."""
-                self.debug(
-                    "Executing attribute read spell on Tuya device %s",
-                    self.ieee,
-                )
-                attr_to_read = [4, 0, 1, 5, 7, 0xFFFE]
-                basic_cluster = self.endpoints[1].in_clusters[Basic.cluster_id]
-                await basic_cluster.read_attributes(attr_to_read)
-                self.debug("Executed attribute read spell on Tuya device %s", self.ieee)
-
-            async def spell_data_query(self):
-                """Cast 'data query' spell, also required for some Tuya devices to send data."""
-                self.debug("Executing data query spell on Tuya device %s", self.ieee)
-                # tests verify that a device with an enabled 'data query spell' has a TuyaNewManufCluster (subclass)
-                tuya_cluster = self.endpoints[1].in_clusters[
-                    TuyaNewManufCluster.cluster_id
-                ]
-                await tuya_cluster.command(TUYA_QUERY_DATA)
-                self.debug("Executed data query spell on Tuya device %s", self.ieee)
+        class EnchantedDeviceV2(CustomDeviceV2, BaseEnchantedDevice):
+            """Enchanted device class for v1 quirks."""
 
         EnchantedDeviceV2.tuya_spell_read_attributes = read_attr_spell
         EnchantedDeviceV2.tuya_spell_data_query = data_query_spell

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -529,7 +529,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         """Set the Tuya enchantment spells."""
 
         class EnchantedDeviceV2(CustomDeviceV2, BaseEnchantedDevice):
-            """Enchanted device class for v1 quirks."""
+            """Enchanted device class for v2 quirks."""
 
         EnchantedDeviceV2.tuya_spell_read_attributes = read_attr_spell
         EnchantedDeviceV2.tuya_spell_data_query = data_query_spell


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

This enables adding enchanted devices using TuyaQuirkBuilder.

```python
(
        TuyaQuirkBuilder("manufacturer", "model")
        .tuya_battery(dp_id=1)
        .tuya_onoff(dp_id=3)
        .tuya_enchantment(
            read_attr_spell=True, data_query_spell=False
        )
        .skip_configuration()
        .add_to_registry()
)
```

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
