### PR TITLE
Remove Tuya `window_open` translation key

### DIFF
--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -229,7 +229,6 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
         dp_id=7,
         attribute_name="window_open",
         device_class=BinarySensorDeviceClass.WINDOW,
-        translation_key="window_open",
         fallback_name="Window open",
     )
     .tuya_switch(


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Removes Tuya "Remove" translation key. This should use the name from the device class.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Noticed these being generated in `strings.json` whilst getting the quirks release ready.

Similar to https://github.com/zigpy/zha-device-handlers/pull/3802


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
