### PR TITLE
Add Aqara Z1 Pro wall switch quirks (lumi.switch.acn056-acn059)

### DIFF
--- a/zhaquirks/const.py
+++ b/zhaquirks/const.py
@@ -14,7 +14,7 @@ from zigpy.quirks import (
 )
 import zigpy.types as t
 
-ACTION="action"
+ACTION = "action"
 ARGS = "args"
 ATTR_ID = "attr_id"
 ATTRIBUTE_ID = "attribute_id"

--- a/zhaquirks/const.py
+++ b/zhaquirks/const.py
@@ -14,6 +14,7 @@ from zigpy.quirks import (
 )
 import zigpy.types as t
 
+ACTION="action"
 ARGS = "args"
 ATTR_ID = "attr_id"
 ATTRIBUTE_ID = "attribute_id"
@@ -73,6 +74,7 @@ COMMAND_STORE = "store"
 COMMAND_TILT = "Tilt"
 COMMAND_TOGGLE = "toggle"
 COMMAND_TRIPLE = "triple"
+COMMAND_SLIDER_EVENT = "slider_event"
 DESCRIPTION = "description"
 DEVICE_TYPE = SIG_EP_TYPE
 DIM_DOWN = "dim_down"
@@ -116,9 +118,15 @@ ALT_SHORT_PRESS = "remote_button_alt_short_press"
 SKIP_CONFIGURATION = SIG_SKIP_CONFIG
 SHORT_RELEASE = "remote_button_short_release"
 TOGGLE = "toggle"
+SLIDER = "slider"
 TRIPLE_PRESS = "remote_button_triple_press"
 TURN_OFF = "turn_off"
 TURN_ON = "turn_on"
+SLIDER_SINGLE = "slider_single"
+SLIDER_DOUBLE = "slider_double"
+SLIDER_HOLD = "slider_hold"
+SLIDER_UP = "slider_up"
+SLIDER_DOWN = "slider_down"
 UNKNOWN = "Unknown"
 VALUE = "value"
 ZHA_SEND_EVENT = "zha_send_event"

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -46,14 +46,14 @@ from zhaquirks.const import (
     COMMAND_ATTRIBUTE_UPDATED,
     COMMAND_SLIDER_EVENT,
     COMMAND_TRIPLE,
-    UNKNOWN,
-    VALUE,
-    ZHA_SEND_EVENT,
     SLIDER_DOUBLE,
     SLIDER_DOWN,
     SLIDER_HOLD,
     SLIDER_SINGLE,
     SLIDER_UP,
+    UNKNOWN,
+    VALUE,
+    ZHA_SEND_EVENT,
     BatterySize,
 )
 
@@ -767,6 +767,7 @@ class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
     }
 
     def __init__(self, *args, **kwargs):
+        """Init."""
         super().__init__(*args, **kwargs)
         self._attr_id = self.ATTR_SLIDER_ACTION
         _LOGGER.debug(

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -48,6 +48,11 @@ from zhaquirks.const import (
     UNKNOWN,
     VALUE,
     ZHA_SEND_EVENT,
+    SLIDER_DOUBLE,
+    SLIDER_DOWN,
+    SLIDER_HOLD,
+    SLIDER_SINGLE,
+    SLIDER_UP,
     BatterySize,
 )
 
@@ -753,11 +758,11 @@ class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
 
     # Action mapping
     ACTION_MAPPING = {
-        1: "slider_single",
-        2: "slider_double",
-        3: "slider_hold",
-        4: "slider_up",
-        5: "slider_down",
+        1: SLIDER_SINGLE,
+        2: SLIDER_DOUBLE,
+        3: SLIDER_HOLD,
+        4: SLIDER_UP,
+        5: SLIDER_DOWN,
     }
 
     def __init__(self, *args, **kwargs):

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -731,6 +731,84 @@ class OnOffCluster(OnOff, CustomCluster):
             bytes([src_ep, tsn, command_id]),
             expect_reply=expect_reply,
         )
