### PR TITLE
Add lx unit to Tuya motion "illuminance threshold"

### DIFF
--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -5,7 +5,7 @@ import math
 from typing import Any
 
 from zigpy.quirks.v2 import EntityPlatform, EntityType
-from zigpy.quirks.v2.homeassistant import UnitOfLength, UnitOfTime
+from zigpy.quirks.v2.homeassistant import LIGHT_LUX, UnitOfLength, UnitOfTime
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
@@ -463,7 +463,7 @@ base_tuya_motion = (
         attribute_name="illuminance_threshold",
         type=t.uint16_t,
         device_class=SensorDeviceClass.ILLUMINANCE,
-        # unit=LIGHT_LUX, # Not supported ZHA yet
+        unit=LIGHT_LUX,
         min_value=0,
         max_value=420,
         step=0.1,


### PR DESCRIPTION
## Proposed change
This adds the `lx` unit to the Tuya motion sensor "Illuminance threshold" entity.


## Additional information
This is now possible due to the merge of https://github.com/zigpy/zha/pull/352
Follow-up to original PR https://github.com/zigpy/zha-device-handlers/pull/3676


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
