### PR TITLE
Add AduroSmart Eria SceneSwitch

### DIFF
--- a/zhaquirks/aduro/adurosmart_eria.py
+++ b/zhaquirks/aduro/adurosmart_eria.py
@@ -1,13 +1,13 @@
 """ADUROSMART Eria SceneSwitch 81847 device."""
+
 from __future__ import annotations
 
 from typing import Any
-from zigpy.typing import AddressingMode
-from zigpy.profiles import zha
+
 from zigpy.profiles.zha import DeviceType
-from zigpy.quirks import CustomDevice, CustomCluster
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.typing import AddressingMode
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -18,8 +18,9 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
+from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 
-from zhaquirks import EventableCluster, PowerConfigurationCluster
+from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -33,9 +34,11 @@ from zhaquirks.const import (
 
 MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCCC  # decimal = 64716
 
+
 # Define the unknown cluster (0xFCCC)
 class AduroSmartCluster(CustomCluster, ManufacturerSpecificCluster):
     """Custom cluster for handling unknown cluster command 0xFCCC."""
+
     cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID
 
     def handle_cluster_request(
@@ -63,6 +66,7 @@ class AduroSmartCluster(CustomCluster, ManufacturerSpecificCluster):
 
         super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
 
+
 class AduroSmartCSC(CustomDevice):
     """ADUROSMART Eria SceneSwitch 81847 device."""
 
@@ -77,7 +81,7 @@ class AduroSmartCSC(CustomDevice):
         MODELS_INFO: [("ADUROLIGHT_CSC", "AduroSmart Eria")],
         ENDPOINTS: {
             1: {
-                PROFILE_ID: 0xc05e,
+                PROFILE_ID: 0xC05E,
                 DEVICE_TYPE: DeviceType.COLOR_SCENE_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,

--- a/zhaquirks/aduro/adurosmart_eria.py
+++ b/zhaquirks/aduro/adurosmart_eria.py
@@ -1,0 +1,114 @@
+"""ADUROSMART Eria SceneSwitch 81847 device."""
+from __future__ import annotations
+
+from typing import Any
+from zigpy.typing import AddressingMode
+from zigpy.profiles import zha
+from zigpy.profiles.zha import DeviceType
+from zigpy.quirks import CustomDevice, CustomCluster
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Scenes,
+)
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from zhaquirks import EventableCluster, PowerConfigurationCluster
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MANUFACTURER,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    ZHA_SEND_EVENT,
+)
+
+MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCCC  # decimal = 64716
+
+# Define the unknown cluster (0xFCCC)
+class AduroSmartCluster(CustomCluster, ManufacturerSpecificCluster):
+    """Custom cluster for handling unknown cluster command 0xFCCC."""
+    cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: AddressingMode | None = None,
+    ):
+        """Handle incoming cluster commands."""
+        if hdr.command_id == 0x00:
+            data = args[0]
+            if data == b"\x00\x00\x00":
+                self.listener_event(ZHA_SEND_EVENT, "BUTTON_PRESS_0", args)
+            elif data == b"\x00\x01\x00":
+                self.listener_event(ZHA_SEND_EVENT, "BUTTON_PRESS_1", args)
+            elif data == b"\x00\x02\x00":
+                self.listener_event(ZHA_SEND_EVENT, "BUTTON_PRESS_2", args)
+            elif data == b"\x00\x03\x00":
+                self.listener_event(ZHA_SEND_EVENT, "BUTTON_PRESS_3", args)
+            else:
+                self.debug("Unknown args for cluster command 0: %s", args)
+
+            return
+
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+class AduroSmartCSC(CustomDevice):
+    """ADUROSMART Eria SceneSwitch 81847 device."""
+
+    cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID
+
+    # <SimpleDescriptor endpoint=1 profile=49246 device_type=2064
+    # device_version=2
+    # input_clusters=[ 0, 1, 3, 4, 5, 6, 8, 768, 4096, 64716 ]
+    # output_clusters=[ 0, 3, 4, 5, 6, 8, 768, 4096, 64716 ]>
+    signature = {
+        MANUFACTURER: "AduroSmart Eria",
+        MODELS_INFO: [("ADUROLIGHT_CSC", "AduroSmart Eria")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: 0xc05e,
+                DEVICE_TYPE: DeviceType.COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfigurationCluster.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                    AduroSmartCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfigurationCluster.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                    AduroSmartCluster.cluster_id,
+                ],
+            },
+            2: {
+                "profile_id": 0xC05E,
+                "device_type": 0x03F2,
+                "input_clusters": [LightLink.cluster_id],
+                "output_clusters": [LightLink.cluster_id],
+            },
+        },
+    }

--- a/zhaquirks/aduro/adurosmart_eria.py
+++ b/zhaquirks/aduro/adurosmart_eria.py
@@ -22,20 +22,27 @@ from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 
 from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