+    
+class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
+    """Custom cluster for Aqara Z1 Pro manufacturer specific events."""
+    
+    cluster_id = 0xfcc0
+    
+    # Attribute IDs
+    ATTR_SLIDER_ACTION = 0x028C  # 652
+    ATTR_SLIDE_TIME = 0x0231     # 561
+    ATTR_SLIDE_SPEED = 0x0232    # 562
+    ATTR_SLIDE_RELATIVE_DISPLACEMENT = 0x0233  # 563
+    ATTR_SLIDE_TIME_DELTA = 0x0301  # 769
+
+    # ATTR_DEVICE_ID_SHADE = 0x0200 # 512
+    # ATTR_LOCK_RELAY = 0x0285 # 645
+    # ATTR_SWITCH_MODE = 0x0004 # 4
+    # ATTR_POWER_ON_BEHAVIOR = 0x0517 # 1303
+    # ATTR_CLICK_MODE = 0x0125 # 293
+    
+    # Action mapping
+    ACTION_MAPPING = {
+        1: "slider_single",
+        2: "slider_double",
+        3: "slider_hold",
+        4: "slider_up",
+        5: "slider_down",
+    }
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._attr_id = self.ATTR_SLIDER_ACTION
+        _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster initialized for device %s", self._endpoint.device.ieee)
+        
+    def _update_attribute(self, attrid, value):
+        """Handle attribute updates."""
+        
+        # Store all attributes for the event
+        if not hasattr(self, "_manufacturer_attrs"):
+            self._manufacturer_attrs = {}
+        
+        # Update the attribute value
+        self._manufacturer_attrs[attrid] = value
+        
+        # If this is the slider action attribute, send the event
+        if attrid == self.ATTR_SLIDER_ACTION:
+            # Get the action name from the mapping
+            action = self.ACTION_MAPPING.get(value, f"slider_unknown_{value}")
+            _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster detected action: %s (value: %s)", action, value)
+            
+            # Prepare the event data
+            event_data = {
+                "action": action,
+                "value": value,
+                "slide_time": self._manufacturer_attrs.get(self.ATTR_SLIDE_TIME),
+                "slide_speed": self._manufacturer_attrs.get(self.ATTR_SLIDE_SPEED),
+                "slide_relative_displacement": self._manufacturer_attrs.get(self.ATTR_SLIDE_RELATIVE_DISPLACEMENT),
+                "slide_time_delta": self._manufacturer_attrs.get(self.ATTR_SLIDE_TIME_DELTA),
+            }
+            
+            _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster sending event data: %s", event_data)
+            
+            # Send the event
+            self.listener_event(
+                ZHA_SEND_EVENT,
+                action,
+                event_data,
+            )
+            
+            # Also send a generic slider event for easier automation
+            self.listener_event(
+                ZHA_SEND_EVENT,
+                "slider_event",
+                event_data,
+            )
+            _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster events sent successfully")
+
+        _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster attribute update: attrid=0x%04x, value=%s", attrid, value)
+        super()._update_attribute(attrid, value)
 
 
 def handle_quick_init(

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -44,6 +44,7 @@ from zhaquirks.const import (
     ATTRIBUTE_ID,
     ATTRIBUTE_NAME,
     COMMAND_ATTRIBUTE_UPDATED,
+    COMMAND_SLIDER_EVENT,
     COMMAND_TRIPLE,
     UNKNOWN,
     VALUE,
@@ -822,7 +823,7 @@ class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
             # Also send a generic slider event for easier automation
             self.listener_event(
                 ZHA_SEND_EVENT,
-                "slider_event",
+                COMMAND_SLIDER_EVENT,
                 event_data,
             )
             _LOGGER.debug(

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -731,16 +731,17 @@ class OnOffCluster(OnOff, CustomCluster):
             bytes([src_ep, tsn, command_id]),
             expect_reply=expect_reply,
         )
-    
+
+
 class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
     """Custom cluster for Aqara Z1 Pro manufacturer specific events."""
-    
-    cluster_id = 0xfcc0
-    
+
+    cluster_id = 0xFCC0
+
     # Attribute IDs
     ATTR_SLIDER_ACTION = 0x028C  # 652
-    ATTR_SLIDE_TIME = 0x0231     # 561
-    ATTR_SLIDE_SPEED = 0x0232    # 562
+    ATTR_SLIDE_TIME = 0x0231  # 561
+    ATTR_SLIDE_SPEED = 0x0232  # 562
     ATTR_SLIDE_RELATIVE_DISPLACEMENT = 0x0233  # 563
     ATTR_SLIDE_TIME_DELTA = 0x0301  # 769
 
@@ -749,7 +750,7 @@ class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
     # ATTR_SWITCH_MODE = 0x0004 # 4
     # ATTR_POWER_ON_BEHAVIOR = 0x0517 # 1303
     # ATTR_CLICK_MODE = 0x0125 # 293
-    
+
     # Action mapping
     ACTION_MAPPING = {
         1: "slider_single",
@@ -758,56 +759,76 @@ class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
         4: "slider_up",
         5: "slider_down",
     }
-    
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._attr_id = self.ATTR_SLIDER_ACTION
-        _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster initialized for device %s", self._endpoint.device.ieee)
-        
+        _LOGGER.debug(
+            "AqaraZ1ProManufacturerSpecificCluster initialized for device %s",
+            self._endpoint.device.ieee,
+        )
+
     def _update_attribute(self, attrid, value):
         """Handle attribute updates."""
-        
+
         # Store all attributes for the event
         if not hasattr(self, "_manufacturer_attrs"):
             self._manufacturer_attrs = {}
-        
+
         # Update the attribute value
         self._manufacturer_attrs[attrid] = value
-        
+
         # If this is the slider action attribute, send the event
         if attrid == self.ATTR_SLIDER_ACTION:
             # Get the action name from the mapping
             action = self.ACTION_MAPPING.get(value, f"slider_unknown_{value}")
-            _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster detected action: %s (value: %s)", action, value)
-            
+            _LOGGER.debug(
+                "AqaraZ1ProManufacturerSpecificCluster detected action: %s (value: %s)",
+                action,
+                value,
+            )
+
             # Prepare the event data
             event_data = {
                 "action": action,
                 "value": value,
                 "slide_time": self._manufacturer_attrs.get(self.ATTR_SLIDE_TIME),
                 "slide_speed": self._manufacturer_attrs.get(self.ATTR_SLIDE_SPEED),
-                "slide_relative_displacement": self._manufacturer_attrs.get(self.ATTR_SLIDE_RELATIVE_DISPLACEMENT),
-                "slide_time_delta": self._manufacturer_attrs.get(self.ATTR_SLIDE_TIME_DELTA),
+                "slide_relative_displacement": self._manufacturer_attrs.get(
+                    self.ATTR_SLIDE_RELATIVE_DISPLACEMENT
+                ),
+                "slide_time_delta": self._manufacturer_attrs.get(
+                    self.ATTR_SLIDE_TIME_DELTA
+                ),
             }
-            
-            _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster sending event data: %s", event_data)
-            
+
+            _LOGGER.debug(
+                "AqaraZ1ProManufacturerSpecificCluster sending event data: %s",
+                event_data,
+            )
+
             # Send the event
             self.listener_event(
                 ZHA_SEND_EVENT,
                 action,
                 event_data,
             )
-            
+
             # Also send a generic slider event for easier automation
             self.listener_event(
                 ZHA_SEND_EVENT,
                 "slider_event",
                 event_data,
             )
-            _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster events sent successfully")
+            _LOGGER.debug(
+                "AqaraZ1ProManufacturerSpecificCluster events sent successfully"
+            )
 
-        _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster attribute update: attrid=0x%04x, value=%s", attrid, value)
+        _LOGGER.debug(
+            "AqaraZ1ProManufacturerSpecificCluster attribute update: attrid=0x%04x, value=%s",
+            attrid,
+            value,
+        )
         super()._update_attribute(attrid, value)
 
 

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_double.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_double.py
@@ -16,12 +16,33 @@ from zigpy.zcl.clusters.general import (
 )
 
 from zhaquirks.const import (
+    ACTION,
+    ARGS,
+    ATTRIBUTE_ID,
+    BUTTON_1,
+    BUTTON_2,
+    COMMAND,
+    COMMAND_SLIDER_EVENT,
+    CLUSTER_ID,
     DEVICE_TYPE,
+    DOUBLE_PRESS,
+    DIM_UP,
+    DIM_DOWN,
     ENDPOINTS,
+    ENDPOINT_ID,
     INPUT_CLUSTERS,
+    LONG_PRESS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    SHORT_PRESS,
+    SLIDER,
+    SLIDER_DOUBLE,
+    SLIDER_DOWN,
+    SLIDER_HOLD,
+    SLIDER_SINGLE,
+    SLIDER_UP,
+    VALUE,
 )
 from zhaquirks.xiaomi import (
     LUMI,
@@ -58,6 +79,8 @@ class AqaraZ1ProDoubleRockerSwitch(XiaomiCustomDevice):
     """Aqara Z1 Pro Double Rocker Switch"""
 
     MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCC0
+    XIAOMI_COMMAND_SINGLE_1 = "1_single"
+    XIAOMI_COMMAND_SINGLE_2 = "2_single"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -198,5 +221,50 @@ class AqaraZ1ProDoubleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON_1): {
+            COMMAND: XIAOMI_COMMAND_SINGLE_1,
+            CLUSTER_ID: 18,
+            ENDPOINT_ID: 1,
+            ARGS: {ATTRIBUTE_ID: 85, VALUE: 1},
+        },
+        (SHORT_PRESS, BUTTON_2): {
+            COMMAND: XIAOMI_COMMAND_SINGLE_2,
+            CLUSTER_ID: 18,
+            ENDPOINT_ID: 2,
+            ARGS: {ATTRIBUTE_ID: 85, VALUE: 1},
+        },
+        (SHORT_PRESS, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_SINGLE, VALUE: 1},
+        },
+        (DOUBLE_PRESS, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_DOUBLE, VALUE: 2},
+        },
+        (LONG_PRESS, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_HOLD, VALUE: 3},
+        },
+        (DIM_UP, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_UP, VALUE: 4},
+        },
+        (DIM_DOWN, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_DOWN, VALUE: 5},
         },
     }

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_double.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_double.py
@@ -31,7 +31,7 @@ from zhaquirks.xiaomi import (
     MeteringCluster,
     OnOffCluster,
     XiaomiCustomDevice,
-    AqaraZ1ProManufacturerSpecificCluster
+    AqaraZ1ProManufacturerSpecificCluster,
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 
@@ -42,22 +42,29 @@ _LOGGER.setLevel(logging.DEBUG)
 # Add a console handler to ensure logs go to stdout
 console_handler = logging.StreamHandler(sys.stdout)
 console_handler.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 console_handler.setFormatter(formatter)
 _LOGGER.addHandler(console_handler)
 
 # Log at module level to verify the file is being loaded
-_LOGGER.debug("AqaraZ1ProDoubleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x", zha.PROFILE_ID, zha.DeviceType.ON_OFF_SWITCH)
+_LOGGER.debug(
+    "AqaraZ1ProDoubleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x",
+    zha.PROFILE_ID,
+    zha.DeviceType.ON_OFF_SWITCH,
+)
+
 
 class AqaraZ1ProDoubleRockerSwitch(XiaomiCustomDevice):
     """Aqara Z1 Pro Double Rocker Switch"""
 
-    MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xfcc0
+    MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCC0
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        _LOGGER.debug("AqaraZ1ProDoubleRockerSwitch device initialized with IEEE: %s", self.ieee)
-    
+        _LOGGER.debug(
+            "AqaraZ1ProDoubleRockerSwitch device initialized with IEEE: %s", self.ieee
+        )
+
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.acn057")],
         ENDPOINTS: {

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_double.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_double.py
@@ -1,0 +1,180 @@
+"""Aqara Z1 Pro double rocker switch quirks."""
+
+import logging
+import sys
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import (
+    AnalogInput,
+    Basic,
+    Groups,
+    Identify,
+    MultistateInput,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    AnalogInputCluster,
+    BasicCluster,
+    ElectricalMeasurementCluster,
+    MeteringCluster,
+    OnOffCluster,
+    XiaomiCustomDevice,
+    AqaraZ1ProManufacturerSpecificCluster
+)
+from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
+
+# Set up logging with a more visible format
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.DEBUG)
+
+# Add a console handler to ensure logs go to stdout
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+console_handler.setFormatter(formatter)
+_LOGGER.addHandler(console_handler)
+
+# Log at module level to verify the file is being loaded
+_LOGGER.debug("AqaraZ1ProDoubleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x", zha.PROFILE_ID, zha.DeviceType.ON_OFF_SWITCH)
+
+class AqaraZ1ProDoubleRockerSwitch(XiaomiCustomDevice):
+    """Aqara Z1 Pro Double Rocker Switch"""
+
+    MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xfcc0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        _LOGGER.debug("AqaraZ1ProDoubleRockerSwitch device initialized with IEEE: %s", self.ieee)
+    
+    signature = {
+        MODELS_INFO: [("Aqara", "lumi.switch.acn057")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    MeteringCluster.cluster_id,
+                    ElectricalMeasurementCluster.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    AnalogInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MeteringCluster,
+                    ElectricalMeasurementCluster,
+                    AqaraZ1ProManufacturerSpecificCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    AnalogInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_double.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_double.py
@@ -61,6 +61,9 @@ class AqaraZ1ProDoubleRockerSwitch(XiaomiCustomDevice):
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.acn057")],
         ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=0
+            # input_clusters=[0, 3, 4, 5, 6, 18, 1794, 2820, 64704]
+            # output_clusters=[10, 25]>
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -80,6 +83,9 @@ class AqaraZ1ProDoubleRockerSwitch(XiaomiCustomDevice):
                     Ota.cluster_id,
                 ],
             },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=0
+            # input_clusters=[4, 5, 6, 18, 64704]
+            # output_clusters=[]>
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -92,6 +98,9 @@ class AqaraZ1ProDoubleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # <SimpleDescriptor endpoint=3 profile=260 device_type=0
+            # input_clusters=[64704]
+            # output_clusters=[]>
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -100,6 +109,9 @@ class AqaraZ1ProDoubleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # <SimpleDescriptor endpoint=4 profile=260 device_type=0
+            # input_clusters=[64704]
+            # output_clusters=[]>
             4: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -108,6 +120,9 @@ class AqaraZ1ProDoubleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # <SimpleDescriptor endpoint=21 profile=260 device_type=0
+            # input_clusters=[12]
+            # output_clusters=[]>
             21: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_double.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_double.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
     AnalogInput,
@@ -21,15 +22,15 @@ from zhaquirks.const import (
     ATTRIBUTE_ID,
     BUTTON_1,
     BUTTON_2,
+    CLUSTER_ID,
     COMMAND,
     COMMAND_SLIDER_EVENT,
-    CLUSTER_ID,
     DEVICE_TYPE,
-    DOUBLE_PRESS,
-    DIM_UP,
     DIM_DOWN,
-    ENDPOINTS,
+    DIM_UP,
+    DOUBLE_PRESS,
     ENDPOINT_ID,
+    ENDPOINTS,
     INPUT_CLUSTERS,
     LONG_PRESS,
     MODELS_INFO,
@@ -45,14 +46,13 @@ from zhaquirks.const import (
     VALUE,
 )
 from zhaquirks.xiaomi import (
-    LUMI,
     AnalogInputCluster,
+    AqaraZ1ProManufacturerSpecificCluster,
     BasicCluster,
     ElectricalMeasurementCluster,
     MeteringCluster,
     OnOffCluster,
     XiaomiCustomDevice,
-    AqaraZ1ProManufacturerSpecificCluster,
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 
@@ -76,13 +76,14 @@ _LOGGER.debug(
 
 
 class AqaraZ1ProDoubleRockerSwitch(XiaomiCustomDevice):
-    """Aqara Z1 Pro Double Rocker Switch"""
+    """Aqara Z1 Pro Double Rocker Switch."""
 
     MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCC0
     XIAOMI_COMMAND_SINGLE_1 = "1_single"
     XIAOMI_COMMAND_SINGLE_2 = "2_single"
 
     def __init__(self, *args, **kwargs):
+        """Init."""
         super().__init__(*args, **kwargs)
         _LOGGER.debug(
             "AqaraZ1ProDoubleRockerSwitch device initialized with IEEE: %s", self.ieee

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_quadruple.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_quadruple.py
@@ -150,15 +150,12 @@ class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
                 OUTPUT_CLUSTERS: [],
             },
             # <SimpleDescriptor endpoint=4 profile=260 device_type=0
-            # input_clusters=[4, 5, 6, 18, 64704]
+            # input_clusters=[18, 64704]
             # output_clusters=[]>
             4: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
                     MultistateInput.cluster_id,
                     MANUFACTURER_SPECIFIC_CLUSTER_ID,
                 ],
@@ -227,9 +224,6 @@ class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOffCluster,
                     MultistateInputCluster,
                     MANUFACTURER_SPECIFIC_CLUSTER_ID,
                 ],

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_quadruple.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_quadruple.py
@@ -1,0 +1,196 @@
+"""Aqara Z1 Pro quadruple rocker switch quirks."""
+
+import logging
+import sys
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import (
+    AnalogInput,
+    Basic,
+    Groups,
+    Identify,
+    MultistateInput,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    AnalogInputCluster,
+    BasicCluster,
+    ElectricalMeasurementCluster,
+    MeteringCluster,
+    OnOffCluster,
+    XiaomiCustomDevice,
+    AqaraZ1ProManufacturerSpecificCluster
+)
+from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
+
+# Set up logging with a more visible format
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.DEBUG)
+
+# Add a console handler to ensure logs go to stdout
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+console_handler.setFormatter(formatter)
+_LOGGER.addHandler(console_handler)
+
+# Log at module level to verify the file is being loaded
+_LOGGER.debug("AqaraZ1ProQuadrupleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x", zha.PROFILE_ID, zha.DeviceType.ON_OFF_SWITCH)
+
+class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
+    """Aqara Z1 Pro Quadruple Rocker Switch"""
+
+    MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xfcc0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        _LOGGER.debug("AqaraZ1ProQuadrupleRockerSwitch device initialized with IEEE: %s", self.ieee)
+    
+    signature = {
+        MODELS_INFO: [("Aqara", "lumi.switch.acn059")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    MeteringCluster.cluster_id,
+                    ElectricalMeasurementCluster.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    AnalogInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MeteringCluster,
+                    ElectricalMeasurementCluster,
+                    AqaraZ1ProManufacturerSpecificCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    AnalogInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_quadruple.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_quadruple.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
     AnalogInput,
@@ -23,15 +24,15 @@ from zhaquirks.const import (
     BUTTON_2,
     BUTTON_3,
     BUTTON_4,
+    CLUSTER_ID,
     COMMAND,
     COMMAND_SLIDER_EVENT,
-    CLUSTER_ID,
     DEVICE_TYPE,
-    DOUBLE_PRESS,
-    DIM_UP,
     DIM_DOWN,
-    ENDPOINTS,
+    DIM_UP,
+    DOUBLE_PRESS,
     ENDPOINT_ID,
+    ENDPOINTS,
     INPUT_CLUSTERS,
     LONG_PRESS,
     MODELS_INFO,
@@ -47,14 +48,13 @@ from zhaquirks.const import (
     VALUE,
 )
 from zhaquirks.xiaomi import (
-    LUMI,
     AnalogInputCluster,
+    AqaraZ1ProManufacturerSpecificCluster,
     BasicCluster,
     ElectricalMeasurementCluster,
     MeteringCluster,
     OnOffCluster,
     XiaomiCustomDevice,
-    AqaraZ1ProManufacturerSpecificCluster,
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 
@@ -78,7 +78,7 @@ _LOGGER.debug(
 
 
 class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
-    """Aqara Z1 Pro Quadruple Rocker Switch"""
+    """Aqara Z1 Pro Quadruple Rocker Switch."""
 
     MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCC0
     XIAOMI_COMMAND_SINGLE_1 = "1_single"
@@ -87,6 +87,7 @@ class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
     XIAOMI_COMMAND_SINGLE_4 = "4_single"
 
     def __init__(self, *args, **kwargs):
+        """Init."""
         super().__init__(*args, **kwargs)
         _LOGGER.debug(
             "AqaraZ1ProQuadrupleRockerSwitch device initialized with IEEE: %s",

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_quadruple.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_quadruple.py
@@ -61,6 +61,9 @@ class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.acn059")],
         ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=0
+            # input_clusters=[0, 3, 4, 5, 6, 18, 1794, 2820, 64704]
+            # output_clusters=[10, 25]>
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -80,6 +83,9 @@ class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
                     Ota.cluster_id,
                 ],
             },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=0
+            # input_clusters=[4, 5, 6, 18, 64704]
+            # output_clusters=[]>
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -92,6 +98,9 @@ class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # <SimpleDescriptor endpoint=3 profile=260 device_type=0
+            # input_clusters=[4, 5, 6, 18, 64704]
+            # output_clusters=[]>
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -104,6 +113,9 @@ class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # <SimpleDescriptor endpoint=4 profile=260 device_type=0
+            # input_clusters=[4, 5, 6, 18, 64704]
+            # output_clusters=[]>
             4: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -116,6 +128,9 @@ class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # <SimpleDescriptor endpoint=21 profile=260 device_type=0
+            # input_clusters=[12]
+            # output_clusters=[]>
             21: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_quadruple.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_quadruple.py
@@ -31,7 +31,7 @@ from zhaquirks.xiaomi import (
     MeteringCluster,
     OnOffCluster,
     XiaomiCustomDevice,
-    AqaraZ1ProManufacturerSpecificCluster
+    AqaraZ1ProManufacturerSpecificCluster,
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 
@@ -42,22 +42,30 @@ _LOGGER.setLevel(logging.DEBUG)
 # Add a console handler to ensure logs go to stdout
 console_handler = logging.StreamHandler(sys.stdout)
 console_handler.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 console_handler.setFormatter(formatter)
 _LOGGER.addHandler(console_handler)
 
 # Log at module level to verify the file is being loaded
-_LOGGER.debug("AqaraZ1ProQuadrupleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x", zha.PROFILE_ID, zha.DeviceType.ON_OFF_SWITCH)
+_LOGGER.debug(
+    "AqaraZ1ProQuadrupleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x",
+    zha.PROFILE_ID,
+    zha.DeviceType.ON_OFF_SWITCH,
+)
+
 
 class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
     """Aqara Z1 Pro Quadruple Rocker Switch"""
 
-    MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xfcc0
+    MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCC0
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        _LOGGER.debug("AqaraZ1ProQuadrupleRockerSwitch device initialized with IEEE: %s", self.ieee)
-    
+        _LOGGER.debug(
+            "AqaraZ1ProQuadrupleRockerSwitch device initialized with IEEE: %s",
+            self.ieee,
+        )
+
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.acn059")],
         ENDPOINTS: {

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_quadruple.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_quadruple.py
@@ -16,12 +16,35 @@ from zigpy.zcl.clusters.general import (
 )
 
 from zhaquirks.const import (
+    ACTION,
+    ARGS,
+    ATTRIBUTE_ID,
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    BUTTON_4,
+    COMMAND,
+    COMMAND_SLIDER_EVENT,
+    CLUSTER_ID,
     DEVICE_TYPE,
+    DOUBLE_PRESS,
+    DIM_UP,
+    DIM_DOWN,
     ENDPOINTS,
+    ENDPOINT_ID,
     INPUT_CLUSTERS,
+    LONG_PRESS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    SHORT_PRESS,
+    SLIDER,
+    SLIDER_DOUBLE,
+    SLIDER_DOWN,
+    SLIDER_HOLD,
+    SLIDER_SINGLE,
+    SLIDER_UP,
+    VALUE,
 )
 from zhaquirks.xiaomi import (
     LUMI,
@@ -58,6 +81,10 @@ class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
     """Aqara Z1 Pro Quadruple Rocker Switch"""
 
     MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCC0
+    XIAOMI_COMMAND_SINGLE_1 = "1_single"
+    XIAOMI_COMMAND_SINGLE_2 = "2_single"
+    XIAOMI_COMMAND_SINGLE_3 = "3_single"
+    XIAOMI_COMMAND_SINGLE_4 = "4_single"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -215,5 +242,62 @@ class AqaraZ1ProQuadrupleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON_1): {
+            COMMAND: XIAOMI_COMMAND_SINGLE_1,
+            CLUSTER_ID: 18,
+            ENDPOINT_ID: 1,
+            ARGS: {ATTRIBUTE_ID: 85, VALUE: 1},
+        },
+        (SHORT_PRESS, BUTTON_2): {
+            COMMAND: XIAOMI_COMMAND_SINGLE_2,
+            CLUSTER_ID: 18,
+            ENDPOINT_ID: 2,
+            ARGS: {ATTRIBUTE_ID: 85, VALUE: 1},
+        },
+        (SHORT_PRESS, BUTTON_3): {
+            COMMAND: XIAOMI_COMMAND_SINGLE_3,
+            CLUSTER_ID: 18,
+            ENDPOINT_ID: 3,
+            ARGS: {ATTRIBUTE_ID: 85, VALUE: 1},
+        },
+        (SHORT_PRESS, BUTTON_4): {
+            COMMAND: XIAOMI_COMMAND_SINGLE_4,
+            CLUSTER_ID: 18,
+            ENDPOINT_ID: 4,
+            ARGS: {ATTRIBUTE_ID: 85, VALUE: 1},
+        },
+        (SHORT_PRESS, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_SINGLE, VALUE: 1},
+        },
+        (DOUBLE_PRESS, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_DOUBLE, VALUE: 2},
+        },
+        (LONG_PRESS, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_HOLD, VALUE: 3},
+        },
+        (DIM_UP, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_UP, VALUE: 4},
+        },
+        (DIM_DOWN, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_DOWN, VALUE: 5},
         },
     }

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -61,6 +61,9 @@ class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.acn056")],
         ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=0
+            # input_clusters=[0, 3, 4, 5, 6, 18, 1794, 2820, 64704]
+            # output_clusters=[10, 25]>
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -80,6 +83,9 @@ class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
                     Ota.cluster_id,
                 ],
             },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=0
