### PR TITLE
Add Tuya solar valve `_TZE200_arge1ptm`

### DIFF
--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -16,7 +16,7 @@ from zhaquirks.const import BatterySize
 from zhaquirks.tuya import TUYA_CLUSTER_ID
 from zhaquirks.tuya.builder import TuyaQuirkBuilder, TuyaValveWaterConsumed
 from zhaquirks.tuya.mcu import TuyaMCUCluster
-from zigpy.backports.enum import StrEnum
+from zigpy.quirks.v2.homeassistant import PERCENTAGE
 
 
 class TuyaValveWeatherDelay(t.enum8):

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta, timezone
 
+from zigpy.backports.enum import StrEnum
 from zigpy.quirks.v2 import BinarySensorDeviceClass, EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant import (
     UnitOfElectricPotential,
@@ -16,7 +17,6 @@ from zhaquirks.const import BatterySize
 from zhaquirks.tuya import TUYA_CLUSTER_ID
 from zhaquirks.tuya.builder import TuyaQuirkBuilder, TuyaValveWaterConsumed
 from zhaquirks.tuya.mcu import TuyaMCUCluster
-from zigpy.backports.enum import StrEnum
 
 
 class TuyaValveWeatherDelay(t.enum8):
@@ -707,6 +707,7 @@ class GiexIrrigationStatus(t.enum8):
     .add_to_registry()
 )
 
+
 # Proportion units
 class UnitOfProportion(StrEnum):
     """Proportion units."""
@@ -719,7 +720,7 @@ class UnitOfProportion(StrEnum):
     TuyaQuirkBuilder("_TZE200_arge1ptm", "TS0601")
     .applies_to("_TZE200_anv5ujhv", "TS0601")
     .applies_to("_TZE200_xlppj4f5", "TS0601")
