### PR TITLE
Fix Tuya negative temperatures, add variants

### DIFF
--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -15,16 +15,19 @@ zhaquirks.setup()
 @pytest.mark.parametrize(
     "model,manuf,rh_scale,temp_scale,test_neg",
     [
-        ("_TZE200_bjawzodf", "TS0601", 10, 10, False),
-        ("_TZE200_zl1kmjqx", "TS0601", 10, 10, False),
-        ("_TZE200_a8sdabtg", "TS0601", 100, 10, True),  # Variant without screen, round
-        ("_TZE200_qoy0ekbd", "TS0601", 100, 10, True),
-        ("_TZE200_znbl8dj5", "TS0601", 100, 10, True),
+        ("_TZE200_bjawzodf", "TS0601", 10, 10, True),
+        ("_TZE200_zl1kmjqx", "TS0601", 10, 10, True),
+        ("_TZE200_a8sdabtg", "TS0601", 100, 10, False),  # Variant without screen, round
+        ("_TZE200_qoy0ekbd", "TS0601", 100, 10, False),
+        ("_TZE200_znbl8dj5", "TS0601", 100, 10, False),
         ("_TZE200_qyflbnbj", "TS0601", 100, 10, True),
-        ("_TZE200_zppcgbdj", "TS0601", 100, 10, True),
-        ("_TZE200_s1xgth2u", "TS0601", 100, 10, True),
+        ("_TZE200_zppcgbdj", "TS0601", 100, 10, False),
+        ("_TZE200_s1xgth2u", "TS0601", 100, 10, False),
         ("_TZE284_qyflbnbj", "TS0601", 100, 10, True),
-        ("_TZE204_s139roas", "TS0601", 100, 10, True),
+        ("_TZE204_s139roas", "TS0601", 100, 10, False),
+        ("_TZE200_bq5c8xfe", "TS0601", 100, 10, True),
+        ("_TZE200_vs0skpuc", "TS0601", 100, 10, True),
+        ("_TZE200_44af8vyi", "TS0601", 100, 10, True),
     ],
 )
 async def test_handle_get_data(

--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -13,21 +13,22 @@ zhaquirks.setup()
 
 
 @pytest.mark.parametrize(
-    "model,manuf,rh_scale,temp_scale",
+    "model,manuf,rh_scale,temp_scale,test_neg",
     [
-        ("_TZE200_bjawzodf", "TS0601", 10, 10),
-        ("_TZE200_zl1kmjqx", "TS0601", 10, 10),
-        ("_TZE200_a8sdabtg", "TS0601", 100, 10),  # Variant without screen, round
-        ("_TZE200_qoy0ekbd", "TS0601", 100, 10),
-        ("_TZE200_znbl8dj5", "TS0601", 100, 10),
-        ("_TZE200_qyflbnbj", "TS0601", 100, 10),
-        ("_TZE200_zppcgbdj", "TS0601", 100, 10),
-        ("_TZE200_s1xgth2u", "TS0601", 100, 10),
-        ("_TZE284_qyflbnbj", "TS0601", 100, 10),
+        ("_TZE200_bjawzodf", "TS0601", 10, 10, False),
+        ("_TZE200_zl1kmjqx", "TS0601", 10, 10, False),
+        ("_TZE200_a8sdabtg", "TS0601", 100, 10, True),  # Variant without screen, round
+        ("_TZE200_qoy0ekbd", "TS0601", 100, 10, True),
+        ("_TZE200_znbl8dj5", "TS0601", 100, 10, True),
+        ("_TZE200_qyflbnbj", "TS0601", 100, 10, True),
+        ("_TZE200_zppcgbdj", "TS0601", 100, 10, True),
+        ("_TZE200_s1xgth2u", "TS0601", 100, 10, True),
+        ("_TZE284_qyflbnbj", "TS0601", 100, 10, True),
+        ("_TZE204_s139roas", "TS0601", 100, 10, True),
     ],
 )
 async def test_handle_get_data(
-    zigpy_device_from_v2_quirk, model, manuf, rh_scale, temp_scale
+    zigpy_device_from_v2_quirk, model, manuf, rh_scale, temp_scale, test_neg
 ):
     """Test handle_get_data for multiple attributes - normal battery."""
 
@@ -66,6 +67,15 @@ async def test_handle_get_data(
 
     status = ep.tuya_manufacturer.handle_get_data(data.data)
     assert status == foundation.Status.UNSUPPORTED_ATTRIBUTE
+
+    if test_neg:
+        message = b"\tH\x01\x00\xd8\x01\x02\x00\x04\x00\x00\xff\xe0"  # -3.1 deg c
+        hdr, data = ep.tuya_manufacturer.deserialize(message)
+
+        status = ep.tuya_manufacturer.handle_get_data(data.data)
+        assert status == foundation.Status.SUCCESS
+
+        assert ep.temperature.get("measured_value") == -310
 
 
 @pytest.mark.parametrize(

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -3,7 +3,11 @@
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
 
-from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkBuilder
+from zhaquirks.tuya.builder import (
+    TuyaPowerConfigurationCluster2AAA,
+    TuyaQuirkBuilder,
+    TuyaTemperatureMeasurement,
+)
 
 (
     TuyaQuirkBuilder("_TZE200_bjawzodf", "TS0601")
@@ -15,7 +19,6 @@ from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkB
     .add_to_registry()
 )
 
-
 (
     TuyaQuirkBuilder("_TZE200_a8sdabtg", "TS0601")  # Variant without screen, round
     .applies_to("_TZE200_qoy0ekbd", "TS0601")
@@ -25,7 +28,14 @@ from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkB
     .applies_to("_TZE204_s139roas", "TS0601")
     .applies_to("_TZE200_s1xgth2u", "TS0601")  # Nedis ZBSC30WT
     .applies_to("_TZE284_qyflbnbj", "TS0601")
-    .tuya_temperature(dp_id=1, scale=10)
+    # Not using tuya_temperature because device reports negative values incorrectly
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=TuyaTemperatureMeasurement.ep_attribute,
+        attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
+        converter=lambda x: ((x - 0xFFFF if x > 0x2000 else x) * 10),
+    )
+    .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=2)
     .tuya_battery(dp_id=4)
     .skip_configuration()

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -53,7 +53,6 @@ from zhaquirks.tuya.builder import (
     .applies_to("_TZE200_zppcgbdj", "TS0601")
     .applies_to("_TZE204_s139roas", "TS0601")
     .applies_to("_TZE200_s1xgth2u", "TS0601")  # Nedis ZBSC30WT
-    # Not using tuya_temperature because device reports negative values incorrectly
     .tuya_temperature(dp_id=1, scale=10)
     .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=2)

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -12,7 +12,14 @@ from zhaquirks.tuya.builder import (
 (
     TuyaQuirkBuilder("_TZE200_bjawzodf", "TS0601")
     .applies_to("_TZE200_zl1kmjqx", "TS0601")
-    .tuya_temperature(dp_id=1, scale=10)
+    # Not using tuya_temperature because device reports negative values incorrectly
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=TuyaTemperatureMeasurement.ep_attribute,
+        attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
+        converter=lambda x: ((x - 0xFFFF if x > 0x2000 else x) * 10),
+    )
+    .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=2, scale=10)
     .tuya_battery(dp_id=4)
     .skip_configuration()
@@ -20,14 +27,11 @@ from zhaquirks.tuya.builder import (
 )
 
 (
-    TuyaQuirkBuilder("_TZE200_a8sdabtg", "TS0601")  # Variant without screen, round
-    .applies_to("_TZE200_qoy0ekbd", "TS0601")
-    .applies_to("_TZE200_znbl8dj5", "TS0601")
+    TuyaQuirkBuilder("_TZE200_bq5c8xfe", "TS0601")
+    .applies_to("_TZE200_vs0skpuc", "TS0601")
     .applies_to("_TZE200_qyflbnbj", "TS0601")
-    .applies_to("_TZE200_zppcgbdj", "TS0601")
-    .applies_to("_TZE204_s139roas", "TS0601")
-    .applies_to("_TZE200_s1xgth2u", "TS0601")  # Nedis ZBSC30WT
     .applies_to("_TZE284_qyflbnbj", "TS0601")
+    .applies_to("_TZE200_44af8vyi", "TS0601")
     # Not using tuya_temperature because device reports negative values incorrectly
     .tuya_dp(
         dp_id=1,
@@ -42,6 +46,21 @@ from zhaquirks.tuya.builder import (
     .add_to_registry()
 )
 
+(
+    TuyaQuirkBuilder("_TZE200_a8sdabtg", "TS0601")  # Variant without screen, round
+    .applies_to("_TZE200_qoy0ekbd", "TS0601")
+    .applies_to("_TZE200_znbl8dj5", "TS0601")
+    .applies_to("_TZE200_zppcgbdj", "TS0601")
+    .applies_to("_TZE204_s139roas", "TS0601")
+    .applies_to("_TZE200_s1xgth2u", "TS0601")  # Nedis ZBSC30WT
+    # Not using tuya_temperature because device reports negative values incorrectly
+    .tuya_temperature(dp_id=1, scale=10)
+    .adds(TuyaTemperatureMeasurement)
+    .tuya_humidity(dp_id=2)
+    .tuya_battery(dp_id=4)
+    .skip_configuration()
+    .add_to_registry()
+)
 
 (
     TuyaQuirkBuilder("_TZE200_yjjdcqsq", "TS0601")


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Some Tuya temperature sensors report negative values oddly.

See: 
- https://github.com/Koenkk/zigbee-herdsman-converters/blob/f62651809e2efda8d886bd93b6dc63aa005bd28e/src/devices/tuya.ts#L1000
- https://github.com/Koenkk/zigbee-herdsman-converters/blob/f62651809e2efda8d886bd93b6dc63aa005bd28e/src/lib/legacy.ts#L3003

Closes: https://github.com/zigpy/zha-device-handlers/issues/3677

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

This also adds some sensors that were present in z2m that we didn't have.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
