### PR TITLE
Add Yandex devices: YNDX-00530, 00531, 00532, 00534, 00535, 00537, 00538, 00591, 00592

### DIFF
--- a/zhaquirks/yandex/__init__.py
+++ b/zhaquirks/yandex/__init__.py
@@ -1,0 +1,190 @@
+"""Common code for Yandex devices."""
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+import zigpy.types as t
+from zigpy.zcl.foundation import (
+    BaseAttributeDefs,
+    BaseCommandDefs,
+    ZCLAttributeDef,
+    ZCLCommandDef,
+)
+
+### CONSTANTS ###
+
+
+YANDEX = "Yandex"
+YANDEX_CLUSTER_ID = 0xFC03
+YANDEX_MANUFACTURER_CODE = 0x140A
+
+
+### TYPES ###
+
+
+class YandexType_SwitchMode(t.enum8):
+    """Wired switches: gang mode."""
+
+    Control_Relay = 0x00
+    Up_Decoupled = 0x01
+    Decoupled = 0x02
+    Down_Decoupled = 0x03
+
+
+class YandexType_SwitchType(t.enum8):
+    """Relays: connected switch type."""
+
+    Rocker = 0x00
+    Button = 0x01
+    Decoupled = 0x02
+
+
+class YandexType_PowerType(t.enum8):
+    """Wired devices: power level."""
+
+    High = 0x00
+    Medium = 0x01
+    Low = 0x02
+
+
+class YandexType_LedIndicator(t.basic.enum8):
+    """Enable/disable LED indicator."""
+
+    Enabled = 0
+    Disabled = 1
+
+
+class YandexType_Interlock(t.basic.enum8):
+    """Double relay only: enable/disable interlock mode."""
+
+    Disabled = 0
+    Enabled = 1
+
+
+class YandexType_ButtonMode(t.enum8):
+    """Dimmer only: button presses interpretation."""
+
+    General = 0x00
+    Alternative = 0x01
+
+
+### ATTRIBUTE DEFINITIONS ###
+
+
+YANDEX_ATTRIBUTE_SWITCH_MODE = ZCLAttributeDef(
+    id=0x0001,
+    name="switch_mode",
+    type=YandexType_SwitchMode,
+    access="rw",
+)
+YANDEX_ATTRIBUTE_SWITCH_TYPE = ZCLAttributeDef(
+    id=0x0002,
+    name="switch_type",
+    type=YandexType_SwitchType,
+    access="rw",
+)
+YANDEX_ATTRIBUTE_POWER_TYPE = ZCLAttributeDef(
+    id=0x0003,
+    name="power_type",
+    type=YandexType_PowerType,
+    access="rw",
+)
+YANDEX_ATTRIBUTE_LED_INDICATOR = ZCLAttributeDef(
+    id=0x0005,
+    name="led_indicator",
+    type=YandexType_LedIndicator,
+    access="rw",
+)
+YANDEX_ATTRIBUTE_INTERLOCK = ZCLAttributeDef(
+    id=0x0007,
+    name="interlock",
+    type=YandexType_Interlock,
+    access="rw",
+)
+YANDEX_ATTRIBUTE_BUTTON_MODE = ZCLAttributeDef(
+    id=0x0008,
+    name="button_mode",
+    type=YandexType_ButtonMode,
+    access="rw",
+)
+
+
+### COMMAND DEFINITIONS ###
+
+
+YANDEX_COMMAND_SWITCH_MODE = ZCLCommandDef(
+    id=0x01,
+    name="switch_mode",
+    schema={"value": YandexType_SwitchMode},
+    direction=False,
+    is_manufacturer_specific=True,
+)
+YANDEX_COMMAND_SWITCH_TYPE = ZCLCommandDef(
+    id=0x02,
+    name="switch_type",
+    schema={"value": YandexType_SwitchType},
+    direction=False,
+    is_manufacturer_specific=True,
+)
+YANDEX_COMMAND_POWER_TYPE = ZCLCommandDef(
+    id=0x03,
+    name="power_type",
+    schema={"value": YandexType_PowerType},
+    direction=False,
+    is_manufacturer_specific=True,
+)
+YANDEX_COMMAND_LED_INDICATOR = ZCLCommandDef(
+    id=0x05,
+    name="led_indicator",
+    schema={"value": YandexType_LedIndicator},
+    direction=False,
+    is_manufacturer_specific=True,
+)
+YANDEX_COMMAND_INTERLOCK = ZCLCommandDef(
+    id=0x07,
+    name="interlock",
+    schema={"value": YandexType_Interlock},
+    direction=False,
+    is_manufacturer_specific=True,
+)
+YANDEX_COMMAND_BUTTON_MODE = ZCLCommandDef(
+    id=0x08,
+    name="button_mode",
+    schema={"value": YandexType_ButtonMode},
+    direction=False,
+    is_manufacturer_specific=True,
+)
+
+
+### COMMON CLUSTERS ###
+
+
+class YandexCluster(CustomCluster):
+    """Common Yandex manufacturer-specific cluster properties."""
+
+    cluster_id = YANDEX_CLUSTER_ID
+    manufacturer_id_override = YANDEX_MANUFACTURER_CODE
+
+
+class YandexClusterFull(YandexCluster):
+    """Complete Yandex manufacturer-specific cluster, with all commands and attributes."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        switch_mode: Final = YANDEX_ATTRIBUTE_SWITCH_MODE
+        switch_type: Final = YANDEX_ATTRIBUTE_SWITCH_TYPE
+        power_type: Final = YANDEX_ATTRIBUTE_POWER_TYPE
+        led_indicator: Final = YANDEX_ATTRIBUTE_LED_INDICATOR
+        interlock: Final = YANDEX_ATTRIBUTE_INTERLOCK
+        button_mode: Final = YANDEX_ATTRIBUTE_BUTTON_MODE
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Command definitions."""
+
+        switch_mode: Final = YANDEX_COMMAND_SWITCH_MODE
+        switch_type: Final = YANDEX_COMMAND_SWITCH_TYPE
+        power_type: Final = YANDEX_COMMAND_POWER_TYPE
+        led_indicator: Final = YANDEX_COMMAND_LED_INDICATOR
+        interlock: Final = YANDEX_COMMAND_INTERLOCK
+        button_mode: Final = YANDEX_COMMAND_BUTTON_MODE

