### PR TITLE
Add Linptech ES1ZZ(TY) TS0225 presence sensor `_TZ3218_awarhusb`

### DIFF
--- a/zhaquirks/tuya/ts0225_presence.py
+++ b/zhaquirks/tuya/ts0225_presence.py
@@ -10,7 +10,7 @@ from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
 class TS0225Cluster(CustomCluster):
-    """TS0225 specific cluster"""
+    """TS0225 specific cluster."""
 
     cluster_id = 0xE002
 

--- a/zhaquirks/tuya/ts0225_presence.py
+++ b/zhaquirks/tuya/ts0225_presence.py
@@ -1,7 +1,7 @@
 """TS0225 presence sensor."""
 
-from homeassistant.const import UnitOfLength, UnitOfTime
 from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2.homeassistant import UnitOfLength, UnitOfTime
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef

--- a/zhaquirks/tuya/ts0225_presence.py
+++ b/zhaquirks/tuya/ts0225_presence.py
@@ -88,8 +88,8 @@ class TS0225Cluster(CustomCluster):
         max_value=10000,
         step=1,
         unit=UnitOfTime.SECONDS,
+        fallback_name="Fading time",
         translation_key="fading_time",
-        fallback_name="fading_time",
     )
     .skip_configuration()
     .add_to_registry()

--- a/zhaquirks/tuya/ts0225_presence.py
+++ b/zhaquirks/tuya/ts0225_presence.py
@@ -1,46 +1,34 @@
 """TS0225 presence sensor."""
 
-from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
-from zigpy.quirks import CustomCluster
-from zhaquirks.tuya.builder import TuyaQuirkBuilder
-
 from homeassistant.const import UnitOfLength, UnitOfTime
-
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
-import zigpy.types as t
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
 
 class TS0225Cluster(CustomCluster):
     cluster_id = 0xE002
+
     class AttributeDefs(BaseAttributeDefs):
         presence_keep_time = ZCLAttributeDef(
-            id = 0xE001,
-            type = t.uint16_t,
-            is_manufacturer_specific=False
+            id=0xE001, type=t.uint16_t, is_manufacturer_specific=False
         )
         motion_detection_sensitivity = ZCLAttributeDef(
-            id = 0xE004,
-            type = t.uint8_t,
-            access="rw",
-            is_manufacturer_specific=False
+            id=0xE004, type=t.uint8_t, access="rw", is_manufacturer_specific=False
         )
         static_detection_sensitivity = ZCLAttributeDef(
-            id = 0xE005,
-            type = t.uint8_t,
-            access="rw",
-            is_manufacturer_specific=False
+            id=0xE005, type=t.uint8_t, access="rw", is_manufacturer_specific=False
         )
         target_distance = ZCLAttributeDef(
-            id = 0xE00A,
-            type = t.uint16_t,
-            is_manufacturer_specific=False
+            id=0xE00A, type=t.uint16_t, is_manufacturer_specific=False
         )
         motion_detection_distance = ZCLAttributeDef(
-            id = 0xE00B,
-            type = t.uint16_t,
-            access="rw",
-            is_manufacturer_specific=False
+            id=0xE00B, type=t.uint16_t, access="rw", is_manufacturer_specific=False
         )
