### PR TITLE
Fix missing attribute ids for IKEA Vindstyrka

### DIFF
--- a/zhaquirks/ikea/vindstyrka.py
+++ b/zhaquirks/ikea/vindstyrka.py
@@ -26,13 +26,13 @@ class VOCIndex(CustomCluster):
         """Attribute definitions."""
 
         measured_value: Final = ZCLAttributeDef(
-            type=t.Single, access="rp", is_manufacturer_specific=True
+            id=0x0000, type=t.Single, access="rp", is_manufacturer_specific=True
         )
         min_measured_value: Final = ZCLAttributeDef(
-            type=t.Single, access="r", is_manufacturer_specific=True
+            id=0x0001, type=t.Single, access="r", is_manufacturer_specific=True
         )
         max_measured_value: Final = ZCLAttributeDef(
-            type=t.Single, access="r", is_manufacturer_specific=True
+            id=0x0002, type=t.Single, access="r", is_manufacturer_specific=True
         )
 
 


### PR DESCRIPTION
## Proposed change
There are reports that the quirk for IKEA Vindstyrka is broken after the upgrade to 2025.2.0. This PR fixes it.


## Additional information
See https://github.com/zigpy/zha-device-handlers/pull/3801


## Checklist
- [X] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