-#    .tuya_onoff(dp_id=1)                           # onoff does not appear to do anything.  Z2M ignores it, so commented out until somebody works out what it does
+    #    .tuya_onoff(dp_id=1)                           # onoff does not appear to do anything.  Z2M ignores it, so commented out until somebody works out what it does
     .tuya_number(
         dp_id=2,
         attribute_name="valve_state_auto_shutdown",

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -16,7 +16,7 @@ from zhaquirks.const import BatterySize
 from zhaquirks.tuya import TUYA_CLUSTER_ID
 from zhaquirks.tuya.builder import TuyaQuirkBuilder, TuyaValveWaterConsumed
 from zhaquirks.tuya.mcu import TuyaMCUCluster
-
+from zigpy.quirks.v2.homeassistant import PERCENTAGE
 
 class TuyaValveWeatherDelay(t.enum8):
     """Tuya Irrigation Valve weather delay enum."""

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime, timedelta, timezone
 
-from zigpy.backports.enum import StrEnum
 from zigpy.quirks.v2 import BinarySensorDeviceClass, EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant import (
     UnitOfElectricPotential,
@@ -17,7 +16,6 @@ from zhaquirks.const import BatterySize
 from zhaquirks.tuya import TUYA_CLUSTER_ID
 from zhaquirks.tuya.builder import TuyaQuirkBuilder, TuyaValveWaterConsumed
 from zhaquirks.tuya.mcu import TuyaMCUCluster
-from zigpy.quirks.v2.homeassistant import PERCENTAGE
 
 
 class TuyaValveWeatherDelay(t.enum8):
@@ -713,7 +711,6 @@ class GiexIrrigationStatus(t.enum8):
     TuyaQuirkBuilder("_TZE200_arge1ptm", "TS0601")
     .applies_to("_TZE200_anv5ujhv", "TS0601")
     .applies_to("_TZE200_xlppj4f5", "TS0601")
-
     .tuya_number(
         dp_id=2,
         attribute_name="valve_state_auto_shutdown",

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -16,6 +16,7 @@ from zhaquirks.const import BatterySize
 from zhaquirks.tuya import TUYA_CLUSTER_ID
 from zhaquirks.tuya.builder import TuyaQuirkBuilder, TuyaValveWaterConsumed
 from zhaquirks.tuya.mcu import TuyaMCUCluster
+from zigpy.backports.enum import StrEnum
 
 
 class TuyaValveWeatherDelay(t.enum8):
@@ -702,6 +703,71 @@ class GiexIrrigationStatus(t.enum8):
         entity_type=EntityType.STANDARD,
         fallback_name="Voltage",
     )
+    .skip_configuration()
+    .add_to_registry()
+)
+
+# Proportion units
+class UnitOfProportion(StrEnum):
+    """Proportion units."""
+
+    PERCENT = "%"
+
+
+# Tuya Solar Valve
+(
+    TuyaQuirkBuilder("_TZE200_arge1ptm", "TS0601")
+    .applies_to("_TZE200_anv5ujhv", "TS0601")
+    .applies_to("_TZE200_xlppj4f5", "TS0601")
+#    .tuya_onoff(dp_id=1)                           # onoff does not appear to do anything.  Z2M ignores it, so commented out until somebody works out what it does
+    .tuya_number(
+        dp_id=2,
+        attribute_name="valve_state_auto_shutdown",
+        type=t.uint32_t,
+        min_value=0,
+        max_value=100,
+        step=5,
+        unit=UnitOfProportion.PERCENT,
+        translation_key="valve_state_auto_shutdown",
+        fallback_name="Valve state auto shutdown",
+    )
+    .tuya_sensor(
+        dp_id=3,
+        attribute_name="water_flow",
+        type=t.uint32_t,
+        unit=UnitOfProportion.PERCENT,
+        translation_key="water_flow",
+        fallback_name="Water flow",
+    )
+    .tuya_number(
+        dp_id=11,
+        attribute_name="shutdown_timer",
+        type=t.uint32_t,
+        min_value=0,
+        max_value=14400,
+        step=5,
+        unit=UnitOfTime.SECONDS,
+        translation_key="shutdown_timer",
+        fallback_name="Shutdown timer",
+    )
+    .tuya_sensor(
+        dp_id=101,
+        attribute_name="remaining_watering_time",
+        type=t.uint32_t,
+        unit=UnitOfTime.SECONDS,
+        translation_key="remaining_watering_time",
+        fallback_name="Remaining watering time",
+    )
+    .tuya_sensor(
+        dp_id=107,
+        attribute_name="last_watering_duration",
+        type=t.uint32_t,
+        unit=UnitOfTime.SECONDS,
+        translation_key="last_watering_duration",
+        fallback_name="Last watering duration",
+    )
+    .tuya_battery(dp_id=110, battery_type=BatterySize.AA, battery_qty=2)
+    .tuya_enchantment()
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 from zigpy.quirks.v2 import BinarySensorDeviceClass, EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant import (
+    PERCENTAGE,
     UnitOfElectricPotential,
     UnitOfTime,
     UnitOfVolume,
@@ -16,7 +17,7 @@ from zhaquirks.const import BatterySize
 from zhaquirks.tuya import TUYA_CLUSTER_ID
 from zhaquirks.tuya.builder import TuyaQuirkBuilder, TuyaValveWaterConsumed
 from zhaquirks.tuya.mcu import TuyaMCUCluster
-from zigpy.quirks.v2.homeassistant import PERCENTAGE
+
 
 class TuyaValveWeatherDelay(t.enum8):
     """Tuya Irrigation Valve weather delay enum."""

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -708,20 +708,12 @@ class GiexIrrigationStatus(t.enum8):
     .add_to_registry()
 )
 
-
-# Proportion units
-class UnitOfProportion(StrEnum):
-    """Proportion units."""
-
-    PERCENT = "%"
-
-
 # Tuya Solar Valve
 (
     TuyaQuirkBuilder("_TZE200_arge1ptm", "TS0601")
     .applies_to("_TZE200_anv5ujhv", "TS0601")
     .applies_to("_TZE200_xlppj4f5", "TS0601")
-    #    .tuya_onoff(dp_id=1)                           # onoff does not appear to do anything.  Z2M ignores it, so commented out until somebody works out what it does
+
     .tuya_number(
         dp_id=2,
         attribute_name="valve_state_auto_shutdown",
@@ -729,7 +721,7 @@ class UnitOfProportion(StrEnum):
         min_value=0,
         max_value=100,
         step=5,
-        unit=UnitOfProportion.PERCENT,
+        unit=UnitOfProportion.PERCENTAGE,
         translation_key="valve_state_auto_shutdown",
         fallback_name="Valve state auto shutdown",
     )
@@ -737,7 +729,7 @@ class UnitOfProportion(StrEnum):
         dp_id=3,
         attribute_name="water_flow",
         type=t.uint32_t,
-        unit=UnitOfProportion.PERCENT,
+        unit=UnitOfProportion.PERCENTAGE,
         translation_key="water_flow",
         fallback_name="Water flow",
     )

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -721,7 +721,7 @@ class GiexIrrigationStatus(t.enum8):
         min_value=0,
         max_value=100,
         step=5,
-        unit=UnitOfProportion.PERCENTAGE,
+        unit=PERCENTAGE,
         translation_key="valve_state_auto_shutdown",
         fallback_name="Valve state auto shutdown",
     )
@@ -729,7 +729,7 @@ class GiexIrrigationStatus(t.enum8):
         dp_id=3,
         attribute_name="water_flow",
         type=t.uint32_t,
-        unit=UnitOfProportion.PERCENTAGE,
+        unit=PERCENTAGE,
         translation_key="water_flow",
         fallback_name="Water flow",
     )


### PR DESCRIPTION
## Proposed change
Add support for Tuya solar valve _TZE200_arge1ptm.  Used information from Z2M so that this valve can be used in core Home Assistant ZHA module


## Additional information
Closes: https://github.com/zigpy/zha-device-handlers/issues/1551

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