+    BUTTON,
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    BUTTON_4,
+    COMMAND,
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
-    MANUFACTURER,
+    LONG_PRESS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
+    PRESS_TYPE,
     PROFILE_ID,
+    SHORT_PRESS,
     ZHA_SEND_EVENT,
 )
 
 MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCCC  # decimal = 64716
 
 
-# Define the unknown cluster (0xFCCC)
 class AduroSmartCluster(CustomCluster, ManufacturerSpecificCluster):
     """Custom cluster for handling unknown cluster command 0xFCCC."""
 
@@ -50,17 +57,41 @@ class AduroSmartCluster(CustomCluster, ManufacturerSpecificCluster):
     ):
         """Handle incoming cluster commands."""
         if hdr.command_id == 0x00:
-            data = args[0]
-            if data == b"\x00\x00\x00":
-                self.listener_event(ZHA_SEND_EVENT, "BUTTON_PRESS_0", args)
-            elif data == b"\x00\x01\x00":
-                self.listener_event(ZHA_SEND_EVENT, "BUTTON_PRESS_1", args)
-            elif data == b"\x00\x02\x00":
-                self.listener_event(ZHA_SEND_EVENT, "BUTTON_PRESS_2", args)
-            elif data == b"\x00\x03\x00":
-                self.listener_event(ZHA_SEND_EVENT, "BUTTON_PRESS_3", args)
-            else:
+            button = None
+            press_type = SHORT_PRESS
+
+            if args == b"\x00\x00\x00":
+                button = BUTTON_1
+            elif args == b"\x00\x01\x00":
+                button = BUTTON_2
+            elif args == b"\x00\x02\x00":
+                button = BUTTON_3
+            elif args == b"\x00\x03\x00":
+                button = BUTTON_4
+            elif args == b"\x01\x00\x00":
+                button = BUTTON_1
+                press_type = LONG_PRESS
+            elif args == b"\x01\x01\x00":
+                button = BUTTON_2
+                press_type = LONG_PRESS
+            elif args == b"\x01\x02\x00":
+                button = BUTTON_3
+                press_type = LONG_PRESS
+            elif args == b"\x01\x03\x00":
+                button = BUTTON_4
+                press_type = LONG_PRESS
+
+            event_args = {
+                BUTTON: button,
+                PRESS_TYPE: press_type,
+            }
+
+            if button is None:
                 self.debug("Unknown args for cluster command 0: %s", args)
+                return
+
+            action = f"{button}_{press_type}"
+            self.listener_event(ZHA_SEND_EVENT, action, event_args)
 
             return
 
@@ -77,8 +108,7 @@ class AduroSmartCSC(CustomDevice):
     # input_clusters=[ 0, 1, 3, 4, 5, 6, 8, 768, 4096, 64716 ]
     # output_clusters=[ 0, 3, 4, 5, 6, 8, 768, 4096, 64716 ]>
     signature = {
-        MANUFACTURER: "AduroSmart Eria",
-        MODELS_INFO: [("ADUROLIGHT_CSC", "AduroSmart Eria")],
+        MODELS_INFO: [("AduroSmart Eria", "ADUROLIGHT_CSC")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: 0xC05E,
@@ -97,7 +127,6 @@ class AduroSmartCSC(CustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
@@ -109,10 +138,60 @@ class AduroSmartCSC(CustomDevice):
                 ],
             },
             2: {
-                "profile_id": 0xC05E,
-                "device_type": 0x03F2,
-                "input_clusters": [LightLink.cluster_id],
-                "output_clusters": [LightLink.cluster_id],
+                PROFILE_ID: 0xC05E,
+                DEVICE_TYPE: 0x03F2,
+                INPUT_CLUSTERS: [LightLink.cluster_id],
+                OUTPUT_CLUSTERS: [LightLink.cluster_id],
             },
         },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: 0xC05E,
+                DEVICE_TYPE: DeviceType.COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfigurationCluster.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                    AduroSmartCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfigurationCluster.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                    AduroSmartCluster,
+                ],
+            },
+            2: {
+                PROFILE_ID: 0xC05E,
+                DEVICE_TYPE: 0x03F2,
+                INPUT_CLUSTERS: [LightLink.cluster_id],
+                OUTPUT_CLUSTERS: [LightLink.cluster_id],
+            },
+        }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON_1): {COMMAND: f"{BUTTON_1}_{SHORT_PRESS}"},
+        (SHORT_PRESS, BUTTON_2): {COMMAND: f"{BUTTON_2}_{SHORT_PRESS}"},
+        (SHORT_PRESS, BUTTON_3): {COMMAND: f"{BUTTON_3}_{SHORT_PRESS}"},
+        (SHORT_PRESS, BUTTON_4): {COMMAND: f"{BUTTON_4}_{SHORT_PRESS}"},
+        (LONG_PRESS, BUTTON_1): {COMMAND: f"{BUTTON_1}_{LONG_PRESS}"},
+        (LONG_PRESS, BUTTON_2): {COMMAND: f"{BUTTON_2}_{LONG_PRESS}"},
+        (LONG_PRESS, BUTTON_3): {COMMAND: f"{BUTTON_3}_{LONG_PRESS}"},
+        (LONG_PRESS, BUTTON_4): {COMMAND: f"{BUTTON_4}_{LONG_PRESS}"},
     }


