### PR TITLE
Assign default manufacturer code in quirks v1 tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,6 +136,7 @@ def zigpy_device_from_quirk(MockAppController, ieee_mock):
         raw_device = zigpy.device.Device(MockAppController, ieee, nwk)
         raw_device.manufacturer = manufacturer
         raw_device.model = model
+        raw_device.node_desc = NodeDescriptor(manufacturer_code=1234)
 
         endpoints = quirk.signature.get(ENDPOINTS, {})
         for ep_id, ep_data in endpoints.items():


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This assigns all zigpy devices generated via the `zigpy_device_from_quirk` fixture a node descriptor with a `manufacturer_code`. This is needed to align more closely with actual devices.



## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Same as https://github.com/zigpy/zha-device-handlers/pull/3859 but for v1 quirks.

Requires:
- https://github.com/zigpy/zha-device-handlers/pull/3864 (tests expect `NO_MANUFACTURER_ID`, we are actually sending manufacturer codes until the linked PR is also merged)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
