### PR TITLE
Improve Tuya local temp calibration, remove setpoint min/max

### DIFF
--- a/tests/test_tuya_thermostat.py
+++ b/tests/test_tuya_thermostat.py
@@ -38,12 +38,6 @@ ZCL_TUYA_SET_TIME = b"\x09\x12\x24\x0d\x00"
         ),  # Setpoint to 25, dp 16
         (
             "_TZE204_p3lqqy2r",
-            b"\t\x17\x02\x00\n\x1c\x02\x00\x04\x00\x00\x00\x00",
-            Thermostat.AttributeDefs.local_temperature_calibration,
-            0,
-        ),  # Local calibration to 0, dp 28
-        (
-            "_TZE204_p3lqqy2r",
             b"\t\x1c\x02\x00\x0fh\x01\x00\x01\x01",
             Thermostat.AttributeDefs.running_state,
             Thermostat.RunningState.Heat_State_On,
@@ -121,3 +115,46 @@ async def test_tuya_no_mcu_version(zigpy_device_from_v2_quirk):
 
     tuya_cluster.handle_message(hdr, args)
     assert len(cluster_listener.attribute_updates) == 0
+
+
+@pytest.mark.parametrize(
+    "manuf,msg,dp_id,value",
+    [
+        (
+            "_TZE204_p3lqqy2r",
+            b"\t\x1d\x02\x00\x10\x1c\x02\x00\x04\xff\xff\xff\xf7",
+            28,
+            -9,
+        ),  # Local temp calibration to -2, dp 28
+        (
+            "_TZE204_lzriup1j",
+            b"\t\x1d\x02\x00\x10\x13\x02\x00\x04\xff\xff\xff\x9d",
+            19,
+            -99,
+        ),  # Local temp calibration to -9.9, dp 19
+    ],
+)
+async def test_handle_get_data_tmcu(
+    zigpy_device_from_v2_quirk, manuf, msg, dp_id, value
+):
+    """Test handle_get_data for multiple attributes."""
+
+    attr_id = (0xEF << 8) | dp_id
+
+    quirked = zigpy_device_from_v2_quirk(manuf, "TS0601")
+    ep = quirked.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+
+    tmcu_listener = ClusterListener(ep.tuya_manufacturer)
+
+    hdr, data = ep.tuya_manufacturer.deserialize(msg)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+
+    assert len(tmcu_listener.attribute_updates) == 1
+    assert tmcu_listener.attribute_updates[0][0] == attr_id
+    assert tmcu_listener.attribute_updates[0][1] == value
+
+    assert ep.tuya_manufacturer.get(attr_id) == value

--- a/zhaquirks/tuya/tuya_thermostat.py
+++ b/zhaquirks/tuya/tuya_thermostat.py
@@ -173,12 +173,16 @@ class NoManufTimeNoVersionRespTuyaMCUCluster(TuyaMCUCluster):
         attribute_name=TuyaThermostat.AttributeDefs.local_temperature.name,
         converter=lambda x: x * 100,
     )
