### PR TITLE
Remove incorrect total power attribute forwarding from Xiaomi

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -627,6 +627,18 @@ async def test_xiaomi_plug_power(zigpy_device_from_quirk, quirk):
     assert em_listener.attribute_updates[2][1] == 400  # multiplied by 10
 
 
+async def test_xiaomi_total_active_power_clear(zigpy_device_from_quirk):
+    """Tests that the total_active_power attribute is cleared during init."""
+
+    with mock.patch(
+        "zhaquirks.xiaomi.ElectricalMeasurementCluster._update_attribute"
+    ) as update_attribute_mock:
+        zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.plug_eu.PlugMAEU01)
+        update_attribute_mock.assert_called_with(
+            ElectricalMeasurement.AttributeDefs.total_active_power.id, None
+        )
+
+
 @pytest.mark.parametrize(
     "attribute, value, expected_bytes",
     [

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -599,8 +599,7 @@ async def test_xiaomi_plug_power(zigpy_device_from_quirk, quirk):
     assert em_listener.attribute_updates[1][0] == zcl_em_current_power
     assert em_listener.attribute_updates[1][1] == 150  # multiplied by 10
 
-    # Test total power consumption on ElectricalMeasurement cluster and SmartEnergy cluster
-    zcl_em_total_power = ElectricalMeasurement.AttributeDefs.total_active_power.id
+    # Test total power consumption on SmartEnergy cluster
     zcl_se_total_power = Metering.AttributeDefs.current_summ_delivered.id
     se_cluster = device.endpoints[1].smartenergy_metering
     se_listener = ClusterListener(se_cluster)
@@ -608,10 +607,6 @@ async def test_xiaomi_plug_power(zigpy_device_from_quirk, quirk):
     basic_cluster.update_attribute(
         XIAOMI_AQARA_ATTRIBUTE, create_aqara_attr_report({149: 0.001})
     )
-    # electrical measurement cluster
-    assert len(em_listener.attribute_updates) == 3
-    assert em_listener.attribute_updates[2][0] == zcl_em_total_power
-    assert em_listener.attribute_updates[2][1] == 1  # multiplied by 1000
 
     # smart energy cluster
     assert len(se_listener.attribute_updates) == 1
@@ -628,8 +623,8 @@ async def test_xiaomi_plug_power(zigpy_device_from_quirk, quirk):
     assert analog_input_listener.attribute_updates[0][0] == zcl_analog_input_value
     assert analog_input_listener.attribute_updates[0][1] == 40
 
-    assert em_listener.attribute_updates[3][0] == zcl_em_current_power
-    assert em_listener.attribute_updates[3][1] == 400  # multiplied by 10
+    assert em_listener.attribute_updates[2][0] == zcl_em_current_power
+    assert em_listener.attribute_updates[2][1] == 400  # multiplied by 10
 
 
 @pytest.mark.parametrize(

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -128,6 +128,17 @@ class XiaomiQuickInitDevice(XiaomiCustomDevice, QuickInitDevice):
 class XiaomiCluster(CustomCluster):
     """Xiaomi cluster implementation."""
 
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        # Previously, this cluster was wrongly setting the total_active_power attribute,
+        # which was not added to HA.
+        # Since it is now added to HA and the incorrect value could be set, we need to
+        # reset it.
+        self._update_attribute(
+            ElectricalMeasurement.AttributeDefs.total_active_power.id, None
+        )
+
     def _iter_parse_attr_report(
         self, data: bytes
     ) -> Iterator[tuple[foundation.Attribute, bytes]]:

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -128,17 +128,6 @@ class XiaomiQuickInitDevice(XiaomiCustomDevice, QuickInitDevice):
 class XiaomiCluster(CustomCluster):
     """Xiaomi cluster implementation."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        # Previously, this cluster was wrongly setting the total_active_power attribute,
-        # which was not added to HA.
-        # Since it is now added to HA and the incorrect value could be set, we need to
-        # reset it.
-        self._update_attribute(
-            ElectricalMeasurement.AttributeDefs.total_active_power.id, None
-        )
-
     def _iter_parse_attr_report(
         self, data: bytes
     ) -> Iterator[tuple[foundation.Attribute, bytes]]:
@@ -666,6 +655,14 @@ class ElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
             self._update_attribute(self.VOLTAGE_ID, 0)
         if self.CONSUMPTION_ID not in self._attr_cache:
             self._update_attribute(self.CONSUMPTION_ID, 0)
+
+        # Previously, this cluster was wrongly setting the total_active_power attribute,
+        # which was not added to HA.
+        # Since it is now added to HA and the incorrect value could be set, we need to
+        # reset it.
+        self._update_attribute(
+            ElectricalMeasurement.AttributeDefs.total_active_power.id, None
+        )
 
 
 class MeteringCluster(LocalDataCluster, Metering):

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -303,10 +303,6 @@ class XiaomiCluster(CustomCluster):
 
         if CONSUMPTION in attributes:
             zcl_consumption = round(attributes[CONSUMPTION] * 1000)
-            self.endpoint.electrical_measurement.update_attribute(
-                ElectricalMeasurement.AttributeDefs.total_active_power.id,
-                zcl_consumption,
-            )
             self.endpoint.smartenergy_metering.update_attribute(
                 Metering.AttributeDefs.current_summ_delivered.id, zcl_consumption
             )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Follow up from https://github.com/zigpy/zha-device-handlers/pull/4057#issuecomment-2917151144 to remove an incorrect mapping from energy to total power.
Since there is currently no entity mapped for total_active_power, this change should not affect any existing entities.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
