### PR TITLE
Add Tuya pool sensor quirk `_TZE200_v1jqz5cy`

### DIFF
--- a/tests/test_tuya_pool_sensor.py
+++ b/tests/test_tuya_pool_sensor.py
@@ -1,0 +1,155 @@
+"""Tests for Tuya Pool Sensor."""
+
+# These tests specifically cover the refresh logic.
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+import zhaquirks
+from zhaquirks.tuya import TUYA_QUERY_DATA
+from zhaquirks.tuya.mcu import TuyaMCUCluster
+from zhaquirks.tuya.ts0601_pool_sensor import TuyaPoolManufCluster
+
+zhaquirks.setup()
+
+
+@pytest.fixture
+def mock_device():
+    """Mock a TuyaMCUCluster device and endpoint."""
+    tuya_cluster = Mock()
+    tuya_cluster.cluster_id = TuyaMCUCluster.cluster_id
+    tuya_cluster.attributes_by_name = {"auto_refresh_interval": None}
+    tuya_cluster.get = Mock(return_value=5)
+
+    endpoint = Mock()
+    endpoint.in_clusters = {TuyaMCUCluster.cluster_id: tuya_cluster}
+
+    device = Mock()
+    device.endpoints = {1: endpoint}
+
+    endpoint.device = device
+
+    return device
+
+
+@pytest.fixture
+def mock_loop():
+    """Mock asyncio loop."""
+    loop = Mock()
+    loop.call_later = Mock()
+    return loop
+
+
+@pytest.mark.parametrize(
+    "model,manuf",
+    [
+        ("_TZE200_v1jqz5cy", "TS0601"),
+    ],
+)
+@pytest.mark.parametrize(
+    "cluster", (zhaquirks.tuya.ts0601_pool_sensor.TuyaPoolManufCluster,)
+)
+async def test_pool_sensor_initialization(
+    zigpy_device_from_v2_quirk, model, manuf, cluster
+):
+    """Tests pool sensor quirk exists."""
+
+    device = zigpy_device_from_v2_quirk(model, manuf)
+    tuya_cluster = device.endpoints[1].in_clusters.get(cluster.cluster_id)
+    assert tuya_cluster is not None
+
+
+@patch("asyncio.get_running_loop")
+def test_tuya_pool_manuf_cluster_init(mock_get_loop, mock_loop, mock_device):
+    """Test initialization of TuyaPoolManufCluster."""
+    # Patch the asyncio loop
+    mock_get_loop.return_value = mock_loop
+
+    cluster = TuyaPoolManufCluster(endpoint=mock_device.endpoints[1])
+
+    # Verify attributes are initialized correctly
+    assert (
+        cluster._update_timer_handle is not None
+    ), "Timer handle should have been set via next_call"
+    assert cluster.check_interval == 60, "Default check_interval should be 60 seconds"
+    assert (
+        cluster.next_refresh_interval == 5 * 60
+    ), "Default next_refresh_interval should be 5*60"
+    assert cluster._loop is mock_loop, "Asyncio loop should be set correctly"
+
+    # Verify that handle_auto_update_check_change is called
+    mock_loop.call_later.assert_any_call(60, cluster.handle_auto_update_check_change)
+
+
+@patch("asyncio.get_running_loop")
+def test_handle_auto_update_cancel(mock_get_loop, mock_device, mock_loop):
+    """Test canceling an auto-update timer."""
+
+    mock_get_loop.return_value = mock_loop
+    cluster = TuyaPoolManufCluster(endpoint=mock_device.endpoints[1])
+
+    # Simulate an active timer
+    mock_timer = Mock()
+    cluster._update_timer_handle = mock_timer
+
+    cluster.handle_auto_update_cancel()
+
+    # Verify the timer was canceled
+    mock_timer.cancel.assert_called_once()
+    assert cluster._update_timer_handle is None, "Timer handle should be reset to None"
+
+
+@patch("asyncio.get_running_loop")
+async def test_handle_auto_update(mock_get_loop, mock_device, mock_loop):
+    """Test the async auto-update logic."""
+
+    mock_get_loop.return_value = mock_loop
+    cluster = TuyaPoolManufCluster(endpoint=mock_device.endpoints[1])
+
+    # Mock TuyaMCUCluster's command method
+    tuya_cluster = mock_device.endpoints[1].in_clusters[TuyaMCUCluster.cluster_id]
+    tuya_cluster.command = AsyncMock()
+
+    await cluster.handle_auto_update()
+
+    # Verify the TUYA_QUERY_DATA command was sent
+    tuya_cluster.command.assert_called_once_with(TUYA_QUERY_DATA)
+
+
+@patch("asyncio.get_running_loop")
+def test_handle_auto_update_setup_next_call(mock_get_loop, mock_device, mock_loop):
+    """Test setting up the next auto-update call."""
+
+    mock_get_loop.return_value = mock_loop
+    cluster = TuyaPoolManufCluster(endpoint=mock_device.endpoints[1])
+
+    # Invoke the method to test
+    cluster.handle_auto_update_setup_next_call(force_new_interval=True)
+
+    # Verify the next call is scheduled correctly
+    mock_loop.call_later.assert_called_with(
+        5 * 60, cluster.handle_auto_update_timer_wrapper
+    )
+
+
+@patch("asyncio.get_running_loop")
+def test_handle_auto_update_timer_wrapper(mock_get_loop, mock_loop, mock_device):
+    """Test handle_auto_update_timer_wrapper behavior."""
+
+    mock_get_loop.return_value = mock_loop
+    cluster = TuyaPoolManufCluster(endpoint=mock_device.endpoints[1])
+
+    cluster.create_catching_task = Mock()
+    cluster.handle_auto_update = Mock(return_value=Mock())
+    cluster.handle_auto_update_setup_next_call = Mock()
+
+    # Call the method under test
+    cluster.handle_auto_update_timer_wrapper()
+
+    cluster.create_catching_task.assert_called_once_with(cluster.handle_auto_update())
+    cluster.handle_auto_update_setup_next_call.assert_called_once_with(
+        force_new_interval=True
+    )
+    cluster.create_catching_task.assert_called_once()
+    cluster.handle_auto_update_setup_next_call.assert_called_once()

