### PR TITLE
Add Tuya siren `_TZE284_nlrfgpny`

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -11,7 +11,13 @@ from zigpy.quirks import BaseCustomDevice, CustomCluster, CustomDevice
 import zigpy.types as t
 from zigpy.zcl import BaseAttributeDefs, foundation
 from zigpy.zcl.clusters.closures import WindowCovering
-from zigpy.zcl.clusters.general import Basic, LevelControl, OnOff, PowerConfiguration
+from zigpy.zcl.clusters.general import (
+    Basic,
+    BatterySize,
+    LevelControl,
+    OnOff,
+    PowerConfiguration,
+)
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.clusters.smartenergy import Metering
@@ -909,7 +915,7 @@ class TuyaPowerConfigurationCluster2AAA(PowerConfiguration, TuyaLocalCluster):
     """PowerConfiguration cluster for devices with 2 AAA."""
 
     _CONSTANT_ATTRIBUTES = {
-        PowerConfiguration.AttributeDefs.battery_size.id: 4,
+        PowerConfiguration.AttributeDefs.battery_size.id: BatterySize.AAA,
         PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
         PowerConfiguration.AttributeDefs.battery_quantity.id: 2,
     }
@@ -919,7 +925,7 @@ class TuyaPowerConfigurationCluster2AA(TuyaPowerConfigurationCluster):
     """PowerConfiguration cluster for devices with 2 AA."""
 
     _CONSTANT_ATTRIBUTES = {
-        PowerConfiguration.AttributeDefs.battery_size.id: 3,
+        PowerConfiguration.AttributeDefs.battery_size.id: BatterySize.AA,
         PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
         PowerConfiguration.AttributeDefs.battery_quantity.id: 2,
     }
@@ -929,7 +935,7 @@ class TuyaPowerConfigurationCluster3AA(TuyaPowerConfigurationCluster):
     """PowerConfiguration cluster for devices with 3 AA."""
 
     _CONSTANT_ATTRIBUTES = {
-        PowerConfiguration.AttributeDefs.battery_size.id: 3,
+        PowerConfiguration.AttributeDefs.battery_size.id: BatterySize.AA,
         PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
         PowerConfiguration.AttributeDefs.battery_quantity.id: 3,
     }
@@ -939,9 +945,19 @@ class TuyaPowerConfigurationCluster4AA(PowerConfiguration, TuyaLocalCluster):
     """PowerConfiguration cluster for devices with 4 AA."""
 
     _CONSTANT_ATTRIBUTES = {
-        PowerConfiguration.AttributeDefs.battery_size.id: 3,
+        PowerConfiguration.AttributeDefs.battery_size.id: BatterySize.AA,
         PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 15,
         PowerConfiguration.AttributeDefs.battery_quantity.id: 4,
+    }
+
+
+class TuyaPowerConfigurationClusterOther(PowerConfiguration, TuyaLocalCluster):
+    """PowerConfiguration cluster for devices with other."""
+
+    _CONSTANT_ATTRIBUTES = {
+        PowerConfiguration.AttributeDefs.battery_size.id: BatterySize.Other,
+        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 36,
+        PowerConfiguration.AttributeDefs.battery_quantity.id: 1,
     }
 
 

