### PR TITLE
Add % unit to Schneider TRV "display brightness"

### DIFF
--- a/zhaquirks/schneiderelectric/thermostat.py
+++ b/zhaquirks/schneiderelectric/thermostat.py
@@ -5,6 +5,7 @@ from typing import Final
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import EntityType, QuirkBuilder
 from zigpy.quirks.v2.homeassistant import (
+    PERCENTAGE,
     EntityPlatform,
     UnitOfPower,
     UnitOfTemperature,
@@ -597,7 +598,7 @@ class SEHeatingCoolingOutput(CustomCluster):
         attribute_name=SEUserInterface.AttributeDefs.se_brightness.name,
         translation_key="display_brightness",
         fallback_name="Display brightness",
-        # unit="%",
+        unit=PERCENTAGE,
         min_value=0,
         max_value=100,
         step=1,
@@ -608,7 +609,7 @@ class SEHeatingCoolingOutput(CustomCluster):
         attribute_name=SEUserInterface.AttributeDefs.se_inactive_brightness.name,
         translation_key="display_inactive_brightness",
         fallback_name="Display inactive brightness",
-        # unit="%",
+        unit=PERCENTAGE,
         min_value=0,
         max_value=100,
         step=1,


### PR DESCRIPTION
## Proposed change
This adds the "percentage" unit to the Schneider thermostat "Display brightness" entities.

## Additional information
This is now possible due to the merge of https://github.com/zigpy/zha/pull/352
Follow-up to original PR https://github.com/zigpy/zha-device-handlers/pull/3575

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