--- a/zhaquirks/yandex/__init__.py
+++ b/zhaquirks/yandex/__init__.py
@@ -4,6 +4,7 @@ from typing import Final
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
+from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
@@ -16,7 +17,8 @@ from zigpy.zcl.foundation import (
 
 YANDEX = "Yandex"
 YANDEX_CLUSTER_ID = 0xFC03
-YANDEX_MANUFACTURER_CODE = 0x140A
+YANDEX_MANUFACTURER_CODE_1 = 0x140A
+YANDEX_MANUFACTURER_CODE_2 = 0x132F
 
 
 ### TYPES ###
@@ -68,6 +70,14 @@ class YandexType_ButtonMode(t.enum8):
     Alternative = 0x01
 
 
+class YandexType_VelocityLift(t.enum16):
+    """Curtain motor: velocity options."""
+
+    Slow = 6
+    Normal = 9
+    Fast = 12
+
+
 ### ATTRIBUTE DEFINITIONS ###
 
 
@@ -106,6 +116,40 @@ YANDEX_ATTRIBUTE_BUTTON_MODE = ZCLAttributeDef(
     name="button_mode",
     type=YandexType_ButtonMode,
     access="rw",
+)
+YANDEX_ATTRIBUTE_VELOCITY_LIFT = ZCLAttributeDef(
+    id=WindowCovering.AttributeDefs.velocity_lift.id,
+    type=YandexType_VelocityLift,
+    access="rw",
+    is_manufacturer_specific=False,
+)
+YANDEX_ATTRIBUTE_MAX_POSITION = ZCLAttributeDef(
+    id=0xF001,
+    name="max_position",
+    type=t.uint8_t,
+    access="rw",
+    is_manufacturer_specific=True,
+)
+YANDEX_ATTRIBUTE_MIN_POSITION = ZCLAttributeDef(
+    id=0xF002,
+    name="min_position",
+    type=t.uint8_t,
+    access="rw",
+    is_manufacturer_specific=True,
+)
+YANDEX_ATTRIBUTE_UNK_FFFD = ZCLAttributeDef(
+    id=0xFFFD,
+    name="unknown_fffd",
+    type=t.uint16_t,
+    access="rw",
+    is_manufacturer_specific=False,
+)
+YANDEX_ATTRIBUTE_UNK_F000 = ZCLAttributeDef(
+    id=0xF000,
+    name="unknown_f000",
+    type=t.Bool,
+    access="rw",
+    is_manufacturer_specific=True,
 )
 
 
@@ -163,7 +207,7 @@ class YandexCluster(CustomCluster):
     """Common Yandex manufacturer-specific cluster properties."""
 
     cluster_id = YANDEX_CLUSTER_ID
-    manufacturer_id_override = YANDEX_MANUFACTURER_CODE
+    manufacturer_id_override = YANDEX_MANUFACTURER_CODE_1
 
 
 class YandexClusterFull(YandexCluster):

--- a/zhaquirks/yandex/yndx_0053x.py
+++ b/zhaquirks/yandex/yndx_0053x.py
@@ -1,0 +1,478 @@
+"""Support for YNDX-0053x devices."""
+
+from typing import Final
+
+from zigpy.profiles import zgp, zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    Scenes,
+)
+from zigpy.zcl.foundation import BaseAttributeDefs, BaseCommandDefs
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.yandex import (
+    YANDEX,
+    YANDEX_ATTRIBUTE_BUTTON_MODE,
+    YANDEX_ATTRIBUTE_INTERLOCK,
+    YANDEX_ATTRIBUTE_LED_INDICATOR,
+    YANDEX_ATTRIBUTE_POWER_TYPE,
+    YANDEX_ATTRIBUTE_SWITCH_MODE,
+    YANDEX_ATTRIBUTE_SWITCH_TYPE,
+    YANDEX_CLUSTER_ID,
+    YANDEX_COMMAND_BUTTON_MODE,
+    YANDEX_COMMAND_INTERLOCK,
+    YANDEX_COMMAND_POWER_TYPE,
+    YANDEX_COMMAND_SWITCH_MODE,
+    YANDEX_COMMAND_SWITCH_TYPE,
+    YandexCluster,
+)
+
+### YNDX-00530 DIMMER ###
+
+
+class YandexClusterDimmer(YandexCluster):
+    """Cluster for dimmer."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        led_indicator: Final = YANDEX_ATTRIBUTE_LED_INDICATOR
+        button_mode: Final = YANDEX_ATTRIBUTE_BUTTON_MODE
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Command definitions."""
+
+        button_mode: Final = YANDEX_COMMAND_BUTTON_MODE
+
+
+class YandexDimmer(CustomDevice):
+    """Dimmer."""
+
+    signature = {
+        MODELS_INFO: [(YANDEX, "YNDX-00530")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=257
+            # device_version=0
+            # input_clusters=[0, 3, 4, 6, 8, 64515]
+            # output_clusters=[25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    YANDEX_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # device_version=0
+            # input_clusters=[]
+            # output_clusters=[33]>
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    YandexClusterDimmer,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+
+### YNDX-00531 AND YNDX-00532 SINGLE-GANG AND DOUBLE-GANG SWITCHES ###
+
+
+class YandexClusterSwitchMain(YandexCluster):
+    """Main cluster for all Yandex switches."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        switch_mode: Final = YANDEX_ATTRIBUTE_SWITCH_MODE
+        power_type: Final = YANDEX_ATTRIBUTE_POWER_TYPE
+        led_indicator: Final = YANDEX_ATTRIBUTE_LED_INDICATOR
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Command definitions."""
+
+        switch_mode: Final = YANDEX_COMMAND_SWITCH_MODE
+        power_type: Final = YANDEX_COMMAND_POWER_TYPE
+
+
+class YandexClusterSwitchSecondary(YandexCluster):
+    """Secondary cluster for all Yandex switches."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        switch_mode: Final = YANDEX_ATTRIBUTE_SWITCH_MODE
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Command definitions."""
+
+        switch_mode: Final = YANDEX_COMMAND_SWITCH_MODE
+
+
+class YandexSingleGangSwitch(CustomDevice):
+    """Single-gang switch."""
+
+    signature = {
+        MODELS_INFO: [(YANDEX, "YNDX-00531")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=256
+            # device_version=0
+            # input_clusters=[0, 3, 6, 64515]
+            # output_clusters=[25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YANDEX_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YandexClusterSwitchMain,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            # Down
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
+                INPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+            # Up
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
+                INPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+        }
+    }
+
+
+class YandexDoubleGangSwitch(CustomDevice):
+    """Double-gang switch."""
+
+    signature = {
+        MODELS_INFO: [(YANDEX, "YNDX-00532")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=256
+            # device_version=0
+            # input_clusters=[0, 3, 6, 64515]
+            # output_clusters=[25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YANDEX_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=256
+            # device_version=0
+            # input_clusters=[0, 3, 6, 64515]
+            # output_clusters=[]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YANDEX_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YandexClusterSwitchMain,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YandexClusterSwitchSecondary,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            # Button 1 Down
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
+                INPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+            # Button 2 Down
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
+                INPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+            # Button 1 Up
+            5: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
+                INPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+            # Button 2 Up
+            6: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
+                INPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+        }
+    }
+
+
+### YNDX-00537 SINGLE RELAY ###
+
+
+class YandexClusterSingleRelay(YandexCluster):
+    """Cluster for single relay."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        switch_type: Final = YANDEX_ATTRIBUTE_SWITCH_TYPE
+        power_type: Final = YANDEX_ATTRIBUTE_POWER_TYPE
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Command definitions."""
+
+        switch_type: Final = YANDEX_COMMAND_SWITCH_TYPE
+        power_type: Final = YANDEX_COMMAND_POWER_TYPE
+
+
+class YandexSingleRelay(CustomDevice):
+    """Single relay."""
+
+    signature = {
+        MODELS_INFO: [(YANDEX, "YNDX-00537")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=256
+            # device_version=0
+            # input_clusters=[0, 3, 6, 64515]
+            # output_clusters=[25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YANDEX_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YandexClusterSingleRelay,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            # Button (decoupled)
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
+                INPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+        },
+    }
+
+
+### YNDX-00538 DOUBLE RELAY ###
+
+
+class YandexClusterDoubleRelayMain(YandexCluster):
+    """Main cluster for double relay."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        switch_type: Final = YANDEX_ATTRIBUTE_SWITCH_TYPE
+        power_type: Final = YANDEX_ATTRIBUTE_POWER_TYPE
+        interlock: Final = YANDEX_ATTRIBUTE_INTERLOCK
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Command definitions."""
+
+        switch_type: Final = YANDEX_COMMAND_SWITCH_TYPE
+        power_type: Final = YANDEX_COMMAND_POWER_TYPE
+        interlock: Final = YANDEX_COMMAND_INTERLOCK
+
+
+class YandexClusterDoubleRelaySecondary(YandexCluster):
+    """Secondary cluster for double relay."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        switch_type: Final = YANDEX_ATTRIBUTE_SWITCH_TYPE
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Command definitions."""
+
+        switch_type: Final = YANDEX_COMMAND_SWITCH_TYPE
+
+
+class YandexDoubleRelay(CustomDevice):
+    """Double relay."""
+
+    signature = {
+        MODELS_INFO: [(YANDEX, "YNDX-00538")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=256
+            # device_version=0
+            # input_clusters=[0, 3, 6, 64515]
+            # output_clusters=[25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YANDEX_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=256
+            # device_version=0
+            # input_clusters=[0, 3, 6, 64515]
+            # output_clusters=[]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YANDEX_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YandexClusterDoubleRelayMain,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YandexClusterDoubleRelaySecondary,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            # Button 1
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
+                INPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+            # Button 2
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
+                INPUT_CLUSTERS: [OnOff.cluster_id],
+            },
+        },
+    }

--- a/zhaquirks/yandex/yndx_0053x.py
+++ b/zhaquirks/yandex/yndx_0053x.py
@@ -194,14 +194,22 @@ class YandexSingleGangSwitch(CustomDevice):
             # Down
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
-                INPUT_CLUSTERS: [OnOff.cluster_id],
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Up
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
-                INPUT_CLUSTERS: [OnOff.cluster_id],
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
         }
     }