+            # input_clusters=[64704]
+            # output_clusters=[]>
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -88,6 +94,9 @@ class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # <SimpleDescriptor endpoint=3 profile=260 device_type=0
+            # input_clusters=[64704]
+            # output_clusters=[]>
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -96,6 +105,9 @@ class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # <SimpleDescriptor endpoint=4 profile=260 device_type=0
+            # input_clusters=[64704]
+            # output_clusters=[]>
             4: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -104,6 +116,9 @@ class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # <SimpleDescriptor endpoint=21 profile=260 device_type=0
+            # input_clusters=[12]
+            # output_clusters=[]>
             21: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -16,12 +16,32 @@ from zigpy.zcl.clusters.general import (
 )
 
 from zhaquirks.const import (
+    ACTION,
+    ARGS,
+    ATTRIBUTE_ID,
+    BUTTON,
+    COMMAND,
+    COMMAND_SLIDER_EVENT,
+    CLUSTER_ID,
     DEVICE_TYPE,
+    DOUBLE_PRESS,
+    DIM_UP,
+    DIM_DOWN,
     ENDPOINTS,
+    ENDPOINT_ID,
     INPUT_CLUSTERS,
+    LONG_PRESS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    SHORT_PRESS,
+    SLIDER,
+    SLIDER_DOUBLE,
+    SLIDER_DOWN,
+    SLIDER_HOLD,
+    SLIDER_SINGLE,
+    SLIDER_UP,
+    VALUE,
 )
 from zhaquirks.xiaomi import (
     LUMI,
@@ -58,6 +78,7 @@ class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
     """Aqara Z1 Pro Single Rocker Switch"""
 
     MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCC0
+    XIAOMI_COMMAND_SINGLE = "1_single"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -190,5 +211,44 @@ class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON): {
+            COMMAND: XIAOMI_COMMAND_SINGLE,
+            CLUSTER_ID: 18,
+            ENDPOINT_ID: 1,
+            ARGS: {ATTRIBUTE_ID: 85, VALUE: 1},
+        },
+        (SHORT_PRESS, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_SINGLE, VALUE: 1},
+        },
+        (DOUBLE_PRESS, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_DOUBLE, VALUE: 2},
+        },
+        (LONG_PRESS, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_HOLD, VALUE: 3},
+        },
+        (DIM_UP, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_UP, VALUE: 4},
+        },
+        (DIM_DOWN, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_DOWN, VALUE: 5},
         },
     }

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -75,7 +75,7 @@ class AqaraZ1ProSliderCluster(CustomCluster):
         self._attr_id = self.ATTR_SLIDER_ACTION
         _LOGGER.debug("AqaraZ1ProSliderCluster initialized for device %s", self._endpoint.device.ieee)
         
