### PR TITLE
Fix wrong Tuya DPToAttributeMapping imports

### DIFF
--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -18,7 +18,6 @@ from zhaquirks.const import BatterySize
 from zhaquirks.tuya import (
     TUYA_QUERY_DATA,
     TUYA_SET_TIME,
-    DPToAttributeMapping,
     TuyaCommand,
     TuyaData,
     TuyaDatapointData,
@@ -42,7 +41,7 @@ from zhaquirks.tuya.builder import (
     TuyaTemperatureMeasurement,
     TuyaValveWaterConsumedNoInstDemand,
 )
-from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaOnOffNM
+from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster, TuyaOnOffNM
 from zhaquirks.tuya.tuya_sensor import NoManufTimeTuyaMCUCluster
 
 ZCL_TUYA_SET_TIME = b"\x09\x12\x24\x0d\x00"

--- a/zhaquirks/tuya/tuya_rain.py
+++ b/zhaquirks/tuya/tuya_rain.py
@@ -6,14 +6,9 @@ from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateC
 import zigpy.types as t
 from zigpy.zcl.clusters.security import IasZone
 
-from zhaquirks.tuya import (
-    TUYA_CLUSTER_ID,
-    BatterySize,
-    DPToAttributeMapping,
-    TuyaLocalCluster,
-)
+from zhaquirks.tuya import TUYA_CLUSTER_ID, BatterySize, TuyaLocalCluster
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
-from zhaquirks.tuya.mcu import TuyaMCUCluster
+from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster
 
 
 class TuyaIasZone(IasZone, TuyaLocalCluster):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
These modules were importing the wrong `DPToAttributeMapping` class, since the builder uses the one from `mcu`.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
