### PR TITLE
Ignore Hue dial `RDM002` LevelControl long press events

### DIFF
--- a/tests/test_philips.py
+++ b/tests/test_philips.py
@@ -826,13 +826,7 @@ def test_RDM002_no_levelcontrol_on_long_press(zigpy_device_from_quirk):
 
     # All below messages are triggered when long pressing button 1 for ~1.5 seconds
 
-    # Received ZCL frame: b'\x1d\x0b\x10\xdf\x00\x01\x00\x000\x00!\x00\x00'
-    # Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x1D>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=True, direction=<Direction.Server_to_Client: 1>, disable_default_response=1, reserved=0, *is_cluster=True, *is_general=False), manufacturer=4107, tsn=223, command_id=0, *direction=<Direction.Server_to_Client: 1>)
-    # Decoded ZCL frame: PhilipsRdm002RemoteCluster:notification(button=1, param2=3145728, press_type=0, param4=33, param5=0)
     # Received command 0x00 (TSN 223): notification(button=1, param2=3145728, press_type=0, param4=33, param5=0)
-    # PhilipsRdm002RemoteCluster - handle_cluster_request tsn: [223] command id: 0 - args: [notification(button=1, param2=3145728, press_type=0, param4=33, param5=0)]
-    # PhilipsRdm002RemoteCluster - handle_cluster_request button id: [1], button name: [<Button id=button_1, trigger=button_1, action=button_1>]
-    # PhilipsRdm002RemoteCluster - handle_cluster_request unknown button press type: [None]
     hdr, args = (
         device.endpoints[1]
         .in_clusters[0xFC00]
@@ -840,13 +834,7 @@ def test_RDM002_no_levelcontrol_on_long_press(zigpy_device_from_quirk):
     )
     device.endpoints[1].in_clusters[0xFC00].handle_message(hdr, args)
 
-    # Received ZCL frame: b'\x01\xe0\x06\x01\xff\x08\x00'
-    # Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x01>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 0>, disable_default_response=0, reserved=0, *is_cluster=True, *is_general=False), tsn=224, command_id=6, *direction=<Direction.Client_to_Server: 0>)
-    # Decoded ZCL frame: PhilipsRdm002LevelControl:step_with_on_off(step_mode=<StepMode.Down: 1>, step_size=255, transition_time=8)
     # Received command 0x06 (TSN 224): step_with_on_off(step_mode=<StepMode.Down: 1>, step_size=255, transition_time=8)
-    # No explicit handler for cluster command 0x06: step_with_on_off(step_mode=<StepMode.Down: 1>, step_size=255, transition_time=8)
-    # PhilipsRdm002LevelControl - listener_event: method: cluster_command - args: [(224, 6, step_with_on_off(step_mode=<StepMode.Down: 1>, step_size=255, transition_time=8))]
-    # PhilipsRdm002LevelControl::listener_event - muting level control method: cluster_command - args: [(224, 6, step_with_on_off(step_mode=<StepMode.Down: 1>, step_size=255, transition_time=8))]
     hdr, args = (
         device.endpoints[1]
         .out_clusters[0x0008]
@@ -854,13 +842,7 @@ def test_RDM002_no_levelcontrol_on_long_press(zigpy_device_from_quirk):
     )
     device.endpoints[1].out_clusters[0x0008].handle_message(hdr, args)
 
-    # Received ZCL frame: b'\x1d\x0b\x10\xe1\x00\x01\x00\x000\x01!\x08\x00'
-    # Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x1D>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=True, direction=<Direction.Server_to_Client: 1>, disable_default_response=1, reserved=0, *is_cluster=True, *is_general=False), manufacturer=4107, tsn=225, command_id=0, *direction=<Direction.Server_to_Client: 1>)
-    # Decoded ZCL frame: PhilipsRdm002RemoteCluster:notification(button=1, param2=3145728, press_type=1, param4=33, param5=8)
     # Received command 0x00 (TSN 225): notification(button=1, param2=3145728, press_type=1, param4=33, param5=8)
