### PR TITLE
Fix duplicate manufacturer/model in Tuya temp sensor

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -256,7 +256,6 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     TuyaQuirkBuilder("_TZE200_yjjdcqsq", "TS0601")
     .applies_to("_TZE200_9yapgbuv", "TS0601")
     .applies_to("_TZE204_9yapgbuv", "TS0601")
-    .applies_to("_TZE204_yjjdcqsq", "TS0601")
     .applies_to("_TZE200_utkemkbs", "TS0601")
     .applies_to("_TZE204_utkemkbs", "TS0601")
     .applies_to("_TZE204_yjjdcqsq", "TS0601")


### PR DESCRIPTION
## Proposed change
This removes a duplicate manufacturer/model tuple for a Tuya temperature/humidity sensor:
`"_TZE204_yjjdcqsq", "TS0601"`


## Additional information
Fixes part of the issues detected in: https://github.com/zigpy/zha-device-handlers/pull/3758#issuecomment-2608872130


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
