### PR TITLE
Fix Tuya/Moes TRV running state `_TZE204_qyr2m29i`

### DIFF
--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -658,7 +658,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         dp_id=3,
         ep_attribute=TuyaThermostatV2.ep_attribute,
         attribute_name=TuyaThermostatV2.AttributeDefs.running_state.name,
-        converter=lambda x: 0x01 if not x else 0x00,  # Heat, Idle
+        converter=lambda x: RunningState.Heat_State_On if x else RunningState.Idle,
     )
     .tuya_dp(
         dp_id=4,


### PR DESCRIPTION
## Proposed change
Fix Tuya/Moes TRV running state for `_TZE204_qyr2m29i` and `_TZE204_ltwbm23f` (Moes TRV602Z and TRV801Z).

## Additional information
See:
- https://github.com/home-assistant/core/issues/140797

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
