### PR TITLE
Ensure all Tuya TRVs use int32 for local temp calibration

### DIFF
--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -145,7 +145,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     .tuya_number(
         dp_id=27,
         attribute_name=TuyaThermostatV2NoSchedule.AttributeDefs.local_temperature_calibration.name,
-        type=t.uint32_t,
+        type=t.int32_t,
         min_value=-6,
         max_value=6,
         unit=UnitOfTemperature.CELSIUS,

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -145,7 +145,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     .tuya_number(
         dp_id=27,
         attribute_name=TuyaThermostatV2NoSchedule.AttributeDefs.local_temperature_calibration.name,
-        type=t.int32_t,
+        type=t.int32s,
         min_value=-6,
         max_value=6,
         unit=UnitOfTemperature.CELSIUS,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Missed a uint to int in Tuya TRVs.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
