### PR TITLE
Update Tuya builder DP attribute_name type to match underlying DPToAttributeMapping class

### DIFF
--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -495,7 +495,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         self,
         dp_id: int,
         ep_attribute: str,
-        attribute_name: str,
+        attribute_name: str | tuple,
         converter: Optional[Callable[[Any], Any]] = None,
         dp_converter: Optional[Callable[[Any], Any]] = None,
         endpoint_id: Optional[int] = None,
@@ -519,7 +519,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_dp_attribute(
         self,
         dp_id: int,
-        attribute_name: str,
+        attribute_name: str | tuple,
         ep_attribute: str = TuyaMCUCluster.ep_attribute,
         converter: Optional[Callable[[Any], Any]] = None,
         dp_converter: Optional[Callable[[Any], Any]] = None,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This amends the `attribute_name` argument type in `tuya.builder` methods `tuya_dp` and `tuya_dp_attribute` to support `str` and `tuple` to match the underlying DPToAttributeMapping class.

This is used in DPToAttributeMapping definitions to map a data point to multiple cluster attributes.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

Class that the attribute_name is used to populate:
```
@dataclasses.dataclass
class DPToAttributeMapping:
    """Container for datapoint to cluster attribute update mapping."""

    ep_attribute: str
    attribute_name: Union[str, tuple]
    converter: Optional[
        Callable[
            [
                Any,
            ],
            Any,
        ]
    ] = None
    endpoint_id: Optional[int] = None
```

This would be used in a v2 quirk as below:

```
    .tuya_dp(
        dp_id=6,
        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
        attribute_name=(
            TuyaElectricalMeasurement.AttributeDefs.rms_voltage.name,
            TuyaElectricalMeasurement.AttributeDefs.rms_current.name,
            TuyaElectricalMeasurement.AttributeDefs.active_power.name,
        ),
        converter=lambda x: TuyaPowerPhase.variant_3(x),
    )



class TuyaPowerPhase:
    """Extract values from a Tuya power phase datapoint."""

    @staticmethod
    def variant_3(value) -> Tuple[t.uint_t, t.uint_t, int]:
        voltage = (value[0] << 8) | value[1]
        current = (value[2] << 16) | (value[3] << 8) | value[4]
        power = (value[5] << 16) | (value[6] << 8) | value[7]
        return voltage, current, power * 1
```

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
