### PR TITLE
Add Tuya/Zemismart cover `_TZE284_fzo2pocs`

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -12,11 +12,11 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import (
+    TUYA_CLUSTER_ED00_ID,
     TuyaManufacturerWindowCover,
     TuyaManufCluster,
     TuyaWindowCover,
     TuyaWindowCoverControl,
-    TUYA_CLUSTER_ED00_ID
 )
 
 
@@ -371,7 +371,7 @@ class TuyaZemismartSmartCover0601_4(TuyaWindowCover):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     TuyaManufCluster.cluster_id,
-                    TUYA_CLUSTER_ED00_ID
+                    TUYA_CLUSTER_ED00_ID,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -16,6 +16,7 @@ from zhaquirks.tuya import (
     TuyaManufCluster,
     TuyaWindowCover,
     TuyaWindowCoverControl,
+    TUYA_CLUSTER_ED00_ID
 )
 
 
@@ -339,6 +340,52 @@ class TuyaZemismartSmartCover0601_2_inv_position(TuyaWindowCover):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     Time.cluster_id,
+                    TuyaManufacturerWindowCover,
+                    TuyaWindowCoverControl,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }
+
+
+class TuyaZemismartSmartCover0601_4(TuyaWindowCover):
+    """Tuya Zemismart blind cover motor."""
+
+    signature = {
+        # "node_descriptor": "<NodeDescriptor byte1=1 byte2=64 mac_capability_flags=142 manufacturer_code=4098
+        #                       maximum_buffer_size=82 maximum_incoming_transfer_size=82 server_mask=11264
+        #                       maximum_outgoing_transfer_size=82 descriptor_capability_field=0>",
+        # input_clusters=[0x0000, 0x0004, 0x0005, 0x000a, 0xef00, 0xed00]
+        # output_clusters=[0x0019]
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=51 input_clusters=[0, 4, 5, 61184, 60672] output_clusters=[25]>
+        MODELS_INFO: [
+            ("_TZE284_fzo2pocs", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                    TUYA_CLUSTER_ED00_ID
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
                     TuyaManufacturerWindowCover,
                     TuyaWindowCoverControl,
                 ],


### PR DESCRIPTION
## Proposed change

Add support for `Zemismart Zigbee 2N (ZM25TQ-2/25)` smart roller shade motor.
A had to add the `0xED00` input cluster and `_TZE284_fzo2pocs`


## Additional information

This is my first contribution here, please feel free to request any change or guide me to any docs to read!

Closes #3270

My process: Just got my Zemismart ZM25TQ-2/25 from Aliexpress (Zemismart Zigbee 2N Smart Roller Shade Blinds Motor for 38mm Tube Works with Tuya Smart Life App Alexa Google Home Voice Control) to be exact. After I paired it, I found out that the cover card is not showing up. Did some search and found out that they change the chip from time to time. Searched for TS0601 quirk on google and found this repo. Tried to adjust on my machine with a local quirk config, and now it is working for me.
 
![image](https://github.com/user-attachments/assets/608cc53d-4981-4e85-b1e3-df5d805db074)
![image](https://github.com/user-attachments/assets/9258aaa6-a2e3-4a5a-9584-d6ae57e1316c)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works



Related: #3574
