### PR TITLE
Add IKEA VINDSTYRKA air quality sensor

### DIFF
--- a/zhaquirks/ikea/vindstyrka.py
+++ b/zhaquirks/ikea/vindstyrka.py
@@ -1,0 +1,54 @@
+"""IKEA VINDSTYRKA device."""
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import (
+    QuirkBuilder,
+    ReportingConfig,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+import zigpy.types as t
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+from zhaquirks.ikea import IKEA
+
+
+class VOCIndex(CustomCluster):
+    """IKEA VOC index cluster."""
+
+    cluster_id: t.uint16_t = 0xFC7E
+    name: str = "IKEA VOC Index"
+    ep_attribute: str = "voc_index"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        measured_value: Final = ZCLAttributeDef(
+            type=t.Single, access="rp", is_manufacturer_specific=True
+        )
+        min_measured_value: Final = ZCLAttributeDef(
+            type=t.Single, access="r", is_manufacturer_specific=True
+        )
+        max_measured_value: Final = ZCLAttributeDef(
+            type=t.Single, access="r", is_manufacturer_specific=True
+        )
+
+
+(
+    QuirkBuilder(IKEA, "VINDSTYRKA")
+    .replaces(VOCIndex)
+    .sensor(
+        VOCIndex.AttributeDefs.measured_value.name,
+        VOCIndex.cluster_id,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.AQI,
+        reporting_config=ReportingConfig(
+            min_interval=60, max_interval=120, reportable_change=1
+        ),
+        translation_key="voc_index",
+        fallback_name="VOC index",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

This adds support for the IKEA VINDSTYRKA air quality sensor.
The VOC index is exposed and attribute reporting is set up for it.

## Additional information

Supersedes:
- https://github.com/zigpy/zha-device-handlers/pull/2315 - Thanks to @just-oblivious for the initial PR!

And also big thanks to @ikruglov who created and tried a v2 quirk version here: https://github.com/zigpy/zha/pull/254#issuecomment-2507695129

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
