### PR TITLE
Fix `ALL_QUIRK_V2_CLASSES` in tests

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -11,8 +11,8 @@ import zhaquirks
 zhaquirks.setup()
 
 
-ALL_QUIRK_V2_CLASSES: list[QuirksV2RegistryEntry] = itertools.chain.from_iterable(
-    zigpy.quirks.DEVICE_REGISTRY.registry_v2.values()
+ALL_QUIRK_V2_CLASSES: list[QuirksV2RegistryEntry] = list(
+    itertools.chain.from_iterable(zigpy.quirks.DEVICE_REGISTRY.registry_v2.values())
 )
 
 


### PR DESCRIPTION
## Proposed change
This actually makes `ALL_QUIRK_V2_CLASSES` a `list[QuirksV2RegistryEntry]` and not an `Iterator`.
If a future test were to be added that also accessed `ALL_QUIRK_V2_CLASSES`, having an `Iterator` would be very confusing, as the first test would have already iterated through it.

This PR thus converts `ALL_QUIRK_V2_CLASSES` into a `list` with `QuirksV2RegistryEntry`.

## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
