### PR TITLE
Set `manufacturer_id_override` to NO_ID on `TuyaManufCluster`

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -322,6 +322,9 @@ class TuyaManufCluster(CustomCluster):
     set_time_offset = 0
     set_time_local_offset = None
 
+    # remove manufacturer id for cluster, important for `TUYA_SET_DATA` commands
+    manufacturer_id_override: t.uint16_t = foundation.ZCLHeader.NO_MANUFACTURER_ID
+
     class Command(t.Struct):
         """Tuya manufacturer cluster command."""
 


### PR DESCRIPTION
## Proposed change
This sets `manufacturer_id_override` in the old `TuyaManufCluster`.


## Additional information
Similar to:
- https://github.com/zigpy/zha-device-handlers/pull/3860


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
