### PR TITLE
Fix CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ZHA Device Handlers For Home Assistant
 
-![CI](https://github.com/zigpy/zha-device-handlers/workflows/CI/badge.svg?branch=dev)
+[![CI](https://github.com/zigpy/zha-device-handlers/actions/workflows/ci.yml/badge.svg)](https://github.com/zigpy/zha-device-handlers/actions/workflows/ci.yml)
 [![Coverage Status](https://codecov.io/gh/zigpy/zha-device-handlers/branch/dev/graph/badge.svg)](https://app.codecov.io/gh/zigpy/zha-device-handlers/tree/dev)
 
 ZHA Device Handlers are custom quirks implementations for [Zigpy](https://github.com/zigpy/zigpy), the library that provides the [Zigbee](http://www.zigbee.org) support for the [ZHA](https://www.home-assistant.io/components/zha/) component in [Home Assistant](https://www.home-assistant.io).


### PR DESCRIPTION
## Proposed change
This fixes the GitHub action CI workflow badge in the `README`.
It now shows the CI as "passing" (or not) and links to the [CI workflow page](https://github.com/zigpy/zha-device-handlers/actions/workflows/ci.yml).


## Additional information
It previously always showed "no status" and when clicked, lead to the picture of the badge, which isn't really helpful.


## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
