### PR TITLE
Add tamper sensor to Tuya smoke detector

### DIFF
--- a/tests/test_tuya_smoke.py
+++ b/tests/test_tuya_smoke.py
@@ -16,11 +16,19 @@ zhaquirks.setup()
     [
         ("_TZE200_dq1mfjug", "TS0601", []),
         ("_TZE200_m9skfctm", "TS0601", []),
-        ("_TZE200_ntcy3xu1", "TS0601", []),
         ("_TZE200_rccxox8p", "TS0601", []),
         ("_TZE284_rccxox8p", "TS0601", []),
         ("_TZE200_vzekyi4c", "TS0601", []),
         ("_TZE204_vawy74yh", "TS0601", []),
+        (
+            "_TZE200_ntcy3xu1",
+            "TS0601",
+            (
+                (b"\x09\x3a\x02\x00\x12\x0e\x04\x00\x01\x02", 200),
+                (b"\x09\x3a\x02\x00\x12\x0e\x04\x00\x01\x01", 80),
+                (b"\x09\x3a\x02\x00\x12\x0e\x04\x00\x01\x00", 10),
+            ),
+        ),
         (
             "_TZE204_ntcy3xu1",
             "TS0601",

--- a/zhaquirks/tuya/tuya_smoke.py
+++ b/zhaquirks/tuya/tuya_smoke.py
@@ -1,12 +1,14 @@
 """Smoke Sensor."""
 
+from zigpy.quirks.v2 import EntityType
+from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
+
 from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkBuilder
 
 (
     TuyaQuirkBuilder("_TZE200_aycxwiau", "TS0601")
     .applies_to("_TZE200_dq1mfjug", "TS0601")
     .applies_to("_TZE200_m9skfctm", "TS0601")
-    .applies_to("_TZE200_ntcy3xu1", "TS0601")
     .applies_to("_TZE200_rccxox8p", "TS0601")
     .applies_to("_TZE284_rccxox8p", "TS0601")
     .applies_to("_TZE200_vzekyi4c", "TS0601")
@@ -20,7 +22,16 @@ from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkB
 
 (
     TuyaQuirkBuilder("_TZE204_ntcy3xu1", "TS0601")
+    .applies_to("_TZE200_ntcy3xu1", "TS0601")
     .tuya_smoke(dp_id=1)
+    .tuya_binary_sensor(
+        dp_id=4,
+        attribute_name="tamper",
+        device_class=BinarySensorDeviceClass.TAMPER,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="tamper",
+        fallback_name="Tamper",
+    )
     .tuya_dp(
         dp_id=14,
         ep_attribute=TuyaPowerConfigurationCluster2AAA.ep_attribute,

--- a/zhaquirks/tuya/tuya_smoke.py
+++ b/zhaquirks/tuya/tuya_smoke.py
@@ -29,7 +29,6 @@ from zhaquirks.tuya.builder import TuyaPowerConfigurationCluster2AAA, TuyaQuirkB
         attribute_name="tamper",
         device_class=BinarySensorDeviceClass.TAMPER,
         entity_type=EntityType.DIAGNOSTIC,
-        translation_key="tamper",
         fallback_name="Tamper",
     )
     .tuya_dp(


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Adds tamper sensor and battery to _TZE200_ntcy3xu1 and _TZE204_ntcy3xu1

Closes: https://github.com/zigpy/zha-device-handlers/issues/3725

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
