### PR TITLE
Fix Tuya temp sensors `_TZE200_vvmbj46n`, `_TZE284_vvmbj46n`

### DIFF
--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -44,7 +44,7 @@ zhaquirks.setup()
         ("_TZE200_eanjj2pa", "TS0601", 100, 10, False),
         ("_TZE200_ydrdfkim", "TS0601", 100, 10, False),
         ("_TZE284_locansqn", "TS0601", 100, 10, False),
-        ("_TZE200_vvmbj46n", "TS0601", 100, 10, True),
+        ("_TZE200_vvmbj46n", "TS0601", 100, 10, False),
     ],
 )
 async def test_handle_get_data(

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -250,6 +250,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
         translation_key="humidity_sensitivity",
         fallback_name="Humidity sensitivity",
     )
+    .tuya_enchantment(data_query_spell=True)
     .skip_configuration()
     .add_to_registry(replacement_cluster=NoManufTimeTuyaMCUCluster)
 )

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -76,8 +76,6 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE200_qyflbnbj", "TS0601")
     .applies_to("_TZE284_qyflbnbj", "TS0601")
     .applies_to("_TZE200_44af8vyi", "TS0601")
-    .applies_to("_TZE200_vvmbj46n", "TS0601")
-    .applies_to("_TZE284_vvmbj46n", "TS0601")
     # Not using tuya_temperature because device reports negative values incorrectly
     .tuya_dp(
         dp_id=1,
@@ -120,6 +118,8 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE200_ydrdfkim", "TS0601")
     .applies_to("_TZE284_locansqn", "TS0601")
     .applies_to("_TZE200_w6n8jeuu", "TS0601")
+    .applies_to("_TZE200_vvmbj46n", "TS0601")
+    .applies_to("_TZE284_vvmbj46n", "TS0601")
     .tuya_temperature(dp_id=1, scale=10)
     .tuya_humidity(dp_id=2)
     .tuya_battery(dp_id=4)


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where various config options would not show up for the following Tuya temperature sensors:
- `_TZE200_vvmbj46n` (since HA 2025.2.0, #3776)
- `_TZE284_vvmbj46n` (since quirks `dev`, #4006)

This also removes unnecessary "fixing" of negative temperature values for these devices.
Both Tuya spells are also enabled due to Z2M source mentioning this being required (might not be true, but doesn't hurt to enable this).
Affected devices that are not reporting need to be re-paired on a version with this bugfix.


## Additional information

Follow-up PR to:
- #3776
- #4006

PR is untested, but looking good when comparing to Z2M code.


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
