### PR TITLE
Only run GitHub stale action once per day

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,7 +3,7 @@ name: Stale
 # yamllint disable-line rule:truthy
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "30 1 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Proposed change
This makes the GitHub stale action only run once per day. We do not need to run it every hour.


## Additional information
Waiting for a successful run of https://github.com/zigpy/zha-device-handlers/pull/3754 before merging this.
EDIT: v9 seems to work fine. First run: https://github.com/zigpy/zha-device-handlers/actions/runs/12921276628/job/36035002367


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
