### PR TITLE
Add Tuya SPM02V2.5 3-phase energy meter (_TZE200_ny94onlb)

### DIFF
--- a/zhaquirks/tuya/_TZE200_ny94onlb_din_power.py
+++ b/zhaquirks/tuya/_TZE200_ny94onlb_din_power.py
@@ -1,0 +1,154 @@
+"""Tuya Din Power Meter."""
+
+from zigpy.quirks.v2.homeassistant import (
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfFrequency,
+    UnitOfPower,
+)
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
+import zigpy.types as t
+
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+(
+    TuyaQuirkBuilder("_TZE200_ny94onlb", "TS0601")
+    .tuya_sensor(
+        dp_id=1,
+        attribute_name="energy",
+        fallback_name="energy",
+        type=t.uint16_t,
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=100,
+    )
+    .tuya_sensor(
+        dp_id=23,
+        attribute_name="produced_energy",
+        fallback_name="produced_energy",
+        type=t.uint16_t,
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=100,
+    )
+    .tuya_sensor(
+        dp_id=29,
+        attribute_name="power",
+        fallback_name="power",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        unit=UnitOfPower.WATT,
+    )
+    .tuya_sensor(
+        dp_id=32,
+        attribute_name="ac_frequency",
+        fallback_name="ac_frequency",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.FREQUENCY,
+        unit=UnitOfFrequency.HERTZ,
+        divisor=100,
+    )
+    .tuya_sensor(
+        dp_id=50,
+        attribute_name="power_factor",
+        fallback_name="power_factor",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER_FACTOR,
+        #        unit=PERCENTAGE,
+    )
+    .tuya_sensor(
+        dp_id=102,
+        attribute_name="voltage_phase_1",
+        fallback_name="voltage_phase_1",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        divisor=10,
+        unit=UnitOfElectricPotential.VOLT,
+    )
+    .tuya_sensor(
+        dp_id=103,
+        attribute_name="phase_a_current",
+        translation_key="phase_a_current",
+        fallback_name="Current (phase A)",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.CURRENT,
+        divisor=1000,
+        unit=UnitOfElectricCurrent.AMPERE,
+    )
+    .tuya_sensor(
+        dp_id=104,
+        attribute_name="power_phase_1",
+        fallback_name="power_phase_1",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        unit=UnitOfPower.WATT,
+    )
+    .tuya_sensor(
+        dp_id=105,
+        attribute_name="voltage_phase_2",
+        fallback_name="voltage_phase_2",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        divisor=10,
+        unit=UnitOfElectricPotential.VOLT,
+    )
+    .tuya_sensor(
+        dp_id=106,
+        attribute_name="current_phase_2",
+        fallback_name="current_phase_2",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.CURRENT,
+        divisor=1000,
+        unit=UnitOfElectricCurrent.AMPERE,
+    )
+    .tuya_sensor(
+        dp_id=107,
+        attribute_name="power_phase_2",
+        fallback_name="power_phase_2",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        unit=UnitOfPower.WATT,
+    )
+    .tuya_sensor(
+        dp_id=108,
+        attribute_name="voltage_phase_3",
+        fallback_name="voltage_phase_3",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        divisor=10,
+        unit=UnitOfElectricPotential.VOLT,
+    )
+    .tuya_sensor(
+        dp_id=109,
+        attribute_name="current_phase_3",
+        fallback_name="current_phase_3",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.CURRENT,
+        divisor=1000,
+        unit=UnitOfElectricCurrent.AMPERE,
+    )
+    .tuya_sensor(
+        dp_id=110,
+        attribute_name="power_phase_3",
+        fallback_name="power_phase_3",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        unit=UnitOfPower.WATT,
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

This is quirk for a 3P+N electrical meter from tuya. 
See https://www.amazon.fr/dp/B0CG3CDMM7?ref=ppx_yo2ov_dt_b_fed_asin_title

It is a port from:
https://github.com/Koenkk/zigbee-herdsman-converters/blob/b222aebf2c560ebe18d427497fa65c7bc5ddc288/src/devices/tuya.ts#L8964

## Additional information

It is somewhat working, but I'm a beginner in the zha space, so I think I could use a bit of help to bring this to the finish line.

* I decided against hacking on top the existing `ts0601_din_power.py` because my understanding is that the quirk builder is the preferred way to build new quirks. Additionally, the functional overlap between my device and the one supported by the current file did not feel that big. I hope this was not a mistake, please tell me if it was :)
* I can not find out how to specify using tuya_sensor that some specific measurement are given for a given phase. The device measure a voltage, a current and a power on each line, but I guess I need to match some i18n from HA or ZHA so they appear as such. With the current code, everything appears with generic names, so I have three currents, three voltages and four powers (as there is also a total). I would appreciate some guidance there...
* I am not 100% sure the signature guidelines in the main README apply to quirks built with the quick builder.




Related: #3654
Related: #3799