-    # PhilipsRdm002RemoteCluster - handle_cluster_request tsn: [225] command id: 0 - args: [notification(button=1, param2=3145728, press_type=1, param4=33, param5=8)]
-    # PhilipsRdm002RemoteCluster - handle_cluster_request button id: [1], button name: [<Button id=button_1, trigger=button_1, action=button_1>]
-    # PhilipsRdm002RemoteCluster - handle_cluster_request button press type: [<PressType name=remote_button_long_press, action=hold, trigger=remote_button_long_press, arg=hold>], duration: [8]
     hdr, args = (
         device.endpoints[1]
         .in_clusters[0xFC00]
@@ -868,13 +850,7 @@ def test_RDM002_no_levelcontrol_on_long_press(zigpy_device_from_quirk):
     )
     device.endpoints[1].in_clusters[0xFC00].handle_message(hdr, args)
 
-    # Received ZCL frame: b'\x1d\x0b\x10\xe2\x00\x01\x00\x000\x03!\n\x00'
-    # Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x1D>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=True, direction=<Direction.Server_to_Client: 1>, disable_default_response=1, reserved=0, *is_cluster=True, *is_general=False), manufacturer=4107, tsn=226, command_id=0, *direction=<Direction.Server_to_Client: 1>)
-    # Decoded ZCL frame: PhilipsRdm002RemoteCluster:notification(button=1, param2=3145728, press_type=3, param4=33, param5=10)
     # Received command 0x00 (TSN 226): notification(button=1, param2=3145728, press_type=3, param4=33, param5=10)
-    # PhilipsRdm002RemoteCluster - handle_cluster_request tsn: [226] command id: 0 - args: [notification(button=1, param2=3145728, press_type=3, param4=33, param5=10)]
-    # PhilipsRdm002RemoteCluster - handle_cluster_request button id: [1], button name: [<Button id=button_1, trigger=button_1, action=button_1>]
-    # PhilipsRdm002RemoteCluster - handle_cluster_request button press type: [<PressType name=remote_button_long_release, action=long_release, trigger=remote_button_long_release, arg=long_release>], duration: [10]
     hdr, args = (
         device.endpoints[1]
         .in_clusters[0xFC00]
@@ -897,13 +873,7 @@ def test_RDM002_levelcontrol_on_dial_rotary_event(zigpy_device_from_quirk):
 
     # All below messages are triggered when quickly rotating the dial counterclockwise
 
-    # Received ZCL frame: b'\x01\xe7\x06\x01D\x04\x00'
-    # Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x01>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 0>, disable_default_response=0, reserved=0, *is_cluster=True, *is_general=False), tsn=231, command_id=6, *direction=<Direction.Client_to_Server: 0>)
-    # Decoded ZCL frame: PhilipsRdm002LevelControl:step_with_on_off(step_mode=<StepMode.Down: 1>, step_size=68, transition_time=4)
     # Received command 0x06 (TSN 231): step_with_on_off(step_mode=<StepMode.Down: 1>, step_size=68, transition_time=4)
-    # No explicit handler for cluster command 0x06: step_with_on_off(step_mode=<StepMode.Down: 1>, step_size=68, transition_time=4)
-    # PhilipsRdm002LevelControl - listener_event: method: cluster_command - args: [(231, 6, step_with_on_off(step_mode=<StepMode.Down: 1>, step_size=68, transition_time=4))]
-    # PhilipsRdm002LevelControl::listener_event - forwarding level control method: cluster_command - args: [(231, 6, step_with_on_off(step_mode=<StepMode.Down: 1>, step_size=68, transition_time=4))]
     hdr, args = (
         device.endpoints[1]
         .out_clusters[0x0008]
@@ -911,13 +881,7 @@ def test_RDM002_levelcontrol_on_dial_rotary_event(zigpy_device_from_quirk):
     )
     device.endpoints[1].out_clusters[0x0008].handle_message(hdr, args)
 
-    # Received ZCL frame: b'\x1d\x0b\x10\xe8\x00\x14\x00\x010\x01)Z\xff!d\x00)Z\xff!d\x00)Z\xff!\x90\x01'
-    # Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x1D>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=True, direction=<Direction.Server_to_Client: 1>, disable_default_response=1, reserved=0, *is_cluster=True, *is_general=False), manufacturer=4107, tsn=232, command_id=0, *direction=<Direction.Server_to_Client: 1>)
-    # Decoded ZCL frame: PhilipsRdm002RemoteCluster:notification(button=20, param2=3145984, press_type=1, param4=41, param5=65370)
-    # Data remains after deserializing ZCL frame: b'!d\x00)Z\xff!d\x00)Z\xff!\x90\x01'
     # Received command 0x00 (TSN 232): notification(button=20, param2=3145984, press_type=1, param4=41, param5=65370)
-    # PhilipsRdm002RemoteCluster - handle_cluster_request tsn: [232] command id: 0 - args: [notification(button=20, param2=3145984, press_type=1, param4=41, param5=65370)]
-    # PhilipsRdm002RemoteCluster - handle_cluster_request unknown button id [20]
     hdr, args = (
         device.endpoints[1]
         .in_clusters[0xFC00]

--- a/zhaquirks/philips/rdm002.py
+++ b/zhaquirks/philips/rdm002.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from zigpy import util
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
+from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -75,7 +75,7 @@ class PhilipsRdm002RemoteCluster(PhilipsRemoteCluster):
     }
 
 
-class PhilipsRdm002LevelControl(LevelControl):
+class PhilipsRdm002LevelControl(CustomCluster, LevelControl):
     """Philips RDM002 LevelControl cluster."""
 
     def listener_event(self, method_name: str, *args) -> list[Any | None]:
@@ -169,7 +169,7 @@ class PhilipsRDM002(CustomDevice):
                     Identify.cluster_id,
                     Groups.cluster_id,
                     OnOff.cluster_id,
-                    PhilipsRdm002LevelControl.cluster_id,
+                    PhilipsRdm002LevelControl,
                     Scenes.cluster_id,
                     LightLink.cluster_id,
                 ],

