### PR TITLE
Add additional Tuya gas sensors

### DIFF
--- a/tests/test_tuya_gas.py
+++ b/tests/test_tuya_gas.py
@@ -9,9 +9,8 @@ import zhaquirks
 import zhaquirks.tuya
 from zhaquirks.tuya.mcu import TuyaMCUCluster
 
-ZCL_TUYA_GAS_PRESENT_ENUM = (
-    b"\tL\x01\x00\x05\x01\x04\x00\x01\x00"  # DP 1, enum, present
-)
+ZCL_TUYA_GAS_PRESENT_ENUM = b"\tL\x01\x00\x05\x01\x04\x00\x01\x00"  # DP 1, enum, gas
+
 ZCL_TUYA_GAS_CLEAR_ENUM = b"\tL\x01\x00\x05\x01\x04\x00\x01\x01"  # DP 1, enum, clear
 
 
@@ -19,14 +18,54 @@ zhaquirks.setup()
 
 
 @pytest.mark.parametrize(
-    "model,manuf,gas_msg,gas_present",
+    "model,manuf,gas_present,gas_clear",
     [
-        ("_TZE200_yojqa8xn", "TS0601", ZCL_TUYA_GAS_PRESENT_ENUM, True),
-        ("_TZE200_yojqa8xn", "TS0601", ZCL_TUYA_GAS_CLEAR_ENUM, False),
+        (
+            "_TZE200_yojqa8xn",
+            "TS0601",
+            ZCL_TUYA_GAS_PRESENT_ENUM,
+            ZCL_TUYA_GAS_CLEAR_ENUM,
+        ),
+        (
+            "_TZE204_zougpkpy",
+            "TS0601",
+            ZCL_TUYA_GAS_PRESENT_ENUM,
+            ZCL_TUYA_GAS_CLEAR_ENUM,
+        ),
+        (
+            "_TZE204_chbyv06x",
+            "TS0601",
+            ZCL_TUYA_GAS_PRESENT_ENUM,
+            ZCL_TUYA_GAS_CLEAR_ENUM,
+        ),
+        (
+            "_TZE204_yojqa8xn",
+            "TS0601",
+            ZCL_TUYA_GAS_PRESENT_ENUM,
+            ZCL_TUYA_GAS_CLEAR_ENUM,
+        ),
+        (
+            "_TZE200_ggev5fsl",
+            "TS0601",
+            ZCL_TUYA_GAS_PRESENT_ENUM,
+            ZCL_TUYA_GAS_CLEAR_ENUM,
+        ),
+        (
+            "_TZE200_u319yc66",
+            "TS0601",
+            ZCL_TUYA_GAS_PRESENT_ENUM,
+            ZCL_TUYA_GAS_CLEAR_ENUM,
+        ),
+        (
+            "_TZE200_kvpwq8z7",
+            "TS0601",
+            ZCL_TUYA_GAS_PRESENT_ENUM,
+            ZCL_TUYA_GAS_CLEAR_ENUM,
+        ),
     ],
 )
 async def test_tuya_gas_quirk(
-    zigpy_device_from_v2_quirk, model, manuf, gas_msg, gas_present
+    zigpy_device_from_v2_quirk, model, manuf, gas_present, gas_clear
 ):
     """Test Tuya Gas Quirks using IAS cluster."""
     quirked_device = zigpy_device_from_v2_quirk(model, manuf)
