### PR TITLE
Add Tuya air sensor `_TZE200_mja3fuja` variant

### DIFF
--- a/zhaquirks/tuya/air/ts0601_air_quality.py
+++ b/zhaquirks/tuya/air/ts0601_air_quality.py
@@ -38,6 +38,7 @@ class TuyaCO2Sensor(CustomDevice):
             ("_TZE204_yvx5lh6k", "TS0601"),
             ("_TZE200_c2fmom5z", "TS0601"),
             ("_TZE204_c2fmom5z", "TS0601"),
+            ("_TZE200_mja3fuja", "TS0601"),
         ],
         ENDPOINTS: {
             1: {
@@ -91,6 +92,7 @@ class TuyaCO2SensorGPP(CustomDevice):
             ("_TZE204_yvx5lh6k", "TS0601"),
             ("_TZE200_c2fmom5z", "TS0601"),
             ("_TZE204_c2fmom5z", "TS0601"),
+            ("_TZE200_mja3fuja", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change

After adding this change, the device reports all sensors available (VOC, CO2, Formaldehyde, Hum, Temp).
Otherwise it would only report VOC.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
