### PR TITLE
Allow alternative Tuya datapoint write command, fix fingerbot

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1478,6 +1478,9 @@ class TuyaNewManufCluster(CustomCluster):
     cluster_id: t.uint16_t = TUYA_CLUSTER_ID
     ep_attribute: str = "tuya_manufacturer"
 
+    # command for writing datapoint values to the device, some use TUYA_SEND_DATA
+    mcu_write_command: foundation.GeneralCommand | int | t.uint8_t = TUYA_SET_DATA
+
     # remove manufacturer id for cluster, important for `TUYA_SET_DATA` commands
     manufacturer_id_override: t.uint16_t = foundation.ZCLHeader.NO_MANUFACTURER_ID
 

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -33,6 +33,7 @@ from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 from zhaquirks.const import BatterySize
 from zhaquirks.tuya import (
     TUYA_CLUSTER_ID,
+    TUYA_SET_DATA,
     BaseEnchantedDevice,
     PowerConfiguration,
     TuyaLocalCluster,
@@ -807,8 +808,17 @@ class TuyaQuirkBuilder(QuirkBuilder):
         self,
         replacement_cluster: TuyaMCUCluster = TuyaMCUCluster,
         force_add_cluster: bool = False,
+        mcu_write_command: foundation.GeneralCommand | int | t.uint8_t = TUYA_SET_DATA,
     ) -> QuirksV2RegistryEntry:
-        """Build the quirks v2 registry entry."""
+        """Build the quirks v2 registry entry.
+
+        :param replacement_cluster: The cluster to add or replace the Tuya cluster with.
+        :param force_add_cluster: Force add the Tuya cluster,
+            even if no new Tuya attributes/datapoints were added before.
+        :param mcu_write_command: The MCU command to use for the Tuya MCU cluster.
+            Default is TUYA_SET_DATA. Few devices use TUYA_SEND_DATA instead.
+        :return: The quirks v2 registry entry.
+        """
 
         if (
             self.new_attributes
@@ -834,6 +844,8 @@ class TuyaQuirkBuilder(QuirkBuilder):
 
             TuyaReplacementCluster.data_point_handlers = self.tuya_data_point_handlers
             TuyaReplacementCluster.dp_to_attribute = self.tuya_dp_to_attribute
+
+            TuyaReplacementCluster.MCU_WRITE_COMMAND = mcu_write_command
 
             self.replaces(TuyaReplacementCluster)
         return super().add_to_registry()

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -17,7 +17,6 @@ from zhaquirks import Bus, DoublingPowerConfigurationCluster
 from zhaquirks.tuya import (
     TUYA_MCU_COMMAND,
     TUYA_MCU_VERSION_RSP,
-    TUYA_SET_DATA,
     TUYA_SET_TIME,
     EnchantedDevice,  # noqa: F401
     NoManufacturerCluster,
@@ -262,7 +261,7 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
         for tuya_command in tuya_commands:
             self.create_catching_task(
                 self.command(
-                    TUYA_SET_DATA,
+                    self.mcu_write_command,
                     tuya_command,
                     expect_reply=cluster_data.expect_reply,
                     manufacturer=cluster_data.manufacturer,

--- a/zhaquirks/tuya/tuya_fingerbot.py
+++ b/zhaquirks/tuya/tuya_fingerbot.py
@@ -4,6 +4,7 @@ from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTime
 import zigpy.types as t
 
 from zhaquirks.const import BatterySize
+from zhaquirks.tuya import TUYA_SEND_DATA
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
@@ -80,5 +81,5 @@ class FingerBotReverse(t.enum8):
         fallback_name="Touch control",
     )
     .tuya_enchantment()
-    .add_to_registry()
+    .add_to_registry(mcu_write_command=TUYA_SEND_DATA)
 )


### PR DESCRIPTION
## Proposed change
This PR allows overriding the command used for writing Tuya datapoint values to a Tuya devices.
The default stays `TUYA_SET_DATA`, but the Tuya fingerbot implementation is changed to use `TUYA_SEND_DATA`.


## Additional information
- Should fix https://github.com/zigpy/zha-device-handlers/issues/3915
- Should fix https://github.com/zigpy/zha-device-handlers/issues/2493

Regression started with:
- https://github.com/zigpy/zha-device-handlers/pull/3860


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