@@ -41,14 +80,18 @@ async def test_tuya_gas_quirk(
     ias_listener = ClusterListener(ep.ias_zone)
     zcl_ias_id = IasZone.AttributeDefs.zone_status.id
 
-    hdr, data = ep.tuya_manufacturer.deserialize(gas_msg)
+    hdr, data = ep.tuya_manufacturer.deserialize(gas_present)
     status = ep.tuya_manufacturer.handle_get_data(data.data)
 
     assert status == foundation.Status.SUCCESS
 
     assert len(ias_listener.attribute_updates) == 1
     assert ias_listener.attribute_updates[0][0] == zcl_ias_id
-    if gas_present:
-        assert ias_listener.attribute_updates[0][1] == IasZone.ZoneStatus.Alarm_1
-    else:
-        assert ias_listener.attribute_updates[0][1] == 0
+    assert ias_listener.attribute_updates[0][1] == IasZone.ZoneStatus.Alarm_1
+
+    hdr, data = ep.tuya_manufacturer.deserialize(gas_clear)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+
+    assert len(ias_listener.attribute_updates) == 2
+    assert ias_listener.attribute_updates[1][0] == zcl_ias_id
+    assert ias_listener.attribute_updates[1][1] == 0

--- a/tests/test_tuya_gas.py
+++ b/tests/test_tuya_gas.py
@@ -1,0 +1,54 @@
+"""Tests for Tuya gas quirks."""
+
+import pytest
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.security import IasZone
+
+from tests.common import ClusterListener
+import zhaquirks
+import zhaquirks.tuya
+from zhaquirks.tuya.mcu import TuyaMCUCluster
+
+ZCL_TUYA_GAS_PRESENT_ENUM = (
+    b"\tL\x01\x00\x05\x01\x04\x00\x01\x00"  # DP 1, enum, present
+)
+ZCL_TUYA_GAS_CLEAR_ENUM = b"\tL\x01\x00\x05\x01\x04\x00\x01\x01"  # DP 1, enum, clear
+
+
+zhaquirks.setup()
+
+
+@pytest.mark.parametrize(
+    "model,manuf,gas_msg,gas_present",
+    [
+        ("_TZE200_yojqa8xn", "TS0601", ZCL_TUYA_GAS_PRESENT_ENUM, True),
+        ("_TZE200_yojqa8xn", "TS0601", ZCL_TUYA_GAS_CLEAR_ENUM, False),
+    ],
+)
+async def test_tuya_gas_quirk(
+    zigpy_device_from_v2_quirk, model, manuf, gas_msg, gas_present
+):
+    """Test Tuya Gas Quirks using IAS cluster."""
+    quirked_device = zigpy_device_from_v2_quirk(model, manuf)
+    ep = quirked_device.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+
+    assert ep.ias_zone is not None
+    assert isinstance(ep.ias_zone, IasZone)
+
+    ias_listener = ClusterListener(ep.ias_zone)
+    zcl_ias_id = IasZone.AttributeDefs.zone_status.id
+
+    hdr, data = ep.tuya_manufacturer.deserialize(gas_msg)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+
+    assert status == foundation.Status.SUCCESS
+
+    assert len(ias_listener.attribute_updates) == 1
+    assert ias_listener.attribute_updates[0][0] == zcl_ias_id
+    if gas_present:
+        assert ias_listener.attribute_updates[0][1] == IasZone.ZoneStatus.Alarm_1
+    else:
+        assert ias_listener.attribute_updates[0][1] == 0

--- a/zhaquirks/tuya/tuya_gas.py
+++ b/zhaquirks/tuya/tuya_gas.py
@@ -131,7 +131,7 @@ tuya_gas_alarm_base = (
         type=t.int16s,
         divisor=10,
         state_class=SensorStateClass.MEASUREMENT,
-        unit=r"LEL",  # Not present in zigpy
+        unit="%LEL",  # Not present in zigpy
         translation_key="lower_explosive_limit",
         fallback_name="% Lower explosive limit",
     )

--- a/zhaquirks/tuya/tuya_gas.py
+++ b/zhaquirks/tuya/tuya_gas.py
@@ -1,8 +1,12 @@
 """Tuya Gas Sensor."""
 
-from zigpy.quirks.v2 import EntityPlatform, EntityType
+from zigpy.quirks.v2 import BinarySensorDeviceClass, EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant import CONCENTRATION_PARTS_PER_MILLION
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.zcl.clusters.general import BatterySize
+
+
 import zigpy.types as t
 
 from zhaquirks.tuya import TuyaPowerConfigurationCluster2AA
@@ -17,6 +21,15 @@ class TuyaSelfTestResult(t.enum8):
     Failure = 0x02
     Others = 0x03
 
+
+class TuyaSirenRingtone(t.enum8):
+    """Tuya siren ringtone enum."""
+
+    Ringtone_01 = 0x00
+    Ringtone_02 = 0x01
+    Ringtone_03 = 0x02
+    Ringtone_04 = 0x03
+    Ringtone_05 = 0x04
 
 (
     TuyaQuirkBuilder("_TZE200_ggev5fsl", "TS0601")
@@ -42,7 +55,7 @@ class TuyaSelfTestResult(t.enum8):
         translation_key="self_test_result",
         fallback_name="Self test result",
     )
-    .tuya_battery(dp_id=15, power_cfg=TuyaPowerConfigurationCluster2AA)
+    .tuya_battery(dp_id=15,battery_type=BatterySize.AA, battery_qty=2)
     .tuya_switch(
         dp_id=16,
         attribute_name="mute_siren",
@@ -51,5 +64,98 @@ class TuyaSelfTestResult(t.enum8):
         fallback_name="Mute siren",
     )
     .skip_configuration()
+    .add_to_registry()
+)
+
+
+tuya_gas_alarm_base = (
+    TuyaQuirkBuilder()
+    .tuya_gas(dp_id=1) # Reports as enum, not bool
+    .tuya_switch(
+        dp_id=8,
+        attribute_name="self_test_switch",
+        entity_type=EntityType.STANDARD,
+        translation_key="self_test_switch",
+        fallback_name="Self test switch",
+    )
+    .tuya_enum(
+        dp_id=9,
+        attribute_name="self_test_result",
+        enum_class=TuyaSelfTestResult,
+        entity_type=EntityType.DIAGNOSTIC,
+        entity_platform=EntityPlatform.SENSOR,
+        translation_key="self_test_result",
+        fallback_name="Self test result",
+    )
+    .tuya_binary_sensor(
+        dp_id=16,
+        attribute_name="silence_alarm",
+        entity_type=EntityType.STANDARD,
+        translation_key="silence_alarm",
+        fallback_name="Silence alarm",
+    )
+    .tuya_enchantment()
+    .skip_configuration()
+
+)
+
+(
+    tuya_gas_alarm_base.clone() # 1, 8, 9, and 16 from base
+    .applies_to("'_TZE200_yojqa8xn", "TS0601")
+    .applies_to("_TZE204_zougpkpy","TS0601")
+    .applies_to("_TZE204_chbyv06x","TS0601")
+    .applies_to("_TZE204_yojqa8xn","TS0601")
+    .tuya_sensor(
+        dp_id=2,
+        attribute_name="lower_explosive_limit",
+        type=t.int16s,
+        divisor=10,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit="\%LEL", # Not present in zigpy
+        translation_key="lower_explosive_limit",
+        fallback_name="\% Lower explosive limit",
+    )
+    .tuya_enum(
+        dp_id=6,
+        attribute_name="alarm_ringtone",
+        enum_class=TuyaSirenRingtone,
+        translation_key="alarm_ringtone",
+        fallback_name="Alarm ringtone",
+    )
+    .tuya_number(
+        dp_id=7,
+        attribute_name="alarm_duration",
+        min_value=1,
+        type=t.uint16_t,
+        max_value=180,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        translation_key="alarm_duration",
+        fallback_name="Alarm duration",
+    )
+    .tuya_binary_sensor(
+        dp_id=10,
+        attribute_name="preheat_active",
+        entity_type=EntityType.STANDARD,
+        translation_key="preheat_active",
+        fallback_name="Preheat active",
+    )
+    # 13 ignored in z2m
+    .add_to_registry()
+)
+
+(
+    tuya_gas_alarm_base.clone() # 1, 8, 9, and 16 from base
+    .applies_to("'_TZE200_ggev5fsl", "TS0601")
+    .applies_to("_TZE200_u319yc66","TS0601")
+    .applies_to("_TZE200_kvpwq8z7","TS0601")
+    .tuya_binary_sensor(
+        dp_id=11,
+        attribute_name="fault_alarm",
+        entity_type=EntityType.STANDARD,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        translation_key="fault_alarm",
+        fallback_name="Fault alarm",
+    )
     .add_to_registry()
 )

