### PR TITLE
Add Tuya/NEO soil sensor NAS-STH02B2 `_TZE284_rqcuwlsa`

### DIFF
--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -20,6 +20,7 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.measurement import (
     PM25,
     CarbonDioxideConcentration,
+    ElectricalConductivity,
     FormaldehydeConcentration,
     IlluminanceMeasurement,
     RelativeHumidity,
@@ -63,6 +64,10 @@ BATTERY_VOLTAGES = {
 
 class TuyaCO2Concentration(CarbonDioxideConcentration, TuyaLocalCluster):
     """Tuya Carbon Dioxide concentration measurement."""
+
+
+class TuyaElectricalConductivity(ElectricalConductivity, TuyaLocalCluster):
+    """Tuya Electrical Conductivity measurement."""
 
 
 class TuyaFormaldehydeConcentration(FormaldehydeConcentration, TuyaLocalCluster):
@@ -293,6 +298,22 @@ class TuyaQuirkBuilder(QuirkBuilder):
             converter=lambda x: x * scale,
         )
         self.adds(co2_cfg)
+        return self
+
+    def tuya_electrical_conductivity(
+        self,
+        dp_id: int,
+        ec_cfg: TuyaLocalCluster = TuyaElectricalConductivity,
+        scale: float = 1,
+    ) -> QuirkBuilder:
+        """Add a Tuya Electrical Conductivity Configuration."""
+        self.tuya_dp(
+            dp_id,
+            ec_cfg.ep_attribute,
+            ElectricalConductivity.AttributeDefs.measured_value.name,
+            converter=lambda x: x * scale,
+        )
+        self.adds(ec_cfg)
         return self
 
     def tuya_formaldehyde(

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -267,6 +267,18 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
 
 
 (
+    TuyaQuirkBuilder("_TZE284_rqcuwlsa", "TS0601")  # NEO NAS-STH02B2
+    .tuya_battery(dp_id=15)
+    .tuya_electrical_conductivity(dp_id=1)
+    .tuya_soil_moisture(dp_id=3)
+    .tuya_temperature(dp_id=5, scale=10)
+    .tuya_enchantment(data_query_spell=True)
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+(
     TuyaQuirkBuilder("_TZE200_myd45weu", "TS0601")
     .applies_to("_TZE200_ga1maeof", "TS0601")
     .applies_to("_TZE200_9cqcpkgb", "TS0601")


### PR DESCRIPTION
## Proposed change

This adds support for the [NEO NAS-STH02B2](https://www.zigbee2mqtt.io/devices/NAS-STH02B2.html) `_TZE284_rqcuwlsa`.

This was heavily inspired from this code: https://github.com/Koenkk/zigbee-herdsman-converters/blob/v23.4.0/src/devices/neo.ts#L369-L456

## Additional information

It works fine for all attributes but the electrical conductivity sensor which does not show in the entities:

![image](https://github.com/user-attachments/assets/264cb84c-c5ff-4341-87dc-d6d790f1cc94)

In Z2M, it reports correctly (value changes when putting the device in different physical conditions):
![image](https://github.com/user-attachments/assets/a4009b5d-59aa-48a3-a134-aa449ef934bd)

## Checklist
* [ ]  The changes are tested and work correctly
* [x]  `pre-commit` checks pass / the code has been formatted using Black
* [ ]  Tests have been added to verify that the new code works