+
 
 (
     TuyaQuirkBuilder("_TZ3218_awarhusb", "TS0225")
@@ -50,14 +38,14 @@ class TS0225Cluster(CustomCluster):
         TS0225Cluster.cluster_id,
         unit=UnitOfLength.CENTIMETERS,
         fallback_name="Target distance",
-        translation_key="target_distance"
+        translation_key="target_distance",
     )
     .sensor(
         TS0225Cluster.AttributeDefs.presence_keep_time.name,
         TS0225Cluster.cluster_id,
         unit=UnitOfTime.MINUTES,
         fallback_name="Presence keep time",
-        translation_key="presence_keep_time"
+        translation_key="presence_keep_time",
     )
     .number(
         TS0225Cluster.AttributeDefs.motion_detection_sensitivity.name,
@@ -66,7 +54,7 @@ class TS0225Cluster(CustomCluster):
         max_value=5,
         step=1,
         fallback_name="Motion detection sensitivity",
-        translation_key="motion_detection_sensitivity"
+        translation_key="motion_detection_sensitivity",
     )
     .number(
         TS0225Cluster.AttributeDefs.static_detection_sensitivity.name,
@@ -75,7 +63,7 @@ class TS0225Cluster(CustomCluster):
         max_value=5,
         step=1,
         fallback_name="Static detection sensitivity",
-        translation_key="static_detection_sensitivity"
+        translation_key="static_detection_sensitivity",
     )
     .number(
         TS0225Cluster.AttributeDefs.motion_detection_distance.name,
@@ -86,7 +74,7 @@ class TS0225Cluster(CustomCluster):
         device_class=NumberDeviceClass.DISTANCE,
         step=75,
         fallback_name="Motion detection distance",
-        translation_key="motion_detection_distance"
+        translation_key="motion_detection_distance",
     )
     .tuya_number(
         dp_id=101,

--- a/zhaquirks/tuya/ts0225_presence.py
+++ b/zhaquirks/tuya/ts0225_presence.py
@@ -10,9 +10,13 @@ from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
 class TS0225Cluster(CustomCluster):
+    """ TS0225 specific cluster """
+
     cluster_id = 0xE002
 
     class AttributeDefs(BaseAttributeDefs):
+        """Attribute Definitions."""
+
         presence_keep_time = ZCLAttributeDef(
             id=0xE001, type=t.uint16_t, is_manufacturer_specific=False
         )

--- a/zhaquirks/tuya/ts0225_presence.py
+++ b/zhaquirks/tuya/ts0225_presence.py
@@ -1,0 +1,104 @@
+"""TS0225 presence sensor."""
+
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+from zigpy.quirks import CustomCluster
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+from homeassistant.const import UnitOfLength, UnitOfTime
+
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+import zigpy.types as t
+
+class TS0225Cluster(CustomCluster):
+    cluster_id = 0xE002
+    class AttributeDefs(BaseAttributeDefs):
+        presence_keep_time = ZCLAttributeDef(
+            id = 0xE001,
+            type = t.uint16_t,
+            is_manufacturer_specific=False
+        )
+        motion_detection_sensitivity = ZCLAttributeDef(
+            id = 0xE004,
+            type = t.uint8_t,
+            access="rw",
+            is_manufacturer_specific=False
+        )
+        static_detection_sensitivity = ZCLAttributeDef(
+            id = 0xE005,
+            type = t.uint8_t,
+            access="rw",
+            is_manufacturer_specific=False
+        )
+        target_distance = ZCLAttributeDef(
+            id = 0xE00A,
+            type = t.uint16_t,
+            is_manufacturer_specific=False
+        )
+        motion_detection_distance = ZCLAttributeDef(
+            id = 0xE00B,
+            type = t.uint16_t,
+            access="rw",
+            is_manufacturer_specific=False
+        )
+
+(
+    TuyaQuirkBuilder("_TZ3218_awarhusb", "TS0225")
+    .replaces(TS0225Cluster)
+    .sensor(
+        TS0225Cluster.AttributeDefs.target_distance.name,
+        TS0225Cluster.cluster_id,
+        unit=UnitOfLength.CENTIMETERS,
+        fallback_name="Target distance",
+        translation_key="target_distance"
+    )
+    .sensor(
+        TS0225Cluster.AttributeDefs.presence_keep_time.name,
+        TS0225Cluster.cluster_id,
+        unit=UnitOfTime.MINUTES,
+        fallback_name="Presence keep time",
+        translation_key="presence_keep_time"
+    )
+    .number(
+        TS0225Cluster.AttributeDefs.motion_detection_sensitivity.name,
+        TS0225Cluster.cluster_id,
+        min_value=0,
+        max_value=5,
+        step=1,
+        fallback_name="Motion detection sensitivity",
+        translation_key="motion_detection_sensitivity"
+    )
+    .number(
+        TS0225Cluster.AttributeDefs.static_detection_sensitivity.name,
+        TS0225Cluster.cluster_id,
+        min_value=0,
+        max_value=5,
+        step=1,
+        fallback_name="Static detection sensitivity",
+        translation_key="static_detection_sensitivity"
+    )
+    .number(
+        TS0225Cluster.AttributeDefs.motion_detection_distance.name,
+        TS0225Cluster.cluster_id,
+        min_value=75,
+        max_value=600,
+        unit=UnitOfLength.CENTIMETERS,
+        device_class=NumberDeviceClass.DISTANCE,
+        step=75,
+        fallback_name="Motion detection distance",
+        translation_key="motion_detection_distance"
+    )
+    .tuya_number(
+        dp_id=101,
+        attribute_name="fading_time",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=10000,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        translation_key="fading_time",
+        fallback_name="fading_time",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0225_presence.py
+++ b/zhaquirks/tuya/ts0225_presence.py
@@ -10,7 +10,7 @@ from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
 class TS0225Cluster(CustomCluster):
-    """ TS0225 specific cluster """
+    """TS0225 specific cluster"""
 
     cluster_id = 0xE002
 


### PR DESCRIPTION
Out of the box support is very limited - only IAS zone sensor is available which makes the device pretty useless.
This quirk is based on zigbee-herdsman-converters linptech.ts and information from this issue https://github.com/Koenkk/zigbee2mqtt/issues/18637
It adds support for setting detection distance, fading time and static and motion sensitivity.
It lacks support of illuminance measurement.

## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Fixes: #2599 

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
