### PR TITLE
Add Niko Connected single/double switch and dimmer

### DIFF
--- a/tests/test_niko.py
+++ b/tests/test_niko.py
@@ -23,12 +23,17 @@ SWITCH_DOUBLE = (
     {"endpoint_ids": [0, 1, 2, 242]},
 )
 
+DIMMER = (
+    ["NIKO NV", "Connectable dimmer,3-200W,2-wire"],
+    {"endpoint_ids": [0, 1, 242]},
+)
+
 
 # pylint: disable=R0903
 class TestNikoSwitch:
     """Tests for Niko Connected Switches (552-721X1 and 552-721X2)."""
 
-    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
+    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE, DIMMER])
     class TestClusters:
         """Test whether all clusters are present and complete."""
 
@@ -91,7 +96,7 @@ class TestNikoSwitch:
                 0x0100: foundation.ZCLAttributeAccess.from_str("rw"),
             }
 
-    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
+    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE, DIMMER])
     # pylint: disable=R0903
     class TestConfiguration:
         """Test device configuration."""
@@ -237,7 +242,7 @@ class TestNikoSwitch:
                 },
             }
 
-    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
+    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE, DIMMER])
     class TestButtonState:
         """Test button state and associated events."""
 
@@ -379,7 +384,7 @@ class TestNikoSwitch:
                         },
                     )
 
-    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
+    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE, DIMMER])
     class TestLedState:
         """Test reading and writing status LED state."""
 
@@ -519,7 +524,7 @@ class TestNikoSwitch:
                 attr = config_cluster.get(0x0105)
                 assert (0 if attr is None else attr) == case["result"]
 
-    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
+    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE, DIMMER])
     class TestLedSync:
         """Test reading and writing status LED synchronization state."""
 
@@ -597,7 +602,7 @@ class TestNikoSwitch:
                     attr = config_cluster.get(0x0107)
                     assert (0 if attr is None else attr) == expected
 
-    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
+    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE, DIMMER])
     class TestLedsAlert:
         """Test reading and writing status LED alert state."""
 

--- a/tests/test_niko.py
+++ b/tests/test_niko.py
@@ -6,6 +6,7 @@ import pytest
 from zigpy import types as t
 from zigpy.zcl import foundation
 
+from tests.common import wait_for_zigpy_tasks
 import zhaquirks
 
 zhaquirks.setup()
@@ -43,6 +44,21 @@ class TestNikoSwitch:
                 0x0107: foundation.ZCLAttributeAccess.from_str("rw"),
             }
 
