### PR TITLE
Add local clusters to Tuya `_TZ3000_bjawzodf` temp sensor

### DIFF
--- a/zhaquirks/tuya/ty0201.py
+++ b/zhaquirks/tuya/ty0201.py
@@ -1,7 +1,11 @@
 """Tuya TY0201 temperature and humidity sensor."""
 
 from zhaquirks.tuya import TuyaPowerConfigurationCluster2AA
-from zhaquirks.tuya.builder import TuyaQuirkBuilder, TuyaRelativeHumidity, TuyaTemperatureMeasurement
+from zhaquirks.tuya.builder import (
+    TuyaQuirkBuilder,
+    TuyaRelativeHumidity,
+    TuyaTemperatureMeasurement,
+)
 
 (
     TuyaQuirkBuilder("_TZ3000_bjawzodf", "TY0201")

--- a/zhaquirks/tuya/ty0201.py
+++ b/zhaquirks/tuya/ty0201.py
@@ -1,12 +1,14 @@
 """Tuya TY0201 temperature and humidity sensor."""
 
 from zhaquirks.tuya import TuyaPowerConfigurationCluster2AA
-from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.builder import TuyaQuirkBuilder, TuyaRelativeHumidity, TuyaTemperatureMeasurement
 
 (
     TuyaQuirkBuilder("_TZ3000_bjawzodf", "TY0201")
     .applies_to("_TZ3000_zl1kmjqx", "TY0201")
     .applies_to("_TZ3000_zl1kmjqx", "")
+    .replaces(TuyaRelativeHumidity)
+    .replaces(TuyaTemperatureMeasurement)
     .replaces(TuyaPowerConfigurationCluster2AA)
     .tuya_enchantment()
     .skip_configuration()


### PR DESCRIPTION
Previous commit made this sensor discoverable as no-feature device

## Proposed change
I have device mentioned in the title, it was discoverable but HA couldn't recognize it's features


## Additional information
I've just restored some changes from the past


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly - tested manually with my device
- [ ] `pre-commit` checks pass / the code has been formatted using Black - edited on smartphone - sorry please format it after merge
- [ ] Tests have been added to verify that the new code works
