### PR TITLE
Fix Tuya smoke detector `_TZ3210_up3pngle`

### DIFF
--- a/tests/test_tuya_smoke.py
+++ b/tests/test_tuya_smoke.py
@@ -79,3 +79,32 @@ async def test_handle_get_data(zigpy_device_from_v2_quirk, model, manuf, battery
 
         assert len(power_listener.attribute_updates) == 1
         assert power_listener.attribute_updates[0][1] == state
+
+
+async def test_tuya_smoke_sensor_attribute_update(zigpy_device_from_v2_quirk):
+    """Test update_attribute on Tuya smoke sensor."""
+
+    device = zigpy_device_from_v2_quirk("_TZ3210_up3pngle", "TS0205")
+
+    tuya_cluster = device.endpoints[1].tuya_manufacturer
+    tuya_listener = ClusterListener(tuya_cluster)
+
+    ias_cluster = device.endpoints[1].ias_zone
+    ias_listener = ClusterListener(ias_cluster)
+
+    zone_status_id = IasZone.AttributeDefs.zone_status.id
+
+    # check that updating smoke attribute also updates zone status on the Ias Zone cluster
+
+    # turn on smoke alarm
+    tuya_cluster.update_attribute(0x0401, 1)
+    assert len(tuya_listener.attribute_updates) == 1
+    assert len(ias_listener.attribute_updates) == 1
+    assert ias_listener.attribute_updates[0][0] == zone_status_id
+    assert ias_listener.attribute_updates[0][1] == 0
+    # turn off smoke alarm
+    tuya_cluster.update_attribute(0x0401, 0)
+    assert len(tuya_listener.attribute_updates) == 2
+    assert len(ias_listener.attribute_updates) == 2
+    assert ias_listener.attribute_updates[1][0] == zone_status_id
+    assert ias_listener.attribute_updates[1][1] == IasZone.ZoneStatus.Alarm_1

--- a/tests/test_tuya_smoke.py
+++ b/tests/test_tuya_smoke.py
@@ -31,7 +31,6 @@ zhaquirks.setup()
             ),
         ),
         ("_TZE284_0zaf1cr8", "TS0601", []),
-        ("_TZ3210_up3pngle", "TS0205", []),
     ],
 )
 async def test_handle_get_data(zigpy_device_from_v2_quirk, model, manuf, battery_test):

--- a/zhaquirks/tuya/tuya_smoke.py
+++ b/zhaquirks/tuya/tuya_smoke.py
@@ -37,7 +37,7 @@ class TuyaSmokeDetectorCluster(TuyaManufClusterAttributes):
         if attrid == self.AttributeDefs.smoke_detected.id:
             self.endpoint.ias_zone.update_attribute(
                 IasZone.AttributeDefs.zone_status.id,
-                lambda x: IasZone.ZoneStatus.Alarm_1 if x == 0 else 0,
+                IasZone.ZoneStatus.Alarm_1 if value == 0 else 0,
             )
 
 

--- a/zhaquirks/tuya/tuya_smoke.py
+++ b/zhaquirks/tuya/tuya_smoke.py
@@ -1,6 +1,55 @@
 """Smoke Sensor."""
 
+from zigpy.quirks.v2 import QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl.clusters.general import OnOff, Time
+from zigpy.zcl.clusters.lightlink import LightLink
+from zigpy.zcl.clusters.security import IasZone
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+from zhaquirks import LocalDataCluster
+from zhaquirks.tuya import TuyaManufClusterAttributes
 from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkBuilder
+
+
+class TuyaIasZone(LocalDataCluster, IasZone):
+    """IAS Zone."""
+
+    _CONSTANT_ATTRIBUTES = {
+        IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Fire_Sensor
+    }
+
+
+class TuyaSmokeDetectorCluster(TuyaManufClusterAttributes):
+    """Manufacturer Specific Cluster of the TS0205 smoke detector."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        smoke_detected = ZCLAttributeDef(
+            id=0x0401,  # [0]/[1] [Detected]/[Clear]
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == self.AttributeDefs.smoke_detected.id:
+            self.endpoint.ias_zone.update_attribute(
+                IasZone.AttributeDefs.zone_status.id,
+                lambda x: IasZone.ZoneStatus.Alarm_1 if x == 0 else 0,
+            )
+
+
+(
+    QuirkBuilder("_TZ3210_up3pngle", "TS0205")
+    .removes(LightLink.cluster_id)
+    .removes(OnOff.cluster_id)
+    .removes(Time.cluster_id)
+    .replaces(TuyaIasZone)
+    .replaces(TuyaSmokeDetectorCluster)
+    .add_to_registry()
+)
 
 (
     TuyaQuirkBuilder("_TZE200_aycxwiau", "TS0601")
@@ -12,7 +61,6 @@ from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkB
     .applies_to("_TZE200_vzekyi4c", "TS0601")
     .applies_to("_TZE204_vawy74yh", "TS0601")
     .applies_to("_TZE284_0zaf1cr8", "TS0601")
-    .applies_to("_TZ3210_up3pngle", "TS0205")
     .tuya_smoke(dp_id=1)
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

When https://github.com/zigpy/zha-device-handlers/pull/3596 updated Tuya smoke detector quirks to v2, it broke _TZ3210_up3pngle. This fixes that.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
