### PR TITLE
Bump zigpy to 0.75.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy>=0.75.0",
+    "zigpy>=0.75.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.75.0
+zigpy>=0.75.1
 ruff==0.0.261


### PR DESCRIPTION
## Proposed change
Bump zigpy to [0.75.1](https://github.com/zigpy/zigpy/releases/tag/0.75.1).

This release fixes/removes a bunch of deprecation warnings when tests were run.


## Additional information
Follow-up to https://github.com/zigpy/zha-device-handlers/pull/3753


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
