### PR TITLE
Set `manufacturer_id_override` to NO_ID for Tuya IR blaster

### DIFF
--- a/zhaquirks/tuya/ts1201.py
+++ b/zhaquirks/tuya/ts1201.py
@@ -56,6 +56,9 @@ class ZosungIRControl(CustomCluster):
     cluster_id = 0xE004
     ep_attribute = "zosung_ircontrol"
 
+    # remove manufacturer id for cluster
+    manufacturer_id_override: t.uint16_t = foundation.ZCLHeader.NO_MANUFACTURER_ID
+
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
 
@@ -159,6 +162,9 @@ class ZosungIRTransmit(CustomCluster):
     name = "Zosung IR Transmit Cluster"
     cluster_id = 0xED00
     ep_attribute = "zosung_irtransmit"
+
+    # remove manufacturer id for cluster
+    manufacturer_id_override: t.uint16_t = foundation.ZCLHeader.NO_MANUFACTURER_ID
 
     current_position = 0
     msg_length = 0


### PR DESCRIPTION
## Proposed change
This forces the Tuya IR blaster to send no manufacturer id, as we generally shouldn't send one for Tuya devices.


## Additional information
Detected by:
- https://github.com/zigpy/zha-device-handlers/pull/3863


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
