### PR TITLE
Fix int data type for local calibration value of Tuya TRV

### DIFF
--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -111,7 +111,7 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
     .tuya_number(
         dp_id=27,
         attribute_name=TuyaThermostatV2.AttributeDefs.local_temperature_calibration.name,
-        type=t.uint32_t,
+        type=t.int32s,
         min_value=-6,
         max_value=6,
         unit=UnitOfTemperature.CELSIUS,
@@ -278,7 +278,7 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
     .tuya_number(
         dp_id=101,
         attribute_name=TuyaThermostatV2.AttributeDefs.local_temperature_calibration.name,
-        type=t.uint32_t,
+        type=t.int32s,
         min_value=-6,
         max_value=6,
         unit=UnitOfTemperature.CELSIUS,
@@ -351,7 +351,7 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
     .tuya_number(
         dp_id=47,
         attribute_name=TuyaThermostatV2.AttributeDefs.local_temperature_calibration.name,
-        type=t.uint32_t,
+        type=t.int32s,
         min_value=-6,
         max_value=6,
         unit=UnitOfTemperature.CELSIUS,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The value can be set from -6 to 6 so a signed integer is needed. Change type from uint32_t to int32s.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Fixes #3871

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
