### PR TITLE
Remove Tuya `tamper` translation keys

### DIFF
--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -965,7 +965,6 @@ base_tuya_motion = (
         attribute_name="tamper",
         device_class=BinarySensorDeviceClass.TAMPER,
         entity_type=EntityType.DIAGNOSTIC,
-        translation_key="tamper",
         fallback_name="Tamper",
     )
     .tuya_number(

--- a/zhaquirks/tuya/tuya_siren.py
+++ b/zhaquirks/tuya/tuya_siren.py
@@ -171,11 +171,10 @@ class NeoBatteryState(t.enum8):
     )
     .tuya_binary_sensor(
         dp_id=20,
-        attribute_name="tamper_state",
+        attribute_name="tamper",
         device_class=BinarySensorDeviceClass.TAMPER,
         entity_type=EntityType.STANDARD,
-        translation_key="tamper_state",
-        fallback_name="Tamper state",
+        fallback_name="Tamper",
     )
     .tuya_enum(
         dp_id=21,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Removes Tuya "tamper" translation keys. These should use the name from the device class.
Also renames the `attribute_name` from `tamper_state` to `tamper` for the Tuya siren. This changes the UID of the entity, but as this was never in a HA release before, we can still do it now.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Noticed these being generated in `strings.json` whilst getting the quirks release ready.


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
