### PR TITLE
Fix Tuya thermostat deadzone temperature multiplier

### DIFF
--- a/zhaquirks/tuya/tuya_thermostat.py
+++ b/zhaquirks/tuya/tuya_thermostat.py
@@ -400,9 +400,10 @@ base_avatto_quirk = (
         attribute_name="deadzone_temperature",
         type=t.uint16_t,
         unit=UnitOfTemperature.CELSIUS,
-        min_value=0.1,
+        min_value=0.5,
         max_value=10,
-        step=0.1,
+        step=0.5,
+        multiplier=0.1,
         translation_key="deadzone_temperature",
         fallback_name="Deadzone temperature",
     )


### PR DESCRIPTION
## Proposed change
This adds a 10 divisor for the deadzone temperature on multiple Tuya thermostats.
Fixes the issue for `_TZE200_viy9ihs7` and other models.


## Additional information
Should fix https://github.com/zigpy/zha-device-handlers/issues/3908


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
