### PR TITLE
Add Bosch control relay II (BMCT-SLC / RBSH-MMS-ZB-EU)

### DIFF
--- a/zhaquirks/bosch/relay_rbsh-mms-zb-eu.py
+++ b/zhaquirks/bosch/relay_rbsh-mms-zb-eu.py
@@ -4,7 +4,7 @@ from typing import Final
 
 from zigpy import types as t
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.quirks.v2.homeassistant import EntityType, UnitOfTime
+from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
@@ -146,6 +146,7 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
         max_value=90,
         step=0.1,
         unit=UnitOfTime.SECONDS,
+        mode="box",
         multiplier=0.1,
         translation_key="closing_duration",
         fallback_name="Closing duration",
@@ -157,6 +158,7 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
         max_value=90,
         step=0.1,
         unit=UnitOfTime.SECONDS,
+        mode="box",
         multiplier=0.1,
         translation_key="opening_duration",
         fallback_name="Opening duration",
@@ -168,6 +170,7 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
         max_value=2,
         step=0.1,
         unit=UnitOfTime.SECONDS,
+        mode="box",
         multiplier=0.1,
         translation_key="long_press_duration",
         fallback_name="Long press duration",
@@ -179,6 +182,7 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
         max_value=20,
         step=0.1,
         unit=UnitOfTime.SECONDS,
+        mode="box",
         multiplier=0.1,
         translation_key="motor_start_delay",
         fallback_name="Motor start delay",

--- a/zhaquirks/bosch/relay_rbsh-mms-zb-eu.py
+++ b/zhaquirks/bosch/relay_rbsh-mms-zb-eu.py
@@ -97,7 +97,7 @@ class BoschLightShutterControlII(CustomCluster):
         motor_state = ZCLAttributeDef(
             id=0x0013,
             type=BoschMotorState,
-            access="rwp",
+            access="rp",
             is_manufacturer_specific=True,
         )
 

--- a/zhaquirks/bosch/relay_rbsh-mms-zb-eu.py
+++ b/zhaquirks/bosch/relay_rbsh-mms-zb-eu.py
@@ -140,7 +140,7 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
         fallback_name="Switch type",
     )
     .number(
-        BoschLightShutterControlII.AttributeDefs.calibration_closing_time,
+        BoschLightShutterControlII.AttributeDefs.calibration_closing_time.name,
         BoschLightShutterControlII.cluster_id,
         min_value=1,
         max_value=90,
@@ -152,7 +152,7 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
         fallback_name="Closing duration",
     )
     .number(
-        BoschLightShutterControlII.AttributeDefs.calibration_opening_time,
+        BoschLightShutterControlII.AttributeDefs.calibration_opening_time.name,
         BoschLightShutterControlII.cluster_id,
         min_value=1,
         max_value=90,
@@ -164,7 +164,7 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
         fallback_name="Opening duration",
     )
     .number(
-        BoschLightShutterControlII.AttributeDefs.calibration_button_hold_time,
+        BoschLightShutterControlII.AttributeDefs.calibration_button_hold_time.name,
         BoschLightShutterControlII.cluster_id,
         min_value=0.1,
         max_value=2,
@@ -176,7 +176,7 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
         fallback_name="Long press duration",
     )
     .number(
-        BoschLightShutterControlII.AttributeDefs.calibration_motor_start_delay,
+        BoschLightShutterControlII.AttributeDefs.calibration_motor_start_delay.name,
         BoschLightShutterControlII.cluster_id,
         min_value=0,
         max_value=20,

--- a/zhaquirks/bosch/relay_rbsh-mms-zb-eu.py
+++ b/zhaquirks/bosch/relay_rbsh-mms-zb-eu.py
@@ -16,7 +16,7 @@ class BoschDeviceMode(t.enum8):
     """Device mode enum."""
 
     Disabled = 0x00
-    Window_Cover = 0x01
+    Cover = 0x01
     Light = 0x04
 
 
@@ -24,9 +24,9 @@ class BoschSwitchType(t.enum8):
     """Switch type enum."""
 
     Button = 0x01
-    Button_Key_Change = 0x02
-    Rocker_Switch = 0x03
-    Rocker_Switch_Key_Change = 0x04
+    Button_key_change = 0x02
+    Rocker_switch = 0x03
+    Rocker_switch_key_change = 0x04
 
 
 class BoschMotorState(t.enum8):
@@ -119,11 +119,9 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
     .friendly_name(manufacturer=BOSCH, model="BMCT-SLZ")
     .replace_cluster_occurrences(BoschLightShutterControlII)
     .replaces(BoschWindowCovering)
-    .enum(
+    .sensor(
         BoschLightShutterControlII.AttributeDefs.motor_state.name,
-        BoschMotorState,
         BoschLightShutterControlII.cluster_id,
-        entity_type=EntityType.STANDARD,
         translation_key="motor_state",
         fallback_name="Motor state",
     )
@@ -148,6 +146,7 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
         max_value=90,
         step=0.1,
         unit=UnitOfTime.SECONDS,
+        multiplier=0.1,
         translation_key="closing_duration",
         fallback_name="Closing duration",
     )
@@ -158,6 +157,7 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
         max_value=90,
         step=0.1,
         unit=UnitOfTime.SECONDS,
+        multiplier=0.1,
         translation_key="opening_duration",
         fallback_name="Opening duration",
     )