@@ -273,26 +281,42 @@ class YandexDoubleGangSwitch(CustomDevice):
             # Button 1 Down
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
-                INPUT_CLUSTERS: [OnOff.cluster_id],
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Button 2 Down
             4: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
-                INPUT_CLUSTERS: [OnOff.cluster_id],
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Button 1 Up
             5: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
-                INPUT_CLUSTERS: [OnOff.cluster_id],
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Button 2 Up
             6: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
-                INPUT_CLUSTERS: [OnOff.cluster_id],
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
         }
     }
@@ -357,8 +381,12 @@ class YandexSingleRelay(CustomDevice):
             # Button (decoupled)
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
-                INPUT_CLUSTERS: [OnOff.cluster_id],
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
         },
     }
@@ -465,14 +493,22 @@ class YandexDoubleRelay(CustomDevice):
             # Button 1
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
-                INPUT_CLUSTERS: [OnOff.cluster_id],
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Button 2
             4: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SENSOR,
-                INPUT_CLUSTERS: [OnOff.cluster_id],
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
         },
     }

--- a/zhaquirks/yandex/yndx_0053x.py
+++ b/zhaquirks/yandex/yndx_0053x.py
@@ -17,12 +17,21 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.foundation import BaseAttributeDefs, BaseCommandDefs
 
 from zhaquirks.const import (
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_TOGGLE,
     DEVICE_TYPE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
+    LONG_PRESS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    SHORT_PRESS,
 )
 from zhaquirks.yandex import (
     YANDEX,
@@ -122,7 +131,23 @@ class YandexDimmer(CustomDevice):
     }
 
 
