### PR TITLE
Ubisys S1-R support

### DIFF
--- a/zhaquirks/ubisys/__init__.py
+++ b/zhaquirks/ubisys/__init__.py
@@ -1,0 +1,1 @@
+"""Ubisys device support."""

--- a/zhaquirks/ubisys/switching_actuator_series_2.py
+++ b/zhaquirks/ubisys/switching_actuator_series_2.py
@@ -1,0 +1,21 @@
+"""Ubisys Switching Actuator S1-R (Series 2) quirk."""
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+
+
+class UbisysElectricalMeasurement(CustomCluster, ElectricalMeasurement):
+    """Sets divisor attributes missing on the device."""
+
+    _CONSTANT_ATTRIBUTES = {
+        ElectricalMeasurement.AttributeDefs.ac_voltage_divisor.id: 10,
+        ElectricalMeasurement.AttributeDefs.ac_frequency_divisor.id: 10,
+    }
+
+
+(
+    QuirkBuilder(manufacturer="ubisys", model="S1-R (5601)")
+    .replaces(UbisysElectricalMeasurement)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Initial support for Ubisys S1-R. For the most part the device works fine, it just has a divisor of 10 that is never set anywhere. I still need to check if it affects *all* readings or just the voltage and current.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
[zha-01JTTNSZ6K776HRYPQJKZQERGZ-ubisys S1-R (5601)-12efeecfbd243adee8baf711407b20fe.json](https://github.com/user-attachments/files/20127180/zha-01JTTNSZ6K776HRYPQJKZQERGZ-ubisys.S1-R.5601.-12efeecfbd243adee8baf711407b20fe.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