+        @mock.patch("zigpy.zcl.Cluster.bind", mock.AsyncMock())
+        async def test_config_cluster_preloading(
+            self, zigpy_device_from_v2_quirk, switch
+        ):
+            """Test whether the config cluster pre-loads all attributes."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+            cluster = device.endpoints[1].niko_config
+
+            with mock.patch.object(
+                cluster, "read_attributes", mock.AsyncMock()
+            ) as read_attributes:
+                await cluster.bind()
+                read_attributes.assert_called_with(cluster.attributes)
+                await wait_for_zigpy_tasks()
+
         def test_state_cluster(self, zigpy_device_from_v2_quirk, switch):
             """Test the state cluster."""
             device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
@@ -64,6 +80,14 @@ class TestNikoSwitch:
                 0x0002: foundation.ZCLAttributeAccess.from_str("rp"),
                 0x0003: foundation.ZCLAttributeAccess.from_str("rp"),
                 0x0004: foundation.ZCLAttributeAccess.from_str("rp"),
+                # Status LED on/off
+                0x0011: foundation.ZCLAttributeAccess.from_str("rwp"),
+                0x0013: foundation.ZCLAttributeAccess.from_str("rwp"),
+                # Status LED sync
+                0x0021: foundation.ZCLAttributeAccess.from_str("rw"),
+                0x0023: foundation.ZCLAttributeAccess.from_str("rw"),
+                # Status LED alert color
+                0x0100: foundation.ZCLAttributeAccess.from_str("rw"),
             }
 
     @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
@@ -353,3 +377,217 @@ class TestNikoSwitch:
                             "press_type": press_type,
                         },
                     )
+
+    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
+    class TestLedState:
+        """Test reading and writing status LED state."""
+
+        @pytest.mark.parametrize(
+            "case",
+            [
+                [(0b00, t.Bool.false, t.Bool.false)],
+                [(0b01, t.Bool.true, t.Bool.false)],
+                [(0b10, t.Bool.false, t.Bool.true)],
+                [(0b11, t.Bool.true, t.Bool.true)],
+            ],
+        )
+        async def test_read(self, zigpy_device_from_v2_quirk, switch, case):
+            """Test whether led state changes cause attribute changes in the buttons cluster."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+
+            config_cluster = device.endpoints[1].niko_config
+            buttons_cluster = device.endpoints[1].buttons
+
+            with mock.patch.object(
+                config_cluster.endpoint, "request", mock.AsyncMock()
+            ) as request:
+                request.return_value = (foundation.Status.SUCCESS, "done")
+
+                for state, led1, led3 in case:
+                    config_cluster.update_attribute(0x0105, state)
+
+                    attrs, _ = await buttons_cluster.read_attributes([0x0011, 0x0013])
+                    assert attrs[0x0011] == led1
+                    assert attrs[0x0013] == led3
+
+        @pytest.mark.parametrize(
+            "case",
+            [
+                # LED 1
+                [
+                    (0x0011, t.Bool.false, 0b00),
+                    (0x0011, t.Bool.true, 0b01),
+                    (0x0011, t.Bool.true, 0b01),
+                    (0x0011, t.Bool.false, 0b00),
+                ],
+                # LED 3
+                [
+                    (0x0013, t.Bool.false, 0b00),
+                    (0x0013, t.Bool.true, 0b10),
+                    (0x0013, t.Bool.true, 0b10),
+                    (0x0013, t.Bool.false, 0b00),
+                ],
+                # Mixed
+                [
+                    (0x0011, t.Bool.false, 0b00),
+                    (0x0013, t.Bool.false, 0b00),
+                    (0x0011, t.Bool.true, 0b01),
+                    (0x0013, t.Bool.true, 0b11),
+                ],
+            ],
+        )
+        async def test_write(self, zigpy_device_from_v2_quirk, switch, case):
+            """Test writes of LED state."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+            config_cluster = device.endpoints[1].niko_config
+            buttons_cluster = device.endpoints[1].buttons
+
+            with mock.patch.object(
+                config_cluster.endpoint, "request", mock.AsyncMock()
+            ) as request:
+                request.return_value = ([], foundation.Status.SUCCESS)
+                for attrid, value, expected in case:
+                    await buttons_cluster.write_attributes({attrid: value})
+                    await wait_for_zigpy_tasks()
+
+                    attr = config_cluster.get(0x0105)
+                    assert (0 if attr is None else attr) == expected
+
+    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
+    class TestLedSync:
+        """Test reading and writing status LED synchronization state."""
+
+        @pytest.mark.parametrize(
+            "case",
+            [
+                [(0x00, 0x0, 0x0)],
+                [(0x01, 0x1, 0x0)],
+                [(0x02, 0x2, 0x0)],
+                [(0x10, 0x0, 0x1)],
+                [(0x20, 0x0, 0x2)],
+                [(0x11, 0x1, 0x1)],
+                [(0x22, 0x2, 0x2)],
+            ],
+        )
+        async def test_read(self, zigpy_device_from_v2_quirk, switch, case):
+            """Test whether led sync changes cause attribute changes in the buttons cluster."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+
+            config_cluster = device.endpoints[1].niko_config
+            buttons_cluster = device.endpoints[1].buttons
+
+            with mock.patch.object(
+                config_cluster.endpoint, "request", mock.AsyncMock()
+            ) as request:
+                request.return_value = (foundation.Status.SUCCESS, "done")
+
+                for state, led1_sync, led3_sync in case:
+                    config_cluster.update_attribute(0x0107, state)
+
+                    attrs, _ = await buttons_cluster.read_attributes([0x0021, 0x0023])
+                    assert attrs[0x0021] == led1_sync
+                    assert attrs[0x0023] == led3_sync
+
+        @pytest.mark.parametrize(
+            "case",
+            [
+                # LED 1
+                [
+                    (0x0021, 0x0, 0x00),
+                    (0x0021, 0x1, 0x01),
+                    (0x0021, 0x2, 0x02),
+                ],
+                # LED 3
+                [
+                    (0x0023, 0x0, 0x00),
+                    (0x0023, 0x1, 0x10),
+                    (0x0023, 0x2, 0x20),
+                ],
+                # Mixed
+                [
+                    (0x0021, 0x0, 0x00),
+                    (0x0023, 0x0, 0x00),
+                    (0x0021, 0x1, 0x01),
+                    (0x0023, 0x1, 0x11),
+                    (0x0021, 0x2, 0x12),
+                    (0x0023, 0x2, 0x22),
+                ],
+            ],
+        )
+        async def test_write(self, zigpy_device_from_v2_quirk, switch, case):
+            """Test writes of LED sync."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+            config_cluster = device.endpoints[1].niko_config
+            buttons_cluster = device.endpoints[1].buttons
+
+            with mock.patch.object(
+                config_cluster.endpoint, "request", mock.AsyncMock()
+            ) as request:
+                request.return_value = ([], foundation.Status.SUCCESS)
+                for attrid, value, expected in case:
+                    await buttons_cluster.write_attributes({attrid: value})
+                    await wait_for_zigpy_tasks()
+
+                    attr = config_cluster.get(0x0107)
+                    assert (0 if attr is None else attr) == expected
+
+    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
+    class TestLedsAlert:
+        """Test reading and writing status LED alert state."""
+
+        @pytest.mark.parametrize(
+            "case",
+            [
+                (0x000000,),
+                (0x0000FF,),
+                (0x00FF00,),
+                (0xFF0000,),
+                (0xFFFFFF,),
+            ],
+        )
+        async def test_read(self, zigpy_device_from_v2_quirk, switch, case):
+            """Test whether LED alert changes cause attribute changes in the buttons cluster."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+
+            config_cluster = device.endpoints[1].niko_config
+            buttons_cluster = device.endpoints[1].buttons
+
+            with mock.patch.object(
+                config_cluster.endpoint, "request", mock.AsyncMock()
+            ) as request:
+                request.return_value = (foundation.Status.SUCCESS, "done")
+
+                for led_alert in case:
+                    config_cluster.update_attribute(0x0100, led_alert)
+
+                    attrs, _ = await buttons_cluster.read_attributes([0x0100])
+                    assert attrs[0x0100] == led_alert
+
+        @pytest.mark.parametrize(
+            "case",
+            [
+                (0x000000,),
+                (0x0000FF,),
+                (0x00FF00,),
+                (0xFF0000,),
+                (0xFFFFFF,),
+            ],
+        )
+        async def test_write(self, zigpy_device_from_v2_quirk, switch, case):
+            """Test writes of LED alert color."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+            config_cluster = device.endpoints[1].niko_config
+            buttons_cluster = device.endpoints[1].buttons
+
+            with mock.patch.object(
+                config_cluster.endpoint, "request", mock.AsyncMock()
+            ) as request:
+                request.return_value = ([], foundation.Status.SUCCESS)
+                for value in case:
+                    await buttons_cluster.write_attributes({0x0100: value})
+                    await wait_for_zigpy_tasks()
+
+                    attrs, _ = await config_cluster.read_attributes(
+                        [0x0100], only_cache=True
+                    )
+                    assert attrs[0x0100] == value

--- a/tests/test_niko.py
+++ b/tests/test_niko.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+from zigpy import types as t
 from zigpy.zcl import foundation
 
 import zhaquirks
@@ -50,6 +51,19 @@ class TestNikoSwitch:
             assert {attr.id: attr.access for attr in cluster.AttributeDefs} == {
                 0x0001: foundation.ZCLAttributeAccess.from_str("rw"),
                 0x0002: foundation.ZCLAttributeAccess.from_str("p"),
+            }
+
+        def test_buttons_cluster(self, zigpy_device_from_v2_quirk, switch):
+            """Test the buttons cluster."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+            cluster = device.endpoints[1].buttons
+
+            assert {attr.id: attr.access for attr in cluster.AttributeDefs} == {
+                # Button states
+                0x0001: foundation.ZCLAttributeAccess.from_str("rp"),
+                0x0002: foundation.ZCLAttributeAccess.from_str("rp"),
+                0x0003: foundation.ZCLAttributeAccess.from_str("rp"),
+                0x0004: foundation.ZCLAttributeAccess.from_str("rp"),
             }
 
     @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
@@ -100,3 +114,242 @@ class TestNikoSwitch:
                 assert (
                     calls[0].kwargs["data"] == b"\x04\x5f\x12\x02\x02\x01\x00\x18\x1e"
                 )
