### PR TITLE
Update issue templates, automatically add labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Report a bug in an existing quirk or a general issue with the project.
 title: "[BUG] "
+labels: ["possible bug"]
 body:
   - type: markdown
     attributes:
@@ -64,7 +65,9 @@ body:
         <details><summary>Device signature</summary>
 
         ```json
+
         [Paste the device signature here]
+
         ```
 
         </details>
@@ -79,7 +82,9 @@ body:
         <details><summary>Diagnostic information</summary>
 
         ```json
+
         [Paste the diagnostic information here]
+
         ```
 
         </details>
@@ -99,7 +104,9 @@ body:
         <details><summary>Logs</summary>
 
         ```python
+
         [Paste the logs here]
+
         ```
 
         </details>

--- a/.github/ISSUE_TEMPLATE/device_support_request.yml
+++ b/.github/ISSUE_TEMPLATE/device_support_request.yml
@@ -1,6 +1,7 @@
 name: Device support request
 description: Request support for an unsupported device or a missing device feature.
 title: "[Device Support Request] "
+labels: ["device support request"]
 body:
   - type: markdown
     attributes:
@@ -53,7 +54,9 @@ body:
         <details><summary>Device signature</summary>
 
         ```json
+
         [Paste the device signature here]
+
         ```
 
         </details>
@@ -68,7 +71,9 @@ body:
         <details><summary>Diagnostic information</summary>
 
         ```json
+
         [Paste the diagnostic information here]
+
         ```
 
         </details>
@@ -88,7 +93,9 @@ body:
         <details><summary>Logs</summary>
 
         ```python
+
         [Paste the logs here]
+
         ```
 
         </details>
@@ -101,7 +108,9 @@ body:
         <details><summary>Custom quirk</summary>
 
         ```python
+
         [Paste your custom quirk here]
+
         ```
 
         </details>


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This updates the issue templates to automatically add "device support request" or "possible bug" labels.
Empty lines are also added in the pre-populated text fields to make pasting text in the right section easier.

Also see this follow-up PR:
- https://github.com/zigpy/zha-device-handlers/pull/3785 (this also adds the new "issue type" (public preview))