### PR DESCRIPTION
## Proposed change

Add support for the AduroSmart Eria SceneSwitch. Currently ZHA in HomeAssistant can couple with the switch, but button presses are logged, no events are emitted to interact with.

About the device: https://adurosmart.com/manuals/remotesceneswitch/81847%20scene%20switch%20manual-EU.pdf

## Additional information

<details>
  <summary>Signature</summary>


```json
{
  "node_descriptor": {
    "logical_type": 2,
    "complex_descriptor_available": 0,
    "user_descriptor_available": 0,
    "reserved": 0,
    "aps_flags": 0,
    "frequency_band": 8,
    "mac_capability_flags": 128,
    "manufacturer_code": 4653,
    "maximum_buffer_size": 127,
    "maximum_incoming_transfer_size": 100,
    "server_mask": 0,
    "maximum_outgoing_transfer_size": 100,
    "descriptor_capability_field": 0
  },
  "endpoints": {
    "1": {
      "profile_id": "0xc05e",
      "device_type": "0x0810",
      "input_clusters": [
        "0x0000",
        "0x0001",
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006",
        "0x0008",
        "0x0300",
        "0x1000",
        "0xfccc"
      ],
      "output_clusters": [
        "0x0000",
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006",
        "0x0008",
        "0x0300",
        "0x1000",
        "0xfccc"
      ]
    },
    "2": {
      "profile_id": "0xc05e",
      "device_type": "0x03f2",
      "input_clusters": [
        "0x1000"
      ],
      "output_clusters": [
        "0x1000"
      ]
    }
  },
  "manufacturer": "AduroSmart Eria",
  "model": "ADUROLIGHT_CSC",
  "class": "zigpy.device.Device"
}
```

</details>



<details>
  <summary>Zigbee logs</summary>