-    async def _update_attribute(self, attrid, value):
+    def _update_attribute(self, attrid, value):
         """Handle attribute updates."""
         _LOGGER.debug("AqaraZ1ProSliderCluster attribute update: attrid=0x%04x, value=%s", attrid, value)
         super()._update_attribute(attrid, value)

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -73,11 +73,11 @@ class AqaraZ1ProSliderCluster(CustomCluster):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._attr_id = self.ATTR_SLIDER_ACTION
-        _LOGGER.critical("AqaraZ1ProSliderCluster initialized for device %s", self._endpoint.device.ieee)
+        _LOGGER.debug("AqaraZ1ProSliderCluster initialized for device %s", self._endpoint.device.ieee)
         
     async def _update_attribute(self, attrid, value):
         """Handle attribute updates."""
-        _LOGGER.critical("AqaraZ1ProSliderCluster attribute update: attrid=0x%04x, value=%s", attrid, value)
+        _LOGGER.debug("AqaraZ1ProSliderCluster attribute update: attrid=0x%04x, value=%s", attrid, value)
         super()._update_attribute(attrid, value)
         
         # Store all attributes for the event
@@ -91,7 +91,7 @@ class AqaraZ1ProSliderCluster(CustomCluster):
         if attrid == self.ATTR_SLIDER_ACTION:
             # Get the action name from the mapping
             action = self.ACTION_MAPPING.get(value, f"slider_unknown_{value}")
