### PR TITLE
Remove "charging" translation key for Aqara E1 roller curtain

### DIFF
--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -344,7 +344,6 @@ class MultistateOutputRollerE1(CustomCluster, MultistateOutput):
         XiaomiAqaraRollerE1.AttributeDefs.charging.name,
         XiaomiAqaraRollerE1.cluster_id,
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
-        translation_key="charging",
         fallback_name="Charging",
         attribute_converter=lambda x: x == AqaraRollerDriverCharging.Charging,
     )


### PR DESCRIPTION
## Proposed change
Remove "charging" translation key for Aqara E1 roller curtain.
It's already "Charging" by default due to the HA device class.

(The `fallback_name` is not used when the PR is merged upstream.)


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
