### PR TITLE
Fix Tuya builder overriding dp write command

### DIFF
--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -866,7 +866,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
             TuyaReplacementCluster.data_point_handlers = self.tuya_data_point_handlers
             TuyaReplacementCluster.dp_to_attribute = self.tuya_dp_to_attribute
 
-            TuyaReplacementCluster.MCU_WRITE_COMMAND = mcu_write_command
+            TuyaReplacementCluster.mcu_write_command = mcu_write_command
 
             self.replaces(TuyaReplacementCluster)
         return super().add_to_registry()


### PR DESCRIPTION
## Proposed change
This fixes an issue where the `TuyaQuirkBuilder` didn't correctly override the `mcu_write_command` attribute of a `TuyaNewManufCluster` due to wrong capitalization.

A test is also added to ensure the Tuya quirks v2 builder correctly overrides the attribute and that the intended effect of using a different `command_id` when writing Tuya datapoint values is achieved.

- Follow-up PR to https://github.com/zigpy/zha-device-handlers/pull/3980

## Additional information
- Should fix https://github.com/zigpy/zha-device-handlers/issues/3915
- Should fix https://github.com/zigpy/zha-device-handlers/issues/3992


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