-            _LOGGER.critical("AqaraZ1ProSliderCluster detected action: %s (value: %s)", action, value)
+            _LOGGER.debug("AqaraZ1ProSliderCluster detected action: %s (value: %s)", action, value)
             
             # Prepare the event data
             event_data = {
@@ -109,7 +109,7 @@ class AqaraZ1ProSliderCluster(CustomCluster):
                 },
             }
             
-            _LOGGER.critical("AqaraZ1ProSliderCluster sending event data: %s", event_data)
+            _LOGGER.debug("AqaraZ1ProSliderCluster sending event data: %s", event_data)
             
             # Send the event
             self.listener_event(
@@ -124,12 +124,7 @@ class AqaraZ1ProSliderCluster(CustomCluster):
                 "slider_event",
                 event_data,
             )
-            _LOGGER.critical("AqaraZ1ProSliderCluster events sent successfully")
-    
-    async def test_logging(self):
-        """Test method to verify logging is working."""
-        _LOGGER.critical("AqaraZ1ProSliderCluster TEST LOGGING - This should appear in Home Assistant logs")
-        return True
+            _LOGGER.debug("AqaraZ1ProSliderCluster events sent successfully")
 
 
 class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
@@ -212,7 +207,7 @@ class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
                     MultistateInputCluster,
                     MeteringCluster,
                     ElectricalMeasurementCluster,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                    AqaraZ1ProSliderCluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -31,7 +31,7 @@ from zhaquirks.xiaomi import (
     MeteringCluster,
     OnOffCluster,
     XiaomiCustomDevice,
-    AqaraZ1ProManufacturerSpecificCluster
+    AqaraZ1ProManufacturerSpecificCluster,
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 
@@ -42,22 +42,29 @@ _LOGGER.setLevel(logging.DEBUG)
 # Add a console handler to ensure logs go to stdout
 console_handler = logging.StreamHandler(sys.stdout)
 console_handler.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 console_handler.setFormatter(formatter)
 _LOGGER.addHandler(console_handler)
 
 # Log at module level to verify the file is being loaded
-_LOGGER.debug("AqaraZ1ProSingleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x", zha.PROFILE_ID, zha.DeviceType.ON_OFF_SWITCH)
+_LOGGER.debug(
+    "AqaraZ1ProSingleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x",
+    zha.PROFILE_ID,
+    zha.DeviceType.ON_OFF_SWITCH,
+)
+
 
 class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
     """Aqara Z1 Pro Single Rocker Switch"""
 
-    MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xfcc0
+    MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCC0
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        _LOGGER.debug("AqaraZ1ProSingleRockerSwitch device initialized with IEEE: %s", self.ieee)
-    
+        _LOGGER.debug(
+            "AqaraZ1ProSingleRockerSwitch device initialized with IEEE: %s", self.ieee
+        )
+
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.acn056")],
         ENDPOINTS: {

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -100,18 +100,12 @@ class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
             
             # Prepare the event data
             event_data = {
-                "device_ieee": str(self._endpoint.device.ieee),
-                "endpoint_id": self._endpoint.endpoint_id,
-                "cluster_id": self.cluster_id,
-                "command": action,
-                "args": {
-                    "action": action,
-                    "value": value,
-                    "slide_time": self._manufacturer_attrs.get(self.ATTR_SLIDE_TIME),
-                    "slide_speed": self._manufacturer_attrs.get(self.ATTR_SLIDE_SPEED),
-                    "slide_relative_displacement": self._manufacturer_attrs.get(self.ATTR_SLIDE_RELATIVE_DISPLACEMENT),
-                    "slide_time_delta": self._manufacturer_attrs.get(self.ATTR_SLIDE_TIME_DELTA),
-                },
+                "action": action,
+                "value": value,
+                "slide_time": self._manufacturer_attrs.get(self.ATTR_SLIDE_TIME),
+                "slide_speed": self._manufacturer_attrs.get(self.ATTR_SLIDE_SPEED),
+                "slide_relative_displacement": self._manufacturer_attrs.get(self.ATTR_SLIDE_RELATIVE_DISPLACEMENT),
+                "slide_time_delta": self._manufacturer_attrs.get(self.ATTR_SLIDE_TIME_DELTA),
             }
             
             _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster sending event data: %s", event_data)

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -49,8 +49,8 @@ _LOGGER.addHandler(console_handler)
 # Log at module level to verify the file is being loaded
 _LOGGER.debug("AqaraZ1ProSingleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x", zha.PROFILE_ID, zha.DeviceType.ON_OFF_SWITCH)
 
-class AqaraZ1ProSliderCluster(CustomCluster):
-    """Custom cluster for Aqara Z1 Pro slider events."""
+class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
+    """Custom cluster for Aqara Z1 Pro manufacturer specific events."""
     
     cluster_id = 0xfcc0
     
@@ -73,25 +73,25 @@ class AqaraZ1ProSliderCluster(CustomCluster):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._attr_id = self.ATTR_SLIDER_ACTION
-        _LOGGER.debug("AqaraZ1ProSliderCluster initialized for device %s", self._endpoint.device.ieee)
+        _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster initialized for device %s", self._endpoint.device.ieee)
         
     def _update_attribute(self, attrid, value):
         """Handle attribute updates."""
-        _LOGGER.debug("AqaraZ1ProSliderCluster attribute update: attrid=0x%04x, value=%s", attrid, value)
+        _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster attribute update: attrid=0x%04x, value=%s", attrid, value)
         super()._update_attribute(attrid, value)
         
         # Store all attributes for the event
-        if not hasattr(self, "_slider_attrs"):
-            self._slider_attrs = {}
+        if not hasattr(self, "_manufacturer_attrs"):
+            self._manufacturer_attrs = {}
         
         # Update the attribute value
-        self._slider_attrs[attrid] = value
+        self._manufacturer_attrs[attrid] = value
         
         # If this is the slider action attribute, send the event
         if attrid == self.ATTR_SLIDER_ACTION:
             # Get the action name from the mapping
             action = self.ACTION_MAPPING.get(value, f"slider_unknown_{value}")
-            _LOGGER.debug("AqaraZ1ProSliderCluster detected action: %s (value: %s)", action, value)
+            _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster detected action: %s (value: %s)", action, value)
             
             # Prepare the event data
             event_data = {
@@ -102,14 +102,14 @@ class AqaraZ1ProSliderCluster(CustomCluster):
                 "args": {
                     "action": action,
                     "value": value,
-                    "slide_time": self._slider_attrs.get(self.ATTR_SLIDE_TIME),
-                    "slide_speed": self._slider_attrs.get(self.ATTR_SLIDE_SPEED),
-                    "slide_relative_displacement": self._slider_attrs.get(self.ATTR_SLIDE_RELATIVE_DISPLACEMENT),
-                    "slide_time_delta": self._slider_attrs.get(self.ATTR_SLIDE_TIME_DELTA),
+                    "slide_time": self._manufacturer_attrs.get(self.ATTR_SLIDE_TIME),
+                    "slide_speed": self._manufacturer_attrs.get(self.ATTR_SLIDE_SPEED),
+                    "slide_relative_displacement": self._manufacturer_attrs.get(self.ATTR_SLIDE_RELATIVE_DISPLACEMENT),
+                    "slide_time_delta": self._manufacturer_attrs.get(self.ATTR_SLIDE_TIME_DELTA),
                 },
             }
             
-            _LOGGER.debug("AqaraZ1ProSliderCluster sending event data: %s", event_data)
+            _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster sending event data: %s", event_data)
             
             # Send the event
             self.listener_event(
@@ -124,7 +124,7 @@ class AqaraZ1ProSliderCluster(CustomCluster):
                 "slider_event",
                 event_data,
             )
-            _LOGGER.debug("AqaraZ1ProSliderCluster events sent successfully")
+            _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster events sent successfully")
 
 
 class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
@@ -207,7 +207,7 @@ class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
                     MultistateInputCluster,
                     MeteringCluster,
                     ElectricalMeasurementCluster,
-                    AqaraZ1ProSliderCluster,
+                    AqaraZ1ProManufacturerSpecificCluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -1,0 +1,151 @@
+"""Aqara Z1 Pro single rocker switch quirks."""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    AnalogInput,
+    Basic,
+    Groups,
+    Identify,
+    MultistateInput,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    AnalogInputCluster,
+    BasicCluster,
+    ElectricalMeasurementCluster,
+    MeteringCluster,
+    OnOffCluster,
+)
+from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
+
+MANUFACTURER_SPECIFIC_CLUSTER_ID = "0xfcc0"
+
+class AqaraZ1ProSingleRockerSwitch(CustomDevice):
+    """Aqara Z1 Pro Single Rocker Switch"""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.switch.acn056")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    MeteringCluster.cluster_id,
+                    ElectricalMeasurementCluster.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    AnalogInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MeteringCluster,
+                    ElectricalMeasurementCluster,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    AnalogInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
     AnalogInput,
@@ -20,15 +21,15 @@ from zhaquirks.const import (
     ARGS,
     ATTRIBUTE_ID,
     BUTTON,
+    CLUSTER_ID,
     COMMAND,
     COMMAND_SLIDER_EVENT,
-    CLUSTER_ID,
     DEVICE_TYPE,
-    DOUBLE_PRESS,
-    DIM_UP,
     DIM_DOWN,
-    ENDPOINTS,
+    DIM_UP,
+    DOUBLE_PRESS,
     ENDPOINT_ID,
+    ENDPOINTS,
     INPUT_CLUSTERS,
     LONG_PRESS,
     MODELS_INFO,
@@ -44,14 +45,13 @@ from zhaquirks.const import (
     VALUE,
 )
 from zhaquirks.xiaomi import (
-    LUMI,
     AnalogInputCluster,
+    AqaraZ1ProManufacturerSpecificCluster,
     BasicCluster,
     ElectricalMeasurementCluster,
     MeteringCluster,
     OnOffCluster,
     XiaomiCustomDevice,
-    AqaraZ1ProManufacturerSpecificCluster,
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 
@@ -75,12 +75,13 @@ _LOGGER.debug(
 
 
 class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
-    """Aqara Z1 Pro Single Rocker Switch"""
+    """Aqara Z1 Pro Single Rocker Switch."""
 
     MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCC0
     XIAOMI_COMMAND_SINGLE = "1_single"
 
     def __init__(self, *args, **kwargs):
+        """Init."""
         super().__init__(*args, **kwargs)
         _LOGGER.debug(
             "AqaraZ1ProSingleRockerSwitch device initialized with IEEE: %s", self.ieee

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -60,6 +60,12 @@ class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
     ATTR_SLIDE_SPEED = 0x0232    # 562
     ATTR_SLIDE_RELATIVE_DISPLACEMENT = 0x0233  # 563
     ATTR_SLIDE_TIME_DELTA = 0x0301  # 769
+
+    # ATTR_DEVICE_ID_SHADE = 0x0200 # 512
+    # ATTR_LOCK_RELAY = 0x0285 # 645
+    # ATTR_SWITCH_MODE = 0x0004 # 4
+    # ATTR_POWER_ON_BEHAVIOR = 0x0517 # 1303
+    # ATTR_CLICK_MODE = 0x0125 # 293
     
     # Action mapping
     ACTION_MAPPING = {

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -1,7 +1,9 @@
 """Aqara Z1 Pro single rocker switch quirks."""
 
+import logging
+import sys
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
+from zigpy.quirks import CustomDevice, CustomCluster
 from zigpy.zcl.clusters.general import (
     AnalogInput,
     Basic,
@@ -29,20 +31,122 @@ from zhaquirks.xiaomi import (
     ElectricalMeasurementCluster,
     MeteringCluster,
     OnOffCluster,
+    XiaomiCustomDevice,
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 
-MANUFACTURER_SPECIFIC_CLUSTER_ID = "0xfcc0"
+# Set up logging with a more visible format
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.DEBUG)
 
-class AqaraZ1ProSingleRockerSwitch(CustomDevice):
+# Add a console handler to ensure logs go to stdout
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+console_handler.setFormatter(formatter)
+_LOGGER.addHandler(console_handler)
+
+# Log at module level to verify the file is being loaded
+_LOGGER.debug("AqaraZ1ProSingleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x", zha.PROFILE_ID, zha.DeviceType.ON_OFF_SWITCH)
+
+class AqaraZ1ProSliderCluster(CustomCluster):
+    """Custom cluster for Aqara Z1 Pro slider events."""
+    
+    cluster_id = 0xfcc0
+    
+    # Attribute IDs
+    ATTR_SLIDER_ACTION = 0x028C  # 652
+    ATTR_SLIDE_TIME = 0x0231     # 561
+    ATTR_SLIDE_SPEED = 0x0232    # 562
+    ATTR_SLIDE_RELATIVE_DISPLACEMENT = 0x0233  # 563
+    ATTR_SLIDE_TIME_DELTA = 0x0301  # 769
+    
+    # Action mapping
+    ACTION_MAPPING = {
+        1: "slider_single",
+        2: "slider_double",
+        3: "slider_hold",
+        4: "slider_up",
+        5: "slider_down",
+    }
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._attr_id = self.ATTR_SLIDER_ACTION
+        _LOGGER.critical("AqaraZ1ProSliderCluster initialized for device %s", self._endpoint.device.ieee)
+        
+    async def _update_attribute(self, attrid, value):
+        """Handle attribute updates."""
+        _LOGGER.critical("AqaraZ1ProSliderCluster attribute update: attrid=0x%04x, value=%s", attrid, value)
+        super()._update_attribute(attrid, value)
+        
+        # Store all attributes for the event
+        if not hasattr(self, "_slider_attrs"):
+            self._slider_attrs = {}
+        
+        # Update the attribute value
+        self._slider_attrs[attrid] = value
+        
+        # If this is the slider action attribute, send the event
+        if attrid == self.ATTR_SLIDER_ACTION:
+            # Get the action name from the mapping
+            action = self.ACTION_MAPPING.get(value, f"slider_unknown_{value}")
+            _LOGGER.critical("AqaraZ1ProSliderCluster detected action: %s (value: %s)", action, value)
+            
+            # Prepare the event data
+            event_data = {
+                "device_ieee": str(self._endpoint.device.ieee),
+                "endpoint_id": self._endpoint.endpoint_id,
+                "cluster_id": self.cluster_id,
+                "command": action,
+                "args": {
+                    "action": action,
+                    "value": value,
+                    "slide_time": self._slider_attrs.get(self.ATTR_SLIDE_TIME),
+                    "slide_speed": self._slider_attrs.get(self.ATTR_SLIDE_SPEED),
+                    "slide_relative_displacement": self._slider_attrs.get(self.ATTR_SLIDE_RELATIVE_DISPLACEMENT),
+                    "slide_time_delta": self._slider_attrs.get(self.ATTR_SLIDE_TIME_DELTA),
+                },
+            }
+            
+            _LOGGER.critical("AqaraZ1ProSliderCluster sending event data: %s", event_data)
+            
+            # Send the event
+            self.listener_event(
+                "zha_send_event",
+                action,
+                event_data,
+            )
+            
+            # Also send a generic slider event for easier automation
+            self.listener_event(
+                "zha_send_event",
+                "slider_event",
+                event_data,
+            )
+            _LOGGER.critical("AqaraZ1ProSliderCluster events sent successfully")
+    
+    async def test_logging(self):
+        """Test method to verify logging is working."""
+        _LOGGER.critical("AqaraZ1ProSliderCluster TEST LOGGING - This should appear in Home Assistant logs")
+        return True
+
+
+class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
     """Aqara Z1 Pro Single Rocker Switch"""
 
+    MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xfcc0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        _LOGGER.debug("AqaraZ1ProSingleRockerSwitch device initialized with IEEE: %s", self.ieee)
+    
     signature = {
-        MODELS_INFO: [(LUMI, "lumi.switch.acn056")],
+        MODELS_INFO: [("Aqara", "lumi.switch.acn056")],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
@@ -61,7 +165,7 @@ class AqaraZ1ProSingleRockerSwitch(CustomDevice):
             },
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     MANUFACTURER_SPECIFIC_CLUSTER_ID,
                 ],
@@ -69,7 +173,7 @@ class AqaraZ1ProSingleRockerSwitch(CustomDevice):
             },
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     MANUFACTURER_SPECIFIC_CLUSTER_ID,
                 ],
@@ -77,7 +181,7 @@ class AqaraZ1ProSingleRockerSwitch(CustomDevice):
             },
             4: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     MANUFACTURER_SPECIFIC_CLUSTER_ID,
                 ],
@@ -85,7 +189,7 @@ class AqaraZ1ProSingleRockerSwitch(CustomDevice):
             },
             21: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     AnalogInput.cluster_id,
                 ],

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -3,7 +3,6 @@
 import logging
 import sys
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice, CustomCluster
 from zigpy.zcl.clusters.general import (
     AnalogInput,
     Basic,
@@ -23,7 +22,6 @@ from zhaquirks.const import (
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    ZHA_SEND_EVENT,
 )
 from zhaquirks.xiaomi import (
     LUMI,
@@ -33,6 +31,7 @@ from zhaquirks.xiaomi import (
     MeteringCluster,
     OnOffCluster,
     XiaomiCustomDevice,
+    AqaraZ1ProManufacturerSpecificCluster
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 
@@ -49,84 +48,6 @@ _LOGGER.addHandler(console_handler)
 
 # Log at module level to verify the file is being loaded
 _LOGGER.debug("AqaraZ1ProSingleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x", zha.PROFILE_ID, zha.DeviceType.ON_OFF_SWITCH)
-
-class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
-    """Custom cluster for Aqara Z1 Pro manufacturer specific events."""
-    
-    cluster_id = 0xfcc0
-    
-    # Attribute IDs
-    ATTR_SLIDER_ACTION = 0x028C  # 652
-    ATTR_SLIDE_TIME = 0x0231     # 561
-    ATTR_SLIDE_SPEED = 0x0232    # 562
-    ATTR_SLIDE_RELATIVE_DISPLACEMENT = 0x0233  # 563
-    ATTR_SLIDE_TIME_DELTA = 0x0301  # 769
-
-    # ATTR_DEVICE_ID_SHADE = 0x0200 # 512
-    # ATTR_LOCK_RELAY = 0x0285 # 645
-    # ATTR_SWITCH_MODE = 0x0004 # 4
-    # ATTR_POWER_ON_BEHAVIOR = 0x0517 # 1303
-    # ATTR_CLICK_MODE = 0x0125 # 293
-    
-    # Action mapping
-    ACTION_MAPPING = {
-        1: "slider_single",
-        2: "slider_double",
-        3: "slider_hold",
-        4: "slider_up",
-        5: "slider_down",
-    }
-    
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._attr_id = self.ATTR_SLIDER_ACTION
-        _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster initialized for device %s", self._endpoint.device.ieee)
-        
-    def _update_attribute(self, attrid, value):
-        """Handle attribute updates."""
-        
-        # Store all attributes for the event
-        if not hasattr(self, "_manufacturer_attrs"):
-            self._manufacturer_attrs = {}
-        
-        # Update the attribute value
-        self._manufacturer_attrs[attrid] = value
-        
-        # If this is the slider action attribute, send the event
-        if attrid == self.ATTR_SLIDER_ACTION:
-            # Get the action name from the mapping
-            action = self.ACTION_MAPPING.get(value, f"slider_unknown_{value}")
-            _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster detected action: %s (value: %s)", action, value)
-            
-            # Prepare the event data
-            event_data = {
-                "action": action,
-                "value": value,
-                "slide_time": self._manufacturer_attrs.get(self.ATTR_SLIDE_TIME),
-                "slide_speed": self._manufacturer_attrs.get(self.ATTR_SLIDE_SPEED),
-                "slide_relative_displacement": self._manufacturer_attrs.get(self.ATTR_SLIDE_RELATIVE_DISPLACEMENT),
-                "slide_time_delta": self._manufacturer_attrs.get(self.ATTR_SLIDE_TIME_DELTA),
-            }
-            
-            _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster sending event data: %s", event_data)
-            
-            # Send the event
-            self.listener_event(
-                ZHA_SEND_EVENT,
-                action,
-                event_data,
-            )
-            
-            # Also send a generic slider event for easier automation
-            self.listener_event(
-                ZHA_SEND_EVENT,
-                "slider_event",
-                event_data,
-            )
-            _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster events sent successfully")
-
-        _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster attribute update: attrid=0x%04x, value=%s", attrid, value)
-        super()._update_attribute(attrid, value)
 
 class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
     """Aqara Z1 Pro Single Rocker Switch"""

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_single.py
@@ -23,6 +23,7 @@ from zhaquirks.const import (
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    ZHA_SEND_EVENT,
 )
 from zhaquirks.xiaomi import (
     LUMI,
@@ -83,8 +84,6 @@ class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
         
     def _update_attribute(self, attrid, value):
         """Handle attribute updates."""
-        _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster attribute update: attrid=0x%04x, value=%s", attrid, value)
-        super()._update_attribute(attrid, value)
         
         # Store all attributes for the event
         if not hasattr(self, "_manufacturer_attrs"):
@@ -119,19 +118,21 @@ class AqaraZ1ProManufacturerSpecificCluster(CustomCluster):
             
             # Send the event
             self.listener_event(
-                "zha_send_event",
+                ZHA_SEND_EVENT,
                 action,
                 event_data,
             )
             
             # Also send a generic slider event for easier automation
             self.listener_event(
-                "zha_send_event",
+                ZHA_SEND_EVENT,
                 "slider_event",
                 event_data,
             )
             _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster events sent successfully")
 
+        _LOGGER.debug("AqaraZ1ProManufacturerSpecificCluster attribute update: attrid=0x%04x, value=%s", attrid, value)
+        super()._update_attribute(attrid, value)
 
 class AqaraZ1ProSingleRockerSwitch(XiaomiCustomDevice):
     """Aqara Z1 Pro Single Rocker Switch"""

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_triple.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_triple.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
     AnalogInput,
@@ -22,15 +23,15 @@ from zhaquirks.const import (
     BUTTON_1,
     BUTTON_2,
     BUTTON_3,
+    CLUSTER_ID,
     COMMAND,
     COMMAND_SLIDER_EVENT,
-    CLUSTER_ID,
     DEVICE_TYPE,
-    DOUBLE_PRESS,
-    DIM_UP,
     DIM_DOWN,
-    ENDPOINTS,
+    DIM_UP,
+    DOUBLE_PRESS,
     ENDPOINT_ID,
+    ENDPOINTS,
     INPUT_CLUSTERS,
     LONG_PRESS,
     MODELS_INFO,
@@ -46,14 +47,13 @@ from zhaquirks.const import (
     VALUE,
 )
 from zhaquirks.xiaomi import (
-    LUMI,
     AnalogInputCluster,
+    AqaraZ1ProManufacturerSpecificCluster,
     BasicCluster,
     ElectricalMeasurementCluster,
     MeteringCluster,
     OnOffCluster,
     XiaomiCustomDevice,
-    AqaraZ1ProManufacturerSpecificCluster,
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 
@@ -77,7 +77,7 @@ _LOGGER.debug(
 
 
 class AqaraZ1ProTripleRockerSwitch(XiaomiCustomDevice):
-    """Aqara Z1 Pro Triple Rocker Switch"""
+    """Aqara Z1 Pro Triple Rocker Switch."""
 
     MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCC0
     XIAOMI_COMMAND_SINGLE_1 = "1_single"
@@ -85,6 +85,7 @@ class AqaraZ1ProTripleRockerSwitch(XiaomiCustomDevice):
     XIAOMI_COMMAND_SINGLE_3 = "3_single"
 
     def __init__(self, *args, **kwargs):
+        """Init."""
         super().__init__(*args, **kwargs)
         _LOGGER.debug(
             "AqaraZ1ProTripleRockerSwitch device initialized with IEEE: %s", self.ieee

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_triple.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_triple.py
@@ -1,0 +1,188 @@
+"""Aqara Z1 Pro triple rocker switch quirks."""
+
+import logging
+import sys
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import (
+    AnalogInput,
+    Basic,
+    Groups,
+    Identify,
+    MultistateInput,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    AnalogInputCluster,
+    BasicCluster,
+    ElectricalMeasurementCluster,
+    MeteringCluster,
+    OnOffCluster,
+    XiaomiCustomDevice,
+    AqaraZ1ProManufacturerSpecificCluster
+)
+from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
+
+# Set up logging with a more visible format
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.DEBUG)
+
+# Add a console handler to ensure logs go to stdout
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+console_handler.setFormatter(formatter)
+_LOGGER.addHandler(console_handler)
+
+# Log at module level to verify the file is being loaded
+_LOGGER.debug("AqaraZ1ProTripleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x", zha.PROFILE_ID, zha.DeviceType.ON_OFF_SWITCH)
+
+class AqaraZ1ProTripleRockerSwitch(XiaomiCustomDevice):
+    """Aqara Z1 Pro Triple Rocker Switch"""
+
+    MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xfcc0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        _LOGGER.debug("AqaraZ1ProTripleRockerSwitch device initialized with IEEE: %s", self.ieee)
+    
+    signature = {
+        MODELS_INFO: [("Aqara", "lumi.switch.acn058")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    MeteringCluster.cluster_id,
+                    ElectricalMeasurementCluster.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    AnalogInput.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MeteringCluster,
+                    ElectricalMeasurementCluster,
+                    AqaraZ1ProManufacturerSpecificCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOffCluster,
+                    MultistateInputCluster,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    AnalogInputCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_triple.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_triple.py
@@ -61,6 +61,9 @@ class AqaraZ1ProTripleRockerSwitch(XiaomiCustomDevice):
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.acn058")],
         ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=0
+            # input_clusters=[0, 3, 4, 5, 6, 18, 1794, 2820, 64704]
+            # output_clusters=[10, 25]>
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -80,6 +83,9 @@ class AqaraZ1ProTripleRockerSwitch(XiaomiCustomDevice):
                     Ota.cluster_id,
                 ],
             },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=0
+            # input_clusters=[4, 5, 6, 18, 64704]
+            # output_clusters=[]>
             2: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -92,6 +98,9 @@ class AqaraZ1ProTripleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # <SimpleDescriptor endpoint=3 profile=260 device_type=0
+            # input_clusters=[4, 5, 6, 18, 64704]
+            # output_clusters=[]>
             3: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -104,6 +113,9 @@ class AqaraZ1ProTripleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # <SimpleDescriptor endpoint=4 profile=260 device_type=0
+            # input_clusters=[64704]
+            # output_clusters=[]>
             4: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
@@ -112,6 +124,9 @@ class AqaraZ1ProTripleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+            # <SimpleDescriptor endpoint=21 profile=260 device_type=0
+            # input_clusters=[12]
+            # output_clusters=[]>
             21: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_triple.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_triple.py
@@ -16,12 +16,34 @@ from zigpy.zcl.clusters.general import (
 )
 
 from zhaquirks.const import (
+    ACTION,
+    ARGS,
+    ATTRIBUTE_ID,
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    COMMAND,
+    COMMAND_SLIDER_EVENT,
+    CLUSTER_ID,
     DEVICE_TYPE,
+    DOUBLE_PRESS,
+    DIM_UP,
+    DIM_DOWN,
     ENDPOINTS,
+    ENDPOINT_ID,
     INPUT_CLUSTERS,
+    LONG_PRESS,
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    SHORT_PRESS,
+    SLIDER,
+    SLIDER_DOUBLE,
+    SLIDER_DOWN,
+    SLIDER_HOLD,
+    SLIDER_SINGLE,
+    SLIDER_UP,
+    VALUE,
 )
 from zhaquirks.xiaomi import (
     LUMI,
@@ -58,6 +80,9 @@ class AqaraZ1ProTripleRockerSwitch(XiaomiCustomDevice):
     """Aqara Z1 Pro Triple Rocker Switch"""
 
     MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCC0
+    XIAOMI_COMMAND_SINGLE_1 = "1_single"
+    XIAOMI_COMMAND_SINGLE_2 = "2_single"
+    XIAOMI_COMMAND_SINGLE_3 = "3_single"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -206,5 +231,56 @@ class AqaraZ1ProTripleRockerSwitch(XiaomiCustomDevice):
                 ],
                 OUTPUT_CLUSTERS: [],
             },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON_1): {
+            COMMAND: XIAOMI_COMMAND_SINGLE_1,
+            CLUSTER_ID: 18,
+            ENDPOINT_ID: 1,
+            ARGS: {ATTRIBUTE_ID: 85, VALUE: 1},
+        },
+        (SHORT_PRESS, BUTTON_2): {
+            COMMAND: XIAOMI_COMMAND_SINGLE_2,
+            CLUSTER_ID: 18,
+            ENDPOINT_ID: 2,
+            ARGS: {ATTRIBUTE_ID: 85, VALUE: 1},
+        },
+        (SHORT_PRESS, BUTTON_3): {
+            COMMAND: XIAOMI_COMMAND_SINGLE_3,
+            CLUSTER_ID: 18,
+            ENDPOINT_ID: 3,
+            ARGS: {ATTRIBUTE_ID: 85, VALUE: 1},
+        },
+        (SHORT_PRESS, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_SINGLE, VALUE: 1},
+        },
+        (DOUBLE_PRESS, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_DOUBLE, VALUE: 2},
+        },
+        (LONG_PRESS, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_HOLD, VALUE: 3},
+        },
+        (DIM_UP, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_UP, VALUE: 4},
+        },
+        (DIM_DOWN, SLIDER): {
+            COMMAND: COMMAND_SLIDER_EVENT,
+            CLUSTER_ID: 64704,
+            ENDPOINT_ID: 1,
+            ARGS: {ACTION: SLIDER_DOWN, VALUE: 5},
         },
     }

