### PR TITLE
Fix test modifying real device registry

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 import zigpy.application
 import zigpy.device
+from zigpy.device import Device
 import zigpy.quirks
 import zigpy.types
 from zigpy.zcl import foundation
@@ -20,6 +21,8 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+
+from .async_mock import sentinel
 
 
 class MockApp(zigpy.application.ControllerApplication):
@@ -202,6 +205,25 @@ def zigpy_device_from_v2_quirk(MockAppController, ieee_mock):
         return quirked
 
     return _dev
+
+
+@pytest.fixture(name="device_mock")
+def real_device(MockAppController):
+    """Device fixture with a single endpoint."""
+    ieee = sentinel.ieee
+    nwk = 0x2233
+    device = Device(MockAppController, ieee, nwk)
+
+    device.add_endpoint(1)
+    device[1].profile_id = 0x0104
+    device[1].device_type = 0x0051
+    device.model = "model"
+    device.manufacturer = "manufacturer"
+    device[1].add_input_cluster(0x0000)
+    device[1].add_input_cluster(0xEF00)
+    device[1].add_output_cluster(0x000A)
+    device[1].add_output_cluster(0x0019)
+    return device
 
 
 @pytest.fixture

--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -3,7 +3,6 @@
 from unittest import mock
 
 import pytest
-from zigpy.device import Device
 from zigpy.quirks.registry import DeviceRegistry
 from zigpy.quirks.v2 import CustomDeviceV2
 import zigpy.types as t
@@ -25,28 +24,7 @@ from zhaquirks.tuya.builder import (
 )
 from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaOnOffNM
 
-from .async_mock import sentinel
-
 zhaquirks.setup()
-
-
-@pytest.fixture(name="device_mock")
-def real_device(MockAppController):
-    """Device fixture with a single endpoint."""
-    ieee = sentinel.ieee
-    nwk = 0x2233
-    device = Device(MockAppController, ieee, nwk)
-
-    device.add_endpoint(1)
-    device[1].profile_id = 0x0104
-    device[1].device_type = 0x0051
-    device.model = "model"
-    device.manufacturer = "manufacturer"
-    device[1].add_input_cluster(0x0000)
-    device[1].add_input_cluster(0xEF00)
-    device[1].add_output_cluster(0x000A)
-    device[1].add_output_cluster(0x0019)
-    return device
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
This moves the `real_device` fixtures to `conftest` and fixes an issue where the `test_local_data_cluster` test was modifying the actual `DeviceRegistry` during tests. That should not happen.


## Additional information
Noticed whilst working on https://github.com/zigpy/zha-device-handlers/pull/3702


## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