-### YNDX-00531 AND YNDX-00532 SINGLE-GANG AND DOUBLE-GANG SWITCHES ###
+### YNDX-00531 & YNDX-00532 SINGLE-GANG & DOUBLE-GANG SWITCHES, ###
+
+YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_ENDPOINT_ID = 2
+YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_ENDPOINT_ID = 3
+
+YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_NAME = "Button (Down)"
+YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_NAME = "Button (Up)"
+
+YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID = 3
+YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID = 4
+YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_ENDPOINT_ID = 5
+YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_ENDPOINT_ID = 6
+
+YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_NAME = "Button 1 (Down)"
+YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_NAME = "Button 2 (Down)"
+YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_NAME = "Button 1 (Up)"
+YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_NAME = "Button 2 (Up)"
 
 
 class YandexClusterSwitchMain(YandexCluster):
@@ -192,7 +217,7 @@ class YandexSingleGangSwitch(CustomDevice):
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
             # Down
-            2: {
+            YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -202,7 +227,7 @@ class YandexSingleGangSwitch(CustomDevice):
                 OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Up
-            3: {
+            YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -212,6 +237,39 @@ class YandexSingleGangSwitch(CustomDevice):
                 OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
         }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_ENDPOINT_ID,
+        },
+        (SHORT_PRESS, YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_ENDPOINT_ID,
+        },
     }
 
 
@@ -279,7 +337,7 @@ class YandexDoubleGangSwitch(CustomDevice):
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
             # Button 1 Down
