### PR TITLE
Only add MCU cluster in `TuyaQuirkBuilder` if attributes are added

### DIFF
--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -778,9 +778,9 @@ class TuyaQuirkBuilder(QuirkBuilder):
 
         if (
             self.new_attributes
-            or force_add_cluster
             or self.tuya_data_point_handlers
             or self.tuya_dp_to_attribute
+            or force_add_cluster
         ):
 
             class NewAttributeDefs(TuyaMCUCluster.AttributeDefs):

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -770,34 +770,38 @@ class TuyaQuirkBuilder(QuirkBuilder):
         return self
 
     def add_to_registry(
-        self, replacement_cluster: TuyaMCUCluster = TuyaMCUCluster
+        self,
+        replacement_cluster: TuyaMCUCluster = TuyaMCUCluster,
+        force_add_cluster: bool = False,
     ) -> QuirksV2RegistryEntry:
         """Build the quirks v2 registry entry."""
 
-        class NewAttributeDefs(TuyaMCUCluster.AttributeDefs):
-            """Attribute Definitions."""
+        if self.new_attributes or force_add_cluster:
 
-        for attr in self.new_attributes:
-            setattr(NewAttributeDefs, attr.name, attr)
-
-        class TuyaReplacementCluster(replacement_cluster):  # type: ignore[valid-type]
-            """Replacement Tuya Cluster."""
-
-            data_point_handlers: dict[int, str]
-            dp_to_attribute: dict[int, DPToAttributeMapping]
-
-            class AttributeDefs(NewAttributeDefs):
+            class NewAttributeDefs(TuyaMCUCluster.AttributeDefs):
                 """Attribute Definitions."""
 
-            async def write_attributes(self, attributes, manufacturer=None):
-                """Overwrite to force manufacturer code."""
+            for attr in self.new_attributes:
+                setattr(NewAttributeDefs, attr.name, attr)
 
-                return await super().write_attributes(
-                    attributes, manufacturer=foundation.ZCLHeader.NO_MANUFACTURER_ID
-                )
+            class TuyaReplacementCluster(replacement_cluster):  # type: ignore[valid-type]
+                """Replacement Tuya Cluster."""
 
-        TuyaReplacementCluster.data_point_handlers = self.tuya_data_point_handlers
-        TuyaReplacementCluster.dp_to_attribute = self.tuya_dp_to_attribute
+                data_point_handlers: dict[int, str]
+                dp_to_attribute: dict[int, DPToAttributeMapping]
 
-        self.replaces(TuyaReplacementCluster)
+                class AttributeDefs(NewAttributeDefs):
+                    """Attribute Definitions."""
+
+                async def write_attributes(self, attributes, manufacturer=None):
+                    """Overwrite to force manufacturer code."""
+
+                    return await super().write_attributes(
+                        attributes, manufacturer=foundation.ZCLHeader.NO_MANUFACTURER_ID
+                    )
+
+            TuyaReplacementCluster.data_point_handlers = self.tuya_data_point_handlers
+            TuyaReplacementCluster.dp_to_attribute = self.tuya_dp_to_attribute
+
+            self.replaces(TuyaReplacementCluster)
         return super().add_to_registry()

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -776,7 +776,12 @@ class TuyaQuirkBuilder(QuirkBuilder):
     ) -> QuirksV2RegistryEntry:
         """Build the quirks v2 registry entry."""
 
-        if self.new_attributes or force_add_cluster:
+        if (
+            self.new_attributes
+            or force_add_cluster
+            or self.tuya_data_point_handlers
+            or self.tuya_dp_to_attribute
+        ):
 
             class NewAttributeDefs(TuyaMCUCluster.AttributeDefs):
                 """Attribute Definitions."""


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

This allows the use of TuyaQuirkBuilder when we don't have an MCU cluster. Allows applying spells for devices that otherwise follow standards. Adds an additional kwarg to force adding the MCU cluster if required.

See: #3781

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
