### PR TITLE
Fix `TuyaQuirkBuilder` `quirk_file` location

### DIFF
--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -2,7 +2,10 @@
 
 from collections.abc import Callable
 from enum import Enum
+import inspect
 import math
+import pathlib
+from types import FrameType
 from typing import Any, Optional
 
 from zigpy.quirks import _DEVICE_REGISTRY
@@ -185,6 +188,12 @@ class TuyaQuirkBuilder(QuirkBuilder):
         self.tuya_dp_to_attribute: dict[int, DPToAttributeMapping] = {}
         self.new_attributes: set[foundation.ZCLAttributeDef] = set()
         super().__init__(manufacturer, model, registry)
+        # quirk_file will point to the init call above if called from this QuirkBuilder,
+        # so we need to re-set it correctly
+        current_frame: FrameType = inspect.currentframe()
+        caller: FrameType = current_frame.f_back
+        self.quirk_file = pathlib.Path(caller.f_code.co_filename)
+        self.quirk_file_line = caller.f_lineno
 
     def _tuya_battery(
         self,


### PR DESCRIPTION
## Proposed change
This fixes the `quirk_file` location for quirks built with the `TuyaQuirkBuilder` always pointing to the `TuyaQuirkBuilder` and not where the `TuyaQuirkBuilder` instance was created (so the quirk file).

## Additional information

Due to quirks v2 no longer having a unique class that inherits from `CustomDevice` per quirk, `quirk_file` and `quirk_file_line` were added to zigpy here: [zigpy/quirks/v2/__init__.py#L549-L552](https://github.com/zigpy/zigpy/blob/08f8f99df3d235aa0c0154331cb7c5b3dffde3e1/zigpy/quirks/v2/__init__.py#L549-L552)

`quirk_file(_line)` is the line/file where a `QuirkBuilder` instance is constructed. Due to `TuyaQuirkBuilder` extending `QuirkBuilder`, this will always point to the `super().__init__(manufacturer, model, registry)` line in `zhaquirks/tuya/builder/__init__.py`, which is unexpected and relatively useless, as it will be the same across all quirks built with the `TuyaQuirkBuilder`.

To fix this for now, we just set the `quirk_file` and `quirk_file_line` again in our `TuyaQuirkBuilder`.

### Future

In the future, we may want to fix this another way in zigpy, but this solution is fine IMO, so we can go with it for now.
We should also consider adding a test for this.

We could also consider doing this from `add_to_registry()`?

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