--- a/zhaquirks/tuya/tuya_siren.py
+++ b/zhaquirks/tuya/tuya_siren.py
@@ -1,0 +1,86 @@
+"""Tuya Siren."""
+
+from zigpy.quirks.v2 import EntityType
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+import zigpy.types as t
+
+from zhaquirks.tuya import TuyaPowerConfigurationClusterOther
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+
+class TuyaSirenState(t.enum8):
+    """Tuya siren state enum."""
+
+    Sound = 0x00
+    Light = 0x01
+    Sound_and_light = 0x02
+    Normal = 0x03
+
+
+class TuyaSirenRingtone(t.enum8):
+    """Tuya siren ringtone enum."""
+
+    Ringtone_01 = 0x00
+    Ringtone_02 = 0x01
+    Ringtone_03 = 0x02
+
+
+(
+    TuyaQuirkBuilder("_TZE204_nlrfgpny", "TS0601")
+    .tuya_binary_sensor(
+        dp_id=1,
+        attribute_name="alarm_state",
+        translation_key="alarm_state",
+        fallback_name="Alarm state",
+    )
+    .tuya_binary_sensor(
+        dp_id=6,
+        attribute_name="charge_state",
+        translation_key="charge_state",
+        fallback_name="Charge state",
+    )
+    .tuya_number(
+        dp_id=7,
+        attribute_name="alarm_duration",
+        min_value=1,
+        type=t.uint16_t,
+        max_value=60,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        translation_key="alarm_duration",
+        fallback_name="Alarm duration",
+    )
+    .tuya_switch(
+        dp_id=13,
+        attribute_name="alarm_switch",
+        entity_type=EntityType.STANDARD,
+        translation_key="alarm_switch",
+        fallback_name="Alarm trigger",
+    )
+    .tuya_battery(dp_id=15, power_cfg=TuyaPowerConfigurationClusterOther)
+    .tuya_contact(dp_id=20)
+    .tuya_enum(
+        dp_id=21,
+        attribute_name="alarm_ringtone",
+        enum_class=TuyaSirenRingtone,
+        translation_key="alarm_ringtone",
+        fallback_name="Alarm ringtone",
+    )
+    .tuya_switch(
+        dp_id=101,
+        attribute_name="tamper_alarm_switch",
+        entity_type=EntityType.STANDARD,
+        translation_key="tamper_alarm_switch",
+        fallback_name="Clear tamper alarm",
+    )
+    .tuya_enum(
+        dp_id=102,
+        attribute_name="alarm_state",
+        enum_class=TuyaSirenState,
+        translation_key="alarm_state",
+        fallback_name="Alarm State",
+    )
+    .tuya_encantment()
+    .skip_configuration()
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/tuya_siren.py
+++ b/zhaquirks/tuya/tuya_siren.py
@@ -1,6 +1,6 @@
 """Tuya Siren."""
 
-from zigpy.quirks.v2 import EntityType
+from zigpy.quirks.v2 import EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 import zigpy.types as t
@@ -28,6 +28,15 @@ class TuyaSirenRingtone(t.enum8):
 
 (
     TuyaQuirkBuilder("_TZE204_nlrfgpny", "TS0601")
+    .tuya_enum(
+        dp_id=1,
+        attribute_name="alarm_state",
+        enum_class=TuyaSirenState,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.STANDARD,
+        translation_key="alarm_state",
+        fallback_name="Alarm state",
+    )
     .tuya_binary_sensor(
         dp_id=6,
         attribute_name="charge_state",
@@ -78,10 +87,10 @@ class TuyaSirenRingtone(t.enum8):
     )
     .tuya_enum(
         dp_id=102,
-        attribute_name="alarm_state",
+        attribute_name="alarm_mode",
         enum_class=TuyaSirenState,
-        translation_key="alarm_state",
-        fallback_name="Alarm State",
+        translation_key="alarm_mode",
+        fallback_name="Alarm mode",
     )
     .tuya_enchantment()
     .skip_configuration()

--- a/zhaquirks/tuya/tuya_siren.py
+++ b/zhaquirks/tuya/tuya_siren.py
@@ -48,9 +48,9 @@ class TuyaSirenRingtone(t.enum8):
     )
     .tuya_switch(
         dp_id=13,
-        attribute_name="alarm_switch",
+        attribute_name="siren_on",
         entity_type=EntityType.STANDARD,
-        translation_key="alarm_switch",
+        translation_key="siren_on",
         fallback_name="Siren on",
     )
     .tuya_battery(dp_id=15, power_cfg=TuyaPowerConfigurationClusterOther)
@@ -71,9 +71,9 @@ class TuyaSirenRingtone(t.enum8):
     )
     .tuya_switch(
         dp_id=101,
-        attribute_name="tamper_alarm_switch",
+        attribute_name="enable_tamper_alarm",
         entity_type=EntityType.STANDARD,
-        translation_key="tamper_alarm_switch",
+        translation_key="enable_tamper_alarm",
         fallback_name="Enable tamper alarm",
     )
     .tuya_enum(

--- a/zhaquirks/tuya/tuya_siren.py
+++ b/zhaquirks/tuya/tuya_siren.py
@@ -51,7 +51,7 @@ class TuyaSirenRingtone(t.enum8):
         type=t.uint16_t,
         max_value=60,
         step=1,
-        unit=UnitOfTime.SECONDS,
+        unit=UnitOfTime.MINUTES,
         translation_key="alarm_duration",
         fallback_name="Alarm duration",
     )

