### PR TITLE
Add Tuya siren `_TZE284_nlrfgpny` variant

### DIFF
--- a/zhaquirks/tuya/tuya_siren.py
+++ b/zhaquirks/tuya/tuya_siren.py
@@ -134,6 +134,7 @@ class NeoBatteryState(t.enum8):
 (
     TuyaQuirkBuilder("_TZE204_nlrfgpny", "TS0601")
     .applies_to("TZE200_nlrfgpny", "TS0601")
+    .applies_to("_TZE284_nlrfgpny", "TS0601")
     .tuya_enum(
         dp_id=1,
         attribute_name="alarm_state",


### PR DESCRIPTION
## Proposed change
add support for siren _TZE284_nlrfgpny


## Additional information
quirks was already working for similar models, the one I received from Aliexpress had a different model ID, so just trying adding the ID _TZE284_nlrfgpny worked for me in Home Assistant 2025.03 with ZHA.

![image](https://github.com/user-attachments/assets/e1d5567c-8c4c-4c2d-802d-8c65eaf0dc45)



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