--- a/tests/test_tuya_pool_sensor.py
+++ b/tests/test_tuya_pool_sensor.py
@@ -69,13 +69,13 @@ def test_tuya_pool_manuf_cluster_init(mock_get_loop, mock_loop, mock_device):
     cluster = TuyaPoolManufCluster(endpoint=mock_device.endpoints[1])
 
     # Verify attributes are initialized correctly
-    assert (
-        cluster._update_timer_handle is not None
-    ), "Timer handle should have been set via next_call"
+    assert cluster._update_timer_handle is not None, (
+        "Timer handle should have been set via next_call"
+    )
     assert cluster.check_interval == 60, "Default check_interval should be 60 seconds"
-    assert (
-        cluster.next_refresh_interval == 5 * 60
-    ), "Default next_refresh_interval should be 5*60"
+    assert cluster.next_refresh_interval == 5 * 60, (
+        "Default next_refresh_interval should be 5*60"
+    )
     assert cluster._loop is mock_loop, "Asyncio loop should be set correctly"
 
     # Verify that handle_auto_update_check_change is called

--- a/zhaquirks/tuya/ts0601_pool_sensor.py
+++ b/zhaquirks/tuya/ts0601_pool_sensor.py
@@ -1,0 +1,255 @@
+"""Tuya pool sensor."""
+
+import asyncio
+
+from zigpy.quirks.v2 import CustomDeviceV2
+from zigpy.quirks.v2.homeassistant import UnitOfTime, UnitOfElectricPotential
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+
+import zigpy.types as t
+
+from zhaquirks.tuya import TUYA_QUERY_DATA, TuyaNewManufCluster, EnchantedDevice
+from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaPowerConfigurationCluster
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+
+# Create a quirks v2 of Tuya's EnchantedDevice as we need Tuya spells
+EnchantedDevice.__bases__ = (CustomDeviceV2,)
+class EnchantedDeviceV2(EnchantedDevice):
+    """Updated version of EnchantedDevice based on CustomDeviceV2."""
+    tuya_spell_data_query: bool = True  # Enable data query spell
+
+
+class TuyaPoolManufCluster(TuyaMCUCluster):
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self._update_timer_handle = None
+        self.check_interval = 60
+        self.next_refresh_interval = 0
+        self._loop = asyncio.get_running_loop()
+        self.handle_auto_update_check_change()
+
+    def handle_auto_update_cancel(self):
+         if self._update_timer_handle:
+            self._update_timer_handle.cancel()
+            self._update_timer_handle = None       
+
+    def handle_auto_update_setup_next_call(self, force_new_interval=False):
+        tuya_cluster = self.endpoint.device.endpoints[1].in_clusters.get(TuyaMCUCluster.cluster_id, None)
+        if tuya_cluster and "auto_refresh_interval" in tuya_cluster.attributes_by_name:
+            interval = tuya_cluster.get("auto_refresh_interval", 0) * 60
+            # Check for a change to auto refresh number
+            if interval != self.next_refresh_interval:
+                self.handle_auto_update_cancel()
+                self.next_refresh_interval = interval
+                force_new_interval = True
+
+        if force_new_interval == True and self.next_refresh_interval > 0:
+            self.debug("using refresh interval of %d minutes", self.next_refresh_interval)
+            self._update_timer_handle = self._loop.call_later(self.next_refresh_interval,
+                                                              self.handle_auto_update_timer_wrapper)
+
+    def handle_auto_update_check_change(self):
+        self.handle_auto_update_setup_next_call()
+        self._loop.call_later(self.check_interval, self.handle_auto_update_check_change)
+
+    def handle_auto_update_timer_wrapper(self):
+        self.create_catching_task(self.handle_auto_update())
+        self.handle_auto_update_setup_next_call(force_new_interval=True)
+
+    async def handle_auto_update(self):
+        tuya_cluster = self.endpoint.device.endpoints[1].in_clusters[TuyaMCUCluster.cluster_id]
+        self.debug("sending refresh query command")
+        await tuya_cluster.command(TUYA_QUERY_DATA)
+
+
+(
+    TuyaQuirkBuilder("_TZE200_v1jqz5cy", "TS0601")
+    .device_class(EnchantedDeviceV2)
+    .replaces(TuyaPoolManufCluster)
+
+    .tuya_battery(dp_id=7, power_cfg=TuyaPowerConfigurationCluster, scale=1)
+    .tuya_temperature(dp_id=2, scale=10)
+    .tuya_sensor(
+        dp_id=10,
+        attribute_name="ph_measured_value",
+        divisor=100,
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.PH,
+        translation_key="ph_measured_value",
+        fallback_name="pH",
+    )
+    .tuya_sensor(
+        dp_id=1,
+        attribute_name="total_dissolved_solids",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="total_dissolved_solids",
+        fallback_name="Total Dissolved Solids",
+    )
+    .tuya_sensor(
+        dp_id=11,
+        attribute_name="ec_measured_value",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="ec_measured_value",
+        fallback_name="Electrical Conductivity",
+    )
+    .tuya_sensor(
+        dp_id=117,
+        attribute_name="salt_measured_value",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="salt_measured_value",
+        fallback_name="Salt Concentration",
+    )
+    .tuya_sensor(
+        dp_id=101,
+        attribute_name="redox_potential",
+        type=t.uint16_t,
+        unit=UnitOfElectricPotential.MILLIVOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="redox_potential",
+        fallback_name="ORP Level",
+    )
+    .tuya_sensor(
+        dp_id=102,
+        attribute_name="cl_measured_value",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="cl_measured_value",
+        fallback_name="Chlorine Concentration",
+    )
+    # TODO: 103 enum ?  pH Calibration
+    # TODO: 104 bool ?
+    # TODO: 105 uint16
+    .tuya_number(
+        dp_id=106,
+        attribute_name="ph_max_value",
+        type=t.uint16_t,
+        multiplier=0.1,
+        step=0.1,
+        min_value=0,
+        max_value=14,
+        mode="box",
+        device_class=NumberDeviceClass.PH,
+        translation_key="ph_max_value",
+        fallback_name="pH Maximum Value",
+    )
+    .tuya_number(
+        dp_id=107,
+        attribute_name="ph_min_value",
+        type=t.uint16_t,
+        multiplier=0.1,
+        step=0.1,
+        min_value=0,
+        max_value=14,
+        mode="box",
+        device_class=NumberDeviceClass.PH,
+        translation_key="ph_min_value",
+        fallback_name="pH Minimum Value",
+    )
+    .tuya_number(
+        dp_id=108,
+        attribute_name="ec_max_value",
+        type=t.uint16_t,
+        multiplier=11,
+        step=1,
+        min_value=0,
+        max_value=20000,
+        mode="box",
+        translation_key="ec_max_value",
+        fallback_name="EC Maximum Value",
+    )
+    .tuya_number(
+        dp_id=109,
+        attribute_name="ec_min_value",
+        type=t.uint16_t,
+        multiplier=1,
+        step=1,
+        min_value=0,
+        max_value=20000,
+        mode="box",
+        translation_key="ec_min_value",
+        fallback_name="EC Minimum Value",
+    )
+    .tuya_number(
+        dp_id=110,
+        attribute_name="orp_max_value",
+        type=t.uint16_t,
+        multiplier=1,
+        step=1,
+        min_value=-999,
+        max_value=999,
+        mode="box",
+        unit=UnitOfElectricPotential.MILLIVOLT,
+        device_class=NumberDeviceClass.VOLTAGE,
+        translation_key="orp_max_value",
+        fallback_name="ORP Maximum Value",
+    )
+    .tuya_number(
+        dp_id=111,
+        attribute_name="orp_min_value",
+        type=t.uint16_t,
+        multiplier=1,
+        step=1,
+        min_value=-999,
+        max_value=999,
+        mode="box",
+        unit=UnitOfElectricPotential.MILLIVOLT,
+        device_class=NumberDeviceClass.VOLTAGE,
+        translation_key="orp_min_value",
+        fallback_name="ORP Minimum Value",
+    )
+    .tuya_number(
+        dp_id=112,
+        attribute_name="cl_max_value",
+        type=t.uint16_t,
+        multiplier=0.1,
+        step=0.1,
+        min_value=0,
+        max_value=4,
+        mode="box",
+        translation_key="cl_max_value",
+        fallback_name="Cl Maximum Value",
+    )
+    .tuya_number(
+        dp_id=113,
+        attribute_name="cl_min_value",
+        type=t.uint16_t,
+        multiplier=0.1,
+        step=0.1,
+        min_value=0,
+        max_value=4,
+        mode="box",
+        translation_key="cl_min_value",
+        fallback_name="Cl Minimum Value",
+    )
+    # TODO: 114 uint16_t payload=0  pH Calibration
+    # TODO: 115 uint16_t payload=0  EC Calibration
+    # TODO: 116 uint16_t payload=0  ORP Calibration
+    # TODO: 118 bool payload=0 (false)
+    # Press button to manually refresh sensor data.
+    .command_button(
+        command_name="query_data",
+        cluster_id=TuyaNewManufCluster.cluster_id,
+        translation_key="Update",
+        fallback_name="Update",
+    )
+    # Automatic refresh interval in minutes. Set to 0 to disable.
+    .tuya_number(
+        dp_id=0x09,
+        attribute_name="auto_refresh_interval",
+        type=t.uint16_t,
+        translation_key="auto_refresh_interval",
+        fallback_name="Refresh Interval",
+        unit=UnitOfTime.MINUTES,
+        step=5,
+        min_value=0,
+        max_value=1440,   
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

This is an initial implementation of a standalone v2 quirk for _TZE200_v1jqz5cy Tuya Pool Sensor that works without HA or other modifications.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

What it does:
* This implementation uses v2 quirks to instantiate a bunch of entities for each of the DP's.
* Provides a derived class of EnchantedDevice for V2 to cast the Tuya spells. These have been tested.
* Provides a refresh data command (via quirks v2), as per @tschiex 's implementation.
* Provides and handles an automatic refresh config option for interval refresh in minutes.
* Sensor readings look good to me.

What it does not do:
* Does not yet expose the calibration config DPs.
* A lot of units are missing as they either don't exist in HA, or are not exposed via zigpy, or are not in the validation list. I don't understand the history of unit's (aside from the need to handle conversions like C to F) but it seems unnecessarily complicated to have to define every unit. I wonder if a generic number could be provided via HA to capture these.
* I couldn't figure out how to get a notification that the config number for auto_refresh_interval has changed, but wondering if there is a cleaner way to do this that what I did in handle_auto_update_..()

All sensors look pretty good to me, and the device on battery runs great. My only concern is chlorine seems to not change, but my CL pool levels are super low.

Suggested next steps:
* I'd like to get this in as a quirk pretty much as-is as I think it makes the device usable.
* Next, I can try help out on adding unit's to HA, and/or zigpy but need guidance here.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works



Related: #2565