```log
2025-02-06 11:58:07.183 DEBUG (MainThread) [zigpy.backups] Adding a new backup NetworkBackup(version=1, backup_time=datetime.datetime(2025, 2, 6, 4, 32, 48, 929900, tzinfo=datetime.timezone.utc), network_info=NetworkInfo(extended_pan_id=dd:dd:dd:dd:dd:dd:dd:dd, pan_id=0x1A62, nwk_update_id=0, nwk_manager_id=0x0000, channel=12, channel_mask=<Channels.ALL_CHANNELS: 134215680>, security_level=5, network_key=Key(key=01:03:05:07:09:0b:0d:0f:00:02:04:06:08:0a:0c:0d, tx_counter=206637, rx_counter=0, seq=0, partner_ieee=ff:ff:ff:ff:ff:ff:ff:ff), tc_link_key=Key(key=5a:69:67:42:65:65:41:6c:6c:69:61:6e:63:65:30:39, tx_counter=28672, rx_counter=0, seq=0, partner_ieee=90:35:ea:ff:fe:b9:18:66), key_table=[], children=[00:15:8d:00:05:8c:e1:cb], nwk_addresses={00:15:8d:00:05:8c:e1:cb: 0xAC6C}, stack_specific={'ezsp': {'hashed_tclk': '955ac70c281e3b4617189883315d54b2'}}, metadata={'ezsp': {'stack_version': 12, 'can_burn_userdata_custom_eui64': True, 'can_rewrite_custom_eui64': True, 'flow_control': None}}, source='bellows@0.42.6'), node_info=NodeInfo(nwk=0x0000, ieee=90:35:ea:ff:fe:b9:18:66, logical_type=<LogicalType.Coordinator: 0>, model=None, manufacturer=None, version='7.3.1.0 build 176'))
2025-02-06 11:58:08.237 DEBUG (MainThread) [zigpy.backups] Adding a new backup NetworkBackup(version=1, backup_time=datetime.datetime(2025, 2, 6, 4, 32, 48, 929900, tzinfo=datetime.timezone.utc), network_info=NetworkInfo(extended_pan_id=dd:dd:dd:dd:dd:dd:dd:dd, pan_id=0x1A62, nwk_update_id=0, nwk_manager_id=0x0000, channel=12, channel_mask=<Channels.ALL_CHANNELS: 134215680>, security_level=5, network_key=Key(key=01:03:05:07:09:0b:0d:0f:00:02:04:06:08:0a:0c:0d, tx_counter=206637, rx_counter=0, seq=0, partner_ieee=ff:ff:ff:ff:ff:ff:ff:ff), tc_link_key=Key(key=5a:69:67:42:65:65:41:6c:6c:69:61:6e:63:65:30:39, tx_counter=28672, rx_counter=0, seq=0, partner_ieee=90:35:ea:ff:fe:b9:18:66), key_table=[], children=[00:15:8d:00:05:8c:e1:cb], nwk_addresses={00:15:8d:00:05:8c:e1:cb: 0xAC6C}, stack_specific={'ezsp': {'hashed_tclk': '955ac70c281e3b4617189883315d54b2'}}, metadata={'ezsp': {'stack_version': 12, 'can_burn_userdata_custom_eui64': True, 'can_rewrite_custom_eui64': True, 'flow_control': None}}, source='bellows@0.42.6'), node_info=NodeInfo(nwk=0x0000, ieee=90:35:ea:ff:fe:b9:18:66, logical_type=<LogicalType.Coordinator: 0>, model=None, manufacturer=None, version='7.3.1.0 build 176'))
2025-02-06 12:05:08.045 DEBUG (MainThread) [bellows.ezsp.protocol] Received command incomingMessageHandler: {'type': <EmberIncomingMessageType.INCOMING_UNICAST: 0>, 'apsFrame': EmberApsFrame(profileId=260, clusterId=64716, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=39), 'lastHopLqi': 188, 'lastHopRssi': -53, 'sender': 0xAC6C, 'bindingIndex': 255, 'addressIndex': 255, 'messageContents': b'\x11R\x00\x00\x00\x00'}
2025-02-06 12:05:08.045 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=64716, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=39), 188, -53, 0xAC6C, 255, 255, b'\x11R\x00\x00\x00\x00']
2025-02-06 12:05:08.046 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 2, 6, 11, 5, 8, 46126, tzinfo=datetime.timezone.utc), priority=0, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xAC6C), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=39, profile_id=260, cluster_id=64716, data=Serialized[b'\x11R\x00\x00\x00\x00'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=188, rssi=-53)
2025-02-06 12:05:08.046 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Received ZCL frame: b'\x11R\x00\x00\x00\x00'
2025-02-06 12:05:08.046 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x11>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 0>, disable_default_response=1, reserved=0, *is_cluster=True, *is_general=False), tsn=82, command_id=0, *direction=<Direction.Client_to_Server: 0>)
2025-02-06 12:05:08.046 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Unknown cluster command 0 b'\x00\x00\x00'
2025-02-06 12:05:08.046 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Received command 0x00 (TSN 82): b'\x00\x00\x00'
2025-02-06 12:05:08.046 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] No explicit handler for cluster command 0x00: b'\x00\x00\x00'
2025-02-06 12:05:08.127 DEBUG (MainThread) [bellows.ezsp.protocol] Received command incomingMessageHandler: {'type': <EmberIncomingMessageType.INCOMING_UNICAST: 0>, 'apsFrame': EmberApsFrame(profileId=260, clusterId=1, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=40), 'lastHopLqi': 184, 'lastHopRssi': -54, 'sender': 0xAC6C, 'bindingIndex': 255, 'addressIndex': 255, 'messageContents': b'\x18S\n \x00 \x1d!\x00 \xbe'}
2025-02-06 12:05:08.127 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=1, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=40), 184, -54, 0xAC6C, 255, 255, b'\x18S\n \x00 \x1d!\x00 \xbe']
2025-02-06 12:05:08.127 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 2, 6, 11, 5, 8, 127847, tzinfo=datetime.timezone.utc), priority=0, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xAC6C), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=40, profile_id=260, cluster_id=1, data=Serialized[b'\x18S\n \x00 \x1d!\x00 \xbe'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=184, rssi=-54)
2025-02-06 12:05:08.128 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Received ZCL frame: b'\x18S\n \x00 \x1d!\x00 \xbe'
2025-02-06 12:05:08.128 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x18>(frame_type=<FrameType.GLOBAL_COMMAND: 0>, is_manufacturer_specific=0, direction=<Direction.Server_to_Client: 1>, disable_default_response=1, reserved=0, *is_cluster=False, *is_general=True), tsn=83, command_id=10, *direction=<Direction.Server_to_Client: 1>)
2025-02-06 12:05:08.128 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Decoded ZCL frame: PowerConfiguration:Report_Attributes(attribute_reports=[Attribute(attrid=0x0020, value=TypeValue(type=uint8_t, value=29)), Attribute(attrid=0x0021, value=TypeValue(type=uint8_t, value=190))])
2025-02-06 12:05:08.128 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Received command 0x0A (TSN 83): Report_Attributes(attribute_reports=[Attribute(attrid=0x0020, value=TypeValue(type=uint8_t, value=29)), Attribute(attrid=0x0021, value=TypeValue(type=uint8_t, value=190))])
2025-02-06 12:05:08.128 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Attribute report received: battery_voltage=29, battery_percentage_remaining=190
2025-02-06 12:05:08.129 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xAC6C:1:0x0001]: cluster_handler[power] attribute_updated - cluster[Power Configuration] attr[battery_voltage] value[29]
2025-02-06 12:05:08.129 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xAC6C:1:0x0001]: cluster_handler[power] attribute_updated - cluster[Power Configuration] attr[battery_percentage_remaining] value[190]
2025-02-06 12:05:09.680 DEBUG (MainThread) [bellows.ezsp.protocol] Received command incomingMessageHandler: {'type': <EmberIncomingMessageType.INCOMING_UNICAST: 0>, 'apsFrame': EmberApsFrame(profileId=260, clusterId=64716, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=41), 'lastHopLqi': 180, 'lastHopRssi': -55, 'sender': 0xAC6C, 'bindingIndex': 255, 'addressIndex': 255, 'messageContents': b'\x11T\x00\x00\x02\x00'}
2025-02-06 12:05:09.680 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=64716, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=41), 180, -55, 0xAC6C, 255, 255, b'\x11T\x00\x00\x02\x00']
2025-02-06 12:05:09.680 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 2, 6, 11, 5, 9, 680675, tzinfo=datetime.timezone.utc), priority=0, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xAC6C), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=41, profile_id=260, cluster_id=64716, data=Serialized[b'\x11T\x00\x00\x02\x00'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=180, rssi=-55)
2025-02-06 12:05:09.680 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Received ZCL frame: b'\x11T\x00\x00\x02\x00'
2025-02-06 12:05:09.681 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x11>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 0>, disable_default_response=1, reserved=0, *is_cluster=True, *is_general=False), tsn=84, command_id=0, *direction=<Direction.Client_to_Server: 0>)
2025-02-06 12:05:09.681 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Unknown cluster command 0 b'\x00\x02\x00'
2025-02-06 12:05:09.681 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Received command 0x00 (TSN 84): b'\x00\x02\x00'
2025-02-06 12:05:09.681 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] No explicit handler for cluster command 0x00: b'\x00\x02\x00'
2025-02-06 12:05:09.696 DEBUG (MainThread) [bellows.ezsp.protocol] Received command incomingMessageHandler: {'type': <EmberIncomingMessageType.INCOMING_UNICAST: 0>, 'apsFrame': EmberApsFrame(profileId=260, clusterId=1, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=42), 'lastHopLqi': 180, 'lastHopRssi': -55, 'sender': 0xAC6C, 'bindingIndex': 255, 'addressIndex': 255, 'messageContents': b'\x18U\n \x00 \x1d!\x00 \xbe'}
2025-02-06 12:05:09.696 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=1, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=42), 180, -55, 0xAC6C, 255, 255, b'\x18U\n \x00 \x1d!\x00 \xbe']
2025-02-06 12:05:09.696 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 2, 6, 11, 5, 9, 696627, tzinfo=datetime.timezone.utc), priority=0, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xAC6C), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=42, profile_id=260, cluster_id=1, data=Serialized[b'\x18U\n \x00 \x1d!\x00 \xbe'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=180, rssi=-55)
2025-02-06 12:05:09.696 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Received ZCL frame: b'\x18U\n \x00 \x1d!\x00 \xbe'
2025-02-06 12:05:09.697 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x18>(frame_type=<FrameType.GLOBAL_COMMAND: 0>, is_manufacturer_specific=0, direction=<Direction.Server_to_Client: 1>, disable_default_response=1, reserved=0, *is_cluster=False, *is_general=True), tsn=85, command_id=10, *direction=<Direction.Server_to_Client: 1>)
2025-02-06 12:05:09.697 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Decoded ZCL frame: PowerConfiguration:Report_Attributes(attribute_reports=[Attribute(attrid=0x0020, value=TypeValue(type=uint8_t, value=29)), Attribute(attrid=0x0021, value=TypeValue(type=uint8_t, value=190))])
2025-02-06 12:05:09.697 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Received command 0x0A (TSN 85): Report_Attributes(attribute_reports=[Attribute(attrid=0x0020, value=TypeValue(type=uint8_t, value=29)), Attribute(attrid=0x0021, value=TypeValue(type=uint8_t, value=190))])
2025-02-06 12:05:09.697 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Attribute report received: battery_voltage=29, battery_percentage_remaining=190
2025-02-06 12:05:09.697 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xAC6C:1:0x0001]: cluster_handler[power] attribute_updated - cluster[Power Configuration] attr[battery_voltage] value[29]
2025-02-06 12:05:09.697 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xAC6C:1:0x0001]: cluster_handler[power] attribute_updated - cluster[Power Configuration] attr[battery_percentage_remaining] value[190]
2025-02-06 12:05:12.988 DEBUG (MainThread) [zha.zigbee.device] [0xAC6C](ADUROLIGHT_CSC): Device seen - marking the device available and resetting counter
2025-02-06 12:05:12.988 DEBUG (MainThread) [zha.zigbee.device] [0xAC6C](ADUROLIGHT_CSC): Update device availability -  device available: True - new availability: True - changed: False
2025-02-06 12:05:17.220 DEBUG (MainThread) [bellows.ezsp.protocol] Received command incomingMessageHandler: {'type': <EmberIncomingMessageType.INCOMING_UNICAST: 0>, 'apsFrame': EmberApsFrame(profileId=260, clusterId=64716, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=45), 'lastHopLqi': 200, 'lastHopRssi': -50, 'sender': 0xAC6C, 'bindingIndex': 255, 'addressIndex': 255, 'messageContents': b'\x11X\x00\x00\x00\x00'}
2025-02-06 12:05:17.220 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=64716, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=45), 200, -50, 0xAC6C, 255, 255, b'\x11X\x00\x00\x00\x00']
2025-02-06 12:05:17.220 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 2, 6, 11, 5, 17, 220717, tzinfo=datetime.timezone.utc), priority=0, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xAC6C), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=45, profile_id=260, cluster_id=64716, data=Serialized[b'\x11X\x00\x00\x00\x00'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=200, rssi=-50)
2025-02-06 12:05:17.221 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Received ZCL frame: b'\x11X\x00\x00\x00\x00'
2025-02-06 12:05:17.221 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x11>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 0>, disable_default_response=1, reserved=0, *is_cluster=True, *is_general=False), tsn=88, command_id=0, *direction=<Direction.Client_to_Server: 0>)
2025-02-06 12:05:17.221 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Unknown cluster command 0 b'\x00\x00\x00'
2025-02-06 12:05:17.221 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Received command 0x00 (TSN 88): b'\x00\x00\x00'
2025-02-06 12:05:17.221 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] No explicit handler for cluster command 0x00: b'\x00\x00\x00'
2025-02-06 12:05:17.226 DEBUG (MainThread) [bellows.ezsp.protocol] Received command incomingMessageHandler: {'type': <EmberIncomingMessageType.INCOMING_UNICAST: 0>, 'apsFrame': EmberApsFrame(profileId=260, clusterId=1, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=46), 'lastHopLqi': 200, 'lastHopRssi': -50, 'sender': 0xAC6C, 'bindingIndex': 255, 'addressIndex': 255, 'messageContents': b'\x18Y\n \x00 \x1d!\x00 \xbe'}
2025-02-06 12:05:17.226 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=1, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=46), 200, -50, 0xAC6C, 255, 255, b'\x18Y\n \x00 \x1d!\x00 \xbe']
2025-02-06 12:05:17.226 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 2, 6, 11, 5, 17, 226708, tzinfo=datetime.timezone.utc), priority=0, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xAC6C), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=46, profile_id=260, cluster_id=1, data=Serialized[b'\x18Y\n \x00 \x1d!\x00 \xbe'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=200, rssi=-50)
2025-02-06 12:05:17.226 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Received ZCL frame: b'\x18Y\n \x00 \x1d!\x00 \xbe'
2025-02-06 12:05:17.227 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x18>(frame_type=<FrameType.GLOBAL_COMMAND: 0>, is_manufacturer_specific=0, direction=<Direction.Server_to_Client: 1>, disable_default_response=1, reserved=0, *is_cluster=False, *is_general=True), tsn=89, command_id=10, *direction=<Direction.Server_to_Client: 1>)
2025-02-06 12:05:17.227 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Decoded ZCL frame: PowerConfiguration:Report_Attributes(attribute_reports=[Attribute(attrid=0x0020, value=TypeValue(type=uint8_t, value=29)), Attribute(attrid=0x0021, value=TypeValue(type=uint8_t, value=190))])
2025-02-06 12:05:17.227 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Received command 0x0A (TSN 89): Report_Attributes(attribute_reports=[Attribute(attrid=0x0020, value=TypeValue(type=uint8_t, value=29)), Attribute(attrid=0x0021, value=TypeValue(type=uint8_t, value=190))])
2025-02-06 12:05:17.227 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Attribute report received: battery_voltage=29, battery_percentage_remaining=190
2025-02-06 12:05:17.227 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xAC6C:1:0x0001]: cluster_handler[power] attribute_updated - cluster[Power Configuration] attr[battery_voltage] value[29]
2025-02-06 12:05:17.227 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xAC6C:1:0x0001]: cluster_handler[power] attribute_updated - cluster[Power Configuration] attr[battery_percentage_remaining] value[190]
2025-02-06 12:05:24.617 DEBUG (MainThread) [bellows.ezsp.protocol] Received command incomingMessageHandler: {'type': <EmberIncomingMessageType.INCOMING_UNICAST: 0>, 'apsFrame': EmberApsFrame(profileId=260, clusterId=64716, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=47), 'lastHopLqi': 184, 'lastHopRssi': -54, 'sender': 0xAC6C, 'bindingIndex': 255, 'addressIndex': 255, 'messageContents': b'\x11Z\x00\x00\x03\x00'}
2025-02-06 12:05:24.617 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=64716, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=47), 184, -54, 0xAC6C, 255, 255, b'\x11Z\x00\x00\x03\x00']
2025-02-06 12:05:24.617 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 2, 6, 11, 5, 24, 617753, tzinfo=datetime.timezone.utc), priority=0, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xAC6C), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=47, profile_id=260, cluster_id=64716, data=Serialized[b'\x11Z\x00\x00\x03\x00'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=184, rssi=-54)
2025-02-06 12:05:24.618 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Received ZCL frame: b'\x11Z\x00\x00\x03\x00'
2025-02-06 12:05:24.618 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x11>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 0>, disable_default_response=1, reserved=0, *is_cluster=True, *is_general=False), tsn=90, command_id=0, *direction=<Direction.Client_to_Server: 0>)
2025-02-06 12:05:24.618 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Unknown cluster command 0 b'\x00\x03\x00'
2025-02-06 12:05:24.618 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Received command 0x00 (TSN 90): b'\x00\x03\x00'
2025-02-06 12:05:24.618 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] No explicit handler for cluster command 0x00: b'\x00\x03\x00'
2025-02-06 12:05:24.674 DEBUG (MainThread) [bellows.ezsp.protocol] Received command incomingMessageHandler: {'type': <EmberIncomingMessageType.INCOMING_UNICAST: 0>, 'apsFrame': EmberApsFrame(profileId=260, clusterId=1, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=48), 'lastHopLqi': 184, 'lastHopRssi': -54, 'sender': 0xAC6C, 'bindingIndex': 255, 'addressIndex': 255, 'messageContents': b'\x18[\n \x00 \x1d!\x00 \xbe'}
2025-02-06 12:05:24.674 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=1, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=48), 184, -54, 0xAC6C, 255, 255, b'\x18[\n \x00 \x1d!\x00 \xbe']
2025-02-06 12:05:24.675 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 2, 6, 11, 5, 24, 675048, tzinfo=datetime.timezone.utc), priority=0, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xAC6C), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=48, profile_id=260, cluster_id=1, data=Serialized[b'\x18[\n \x00 \x1d!\x00 \xbe'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=184, rssi=-54)
2025-02-06 12:05:24.675 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Received ZCL frame: b'\x18[\n \x00 \x1d!\x00 \xbe'
2025-02-06 12:05:24.675 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x18>(frame_type=<FrameType.GLOBAL_COMMAND: 0>, is_manufacturer_specific=0, direction=<Direction.Server_to_Client: 1>, disable_default_response=1, reserved=0, *is_cluster=False, *is_general=True), tsn=91, command_id=10, *direction=<Direction.Server_to_Client: 1>)
2025-02-06 12:05:24.675 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Decoded ZCL frame: PowerConfiguration:Report_Attributes(attribute_reports=[Attribute(attrid=0x0020, value=TypeValue(type=uint8_t, value=29)), Attribute(attrid=0x0021, value=TypeValue(type=uint8_t, value=190))])
2025-02-06 12:05:24.675 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Received command 0x0A (TSN 91): Report_Attributes(attribute_reports=[Attribute(attrid=0x0020, value=TypeValue(type=uint8_t, value=29)), Attribute(attrid=0x0021, value=TypeValue(type=uint8_t, value=190))])
2025-02-06 12:05:24.676 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Attribute report received: battery_voltage=29, battery_percentage_remaining=190
2025-02-06 12:05:24.676 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xAC6C:1:0x0001]: cluster_handler[power] attribute_updated - cluster[Power Configuration] attr[battery_voltage] value[29]
2025-02-06 12:05:24.676 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xAC6C:1:0x0001]: cluster_handler[power] attribute_updated - cluster[Power Configuration] attr[battery_percentage_remaining] value[190]
2025-02-06 12:05:45.937 DEBUG (MainThread) [bellows.ezsp.protocol] Received command incomingMessageHandler: {'type': <EmberIncomingMessageType.INCOMING_UNICAST: 0>, 'apsFrame': EmberApsFrame(profileId=260, clusterId=64716, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=50), 'lastHopLqi': 208, 'lastHopRssi': -48, 'sender': 0xAC6C, 'bindingIndex': 255, 'addressIndex': 255, 'messageContents': b'\x11]\x00\x00\x01\x00'}
2025-02-06 12:05:45.937 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=64716, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=50), 208, -48, 0xAC6C, 255, 255, b'\x11]\x00\x00\x01\x00']
2025-02-06 12:05:45.937 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 2, 6, 11, 5, 45, 937574, tzinfo=datetime.timezone.utc), priority=0, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xAC6C), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=50, profile_id=260, cluster_id=64716, data=Serialized[b'\x11]\x00\x00\x01\x00'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=208, rssi=-48)
2025-02-06 12:05:45.937 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Received ZCL frame: b'\x11]\x00\x00\x01\x00'
2025-02-06 12:05:45.938 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x11>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 0>, disable_default_response=1, reserved=0, *is_cluster=True, *is_general=False), tsn=93, command_id=0, *direction=<Direction.Client_to_Server: 0>)
2025-02-06 12:05:45.938 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Unknown cluster command 0 b'\x00\x01\x00'
2025-02-06 12:05:45.938 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] Received command 0x00 (TSN 93): b'\x00\x01\x00'
2025-02-06 12:05:45.938 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0xfccc] No explicit handler for cluster command 0x00: b'\x00\x01\x00'
2025-02-06 12:05:45.953 DEBUG (MainThread) [bellows.ezsp.protocol] Received command incomingMessageHandler: {'type': <EmberIncomingMessageType.INCOMING_UNICAST: 0>, 'apsFrame': EmberApsFrame(profileId=260, clusterId=1, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=51), 'lastHopLqi': 204, 'lastHopRssi': -49, 'sender': 0xAC6C, 'bindingIndex': 255, 'addressIndex': 255, 'messageContents': b'\x18^\n \x00 \x1d!\x00 \xbe'}
2025-02-06 12:05:45.953 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=1, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=51), 204, -49, 0xAC6C, 255, 255, b'\x18^\n \x00 \x1d!\x00 \xbe']
2025-02-06 12:05:45.953 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 2, 6, 11, 5, 45, 953375, tzinfo=datetime.timezone.utc), priority=0, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xAC6C), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=51, profile_id=260, cluster_id=1, data=Serialized[b'\x18^\n \x00 \x1d!\x00 \xbe'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=204, rssi=-49)
2025-02-06 12:05:45.953 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Received ZCL frame: b'\x18^\n \x00 \x1d!\x00 \xbe'
2025-02-06 12:05:45.953 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x18>(frame_type=<FrameType.GLOBAL_COMMAND: 0>, is_manufacturer_specific=0, direction=<Direction.Server_to_Client: 1>, disable_default_response=1, reserved=0, *is_cluster=False, *is_general=True), tsn=94, command_id=10, *direction=<Direction.Server_to_Client: 1>)
2025-02-06 12:05:45.954 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Decoded ZCL frame: PowerConfiguration:Report_Attributes(attribute_reports=[Attribute(attrid=0x0020, value=TypeValue(type=uint8_t, value=29)), Attribute(attrid=0x0021, value=TypeValue(type=uint8_t, value=190))])
2025-02-06 12:05:45.954 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Received command 0x0A (TSN 94): Report_Attributes(attribute_reports=[Attribute(attrid=0x0020, value=TypeValue(type=uint8_t, value=29)), Attribute(attrid=0x0021, value=TypeValue(type=uint8_t, value=190))])
2025-02-06 12:05:45.954 DEBUG (MainThread) [zigpy.zcl] [0xAC6C:1:0x0001] Attribute report received: battery_voltage=29, battery_percentage_remaining=190
2025-02-06 12:05:45.954 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xAC6C:1:0x0001]: cluster_handler[power] attribute_updated - cluster[Power Configuration] attr[battery_voltage] value[29]
2025-02-06 12:05:45.954 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xAC6C:1:0x0001]: cluster_handler[power] attribute_updated - cluster[Power Configuration] attr[battery_percentage_remaining] value[190]
2025-02-06 12:05:54.989 DEBUG (MainThread) [zha.zigbee.device] [0xAC6C](ADUROLIGHT_CSC): Device seen - marking the device available and resetting counter
2025-02-06 12:05:54.989 DEBUG (MainThread) [zha.zigbee.device] [0xAC6C](ADUROLIGHT_CSC): Update device availability -  device available: True - new availability: True - changed: False
```

</details>

## Checklist


- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works

Logs of button click:

```
2025-02-07 16:41:08.386 DEBUG (MainThread) [zigpy.zcl] [0x8AAF:1:0xfccc] Received command 0x00 (TSN 36): b'\x00\x02\x00'
2025-02-07 16:41:08.386 DEBUG (MainThread) [zha] Emitting event zha_event with data ZHAEvent(device_ieee=00:15:8d:00:05:8c:e1:cb, unique_id='00:15:8d:00:05:8c:e1:cb', data={'unique_id': '00:15:8d:00:05:8c:e1:cb:1:0xfccc', 'endpoint_id': 1, 'cluster_id': 64716, 'command': 'button_3_remote_button_short_press', 'args': {'button': 'button_3', 'press_type': 'remote_button_short_press'}, 'params': {}}, event_type='zha_event', event='zha_event') (1 listeners)
```

![image](https://github.com/user-attachments/assets/8d70244a-d3c7-4f24-b0ec-f6411349f7f1)



Related: #2655
