### PR TITLE
Expose 'multicolor' command on more Hue lights

### DIFF
--- a/zhaquirks/philips/hue_light.py
+++ b/zhaquirks/philips/hue_light.py
@@ -123,10 +123,47 @@ from zhaquirks.philips import PHILIPS, SIGNIFY, PhilipsHueLightCluster
 
 (
     QuirkBuilder()
+    .applies_to(SIGNIFY, "LTA001")
+    .friendly_name(
+        model="Hue white ambiance E27 with Bluetooth",
+        manufacturer="Philips",
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder()
+    .applies_to(SIGNIFY, "LWU001")
+    .friendly_name(
+        model="Hue P45 light bulb",
+        manufacturer="Philips",
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder()
     .applies_to(PHILIPS, "7602031P7")
     .applies_to(PHILIPS, "7602031U7")
     .friendly_name(
         model="Hue Go",
+        manufacturer="Philips",
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder()
+    .applies_to(PHILIPS, "1743130P7")
+    .applies_to(PHILIPS, "1743430P7")
+    .applies_to(PHILIPS, "1743230P7")
+    .applies_to(PHILIPS, "1745430A7")
+    .applies_to(PHILIPS, "1745430P7")
+    .friendly_name(
+        model="Hue Impress outdoor Pedestal",
         manufacturer="Philips",
     )
     .replaces(PhilipsHueLightCluster, endpoint_id=11)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Adding support for more Philips Hue lights. Original PR: https://github.com/zigpy/zha-device-handlers/pull/3664


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