--- a/zhaquirks/xiaomi/aqara/aqara_z1_pro_triple.py
+++ b/zhaquirks/xiaomi/aqara/aqara_z1_pro_triple.py
@@ -31,7 +31,7 @@ from zhaquirks.xiaomi import (
     MeteringCluster,
     OnOffCluster,
     XiaomiCustomDevice,
-    AqaraZ1ProManufacturerSpecificCluster
+    AqaraZ1ProManufacturerSpecificCluster,
 )
 from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
 
@@ -42,22 +42,29 @@ _LOGGER.setLevel(logging.DEBUG)
 # Add a console handler to ensure logs go to stdout
 console_handler = logging.StreamHandler(sys.stdout)
 console_handler.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 console_handler.setFormatter(formatter)
 _LOGGER.addHandler(console_handler)
 
 # Log at module level to verify the file is being loaded
-_LOGGER.debug("AqaraZ1ProTripleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x", zha.PROFILE_ID, zha.DeviceType.ON_OFF_SWITCH)
+_LOGGER.debug(
+    "AqaraZ1ProTripleRockerSwitch quirk module is being loaded! ZHA Profile ID: 0x%04x, Device Type: 0x%04x",
+    zha.PROFILE_ID,
+    zha.DeviceType.ON_OFF_SWITCH,
+)
+
 
 class AqaraZ1ProTripleRockerSwitch(XiaomiCustomDevice):
     """Aqara Z1 Pro Triple Rocker Switch"""
 
