### PR TITLE
Add device triggers for Paulmann 501.41 remote

### DIFF
--- a/zhaquirks/paulmann/sevenbtnremote.py
+++ b/zhaquirks/paulmann/sevenbtnremote.py
@@ -1,25 +1,8 @@
 """Device handler for Paulmann Smart Home 7-button remote control."""
 
-from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    PowerConfiguration,
-    Identify,
-    Groups,
-    Scenes,
-    OnOff,
-    LevelControl,
-)
-from zigpy.zcl.clusters.lighting import Color
-from zigpy.zcl.clusters.general import Ota
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
+
+from zhaquirks.const import DEVICE_TYPE, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
 
 EP = 1
 CLUSTER_ONOFF = 6

--- a/zhaquirks/paulmann/sevenbtnremote.py
+++ b/zhaquirks/paulmann/sevenbtnremote.py
@@ -1,0 +1,142 @@
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    PowerConfiguration,
+    Identify,
+    Groups,
+    Scenes,
+    OnOff,
+    LevelControl,
+)
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.general import Ota
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+EP = 1
+CLUSTER_ONOFF = 6
+CLUSTER_LEVEL = 8
+CLUSTER_SCENES = 5
+CLUSTER_COLOR_TEMP = 768
+
+
+class PaulmannHomeRemote(CustomDevice):
+    """Quirk for Paulmann 501.41 Zigbee Smart Home Remote with 7 buttons.
+
+    Provides device automation triggers for brightness, color temp, scenes, and power.
+    """
+
+    signature = {
+        "model": None,
+        "manufacturer": None,
+        "endpoints": {
+            EP: {
+                PROFILE_ID: 0x0104,
+                DEVICE_TYPE: 0x0105,
+                INPUT_CLUSTERS: [0x0000, 0x0001, 0x0003],
+                OUTPUT_CLUSTERS: [
+                    0x0003,
+                    0x0004,
+                    0x0005,
+                    CLUSTER_ONOFF,
+                    CLUSTER_LEVEL,
+                    0x0019,
+                    CLUSTER_COLOR_TEMP,
+                    0x1000,
+                ],
+            }
+        },
+    }
+
+    replacement = signature
+
+    device_automation_triggers = {
+        # Power Button (Only toggles on/off as command, not useful for automation)
+        ("short_press", "Power Button"): {
+            "cluster_id": CLUSTER_ONOFF,
+            "endpoint_id": EP,
+        },
+        # Brightness Up (Plus)
+        ("short_press", "Plus Button"): {
+            "command": "step_with_on_off",
+            "cluster_id": CLUSTER_LEVEL,
+            "endpoint_id": EP,
+            "args": [0, 26, 2],
+        },
+        ("long_press", "Plus Button"): {
+            "command": "move_with_on_off",
+            "cluster_id": CLUSTER_LEVEL,
+            "endpoint_id": EP,
+            "args": [0, 50],
+        },
+        # Brightness Down (Minus)
+        ("short_press", "Minus Button"): {
+            "command": "step",
+            "cluster_id": CLUSTER_LEVEL,
+            "endpoint_id": EP,
+            "args": [1, 26, 2],
+        },
+        ("long_press", "Minus Button"): {
+            "command": "move",
+            "cluster_id": CLUSTER_LEVEL,
+            "endpoint_id": EP,
+            "args": [1, 50],
+        },
+        # Color Temp: Warmer (Fire)
+        ("short_press", "Fire Button"): {
+            "command": "step_color_temp",
+            "cluster_id": CLUSTER_COLOR_TEMP,
+            "endpoint_id": EP,
+            "args": [1, 30, 2, 0, 0, 0, 0],
+        },
+        ("long_press", "Fire Button"): {
+            "command": "move_color_temp",
+            "cluster_id": CLUSTER_COLOR_TEMP,
+            "endpoint_id": EP,
+            "args": [1, 60, 0, 0, 0, 0],
+        },
+        # Color Temp: Cooler (Ice)
+        ("short_press", "Ice Button"): {
+            "command": "step_color_temp",
+            "cluster_id": CLUSTER_COLOR_TEMP,
+            "endpoint_id": EP,
+            "args": [3, 30, 2, 0, 0, 0, 0],
+        },
+        ("long_press", "Ice Button"): {
+            "command": "move_color_temp",
+            "cluster_id": CLUSTER_COLOR_TEMP,
+            "endpoint_id": EP,
+            "args": [3, 60, 0, 0, 0, 0],
+        },
+        # Scene buttons (Events distinguished by arguments)
+        ("short_press", "S1 Button"): {
+            "command": "recall",
+            "cluster_id": CLUSTER_SCENES,
+            "endpoint_id": EP,
+            "args": [0, 1, 2],
+        },
+        ("long_press", "S1 Button"): {
+            "command": "store",
+            "cluster_id": CLUSTER_SCENES,
+            "endpoint_id": EP,
+            "args": [0, 1],
+        },
+        ("short_press", "S2 Button"): {
+            "command": "recall",
+            "cluster_id": CLUSTER_SCENES,
+            "endpoint_id": EP,
+            "args": [0, 2, 2],
+        },
+        ("long_press", "S2 Button"): {
+            "command": "store",
+            "cluster_id": CLUSTER_SCENES,
+            "endpoint_id": EP,
+            "args": [0, 2],
+        },
+    }

