### PR TITLE
Give Tuya backlight values descriptive names

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -956,9 +956,9 @@ class TuyaThermostat(CustomDevice):
 class SwitchBackLight(t.enum8):
     """Tuya switch back light mode enum."""
 
-    Mode_0 = 0x00
-    Mode_1 = 0x01
-    Mode_2 = 0x02
+    Off = 0x00
+    Normal = 0x01
+    Reverse = 0x02
 
 
 class SwitchMode(t.enum8):


### PR DESCRIPTION
## Proposed change
Tuya Backlight enum names are not descriptive. Users needed to search the Internet to get the meaning of each value.


## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
