### PR TITLE
Replace deprecated `dev.handle_message` usage in tests

### DIFF
--- a/tests/test_inovelli_blue.py
+++ b/tests/test_inovelli_blue.py
@@ -3,6 +3,8 @@
 from unittest import mock
 from unittest.mock import MagicMock
 
+import zigpy.types as t
+
 import zhaquirks
 from zhaquirks.inovelli.VZM31SN import InovelliVZM31SNv11
 
@@ -25,7 +27,15 @@ def test_mfg_cluster_events(zigpy_device_from_quirk):
         cluster_listener
     )
 
-    device.handle_message(260, cluster_id, endpoint_id, endpoint_id, data)
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=cluster_id,
+            src_ep=endpoint_id,
+            dst_ep=endpoint_id,
+            data=t.SerializableBytes(data),
+        )
+    )
 
     assert cluster_listener.zha_send_event.call_count == 1
     assert cluster_listener.zha_send_event.call_args == mock.call(
@@ -35,8 +45,14 @@ def test_mfg_cluster_events(zigpy_device_from_quirk):
     cluster_listener.zha_send_event.reset_mock()
 
     led_effect_complete_data = b"\x15/\x12\x0c$\x10"
-    device.handle_message(
-        260, cluster_id, endpoint_id, endpoint_id, led_effect_complete_data
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=cluster_id,
+            src_ep=endpoint_id,
+            dst_ep=endpoint_id,
+            data=t.SerializableBytes(led_effect_complete_data),
+        )
     )
 
     assert cluster_listener.zha_send_event.call_count == 1

--- a/tests/test_konke.py
+++ b/tests/test_konke.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest import mock
 
 import pytest
+import zigpy.types as t
 
 from tests.common import ZCL_IAS_MOTION_COMMAND, ClusterListener
 import zhaquirks
@@ -83,7 +84,15 @@ async def test_konke_button(zigpy_device_from_quirk, quirk):
 
     # single press
     message = b"\x08W\n\x00\x00\x10\x80"
-    device.handle_message(260, cluster.cluster_id, 1, 1, message)
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=cluster.cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(message),
+        )
+    )
     assert listener.zha_send_event.call_count == 1
     assert listener.zha_send_event.call_args_list[0][0][0] == COMMAND_SINGLE
     assert listener.zha_send_event.call_args_list[0][0][1][PRESS_TYPE] == COMMAND_SINGLE
@@ -92,7 +101,15 @@ async def test_konke_button(zigpy_device_from_quirk, quirk):
     # double press
     listener.reset_mock()
     message = b"\x08X\n\x00\x00\x10\x81"
-    device.handle_message(260, cluster.cluster_id, 1, 1, message)
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=cluster.cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(message),
+        )
+    )
     assert listener.zha_send_event.call_count == 1
     assert listener.zha_send_event.call_args_list[0][0][0] == COMMAND_DOUBLE
     assert listener.zha_send_event.call_args_list[0][0][1][PRESS_TYPE] == COMMAND_DOUBLE
@@ -101,7 +118,15 @@ async def test_konke_button(zigpy_device_from_quirk, quirk):
     # long press
     listener.reset_mock()
     message = b"\x08Y\n\x00\x00\x10\x82"
-    device.handle_message(260, cluster.cluster_id, 1, 1, message)
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=cluster.cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(message),
+        )
+    )
     assert listener.zha_send_event.call_count == 1
     assert listener.zha_send_event.call_args_list[0][0][0] == COMMAND_HOLD
     assert listener.zha_send_event.call_args_list[0][0][1][PRESS_TYPE] == COMMAND_HOLD

--- a/tests/test_linxura.py
+++ b/tests/test_linxura.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+import zigpy.types as t
 from zigpy.zcl.clusters.security import IasZone
 
 import zhaquirks
