### PR TITLE
Add IKEA Vallhorn quirk

### DIFF
--- a/zhaquirks/ikea/vallhorn.py
+++ b/zhaquirks/ikea/vallhorn.py
@@ -1,0 +1,52 @@
+"""IKEA Vallhorn quirk."""
+
+from typing import Final
+
+from zigpy import types as t
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+
+class IkeaVallhornManufSpecificConfig(CustomCluster):
+    """Ikea Vallhorn manufacturer specific config cluster."""
+
+    name = "IKEA manufacturer specific config"
+    cluster_id = 0xFC81
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        on_only_when_dark: Final = ZCLAttributeDef(
+            id=0x0000,
+            type=t.Bool,
+        )
+
+        on_time: Final = ZCLAttributeDef(
+            id=0x0002,
+            type=t.uint16_t,
+        )
+
+
+(
+    QuirkBuilder("IKEA of Sweden", "VALLHORN Wireless Motion Sensor")
+    .replaces(IkeaVallhornManufSpecificConfig)
+    .switch(
+        IkeaVallhornManufSpecificConfig.AttributeDefs.on_only_when_dark.name,
+        IkeaVallhornManufSpecificConfig.cluster_id,
+        translation_key="on_only_when_dark",
+        fallback_name="On only when dark",
+    )
+    .number(
+        IkeaVallhornManufSpecificConfig.AttributeDefs.on_time.name,
+        IkeaVallhornManufSpecificConfig.cluster_id,
+        step=1,
+        min_value=10,
+        max_value=65534,
+        unit=UnitOfTime.SECONDS,
+        translation_key="on_time",
+        fallback_name="On time",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Allows to configure the "on only when dark" and the "on time"
value. Both "only when dark" (on/off) and "on time" (only 60s or 300s) can also be
configured by buttons on the device itself.
    
There is another attribute 0x0004 in this cluster which I haven't figured out what
it does.


## Additional information

Looks like this in my 2025.01.0 HomeAssistant:

![grafik](https://github.com/user-attachments/assets/f2728fd3-858e-4b59-bb70-7101e16ebff5)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