+
+    class TestDeviceAutomationTriggers:
+        """Test whether all device automation triggers are present."""
+
+        def test_single_switch(self, zigpy_device_from_v2_quirk):
+            """Test device automation triggers for 552-721X1."""
+            device = zigpy_device_from_v2_quirk(*SWITCH_SINGLE[0], **SWITCH_SINGLE[1])
+            triggers = device.device_automation_triggers
+
+            assert triggers == {
+                # Button 1
+                ("remote_button_short_press", "button_1"): {
+                    "command": "button_1_remote_button_short_press"
+                },
+                ("remote_button_short_release", "button_1"): {
+                    "command": "button_1_remote_button_short_release"
+                },
+                ("remote_button_long_press", "button_1"): {
+                    "command": "button_1_remote_button_long_press"
+                },
+                ("remote_button_long_release", "button_1"): {
+                    "command": "button_1_remote_button_long_release"
+                },
+                # Button 2
+                ("remote_button_short_press", "button_2"): {
+                    "command": "button_2_remote_button_short_press"
+                },
+                ("remote_button_short_release", "button_2"): {
+                    "command": "button_2_remote_button_short_release"
+                },
+                ("remote_button_long_press", "button_2"): {
+                    "command": "button_2_remote_button_long_press"
+                },
+                ("remote_button_long_release", "button_2"): {
+                    "command": "button_2_remote_button_long_release"
+                },
+            }
+
+        def test_double_switch(self, zigpy_device_from_v2_quirk):
+            """Test device automation triggers for 552-721X2."""
+            device = zigpy_device_from_v2_quirk(*SWITCH_DOUBLE[0], **SWITCH_DOUBLE[1])
+            triggers = device.device_automation_triggers
+
+            assert triggers == {
+                # Button 1
+                ("remote_button_short_press", "button_1"): {
+                    "command": "button_1_remote_button_short_press"
+                },
+                ("remote_button_short_release", "button_1"): {
+                    "command": "button_1_remote_button_short_release"
+                },
+                ("remote_button_long_press", "button_1"): {
+                    "command": "button_1_remote_button_long_press"
+                },
+                ("remote_button_long_release", "button_1"): {
+                    "command": "button_1_remote_button_long_release"
+                },
+                # Button 2
+                ("remote_button_short_press", "button_2"): {
+                    "command": "button_2_remote_button_short_press"
+                },
+                ("remote_button_short_release", "button_2"): {
+                    "command": "button_2_remote_button_short_release"
+                },
+                ("remote_button_long_press", "button_2"): {
+                    "command": "button_2_remote_button_long_press"
+                },
+                ("remote_button_long_release", "button_2"): {
+                    "command": "button_2_remote_button_long_release"
+                },
+                # Button 3
+                ("remote_button_short_press", "button_3"): {
+                    "command": "button_3_remote_button_short_press"
+                },
+                ("remote_button_short_release", "button_3"): {
+                    "command": "button_3_remote_button_short_release"
+                },
+                ("remote_button_long_press", "button_3"): {
+                    "command": "button_3_remote_button_long_press"
+                },
+                ("remote_button_long_release", "button_3"): {
+                    "command": "button_3_remote_button_long_release"
+                },
+                # Button 4
+                ("remote_button_short_press", "button_4"): {
+                    "command": "button_4_remote_button_short_press"
+                },
+                ("remote_button_short_release", "button_4"): {
+                    "command": "button_4_remote_button_short_release"
+                },
+                ("remote_button_long_press", "button_4"): {
+                    "command": "button_4_remote_button_long_press"
+                },
+                ("remote_button_long_release", "button_4"): {
+                    "command": "button_4_remote_button_long_release"
+                },
+            }
+
+    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
+    class TestButtonState:
+        """Test button state and associated events."""
+
+        @pytest.mark.parametrize(
+            "case",
+            [
+                # Button 1
+                [(0x00000, {})],
+                [(0x00010, {0x0001})],
+                [(0x00040, {})],
+                # Button 2
+                [(0x00000, {})],
+                [(0x00100, {0x0002})],
+                [(0x00400, {})],
+                # Button 3
+                [(0x00000, {})],
+                [(0x01000, {0x0003})],
+                [(0x04000, {})],
+                # Button 4
+                [(0x00000, {})],
+                [(0x10000, {0x0004})],
+                [(0x40000, {})],
+                # Mixed
+                [
+                    (0x00000, {}),
+                    (0x44440, {}),
+                    (0x00010, {0x0001}),
+                    (0x00110, {0x0001, 0x0002}),
+                    (0x00140, {0x0002}),
+                    (0x01100, {0x0002, 0x0003}),
+                    (0x01400, {0x0003}),
+                    (0x11000, {0x0003, 0x0004}),
+                    (0x14000, {0x0004}),
+                    (0x40000, {}),
+                    (0x00110, {0x0001, 0x0002}),
+                    (0x00440, {}),
+                    (0x11110, {0x0001, 0x0002, 0x0003, 0x0004}),
+                    (0x44440, {}),
+                ],
+            ],
+        )
+        async def test_read(self, zigpy_device_from_v2_quirk, switch, case):
+            """Test whether button state changes cause attribute changes in the buttons cluster."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+
+            state_cluster = device.endpoints[1].niko_state
+            buttons_cluster = device.endpoints[1].buttons
+
+            with mock.patch.object(
+                state_cluster.endpoint, "request", mock.AsyncMock()
+            ) as request:
+                request.return_value = (foundation.Status.SUCCESS, "done")
+
+                for state, on_buttons in case:
+                    state_cluster.update_attribute(0x0002, state)
+
+                    attrs, _ = await buttons_cluster.read_attributes(
+                        [
+                            0x0001,
+                            0x0002,
+                            0x0003,
+                            0x0004,
+                        ]
+                    )
+                    assert attrs[0x0001] == t.Bool(0x0001 in on_buttons)
+                    assert attrs[0x0002] == t.Bool(0x0002 in on_buttons)
+                    assert attrs[0x0003] == t.Bool(0x0003 in on_buttons)
+                    assert attrs[0x0004] == t.Bool(0x0004 in on_buttons)
+
+        @pytest.mark.parametrize(
+            "case",
+            [
+                # Button 1
+                [(0x00000, None, None)],
+                [(0x00010, "button_1", "remote_button_short_press")],
+                [(0x00040, "button_1", "remote_button_short_release")],
+                # Button 2
+                [(0x00000, None, None)],
+                [(0x00100, "button_2", "remote_button_short_press")],
+                [(0x00400, "button_2", "remote_button_short_release")],
+                # Button 3
+                [(0x00000, None, None)],
+                [(0x01000, "button_3", "remote_button_short_press")],
+                [(0x04000, "button_3", "remote_button_short_release")],
+                # Button 4
+                [(0x00000, None, None)],
+                [(0x10000, "button_4", "remote_button_short_press")],
+                [(0x40000, "button_4", "remote_button_short_release")],
+                # Repeated same state
+                [
+                    (0x00000, None, None),
+                    (0x00010, "button_1", "remote_button_short_press"),
+                    (0x00010, None, None),
+                    (0x00010, None, None),
+                    (0x00000, None, None),
+                    (0x00010, None, None),
+                    (0x00040, "button_1", "remote_button_short_release"),
+                    (0x00040, None, None),
+                ],
+                # Multi-button presses
+                [
+                    (0x00000, None, None),
+                    (0x00010, "button_1", "remote_button_short_press"),
+                    (0x00110, "button_2", "remote_button_short_press"),
+                    (0x01110, "button_3", "remote_button_short_press"),
+                    (0x11110, "button_4", "remote_button_short_press"),
+                    (0x41110, "button_4", "remote_button_short_release"),
+                    (0x04110, "button_3", "remote_button_short_release"),
+                    (0x00410, "button_2", "remote_button_short_release"),
+                    (0x00040, "button_1", "remote_button_short_release"),
+                    (0x00000, None, None),
+                ],
+            ],
+        )
+        def test_events(self, zigpy_device_from_v2_quirk, switch, case):
+            """Test whether button state changes cause events."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+
+            state_cluster = device.endpoints[1].niko_state
+
+            buttons_cluster = device.endpoints[1].buttons
+            listener = mock.MagicMock()
+            buttons_cluster.add_listener(listener)
+
+            for state, button, press_type in case:
+                listener.reset_mock()
+                state_cluster.update_attribute(0x0002, state)
+
+                # Test whether the event was emitted
+                if not button:
+                    assert listener.zha_send_event.call_count == 0
+                else:
+                    assert listener.zha_send_event.call_count == 1
+                    assert listener.zha_send_event.call_args_list[0] == mock.call(
+                        f"{button}_{press_type}",
+                        {
+                            "button": button,
+                            "press_type": press_type,
+                        },
+                    )

