### PR TITLE
Fix typing of Tuya `DPToAttributeMapping` classes

### DIFF
--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import dataclasses
 import datetime
 from typing import Any
 
@@ -19,6 +18,7 @@ from zhaquirks.tuya import (
     TUYA_MCU_VERSION_RSP,
     TUYA_SET_DATA,
     TUYA_SET_TIME,
+    DPToAttributeMapping as DpToAttributeMappingBase,
     EnchantedDevice,  # noqa: F401
     NoManufacturerCluster,
     PowerOnState,
@@ -36,15 +36,20 @@ ATTR_MCU_VERSION = 0xEF00
 TUYA_MCU_CONNECTION_STATUS = 0x25
 
 
-@dataclasses.dataclass
-class DPToAttributeMapping:
+class DPToAttributeMapping(DpToAttributeMappingBase):
     """Container for datapoint to cluster attribute update mapping."""
 
-    ep_attribute: str
-    attribute_name: str | tuple[str, ...]
-    converter: Callable[[Any], Any] | None = None
-    dp_converter: Callable[[Any], Any] | None = None
-    endpoint_id: int | None = None
+    def __init__(
+        self,
+        ep_attribute: str,
+        attribute_name: str | tuple[str, ...],
+        converter: Callable[[Any], Any] | None = None,
+        dp_converter: Callable[[Any], Any] | None = None,
+        endpoint_id: int | None = None,
+    ):
+        """Init method for compatibility with previous quirks using positional arguments."""
+        super().__init__(ep_attribute, attribute_name, converter, endpoint_id)
+        self.dp_converter = dp_converter
 
 
 class TuyaClusterData(t.Struct):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Previously, the `DPToAttributeMapping` classes were duplicated, with the one in `zhaquirks.tuya.mcu` having an extra attribute. Both were stored in `_dp_to_attributes`, despite the typing using only the one in `zhaquirks.tuya`.

This change fixes that by making the class in the `zhaquirks.tuya.mcu` module inherit from the one in `zhaquirks.tuya`. The `__init__` method needs to be specified instead of using `dataclass` to keep backwards compatibility due to the order of the attributes being different now.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