--- a/zhaquirks/paulmann/sevenbtnremote.py
+++ b/zhaquirks/paulmann/sevenbtnremote.py
@@ -1,3 +1,5 @@
+"""Device handler for Paulmann Smart Home 7-button remote control."""
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -33,8 +35,8 @@ class PaulmannHomeRemote(CustomDevice):
     """
 
     signature = {
-        "model": None,
-        "manufacturer": None,
+        "model": "unk_model",
+        "manufacturer": "unk_manufacturer",
         "endpoints": {
             EP: {
                 PROFILE_ID: 0x0104,
@@ -67,76 +69,134 @@ class PaulmannHomeRemote(CustomDevice):
             "command": "step_with_on_off",
             "cluster_id": CLUSTER_LEVEL,
             "endpoint_id": EP,
-            "args": [0, 26, 2],
+            "params": {
+                "step_mode": 0,
+                "step_size": 26,
+                "transition_time": 2,
+            },
         },
         ("long_press", "Plus Button"): {
             "command": "move_with_on_off",
             "cluster_id": CLUSTER_LEVEL,
             "endpoint_id": EP,
-            "args": [0, 50],
+            "params": {
+                "move_mode": 0,
+                "rate": 50,
+            },
         },
         # Brightness Down (Minus)
         ("short_press", "Minus Button"): {
             "command": "step",
             "cluster_id": CLUSTER_LEVEL,
             "endpoint_id": EP,
-            "args": [1, 26, 2],
+            "params": {
+                "step_mode": 1,
+                "step_size": 26,
+                "transition_time": 2,
+            },
         },
         ("long_press", "Minus Button"): {
             "command": "move",
             "cluster_id": CLUSTER_LEVEL,
             "endpoint_id": EP,
-            "args": [1, 50],
+            "params": {
+                "move_mode": 1,
+                "rate": 50,
+            },
         },
         # Color Temp: Warmer (Fire)
         ("short_press", "Fire Button"): {
             "command": "step_color_temp",
             "cluster_id": CLUSTER_COLOR_TEMP,
             "endpoint_id": EP,
-            "args": [1, 30, 2, 0, 0, 0, 0],
+            "params": {
+                "step_mode": 1,
+                "step_size": 30,
+                "transition_time": 2,
+                "color_temp_min_mireds": 0,
+                "color_temp_max_mireds": 0,
+                "options_mask": 0,
+                "options_override": 0,
+            },
         },
         ("long_press", "Fire Button"): {
             "command": "move_color_temp",
             "cluster_id": CLUSTER_COLOR_TEMP,
             "endpoint_id": EP,
-            "args": [1, 60, 0, 0, 0, 0],
+            "params": {
+                "move_mode": 1,
+                "rate": 60,
+                "color_temp_min_mireds": 0,
+                "color_temp_max_mireds": 0,
+                "options_mask": 0,
+                "options_override": 0,
+            },
         },
         # Color Temp: Cooler (Ice)
         ("short_press", "Ice Button"): {
             "command": "step_color_temp",
             "cluster_id": CLUSTER_COLOR_TEMP,
             "endpoint_id": EP,
-            "args": [3, 30, 2, 0, 0, 0, 0],
+            "params": {
+                "step_mode": 3,
+                "step_size": 30,
+                "transition_time": 2,
+                "color_temp_min_mireds": 0,
+                "color_temp_max_mireds": 0,
+                "options_mask": 0,
+                "options_override": 0,
+            },
         },
         ("long_press", "Ice Button"): {
             "command": "move_color_temp",
             "cluster_id": CLUSTER_COLOR_TEMP,
             "endpoint_id": EP,
-            "args": [3, 60, 0, 0, 0, 0],
+            "params": {
+                "move_mode": 3,
+                "rate": 60,
+                "color_temp_min_mireds": 0,
+                "color_temp_max_mireds": 0,
+                "options_mask": 0,
+                "options_override": 0,
+            },
         },
-        # Scene buttons (Events distinguished by arguments)
+        # Scene Buttons S1 and S2 (Events distinguished by params)
         ("short_press", "S1 Button"): {
             "command": "recall",
             "cluster_id": CLUSTER_SCENES,
             "endpoint_id": EP,
-            "args": [0, 1, 2],
+            "params": {
+                "group_id": 0,
+                "scene_id": 1,
+                "transition_time": 2,
+            },
         },
         ("long_press", "S1 Button"): {
             "command": "store",
             "cluster_id": CLUSTER_SCENES,
             "endpoint_id": EP,
-            "args": [0, 1],
+            "params": {
+                "group_id": 0,
+                "scene_id": 1,
+            },
         },
         ("short_press", "S2 Button"): {
             "command": "recall",
             "cluster_id": CLUSTER_SCENES,
             "endpoint_id": EP,
-            "args": [0, 2, 2],
+            "params": {
+                "group_id": 0,
+                "scene_id": 2,
+                "transition_time": 2,
+            },
         },
         ("long_press", "S2 Button"): {
             "command": "store",
             "cluster_id": CLUSTER_SCENES,
             "endpoint_id": EP,
-            "args": [0, 2],
+            "params": {
+                "group_id": 0,
+                "scene_id": 2,
+            },
         },
     }

--- a/zhaquirks/paulmann/sevenbtnremote.py
+++ b/zhaquirks/paulmann/sevenbtnremote.py
@@ -35,8 +35,8 @@ class PaulmannHomeRemote(CustomDevice):
     """
 
     signature = {
-        "model": "unk_model",
-        "manufacturer": "unk_manufacturer",
+        "model": "50141",
+        "manufacturer": "Paulmann Licht GmbH",
         "endpoints": {
             EP: {
                 PROFILE_ID: 0x0104,


### PR DESCRIPTION
## Proposed change

Add a quirk for the [Paulmann 501.41 Zigbee Smart Home Remote](https://en.paulmann.com/p/remote-control-smart-home-zigbee-3.0-white/50141). This remote is available separate or included with various Paulmann Zigbee lighting kits. It does not report a model or manufacturer via the Basic cluster, so matching is done using endpoint and cluster signature. The quirk provides device automation triggers for:

- Brightness control (plus/minus buttons)
- Color temperature adjustment (fire/ice buttons)
- Scene recall and storage (S1/S2 buttons)
- A general-purpose power button (on/off/toggle)

Only meaningful, distinguishable button actions are included. Long press release events (e.g., `stop_move_step`) are intentionally omitted due to lack of distinguishing data in the Zigbee payload.


## Checklist
- [x] The changes are tested and work correctly
- [x] pre-commit checks pass / the code has been formatted using Black
- [x] Tests have been **executed** to verify that the new code works