--- a/tests/test_niko.py
+++ b/tests/test_niko.py
@@ -1,0 +1,102 @@
+"""Tests for Niko quirks."""
+
+from unittest import mock
+
+import pytest
+from zigpy.zcl import foundation
+
+import zhaquirks
+
+zhaquirks.setup()
+
+
+SWITCH_SINGLE = (
+    ["NIKO NV", "Single connectable switch,10A"],
+    {"endpoint_ids": [0, 1, 242]},
+)
+
+SWITCH_DOUBLE = (
+    ["NIKO NV", "Double connectable switch,10A"],
+    {"endpoint_ids": [0, 1, 2, 242]},
+)
+
+
+# pylint: disable=R0903
+class TestNikoSwitch:
+    """Tests for Niko Connected Switches (552-721X1 and 552-721X2)."""
+
+    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
+    class TestClusters:
+        """Test whether all clusters are present and complete."""
+
+        def test_config_cluster(self, zigpy_device_from_v2_quirk, switch):
+            """Test the configuration cluster."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+            cluster = device.endpoints[1].niko_config
+
+            assert {attr.id: attr.access for attr in cluster.AttributeDefs} == {
+                0x0000: foundation.ZCLAttributeAccess.from_str("rw"),
+                0x0100: foundation.ZCLAttributeAccess.from_str("rw"),
+                0x0104: foundation.ZCLAttributeAccess.from_str("rw"),
+                0x0105: foundation.ZCLAttributeAccess.from_str("rw"),
+                0x0107: foundation.ZCLAttributeAccess.from_str("rw"),
+            }
+
+        def test_state_cluster(self, zigpy_device_from_v2_quirk, switch):
+            """Test the state cluster."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+            cluster = device.endpoints[1].niko_state
+
+            assert {attr.id: attr.access for attr in cluster.AttributeDefs} == {
+                0x0001: foundation.ZCLAttributeAccess.from_str("rw"),
+                0x0002: foundation.ZCLAttributeAccess.from_str("p"),
+            }
+
+    @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
+    # pylint: disable=R0903
+    class TestConfiguration:
+        """Test device configuration."""
+
+        async def test_apply_custom_configuration(
+            self, zigpy_device_from_v2_quirk, switch
+        ):
+            """Test whether attributes are set correctly."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+            config_cluster = device.endpoints[1].niko_config
+            state_cluster = device.endpoints[1].niko_state
+
+            with mock.patch.object(
+                config_cluster.endpoint, "request", mock.AsyncMock()
+            ) as request:
+                request.return_value = (foundation.Status.SUCCESS, "done")
+
+                await config_cluster.apply_custom_configuration()
+                calls = request.mock_calls
+
+                assert len(calls) == 1
+                assert calls[0].kwargs["cluster"] == config_cluster.cluster_id
+                assert (
+                    calls[0].kwargs["command_id"]
+                    == foundation.GeneralCommand.Write_Attributes
+                )
+                assert (
+                    calls[0].kwargs["data"] == b"\x04\x5f\x12\x01\x02\x04\x01\x20\x01"
+                )
+
+            with mock.patch.object(
+                state_cluster.endpoint, "request", mock.AsyncMock()
+            ) as request:
+                request.return_value = (foundation.Status.SUCCESS, "done")
+
+                await state_cluster.apply_custom_configuration()
+                calls = request.mock_calls
+
+                assert len(calls) == 1
+                assert calls[0].kwargs["cluster"] == state_cluster.cluster_id
+                assert (
+                    calls[0].kwargs["command_id"]
+                    == foundation.GeneralCommand.Write_Attributes
+                )
+                assert (
+                    calls[0].kwargs["data"] == b"\x04\x5f\x12\x02\x02\x01\x00\x18\x1e"
+                )

--- a/tests/test_niko.py
+++ b/tests/test_niko.py
@@ -1,5 +1,6 @@
 """Tests for Niko quirks."""
 
+import asyncio
 from unittest import mock
 
 import pytest
@@ -452,6 +453,71 @@ class TestNikoSwitch:
 
                     attr = config_cluster.get(0x0105)
                     assert (0 if attr is None else attr) == expected
+
+        @pytest.mark.parametrize(
+            "case",
+            [
+                # LED 1
+                {
+                    "writes": [
+                        {0x0011: t.Bool.true},
+                        {0x0011: t.Bool.true},
+                        {0x0011: t.Bool.false},
+                        {0x0011: t.Bool.true},
+                    ],
+                    "result": 0b01,
+                    "calls": 3,
+                },
+                # LED 2
+                {
+                    "writes": [
+                        {0x0013: t.Bool.true},
+                        {0x0013: t.Bool.true},
+                        {0x0013: t.Bool.false},
+                        {0x0013: t.Bool.true},
+                    ],
+                    "result": 0b10,
+                    "calls": 3,
+                },
+                # Mixed
+                {
+                    "writes": [
+                        {0x0011: t.Bool.true},
+                        {0x0011: t.Bool.true},
+                        {0x0011: t.Bool.true},
+                        {0x0013: t.Bool.true},
+                        {0x0011: t.Bool.true},
+                        {0x0013: t.Bool.true},
+                    ],
+                    "result": 0b11,
+                    "calls": 2,
+                },
+            ],
+        )
+        async def test_rapid_write(self, zigpy_device_from_v2_quirk, switch, case):
+            """Test rapid consecutive writes of LED state."""
+            device = zigpy_device_from_v2_quirk(*switch[0], **switch[1])
+            config_cluster = device.endpoints[1].niko_config
+            buttons_cluster = device.endpoints[1].buttons
+
+            async def slow_request(*args, **kwargs):
+                assert not args
+                assert kwargs["expect_reply"]
+                await asyncio.sleep(0)
+                return ([], foundation.Status.SUCCESS)
+
+            with mock.patch.object(
+                config_cluster.endpoint, "request", side_effect=slow_request
+            ) as request:
+                for attributes in case["writes"]:
+                    await buttons_cluster.write_attributes(attributes)
+                await wait_for_zigpy_tasks()
+
+                assert request.called
+                assert request.call_count == case["calls"]
+
+                attr = config_cluster.get(0x0105)
+                assert (0 if attr is None else attr) == case["result"]
 
     @pytest.mark.parametrize("switch", [SWITCH_SINGLE, SWITCH_DOUBLE])
     class TestLedSync:

--- a/zhaquirks/niko/__init__.py
+++ b/zhaquirks/niko/__init__.py
@@ -1,0 +1,4 @@
+"""Quirks for Niko devices."""
+
+NIKO = "NIKO NV"
+NIKO_MFG_CODE = 0x125F

--- a/zhaquirks/niko/switch.py
+++ b/zhaquirks/niko/switch.py
@@ -1,0 +1,240 @@
+"""Niko Connected Switches (552-721X1 and 552-721X2)."""
+
+from zigpy import types as t
+from zigpy.quirks.v2 import CustomCluster, EntityType, QuirkBuilder
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, Scenes
+from zigpy.zcl.clusters.homeautomation import Diagnostic
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+from zhaquirks.niko import NIKO, NIKO_MFG_CODE
+
+
+class NikoCluster(CustomCluster):
+    """Niko custom cluster for device configuration."""
+
+    attr_config = {}
+
+    async def apply_custom_configuration(self, *args, **kwargs):
+        """Apply custom configuration."""
+        await self.write_attributes(self.attr_config, manufacturer=NIKO_MFG_CODE)
+
+
+class ButtonsDefaultAction(t.enum8):
+    """Whether pressing buttons automatically triggers the corresponding switch."""
+
+    Disabled = 0x01
+    Enabled = 0x02  # Default
+
+
+class LedsFunctionality(t.uint8_t):
+    """Whether all status LEDs are enabled, or always off."""
+
+    Disabled = 0x00
+    Enabled = 0x01  # Default
+
+
+class LedsAlert(t.uint24_t):
+    """Sets all LEDs to an alert color."""
+
+    Off = 0x000000  # Default
+    White = 0x0000FF
+    Blue = 0x00FF00
+    Red = 0xFF0000
+    Purple = 0xFFFFFF
+
+
+class LedsAlertColors(t.enum32):
+    """Alert colors for status LEDs."""
+
+    Off = LedsAlert.Off
+    White = LedsAlert.White
+    Blue = LedsAlert.Blue
+    Red = LedsAlert.Red
+    Purple = LedsAlert.Purple
+
+
+class LedSwitchSync(t.bitmap32):
+    """Whether to synchronize a LED with its associated switch status."""
+
+    Off = 0x00
+
+    Led_1_On = 0x01  # Default
+    Led_1_Inverted = 0x02
+
+    Led_3_On = 0x10  # Default
+    Led_3_Inverted = 0x20
+
+
+class LedSwitchSyncOptions(t.enum8):
+    """Synchronization options for status LED."""
+
+    Off = 0x0
+    On = 0x1
+    Inverted = 0x2
+
+
+class NikoConfigCluster(NikoCluster):
+    """Niko cluster for device configuration."""
+
+    cluster_id = 0xFC00
+    ep_attribute = "niko_config"
+
+    # pylint: disable=R0903
+    class AttributeDefs(BaseAttributeDefs):
+        """Attributes for general device configuration."""
+
+        buttons_default_action = ZCLAttributeDef(
+            id=0x0000,
+            type=ButtonsDefaultAction,
+            access="rw",
+            manufacturer_code=NIKO_MFG_CODE,
+        )
+        leds_alert = ZCLAttributeDef(
+            id=0x0100,
+            type=LedsAlert,
+            access="rw",
+            manufacturer_code=NIKO_MFG_CODE,
+        )
+        leds_functionality = ZCLAttributeDef(
+            id=0x0104,
+            type=LedsFunctionality,
+            access="rw",
+            manufacturer_code=NIKO_MFG_CODE,
+        )
+        leds_on = ZCLAttributeDef(
+            id=0x0105,
+            type=t.bitmap8,
+            access="rw",
+            manufacturer_code=NIKO_MFG_CODE,
+        )
+        leds_switch_sync = ZCLAttributeDef(
+            id=0x0107,
+            type=t.bitmap32,
+            access="rw",
+            manufacturer_code=NIKO_MFG_CODE,
+        )
+
+    attr_config = {
+        AttributeDefs.leds_functionality.id: LedsFunctionality.Enabled,
+    }
+
+
+class ButtonStateReporting(t.bitmap8):
+    """Report state changes for these buttons."""
+
+    Off = 0b00000  # Default
+    Button_1 = 0b00010
+    Button_2 = 0b00100
+    Button_3 = 0b01000
+    Button_4 = 0b10000
+
+
+class ButtonsState(t.bitmap32):
+    """Combined state of all individual buttons."""
+
+    Button_1_Short_Press = 0x00010
+    Button_1_Short_Release = 0x00040
+    Button_1_Long_Press = 0x00020
+    Button_1_Long_Release = 0x00030
+
+    Button_2_Short_Press = 0x00100
+    Button_2_Short_Release = 0x00400
+    Button_2_Long_Press = 0x00200
+    Button_2_Long_Release = 0x00300
+
+    Button_3_Short_Press = 0x01000
+    Button_3_Short_Release = 0x04000
+    Button_3_Long_Press = 0x02000
+    Button_3_Long_Release = 0x03000
+
+    Button_4_Short_Press = 0x10000
+    Button_4_Short_Release = 0x40000
+    Button_4_Long_Press = 0x20000
+    Button_4_Long_Release = 0x30000
+
+
+class NikoStateCluster(NikoCluster):
+    """Niko cluster for device state."""
+
+    cluster_id = 0xFC01
+    ep_attribute = "niko_state"
+
+    # pylint: disable=R0903
+    class AttributeDefs(BaseAttributeDefs):
+        """Attributes for state configuration."""
+
+        report_button_state = ZCLAttributeDef(
+            id=0x0001,
+            type=ButtonStateReporting,
+            access="rw",
+            manufacturer_code=NIKO_MFG_CODE,
+        )
+        buttons_state = ZCLAttributeDef(
+            id=0x0002,
+            type=ButtonsState,
+            access="p",
+            manufacturer_code=NIKO_MFG_CODE,
+        )
+
+    attr_config = {
+        AttributeDefs.report_button_state.id: ButtonStateReporting.Off
+        | ButtonStateReporting.Button_1
+        | ButtonStateReporting.Button_2
+        | ButtonStateReporting.Button_3
+        | ButtonStateReporting.Button_4
+    }
+
+
+class NikoQuirkBuilder(QuirkBuilder):
+    """QuirkBuilder for Niko devices."""
+
+    def __init__(self, model):
+        """Initialize the quirk builder."""
+        super().__init__(NIKO, model)
+        self.replaces(NikoConfigCluster, endpoint_id=1)
+        self.replaces(NikoStateCluster, endpoint_id=1)
+
+    def setup_buttons(self):
+        """Set up the device's physical buttons."""
+        # Configuration entities
+        self.switch(
+            NikoConfigCluster.AttributeDefs.buttons_default_action.name,
+            NikoConfigCluster.cluster_id,
+            off_value=ButtonsDefaultAction.Disabled,
+            on_value=ButtonsDefaultAction.Enabled,
+            entity_type=EntityType.CONFIG,
+            translation_key="switch_mode",
+            fallback_name="Switch When Pressed",
+        )
+        self.switch(
+            NikoConfigCluster.AttributeDefs.leds_functionality.name,
+            NikoConfigCluster.cluster_id,
+            entity_type=EntityType.CONFIG,
+            translation_key="enabled_led_indicator",
+            fallback_name="Enable LEDs",
+            initially_disabled=True,
+        )
+        return self
+
+
+(
+    NikoQuirkBuilder("Single connectable switch,10A")
+    .friendly_name(manufacturer="Niko", model="Connected single switch")
+    .setup_buttons()
+    .add_to_registry()
+)
+
+(
+    NikoQuirkBuilder("Double connectable switch,10A")
+    .friendly_name(manufacturer="Niko", model="Connected double switch")
+    .setup_buttons()
+    # Remove duplicated clusters in second endpoint
+    .removes(Basic.cluster_id, endpoint_id=2)
+    .removes(Identify.cluster_id, endpoint_id=2)
+    .removes(Groups.cluster_id, endpoint_id=2)
+    .removes(Scenes.cluster_id, endpoint_id=2)
+    .removes(Diagnostic.cluster_id, endpoint_id=2)
+    .removes(NikoConfigCluster.cluster_id, endpoint_id=2)
+    .removes(NikoStateCluster.cluster_id, endpoint_id=2)
+    .add_to_registry()
+)

