### PR TITLE
Set `manufacturer_id_override` to NO_ID on `TuyaNewManufCluster`

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1488,6 +1488,9 @@ class TuyaNewManufCluster(CustomCluster):
     cluster_id: t.uint16_t = TUYA_CLUSTER_ID
     ep_attribute: str = "tuya_manufacturer"
 
+    # remove manufacturer id for cluster, important for `TUYA_SET_DATA` commands
+    manufacturer_id_override: t.uint16_t = foundation.ZCLHeader.NO_MANUFACTURER_ID
+
     class AttributeDefs(BaseAttributeDefs):
         """Attribute Definitions."""
 

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -813,11 +813,6 @@ class TuyaQuirkBuilder(QuirkBuilder):
             class TuyaReplacementCluster(replacement_cluster):  # type: ignore[valid-type]
                 """Replacement Tuya Cluster."""
 
-                # remove manufacturer id for all datapoint `TUYA_SET_DATA` commands
-                manufacturer_id_override: t.uint16_t = (
-                    foundation.ZCLHeader.NO_MANUFACTURER_ID
-                )
-
                 data_point_handlers: dict[int, str]
                 dp_to_attribute: dict[int, DPToAttributeMapping]
 

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -813,18 +813,16 @@ class TuyaQuirkBuilder(QuirkBuilder):
             class TuyaReplacementCluster(replacement_cluster):  # type: ignore[valid-type]
                 """Replacement Tuya Cluster."""
 
+                # remove manufacturer id for all datapoint `TUYA_SET_DATA` commands
+                manufacturer_id_override: t.uint16_t = (
+                    foundation.ZCLHeader.NO_MANUFACTURER_ID
+                )
+
                 data_point_handlers: dict[int, str]
                 dp_to_attribute: dict[int, DPToAttributeMapping]
 
                 class AttributeDefs(NewAttributeDefs):
                     """Attribute Definitions."""
-
-                async def write_attributes(self, attributes, manufacturer=None):
-                    """Overwrite to force manufacturer code."""
-
-                    return await super().write_attributes(
-                        attributes, manufacturer=foundation.ZCLHeader.NO_MANUFACTURER_ID
-                    )
 
             TuyaReplacementCluster.data_point_handlers = self.tuya_data_point_handlers
             TuyaReplacementCluster.dp_to_attribute = self.tuya_dp_to_attribute

--- a/zhaquirks/tuya/ts0001_fingerbot.py
+++ b/zhaquirks/tuya/ts0001_fingerbot.py
@@ -1,7 +1,5 @@
 """Tuya Fingerbot device."""
 
-from typing import Any, Optional, Union
-
 from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.zcl import foundation
@@ -15,7 +13,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import TUYA_SEND_DATA, EnchantedDevice
+from zhaquirks.tuya import EnchantedDevice
 from zhaquirks.tuya.mcu import (
     DPToAttributeMapping,
     TuyaMCUCluster,
@@ -64,26 +62,6 @@ class TuyaFingerbotCluster(TuyaMCUCluster):
         )
         touch_control = foundation.ZCLAttributeDef(
             id=107, type=t.Bool, is_manufacturer_specific=True
-        )
-
-    async def command(
-        self,
-        command_id: Union[foundation.GeneralCommand, int, t.uint8_t],
-        *args,
-        manufacturer: Optional[Union[int, t.uint16_t]] = None,
-        expect_reply: bool = True,
-        tsn: Optional[Union[int, t.uint8_t]] = None,
-        **kwargs: Any,
-    ):
-        """Override the default Cluster command."""
-
-        return await super().command(
-            TUYA_SEND_DATA,
-            *args,
-            manufacturer=foundation.ZCLHeader.NO_MANUFACTURER_ID,
-            expect_reply=expect_reply,
-            tsn=tsn,
-            **kwargs,
         )
 
     dp_to_attribute: dict[int, DPToAttributeMapping] = {

--- a/zhaquirks/tuya/ts0601_garage.py
+++ b/zhaquirks/tuya/ts0601_garage.py
@@ -14,13 +14,12 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import NoManufacturerCluster
 from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster
 
 TUYA_MANUFACTURER_GARAGE = "tuya_manufacturer_garage"
 
 
-class TuyaGarageManufCluster(NoManufacturerCluster, TuyaMCUCluster):
+class TuyaGarageManufCluster(TuyaMCUCluster):
     """Tuya garage door opener."""
 
     ep_attribute = TUYA_MANUFACTURER_GARAGE

--- a/zhaquirks/tuya/tuya_thermostat.py
+++ b/zhaquirks/tuya/tuya_thermostat.py
@@ -99,8 +99,6 @@ class WorkingDayV02(t.enum8):
 class TuyaThermostat(Thermostat, TuyaAttributesCluster):
     """Tuya local thermostat cluster."""
 
-    manufacturer_id_override: t.uint16_t = foundation.ZCLHeader.NO_MANUFACTURER_ID
-
     _CONSTANT_ATTRIBUTES = {
         Thermostat.AttributeDefs.ctrl_sequence_of_oper.id: Thermostat.ControlSequenceOfOperation.Heating_Only
     }

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -5,7 +5,6 @@ from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTemperature
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorStateClass
 import zigpy.types as t
-from zigpy.zcl import foundation
 from zigpy.zcl.clusters.hvac import RunningState, Thermostat
 
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
@@ -51,7 +50,6 @@ class ScheduleState(t.enum8):
 class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
     """Tuya local thermostat cluster."""
 
-    manufacturer_id_override: t.uint16_t = foundation.ZCLHeader.NO_MANUFACTURER_ID
     _CONSTANT_ATTRIBUTES = {
         Thermostat.AttributeDefs.min_heat_setpoint_limit.id: 500,
         Thermostat.AttributeDefs.max_heat_setpoint_limit.id: 3000,
@@ -68,12 +66,6 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
             Thermostat.AttributeDefs.setpoint_change_source_timestamp.id
         )
         self.add_unsupported_attribute(Thermostat.AttributeDefs.pi_heating_demand.id)
-
-    async def write_attributes(self, attributes, manufacturer=None):
-        """Overwrite to force manufacturer code."""
-        return await super().write_attributes(
-            attributes, manufacturer=foundation.ZCLHeader.NO_MANUFACTURER_ID
-        )
 
 
 (


### PR DESCRIPTION
## Proposed change

This sets `manufacturer_id_override` in the `TuyaNewManufCluster` (used by the `TuyaMCUCluster`).

Before, it was overwritten in `writes_attributes`. Then, it also needed to be done in other clusters where Tuya attributes are mapped to (like `Thermostat` for TRVs/thermostats for example) due to the way how the `TuyaAttributesCluster` class forwards the fake attribute writes as a command to the ZCL cluster.

An alternative would be to always overwrite in `command()` in the Tuya MCU cluster used in our builder, but I think we can just use `manufacturer_id_override` for everything.

> [!WARNING]  
> This applies to all commands/actions now. Also to "query data" commands and so on. We should make sure that this doesn't break Tuya spells or anything else.
> 
> I've checked Z2M (they always need to explicitly define the manufacturer code if needed) and it's never done anywhere. So, this should be fine.

The "no manufacturer id" override is also removed from other classes, where it's no longer needed now.

## Additional information

After https://github.com/zigpy/zha-device-handlers/pull/3859 and without these changes, tests actually fail as expected now if the manufacturer id isn't overridden.

Supersedes:
- https://github.com/zigpy/zha-device-handlers/pull/3839


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
