### PR TITLE
Allow extra cluster ids for `zigpy_device_from_v2_quirk` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,20 +193,15 @@ def zigpy_device_from_v2_quirk(MockAppController, ieee_mock):
             ieee = ieee_mock
 
         # copy cluster_ids entries to endpoint_clusters default dict
-        endpoint_clusters: dict[int, dict[int, ClusterType]] = defaultdict(dict)
-        for ep_id, clusters in cluster_ids.items():
-            for cluster_id, cluster_type in clusters.items():
-                endpoint_clusters[ep_id][cluster_id] = cluster_type
+        endpoint_clusters: defaultdict[int, dict[int, ClusterType]] = defaultdict(
+            dict, {ep_id: dict(clusters) for ep_id, clusters in cluster_ids.items()}
+        )
 
-        # convert simple endpoint_ids argument to advanced cluster_ids dictionary
+        # convert simple arg and add mandatory basic cluster to ep 1 if in endpoint_ids
         for ep_id in endpoint_ids:
-            # add mandatory basic cluster to endpoint 1 if in endpoint_ids
+            endpoint_clusters.setdefault(ep_id, {})
             if ep_id == 1:
-                endpoint_clusters[ep_id] |= {Basic.cluster_id: ClusterType.Server}
-
-            # add other specified endpoints with no clusters
-            if ep_id not in endpoint_clusters:
-                endpoint_clusters[ep_id] = {}
+                endpoint_clusters[ep_id][Basic.cluster_id] = ClusterType.Server
 
         raw_device = zigpy.device.Device(MockAppController, ieee, nwk)
         raw_device.manufacturer = manufacturer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 """Fixtures for all tests."""
 
-from collections import defaultdict
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -192,10 +191,10 @@ def zigpy_device_from_v2_quirk(MockAppController, ieee_mock):
         if ieee is None:
             ieee = ieee_mock
 
-        # copy cluster_ids entries to endpoint_clusters default dict
-        endpoint_clusters: defaultdict[int, dict[int, ClusterType]] = defaultdict(
-            dict, {ep_id: dict(clusters) for ep_id, clusters in cluster_ids.items()}
-        )
+        # copy cluster_ids entries to endpoint_clusters dict
+        endpoint_clusters: dict[int, dict[int, ClusterType]] = {
+            ep_id: clusters.copy() for ep_id, clusters in cluster_ids.items()
+        }
 
         # convert simple arg and add mandatory basic cluster to ep 1 if in endpoint_ids
         for ep_id in endpoint_ids:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures for all tests."""
 
+from collections import defaultdict
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -8,7 +9,7 @@ import zigpy.device
 from zigpy.device import Device
 import zigpy.quirks
 import zigpy.types
-from zigpy.zcl import foundation
+from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import Basic
 from zigpy.zdo.types import NodeDescriptor
 
@@ -116,7 +117,7 @@ def zigpy_device_mock(MockAppController, ieee_mock):
 
 
 @pytest.fixture
-def zigpy_device_from_quirk(MockAppController, ieee_mock):
+def zigpy_device_from_quirk(MockAppController, ieee_mock) -> Device:
     """Create zigpy device from Quirk's signature."""
 
     def _dev(quirk, ieee=None, nwk=zigpy.types.NWK(0x1234), apply_quirk=True):
@@ -163,29 +164,65 @@ def zigpy_device_from_quirk(MockAppController, ieee_mock):
 
 @pytest.fixture
 def zigpy_device_from_v2_quirk(MockAppController, ieee_mock):
-    """Create zigpy device from Quirk's signature."""
+    """Create zigpy device for v2 quirks test by manufacturer and model."""
 
     def _dev(
         manufacturer: str,
         model: str,
         endpoint_ids: list[int] = [1],
+        cluster_ids: dict[int, dict[int, ClusterType]] = {},
         ieee=None,
         nwk=zigpy.types.NWK(0x1234),
         apply_quirk=True,
-    ):
+    ) -> Device:
+        """Create zigpy device for v2 quirks test by manufacturer and model.
+
+        :param manufacturer: Manufacturer name.
+        :param model: Model name.
+        :param endpoint_ids: Endpoint ids to be added to the device, ep 1 by default.
+        :param cluster_ids: Dictionary of additional endpoints
+            and their cluster ids and types to be added to the device.
+            More advanced version of endpoint_ids argument.
+            Example: `cluster_ids={2: {OnOff.cluster_id: ClusterType.Client}}`
+        :param ieee: IEEE address of the device.
+        :param nwk: Network address of the device.
+        :param apply_quirk: Whether to apply the quirk to the device.
+        :return: Zigpy device object.
+        """
         if ieee is None:
             ieee = ieee_mock
