### PR TITLE
Remove Group cluster in IKEA Somrig smart button

### DIFF
--- a/zhaquirks/ikea/somrigsmartbtn.py
+++ b/zhaquirks/ikea/somrigsmartbtn.py
@@ -110,7 +110,6 @@ class IkeaSomrigSmartButton(CustomDevice):
                     Basic.cluster_id,
                     PowerConfig1AAACluster,
                     Identify.cluster_id,
-                    Groups.cluster_id,
                     PollControl.cluster_id,
                     LightLink.cluster_id,
                     IKEA_CLUSTER_ID,
@@ -132,7 +131,6 @@ class IkeaSomrigSmartButton(CustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    Groups.cluster_id,
                     ShortcutV2Cluster,
                 ],
                 OUTPUT_CLUSTERS: [


### PR DESCRIPTION
The controller is showing up in ZHA light groups for being added as lights but its one good Zigbee device and is using binding and not adding groups as light (like some tuya controller is doing).

PS i think its one rest from IKEAs direct pairing / binding to devices that is being reused in coordinator paring.

PS2 Styrbar is having the same in the latest firmware but i dont know how to fixing it in V2 quirks.

## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
