### PR TITLE
Invert running state, fix local temp cal for `_TZE204_rtrmfadk`

### DIFF
--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -223,7 +223,7 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
         dp_id=6,
         ep_attribute=TuyaThermostatV2.ep_attribute,
         attribute_name=TuyaThermostatV2.AttributeDefs.running_state.name,
-        converter=lambda x: 0x01 if not x else 0x00,  # Heat, Idle
+        converter=lambda x: 0x01 if x else 0x00,  # Heat, Idle
     )
     .tuya_binary_sensor(
         dp_id=7,

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -273,12 +273,16 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
         translation_key="max_temperature",
         fallback_name="Max temperature",
     )
-    .tuya_dp(
+    .tuya_number(
         dp_id=101,
-        ep_attribute=TuyaThermostatV2.ep_attribute,
         attribute_name=TuyaThermostatV2.AttributeDefs.local_temperature_calibration.name,
-        converter=lambda x: x,
-        dp_converter=lambda x: x + 0x100000000 if x < 0 else x,
+        type=t.uint32_t,
+        min_value=-6,
+        max_value=6,
+        unit=UnitOfTemperature.CELSIUS,
+        step=1,
+        translation_key="local_temperature_calibration",
+        fallback_name="Local temperature calibration",
     )
     .tuya_enum(
         dp_id=114,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Invert running state for `_TZE204_rtrmfadk`, use `tuya_number` for `local_temperature_calibration`.

Closes: #3847

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
