### PR TITLE
Add Tuya PowerConfiguration cluster for CR2032 battery sizes

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -960,6 +960,7 @@ class TuyaPowerConfigurationClusterOther(PowerConfiguration, TuyaLocalCluster):
         PowerConfiguration.AttributeDefs.battery_quantity.id: 1,
     }
 
+
 class TuyaPowerConfigurationClusterCR2032(PowerConfiguration, TuyaLocalCluster):
     """PowerConfiguration cluster for devices with 1 CR2032."""
 

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -965,7 +965,7 @@ class TuyaPowerConfigurationClusterCR2032(PowerConfiguration, TuyaLocalCluster):
     """PowerConfiguration cluster for devices with 1 CR2032."""
 
     _CONSTANT_ATTRIBUTES = {
-        PowerConfiguration.AttributeDefs.battery_size.id: BatterySize.CR2032,
+        PowerConfiguration.AttributeDefs.battery_size.id: 10,
         PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 30,
         PowerConfiguration.AttributeDefs.battery_quantity.id: 1,
     }

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -960,6 +960,15 @@ class TuyaPowerConfigurationClusterOther(PowerConfiguration, TuyaLocalCluster):
         PowerConfiguration.AttributeDefs.battery_quantity.id: 1,
     }
 
+class TuyaPowerConfigurationClusterCR2032(PowerConfiguration, TuyaLocalCluster):
+    """PowerConfiguration cluster for devices with 1 CR2032."""
+
+    _CONSTANT_ATTRIBUTES = {
+        PowerConfiguration.AttributeDefs.battery_size.id: BatterySize.CR2032,
+        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 30,
+        PowerConfiguration.AttributeDefs.battery_quantity.id: 1,
+    }
+
 
 class TuyaThermostat(CustomDevice):
     """Generic Tuya thermostat device."""

--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -3,6 +3,7 @@
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
 
+from zhaquirks.tuya import TuyaPowerConfigurationClusterCR2032
 from zhaquirks.tuya.builder import (
     TuyaPowerConfigurationCluster2AAA,
     TuyaQuirkBuilder,
@@ -121,7 +122,7 @@ from zhaquirks.tuya.builder import (
         state_class=SensorStateClass.MEASUREMENT,
     )
     .tuya_contact(dp_id=1)
-    .tuya_battery(dp_id=2)
+    .tuya_battery(dp_id=2, power_cfg=TuyaPowerConfigurationClusterCR2032)
     .skip_configuration()
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Add `TuyaPowerConfigurationClusterCR2032` for devices that use CR2032 batteries

~Requires:~
- ~https://github.com/zigpy/zigpy/pull/1530~

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

There may be various other devices that use this type of battery and could be updated, if it were known what battery they use but i only know from this one, which was reported here: https://github.com/zigpy/zha-device-handlers/issues/3713


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
