### PR TITLE
Add Sonoff water valve leak and supply sensors

### DIFF
--- a/zhaquirks/sonoff/swv.py
+++ b/zhaquirks/sonoff/swv.py
@@ -38,7 +38,7 @@ class CustomSonoffCluster(CustomCluster):
     .binary_sensor(
         CustomSonoffCluster.AttributeDefs.water_valve_state.name,
         CustomSonoffCluster.cluster_id,
-        device_class=BinarySensorDeviceClass.PROBLEM,
+        device_class=BinarySensorDeviceClass.MOISTURE,
         attribute_converter=lambda x: x & ValveState.Water_Leakage,
         unique_id_suffix="water_leak_status",
         reporting_config=ReportingConfig(

--- a/zhaquirks/sonoff/swv.py
+++ b/zhaquirks/sonoff/swv.py
@@ -1,9 +1,10 @@
 """Sonoff SWV - Zigbee smart water valve."""
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2 import QuirkBuilder, ReportingConfig
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 import zigpy.types as t
+from zigpy.zcl import foundation
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 
@@ -20,6 +21,7 @@ class CustomSonoffCluster(CustomCluster):
     """Custom Sonoff cluster."""
 
     cluster_id = 0xFC11
+    manufacturer_id_override: t.uint16_t = foundation.ZCLHeader.NO_MANUFACTURER_ID
 
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
@@ -28,10 +30,6 @@ class CustomSonoffCluster(CustomCluster):
             id=0x500C,
             type=ValveState,
         )
-
-    @property
-    def _is_manuf_specific(self):
-        return False
 
 
 (
@@ -43,6 +41,9 @@ class CustomSonoffCluster(CustomCluster):
         device_class=BinarySensorDeviceClass.PROBLEM,
         attribute_converter=lambda x: x & ValveState.Water_Leakage,
         unique_id_suffix="water_leak_status",
+        reporting_config=ReportingConfig(
+            min_interval=30, max_interval=900, reportable_change=1
+        ),
         translation_key="water_leak",
         fallback_name="Water leak",
     )

--- a/zhaquirks/sonoff/swv.py
+++ b/zhaquirks/sonoff/swv.py
@@ -57,4 +57,4 @@ class CustomSonoffCluster(CustomCluster):
         fallback_name="Water supply",
     )
     .add_to_registry()
-)  # fmt: skip
+)

--- a/zhaquirks/sonoff/swv.py
+++ b/zhaquirks/sonoff/swv.py
@@ -2,6 +2,7 @@
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
@@ -15,8 +16,8 @@ class ValveState(t.enum8):
     Water_Shortage_And_Leakage = 3
 
 
-class EwelinkCluster(CustomCluster):
-    """Ewelink specific cluster."""
+class CustomSonoffCluster(CustomCluster):
+    """Custom Sonoff cluster."""
 
     cluster_id = 0xFC11
 
@@ -35,6 +36,24 @@ class EwelinkCluster(CustomCluster):
 
 (
     QuirkBuilder("SONOFF", "SWV")
-    .replaces(EwelinkCluster)
+    .replaces(CustomSonoffCluster)
+    .binary_sensor(
+        CustomSonoffCluster.AttributeDefs.water_valve_state.name,
+        CustomSonoffCluster.cluster_id,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        attribute_converter=lambda x: x & ValveState.Water_Leakage,
+        unique_id_suffix="water_leak_status",
+        translation_key="water_leak",
+        fallback_name="Water leak",
+    )
+    .binary_sensor(
+        CustomSonoffCluster.AttributeDefs.water_valve_state.name,
+        CustomSonoffCluster.cluster_id,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        attribute_converter=lambda x: x & ValveState.Water_Shortage,
+        unique_id_suffix="water_supply_status",
+        translation_key="water_supply",
+        fallback_name="Water supply",
+    )
     .add_to_registry()
 )  # fmt: skip


### PR DESCRIPTION
## Proposed change

Add sensors for water leaks and supply problems.
While here rename EwelinkCluster to match other Sonoff quirks.

## Additional information

Follow-up from https://github.com/zigpy/zha-device-handlers/pull/3346. 
Supersedes https://github.com/zigpy/zha/pull/189.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