+
+        # copy cluster_ids entries to endpoint_clusters default dict
+        endpoint_clusters: dict[int, dict[int, ClusterType]] = defaultdict(dict)
+        for ep_id, clusters in cluster_ids.items():
+            for cluster_id, cluster_type in clusters.items():
+                endpoint_clusters[ep_id][cluster_id] = cluster_type
+
+        # convert simple endpoint_ids argument to advanced cluster_ids dictionary
+        for ep_id in endpoint_ids:
+            # add mandatory basic cluster to endpoint 1 if in endpoint_ids
+            if ep_id == 1:
+                endpoint_clusters[ep_id] |= {Basic.cluster_id: ClusterType.Server}
+
+            # add other specified endpoints with no clusters
+            if ep_id not in endpoint_clusters:
+                endpoint_clusters[ep_id] = {}
 
         raw_device = zigpy.device.Device(MockAppController, ieee, nwk)
         raw_device.manufacturer = manufacturer
         raw_device.model = model
         raw_device.node_desc = NodeDescriptor(manufacturer_code=1234)
 
-        for endpoint_id in endpoint_ids:
+        # add additional endpoints to the device
+        for endpoint_id, clusters in endpoint_clusters.items():
             ep = raw_device.add_endpoint(endpoint_id)
-            # basic is mandatory
-            if endpoint_id == 1:
-                ep.add_input_cluster(Basic.cluster_id)
+
+            # add custom cluster ids to test device
+            for cluster_id, cluster_type in clusters.items():
+                if cluster_type == ClusterType.Client:
+                    ep.add_output_cluster(cluster_id)
+                else:
+                    ep.add_input_cluster(cluster_id)
 
         quirked = zigpy.quirks.get_device(raw_device)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,7 @@ def zigpy_device_mock(MockAppController, ieee_mock):
 
 
 @pytest.fixture
-def zigpy_device_from_quirk(MockAppController, ieee_mock) -> Device:
+def zigpy_device_from_quirk(MockAppController, ieee_mock):
     """Create zigpy device from Quirk's signature."""
 
     def _dev(quirk, ieee=None, nwk=zigpy.types.NWK(0x1234), apply_quirk=True):


### PR DESCRIPTION
## Proposed change
This PR allows specifying custom cluster ids to be added to the zigpy device created via the `zigpy_device_from_v2_quirk` fixture for use in quirks v2 tests.

The old style of only adding an endpoint with no additional clusters is kept as the `endpoint_ids` argument.
This was done partly to allow for backwards compatibility in tests, but more crucially to keep use of this fixture simple, as most tests just require an additional endpoint to be added, with no clusters.

However, in some cases, we do need the device to have custom clusters, especially if the v2 quirk to be tested uses `replace_cluster_occurrences`. This is where the new `cluster_ids` argument comes in.
It allows us to add additional clusters to the specified endpoints, like this:
```python
dev = zigpy_device_from_v2_quirk("Test", "Dev", cluster_ids={2: {OnOff.cluster_id: ClusterType.Client}})
```

Or a longer example with multiple endpoints and clusters:
```python
dev = zigpy_device_from_v2_quirk(
    "Test",
    "Dev",
    cluster_ids={
        1: {
            OnOff.cluster_id: ClusterType.Client,
            Color.cluster_id: ClusterType.Server,
        },
        2: {0xFC31: ClusterType.Client},
    },
)
```

### Side note
Due to keeping the old behavior of the `endpoint_ids` argument (accepting endpoint ids in a list), the `Basic` cluster id is still added for endpoint 1 by default. However, it is now possible to also override this behavior by setting `endpoint_ids = []` and `cluster_ids={1: {}}`.

I don't think this will really be needed, but it wasn't possible to have an endpoint 1 without a `Basic` cluster with this fixture before.

### Implementation detail
I've experimented with different implementations of this and removing the `endpoint_ids` argument before, but the code from this PR was the best I came up with, as it still allows for the simple `endpoint_ids` usage and the more advanced `cluster_ids` usage.

We copy the dict at the start of the method to both avoid modifying the default argument value and a passed value.
The `endpoint_ids` argument value is then converted to the newer style of `endpoint_ids`, keeping the old behavior and merging the two argument values into the copied/new dict: `endpoint_clusters`.
Afterwards, we go through that dict and add the endpoints, similar to before.
Now, we also go through the inner dictionary with the different cluster ids and the respective server type and add them as input/output clusters, except if the inner dictionary is empty.


## Additional information
This unblocks the tests for:
- https://github.com/zigpy/zha-device-handlers/pull/3232
  The line using the fixture just has to be changed to something like this:
  ```python
  device = zigpy_device_from_v2_quirk("Inovelli", "VZM31-SN", cluster_ids={2: {0xFC31: ClusterType.Client}})
  ```
  
  cc @codyhackw


## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
