### PR TITLE
Keep overriden functions async

### DIFF
--- a/zhaquirks/eurotronic/__init__.py
+++ b/zhaquirks/eurotronic/__init__.py
@@ -133,19 +133,19 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
         return success, error
 
-    def write_attributes(self, attributes, manufacturer=None, **kwargs):
+    async def write_attributes(self, attributes, manufacturer=None, **kwargs):
         """Override wrong writes to thermostat attributes."""
         if "system_mode" in attributes:
             host_flags = self._attr_cache.get(HOST_FLAGS_ATTR, 1)
             _LOGGER.debug("current host_flags: %s", host_flags)
 
             if attributes.get("system_mode") == 0x0:
-                return super().write_attributes(
+                return await super().write_attributes(
                     {"host_flags": host_flags | SET_OFF_MODE_FLAG}, MANUFACTURER
                 )
             if attributes.get("system_mode") == 0x4:
-                return super().write_attributes(
+                return await super().write_attributes(
                     {"host_flags": host_flags | CLR_OFF_MODE_FLAG}, MANUFACTURER
                 )
 
-        return super().write_attributes(attributes, manufacturer, **kwargs)
+        return await super().write_attributes(attributes, manufacturer, **kwargs)

--- a/zhaquirks/plaid/soil.py
+++ b/zhaquirks/plaid/soil.py
@@ -36,15 +36,17 @@ class PowerConfigurationClusterMains(PowerConfigurationCluster):
             return self.MAINS_VOLTAGE_ATTR
         return attr
 
-    def read_attributes(self, attributes, *args, **kwargs):  # pylint: disable=W0221
+    async def read_attributes(self, attributes, *args, **kwargs):
         """Replace battery voltage with mains voltage."""
-        return super().read_attributes(
+        return await super().read_attributes(
             [self._remap(attr) for attr in attributes], *args, **kwargs
         )
 
-    def configure_reporting(self, attribute, *args, **kwargs):  # pylint: disable=W0221
+    async def configure_reporting(self, attribute, *args, **kwargs):
         """Replace battery voltage with mains voltage."""
-        return super().configure_reporting(self._remap(attribute), *args, **kwargs)
+        return await super().configure_reporting(
+            self._remap(attribute), *args, **kwargs
+        )
 
 
 class SoilMoisture(CustomDevice):

--- a/zhaquirks/plaid/soil.py
+++ b/zhaquirks/plaid/soil.py
@@ -1,19 +1,8 @@
 """PLAID SYSTEMS PS-SPRZMS-SLP3 soil moisture sensor."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
-from zigpy.zcl.clusters.measurement import RelativeHumidity, TemperatureMeasurement
+from zigpy.quirks.v2 import QuirkBuilder
 
 from zhaquirks import PowerConfigurationCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.plaid import PLAID_SYSTEMS
 
 
@@ -49,44 +38,8 @@ class PowerConfigurationClusterMains(PowerConfigurationCluster):
         )
 
 
-class SoilMoisture(CustomDevice):
-    """Custom device representing plaid systems soil sensors."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1029
-        # device_version=0
-        # input_clusters=[0, 1, 3, 1026, 1029]
-        # output_clusters=[3, 25]>
-        MODELS_INFO: [(PLAID_SYSTEMS, "PS-SPRZMS-SLP3")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: 1029,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    RelativeHumidity.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: 1029,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationClusterMains,
-                    Identify.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    RelativeHumidity.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(PLAID_SYSTEMS, "PS-SPRZMS-SLP3")
+    .replaces(PowerConfigurationClusterMains, endpoint_id=1)
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -499,12 +499,12 @@ class TuyaManufClusterAttributes(TuyaManufCluster):
         zvalue = ztype(tuya_data)
         self._update_attribute(tuya_cmd, zvalue)
 
-    def read_attributes(
+    async def read_attributes(
         self, attributes, allow_cache=False, only_cache=False, manufacturer=None
     ):
         """Ignore remote reads as the "get_data" command doesn't seem to do anything."""
 
-        return super().read_attributes(
+        return await super().read_attributes(
             attributes, allow_cache=True, only_cache=True, manufacturer=manufacturer
         )
 

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -80,13 +80,13 @@ class TuyaPowerConfigurationCluster(
 class TuyaAttributesCluster(TuyaLocalCluster):
     """Manufacturer specific cluster for Tuya converting attributes <-> commands."""
 
-    def read_attributes(
+    async def read_attributes(
         self, attributes, allow_cache=False, only_cache=False, manufacturer=None
     ):
         """Ignore remote reads as the "get_data" command doesn't seem to do anything."""
 
         self.debug("read_attributes --> attrs: %s", attributes)
-        return super().read_attributes(
+        return await super().read_attributes(
             attributes, allow_cache=True, only_cache=True, manufacturer=manufacturer
         )
 


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Some functions, like `read_attributes`, are now async in zigpy but are overridden by a few quirks and replaced with sync overloads. This is functionally equivalent but results in ZHA test warnings:

```
Warning: coroutine 'Cluster.read_attributes' was never awaited
```

I've also converted the quirk for the affected device into a v2 quirk, since it did nothing but replace a single cluster.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
