### PR TITLE
Return datetimes for Tuya timestamp sensors

### DIFF
--- a/tests/test_tuya_valve.py
+++ b/tests/test_tuya_valve.py
@@ -181,7 +181,7 @@ async def test_giex_02_quirk(zigpy_device_from_v2_quirk, model, manuf, use_minut
 async def test_giex_functions():
     """Test various Giex Valve functions."""
     assert zhaquirks.tuya.tuya_valve.giex_string_to_td("12:01:05,3") == 43265
-    assert zhaquirks.tuya.tuya_valve.giex_string_to_ts("--:--:--") is None
+    assert zhaquirks.tuya.tuya_valve.giex_string_to_dt("--:--:--") is None
 
     class MockDatetime:
         def now(self, tz: timezone):
@@ -193,11 +193,9 @@ async def test_giex_functions():
             return datetime.strptime(v, fmt)
 
     with patch("zhaquirks.tuya.tuya_valve.datetime", MockDatetime()):
-        assert (
-            zhaquirks.tuya.tuya_valve.giex_string_to_ts("20:12:01")
-            == datetime.fromisoformat("2024-10-02T12:10:23+04:00").timestamp()
-            + zhaquirks.tuya.tuya_valve.UNIX_EPOCH_TO_ZCL_EPOCH
-        )
+        assert zhaquirks.tuya.tuya_valve.giex_string_to_dt(
+            "20:12:01"
+        ) == datetime.fromisoformat("2024-10-02T20:12:01+04:00")
 
 
 @pytest.mark.parametrize(

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -211,16 +211,17 @@ def giex_string_to_td(v: str) -> int:
     return timedelta(hours=dt.hour, minutes=dt.minute, seconds=dt.second).seconds
 
 
-def giex_string_to_ts(v: str) -> int | None:
+def giex_string_to_dt(v: str) -> datetime | None:
     """Convert Giex String Duration datetime."""
     dev_tz = timezone(timedelta(hours=4))
     dev_dt = datetime.now(dev_tz)
+
     try:
         dt = datetime.strptime(v, "%H:%M:%S").replace(tzinfo=dev_tz)
-        dev_dt.replace(hour=dt.hour, minute=dt.minute, second=dt.second)
     except ValueError:
         return None  # on initial start the device will return '--:--:--'
-    return int(dev_dt.timestamp() + UNIX_EPOCH_TO_ZCL_EPOCH)
+    else:
+        return dev_dt.replace(hour=dt.hour, minute=dt.minute, second=dt.second)
 
 
 gx02_base_quirk = (
@@ -273,7 +274,7 @@ gx02_base_quirk = (
         dp_id=101,
         attribute_name="irrigation_start_time",
         type=t.CharacterString,
-        converter=lambda x: giex_string_to_ts(x),
+        converter=lambda x: giex_string_to_dt(x),
         device_class=SensorDeviceClass.TIMESTAMP,
         translation_key="irrigation_start_time",
         fallback_name="Irrigation start time",
@@ -282,7 +283,7 @@ gx02_base_quirk = (
         dp_id=102,
         attribute_name="irrigation_end_time",
         type=t.CharacterString,
-        converter=lambda x: giex_string_to_ts(x),
+        converter=lambda x: giex_string_to_dt(x),
         device_class=SensorDeviceClass.TIMESTAMP,
         translation_key="irrigation_end_time",
         fallback_name="Irrigation end time",


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Currently, we perform an unnecessary round-trip conversion of timestamps from integers, to datetimes, back to integers (to pass to ZHA), and then back to datetimes in ZHA for formatting. This PR modifies the few quirks v2 entities to use datetime objects directly.

Unrelated, but I noticed that the current code did not actually work as intended because `datetime.replace` is not an in-place method. Thus, we currently just return the local time directly. This PR fixes this behavior.

In the end, it will allow us to remove this workaround: https://github.com/zigpy/zha/blob/ecb2b9b85999bb76d852fa1177cbaa934e9eae92/zha/application/discovery.py#L218-L220


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
It requires a corresponding PR to ZHA. (insert link here)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