--- a/zhaquirks/niko/switch.py
+++ b/zhaquirks/niko/switch.py
@@ -54,6 +54,12 @@ class NikoCluster(CustomCluster):
         """Apply custom configuration."""
         await self.write_attributes(self.attr_config, manufacturer=NIKO_MFG_CODE)
 
+    async def write_attributes(self, attributes, **kwargs):
+        """Write the attributes and inform the config cluster."""
+        result = await super().write_attributes(attributes, **kwargs)
+        self._notify_cluster("niko_config", attributes)
+        return result
+
     def _handle_attribute_event(
         self, event: AttributeReportedEvent | AttributeUpdatedEvent
     ):
@@ -173,6 +179,59 @@ class NikoConfigCluster(NikoCluster):
         AttributeDefs.leds_functionality.id: LedsFunctionality.Enabled,
     }
 
+    async def bind(self):
+        """Bind cluster and pre-load attributes."""
+        self.create_catching_task(self.read_attributes(self.attributes))
+        return await super().bind()
+
+    def led_1_on_changed(self, value: bool):
+        """Process a write to the led_1_on attribute."""
+        self.create_catching_task(self.write_led_on(0, value))
+
+    def led_3_on_changed(self, value: bool):
+        """Process a write to the led_3_on attribute."""
+        self.create_catching_task(self.write_led_on(1, value))
+
+    def led_1_switch_sync_changed(self, value: LedSwitchSyncOptions):
+        """Process a write to the led_1_switch_sync attribute."""
+        self.create_catching_task(self.write_led_switch_sync(0, value))
+
+    def led_3_switch_sync_changed(self, value: LedSwitchSyncOptions):
+        """Process a write to the led_3_switch_sync attribute."""
+        self.create_catching_task(self.write_led_switch_sync(1, value))
+
+    def alert_color_changed(self, value: LedsAlertColors):
+        """Process a write to the alert_color attribute."""
+        self.create_catching_task(self.write_leds_alert(value))
+
+    async def write_led_on(self, led: int, value: bool):
+        """Set the status LED to on or off using the leds_on attribute."""
+        # Determine the previous state of the specific status LED
+        state = self.get(self.AttributeDefs.leds_on.id) or 0
+        mask = 1 << led
+        previous = bool(state & mask)
+
+        # If the status LED changed, update the leds_on attribute
+        if value != previous:
+            state = (state | mask) if value else state & ~mask
+            await self.write_attributes({self.AttributeDefs.leds_on.id: state})
+
+    async def write_led_switch_sync(self, led: int, value: LedSwitchSyncOptions):
+        """Set LED/switch synchronization using the leds_switch_sync attribute."""
+        # Determine previous state of individual LED
+        state = self.get(self.AttributeDefs.leds_switch_sync.id) or 0
+        shift = led << 2
+        previous = state >> shift & 0xF
+
+        # Update if the LED's state changed
+        if value != previous:
+            state = state & ~(0xF << shift) | (value << shift)
+            await self.write_attributes({self.AttributeDefs.leds_switch_sync.id: state})
+
+    async def write_leds_alert(self, value: LedsAlertColors):
+        """Write the leds_alert attribute."""
+        await self.write_attributes({self.AttributeDefs.leds_alert.id: value})
+
 
 class ButtonStateReporting(t.bitmap8):
     """Report state changes for these buttons."""
