### PR TITLE
Add quirk for Colorock power monitor switch

### DIFF
--- a/zhaquirks/tuya/ts0001_switch.py
+++ b/zhaquirks/tuya/ts0001_switch.py
@@ -2,13 +2,23 @@
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.tuya import TuyaZBOnOffAttributeCluster
 
 
+class CustomElectricalMeasurement(ElectricalMeasurement, CustomCluster):
+    """Custom electrical measurement cluster."""
+
+    _CONSTANT_ATTRIBUTES = {
+        ElectricalMeasurement.AttributeDefs.ac_current_multiplier.id: 1,
+        ElectricalMeasurement.AttributeDefs.ac_current_divisor.id: 1000,
+    }
+
+
 class CustomMetering(Metering, CustomCluster):
-    """Tuya Valve Water consumed cluster."""
+    """Custom metering cluster."""
 
     KILOWATT_HOURS = 0x0
     ELECTRIC_METERING = 0x0
@@ -16,12 +26,26 @@ class CustomMetering(Metering, CustomCluster):
     _CONSTANT_ATTRIBUTES = {
         Metering.AttributeDefs.unit_of_measure.id: KILOWATT_HOURS,
         Metering.AttributeDefs.metering_device_type.id: ELECTRIC_METERING,
+        Metering.AttributeDefs.multiplier.id: 1,
+        Metering.AttributeDefs.divisor.id: 100,
     }
 
 
 (
-    QuirkBuilder("_TZ3000_tgddllx4", "TS0001")
+    QuirkBuilder("_TZ3000_xkap8wtb", "TS0001")
+    .applies_to("_TZ3000_qnejhcsu", "TS0001")
+    .applies_to("_TZ3000_x3ewpzyr", "TS0001")
+    .applies_to("_TZ3000_mkhkxx1p", "TS0001")
+    .applies_to("_TZ3000_tgddllx4", "TS0001")
+    .applies_to("_TZ3000_kqvb5akv", "TS0001")
+    .applies_to("_TZ3000_g92baclx", "TS0001")
+    .applies_to("_TZ3000_qlai3277", "TS0001")
+    .applies_to("_TZ3000_qaabwu5c", "TS0001")
+    .applies_to("_TZ3000_ikuxinvo", "TS0001")
+    .applies_to("_TZ3000_hzlsaltw", "TS0001")
+    .applies_to("_TZ3000_jsfzkftc", "TS0001")
     .replaces(CustomMetering)
+    .replaces(CustomElectricalMeasurement)
     .replaces(TuyaZBOnOffAttributeCluster)
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0001_switch.py
+++ b/zhaquirks/tuya/ts0001_switch.py
@@ -1,0 +1,27 @@
+"""Tuya switch device."""
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.smartenergy import Metering
+
+from zhaquirks.tuya import TuyaZBOnOffAttributeCluster
+
+
+class CustomMetering(Metering, CustomCluster):
+    """Tuya Valve Water consumed cluster."""
+
+    KILOWATT_HOURS = 0x0
+    ELECTRIC_METERING = 0x0
+
+    _CONSTANT_ATTRIBUTES = {
+        Metering.AttributeDefs.unit_of_measure.id: KILOWATT_HOURS,
+        Metering.AttributeDefs.metering_device_type.id: ELECTRIC_METERING,
+    }
+
+
+(
+    QuirkBuilder("_TZ3000_tgddllx4", "TS0001")
+    .replaces(CustomMetering)
+    .replaces(TuyaZBOnOffAttributeCluster)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The device is missing the type and unit for the energy to be displayed properly, and divisors for energy and current.
Also, needs the OnOff replacement for the `start_up_on_off` attribute to work.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Product page: https://www.aliexpress.com/item/1005005037224711.html
Device on Z2M: https://www.zigbee2mqtt.io/devices/CR-MNZ1.html


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
