### PR TITLE
Fix Tuya Saswell TRVs causing ZHA to generate new climate entity

### DIFF
--- a/tests/test_tuya_trv.py
+++ b/tests/test_tuya_trv.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.hvac import Thermostat
@@ -50,19 +51,33 @@ TUYA_TEST_PLAN_V02 = (
 
 
 @pytest.mark.parametrize(
-    "model, manuf, test_plan, set_pnt_msg",
+    "model, manuf, test_plan, set_pnt_msg, ep_type",
     (
-        ("_TZE204_ogx8u5z6", "TS0601", TUYA_TEST_PLAN_V01, TUYA_SP_V01),
-        ("_TZE200_3yp57tby", "TS0601", TUYA_TEST_PLAN_V02, TUYA_SP_V02),
+        (
+            "_TZE204_ogx8u5z6",
+            "TS0601",
+            TUYA_TEST_PLAN_V01,
+            TUYA_SP_V01,
+            None,  # test device has specific device type, real one has SMART_PLUG
+        ),
+        (
+            "_TZE200_3yp57tby",
+            "TS0601",
+            TUYA_TEST_PLAN_V02,
+            TUYA_SP_V02,
+            zha.DeviceType.THERMOSTAT,  # quirk replaces device type with THERMOSTAT
+        ),
     ),
 )
 async def test_handle_get_data(
-    zigpy_device_from_v2_quirk, model, manuf, test_plan, set_pnt_msg
+    zigpy_device_from_v2_quirk, model, manuf, test_plan, set_pnt_msg, ep_type
 ):
     """Test handle_get_data for multiple attributes."""
 
     quirked = zigpy_device_from_v2_quirk(model, manuf)
     ep = quirked.endpoints[1]
+
+    assert ep.device_type == ep_type
 
     assert ep.tuya_manufacturer is not None
     assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -1,5 +1,6 @@
 """Map from manufacturer to standard clusters for thermostatic valves."""
 
+from zigpy.profiles import zha
 from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTemperature
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorStateClass
@@ -94,6 +95,7 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
     .applies_to("_TZE200_exfrnlow", "TS0601")
     .applies_to("_TZE200_9m4kmbfu", "TS0601")
     .applies_to("_TZE200_3yp57tby", "TS0601")
+    .replaces_endpoint(1, device_type=zha.DeviceType.THERMOSTAT)
     .tuya_dp(
         dp_id=3,
         ep_attribute=TuyaThermostatV2.ep_attribute,

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -95,6 +95,8 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
     .applies_to("_TZE200_exfrnlow", "TS0601")
     .applies_to("_TZE200_9m4kmbfu", "TS0601")
     .applies_to("_TZE200_3yp57tby", "TS0601")
+    # default device type is `SMART_PLUG` for this,
+    # so change it back to keep UID/entity the same
     .replaces_endpoint(1, device_type=zha.DeviceType.THERMOSTAT)
     .tuya_dp(
         dp_id=3,


### PR DESCRIPTION
## Proposed change

This works around an issue in ZHA where the updated v2 quirk for the Tuya Saswell TRV caused ZHA to generate a new climate entity.

### Cause

The v2 quirk replaced an old v1 quirk in https://github.com/zigpy/zha-device-handlers/pull/3772. The v1 quirk changed the `DEVICE_TYPE` for endpoint 1 from the Tuya-reported `SMART_PLUG` to `THERMOSTAT`. As this `DEVICE_TYPE` is generally not used anymore, we do not change them in v2 quirks.
However, there's some old legacy code in ZHA that changes unique IDs depending on if ZHA and HA platform match. This is rarely the case (the code is somewhat bad), but for thermostats, it unfortunately applied before: https://github.com/zigpy/zha/blob/d6bb4a89ff857137e96b2932f711f1bdb2fbe80b/zha/application/discovery.py#L564-L573

So, we need to change back the profile type to `THERMOSTAT` for Tuya Saswell TRVs again, like the v1 quirk did.
In the future, we should really remove that code in ZHA and migrate existing UIDs to new ones.

### Other v2 TRV quirks

Some other v2 TRV quirks were added in 0.0.131 too, but I think this was the only TRV quirk that replaced an existing v1 quirk. If we were to change this for all v2 quirks, we'd break the entity used by everyone in 2025.2.0 and 2025.1.

But if they were using custom quirks before, they would have already changed the `DEVICE_TYPE` to `THERMOSTAT`. E.g. this one: https://github.com/jacekk015/zha_quirks/blob/dcfc3beb98008bbb40780dbcf4f38af82c117e5d/ts0601_trv_me167.py#L466-L493
So, for those people, it already broke in 2025.2.x and adding this to all v2 TRV quirks would restore functionality.

Now, we don't support custom quirks, of course. But it's an unfortunate reality that they're used a lot in production instances, without being contributed upstream. Maybe we do want to add this to all Tuya v2 TRV (+ thermostat?) quirks for now, so they cause ZHA to use the same unique ID?

(cc @prairiesnpr for thoughts on this when you're back 😄)


## Additional information

- Cause related to: https://github.com/zigpy/zha/issues/158
- Noticed in: https://github.com/home-assistant/core/issues/138058
- There are still other issues with the v2 quirk for some Tuya TRVs, not fixed by this, see this thread:
   https://github.com/zigpy/zha-device-handlers/issues/3837

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
