### PR TITLE
Add Tuya temperature sensor `_TZE284_yjjdcqsq` variant

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -304,6 +304,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE204_jygvp6fk", "TS0601")
     .applies_to("_TZE200_yjjdcqsq", "TS0601")
     .applies_to("_TZE204_yjjdcqsq", "TS0601")
+    .applies_to("_TZE284_yjjdcqsq", "TS0601")
     .applies_to("_TZE200_9yapgbuv", "TS0601")
     .applies_to("_TZE204_9yapgbuv", "TS0601")
     .applies_to("_TZE200_utkemkbs", "TS0601")


### PR DESCRIPTION
## Proposed change
  Added support for a new TS601 Temperature / humidity sensor with different signature


## Additional information
I buy the same sensors from the same vendor. Last batch (same shape, same part number, same box) arrived with the _TZE284_yjjdcqsq instead of _TZE204_yjjdcqsq or _TZE200_yjjdcqsq.
I changed this file on my Home Assistant staging environment to confirm that the sensor works like the previous ones by adding only the "applies_to" line, and it works. 


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
