### PR TITLE
Add pilot wire mode enum select for Adeo SIN-4-FP-21_EQU

### DIFF
--- a/zhaquirks/nodon/pilot_wire.py
+++ b/zhaquirks/nodon/pilot_wire.py
@@ -71,6 +71,14 @@ adeo = (
     nodon.clone(omit_man_model_data=True)
     .applies_to(ADEO, "SIN-4-FP-21_EQU")
     .replaces(AdeoPilotWireCluster)
+    .enum(
+        attribute_name=AdeoPilotWireCluster.AttributeDefs.pilot_wire_mode.name,
+        enum_class=NodOnPilotWireMode,
+        cluster_id=AdeoPilotWireCluster.cluster_id,
+        entity_type=EntityType.STANDARD,
+        translation_key="pilot_wire_mode",
+        fallback_name="Pilot wire mode",
+    )
 )
 
 


### PR DESCRIPTION
## Proposed change
Going through the code, I've noticed that https://github.com/zigpy/zha-device-handlers/pull/3798 added the enum for NodOn and Legrand but not for Adeo. This PR fixes it.

## Additional information
Adeo is a clone of NodOn but with a different manufacturer_id. 
I don't have Adeo devices, but I recall that @papylhomme has. Can you please test it?

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
