### PR TITLE
Fix Saswell TRV local temperature calibration and system mode

### DIFF
--- a/tests/test_tuya_trv.py
+++ b/tests/test_tuya_trv.py
@@ -49,15 +49,26 @@ TUYA_TEST_PLAN_V02 = (
     ),  # Set to Off (0x02), dp 3
 )
 
+TUYA_SYS_MODE_V01 = {
+    Thermostat.SystemMode.Heat: b"\x01\x02\x00\x00\x02\x02\x04\x00\x01\x01",
+    Thermostat.SystemMode.Off: b"\x01\x03\x00\x00\x03\x02\x04\x00\x01\x02",
+}
+
+TUYA_SYS_MODE_V02 = {
+    Thermostat.SystemMode.Heat: b"\x01\x02\x00\x00\x02\x65\x01\x00\x01\x01",
+    Thermostat.SystemMode.Off: b"\x01\x03\x00\x00\x03\x65\x01\x00\x01\x00",
+}
+
 
 @pytest.mark.parametrize(
-    "model, manuf, test_plan, set_pnt_msg, ep_type",
+    "model, manuf, test_plan, set_pnt_msg, sys_mode_msg, ep_type",
     (
         (
             "_TZE204_ogx8u5z6",
             "TS0601",
             TUYA_TEST_PLAN_V01,
             TUYA_SP_V01,
+            TUYA_SYS_MODE_V01,
             None,  # test device has specific device type, real one has SMART_PLUG
         ),
         (
@@ -65,12 +76,19 @@ TUYA_TEST_PLAN_V02 = (
             "TS0601",
             TUYA_TEST_PLAN_V02,
             TUYA_SP_V02,
+            TUYA_SYS_MODE_V02,
             zha.DeviceType.THERMOSTAT,  # quirk replaces device type with THERMOSTAT
         ),
     ),
 )
 async def test_handle_get_data(
-    zigpy_device_from_v2_quirk, model, manuf, test_plan, set_pnt_msg, ep_type
+    zigpy_device_from_v2_quirk,
+    model,
+    manuf,
+    test_plan,
+    set_pnt_msg,
+    sys_mode_msg,
+    ep_type,
 ):
     """Test handle_get_data for multiple attributes."""
 
@@ -114,6 +132,54 @@ async def test_handle_get_data(
             cluster=0xEF00,
             sequence=1,
             data=set_pnt_msg,
+            command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
+        )
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
+
+    with mock.patch.object(
+        ep.tuya_manufacturer.endpoint, "request", side_effect=async_success
+    ) as m1:
+        (status,) = await ep.thermostat.write_attributes(
+            {
+                "system_mode": Thermostat.SystemMode.Heat,
+            }
+        )
+        await wait_for_zigpy_tasks()
+        m1.assert_called_with(
+            cluster=0xEF00,
+            sequence=2,
+            data=sys_mode_msg[Thermostat.SystemMode.Heat],
+            command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
+            priority=t.PacketPriority.NORMAL,
+        )
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
+
+    with mock.patch.object(
+        ep.tuya_manufacturer.endpoint, "request", side_effect=async_success
+    ) as m1:
+        (status,) = await ep.thermostat.write_attributes(
+            {
+                "system_mode": Thermostat.SystemMode.Off,
+            }
+        )
+        await wait_for_zigpy_tasks()
+        m1.assert_called_with(
+            cluster=0xEF00,
+            sequence=3,
+            data=sys_mode_msg[Thermostat.SystemMode.Off],
             command_id=0,
             timeout=5,
             expect_reply=False,

--- a/tests/test_tuya_trv.py
+++ b/tests/test_tuya_trv.py
@@ -38,12 +38,12 @@ TUYA_TEST_PLAN_V01 = (
 
 TUYA_TEST_PLAN_V02 = (
     (
-        b"\t\xc3\x02\x00r\x65\x04\x00\x01\x01",
+        b"\t\xc3\x02\x00r\x65\x01\x00\x01\x01",
         Thermostat.AttributeDefs.system_mode,
         Thermostat.SystemMode.Heat,
     ),  # Set to Heat (0x01), dp 3
     (
-        b"\t\xc2\x02\x00q\x65\x04\x00\x01\x02",
+        b"\t\xc2\x02\x00q\x65\x01\x00\x01\x00",
         Thermostat.AttributeDefs.system_mode,
         Thermostat.SystemMode.Off,
     ),  # Set to Off (0x02), dp 3

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -126,7 +126,7 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
         min_value=-6,
         max_value=6,
         unit=UnitOfTemperature.CELSIUS,
-        step=0.1,
+        step=1,
         translation_key="local_temperature_calibration",
         fallback_name="Local temperature calibration",
     )

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -6,7 +6,7 @@ from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorStateClass
 import zigpy.types as t
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.hvac import Thermostat
+from zigpy.zcl.clusters.hvac import RunningState, Thermostat
 
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zhaquirks.tuya.mcu import TuyaAttributesCluster
@@ -102,6 +102,7 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
         dp_id=3,
         ep_attribute=TuyaThermostatV2.ep_attribute,
         attribute_name=TuyaThermostatV2.AttributeDefs.running_state.name,
+        converter=lambda x: RunningState.Heat_State_On if x else RunningState.Idle,
     )
     .tuya_switch(
         dp_id=8,

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -19,6 +19,13 @@ class TuyaThermostatSystemMode(t.enum8):
     Off = 0x02
 
 
+class TuyaThermostatSystemModeV2(t.enum8):
+    """Tuya thermostat system mode enum, off and heat only."""
+
+    Off = 0x00
+    Heat = 0x01
+
+
 class TuyaThermostatEcoMode(t.enum8):
     """Tuya thermostat eco mode enum."""
 
@@ -112,12 +119,16 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
         translation_key="frost_protection",
         fallback_name="Frost protection",
     )
-    .tuya_dp(
+    .tuya_number(
         dp_id=27,
-        ep_attribute=TuyaThermostatV2.ep_attribute,
         attribute_name=TuyaThermostatV2.AttributeDefs.local_temperature_calibration.name,
-        converter=lambda x: x,
-        dp_converter=lambda x: 0xFFFFFFFF - x if x > 6 else x,
+        type=t.uint32_t,
+        min_value=-6,
+        max_value=6,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.1,
+        translation_key="local_temperature_calibration",
+        fallback_name="Local temperature calibration",
     )
     .tuya_switch(
         dp_id=40,
@@ -132,9 +143,9 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
         converter=lambda x: Thermostat.SystemMode.Heat
         if x == TuyaThermostatSystemMode.Heat
         else Thermostat.SystemMode.Off,
-        dp_converter=lambda x: TuyaThermostatSystemMode.Heat
+        dp_converter=lambda x: TuyaThermostatSystemModeV2.Heat
         if x == Thermostat.SystemMode.Heat
-        else 0x00,
+        else TuyaThermostatSystemModeV2.Off,
     )
     .tuya_dp(
         dp_id=102,

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -102,7 +102,6 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
         dp_id=3,
         ep_attribute=TuyaThermostatV2.ep_attribute,
         attribute_name=TuyaThermostatV2.AttributeDefs.running_state.name,
-        converter=lambda x: 0x01 if not x else 0x00,  # Heat, Idle
     )
     .tuya_switch(
         dp_id=8,

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -20,13 +20,6 @@ class TuyaThermostatSystemMode(t.enum8):
     Off = 0x02
 
 
-class TuyaThermostatSystemModeV2(t.enum8):
-    """Tuya thermostat system mode enum, off and heat only."""
-
-    Off = 0x00
-    Heat = 0x01
-
-
 class TuyaThermostatEcoMode(t.enum8):
     """Tuya thermostat eco mode enum."""
 
@@ -144,12 +137,14 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
         dp_id=101,
         ep_attribute=TuyaThermostatV2.ep_attribute,
         attribute_name=TuyaThermostatV2.AttributeDefs.system_mode.name,
-        converter=lambda x: Thermostat.SystemMode.Heat
-        if x == TuyaThermostatSystemModeV2.Heat
-        else Thermostat.SystemMode.Off,
-        dp_converter=lambda x: TuyaThermostatSystemModeV2.Heat
-        if x == Thermostat.SystemMode.Heat
-        else TuyaThermostatSystemModeV2.Off,
+        converter=lambda x: {
+            True: Thermostat.SystemMode.Heat,
+            False: Thermostat.SystemMode.Off,
+        }[x],
+        dp_converter=lambda x: {
+            Thermostat.SystemMode.Heat: True,
+            Thermostat.SystemMode.Off: False,
+        }[x],
     )
     .tuya_dp(
         dp_id=102,

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -141,7 +141,7 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
         ep_attribute=TuyaThermostatV2.ep_attribute,
         attribute_name=TuyaThermostatV2.AttributeDefs.system_mode.name,
         converter=lambda x: Thermostat.SystemMode.Heat
-        if x == TuyaThermostatSystemMode.Heat
+        if x == TuyaThermostatSystemModeV2.Heat
         else Thermostat.SystemMode.Off,
         dp_converter=lambda x: TuyaThermostatSystemModeV2.Heat
         if x == Thermostat.SystemMode.Heat


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

This ensures that the off value for system mode is sent as an enum. It also uses a number for local temperature calibration and sets the correct range and step values.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

Closes: #3837 
Closes: #3834

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
