### PR TITLE
Add Innr SP 242 plug quirk

### DIFF
--- a/zhaquirks/innr/innr_sp242_plug.py
+++ b/zhaquirks/innr/innr_sp242_plug.py
@@ -1,0 +1,11 @@
+"""Innr SP 242 plug."""
+
+from zigpy.quirks.v2 import QuirkBuilder
+
+from zhaquirks.innr import INNR, MeteringClusterInnr
+
+(
+    QuirkBuilder(INNR, "SP 242")
+    .replaces(MeteringClusterInnr, endpoint_id=1)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

V2 Quirk for the inner SP-242 plug that updates the MeteringCluster to use the existing MeteringClusterInnr. This adds a divisor for the summed energy usage to report correct usage.

## Additional information

Tested in HA as a custom quirk against an SP-242.

## Checklist

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [X] Tests have been added to verify that the new code works



Related: #4009