--- a/zhaquirks/tuya/tuya_gas.py
+++ b/zhaquirks/tuya/tuya_gas.py
@@ -169,7 +169,7 @@ tuya_gas_alarm_base = (
 
 (
     tuya_gas_alarm_base.clone()  # 1, 8, 9, and 16 from base
-    .applies_to("'_TZE200_ggev5fsl", "TS0601")
+    .applies_to("_TZE200_ggev5fsl", "TS0601")
     .applies_to("_TZE200_u319yc66", "TS0601")
     .applies_to("_TZE200_kvpwq8z7", "TS0601")
     .tuya_binary_sensor(

--- a/zhaquirks/tuya/tuya_gas.py
+++ b/zhaquirks/tuya/tuya_gas.py
@@ -1,13 +1,10 @@
 """Tuya Gas Sensor."""
 
 from zigpy.quirks.v2 import BinarySensorDeviceClass, EntityPlatform, EntityType
-from zigpy.quirks.v2.homeassistant import CONCENTRATION_PARTS_PER_MILLION
-from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant import CONCENTRATION_PARTS_PER_MILLION, UnitOfTime
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
-from zigpy.zcl.clusters.general import BatterySize
-
-
 import zigpy.types as t
+from zigpy.zcl.clusters.general import BatterySize
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks.tuya import TuyaLocalCluster
@@ -47,9 +44,9 @@ class TuyaIasGasLEL(IasZone, TuyaLocalCluster):
         IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Standard_Warning_Device
     }
 
+
 (
-    TuyaQuirkBuilder("_TZE200_ggev5fsl", "TS0601")
-    .applies_to("_TZE200_hr0tdd47", "TS0601")
+    TuyaQuirkBuilder("_TZE200_hr0tdd47", "TS0601")
     .applies_to("_TZE200_rjxqso4a", "TS0601")
     .applies_to("_TZE284_rjxqso4a", "TS0601")
     .tuya_gas(dp_id=1)
@@ -71,7 +68,7 @@ class TuyaIasGasLEL(IasZone, TuyaLocalCluster):
         translation_key="self_test_result",
         fallback_name="Self test result",
     )
-    .tuya_battery(dp_id=15,battery_type=BatterySize.AA, battery_qty=2)
+    .tuya_battery(dp_id=15, battery_type=BatterySize.AA, battery_qty=2)
     .tuya_switch(
         dp_id=16,
         attribute_name="mute_siren",
@@ -95,7 +92,6 @@ tuya_gas_alarm_base = (
     )  # Reports as enum, not bool
     .tuya_switch(
         dp_id=8,
-        attribute_name="self_test_switch",
         attribute_name="self_test_switch",
         entity_type=EntityType.STANDARD,
         translation_key="self_test_switch",
@@ -134,9 +130,9 @@ tuya_gas_alarm_base = (
         type=t.int16s,
         divisor=10,
         state_class=SensorStateClass.MEASUREMENT,
-        unit="\%LEL", # Not present in zigpy
+        unit=r"\%LEL",  # Not present in zigpy
         translation_key="lower_explosive_limit",
-        fallback_name="\% Lower explosive limit",
+        fallback_name=r"\% Lower explosive limit",
     )
     .tuya_enum(
         dp_id=6,

--- a/zhaquirks/tuya/tuya_gas.py
+++ b/zhaquirks/tuya/tuya_gas.py
@@ -130,9 +130,9 @@ tuya_gas_alarm_base = (
         type=t.int16s,
         divisor=10,
         state_class=SensorStateClass.MEASUREMENT,
-        unit=r"\%LEL",  # Not present in zigpy
+        unit=r"%LEL",  # Not present in zigpy
         translation_key="lower_explosive_limit",
-        fallback_name=r"\% Lower explosive limit",
+        fallback_name=r"% Lower explosive limit",
     )
     .tuya_enum(
         dp_id=6,

--- a/zhaquirks/tuya/tuya_gas.py
+++ b/zhaquirks/tuya/tuya_gas.py
@@ -118,6 +118,7 @@ tuya_gas_alarm_base = (
     .skip_configuration()
 )
 
+
 (
     tuya_gas_alarm_base.clone()  # 1, 8, 9, and 16 from base
     .applies_to("_TZE200_yojqa8xn", "TS0601")
@@ -130,9 +131,9 @@ tuya_gas_alarm_base = (
         type=t.int16s,
         divisor=10,
         state_class=SensorStateClass.MEASUREMENT,
-        unit=r"%LEL",  # Not present in zigpy
+        unit=r"LEL",  # Not present in zigpy
         translation_key="lower_explosive_limit",
-        fallback_name=r"% Lower explosive limit",
+        fallback_name="% Lower explosive limit",
     )
     .tuya_enum(
         dp_id=6,
@@ -162,6 +163,7 @@ tuya_gas_alarm_base = (
     # 13 ignored in z2m
     .add_to_registry()
 )
+
 
 (
     tuya_gas_alarm_base.clone()  # 1, 8, 9, and 16 from base

--- a/zhaquirks/tuya/tuya_gas.py
+++ b/zhaquirks/tuya/tuya_gas.py
@@ -2,14 +2,15 @@
 
 from zigpy.quirks.v2 import BinarySensorDeviceClass, EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant import CONCENTRATION_PARTS_PER_MILLION
-from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 from zigpy.zcl.clusters.general import BatterySize
 
 
 import zigpy.types as t
+from zigpy.zcl.clusters.security import IasZone
 
-from zhaquirks.tuya import TuyaPowerConfigurationCluster2AA
+from zhaquirks.tuya import TuyaLocalCluster
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
@@ -30,6 +31,21 @@ class TuyaSirenRingtone(t.enum8):
     Ringtone_03 = 0x02
     Ringtone_04 = 0x03
     Ringtone_05 = 0x04
+
+
+class TuyaGasState(t.enum8):
+    """Tuya enum gas state."""
+
+    Present = 0x00
+    Clear = 0x01
+
+
+class TuyaIasGasLEL(IasZone, TuyaLocalCluster):
+    """Tuya local IAS LEL gas cluster."""
+
+    _CONSTANT_ATTRIBUTES = {
+        IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Standard_Warning_Device
+    }
 
 (
     TuyaQuirkBuilder("_TZE200_ggev5fsl", "TS0601")
@@ -70,21 +86,28 @@ class TuyaSirenRingtone(t.enum8):
 
 tuya_gas_alarm_base = (
     TuyaQuirkBuilder()
-    .tuya_gas(dp_id=1) # Reports as enum, not bool
+    .tuya_ias(
+        dp_id=1,
+        ias_cfg=TuyaIasGasLEL,
+        converter=lambda x: IasZone.ZoneStatus.Alarm_1
+        if x == TuyaGasState.Present
+        else 0,
+    )  # Reports as enum, not bool
     .tuya_switch(
         dp_id=8,
         attribute_name="self_test_switch",
+        attribute_name="self_test_switch",
         entity_type=EntityType.STANDARD,
         translation_key="self_test_switch",
-        fallback_name="Self test switch",
+        fallback_name="Self test",
     )
     .tuya_enum(
         dp_id=9,
-        attribute_name="self_test_result",
+        attribute_name="self_test",
         enum_class=TuyaSelfTestResult,
         entity_type=EntityType.DIAGNOSTIC,
         entity_platform=EntityPlatform.SENSOR,
-        translation_key="self_test_result",
+        translation_key="self_test",
         fallback_name="Self test result",
     )
     .tuya_binary_sensor(
@@ -95,16 +118,16 @@ tuya_gas_alarm_base = (
         fallback_name="Silence alarm",
     )
     .tuya_enchantment()
+    .tuya_enchantment()
     .skip_configuration()
-
 )
 
 (
-    tuya_gas_alarm_base.clone() # 1, 8, 9, and 16 from base
+    tuya_gas_alarm_base.clone()  # 1, 8, 9, and 16 from base
     .applies_to("'_TZE200_yojqa8xn", "TS0601")
-    .applies_to("_TZE204_zougpkpy","TS0601")
-    .applies_to("_TZE204_chbyv06x","TS0601")
-    .applies_to("_TZE204_yojqa8xn","TS0601")
+    .applies_to("_TZE204_zougpkpy", "TS0601")
+    .applies_to("_TZE204_chbyv06x", "TS0601")
+    .applies_to("_TZE204_yojqa8xn", "TS0601")
     .tuya_sensor(
         dp_id=2,
         attribute_name="lower_explosive_limit",
@@ -145,10 +168,10 @@ tuya_gas_alarm_base = (
 )
 
 (
-    tuya_gas_alarm_base.clone() # 1, 8, 9, and 16 from base
+    tuya_gas_alarm_base.clone()  # 1, 8, 9, and 16 from base
     .applies_to("'_TZE200_ggev5fsl", "TS0601")
-    .applies_to("_TZE200_u319yc66","TS0601")
-    .applies_to("_TZE200_kvpwq8z7","TS0601")
+    .applies_to("_TZE200_u319yc66", "TS0601")
+    .applies_to("_TZE200_kvpwq8z7", "TS0601")
     .tuya_binary_sensor(
         dp_id=11,
         attribute_name="fault_alarm",

--- a/zhaquirks/tuya/tuya_gas.py
+++ b/zhaquirks/tuya/tuya_gas.py
@@ -124,7 +124,7 @@ tuya_gas_alarm_base = (
 
 (
     tuya_gas_alarm_base.clone()  # 1, 8, 9, and 16 from base
-    .applies_to("'_TZE200_yojqa8xn", "TS0601")
+    .applies_to("_TZE200_yojqa8xn", "TS0601")
     .applies_to("_TZE204_zougpkpy", "TS0601")
     .applies_to("_TZE204_chbyv06x", "TS0601")
     .applies_to("_TZE204_yojqa8xn", "TS0601")


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Adds Tuya explosive gas detectors:

- _TZE200_yojqa8xn
- _TZE204_zougpkpy
- _TZE204_chbyv06x
- _TZE204_yojqa8xn
- _TZE200_ggev5fsl
- _TZE200_u319yc66
- _TZE200_kvpwq8z7

Merge: #3635 first

Units are in LEL, not available in zigpy or HA.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

Based on: https://github.com/Koenkk/zigbee-herdsman-converters/blob/40e72bc2515deb67ef35dddab04437342b7b3eb9/src/devices/tuya.ts#L1362

Closes: #2324
Closes: #2748

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