-    MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xfcc0
+    MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFCC0
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        _LOGGER.debug("AqaraZ1ProTripleRockerSwitch device initialized with IEEE: %s", self.ieee)
-    
+        _LOGGER.debug(
+            "AqaraZ1ProTripleRockerSwitch device initialized with IEEE: %s", self.ieee
+        )
+
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.acn058")],
         ENDPOINTS: {


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Related Issue: https://github.com/zigpy/zha-device-handlers/issues/3127
Added partial support for [Aqara Z1 Pro Light Switch](https://www.aqara.com/en/product/smart-wall-switch-z1-pro-sea/).
I have tested the changes in single rocker, double rocker and triple rocker version.
The changes enable the slider events detection that cannot be supported by default in ZHA.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

I have created custom ZHA quirks that can help detect slider events from the Aqara Z1 Pro switch. Users can set up automation based on the received ZHA events. For those who are eager to test it before the official release, please follow the steps below to set it up on your local device:  
   
1. Add the following files to your Home Assistant **/config/custom_zha_quirks** directory (create it if it does not exist):  
   - [aqara_z1_pro_single.py](https://gist.github.com/KwFung7/4eeb4190cdabebc340c15a183a1ea928#file-aqara_z1_pro_single-py)
   - [aqara_z1_pro_double.py](https://gist.github.com/KwFung7/4eeb4190cdabebc340c15a183a1ea928#file-aqara_z1_pro_double-py)  
   - [aqara_z1_pro_triple.py](https://gist.github.com/KwFung7/4eeb4190cdabebc340c15a183a1ea928#file-aqara_z1_pro_triple-py)
   - [aqara_z1_pro_quadruple.py](https://gist.github.com/KwFung7/4eeb4190cdabebc340c15a183a1ea928#file-aqara_z1_pro_quadruple-py)
   
2. (Optional) Enable logging for custom ZHA quirks in **/config/configuration.yaml**:  
   ```yaml  
   logger:  
     default: info  
     logs:  
       zigpy: debug  
       homeassistant.components.zha: debug  
       zhaquirks: debug  
   ```  
   
3. Restart Home Assistant to activate the custom quirks.  
   
4. Verify that the quirks are loaded on the target devices and check the logs in **/config/home-assistant.log**.  
<img width="600" alt="Image" src="https://github.com/user-attachments/assets/575eb05d-4c13-4e93-a336-698edea7b1f8" />
   
5. Test the Aqara Z1 Pro slider and attempt to capture the ZHA slider event in Developer Tools.
<img width="600" alt="Image" src="https://github.com/user-attachments/assets/d2bc1f4b-77b9-4c15-9494-165679fba313" />


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
