### PR TITLE
Fix Hue remote test not marked as `async`

### DIFF
--- a/tests/test_philips.py
+++ b/tests/test_philips.py
@@ -628,7 +628,7 @@ def test_PhilipsRemoteCluster_long_press(
         (4),
     ),
 )
-def test_ButtonPressQueue_presses_without_pause(button_presses):
+async def test_ButtonPressQueue_presses_without_pause(button_presses):
     """Test ButtonPressQueue presses without pause in between presses."""
 
     q = ButtonPressQueue()


### PR DESCRIPTION
## Proposed change

This marks the `test_ButtonPressQueue_presses_without_pause` test for the Philips Hue remotes as `async`, as no event loop will exist otherwise.


## Additional information

This fixes the following warnings produced during the test:
- "RuntimeWarning: coroutine 'ButtonPressQueue._job' was never awaited"
- DeprecationWarning: There is no current event loop

"caused" from here:
https://github.com/zigpy/zha-device-handlers/blob/c52aee365ca8cc2bc81653d20ffe84ae66c7fc33/zhaquirks/philips/__init__.py#L102

(just FYI @fholzer)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