@@ -276,6 +335,42 @@ class ButtonsCluster(NikoCluster, LocalDataCluster):
             is_manufacturer_specific=True,
         )
 
+        # Status lights
+        led_1_on = ZCLAttributeDef(
+            id=0x0011,
+            type=t.Bool,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+        led_3_on = ZCLAttributeDef(
+            id=0x0013,
+            type=t.Bool,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+        # Status light synchronization with switches
+        led_1_switch_sync = ZCLAttributeDef(
+            id=0x0021,
+            type=LedSwitchSyncOptions,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+        led_3_switch_sync = ZCLAttributeDef(
+            id=0x0023,
+            type=LedSwitchSyncOptions,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+
+        # Status light alerts
+        alert_color = ZCLAttributeDef(
+            id=0x0100,
+            type=LedsAlertColors,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+
     _VALID_ATTRIBUTES = [attr.id for attr in AttributeDefs]
 
     PRESSED_ATTRIBUTES = [
@@ -283,6 +378,14 @@ class ButtonsCluster(NikoCluster, LocalDataCluster):
         AttributeDefs.button_2_pressed,
         AttributeDefs.button_3_pressed,
         AttributeDefs.button_4_pressed,
+    ]
+    LED_ON_ATTRIBUTES = [
+        AttributeDefs.led_1_on,
+        AttributeDefs.led_3_on,
+    ]
+    LED_SWITCH_SYNC_ATTRIBUTES = [
+        AttributeDefs.led_1_switch_sync,
+        AttributeDefs.led_3_switch_sync,
     ]
 
     def __init__(self, *args, **kwargs):
@@ -306,6 +409,22 @@ class ButtonsCluster(NikoCluster, LocalDataCluster):
                     f"{button}_{press}",
                     {BUTTON: button, PRESS_TYPE: press},
                 )
+
+    def leds_on_changed(self, value):
+        """Reflect leds_on in individual led_on_x attributes."""
+        for i, attr in enumerate(self.LED_ON_ATTRIBUTES):
+            on = t.Bool(value >> i & 0b1)
+            self._update_attribute(attr.id, on)
+
+    def leds_switch_sync_changed(self, value):
+        """Reflect leds_switch_sync in individual leds_switch_sync_x attributes."""
+        for i, attr in enumerate(self.LED_SWITCH_SYNC_ATTRIBUTES):
+            sync = (value >> 4 * i) & 0xF
+            self._update_attribute(attr.id, sync)
+
+    def leds_alert_changed(self, value: LedsAlert):
+        """Mirror leds_alert in the alert_color property."""
+        self._update_attribute(self.AttributeDefs.alert_color.id, value)
 
 
 class NikoQuirkBuilder(QuirkBuilder):
@@ -339,6 +458,17 @@ class NikoQuirkBuilder(QuirkBuilder):
                 fallback_name=f"Button {b + 1}",
             )
 
+        # Status LED entities
+        for b, key in enumerate(BUTTONS[::2]):
+            self.switch(
+                ButtonsCluster.LED_ON_ATTRIBUTES[b].name,
+                ButtonsCluster.cluster_id,
+                entity_type=EntityType.STANDARD,
+                translation_key=f"{key}_led_indicator",
+                fallback_name=f"Button {2 * b + 1} LED",
+                initially_disabled=True,
+            )
+
         # Configuration entities
         self.switch(
             NikoConfigCluster.AttributeDefs.buttons_default_action.name,
@@ -355,6 +485,24 @@ class NikoQuirkBuilder(QuirkBuilder):
             entity_type=EntityType.CONFIG,
             translation_key="enabled_led_indicator",
             fallback_name="Enable LEDs",
+            initially_disabled=True,
+        )
+        for b, key in enumerate(BUTTONS[::2]):
+            self.enum(
+                ButtonsCluster.LED_SWITCH_SYNC_ATTRIBUTES[b].name,
+                LedSwitchSyncOptions,
+                ButtonsCluster.cluster_id,
+                entity_type=EntityType.CONFIG,
+                translation_key=f"{key}_sync",
+                fallback_name=f"Button {b + 1} LED Switch Sync",
+            )
+        self.enum(
+            ButtonsCluster.AttributeDefs.alert_color.name,
+            LedsAlertColors,
+            ButtonsCluster.cluster_id,
+            entity_type=EntityType.CONFIG,
+            translation_key="alert",
+            fallback_name="Alert",
             initially_disabled=True,
         )
         return self

--- a/zhaquirks/niko/switch.py
+++ b/zhaquirks/niko/switch.py
@@ -43,6 +43,7 @@ class NikoCluster(CustomCluster):
     """Niko custom cluster for device configuration."""
 
     attr_config = {}
+    attr_pending = {}
 
     def __init__(self, *args, **kwargs):
         """Initialize the cluster."""
@@ -57,8 +58,21 @@ class NikoCluster(CustomCluster):
     async def write_attributes(self, attributes, **kwargs):
         """Write the attributes and inform the config cluster."""
         result = await super().write_attributes(attributes, **kwargs)
+        for attr in attributes.keys() & self.attr_pending.keys():
+            if self.attr_pending[attr] == attributes[attr]:
+                del self.attr_pending[attr]
         self._notify_cluster("niko_config", attributes)
         return result
+
+    def get_pending(self, attrid):
+        """Retrieve the attribute value (possibly pending a write operation)."""
+        if attrid in self.attr_pending:
+            return self.attr_pending[attrid]
+        return super().get(attrid)
+
+    async def write_pending(self):
+        """Write all pending attribute changes."""
+        await self.write_attributes(self.attr_pending)
 
     def _handle_attribute_event(
         self, event: AttributeReportedEvent | AttributeUpdatedEvent
@@ -72,12 +86,15 @@ class NikoCluster(CustomCluster):
         """Notifies the cluster of attributes changes."""
         if ep_attribute != self.ep_attribute:
             cluster = getattr(self.endpoint, ep_attribute)
+            attr_pending = cluster.attr_pending.copy()
             for attrid, value in attributes.items():
                 if isinstance(attrid, int):
                     attrid = self.attributes[attrid].name
                 callback_name = f"{attrid}_changed"
                 if hasattr(cluster, callback_name):
                     getattr(cluster, callback_name)(value)
+            if attr_pending != cluster.attr_pending:
+                self.create_catching_task(cluster.write_pending())
 
 
 class ButtonsDefaultAction(t.enum8):
@@ -186,51 +203,39 @@ class NikoConfigCluster(NikoCluster):
 
     def led_1_on_changed(self, value: bool):
         """Process a write to the led_1_on attribute."""
-        self.create_catching_task(self.write_led_on(0, value))
+        self.write_led_on(0, value)
 
     def led_3_on_changed(self, value: bool):
         """Process a write to the led_3_on attribute."""
-        self.create_catching_task(self.write_led_on(1, value))
+        self.write_led_on(1, value)
 
     def led_1_switch_sync_changed(self, value: LedSwitchSyncOptions):
         """Process a write to the led_1_switch_sync attribute."""
-        self.create_catching_task(self.write_led_switch_sync(0, value))
+        self.write_led_switch_sync(0, value)
 
     def led_3_switch_sync_changed(self, value: LedSwitchSyncOptions):
         """Process a write to the led_3_switch_sync attribute."""
-        self.create_catching_task(self.write_led_switch_sync(1, value))
+        self.write_led_switch_sync(1, value)
 
     def alert_color_changed(self, value: LedsAlertColors):
         """Process a write to the alert_color attribute."""
-        self.create_catching_task(self.write_leds_alert(value))
+        self.attr_pending[self.AttributeDefs.leds_alert.id] = value
 
-    async def write_led_on(self, led: int, value: bool):
+    def write_led_on(self, led: int, value: bool):
         """Set the status LED to on or off using the leds_on attribute."""
-        # Determine the previous state of the specific status LED
-        state = self.get(self.AttributeDefs.leds_on.id) or 0
+        state = self.get_pending(self.AttributeDefs.leds_on.id) or 0
         mask = 1 << led
-        previous = bool(state & mask)
+        update = (state | mask) if value else state & ~mask
+        if state != update:
+            self.attr_pending[self.AttributeDefs.leds_on.id] = update
 
-        # If the status LED changed, update the leds_on attribute
-        if value != previous:
-            state = (state | mask) if value else state & ~mask
-            await self.write_attributes({self.AttributeDefs.leds_on.id: state})
-
-    async def write_led_switch_sync(self, led: int, value: LedSwitchSyncOptions):
+    def write_led_switch_sync(self, led: int, value: LedSwitchSyncOptions):
         """Set LED/switch synchronization using the leds_switch_sync attribute."""
-        # Determine previous state of individual LED
-        state = self.get(self.AttributeDefs.leds_switch_sync.id) or 0
+        state = self.get_pending(self.AttributeDefs.leds_switch_sync.id) or 0
         shift = led << 2
-        previous = state >> shift & 0xF
-
-        # Update if the LED's state changed
-        if value != previous:
-            state = state & ~(0xF << shift) | (value << shift)
-            await self.write_attributes({self.AttributeDefs.leds_switch_sync.id: state})
-
-    async def write_leds_alert(self, value: LedsAlertColors):
-        """Write the leds_alert attribute."""
-        await self.write_attributes({self.AttributeDefs.leds_alert.id: value})
+        update = state & ~(0xF << shift) | (value << shift)
+        if state != update:
+            self.attr_pending[self.AttributeDefs.leds_switch_sync.id] = update
 
 
 class ButtonStateReporting(t.bitmap8):

--- a/zhaquirks/niko/switch.py
+++ b/zhaquirks/niko/switch.py
@@ -1,4 +1,4 @@
-"""Niko Connected Switches (552-721X1 and 552-721X2)."""
+"""Niko Connected Switches (552-721X1 and 552-721X2) and Dimmer (552-722X1)."""
 
 from zigpy import types as t
 from zigpy.quirks.v2 import CustomCluster, EntityType, QuirkBuilder
@@ -532,5 +532,12 @@ class NikoQuirkBuilder(QuirkBuilder):
     .removes(Diagnostic.cluster_id, endpoint_id=2)
     .removes(NikoConfigCluster.cluster_id, endpoint_id=2)
     .removes(NikoStateCluster.cluster_id, endpoint_id=2)
+    .add_to_registry()
+)
+
+(
+    NikoQuirkBuilder("Connectable dimmer,3-200W,2-wire")
+    .friendly_name(manufacturer="Niko", model="Connected dimmer")
+    .setup_buttons(2)
     .add_to_registry()
 )

--- a/zhaquirks/niko/switch.py
+++ b/zhaquirks/niko/switch.py
@@ -2,11 +2,41 @@
 
 from zigpy import types as t
 from zigpy.quirks.v2 import CustomCluster, EntityType, QuirkBuilder
+from zigpy.zcl import AttributeReportedEvent, AttributeUpdatedEvent
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, Scenes
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
+from zhaquirks import LocalDataCluster
+from zhaquirks.const import (
+    BUTTON,
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    BUTTON_4,
+    COMMAND,
+    LONG_PRESS,
+    LONG_RELEASE,
+    PRESS_TYPE,
+    SHORT_PRESS,
+    SHORT_RELEASE,
+    ZHA_SEND_EVENT,
+)
 from zhaquirks.niko import NIKO, NIKO_MFG_CODE
+
+BUTTONS = [
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    BUTTON_4,
+]
+
+PRESS_TYPES = {
+    0x1: SHORT_PRESS,
+    0x4: SHORT_RELEASE,
+    0x2: LONG_PRESS,
+    0x3: LONG_RELEASE,
+}
 
 
 class NikoCluster(CustomCluster):
@@ -14,9 +44,34 @@ class NikoCluster(CustomCluster):
 
     attr_config = {}
 
+    def __init__(self, *args, **kwargs):
+        """Initialize the cluster."""
+        super().__init__(*args, **kwargs)
+        self.on_event(AttributeReportedEvent.event_type, self._handle_attribute_event)
+        self.on_event(AttributeUpdatedEvent.event_type, self._handle_attribute_event)
+
     async def apply_custom_configuration(self, *args, **kwargs):
         """Apply custom configuration."""
         await self.write_attributes(self.attr_config, manufacturer=NIKO_MFG_CODE)
+
+    def _handle_attribute_event(
+        self, event: AttributeReportedEvent | AttributeUpdatedEvent
+    ):
+        """Inform the buttons cluster of attribute updates."""
+        attrid = event.attribute_id
+        value = event.value
+        self._notify_cluster("buttons", {attrid: value})
+
+    def _notify_cluster(self, ep_attribute, attributes):
+        """Notifies the cluster of attributes changes."""
+        if ep_attribute != self.ep_attribute:
+            cluster = getattr(self.endpoint, ep_attribute)
+            for attrid, value in attributes.items():
+                if isinstance(attrid, int):
+                    attrid = self.attributes[attrid].name
+                callback_name = f"{attrid}_changed"
+                if hasattr(cluster, callback_name):
+                    getattr(cluster, callback_name)(value)
 
 
 class ButtonsDefaultAction(t.enum8):
@@ -185,6 +240,74 @@ class NikoStateCluster(NikoCluster):
     }
 
 
+class ButtonsCluster(NikoCluster, LocalDataCluster):
+    """Virtual cluster to manage individual button state and attributes."""
+
+    cluster_id = 0xFC02
+    ep_attribute = "buttons"
+
+    # pylint: disable=R0903
+    class AttributeDefs(BaseAttributeDefs):
+        """Attributes for button configuration."""
+
+        # Button press state
+        button_1_pressed = ZCLAttributeDef(
+            id=0x0001,
+            type=t.Bool,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+        button_2_pressed = ZCLAttributeDef(
+            id=0x0002,
+            type=t.Bool,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+        button_3_pressed = ZCLAttributeDef(
+            id=0x0003,
+            type=t.Bool,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+        button_4_pressed = ZCLAttributeDef(
+            id=0x0004,
+            type=t.Bool,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+
+    _VALID_ATTRIBUTES = [attr.id for attr in AttributeDefs]
+
+    PRESSED_ATTRIBUTES = [
+        AttributeDefs.button_1_pressed,
+        AttributeDefs.button_2_pressed,
+        AttributeDefs.button_3_pressed,
+        AttributeDefs.button_4_pressed,
+    ]
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the cluster."""
+        super().__init__(*args, **kwargs)
+        self.presses = [0] * len(self.PRESSED_ATTRIBUTES)
+        for attr in self.attributes:
+            self.update_attribute(attr, t.Bool.false)
+
+    def buttons_state_changed(self, state):
+        """Emit events based on button state changes."""
+        for b, button in enumerate(BUTTONS):
+            code = state >> (4 * b + 4) & 0xF
+            press = PRESS_TYPES.get(code)
+            if press and self.presses[b] != code:
+                self.presses[b] = code
+                down = t.Bool(press in {SHORT_PRESS, LONG_PRESS})
+                self._update_attribute(self.PRESSED_ATTRIBUTES[b].id, down)
+                self.listener_event(
+                    ZHA_SEND_EVENT,
+                    f"{button}_{press}",
+                    {BUTTON: button, PRESS_TYPE: press},
+                )
+
+
 class NikoQuirkBuilder(QuirkBuilder):
     """QuirkBuilder for Niko devices."""
 
@@ -193,9 +316,29 @@ class NikoQuirkBuilder(QuirkBuilder):
         super().__init__(NIKO, model)
         self.replaces(NikoConfigCluster, endpoint_id=1)
         self.replaces(NikoStateCluster, endpoint_id=1)
+        self.adds(ButtonsCluster)
 
-    def setup_buttons(self):
+    def setup_buttons(self, button_count):
         """Set up the device's physical buttons."""
+        # Button triggers
+        self.device_automation_triggers(
+            {
+                (press_type, button): {COMMAND: f"{button}_{press_type}"}
+                for press_type in PRESS_TYPES.values()
+                for button in BUTTONS[:button_count]
+            }
+        )
+
+        # Button entities
+        for b, key in enumerate(BUTTONS[:button_count]):
+            self.binary_sensor(
+                ButtonsCluster.PRESSED_ATTRIBUTES[b].name,
+                ButtonsCluster.cluster_id,
+                entity_type=EntityType.STANDARD,
+                translation_key=key,
+                fallback_name=f"Button {b + 1}",
+            )
+
         # Configuration entities
         self.switch(
             NikoConfigCluster.AttributeDefs.buttons_default_action.name,
@@ -220,14 +363,14 @@ class NikoQuirkBuilder(QuirkBuilder):
 (
     NikoQuirkBuilder("Single connectable switch,10A")
     .friendly_name(manufacturer="Niko", model="Connected single switch")
-    .setup_buttons()
+    .setup_buttons(2)
     .add_to_registry()
 )
 
 (
     NikoQuirkBuilder("Double connectable switch,10A")
     .friendly_name(manufacturer="Niko", model="Connected double switch")
-    .setup_buttons()
+    .setup_buttons(4)
     # Remove duplicated clusters in second endpoint
     .removes(Basic.cluster_id, endpoint_id=2)
     .removes(Identify.cluster_id, endpoint_id=2)


### PR DESCRIPTION
## Proposed change
Add support for the Niko [Connected single switch](https://www.niko.eu/en/products/niko-home-control/products-for-traditional-wiring/connected-single-switch-10-a-zigbee-productmodel-niko-6f86be91-a2f1-5421-a5ce-234092bfe9c3) (`552-721X1`) and [Connected double switch](https://www.niko.eu/en/products/niko-home-control/products-for-traditional-wiring/connected-double-switch-2-x-10-a-max-16-a-in-total-zigbee-productmodel-niko-c9127021-e751-5640-9021-a6b458788b2e) (`552-721X2`).

## Additional information

### Request and previous work
- This PR implements https://github.com/zigpy/zha-device-handlers/issues/2286, informed by https://github.com/zigpy/zha-device-handlers/pull/2723
- Not all switches were working with previous approaches (https://github.com/Koenkk/zigbee2mqtt/issues/13737), so I [re-performed an analysis of the Niko protocol](https://github.com/Koenkk/zigbee2mqtt/issues/13737#issuecomment-2563955184), which I incorporated into this PR.

### Functionality
- These Niko switches actually consist of three kinds of entities, which are coupled in the default configuration but can be decoupled:
  - 1 or 2 **switches**
  - 2 or 4 **buttons** (each on-device button can have its external extension button)
  - 1 of 2 **status LEDs**
- This PR exposes each of those entities separately, such that they can be controlled individually:

|<img width="200" alt="" src="https://github.com/user-attachments/assets/8222bbe7-1249-499c-af8b-ef757289837a" />|<img width="500" alt="" src="https://github.com/user-attachments/assets/518195e7-ed89-4eaa-a49f-c095712ee526" />|
|---|---|
|<img width="200" alt="" src="https://github.com/user-attachments/assets/4c76d7bf-5d37-496c-a851-a4ea7ba4bfc0" />|<img width="500" alt="" src="https://github.com/user-attachments/assets/57311898-bd32-4a25-87f5-74f1da6c1545" />|

### Events
- The buttons additionally generate events (short and long presses):

<img width="600" alt="" src="https://github.com/user-attachments/assets/ab3a51b1-29c5-4ea3-a805-3eaf7c9545af" />

### Configuration
- Several configuration options are exposed as entities:

<img width="300" alt="" src="https://github.com/user-attachments/assets/a182426b-bd0a-401e-a5f0-191b475c06d4" />




## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