-            3: {
+            YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -289,7 +347,7 @@ class YandexDoubleGangSwitch(CustomDevice):
                 OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Button 2 Down
-            4: {
+            YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -299,7 +357,7 @@ class YandexDoubleGangSwitch(CustomDevice):
                 OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Button 1 Up
-            5: {
+            YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -309,7 +367,7 @@ class YandexDoubleGangSwitch(CustomDevice):
                 OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Button 2 Up
-            6: {
+            YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -321,8 +379,81 @@ class YandexDoubleGangSwitch(CustomDevice):
         }
     }
 
+    device_automation_triggers = {
+        (SHORT_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID,
+        },
+        (SHORT_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID,
+        },
+        (SHORT_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_ENDPOINT_ID,
+        },
+        (SHORT_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_ENDPOINT_ID,
+        },
+    }
+
 
 ### YNDX-00537 SINGLE RELAY ###
+
+YANDEX_SINGLE_RELAY_BUTTON_ENDPOINT_ID = 2
+
+YANDEX_SINGLE_RELAY_BUTTON_NAME = "Button"
+
+YANDEX_DOUBLE_RELAY_BUTTON_1_ENDPOINT_ID = 3
+YANDEX_DOUBLE_RELAY_BUTTON_2_ENDPOINT_ID = 4
+
+YANDEX_DOUBLE_RELAY_BUTTON_1_NAME = "Button 1"
+YANDEX_DOUBLE_RELAY_BUTTON_2_NAME = "Button 2"
 
 
 class YandexClusterSingleRelay(YandexCluster):
@@ -379,7 +510,7 @@ class YandexSingleRelay(CustomDevice):
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
             # Button (decoupled)
-            2: {
+            YANDEX_SINGLE_RELAY_BUTTON_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -388,6 +519,24 @@ class YandexSingleRelay(CustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, YANDEX_SINGLE_RELAY_BUTTON_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_RELAY_BUTTON_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_SINGLE_RELAY_BUTTON_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_RELAY_BUTTON_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_SINGLE_RELAY_BUTTON_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_RELAY_BUTTON_ENDPOINT_ID,
         },
     }
 
@@ -491,7 +640,7 @@ class YandexDoubleRelay(CustomDevice):
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
             # Button 1
-            3: {
+            YANDEX_DOUBLE_RELAY_BUTTON_1_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -501,7 +650,7 @@ class YandexDoubleRelay(CustomDevice):
                 OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Button 2
-            4: {
+            YANDEX_DOUBLE_RELAY_BUTTON_2_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -510,5 +659,38 @@ class YandexDoubleRelay(CustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, YANDEX_DOUBLE_RELAY_BUTTON_1_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_RELAY_BUTTON_1_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_DOUBLE_RELAY_BUTTON_1_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_RELAY_BUTTON_1_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_DOUBLE_RELAY_BUTTON_1_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_RELAY_BUTTON_1_ENDPOINT_ID,
+        },
+        (SHORT_PRESS, YANDEX_DOUBLE_RELAY_BUTTON_2_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_RELAY_BUTTON_2_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_DOUBLE_RELAY_BUTTON_2_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_RELAY_BUTTON_2_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_DOUBLE_RELAY_BUTTON_2_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_RELAY_BUTTON_2_ENDPOINT_ID,
         },
     }

--- a/zhaquirks/yandex/yndx_0053x.py
+++ b/zhaquirks/yandex/yndx_0053x.py
@@ -1,4 +1,4 @@
-"""Support for YNDX-0053x devices."""
+"""Support for YNDX-0053x devices: wired and wireless zigbee switches, relays and dimmer."""
 
 from typing import Final
 

--- a/zhaquirks/yandex/yndx_0053x.py
+++ b/zhaquirks/yandex/yndx_0053x.py
@@ -12,6 +12,7 @@ from zigpy.zcl.clusters.general import (
     LevelControl,
     OnOff,
     Ota,
+    PowerConfiguration,
     Scenes,
 )
 from zigpy.zcl.foundation import BaseAttributeDefs, BaseCommandDefs
@@ -131,27 +132,27 @@ class YandexDimmer(CustomDevice):
     }
 
 
-### YNDX-00531 & YNDX-00532 SINGLE-GANG & DOUBLE-GANG SWITCHES, ###
+### YNDX-00531 & YNDX-00532 SINGLE-GANG & DOUBLE-GANG WIRED SWITCHES ###
 
-YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_ENDPOINT_ID = 2
-YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_ENDPOINT_ID = 3
+YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_DOWN_ENDPOINT_ID = 2
+YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_UP_ENDPOINT_ID = 3
 
-YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_NAME = "Button (Down)"
-YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_NAME = "Button (Up)"
+YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_DOWN_NAME = "Button (Down)"
+YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_UP_NAME = "Button (Up)"
 
-YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID = 3
-YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID = 4
-YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_ENDPOINT_ID = 5
-YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_ENDPOINT_ID = 6
+YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID = 3
+YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID = 4
+YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_UP_ENDPOINT_ID = 5
+YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_UP_ENDPOINT_ID = 6
 
-YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_NAME = "Button 1 (Down)"
-YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_NAME = "Button 2 (Down)"
-YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_NAME = "Button 1 (Up)"
-YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_NAME = "Button 2 (Up)"
+YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_DOWN_NAME = "Button 1 (Down)"
+YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_DOWN_NAME = "Button 2 (Down)"
+YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_UP_NAME = "Button 1 (Up)"
+YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_UP_NAME = "Button 2 (Up)"
 
 
-class YandexClusterSwitchMain(YandexCluster):
-    """Main cluster for all Yandex switches."""
+class YandexClusterWiredSwitchMain(YandexCluster):
+    """Main cluster for all wired Yandex switches."""
 
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
@@ -167,8 +168,8 @@ class YandexClusterSwitchMain(YandexCluster):
         power_type: Final = YANDEX_COMMAND_POWER_TYPE
 
 
-class YandexClusterSwitchSecondary(YandexCluster):
-    """Secondary cluster for all Yandex switches."""
+class YandexClusterWiredSwitchSecondary(YandexCluster):
+    """Secondary cluster for all wired Yandex switches."""
 
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
@@ -181,8 +182,8 @@ class YandexClusterSwitchSecondary(YandexCluster):
         switch_mode: Final = YANDEX_COMMAND_SWITCH_MODE
 
 
-class YandexSingleGangSwitch(CustomDevice):
-    """Single-gang switch."""
+class YandexSingleGangWiredSwitch(CustomDevice):
+    """Single-gang wired switch."""
 
     signature = {
         MODELS_INFO: [(YANDEX, "YNDX-00531")],
@@ -212,12 +213,12 @@ class YandexSingleGangSwitch(CustomDevice):
                     Basic.cluster_id,
                     Identify.cluster_id,
                     OnOff.cluster_id,
-                    YandexClusterSwitchMain,
+                    YandexClusterWiredSwitchMain,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
             # Down
-            YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_ENDPOINT_ID: {
+            YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_DOWN_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -227,7 +228,7 @@ class YandexSingleGangSwitch(CustomDevice):
                 OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Up
-            YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_ENDPOINT_ID: {
+            YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_UP_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -240,41 +241,41 @@ class YandexSingleGangSwitch(CustomDevice):
     }
 
     device_automation_triggers = {
-        (SHORT_PRESS, YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_NAME): {
+        (SHORT_PRESS, YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_DOWN_NAME): {
             COMMAND: COMMAND_TOGGLE,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_DOWN_ENDPOINT_ID,
         },
-        (DOUBLE_PRESS, YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_NAME): {
+        (DOUBLE_PRESS, YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_DOWN_NAME): {
             COMMAND: COMMAND_ON,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_DOWN_ENDPOINT_ID,
         },
-        (LONG_PRESS, YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_NAME): {
+        (LONG_PRESS, YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_DOWN_NAME): {
             COMMAND: COMMAND_OFF,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_SINGLE_GANG_SWITCH_BUTTON_DOWN_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_DOWN_ENDPOINT_ID,
         },
-        (SHORT_PRESS, YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_NAME): {
+        (SHORT_PRESS, YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_UP_NAME): {
             COMMAND: COMMAND_TOGGLE,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_UP_ENDPOINT_ID,
         },
-        (DOUBLE_PRESS, YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_NAME): {
+        (DOUBLE_PRESS, YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_UP_NAME): {
             COMMAND: COMMAND_ON,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_UP_ENDPOINT_ID,
         },
-        (LONG_PRESS, YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_NAME): {
+        (LONG_PRESS, YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_UP_NAME): {
             COMMAND: COMMAND_OFF,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_SINGLE_GANG_SWITCH_BUTTON_UP_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_WIRED_SWITCH_BUTTON_UP_ENDPOINT_ID,
         },
     }
 
 
-class YandexDoubleGangSwitch(CustomDevice):
-    """Double-gang switch."""
+class YandexDoubleGangWiredSwitch(CustomDevice):
+    """Double-gang wired switch."""
 
     signature = {
         MODELS_INFO: [(YANDEX, "YNDX-00532")],
@@ -321,7 +322,7 @@ class YandexDoubleGangSwitch(CustomDevice):
                     Basic.cluster_id,
                     Identify.cluster_id,
                     OnOff.cluster_id,
-                    YandexClusterSwitchMain,
+                    YandexClusterWiredSwitchMain,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
@@ -332,12 +333,12 @@ class YandexDoubleGangSwitch(CustomDevice):
                     Basic.cluster_id,
                     Identify.cluster_id,
                     OnOff.cluster_id,
-                    YandexClusterSwitchSecondary,
+                    YandexClusterWiredSwitchSecondary,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             },
             # Button 1 Down
-            YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID: {
+            YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -347,7 +348,7 @@ class YandexDoubleGangSwitch(CustomDevice):
                 OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Button 2 Down
-            YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID: {
+            YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -357,7 +358,7 @@ class YandexDoubleGangSwitch(CustomDevice):
                 OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Button 1 Up
-            YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_ENDPOINT_ID: {
+            YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_UP_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -367,7 +368,7 @@ class YandexDoubleGangSwitch(CustomDevice):
                 OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
             },
             # Button 2 Up
-            YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_ENDPOINT_ID: {
+            YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_UP_ENDPOINT_ID: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
                 INPUT_CLUSTERS: [
@@ -380,65 +381,392 @@ class YandexDoubleGangSwitch(CustomDevice):
     }
 
     device_automation_triggers = {
-        (SHORT_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_NAME): {
+        (SHORT_PRESS, YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_DOWN_NAME): {
             COMMAND: COMMAND_TOGGLE,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID,
         },
-        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_NAME): {
+        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_DOWN_NAME): {
             COMMAND: COMMAND_ON,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID,
         },
-        (LONG_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_NAME): {
+        (LONG_PRESS, YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_DOWN_NAME): {
             COMMAND: COMMAND_OFF,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID,
         },
-        (SHORT_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_NAME): {
+        (SHORT_PRESS, YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_DOWN_NAME): {
             COMMAND: COMMAND_TOGGLE,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID,
         },
-        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_NAME): {
+        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_DOWN_NAME): {
             COMMAND: COMMAND_ON,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID,
         },
-        (LONG_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_NAME): {
+        (LONG_PRESS, YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_DOWN_NAME): {
             COMMAND: COMMAND_OFF,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID,
         },
-        (SHORT_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_NAME): {
+        (SHORT_PRESS, YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_UP_NAME): {
             COMMAND: COMMAND_TOGGLE,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_UP_ENDPOINT_ID,
         },
-        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_NAME): {
+        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_UP_NAME): {
             COMMAND: COMMAND_ON,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_UP_ENDPOINT_ID,
         },
-        (LONG_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_NAME): {
+        (LONG_PRESS, YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_UP_NAME): {
             COMMAND: COMMAND_OFF,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_1_UP_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_1_UP_ENDPOINT_ID,
         },
-        (SHORT_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_NAME): {
+        (SHORT_PRESS, YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_UP_NAME): {
             COMMAND: COMMAND_TOGGLE,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_UP_ENDPOINT_ID,
         },
-        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_NAME): {
+        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_UP_NAME): {
             COMMAND: COMMAND_ON,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_UP_ENDPOINT_ID,
         },
-        (LONG_PRESS, YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_NAME): {
+        (LONG_PRESS, YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_UP_NAME): {
             COMMAND: COMMAND_OFF,
             CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: YANDEX_DOUBLE_GANG_SWITCH_BUTTON_2_UP_ENDPOINT_ID,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRED_SWITCH_BUTTON_2_UP_ENDPOINT_ID,
+        },
+    }
+
+
+### YNDX-00534 & YNDX-00535 SINGLE-GANG & DOUBLE-GANG WIRELESS SWITCHES ###
+
+YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_DOWN_ENDPOINT_ID = 1
+YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_UP_ENDPOINT_ID = 2
+
+YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_DOWN_NAME = "Button (Down)"
+YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_UP_NAME = "Button (Up)"
+
+YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID = 1
+YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID = 2
+YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_UP_ENDPOINT_ID = 3
+YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_UP_ENDPOINT_ID = 4
+
+YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_DOWN_NAME = "Button 1 (Down)"
+YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_DOWN_NAME = "Button 2 (Down)"
+YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_UP_NAME = "Button 1 (Up)"
+YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_UP_NAME = "Button 2 (Up)"
+
+
+class YandexSingleGangWirelessSwitch(CustomDevice):
+    """Single-gang wireless switch."""
+
+    signature = {
+        MODELS_INFO: [(YANDEX, "YNDX-00534")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=259
+            # device_version=0
+            # input_clusters=[0, 1, 3]
+            # output_clusters=[3, 6, 25]>
+            YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_DOWN_ENDPOINT_ID: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=259
+            # device_version=0
+            # input_clusters=[0, 3]
+            # output_clusters=[3, 6]>
+            YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_UP_ENDPOINT_ID: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            # Down
+            YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_DOWN_ENDPOINT_ID: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            # Up
+            YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_UP_ENDPOINT_ID: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+        }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_DOWN_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_DOWN_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_DOWN_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_DOWN_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_DOWN_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_DOWN_ENDPOINT_ID,
+        },
+        (SHORT_PRESS, YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_UP_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_UP_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_UP_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_UP_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_UP_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_SINGLE_GANG_WIRELESS_SWITCH_BUTTON_UP_ENDPOINT_ID,
+        },
+    }
+
+
+class YandexDoubleGangWirelessSwitch(CustomDevice):
+    """Double-gang wireless switch."""
+
+    signature = {
+        MODELS_INFO: [(YANDEX, "YNDX-00535")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=259
+            # device_version=0
+            # input_clusters=[0, 1, 3]
+            # output_clusters=[3, 6, 25]>
+            YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=259
+            # device_version=0
+            # input_clusters=[0, 3]
+            # output_clusters=[3, 6]>
+            YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+            # <SimpleDescriptor endpoint=3 profile=260 device_type=259
+            # device_version=0
+            # input_clusters=[0, 3]
+            # output_clusters=[3, 6]>
+            YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_UP_ENDPOINT_ID: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+            # <SimpleDescriptor endpoint=4 profile=260 device_type=259
+            # device_version=0
+            # input_clusters=[0, 3]
+            # output_clusters=[3, 6]>
+            YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_UP_ENDPOINT_ID: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            # Button 1 Down
+            YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            # Button 2 Down
+            YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+            # Button 1 Up
+            YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_UP_ENDPOINT_ID: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+            # Button 2 Up
+            YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_UP_ENDPOINT_ID: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                ],
+            },
+        }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_DOWN_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_DOWN_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_DOWN_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_DOWN_ENDPOINT_ID,
+        },
+        (SHORT_PRESS, YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_DOWN_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_DOWN_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_DOWN_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_DOWN_ENDPOINT_ID,
+        },
+        (SHORT_PRESS, YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_UP_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_UP_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_UP_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_UP_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_UP_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_1_UP_ENDPOINT_ID,
+        },
+        (SHORT_PRESS, YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_UP_NAME): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_UP_ENDPOINT_ID,
+        },
+        (DOUBLE_PRESS, YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_UP_NAME): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_UP_ENDPOINT_ID,
+        },
+        (LONG_PRESS, YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_UP_NAME): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: YANDEX_DOUBLE_GANG_WIRELESS_SWITCH_BUTTON_2_UP_ENDPOINT_ID,
         },
     }
 

--- a/zhaquirks/yandex/yndx_0059x.py
+++ b/zhaquirks/yandex/yndx_0059x.py
@@ -1,0 +1,149 @@
+"""Support for YNDX-0059x devices: curtain motor."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from zigpy.profiles import zgp, zha
+from zigpy.quirks import CustomDevice
+import zigpy.types as t
+from zigpy.zcl import BaseAttributeDefs, BaseCommandDefs
+from zigpy.zcl.clusters.closures import (
+    ConfigStatus,
+    WindowCovering,
+    WindowCoveringMode,
+    WindowCoveringType,
+)
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    Ota,
+    Scenes,
+)
+from zigpy.zcl.clusters.homeautomation import Diagnostic
+from zigpy.zcl.foundation import Direction, ZCLAttributeDef, ZCLCommandDef
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.yandex import YANDEX
+
+
+class YandexWindowCovering(WindowCovering):
+    """Yandex-specific window covering cluster implementation."""
+
+    cluster_id: Final[t.uint16_t] = 0x0102
+    name: Final = "Window Covering"
+    ep_attribute: Final = "window_covering"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        # Window Covering Information
+        window_covering_type: Final = ZCLAttributeDef(
+            id=0x0000, type=WindowCoveringType, access="r", mandatory=True
+        )
+        config_status: Final = ZCLAttributeDef(
+            id=0x0007, type=ConfigStatus, access="r", mandatory=True
+        )
+        # All subsequent attributes are mandatory if their control types are enabled
+        current_position_lift_percentage: Final = ZCLAttributeDef(
+            id=0x0008, type=t.uint8_t, access="rps"
+        )
+        # Window Covering Settings
+        installed_open_limit_lift: Final = ZCLAttributeDef(
+            id=0x0010, type=t.uint16_t, access="r"
+        )
+        installed_closed_limit_lift: Final = ZCLAttributeDef(
+            id=0x0011, type=t.uint16_t, access="r"
+        )
+        velocity_lift: Final = ZCLAttributeDef(id=0x0014, type=t.uint16_t, access="rw")
+        window_covering_mode: Final = ZCLAttributeDef(
+            id=0x0017, type=WindowCoveringMode, access="rw", mandatory=True
+        )
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Command definitions."""
+
+        down_close: Final = ZCLCommandDef(
+            id=0x00, schema={}, direction=Direction.Client_to_Server
+        )
+        up_open: Final = ZCLCommandDef(
+            id=0x01, schema={}, direction=Direction.Client_to_Server
+        )
+        stop: Final = ZCLCommandDef(
+            id=0x02, schema={}, direction=Direction.Client_to_Server
+        )
+        go_to_lift_percentage: Final = ZCLCommandDef(
+            id=0x05,
+            schema={"percentage_lift_value": t.uint8_t},
+            direction=Direction.Client_to_Server,
+        )
+
+
+class YandexCurtainMotor(CustomDevice):
+    """Yandex curtain motor."""
+
+    signature = {
+        MODELS_INFO: [(YANDEX, "YNDX-00591")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=514
+            # device_version=0
+            # input_clusters=[0, 3, 4, 5, 258, 2821]
+            # output_clusters=[3, 25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    WindowCovering.cluster_id,
+                    Diagnostic.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # device_version=0
+            # input_clusters=[]
+            # output_clusters=[33]>
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    YandexWindowCovering,
+                    0x0B05,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }

--- a/zhaquirks/yandex/yndx_0059x.py
+++ b/zhaquirks/yandex/yndx_0059x.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from typing import Final
 
 from zigpy.profiles import zgp, zha
-from zigpy.quirks import CustomDevice
+from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
-from zigpy.zcl import BaseAttributeDefs, BaseCommandDefs
 from zigpy.zcl.clusters.closures import (
     ConfigStatus,
     WindowCovering,
@@ -33,44 +32,45 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.yandex import YANDEX
+from zhaquirks.yandex import (
+    YANDEX,
+    YANDEX_ATTRIBUTE_MAX_POSITION,
+    YANDEX_ATTRIBUTE_MIN_POSITION,
+    YANDEX_ATTRIBUTE_UNK_F000,
+    YANDEX_ATTRIBUTE_UNK_FFFD,
+    YANDEX_ATTRIBUTE_VELOCITY_LIFT,
+    YANDEX_MANUFACTURER_CODE_2,
+)
 
 
-class YandexWindowCovering(WindowCovering):
-    """Yandex-specific window covering cluster implementation."""
+class YandexWindowCovering(CustomCluster, WindowCovering):
+    """Yandex-flavor window covering cluster."""
 
-    cluster_id: Final[t.uint16_t] = 0x0102
-    name: Final = "Window Covering"
-    ep_attribute: Final = "window_covering"
+    manufacturer_id_override = YANDEX_MANUFACTURER_CODE_2
 
-    class AttributeDefs(BaseAttributeDefs):
+    class AttributeDefs(WindowCovering.AttributeDefs):
         """Attribute definitions."""
 
-        # Window Covering Information
         window_covering_type: Final = ZCLAttributeDef(
             id=0x0000, type=WindowCoveringType, access="r", mandatory=True
         )
         config_status: Final = ZCLAttributeDef(
             id=0x0007, type=ConfigStatus, access="r", mandatory=True
         )
-        # All subsequent attributes are mandatory if their control types are enabled
         current_position_lift_percentage: Final = ZCLAttributeDef(
             id=0x0008, type=t.uint8_t, access="rps"
         )
-        # Window Covering Settings
-        installed_open_limit_lift: Final = ZCLAttributeDef(
-            id=0x0010, type=t.uint16_t, access="r"
-        )
-        installed_closed_limit_lift: Final = ZCLAttributeDef(
-            id=0x0011, type=t.uint16_t, access="r"
-        )
-        velocity_lift: Final = ZCLAttributeDef(id=0x0014, type=t.uint16_t, access="rw")
+        velocity_lift: Final = YANDEX_ATTRIBUTE_VELOCITY_LIFT
         window_covering_mode: Final = ZCLAttributeDef(
             id=0x0017, type=WindowCoveringMode, access="rw", mandatory=True
         )
+        min_position: Final = YANDEX_ATTRIBUTE_MIN_POSITION
+        max_position: Final = YANDEX_ATTRIBUTE_MAX_POSITION
+        unknown_f000: Final = YANDEX_ATTRIBUTE_UNK_F000
+        unknown_fffd: Final = YANDEX_ATTRIBUTE_UNK_FFFD
 
-    class ServerCommandDefs(BaseCommandDefs):
-        """Command definitions."""
+    class ServerCommandDefs(WindowCovering.ServerCommandDefs):
+        """Server command definitions."""
 
         down_close: Final = ZCLCommandDef(
             id=0x00, schema={}, direction=Direction.Client_to_Server
@@ -92,7 +92,7 @@ class YandexCurtainMotor(CustomDevice):
     """Yandex curtain motor."""
 
     signature = {
-        MODELS_INFO: [(YANDEX, "YNDX-00591")],
+        MODELS_INFO: [(YANDEX, "YNDX-00591"), (YANDEX, "YNDX-00592")],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=514
             # device_version=0
@@ -135,7 +135,7 @@ class YandexCurtainMotor(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     YandexWindowCovering,
-                    0x0B05,
+                    Diagnostic.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
             },


### PR DESCRIPTION
## Proposed change

Add support for manufacturer-specific features of the following Yandex devices:

- YNDX-00530 Dimmer
- YNDX-00531 Single-gang Wired Switch
- YNDX-00532 Double-gang Wired Switch
- YNDX-00531 Single-gang Wireless Switch
- YNDX-00532 Double-gang Wireless Switch
- YNDX-00537 Single Relay
- YNDX-00538 Double Relay
- YNDX-00591 Curtain Motor
- YNDX-00592 Curtain Motor

(YNDX-00534 and YNDX-00535 wireless switch quirks are only really there for automation triggers' sake)

## Additional information

I've used code from Koenkk/zigbee-herdsman-converters#8345 and Koenkk/zigbee-herdsman-converters#9017 as reference for cluster attributes and commands.

Known issues (fixed):
- ~~Dimmer is pretty much untested. I'll test it when I have time.~~
- ~~Some of the endpoints added in replacement signatures are 'fake' and only work if the device is set into a 'decoupled' mode, if the endpoints are used in HA in any way when the device is not in the 'decoupled' mode, HA hangs until the requests time out.~~
- ~~I haven't been able to find the manufacturer code for the curtain motor as of yet~~

Known issues (wontfix):
- ~~The led_indicator attribute is weird, I don't think it's working as it should on all devices. (Seems to be Yandex's problem)~~
- Various buggy behavior that has to do with adding new devices. Probably Yandex's fault, because device adding pretty much always works flawlessly if you only start scanning for new devices in HA like 5 seconds after initiating device reset. And in the rare cases it doesn't, power cycling both the device and HA always helps, for some reason.
  - When adding devices, they get stuck in "Configuring" stage for a long while, but eventually get added (a restart of Home Assistant helps)
  - If `SKIP_CONFIGURATION: True` is added to replacement signature, devices don't get stuck in "Configuring" stage, but attribute reporting doesn't work
  - After adding double-gang switch or double relay, attribute reporting may not work for the second endpoint, which somehow gets fixed after pressing 'Reconfigure' on device page in HA

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
