### PR TITLE
Bump zigpy to 0.80.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy>=0.76.0",
+    "zigpy>=0.80.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,5 @@ pytest-sugar
 pytest-timeout
 pytest-asyncio
 pytest>=7.1.3
-zigpy>=0.76.0
+zigpy>=0.80.0
 ruff==0.0.261

--- a/tests/test_tuya_clusters.py
+++ b/tests/test_tuya_clusters.py
@@ -252,7 +252,7 @@ def test_tuya_cluster_request(
     """Test cluster specific request."""
 
     hdr = zcl_f.ZCLHeader.general(1, cmd_id, direction=zcl_f.Direction.Server_to_Client)
-    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=False)
 
     with mock.patch.object(TuyaCluster, handler_name) as handler:
         handler.return_value = mock.sentinel.status
@@ -267,7 +267,7 @@ def test_tuya_cluster_request_unk_command(default_rsp_mock, TuyaCluster):
     """Test cluster specific request handler -- no handler."""
 
     hdr = zcl_f.ZCLHeader.general(1, 0xFE, direction=zcl_f.Direction.Server_to_Client)
-    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=False)
 
     TuyaCluster.handle_cluster_request(hdr, (mock.sentinel.args,))
     assert default_rsp_mock.call_count == 1
@@ -279,7 +279,7 @@ def test_tuya_cluster_request_no_handler(default_rsp_mock, TuyaCluster):
     """Test cluster specific request handler -- no handler."""
 
     hdr = zcl_f.ZCLHeader.general(1, 0xFE, direction=zcl_f.Direction.Server_to_Client)
-    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=False)
 
     new_client_commands = TuyaCluster.client_commands.copy()
     new_client_commands[0xFE] = zcl_f.ZCLCommandDef(

--- a/tests/test_tuya_clusters.py
+++ b/tests/test_tuya_clusters.py
@@ -252,7 +252,7 @@ def test_tuya_cluster_request(
     """Test cluster specific request."""
 
     hdr = zcl_f.ZCLHeader.general(1, cmd_id, direction=zcl_f.Direction.Server_to_Client)
-    hdr.frame_control.disable_default_response = False
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
 
     with mock.patch.object(TuyaCluster, handler_name) as handler:
         handler.return_value = mock.sentinel.status
@@ -267,7 +267,7 @@ def test_tuya_cluster_request_unk_command(default_rsp_mock, TuyaCluster):
     """Test cluster specific request handler -- no handler."""
 
     hdr = zcl_f.ZCLHeader.general(1, 0xFE, direction=zcl_f.Direction.Server_to_Client)
-    hdr.frame_control.disable_default_response = False
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
 
     TuyaCluster.handle_cluster_request(hdr, (mock.sentinel.args,))
     assert default_rsp_mock.call_count == 1
@@ -279,7 +279,7 @@ def test_tuya_cluster_request_no_handler(default_rsp_mock, TuyaCluster):
     """Test cluster specific request handler -- no handler."""
 
     hdr = zcl_f.ZCLHeader.general(1, 0xFE, direction=zcl_f.Direction.Server_to_Client)
-    hdr.frame_control.disable_default_response = False
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
 
     new_client_commands = TuyaCluster.client_commands.copy()
     new_client_commands[0xFE] = zcl_f.ZCLCommandDef(

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -148,12 +148,36 @@ class TuyaDPType(t.enum8):
     BITMAP = 0x05
 
 
-class TuyaData(t.Struct):
+class TuyaData:
     """Tuya Data type."""
 
     dp_type: TuyaDPType
     function: t.uint8_t
     raw: t.LVBytes
+
+    def __init__(
+        self, value: TuyaDPType | None = None, function: t.uint8_t = t.uint8_t(0)
+    ):
+        """Convert from a zigpy typed value to a tuya data payload."""
+        self.dp_type = None
+        self.function = function
+
+        if value is None:
+            return
+        elif isinstance(value, (t.bitmap8, t.bitmap16, t.bitmap32)):
+            self.dp_type = TuyaDPType.BITMAP
+        elif isinstance(value, (bool, t.Bool)):
+            self.dp_type = TuyaDPType.BOOL
+        elif isinstance(value, enum.Enum):
+            self.dp_type = TuyaDPType.ENUM
+        elif isinstance(value, int):
+            self.dp_type = TuyaDPType.VALUE
+        elif isinstance(value, str):
+            self.dp_type = TuyaDPType.STRING
+        else:
+            self.dp_type = TuyaDPType.RAW
+
+        self.payload = value
 
     @property
     def payload(
@@ -208,26 +232,28 @@ class TuyaData(t.Struct):
         else:
             raise ValueError(f"Unknown {self.dp_type} datapoint type")
 
-    def __init__(self, value=None, function=0, *args, **kwargs):
-        """Convert from a zigpy typed value to a tuya data payload."""
-        self.function = function
+    def serialize(self) -> bytes:
+        """Serialize Tuya data."""
+        return (
+            self.dp_type.serialize()
+            + self.function.serialize()
+            + bytes([len(self.raw)])
+            + self.raw
+        )
 
-        if value is None:
-            return
-        elif isinstance(value, (t.bitmap8, t.bitmap16, t.bitmap32)):
-            self.dp_type = TuyaDPType.BITMAP
-        elif isinstance(value, (bool, t.Bool)):
-            self.dp_type = TuyaDPType.BOOL
-        elif isinstance(value, enum.Enum):  # type: ignore
-            self.dp_type = TuyaDPType.ENUM
-        elif isinstance(value, int):
-            self.dp_type = TuyaDPType.VALUE
-        elif isinstance(value, str):
-            self.dp_type = TuyaDPType.STRING
-        else:
-            self.dp_type = TuyaDPType.RAW
+    @classmethod
+    def deserialize(cls, data: bytes) -> tuple[TuyaData, bytes]:
+        """Deserialize Tuya data."""
+        dp_type, data = TuyaDPType.deserialize(data)
+        function, data = t.uint8_t.deserialize(data)
+        raw, data = t.LVBytes.deserialize(data)
 
-        self.payload = value
+        instance = cls()
+        instance.dp_type = dp_type
+        instance.function = function
+        instance.raw = raw
+
+        return instance, data
 
 
 class Data(t.List, item_type=t.uint8_t):

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -156,11 +156,15 @@ class TuyaData:
     raw: t.LVBytes
 
     def __init__(
-        self, value: TuyaDPType | None = None, function: t.uint8_t = t.uint8_t(0)
+        self,
+        value: TuyaDPType | None = None,
+        function: t.uint8_t = t.uint8_t(0),
+        raw: bytes | None = None,
     ):
         """Convert from a zigpy typed value to a tuya data payload."""
         self.dp_type = None
         self.function = function
+        self.raw = raw
 
         if value is None:
             return

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -208,10 +208,6 @@ class TuyaData(t.Struct):
         else:
             raise ValueError(f"Unknown {self.dp_type} datapoint type")
 
-    def __new__(cls, *args, **kwargs):
-        """Disable copy constructor."""
-        return super().__new__(cls)
-
     def __init__(self, value=None, function=0, *args, **kwargs):
         """Convert from a zigpy typed value to a tuya data payload."""
         self.function = function

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1580,7 +1580,7 @@ class TuyaNewManufCluster(CustomCluster):
                 self.send_default_rsp(
                     hdr, status=foundation.Status.UNSUP_CLUSTER_COMMAND
                 )
-                return
+            return
 
         try:
             status = getattr(self, handler_name)(*args)

--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -284,6 +284,7 @@ class XBeeRemoteATRequest(LocalDataCluster):
             name=v[0].replace("%V", "PercentV").replace("V+", "VPlus"),
             schema={"param?": v[1]} if v[1] else {},
             is_manufacturer_specific=True,
+            direction=foundation.Direction.Client_to_Server,
         )
         for k, v in zip(range(1, len(AT_COMMANDS) + 1), AT_COMMANDS.items())
     }
@@ -472,6 +473,7 @@ class XBeeRemoteATResponse(LocalDataCluster):
                 "value": Bytes,
             },
             is_manufacturer_specific=True,
+            direction=foundation.Direction.Client_to_Server,
         )
     }
 
