### PR TITLE
Add pilot wire mode enum select for nodon and legrand

### DIFF
--- a/zhaquirks/legrand/cable_outlet.py
+++ b/zhaquirks/legrand/cable_outlet.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2 import EntityType, QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
@@ -108,5 +108,20 @@ class LegrandCableOutletCluster(CustomCluster):
     QuirkBuilder(f" {LEGRAND}", " Cable outlet")
     .replaces(LegrandCluster)
     .replaces(LegrandCableOutletCluster)
+    .enum(
+        attribute_name=LegrandCluster.AttributeDefs.device_mode.name,
+        cluster_id=LegrandCluster.cluster_id,
+        enum_class=DeviceMode,
+        translation_key="legrand_device_mode",
+        fallback_name="Device mode",
+    )
+    .enum(
+        attribute_name=LegrandCableOutletCluster.AttributeDefs.pilot_wire_mode.name,
+        cluster_id=LegrandCableOutletCluster.cluster_id,
+        enum_class=PilotWireMode,
+        translation_key="pilot_wire_mode",
+        fallback_name="Pilot Wire mode",
+        entity_type=EntityType.STANDARD,
+    )
     .add_to_registry()
 )

--- a/zhaquirks/legrand/cable_outlet.py
+++ b/zhaquirks/legrand/cable_outlet.py
@@ -112,7 +112,7 @@ class LegrandCableOutletCluster(CustomCluster):
         attribute_name=LegrandCluster.AttributeDefs.device_mode.name,
         cluster_id=LegrandCluster.cluster_id,
         enum_class=DeviceMode,
-        translation_key="legrand_device_mode",
+        translation_key="device_mode",
         fallback_name="Device mode",
     )
     .enum(

--- a/zhaquirks/legrand/cable_outlet.py
+++ b/zhaquirks/legrand/cable_outlet.py
@@ -120,7 +120,7 @@ class LegrandCableOutletCluster(CustomCluster):
         cluster_id=LegrandCableOutletCluster.cluster_id,
         enum_class=PilotWireMode,
         translation_key="pilot_wire_mode",
-        fallback_name="Pilot Wire mode",
+        fallback_name="Pilot wire mode",
         entity_type=EntityType.STANDARD,
     )
     .add_to_registry()

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -1,7 +1,7 @@
 """NodOn pilot wire heating module."""
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2 import EntityType, QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
 
@@ -56,6 +56,14 @@ class AdeoPilotWireCluster(NodOnPilotWireCluster):
 nodon = (
     QuirkBuilder(NODON, "SIN-4-FP-21")
     .replaces(NodOnPilotWireCluster)
+    .enum(
+        attribute_name=NodOnPilotWireCluster.AttributeDefs.pilot_wire_mode.name,
+        enum_class=NodOnPilotWireMode,
+        cluster_id=NodOnPilotWireCluster.cluster_id,
+        entity_type=EntityType.STANDARD,
+        translation_key="pilot_wire_mode",
+        fallback_name="Pilot Wire mode",
+    )
 )  # fmt: skip
 
 

--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -62,7 +62,7 @@ nodon = (
         cluster_id=NodOnPilotWireCluster.cluster_id,
         entity_type=EntityType.STANDARD,
         translation_key="pilot_wire_mode",
-        fallback_name="Pilot Wire mode",
+        fallback_name="Pilot wire mode",
     )
 )  # fmt: skip
 


### PR DESCRIPTION
## Proposed change

Following https://github.com/zigpy/zha-device-handlers/pull/3364 and https://github.com/zigpy/zha-device-handlers/pull/3031
Add pilot wire mode enum select for Nodon and Legrand devices. Device mode is also added to Legrand to switch between wire pilot mode and switch mode.

I discussed with @TheJulianJES and having the select entity is better than nothing and in the current state, the quirk is unusable because the modes was not exposed to HA.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
