### PR TITLE
Add 2 empty lines between v2 quirk definitions

### DIFF
--- a/zhaquirks/nimly/lock.py
+++ b/zhaquirks/nimly/lock.py
@@ -33,6 +33,7 @@ NIMLY_LOCK_NODE_DESCRIPTOR = NodeDescriptor(
     .add_to_registry()
 )
 
+
 (
     QuirkBuilder(NIMLY, "NimlyPRO")
     .applies_to(NIMLY, "NimlyCode")

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -58,11 +58,13 @@ nodon = (
     .replaces(NodOnPilotWireCluster)
 )  # fmt: skip
 
+
 adeo = (
     nodon.clone(omit_man_model_data=True)
     .applies_to(ADEO, "SIN-4-FP-21_EQU")
     .replaces(AdeoPilotWireCluster)
 )
+
 
 nodon.add_to_registry()
 adeo.add_to_registry()

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -23,6 +23,7 @@ from zhaquirks.schneiderelectric import (
     .add_to_registry()
 )
 
+
 (
     QuirkBuilder(SE_MANUF_NAME, "NHPB/SWITCH/1")
     .replaces(SEBasic)


### PR DESCRIPTION
## Proposed change
This adds two empty lines between each v2 quirk definition when there are multiple in a single file.


## Additional information
This was done inconsistently before and pre-commit/ruff doesn't enforce this, since we don't create a new class here or anything. So, this PR just adds them manually to existing files.


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
