### PR TITLE
Add Tuya/Zemismart 3 phase power meter variants

### DIFF
--- a/zhaquirks/tuya/ts0601_power.py
+++ b/zhaquirks/tuya/ts0601_power.py
@@ -314,7 +314,7 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
         dp_id=110,
         attribute_name="energy_produced_ph_a",
         type=t.uint32_t,
-        converter=lambda x: x / 100,
+        divisor=100,
         state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.ENERGY,
         unit=UnitOfEnergy.KILO_WATT_HOUR,

--- a/zhaquirks/tuya/ts0601_power.py
+++ b/zhaquirks/tuya/ts0601_power.py
@@ -2,11 +2,13 @@
 
 from collections.abc import ByteString
 
-from zigpy.quirks.v2 import SensorDeviceClass, SensorStateClass
+from zigpy.quirks.v2 import EntityType, SensorDeviceClass, SensorStateClass
 from zigpy.quirks.v2.homeassistant import (
+    PERCENTAGE,
     UnitOfElectricCurrent,
     UnitOfEnergy,
     UnitOfPower,
+    UnitOfTime,
 )
 import zigpy.types as t
 from zigpy.zcl.clusters.general import LevelControl, OnOff
@@ -213,6 +215,199 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     .adds(Tuya3PhaseElectricalMeasurement)
     .removes(LevelControl.cluster_id)
     .removes(OnOff.cluster_id)
+    .skip_configuration()
+    .add_to_registry()
+)
+
+(
+    TuyaQuirkBuilder("_TZE200_dikb3dp6", "TS0601")
+    .applies_to("_TZE204_dikb3dp6", "TS0601")
+    .applies_to("_TZE284_dikb3dp6", "TS0601")
+    .tuya_sensor(
+        dp_id=1,
+        attribute_name="energy",
+        type=t.int32s,
+        divisor=100,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        fallback_name="Total energy",
+    )
+    .tuya_sensor(
+        dp_id=23,
+        attribute_name="energy_produced",
+        type=t.uint32_t,
+        divisor=100,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="energy_produced",
+        fallback_name="Energy produced",
+    )
+    .tuya_dp(
+        dp_id=29,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="total_active_power",
+    )
+    .tuya_dp(
+        dp_id=32,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="ac_frequency",
+        converter=lambda x: x / 100,
+    )
+    .tuya_sensor(
+        dp_id=50,
+        attribute_name="power_factor",
+        type=t.uint8_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER_FACTOR,
+        unit=PERCENTAGE,
+        translation_key="total_power_factor",
+        fallback_name="Total power factor",
+    )
+    .tuya_number(
+        dp_id=102,
+        attribute_name="update_frequency",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        min_value=5,
+        max_value=3600,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        translation_key="update_frequency",
+        fallback_name="Update frequency",
+    )
+    # Phase A
+    .tuya_dp(
+        dp_id=103,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="rms_voltage",
+    )
+    .tuya_dp(
+        dp_id=104,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="rms_current",
+    )
+    .tuya_dp(
+        dp_id=105,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="active_power",
+    )
+    .tuya_dp(
+        dp_id=108,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="power_factor",
+    )
+    .tuya_sensor(
+        dp_id=109,
+        attribute_name="energy_consumed_ph_a",
+        type=t.uint32_t,
+        divisor=100,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="energy_ph_a",
+        fallback_name="Energy phase A",
+    )
+    .tuya_sensor(
+        dp_id=110,
+        attribute_name="energy_produced_ph_a",
+        type=t.uint32_t,
+        converter=lambda x: x / 100,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="energy_produced_ph_a",
+        fallback_name="Energy produced phase A",
+    )
+    # Phase B
+    .tuya_dp(
+        dp_id=112,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="rms_voltage_ph_b",
+    )
+    .tuya_dp(
+        dp_id=113,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="rms_current_ph_b",
+    )
+    .tuya_dp(
+        dp_id=114,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="active_power_ph_b",
+    )
+    .tuya_dp(
+        dp_id=117,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="power_factor_ph_b",
+    )
+    .tuya_sensor(
+        dp_id=118,
+        attribute_name="energy_consumed_ph_b",
+        type=t.uint32_t,
+        divisor=100,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="energy_ph_b",
+        fallback_name="Energy phase B",
+    )
+    .tuya_sensor(
+        dp_id=119,
+        attribute_name="energy_produced_ph_b",
+        type=t.uint32_t,
+        divisor=100,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="energy_produced_ph_b",
+        fallback_name="Energy produced phase B",
+    )
+    # Phase C
+    .tuya_dp(
+        dp_id=121,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="rms_voltage_ph_c",
+    )
+    .tuya_dp(
+        dp_id=122,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="rms_current_ph_c",
+    )
+    .tuya_dp(
+        dp_id=123,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="active_power_ph_c",
+    )
+    .tuya_dp(
+        dp_id=126,
+        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        attribute_name="power_factor_ph_c",
+    )
+    .tuya_sensor(
+        dp_id=127,
+        attribute_name="energy_consumed_ph_c",
+        divisor=100,
+        type=t.uint32_t,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="energy_ph_c",
+        fallback_name="Energy phase C",
+    )
+    .tuya_sensor(
+        dp_id=128,
+        attribute_name="energy_produced_ph_c",
+        type=t.uint32_t,
+        divisor=100,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="energy_produced_ph_c",
+        fallback_name="Energy produced phase C",
+    )
+    .adds(Tuya3PhaseElectricalMeasurement)
     .skip_configuration()
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Add Zemismart SPM02 3 phase power meter.

Product link: https://www.zemismart.com/products/spm02-d2tz
Spec in Z2M: https://github.com/Koenkk/zigbee-herdsman-converters/blob/da540f0285a6d4fe6ec09e6a77024db3dcf534b1/src/devices/tuya.ts#L11389

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