--- a/zhaquirks/tuya/tuya_siren.py
+++ b/zhaquirks/tuya/tuya_siren.py
@@ -80,7 +80,7 @@ class TuyaSirenRingtone(t.enum8):
         translation_key="alarm_state",
         fallback_name="Alarm State",
     )
-    .tuya_encantment()
+    .tuya_enchantment()
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/tuya_siren.py
+++ b/zhaquirks/tuya/tuya_siren.py
@@ -2,6 +2,7 @@
 
 from zigpy.quirks.v2 import EntityType
 from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 import zigpy.types as t
 
 from zhaquirks.tuya import TuyaPowerConfigurationClusterOther
@@ -28,15 +29,10 @@ class TuyaSirenRingtone(t.enum8):
 (
     TuyaQuirkBuilder("_TZE204_nlrfgpny", "TS0601")
     .tuya_binary_sensor(
-        dp_id=1,
-        attribute_name="alarm_state",
-        translation_key="alarm_state",
-        fallback_name="Alarm state",
-    )
-    .tuya_binary_sensor(
         dp_id=6,
         attribute_name="charge_state",
         translation_key="charge_state",
+        device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         fallback_name="Charge state",
     )
     .tuya_number(
@@ -55,10 +51,17 @@ class TuyaSirenRingtone(t.enum8):
         attribute_name="alarm_switch",
         entity_type=EntityType.STANDARD,
         translation_key="alarm_switch",
-        fallback_name="Alarm trigger",
+        fallback_name="Siren on",
     )
     .tuya_battery(dp_id=15, power_cfg=TuyaPowerConfigurationClusterOther)
-    .tuya_contact(dp_id=20)
+    .tuya_binary_sensor(
+        dp_id=20,
+        attribute_name="tamper_state",
+        device_class=BinarySensorDeviceClass.TAMPER,
+        entity_type=EntityType.STANDARD,
+        translation_key="tamper_state",
+        fallback_name="Tamper state",
+    )
     .tuya_enum(
         dp_id=21,
         attribute_name="alarm_ringtone",
@@ -71,7 +74,7 @@ class TuyaSirenRingtone(t.enum8):
         attribute_name="tamper_alarm_switch",
         entity_type=EntityType.STANDARD,
         translation_key="tamper_alarm_switch",
-        fallback_name="Clear tamper alarm",
+        fallback_name="Enable tamper alarm",
     )
     .tuya_enum(
         dp_id=102,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Adds _TZE284_nlrfgpny 

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

Closes: https://github.com/zigpy/zha-device-handlers/issues/3667

Datapoints:
{
"1":"Alarm state", bool - Does not report
"6":"Charge state", 
"7":"Alarm Time", 
"13":"Alarm Switch", 
"15":"Battery level",
"20":"tamper_alarm",
"21":"Alarm Ringtone", 
"101":"Tamper alarm Switch",
"102":"Set alarm state" 
}

- Have yet to see a battery report



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
