### PR TITLE
Expose Sonoff TRVZB attributes for 1.3 firmware

### DIFF
--- a/zhaquirks/sonoff/trvzb.py
+++ b/zhaquirks/sonoff/trvzb.py
@@ -70,6 +70,21 @@ class CustomSonoffCluster(CustomCluster):
             type=t.uint8_t,
         )
 
+        external_temperature_sensor_enable = ZCLAttributeDef(
+            id=0x600E,
+            type=t.uint8_t,
+        )
+
+        external_temperature_sensor_value = ZCLAttributeDef(
+            id=0x600D,
+            type=t.int16s,
+        )
+
+        temperature_control_accuracy = ZCLAttributeDef(
+            id=0x6011,
+            type=t.int16s,
+        )
+
     @property
     def _is_manuf_specific(self):
         return False
@@ -120,6 +135,34 @@ class CustomSonoffCluster(CustomCluster):
         translation_key="valve_closing_degree",
         fallback_name="Valve closing degree",
         initially_disabled=True,
+    )
+    .number(
+        CustomSonoffCluster.AttributeDefs.temperature_control_accuracy.name,
+        CustomSonoffCluster.cluster_id,
+        min_value=-1.0,
+        max_value=-0.2,
+        step=0.2,
+        unit=UnitOfTemperature.CELSIUS,
+        multiplier=0.01,
+        translation_key="temperature_control_accuracy",
+        fallback_name="Temperature control accuracy",
+    )
+    .switch(
+        CustomSonoffCluster.AttributeDefs.external_temperature_sensor_enable.name,
+        CustomSonoffCluster.cluster_id,
+        translation_key="external_temperature_sensor_enable",
+        fallback_name="External temperature sensor",
+    )
+    .number(
+        CustomSonoffCluster.AttributeDefs.external_temperature_sensor_value.name,
+        CustomSonoffCluster.cluster_id,
+        min_value=0.0,
+        max_value=99.9,
+        step=0.1,
+        unit=UnitOfTemperature.CELSIUS,
+        multiplier=0.01,
+        translation_key="external_temperature_sensor_value",
+        fallback_name="External temperature sensor value",
     )
     .add_to_registry()
 )

--- a/zhaquirks/sonoff/trvzb.py
+++ b/zhaquirks/sonoff/trvzb.py
@@ -1,7 +1,7 @@
 """Sonoff TRVZB - Zigbee Thermostatic Radiator Valve."""
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2 import NumberDeviceClass, QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTemperature
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
@@ -142,6 +142,7 @@ class CustomSonoffCluster(CustomCluster):
         min_value=-1.0,
         max_value=-0.2,
         step=0.2,
+        device_class=NumberDeviceClass.TEMPERATURE,
         unit=UnitOfTemperature.CELSIUS,
         multiplier=0.01,
         translation_key="temperature_control_accuracy",
@@ -159,6 +160,7 @@ class CustomSonoffCluster(CustomCluster):
         min_value=0.0,
         max_value=99.9,
         step=0.1,
+        device_class=NumberDeviceClass.TEMPERATURE,
         unit=UnitOfTemperature.CELSIUS,
         multiplier=0.01,
         translation_key="external_temperature_sensor_value",

--- a/zhaquirks/sonoff/trvzb.py
+++ b/zhaquirks/sonoff/trvzb.py
@@ -150,7 +150,7 @@ class CustomSonoffCluster(CustomCluster):
     .switch(
         CustomSonoffCluster.AttributeDefs.external_temperature_sensor_enable.name,
         CustomSonoffCluster.cluster_id,
-        translation_key="external_temperature_sensor_enable",
+        translation_key="external_temperature_sensor",
         fallback_name="External temperature sensor",
     )
     .number(


### PR DESCRIPTION
## Proposed change
This change exposes new attributes of the current firmware.

Values are adopted from zigbee-herdsman:
https://github.com/Koenkk/zigbee-herdsman-converters/pull/8837
https://github.com/Koenkk/zigbee-herdsman-converters/pull/8873

I am unsure about the naming. [Hysteresis](https://en.wikipedia.org/wiki/Hysteresis) could be better than "Temperature control accuracy". 

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