-    .tuya_dp(
+    .tuya_number(
         dp_id=28,
-        ep_attribute=TuyaThermostat.ep_attribute,
-        attribute_name=Thermostat.AttributeDefs.local_temperature_calibration.name,
-        converter=lambda x: x * 100,
-        dp_converter=lambda x: x // 100,
+        attribute_name=TuyaThermostat.AttributeDefs.local_temperature_calibration.name,
+        type=t.int32s,
+        min_value=-9,
+        max_value=9,
+        unit=UnitOfTemperature.CELSIUS,
+        step=1,
+        translation_key="local_temperature_calibration",
+        fallback_name="Local temperature calibration",
     )
     .tuya_switch(
         dp_id=30,
@@ -341,12 +345,17 @@ base_avatto_quirk = (
         converter=lambda x: x * 10,
         dp_converter=lambda x: x // 10,
     )
-    .tuya_dp(
+    .tuya_number(
         dp_id=19,
-        ep_attribute=TuyaThermostat.ep_attribute,
         attribute_name=TuyaThermostat.AttributeDefs.local_temperature_calibration.name,
-        converter=lambda x: x * 10,
-        dp_converter=lambda x: x // 10,
+        type=t.int32s,
+        min_value=-9.9,
+        max_value=9.9,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.1,
+        multiplier=10,
+        translation_key="local_temperature_calibration",
+        fallback_name="Local temperature calibration",
     )
     .tuya_dp(
         dp_id=101,

--- a/zhaquirks/tuya/tuya_thermostat.py
+++ b/zhaquirks/tuya/tuya_thermostat.py
@@ -353,7 +353,7 @@ base_avatto_quirk = (
         max_value=9.9,
         unit=UnitOfTemperature.CELSIUS,
         step=0.1,
-        multiplier=10,
+        multiplier=0.1,
         translation_key="local_temperature_calibration",
         fallback_name="Local temperature calibration",
     )

--- a/zhaquirks/tuya/tuya_thermostat.py
+++ b/zhaquirks/tuya/tuya_thermostat.py
@@ -114,6 +114,11 @@ class TuyaThermostat(Thermostat, TuyaAttributesCluster):
         )
         self.add_unsupported_attribute(Thermostat.AttributeDefs.pi_heating_demand.id)
 
+        # Previously mapped, marking as explicitly unsupported.
+        self.add_unsupported_attribute(
+            Thermostat.AttributeDefs.local_temperature_calibration.id
+        )
+
 
 class NoManufTimeNoVersionRespTuyaMCUCluster(TuyaMCUCluster):
     """Tuya Manufacturer Cluster with set_time mod."""

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -66,6 +66,11 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
             Thermostat.AttributeDefs.setpoint_change_source_timestamp.id
         )
         self.add_unsupported_attribute(Thermostat.AttributeDefs.pi_heating_demand.id)
+
+        # Previously mapped, marking as explicitly unsupported.
+        self.add_unsupported_attribute(
+            Thermostat.AttributeDefs.local_temperature_calibration.id
+        )
         self.add_unsupported_attribute(
             Thermostat.AttributeDefs.min_heat_setpoint_limit.id
         )

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -51,8 +51,8 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
     """Tuya local thermostat cluster."""
 
     _CONSTANT_ATTRIBUTES = {
-        Thermostat.AttributeDefs.min_heat_setpoint_limit.id: 500,
-        Thermostat.AttributeDefs.max_heat_setpoint_limit.id: 3000,
+        Thermostat.AttributeDefs.abs_min_heat_setpoint_limit.id: 500,
+        Thermostat.AttributeDefs.abs_max_heat_setpoint_limit.id: 3000,
         Thermostat.AttributeDefs.ctrl_sequence_of_oper.id: Thermostat.ControlSequenceOfOperation.Heating_Only,
     }
 
@@ -66,6 +66,12 @@ class TuyaThermostatV2(Thermostat, TuyaAttributesCluster):
             Thermostat.AttributeDefs.setpoint_change_source_timestamp.id
         )
         self.add_unsupported_attribute(Thermostat.AttributeDefs.pi_heating_demand.id)
+        self.add_unsupported_attribute(
+            Thermostat.AttributeDefs.min_heat_setpoint_limit.id
+        )
+        self.add_unsupported_attribute(
+            Thermostat.AttributeDefs.max_heat_setpoint_limit.id
+        )
 
 
 (


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Ensure we use `tuya_number` for all `local_temperature_calibrtation` entities. 

Updates Tuya TRVs to use `abs_min_heat_setpoint_limit` and `abs_max_heat_setpoint_limit` to no longer create unnecessary config entities from ZHA.
Adds `min_heat_setpoint_limit` and `max_heat_setpoint_limit` to unsupported attributes, for TRVs to remove them on previously paired devices.

Adds tests.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
