### PR TITLE
Add device triggers for Legrand radiant wireless switch

### DIFF
--- a/zhaquirks/legrand/wirelessswitch.py
+++ b/zhaquirks/legrand/wirelessswitch.py
@@ -6,32 +6,32 @@ from zigpy.zcl.clusters.general import (
     Basic,
     BinaryInput,
     Identify,
+    LevelControl,
     OnOff,
     Ota,
     PollControl,
-    LevelControl,
 )
 
 from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
+    BUTTON,
     COMMAND,
+    COMMAND_MOVE,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_STOP,
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     LONG_PRESS,
+    LONG_RELEASE,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
+    PARAMS,
     PROFILE_ID,
     SHORT_PRESS,
-    TURN_ON,
-    COMMAND_ON,
     TURN_OFF,
-    COMMAND_OFF,
-    COMMAND_MOVE,
-    PARAMS,
-    LONG_RELEASE,
-    BUTTON,
-    COMMAND_STOP,
+    TURN_ON,
 )
 from zhaquirks.legrand import LEGRAND, LegrandCluster, LegrandPowerConfigurationCluster
 

--- a/zhaquirks/legrand/wirelessswitch.py
+++ b/zhaquirks/legrand/wirelessswitch.py
@@ -1,18 +1,8 @@
 """Module for Legrand wireless radiant switch."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    BinaryInput,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    PollControl,
-)
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.general import BinaryInput
 
-from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
     BUTTON,
     COMMAND,
@@ -20,86 +10,33 @@ from zhaquirks.const import (
     COMMAND_OFF,
     COMMAND_ON,
     COMMAND_STOP,
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
     LONG_PRESS,
     LONG_RELEASE,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
     PARAMS,
-    PROFILE_ID,
     SHORT_PRESS,
     TURN_OFF,
     TURN_ON,
 )
-from zhaquirks.legrand import LEGRAND, LegrandCluster, LegrandPowerConfigurationCluster
+from zhaquirks.legrand import LEGRAND, LegrandPowerConfigurationCluster
 
-
-class RadiantWirelessSwitch(CustomDevice):
-    """Wireless radiant switch."""
-
-    signature = {
-        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=260,
-        # device_version=1, input_clusters=[0, 3, 15, 32, 1, 64513],
-        # output_clusters=[3, 6, 8, 0, 64513, 25])
-        MODELS_INFO: [(f" {LEGRAND}", " Remote switch")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
-                    Identify.cluster_id,
-                    BinaryInput.cluster_id,
-                    PollControl.cluster_id,
-                    LegrandCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    LegrandCluster.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    LegrandPowerConfigurationCluster,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    LegrandCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    LegrandCluster,
-                ],
-            }
+(
+    QuirkBuilder(f" {LEGRAND}", " Remote switch")
+    .replaces(LegrandPowerConfigurationCluster)
+    .removes(BinaryInput.cluster_id)
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON},
+            (LONG_PRESS, TURN_ON): {
+                COMMAND: COMMAND_MOVE,
+                PARAMS: {"move_mode": 0, "rate": 255},
+            },
+            (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF},
+            (LONG_PRESS, TURN_OFF): {
+                COMMAND: COMMAND_MOVE,
+                PARAMS: {"move_mode": 1, "rate": 255},
+            },
+            (LONG_RELEASE, BUTTON): {COMMAND: COMMAND_STOP},
         }
-    }
-
-    device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON},
-        (LONG_PRESS, TURN_ON): {
-            COMMAND: COMMAND_MOVE,
-            PARAMS: {"move_mode": 0, "rate": 255},
-        },
-        (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF},
-        (LONG_PRESS, TURN_OFF): {
-            COMMAND: COMMAND_MOVE,
-            PARAMS: {"move_mode": 1, "rate": 255},
-        },
-        (LONG_RELEASE, BUTTON): {COMMAND: COMMAND_STOP},
-    }
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/legrand/wirelessswitch.py
+++ b/zhaquirks/legrand/wirelessswitch.py
@@ -22,7 +22,7 @@ from zhaquirks.legrand import LEGRAND, LegrandPowerConfigurationCluster
 (
     QuirkBuilder(f" {LEGRAND}", " Remote switch")
     .replaces(LegrandPowerConfigurationCluster)
-    .removes(BinaryInput.cluster_id)
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=BinaryInput.cluster_id)
     .device_automation_triggers(
         {
             (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON},

--- a/zhaquirks/legrand/wirelessswitch.py
+++ b/zhaquirks/legrand/wirelessswitch.py
@@ -37,7 +37,7 @@ from zhaquirks.legrand import LEGRAND, LegrandCluster, LegrandPowerConfiguration
 
 
 class RadiantWirelessSwitch(CustomDevice):
-    """Wireless radiant switch"""
+    """Wireless radiant switch."""
 
     signature = {
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=260,

--- a/zhaquirks/legrand/wirelessswitch.py
+++ b/zhaquirks/legrand/wirelessswitch.py
@@ -1,0 +1,105 @@
+"""Module for Legrand wireless radiant switch."""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    BinaryInput,
+    Identify,
+    OnOff,
+    Ota,
+    PollControl,
+    LevelControl,
+)
+
+from zhaquirks import PowerConfigurationCluster
+from zhaquirks.const import (
+    COMMAND,
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    LONG_PRESS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+    TURN_ON,
+    COMMAND_ON,
+    TURN_OFF,
+    COMMAND_OFF,
+    COMMAND_MOVE,
+    PARAMS,
+    LONG_RELEASE,
+    BUTTON,
+    COMMAND_STOP,
+)
+from zhaquirks.legrand import LEGRAND, LegrandCluster, LegrandPowerConfigurationCluster
+
+
+class RadiantWirelessSwitch(CustomDevice):
+    """Wireless radiant switch"""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=260,
+        # device_version=1, input_clusters=[0, 3, 15, 32, 1, 64513],
+        # output_clusters=[3, 6, 8, 0, 64513, 25])
+        MODELS_INFO: [(f" {LEGRAND}", " Remote switch")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfigurationCluster.cluster_id,
+                    Identify.cluster_id,
+                    BinaryInput.cluster_id,
+                    PollControl.cluster_id,
+                    LegrandCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LegrandCluster.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    LegrandPowerConfigurationCluster,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    LegrandCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LegrandCluster,
+                ],
+            }
+        }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON},
+        (LONG_PRESS, TURN_ON): {
+            COMMAND: COMMAND_MOVE,
+            PARAMS: {"move_mode": 0, "rate": 255},
+        },
+        (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF},
+        (LONG_PRESS, TURN_OFF): {
+            COMMAND: COMMAND_MOVE,
+            PARAMS: {"move_mode": 1, "rate": 255},
+        },
+        (LONG_RELEASE, BUTTON): {COMMAND: COMMAND_STOP},
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Adds on/off press and long press event support for the [Legrand radiant wireless switch](https://www.legrand.us/wiring-devices/designer-switches-and-outlets/radiant-wireless-smart-switch-with-netatmo-white/p/wnrl23wh)

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/f7a5e051-394e-4b86-96c5-b5920730fed2" />
<img width="686" alt="image" src="https://github.com/user-attachments/assets/91d87f1c-bd09-45fb-af68-b655e03e210e" />


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
- fixes #3330 

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
