### PR TITLE
Fix Tuya siren manufacturer/model `_TZE204_hcxvyxa5`

### DIFF
--- a/zhaquirks/tuya/tuya_siren.py
+++ b/zhaquirks/tuya/tuya_siren.py
@@ -359,9 +359,7 @@ class NeoBatteryState(t.enum8):
 
 # Tuya ZA03
 (
-    TuyaQuirkBuilder("_TZE200_t1blo2bj", "TS0601")
-    .applies_to("_TZE204_t1blo2bj", "TS0601")
-    .applies_to("_TZE204_q76rtoa9", "TS0601")
+    TuyaQuirkBuilder("_TZE204_hcxvyxa5", "TS0601")
     .tuya_enum(
         dp_id=5,
         attribute_name="alarm_volume",


### PR DESCRIPTION
## Proposed change
This removes a duplicate manufacturer/model tuple for a Tuya siren `"_TZE204_hcxvyxa5", "TS0601"` and changes the manufacturer/model info to `_TZE204_hcxvyxa5` for the "Tuya ZA03" siren quirk.


## Additional information

Fixes part of the issues detected in: https://github.com/zigpy/zha-device-handlers/pull/3758#issuecomment-2608872130

It seems like the manufacturer/model info was just copy-pasted from the "Neo NAS-AB02B2" siren to the "Tuya ZA03" siren, but the rest is correct.


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