@@ -105,7 +106,15 @@ async def test_button_triggers(zigpy_device_from_quirk, message, button, press_t
     listener = mock.MagicMock()
     cluster.add_listener(listener)
 
-    device.handle_message(260, cluster.cluster_id, 1, 1, message)
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=cluster.cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(message),
+        )
+    )
     assert listener.zha_send_event.call_count == 1
     assert listener.zha_send_event.call_args == mock.call(
         f"{button}_{press_type}",

--- a/tests/test_tuya_air.py
+++ b/tests/test_tuya_air.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import zigpy.profiles.zha
+import zigpy.types as t
 
 import zhaquirks
 from zhaquirks.tuya import TuyaNewManufCluster
@@ -65,8 +66,14 @@ def air_quality_device(zigpy_device_from_v2_quirk):
 def test_co2_sensor(air_quality_device, data, ep_attr, expected_value):
     """Test Tuya Air Quality Sensor."""
 
-    air_quality_device.handle_message(
-        zigpy.profiles.zha.PROFILE_ID, TuyaNewManufCluster.cluster_id, 1, 1, data
+    air_quality_device.packet_received(
+        t.ZigbeePacket(
+            profile_id=zigpy.profiles.zha.PROFILE_ID,
+            cluster_id=TuyaNewManufCluster.cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(data),
+        )
     )
     cluster = getattr(air_quality_device.endpoints[1], ep_attr)
     assert cluster.get("measured_value") == expected_value
@@ -132,8 +139,14 @@ def smart_air_quality_device(zigpy_device_from_v2_quirk):
 def test_smart_air_sensor(smart_air_quality_device, data, ep_attr, expected_value):
     """Test Tuya Smart Air Sensor."""
 
-    smart_air_quality_device.handle_message(
-        zigpy.profiles.zha.PROFILE_ID, TuyaNewManufCluster.cluster_id, 1, 1, data
+    smart_air_quality_device.packet_received(
+        t.ZigbeePacket(
+            profile_id=zigpy.profiles.zha.PROFILE_ID,
+            cluster_id=TuyaNewManufCluster.cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(data),
+        )
     )
     cluster = getattr(smart_air_quality_device.endpoints[1], ep_attr)
     assert cluster.get("measured_value") == expected_value

--- a/tests/test_xbee.py
+++ b/tests/test_xbee.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import AnalogOutput, Basic, LevelControl, OnOff
 
@@ -177,12 +178,14 @@ async def test_receive_serial_data(zigpy_device_from_quirk):
     ].add_listener(listener)
 
     # Receive serial data
-    xbee3_device.handle_message(
-        XBEE_PROFILE_ID,
-        XBEE_DATA_CLUSTER,
-        XBEE_DATA_ENDPOINT,
-        XBEE_DATA_ENDPOINT,
-        b"Test UART data",
+    xbee3_device.packet_received(
+        t.ZigbeePacket(
+            profile_id=XBEE_PROFILE_ID,
+            cluster_id=XBEE_DATA_CLUSTER,
+            src_ep=XBEE_DATA_ENDPOINT,
+            dst_ep=XBEE_DATA_ENDPOINT,
+            data=t.SerializableBytes(b"Test UART data"),
+        )
     )
 
     listener.zha_send_event.assert_called_once_with(
@@ -350,12 +353,14 @@ async def test_remote_at_non_native(
 
     def mock_at_response(*args, **kwargs):
         """Simulate remote AT command response from device."""
-        xbee3_device.handle_message(
-            XBEE_PROFILE_ID,
-            XBEE_AT_RESPONSE_CLUSTER,
-            XBEE_AT_ENDPOINT,
-            XBEE_AT_ENDPOINT,
-            response_data,
+        xbee3_device.packet_received(
+            t.ZigbeePacket(
+                profile_id=XBEE_PROFILE_ID,
+                cluster_id=XBEE_AT_RESPONSE_CLUSTER,
+                src_ep=XBEE_AT_ENDPOINT,
+                dst_ep=XBEE_AT_ENDPOINT,
+                data=t.SerializableBytes(response_data),
+            )
         )
         return mock.DEFAULT
 
@@ -477,12 +482,14 @@ async def test_remote_at_tx_failure(zigpy_device_from_quirk):
 
     def mock_at_response(*args, **kwargs):
         """Simulate remote AT command response from device."""
-        xbee3_device.handle_message(
-            XBEE_PROFILE_ID,
-            XBEE_AT_RESPONSE_CLUSTER,
-            XBEE_AT_ENDPOINT,
-            XBEE_AT_ENDPOINT,
-            b"\x01TP\x04",
+        xbee3_device.packet_received(
+            t.ZigbeePacket(
+                profile_id=XBEE_PROFILE_ID,
+                cluster_id=XBEE_AT_RESPONSE_CLUSTER,
+                src_ep=XBEE_AT_ENDPOINT,
+                dst_ep=XBEE_AT_ENDPOINT,
+                data=t.SerializableBytes(b"\x01TP\x04"),
+            )
         )
         return mock.DEFAULT
 
@@ -515,12 +522,16 @@ async def test_io_sample_report(zigpy_device_from_quirk):
     ]
 
     #   {'digital_samples': [1, None, 0, None, 1, None, 0, None, 1, None, 0, None, 1, None, 0], 'analog_samples': [341, None, 682, None, None, None, None, 3305]}
-    xbee3_device.handle_message(
-        XBEE_PROFILE_ID,
-        XBEE_IO_CLUSTER,
-        XBEE_DATA_ENDPOINT,
-        XBEE_DATA_ENDPOINT,
-        b"\x01\x55\x55\x85\x11\x11\x01\x55\x02\xaa\x0c\xe9",
+    xbee3_device.packet_received(
+        t.ZigbeePacket(
+            profile_id=XBEE_PROFILE_ID,
+            cluster_id=XBEE_IO_CLUSTER,
+            src_ep=XBEE_DATA_ENDPOINT,
+            dst_ep=XBEE_DATA_ENDPOINT,
+            data=t.SerializableBytes(
+                b"\x01\x55\x55\x85\x11\x11\x01\x55\x02\xaa\x0c\xe9"
+            ),
+        )
     )
 
     for i in range(len(digital_listeners)):
@@ -564,12 +575,16 @@ async def test_io_sample_report_on_at_response(zigpy_device_from_quirk):
 
     def mock_at_response(*args, **kwargs):
         """Simulate remote AT command response from device."""
-        xbee_device.handle_message(
-            XBEE_PROFILE_ID,
-            XBEE_AT_RESPONSE_CLUSTER,
-            XBEE_AT_ENDPOINT,
-            XBEE_AT_ENDPOINT,
-            b"\x01IS\x00\x01\x55\x55\x85\x11\x11\x01\x55\x02\xaa\x0c\xe9",
+        xbee_device.packet_received(
+            t.ZigbeePacket(
+                profile_id=XBEE_PROFILE_ID,
+                cluster_id=XBEE_AT_RESPONSE_CLUSTER,
+                src_ep=XBEE_AT_ENDPOINT,
+                dst_ep=XBEE_AT_ENDPOINT,
+                data=t.SerializableBytes(
+                    b"\x01IS\x00\x01\x55\x55\x85\x11\x11\x01\x55\x02\xaa\x0c\xe9"
+                ),
+            )
         )
         return mock.DEFAULT
 
@@ -649,7 +664,15 @@ async def test_zdo(handle_mgmt_lqi_resp, zigpy_device_from_quirk):
     xbee3_device = zigpy_device_from_quirk(XBee3Sensor)
 
     # Receive ZDOCmd.IEEE_addr_req
-    xbee3_device.handle_message(0, 0x0001, 0, 0, b"\x07\x34\x12\x00\x00")
+    xbee3_device.packet_received(
+        t.ZigbeePacket(
+            profile_id=0,
+            cluster_id=0x01,
+            src_ep=0,
+            dst_ep=0,
+            data=t.SerializableBytes(b"\x07\x34\x12\x00\x00"),
+        )
+    )
 
     assert handle_mgmt_lqi_resp.call_count == 1
     assert len(handle_mgmt_lqi_resp.call_args_list[0][0]) == 4

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -336,8 +336,14 @@ async def test_xiaomi_battery(zigpy_device_from_quirk, voltage, bpr):
     )
 
     device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.vibration_aq1.VibrationAQ1)
-    device.handle_message(
-        0x260, 0x0000, 1, 1, data_1 + t.uint16_t(voltage).serialize() + data_2
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=0x260,
+            cluster_id=0x0000,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(data_1 + t.uint16_t(voltage).serialize() + data_2),
+        )
     )
     power_cluster = device.endpoints[1].power
     assert power_cluster["battery_percentage_remaining"] == bpr
@@ -362,8 +368,14 @@ async def test_mija_battery(zigpy_device_from_quirk, voltage, bpr):
     data_2 = b"!\xa8\x01$\x00\x00\x00\x00\x00!n\x00 P"
 
     device = zigpy_device_from_quirk(zhaquirks.xiaomi.mija.motion.Motion)
-    device.handle_message(
-        0x260, 0x0000, 1, 1, data_1 + t.uint16_t(voltage).serialize() + data_2
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=0x260,
+            cluster_id=0x0000,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(data_1 + t.uint16_t(voltage).serialize() + data_2),
+        )
     )
     power_cluster = device.endpoints[1].power
     assert power_cluster["battery_percentage_remaining"] == bpr
@@ -764,12 +776,14 @@ async def test_aqara_feeder_attr_reports(
     cluster_listener = Listener()
     opple_cluster.add_listener(cluster_listener)
 
-    device.handle_message(
-        260,
-        opple_cluster.cluster_id,
-        opple_cluster.endpoint.endpoint_id,
-        opple_cluster.endpoint.endpoint_id,
-        bytes_received,
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=0x260,
+            cluster_id=opple_cluster.cluster_id,
+            src_ep=opple_cluster.endpoint.endpoint_id,
+            dst_ep=opple_cluster.endpoint.endpoint_id,
+            data=t.SerializableBytes(bytes_received),
+        )
     )
 
     assert cluster_listener.attribute_updated.call_count == call_count
@@ -840,12 +854,14 @@ async def test_aqara_smoke_sensor_xiaomi_attribute_report(
     ias_cluster = device.endpoints[1].ias_zone
     ias_listener = ClusterListener(ias_cluster)
 
-    device.handle_message(
-        260,
-        opple_cluster.cluster_id,
-        opple_cluster.endpoint.endpoint_id,
-        opple_cluster.endpoint.endpoint_id,
-        raw_report,
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=0x260,
+            cluster_id=opple_cluster.cluster_id,
+            src_ep=opple_cluster.endpoint.endpoint_id,
+            dst_ep=opple_cluster.endpoint.endpoint_id,
+            data=t.SerializableBytes(raw_report),
+        )
     )
 
     # check that Xiaomi attribute report also updates attribute cache
@@ -1264,12 +1280,14 @@ async def test_xiaomi_weather(
         PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
     )
 
-    device.handle_message(
-        260,
-        xiaomi_attr_cluster.cluster_id,
-        xiaomi_attr_cluster.endpoint.endpoint_id,
-        xiaomi_attr_cluster.endpoint.endpoint_id,
-        raw_report,
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=xiaomi_attr_cluster.cluster_id,
+            src_ep=xiaomi_attr_cluster.endpoint.endpoint_id,
+            dst_ep=xiaomi_attr_cluster.endpoint.endpoint_id,
+            data=t.SerializableBytes(raw_report),
+        )
     )
 
     assert len(temperature_listener.attribute_updates) == 1
@@ -1331,12 +1349,14 @@ async def test_xiaomi_motion_sensor_misc(
         PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
     )
 
-    device.handle_message(
-        260,
-        basic_cluster.cluster_id,
-        basic_cluster.endpoint.endpoint_id,
-        basic_cluster.endpoint.endpoint_id,
-        raw_report,
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=basic_cluster.cluster_id,
+            src_ep=basic_cluster.endpoint.endpoint_id,
+            dst_ep=basic_cluster.endpoint.endpoint_id,
+            data=t.SerializableBytes(raw_report),
+        )
     )
 
     assert len(device_temperature_listener.attribute_updates) == 1
@@ -1451,12 +1471,14 @@ async def test_xiaomi_t1_door_sensor(
     on_off_listener = ClusterListener(on_off_cluster)
 
     # check open state
-    device.handle_message(
-        260,
-        on_off_cluster.cluster_id,
-        on_off_cluster.endpoint.endpoint_id,
-        on_off_cluster.endpoint.endpoint_id,
-        bytes.fromhex("185D0A00001001"),
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=on_off_cluster.cluster_id,
+            src_ep=on_off_cluster.endpoint.endpoint_id,
+            dst_ep=on_off_cluster.endpoint.endpoint_id,
+            data=t.SerializableBytes(bytes.fromhex("185D0A00001001")),
+        )
     )
 
     assert len(on_off_listener.attribute_updates) == 1
@@ -1464,12 +1486,14 @@ async def test_xiaomi_t1_door_sensor(
     assert on_off_listener.attribute_updates[0][1] == t.Bool.true
 
     # check closed state
-    device.handle_message(
-        260,
-        on_off_cluster.cluster_id,
-        on_off_cluster.endpoint.endpoint_id,
-        on_off_cluster.endpoint.endpoint_id,
-        bytes.fromhex("18640A00001000"),
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=on_off_cluster.cluster_id,
+            src_ep=on_off_cluster.endpoint.endpoint_id,
+            dst_ep=on_off_cluster.endpoint.endpoint_id,
+            data=t.SerializableBytes(bytes.fromhex("185D0A00001000")),
+        )
     )
 
     assert len(on_off_listener.attribute_updates) == 2
@@ -1488,12 +1512,14 @@ async def test_xiaomi_t1_door_sensor(
     )
 
     # check Xiaomi attribute report
-    device.handle_message(
-        260,
-        opple_cluster.cluster_id,
-        opple_cluster.endpoint.endpoint_id,
-        opple_cluster.endpoint.endpoint_id,
-        raw_report,
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=opple_cluster.cluster_id,
+            src_ep=opple_cluster.endpoint.endpoint_id,
+            dst_ep=opple_cluster.endpoint.endpoint_id,
+            data=t.SerializableBytes(raw_report),
+        )
     )
 
     assert len(power_listener.attribute_updates) == 2


### PR DESCRIPTION
## Proposed change
Replace deprecated `device.handle_message` with `device.packet_received` in tests.


## Additional information
Original zigpy PR that deprecated `device.handle_message` and introduced `device.packet_received`:
- https://github.com/zigpy/zigpy/pull/1043


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
