### PR TITLE
Fix missing endpoints for Aqara H1 wireless remotes

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1804,3 +1804,20 @@ async def test_aqara_fp1e_sensor(
     assert len(ias_listener.attribute_updates) == 1
     assert ias_listener.attribute_updates[0][0] == IasZone.AttributeDefs.zone_status.id
     assert ias_listener.attribute_updates[0][1] == expected_motion_status
+
+
+def test_h1_wireless_remotes(zigpy_device_from_v2_quirk):
+    """Test Aqara H1 wireless remote signature replacement adds missing endpoints."""
+    # create device with only endpoint 1 and verify we don't get a KeyError
+    quirk = zigpy_device_from_v2_quirk(LUMI, "lumi.remote.b28ac1")
+
+    # verify the quirk adds endpoints 2 and 3
+    assert 2 in quirk.endpoints
+    assert 3 in quirk.endpoints
+
+    # verify the quirk adds the correct clusters to the new endpoints
+    assert OnOff.cluster_id in quirk.endpoints[2].out_clusters
+    assert OnOff.cluster_id in quirk.endpoints[3].out_clusters
+
+    assert MultistateInput.cluster_id in quirk.endpoints[2].in_clusters
+    assert MultistateInput.cluster_id in quirk.endpoints[3].in_clusters

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1807,8 +1807,8 @@ async def test_aqara_fp1e_sensor(
 
 
 def test_h1_wireless_remotes(zigpy_device_from_v2_quirk):
-    """Test Aqara H1 wireless remote signature replacement adds missing endpoints."""
-    # create device with only endpoint 1 and verify we don't get a KeyError
+    """Test Aqara H1 wireless remote quirk adds missing endpoints."""
+    # create device with endpoint 1 only and verify we don't get a KeyError
     quirk = zigpy_device_from_v2_quirk(LUMI, "lumi.remote.b28ac1")
 
     # verify the quirk adds endpoints 2 and 3

--- a/zhaquirks/xiaomi/aqara/remote_h1.py
+++ b/zhaquirks/xiaomi/aqara/remote_h1.py
@@ -1,6 +1,7 @@
 """Aqara H1-series wireless remote."""
 
 from zigpy import types
+from zigpy.profiles import zha
 from zigpy.quirks.v2 import ClusterType, QuirkBuilder
 from zigpy.zcl.clusters.general import Identify, OnOff
 from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
@@ -144,6 +145,9 @@ class PowerConfigurationClusterH1Remote(PowerConfigurationCluster):
     # .friendly_name(
     #     manufacturer="Aqara", model="Wireless Remote Switch H1 (Double Rocker)"
     # )
+    # add endpoints that are present but not exposed sometimes
+    .adds_endpoint(2, device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH)
+    .adds_endpoint(3, device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH)
     .replaces(AqaraRemoteManuSpecificCluster)
     .adds(Identify)
     .replaces(MultistateInputCluster)


### PR DESCRIPTION
## Proposed change
Fix missing endpoints for Aqara H1 wireless remotes.

The device sometimes doesn't report these endpoints as available, so quirks v2 code that `adds` or `replaces` clusters on those endpoints will cause ZHA to break.
Zigpy now allows us to add these endpoints to the zigpy device, so we can also add clusters to the endpoints in the same quirk without issues.


## Additional information

Addresses https://github.com/home-assistant/core/issues/134686 and https://github.com/home-assistant/core/issues/134691.
Follow-up to https://github.com/zigpy/zha-device-handlers/pull/3564

~~This needs https://github.com/zigpy/zigpy/pull/1524 and a corresponding [zigpy bump](https://github.com/zigpy/zha-device-handlers/pull/3675), then a rebase before tests will pass.~~ (done)

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
