### PR TITLE
Remove `multiplier=1` from Tuya motion sensor

### DIFF
--- a/zhaquirks/tuya/ts0601_motion.py
+++ b/zhaquirks/tuya/ts0601_motion.py
@@ -384,7 +384,6 @@ base_tuya_motion = (
         min_value=0.1,
         max_value=10,
         step=0.1,
-        multiplier=1,
         translation_key="detection_delay",
         fallback_name="Detection delay",
     )
@@ -397,7 +396,6 @@ base_tuya_motion = (
         min_value=5,
         max_value=1500,
         step=5,
-        multiplier=1,
         translation_key="fading_time",
         fallback_name="Fading time",
     )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Removes unnecessary `multiplier=1` from Tuya motion sensor quirk.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Small follow-up to https://github.com/zigpy/zha-device-handlers/pull/3695


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
