### PR TITLE
Assign default manufacturer code in quirks v2 tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,9 +176,9 @@ def zigpy_device_from_v2_quirk(MockAppController, ieee_mock):
             ieee = ieee_mock
 
         raw_device = zigpy.device.Device(MockAppController, ieee, nwk)
-        raw_device.node_desc = NodeDescriptor(manufacturer_code=1234)
         raw_device.manufacturer = manufacturer
         raw_device.model = model
+        raw_device.node_desc = NodeDescriptor(manufacturer_code=1234)
 
         for endpoint_id in endpoint_ids:
             ep = raw_device.add_endpoint(endpoint_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import zigpy.quirks
 import zigpy.types
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic
+from zigpy.zdo.types import NodeDescriptor
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -175,6 +176,7 @@ def zigpy_device_from_v2_quirk(MockAppController, ieee_mock):
             ieee = ieee_mock
 
         raw_device = zigpy.device.Device(MockAppController, ieee, nwk)
+        raw_device.node_desc = NodeDescriptor(manufacturer_code=1234)
         raw_device.manufacturer = manufacturer
         raw_device.model = model
 


### PR DESCRIPTION
## Proposed change
This assigns all zigpy devices generated via the `zigpy_device_from_v2_quirk` fixture a node descriptor with a `manufacturer_code`. This is needed to align more closely with actual devices.

We may need to include a full node descriptor instead of only the code?
Also, what code do we want to use? Shouldn't conflict with any real ones ideally.

## Additional information
cc @prairiesnpr 


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
