### PR TITLE
Add Aqara light switch H2 US quirk

### DIFF
--- a/zhaquirks/xiaomi/aqara/switch_h2.py
+++ b/zhaquirks/xiaomi/aqara/switch_h2.py
@@ -57,7 +57,7 @@ class PowerMeasurementCluster(AnalogInputCluster):
         """Bind cluster."""
         result = await super().bind()
         await self.configure_reporting(
-            self.PRESENT_VALUE_ATTRIBUTE,  # attribute
+            self.PRESENT_VALUE_ATTRIBUTE,
             0,  # minimum reporting interval
             600,  # maximum reporting interval
             1,  # reportable change
@@ -65,12 +65,7 @@ class PowerMeasurementCluster(AnalogInputCluster):
         return result
     
     def _update_attribute(self, attrid, value):
-        """Override to handle power measurement attribute."""
-        if attrid == self.PRESENT_VALUE_ATTRIBUTE:
-            # Convert value if needed (e.g., scaling factor)
-            # For example, if the value is in 0.01W units:
-            # value = value / 100.0
-            
+        if attrid == self.PRESENT_VALUE_ATTRIBUTE:            
             super()._update_attribute(attrid, value)
             self.listener_event(
                 ZHA_SEND_EVENT,

--- a/zhaquirks/xiaomi/aqara/switch_h2.py
+++ b/zhaquirks/xiaomi/aqara/switch_h2.py
@@ -23,9 +23,9 @@ from zhaquirks.const import (
     BUTTON_2,
     CLUSTER_ID,
     COMMAND_DOUBLE,
-    COMMAND_SINGLE,
     COMMAND_HOLD,
     COMMAND_RELEASE,
+    COMMAND_SINGLE,
     DEVICE_TYPE,
     ENDPOINT_ID,
     ENDPOINTS,
@@ -37,7 +37,6 @@ from zhaquirks.const import (
     VALUE,
     ZHA_SEND_EVENT,
 )
-
 from zhaquirks.xiaomi import (
     AnalogInputCluster,
     BasicCluster,
@@ -45,16 +44,15 @@ from zhaquirks.xiaomi import (
     OnOffCluster,
     XiaomiCustomDevice,
 )
-
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 from zhaquirks.xiaomi.aqara.opple_switch import OppleSwitchCluster
 
 
 class PowerMeasurementCluster(AnalogInputCluster):
     """Custom cluster for power measurement."""
-    
+
     PRESENT_VALUE_ATTRIBUTE = 0x0055
-    
+
     async def bind(self):
         """Bind cluster."""
         result = await super().bind()
@@ -65,10 +63,10 @@ class PowerMeasurementCluster(AnalogInputCluster):
             1,  # reportable change
         )
         return result
-    
+
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
-        if attrid == self.PRESENT_VALUE_ATTRIBUTE:            
+        if attrid == self.PRESENT_VALUE_ATTRIBUTE:
             self.listener_event(
                 ZHA_SEND_EVENT,
                 {
@@ -80,6 +78,7 @@ class PowerMeasurementCluster(AnalogInputCluster):
 
 class AqaraLightSwitchH2US2B1C(XiaomiCustomDevice):
     """Wrapper for Aqara Light Switch H2 US with 2 buttons and 1 channel (WS-K02E)"""
+
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.agl004")],
         ENDPOINTS: {
@@ -242,6 +241,7 @@ class AqaraLightSwitchH2US2B1C(XiaomiCustomDevice):
 
 class AqaraLightSwitchH2US2B2C(XiaomiCustomDevice):
     """Wrapper for Aqara Light Switch H2 US with 2 buttons and 2 channels (WS-K03E)"""
+
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.agl005")],
         ENDPOINTS: {

--- a/zhaquirks/xiaomi/aqara/switch_h2.py
+++ b/zhaquirks/xiaomi/aqara/switch_h2.py
@@ -1,3 +1,5 @@
+"""Aqara H2 single rocker switch quirks. Also see opple_switch.py for similar switches."""
+
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
     AnalogInput,
@@ -21,9 +23,9 @@ from zhaquirks.const import (
     BUTTON_2,
     CLUSTER_ID,
     COMMAND_DOUBLE,
+    COMMAND_SINGLE,
     COMMAND_HOLD,
     COMMAND_RELEASE,
-    COMMAND_SINGLE,
     DEVICE_TYPE,
     ENDPOINT_ID,
     ENDPOINTS,
@@ -35,6 +37,7 @@ from zhaquirks.const import (
     VALUE,
     ZHA_SEND_EVENT,
 )
+
 from zhaquirks.xiaomi import (
     AnalogInputCluster,
     BasicCluster,
@@ -42,15 +45,16 @@ from zhaquirks.xiaomi import (
     OnOffCluster,
     XiaomiCustomDevice,
 )
+
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 from zhaquirks.xiaomi.aqara.opple_switch import OppleSwitchCluster
 
 
 class PowerMeasurementCluster(AnalogInputCluster):
     """Custom cluster for power measurement."""
-
+    
     PRESENT_VALUE_ATTRIBUTE = 0x0055
-
+    
     async def bind(self):
         """Bind cluster."""
         result = await super().bind()
@@ -61,10 +65,10 @@ class PowerMeasurementCluster(AnalogInputCluster):
             1,  # reportable change
         )
         return result
-
+    
     def _update_attribute(self, attrid, value):
-        if attrid == self.PRESENT_VALUE_ATTRIBUTE:
-            super()._update_attribute(attrid, value)
+        super()._update_attribute(attrid, value)
+        if attrid == self.PRESENT_VALUE_ATTRIBUTE:            
             self.listener_event(
                 ZHA_SEND_EVENT,
                 {
@@ -72,13 +76,10 @@ class PowerMeasurementCluster(AnalogInputCluster):
                     "value": value,
                 },
             )
-        else:
-            super()._update_attribute(attrid, value)
 
 
 class AqaraLightSwitchH2US2B1C(XiaomiCustomDevice):
-    """Wrapper for Aqara Light Switch H2 US with 2 buttons and 1 channel."""
-
+    """Wrapper for Aqara Light Switch H2 US with 2 buttons and 1 channel (WS-K02E)"""
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.agl004")],
         ENDPOINTS: {
@@ -158,7 +159,6 @@ class AqaraLightSwitchH2US2B1C(XiaomiCustomDevice):
                     OnOffCluster,
                     MultistateInputCluster,
                     MeteringCluster,
-                    # ElectricalMeasurementCluster,
                     ElectricalMeasurement.cluster_id,
                     OppleSwitchCluster,
                 ],
@@ -241,8 +241,7 @@ class AqaraLightSwitchH2US2B1C(XiaomiCustomDevice):
 
 
 class AqaraLightSwitchH2US2B2C(XiaomiCustomDevice):
-    """Wrapper for Aqara Light Switch H2 US with 2 buttons and 2 channels."""
-
+    """Wrapper for Aqara Light Switch H2 US with 2 buttons and 2 channels (WS-K03E)"""
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.agl005")],
         ENDPOINTS: {

--- a/zhaquirks/xiaomi/aqara/switch_h2.py
+++ b/zhaquirks/xiaomi/aqara/switch_h2.py
@@ -1,0 +1,397 @@
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import (
+    AnalogInput,
+    Basic,
+    Groups,
+    Identify,
+    MultistateInput,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.smartenergy import Metering
+
+from zhaquirks.const import (
+    ARGS,
+    ATTR_ID,
+    BUTTON,
+    BUTTON_1,
+    BUTTON_2,
+    CLUSTER_ID,
+    COMMAND_DOUBLE,
+    COMMAND_SINGLE,
+    COMMAND_HOLD,
+    COMMAND_RELEASE,
+    DEVICE_TYPE,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PRESS_TYPE,
+    PROFILE_ID,
+    VALUE,
+    ZHA_SEND_EVENT,
+)
+
+from zhaquirks.xiaomi import (
+    AnalogInputCluster,
+    BasicCluster,
+    MeteringCluster,
+    OnOffCluster,
+    XiaomiCustomDevice,
+)
+
+from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
+from zhaquirks.xiaomi.aqara.opple_switch import OppleSwitchCluster
+
+
+class PowerMeasurementCluster(AnalogInputCluster):
+    """Custom cluster for power measurement."""
+    
+    PRESENT_VALUE_ATTRIBUTE = 0x0055
+    
+    async def bind(self):
+        """Bind cluster."""
+        result = await super().bind()
+        await self.configure_reporting(
+            self.PRESENT_VALUE_ATTRIBUTE,  # attribute
+            0,  # minimum reporting interval
+            600,  # maximum reporting interval
+            1,  # reportable change
+        )
+        return result
+    
+    def _update_attribute(self, attrid, value):
+        """Override to handle power measurement attribute."""
+        if attrid == self.PRESENT_VALUE_ATTRIBUTE:
+            # Convert value if needed (e.g., scaling factor)
+            # For example, if the value is in 0.01W units:
+            # value = value / 100.0
+            
+            super()._update_attribute(attrid, value)
+            self.listener_event(
+                ZHA_SEND_EVENT,
+                {
+                    "type": "power_measurement",
+                    "value": value,
+                },
+            )
+        else:
+            super()._update_attribute(attrid, value)
+
+class AqaraLightSwitchH2US2B1C(XiaomiCustomDevice):
+    """Wrapper for Aqara Light Switch H2 US with 2 buttons and 1 channel."""
+    signature = {
+        MODELS_INFO: [("Aqara", "lumi.switch.agl004")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    OppleSwitchCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    OppleSwitchCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    OppleSwitchCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MultistateInput.cluster_id,
+                    OppleSwitchCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            5: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    OppleSwitchCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    AnalogInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MeteringCluster,
+                    # ElectricalMeasurementCluster,
+                    ElectricalMeasurement.cluster_id,
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MultistateInputCluster,
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            5: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerMeasurementCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (COMMAND_SINGLE, BUTTON_1): {
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 18,
+            ARGS: {BUTTON: 1, ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
+        },
+        (COMMAND_SINGLE, BUTTON_2): {
+            ENDPOINT_ID: 4,
+            CLUSTER_ID: 18,
+            ARGS: {BUTTON: 4, ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
+        },
+        (COMMAND_DOUBLE, BUTTON_2): {
+            ENDPOINT_ID: 4,
+            CLUSTER_ID: 18,
+            ARGS: {BUTTON: 4, ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_DOUBLE, VALUE: 2},
+        },
+        (COMMAND_HOLD, BUTTON_2): {
+            ENDPOINT_ID: 4,
+            CLUSTER_ID: 18,
+            ARGS: {BUTTON: 4, ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_HOLD, VALUE: 0},
+        },
+        (COMMAND_RELEASE, BUTTON_2): {
+            ENDPOINT_ID: 4,
+            CLUSTER_ID: 18,
+            ARGS: {BUTTON: 4, ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_RELEASE, VALUE: 255},
+        },
+    }
+
+class AqaraLightSwitchH2US2B2C(XiaomiCustomDevice):
+    """Wrapper for Aqara Light Switch H2 US with 2 buttons and 2 channels."""
+    signature = {
+        MODELS_INFO: [("Aqara", "lumi.switch.agl005")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    OppleSwitchCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    OppleSwitchCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    OppleSwitchCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    OppleSwitchCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            5: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    OppleSwitchCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    AnalogInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MeteringCluster,
+                    ElectricalMeasurement.cluster_id,
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            5: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    OppleSwitchCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    PowerMeasurementCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (COMMAND_SINGLE, BUTTON_1): {
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 18,
+            ARGS: {BUTTON: 1, ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
+        },
+        (COMMAND_SINGLE, BUTTON_2): {
+            ENDPOINT_ID: 2,
+            CLUSTER_ID: 18,
+            ARGS: {BUTTON: 2, ATTR_ID: 0x0055, PRESS_TYPE: COMMAND_SINGLE, VALUE: 1},
+        },
+    }

--- a/zhaquirks/xiaomi/aqara/switch_h2.py
+++ b/zhaquirks/xiaomi/aqara/switch_h2.py
@@ -21,9 +21,9 @@ from zhaquirks.const import (
     BUTTON_2,
     CLUSTER_ID,
     COMMAND_DOUBLE,
-    COMMAND_SINGLE,
     COMMAND_HOLD,
     COMMAND_RELEASE,
+    COMMAND_SINGLE,
     DEVICE_TYPE,
     ENDPOINT_ID,
     ENDPOINTS,
@@ -35,7 +35,6 @@ from zhaquirks.const import (
     VALUE,
     ZHA_SEND_EVENT,
 )
-
 from zhaquirks.xiaomi import (
     AnalogInputCluster,
     BasicCluster,
@@ -43,16 +42,15 @@ from zhaquirks.xiaomi import (
     OnOffCluster,
     XiaomiCustomDevice,
 )
-
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 from zhaquirks.xiaomi.aqara.opple_switch import OppleSwitchCluster
 
 
 class PowerMeasurementCluster(AnalogInputCluster):
     """Custom cluster for power measurement."""
-    
+
     PRESENT_VALUE_ATTRIBUTE = 0x0055
-    
+
     async def bind(self):
         """Bind cluster."""
         result = await super().bind()
@@ -63,9 +61,9 @@ class PowerMeasurementCluster(AnalogInputCluster):
             1,  # reportable change
         )
         return result
-    
+
     def _update_attribute(self, attrid, value):
-        if attrid == self.PRESENT_VALUE_ATTRIBUTE:            
+        if attrid == self.PRESENT_VALUE_ATTRIBUTE:
             super()._update_attribute(attrid, value)
             self.listener_event(
                 ZHA_SEND_EVENT,
@@ -77,8 +75,10 @@ class PowerMeasurementCluster(AnalogInputCluster):
         else:
             super()._update_attribute(attrid, value)
 
+
 class AqaraLightSwitchH2US2B1C(XiaomiCustomDevice):
     """Wrapper for Aqara Light Switch H2 US with 2 buttons and 1 channel."""
+
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.agl004")],
         ENDPOINTS: {
@@ -239,8 +239,10 @@ class AqaraLightSwitchH2US2B1C(XiaomiCustomDevice):
         },
     }
 
+
 class AqaraLightSwitchH2US2B2C(XiaomiCustomDevice):
     """Wrapper for Aqara Light Switch H2 US with 2 buttons and 2 channels."""
+
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.agl005")],
         ENDPOINTS: {


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Added partial support for [Aqara Light Switch H2 US](https://www.aqara.com/us/product/light-switch-h2-us/). I only have the 2 button 1 channel (WS-K02E) and 2 button 2 channel (WS-K03E) versions so I only added these two.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
The change enable the button events for the switch, as well as the correct power reading from the switch.

Mentioned in [this issue](https://github.com/zigpy/zha-device-handlers/issues/3957).

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
