### PR TITLE
Add Tuya cover TS0601 `_TZE200_ba69l9ol` variant

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -176,6 +176,7 @@ class TuyaZemismartSmartCover0601_3(TuyaWindowCover):
             ("_TZE200_iossyxra", "TS0601"),
             ("_TZE200_pw7mji0l", "TS0601"),
             ("_TZE200_9vpe3fl1", "TS0601"),
+            ("_TZE200_ba69l9ol", "TS0601"),
         ],
         ENDPOINTS: {
             1: {

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -176,7 +176,6 @@ class TuyaZemismartSmartCover0601_3(TuyaWindowCover):
             ("_TZE200_iossyxra", "TS0601"),
             ("_TZE200_pw7mji0l", "TS0601"),
             ("_TZE200_9vpe3fl1", "TS0601"),
-            ("_TZE200_ba69l9ol", "TS0601"),
         ],
         ENDPOINTS: {
             1: {
@@ -223,6 +222,7 @@ class TuyaZemismartSmartCover0601_3_inv_position(TuyaWindowCover):
         # <SimpleDescriptor endpoint=1 profile=260 device_type=51 input_clusters=[0, 4, 5, 61184] output_clusters=[25]>
         MODELS_INFO: [
             ("_TZE200_zpzndjez", "TS0601"),
+            ("_TZE200_ba69l9ol", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
New cover model _TZE200_ba69l9ol added for Tuya TS0601

## Additional information
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/e17ee871-b1ff-4411-b9de-a4c66d35f3ed" />
New Python file was tested as a custom quirk and works as intended.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
