### PR TITLE
Bump zigpy to 0.75.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy>=0.74.0",
+    "zigpy>=0.75.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.74.0
+zigpy>=0.75.0
 ruff==0.0.261

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -60,7 +60,7 @@ import zhaquirks.xiaomi.aqara.vibration_aq1
 zhaquirks.setup()
 
 ALL_QUIRK_CLASSES = []
-for manufacturer in zq._DEVICE_REGISTRY._registry_v1.values():
+for manufacturer in zq._DEVICE_REGISTRY.registry_v1.values():
     for model_quirk_list in manufacturer.values():
         for quirk in model_quirk_list:
             if quirk in ALL_QUIRK_CLASSES:

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -60,7 +60,7 @@ import zhaquirks.xiaomi.aqara.vibration_aq1
 zhaquirks.setup()
 
 ALL_QUIRK_CLASSES = []
-for manufacturer in zq._DEVICE_REGISTRY.registry_v1.values():
+for manufacturer in zq.DEVICE_REGISTRY.registry_v1.values():
     for model_quirk_list in manufacturer.values():
         for quirk in model_quirk_list:
             if quirk in ALL_QUIRK_CLASSES:

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -60,7 +60,7 @@ import zhaquirks.xiaomi.aqara.vibration_aq1
 zhaquirks.setup()
 
 ALL_QUIRK_CLASSES = []
-for manufacturer in zq._DEVICE_REGISTRY._registry.values():
+for manufacturer in zq._DEVICE_REGISTRY._registry_v1.values():
     for model_quirk_list in manufacturer.values():
         for quirk in model_quirk_list:
             if quirk in ALL_QUIRK_CLASSES:

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -12,7 +12,7 @@ zhaquirks.setup()
 
 
 ALL_QUIRK_V2_CLASSES: list[QuirksV2RegistryEntry] = itertools.chain.from_iterable(
-    zigpy.quirks._DEVICE_REGISTRY.registry_v2.values()
+    zigpy.quirks.DEVICE_REGISTRY.registry_v2.values()
 )
 
 

--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -12,7 +12,7 @@ zhaquirks.setup()
 
 
 ALL_QUIRK_V2_CLASSES: list[QuirksV2RegistryEntry] = itertools.chain.from_iterable(
-    zigpy.quirks._DEVICE_REGISTRY._registry_v2.values()
+    zigpy.quirks._DEVICE_REGISTRY.registry_v2.values()
 )
 
 

--- a/tests/test_tuya_spells.py
+++ b/tests/test_tuya_spells.py
@@ -65,7 +65,7 @@ class TuyaTestSpellDevice(EnchantedDevice):
 
 
 ENCHANTED_QUIRKS = [TuyaTestSpellDevice]
-for manufacturer in zigpy.quirks._DEVICE_REGISTRY.registry_v1.values():
+for manufacturer in zigpy.quirks.DEVICE_REGISTRY.registry_v1.values():
     for model_quirk_list in manufacturer.values():
         for quirk_entry in model_quirk_list:
             if quirk_entry in ENCHANTED_QUIRKS:

--- a/tests/test_tuya_spells.py
+++ b/tests/test_tuya_spells.py
@@ -65,7 +65,7 @@ class TuyaTestSpellDevice(EnchantedDevice):
 
 
 ENCHANTED_QUIRKS = [TuyaTestSpellDevice]
-for manufacturer in zigpy.quirks._DEVICE_REGISTRY._registry_v1.values():
+for manufacturer in zigpy.quirks._DEVICE_REGISTRY.registry_v1.values():
     for model_quirk_list in manufacturer.values():
         for quirk_entry in model_quirk_list:
             if quirk_entry in ENCHANTED_QUIRKS:

--- a/tests/test_tuya_spells.py
+++ b/tests/test_tuya_spells.py
@@ -65,7 +65,7 @@ class TuyaTestSpellDevice(EnchantedDevice):
 
 
 ENCHANTED_QUIRKS = [TuyaTestSpellDevice]
-for manufacturer in zigpy.quirks._DEVICE_REGISTRY._registry.values():
+for manufacturer in zigpy.quirks._DEVICE_REGISTRY._registry_v1.values():
     for model_quirk_list in manufacturer.values():
         for quirk_entry in model_quirk_list:
             if quirk_entry in ENCHANTED_QUIRKS:


### PR DESCRIPTION
## Proposed change
Bump zigpy to [0.75.0](https://github.com/zigpy/zigpy/releases/tag/0.75.0).
Also changes tests to access the quirks registry with the new attribute name(s).

## Additional information

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