--- a/zhaquirks/philips/rdm002.py
+++ b/zhaquirks/philips/rdm002.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Any
 
-from zigpy import util
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -112,7 +111,7 @@ class PhilipsRdm002LevelControl(CustomCluster, LevelControl):
                 method_name,
                 args,
             )
-            return util.ListenableMixin.listener_event(self, method_name, *args)
+            return super().listener_event(method_name, *args)
 
         return []
 

--- a/zhaquirks/philips/rdm002.py
+++ b/zhaquirks/philips/rdm002.py
@@ -80,13 +80,6 @@ class PhilipsRdm002LevelControl(CustomCluster, LevelControl):
     def listener_event(self, method_name: str, *args) -> list[Any | None]:
         """Blackhole requests with transition_time=8, which originate from button long-presses."""
 
-        _LOGGER.debug(
-            "%s - listener_event: method: %s - args: [%s]",
-            self.__class__.__name__,
-            method_name,
-            args,
-        )
-
         # example args we want to mute:
         # [(224, 6, step_with_on_off(step_mode=<StepMode.Down: 1>, step_size=255, transition_time=8))]
         # transition_time=8 when step command is sent for long-press of button 1.
@@ -103,17 +96,9 @@ class PhilipsRdm002LevelControl(CustomCluster, LevelControl):
                 method_name,
                 args,
             )
+            return []
 
-        else:
-            _LOGGER.debug(
-                "%s::listener_event - forwarding level control method: %s - args: [%s]",
-                self.__class__.__name__,
-                method_name,
-                args,
-            )
-            return super().listener_event(method_name, *args)
-
-        return []
+        return super().listener_event(method_name, *args)
 
 
 class PhilipsRDM002(CustomDevice):


### PR DESCRIPTION
## Proposed change
Override LevelControl's listener_event, and filter out those events that have transition_time == 8, which originate from long-pressing buttons. Rotary events have a transition_time of 4, and won't be muted.

This fixes #3696

## Additional information
Details in #3696

## Checklist

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [X] Tests have been added to verify that the new code works
