### PR TITLE
Fix Tuya TRV `_TZE204_ltwbm23f` hysteresis enum

### DIFF
--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -834,7 +834,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     .tuya_enum(
         dp_id=127,
         attribute_name="hysteresis_mode",
-        enum_class=TuyaDisplayOrientation,
+        enum_class=TuyaHysteresis,
         translation_key="hysteresis_mode",
         fallback_name="Hysteresis mode",
     )


### PR DESCRIPTION
## Proposed change
enum_class TuyaHysteresis is not used for hysteresis mode of Tuya TRV.


## Additional information
n/a

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
