### PR TITLE
Prevent adding a Tuya DP converter twice for the same DP id

### DIFF
--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -252,6 +252,23 @@ async def test_tuya_quirkbuilder(device_mock):
     assert tuya_listener.attribute_updates[0][1] == TestEnum.B
 
 
+async def test_tuya_quirkbuilder_duplicated_mappings(device_mock):
+    """Test that mapping the same DP multiple times will raise."""
+
+    registry = DeviceRegistry()
+
+    with pytest.raises(ValueError):
+        (
+            TuyaQuirkBuilder(
+                device_mock.manufacturer, device_mock.model, registry=registry
+            )
+            .tuya_battery(dp_id=1)
+            .tuya_onoff(dp_id=1)
+            .skip_configuration()
+            .add_to_registry()
+        )
+
+
 @pytest.mark.parametrize(
     "read_attr_spell,data_query_spell",
     [

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -502,6 +502,10 @@ class TuyaQuirkBuilder(QuirkBuilder):
         dp_handler: str = "_dp_2_attr_update",
     ) -> QuirkBuilder:  # fmt: skip
         """Add Tuya DP Converter."""
+
+        if dp_id in self.tuya_dp_to_attribute:
+            raise ValueError(f"DP {dp_id} is already mapped.")
+
         self.tuya_dp_to_attribute.update(
             {
                 dp_id: DPToAttributeMapping(

--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -1192,7 +1192,7 @@ base_tuya_motion = (
         fallback_name="Maximum range",
     )
     .tuya_number(
-        dp_id=107,
+        dp_id=108,
         attribute_name="detection_distance_min",
         type=t.uint16_t,
         device_class=SensorDeviceClass.DISTANCE,

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -577,7 +577,7 @@ class GiexIrrigationStatus(t.enum8):
         fallback_name="Total flow reset switch",
     )
     .tuya_sensor(
-        dp_id=102,
+        dp_id=38,
         attribute_name="irrigation_duration",
         type=t.uint32_t,
         state_class=SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This prevents calling `tuya_dp` multiple times for the same DP id, which would previously overwrite previous mappings silently.
Two quirks were fixed since they had duplicated mappings. The values for those quirks were updated according to Z2M.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