@@ -168,6 +168,7 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
         max_value=2,
         step=0.1,
         unit=UnitOfTime.SECONDS,
+        multiplier=0.1,
         translation_key="long_press_duration",
         fallback_name="Long press duration",
     )
@@ -178,6 +179,7 @@ class BoschWindowCovering(CustomCluster, WindowCovering):
         max_value=20,
         step=0.1,
         unit=UnitOfTime.SECONDS,
+        multiplier=0.1,
         translation_key="motor_start_delay",
         fallback_name="Motor start delay",
     )

--- a/zhaquirks/bosch/relay_rbsh-mms-zb-eu.py
+++ b/zhaquirks/bosch/relay_rbsh-mms-zb-eu.py
@@ -1,0 +1,205 @@
+"""Device handler for Bosch Light/shutter control unit II."""
+
+from typing import Final
+
+from zigpy import types as t
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import EntityType, UnitOfTime
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+from zhaquirks import CustomCluster
+from zhaquirks.bosch import BOSCH
+
+
+class BoschDeviceMode(t.enum8):
+    """Device mode enum."""
+
+    Disabled = 0x00
+    Window_Cover = 0x01
+    Light = 0x04
+
+
+class BoschSwitchType(t.enum8):
+    """Switch type enum."""
+
+    Button = 0x01
+    Button_Key_Change = 0x02
+    Rocker_Switch = 0x03
+    Rocker_Switch_Key_Change = 0x04
+
+
+class BoschMotorState(t.enum8):
+    """Motor state enum."""
+
+    Stopped = 0x00
+    Opening = 0x01
+    Closing = 0x02
+
+
+class BoschLightShutterControlII(CustomCluster):
+    """Custom cluster for Bosch BMCT-SLZ device control."""
+
+    cluster_id: Final[t.uint16_t] = 0xFCA0
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Manufacturer specific attributes."""
+
+        device_mode = ZCLAttributeDef(
+            id=0x0000,
+            type=BoschDeviceMode,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+        switch_type = ZCLAttributeDef(
+            id=0x0001,
+            type=BoschSwitchType,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+        calibration_opening_time = ZCLAttributeDef(
+            id=0x0002,
+            type=t.uint32_t,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+        calibration_closing_time = ZCLAttributeDef(
+            id=0x0003,
+            type=t.uint32_t,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+        calibration_button_hold_time = ZCLAttributeDef(
+            id=0x0005,
+            type=t.uint8_t,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+        child_lock = ZCLAttributeDef(
+            id=0x0008,
+            type=t.Bool,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+        calibration_motor_start_delay = ZCLAttributeDef(
+            id=0x000F,
+            type=t.uint8_t,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+        motor_state = ZCLAttributeDef(
+            id=0x0013,
+            type=BoschMotorState,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+
+class BoschWindowCovering(CustomCluster, WindowCovering):
+    """Custom Bosch window covering cluster.
+
+    The Bosch reported type of Shutter only enables tilt commands (per the Zigbee cluster spec).
+    This is overridden to Tilt_blind_tilt_and_lift because the device is a generic relay.
+    """
+
+    _CONSTANT_ATTRIBUTES = {
+        WindowCovering.AttributeDefs.window_covering_type.id: WindowCovering.WindowCoveringType.Tilt_blind_tilt_and_lift,
+    }
+
+
+(
+    QuirkBuilder(BOSCH, "RBSH-MMS-ZB-EU")
+    .friendly_name(manufacturer=BOSCH, model="BMCT-SLZ")
+    .replace_cluster_occurrences(BoschLightShutterControlII)
+    .replaces(BoschWindowCovering)
+    .enum(
+        BoschLightShutterControlII.AttributeDefs.motor_state.name,
+        BoschMotorState,
+        BoschLightShutterControlII.cluster_id,
+        entity_type=EntityType.STANDARD,
+        translation_key="motor_state",
+        fallback_name="Motor state",
+    )
+    .enum(
+        BoschLightShutterControlII.AttributeDefs.device_mode.name,
+        BoschDeviceMode,
+        BoschLightShutterControlII.cluster_id,
+        translation_key="device_mode",
+        fallback_name="Device mode",
+    )
+    .enum(
+        BoschLightShutterControlII.AttributeDefs.switch_type.name,
+        BoschSwitchType,
+        BoschLightShutterControlII.cluster_id,
+        translation_key="switch_type",
+        fallback_name="Switch type",
+    )
+    .number(
+        BoschLightShutterControlII.AttributeDefs.calibration_closing_time,
+        BoschLightShutterControlII.cluster_id,
+        min_value=1,
+        max_value=90,
+        step=0.1,
+        unit=UnitOfTime.SECONDS,
+        translation_key="closing_duration",
+        fallback_name="Closing duration",
+    )
+    .number(
+        BoschLightShutterControlII.AttributeDefs.calibration_opening_time,
+        BoschLightShutterControlII.cluster_id,
+        min_value=1,
+        max_value=90,
+        step=0.1,
+        unit=UnitOfTime.SECONDS,
+        translation_key="opening_duration",
+        fallback_name="Opening duration",
+    )
+    .number(
+        BoschLightShutterControlII.AttributeDefs.calibration_button_hold_time,
+        BoschLightShutterControlII.cluster_id,
+        min_value=0.1,
+        max_value=2,
+        step=0.1,
+        unit=UnitOfTime.SECONDS,
+        translation_key="long_press_duration",
+        fallback_name="Long press duration",
+    )
+    .number(
+        BoschLightShutterControlII.AttributeDefs.calibration_motor_start_delay,
+        BoschLightShutterControlII.cluster_id,
+        min_value=0,
+        max_value=20,
+        step=0.1,
+        unit=UnitOfTime.SECONDS,
+        translation_key="motor_start_delay",
+        fallback_name="Motor start delay",
+    )
+    .switch(
+        BoschLightShutterControlII.AttributeDefs.child_lock.name,
+        BoschLightShutterControlII.cluster_id,
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    .switch(
+        BoschLightShutterControlII.AttributeDefs.child_lock.name,
+        BoschLightShutterControlII.cluster_id,
+        endpoint_id=2,
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    .switch(
+        BoschLightShutterControlII.AttributeDefs.child_lock.name,
+        BoschLightShutterControlII.cluster_id,
+        endpoint_id=3,
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

This quirk also overrides the `window_covering_type` from the tilt only `Shade` type, to `Tilt_blind_tilt_and_lift` because the device is a generic relay supporting commands for both lift and tilt.

Uses https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/bosch.ts as reference for exposing the device's configuration and status entities.

zigbee2mqtt supports the ability to manage entity availability depending on a device attribute value (in this case it exposes light entities when the device is in light mode, and the cover entity when in shade mode).
ZHA can't currently do this, so instead users will need to disable the redundant entities based on their configuration.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
- Adds support for the device https://github.com/zigpy/zha-device-handlers/issues/2518
- Addresses issue https://github.com/home-assistant/core/issues/143875

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
