### PR TITLE
Update ts0601_sensor.py with _TZE200_w6n8jeuu

### DIFF
--- a/zhaquirks/tuya/ts0601_sensor.py
+++ b/zhaquirks/tuya/ts0601_sensor.py
@@ -185,6 +185,7 @@ class TuyaTempHumiditySensorVar03(CustomDevice):
             ("_TZE200_9yapgbuv", "TS0601"),
             ("_TZE200_qyflbnbj", "TS0601"),
             ("_TZE200_utkemkbs", "TS0601"),
+            ("_TZE200_w6n8jeuu", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Add `_TZE200_w6n8jeuu` to list of Tuya TS0601 temperature sensors

## Proposed change
Add a new Tuya device id to the TS0601 quirk.

_TZE200_w6n8jeuu is the device id I see in ZHA, but paring it with ZHA had no usable entities. Adding the device id to a local quirk file fixed the issue for me.  After my change my sensor entities are detected and works:

<img width="461" alt="Screenshot 2025-04-17 at 5 11 52 PM" src="https://github.com/user-attachments/assets/89cd6904-d4c6-4f55-92ba-7ece296287c0" />


## Additional information

Link to the device on aliexpress: https://www.aliexpress.us/item/3256807102148050.html?spm=a2g0o.order_list.order_list_main.22.52b0180242jdlY&gatewayAdapt=glo2usa


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