@@ -525,6 +527,7 @@ class XBeeDigitalIOCluster(LocalDataCluster, BinaryInput):
             name="io_sample",
             schema={"io_sample": IOSample},
             is_manufacturer_specific=True,
+            direction=foundation.Direction.Client_to_Server,
         )
     }
 
@@ -541,11 +544,15 @@ class XBeeEventRelayCluster(EventableCluster, LocalDataCluster, LevelControl):
             + "_command_response",
             schema={"response?": v[1]} if v[1] else {},
             is_manufacturer_specific=True,
+            direction=foundation.Direction.Client_to_Server,
         )
         for k, v in zip(range(1, len(AT_COMMANDS) + 1), AT_COMMANDS.items())
     }
     server_commands[SERIAL_DATA_CMD] = foundation.ZCLCommandDef(
-        name="receive_data", schema={"data": str}, is_manufacturer_specific=True
+        name="receive_data",
+        schema={"data": str},
+        is_manufacturer_specific=True,
+        direction=foundation.Direction.Client_to_Server,
     )
 
 
@@ -605,6 +612,7 @@ class XBeeSerialDataCluster(LocalDataCluster):
             name="send_data",
             schema={"data": BinaryString},
             is_manufacturer_specific=True,
+            direction=foundation.Direction.Server_to_Client,
         )
     }
     server_commands = {
@@ -612,6 +620,7 @@ class XBeeSerialDataCluster(LocalDataCluster):
             name="receive_data",
             schema={"data": BinaryString},
             is_manufacturer_specific=True,
+            direction=foundation.Direction.Client_to_Server,
         )
     }
 


### PR DESCRIPTION
## Proposed change
Bump zigpy to [0.80.0](https://github.com/zigpy/zigpy/releases/tag/0.80.0) and adjust a bunch of quirks code to work properly.


## Additional information
0.79.0 includes `suggested_display_precision`, which we need for some v2 quirks.


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
