### PR TITLE
Add Tuya temp sensor `_TZE200_w6n8jeuu` variant

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -118,6 +118,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE200_eanjj2pa", "TS0601")
     .applies_to("_TZE200_ydrdfkim", "TS0601")
     .applies_to("_TZE284_locansqn", "TS0601")
+    .applies_to("_TZE200_w6n8jeuu", "TS0601")
     .tuya_temperature(dp_id=1, scale=10)
     .tuya_humidity(dp_id=2)
     .tuya_battery(dp_id=4)


### PR DESCRIPTION
Add `_TZE200_w6n8jeuu` to list of Tuya TS0601 temperature sensors

## Proposed change
Add a new Tuya device id to the TS0601 quirk.

_TZE200_w6n8jeuu is the device id I see in ZHA, but paring it with ZHA had no usable entities. Adding the device id to a local quirk file fixed the issue for me.  After my change my sensor entities are detected and works:

<img width="461" alt="Screenshot 2025-04-17 at 5 11 52 PM" src="https://github.com/user-attachments/assets/89cd6904-d4c6-4f55-92ba-7ece296287c0" />


## Additional information

Link to the device on aliexpress: https://www.aliexpress.us/item/3256807102148050.html?spm=a2g0o.order_list.order_list_main.22.52b0180242jdlY&gatewayAdapt=glo2usa


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
