### PR TITLE
Fix Tuya valve using incorrect MCU write command

### DIFF
--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -14,7 +14,7 @@ import zigpy.types as t
 from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.const import BatterySize
-from zhaquirks.tuya import TUYA_CLUSTER_ID
+from zhaquirks.tuya import TUYA_CLUSTER_ID, TUYA_SEND_DATA
 from zhaquirks.tuya.builder import TuyaQuirkBuilder, TuyaValveWaterConsumed
 from zhaquirks.tuya.mcu import TuyaMCUCluster
 
@@ -669,7 +669,7 @@ class GiexIrrigationStatus(t.enum8):
     .tuya_battery(dp_id=115, battery_type=BatterySize.AA, battery_qty=2)
     .tuya_enchantment()
     .skip_configuration()
-    .add_to_registry()
+    .add_to_registry(mcu_write_command=TUYA_SEND_DATA)
 )
 
 


### PR DESCRIPTION
## Proposed change
This fixes an issue where the Tuya valve quirk (for a Rain Seer valve) was using the incorrect MCU write command.
`TUYA_SEND_DATA` is now used for this device (instead of the `TUYA_SET_DATA` command).

- v2 quirk orginally added in https://github.com/zigpy/zha-device-handlers/pull/3737


## Additional information
- Should fix https://github.com/zigpy/zha-device-handlers/issues/3993
- Should fix https://github.com/zigpy/zha-device-handlers/issues/3931
- Original issue of this device not being supported: https://github.com/zigpy/zha-device-handlers/issues/2377#issuecomment-2766119438


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
