### PR TITLE
Add Tuya curtain motor `_TZE200_rmymn92d`

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -1,7 +1,16 @@
 """Tuya based cover and blinds."""
 
 from zigpy.profiles import zha
-from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Groups, Identify, OnOff, Ota, Scenes, Time
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -346,6 +355,7 @@ class TuyaZemismartSmartCover0601_2_inv_position(TuyaWindowCover):
             },
         },
     }
+
 
 class TuyaZemismartSmartCover0601_2_inv_position_ac(TuyaWindowCover):
     """Tuya Zemismart curtain cover motor, AC-powered."""

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -1,7 +1,7 @@
 """Tuya based cover and blinds."""
 
 from zigpy.profiles import zha
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
+from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Groups, Identify, OnOff, Ota, Scenes, Time
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -345,6 +345,77 @@ class TuyaZemismartSmartCover0601_2_inv_position(TuyaWindowCover):
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
         },
+    }
+
+class TuyaZemismartSmartCover0601_2_inv_position_ac(TuyaWindowCover):
+    """Tuya Zemismart curtain cover motor, AC-powered."""
+
+    tuya_cover_inverted_by_default = True
+
+    signature = {
+        # "node_descriptor": { "logical_type": 1, "complex_descriptor_available": 0, "user_descriptor_available": 0,
+        #                      "reserved": 0, "aps_flags": 0, "frequency_band": 8, "mac_capability_flags": 142,
+        #                      "manufacturer_code": 4417, "maximum_buffer_size": 66, "maximum_incoming_transfer_size": 66,
+        #                      "server_mask": 10752, "maximum_outgoing_transfer_size": 66, "descriptor_capability_field": 0
+        #                    },
+        # "endpoints": {
+        # "1": { "profile_id": "0x0104", "device_type": "0x0202",
+        #        "input_clusters": [ "0x0000", "0x0004", "0x0005", "0x0102", "0xef00" ],
+        #        "output_clusters": [ "0x000a", "0x0019" ]
+        #      },
+        # "242": { "profile_id": "0xa1e0",
+        #          "device_type": "0x0061",
+        #          "input_clusters": [],
+        #          "output_clusters": [ "0x0021" ]
+        #        }
+        # },
+        # "manufacturer": "_TZE200_rmymn92d",
+        # "model": "TS0601",
+        MODELS_INFO: [
+            ("_TZE200_rmymn92d", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufacturerWindowCover,
+                    TuyaWindowCoverControl,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
     }
 
 


### PR DESCRIPTION
## Proposed change
This adds support for Tuya curtain motors with the manufacturer string `_TZE200_rmymn92d`.


## Additional information
Fixes: #3269

This is based on the custom quirk here: https://github.com/zigpy/zha-device-handlers/issues/1294#issuecomment-1652977726 (with a few minor changes - most notably, inverting the cover by default).

This works locally against my curtain. All features appear to be functional and work correctly: controlling the curtain with open/close/stop, opening/closing to a percentage, and status reporting.

There are a few mysteries that I haven't solved; I'm not an expert in Zigbee or Tuya devices:
1. Status reporting is really laggy.
2. Most people's device signatures posted across various issues don't include the input cluster `0x0102` in endpoint 1, but my motor exposes this cluster. I have no idea what this cluster does and didn't add it to the quirk.
3. Unlike all of the other devices in this file, this curtain motor appears to support Green Power Proxy as it exposes endpoint 242.
4. The firmware version can't be read by ZHA. I don't have any other Tuya Zigbee devices, so I don't know if this is typical.
5. The quirk exposes a `_window_covering_type` entity that is always `Unknown`.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
