### PR TITLE
Support Aqara Dimmer Switch H2 EU

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2240,57 +2240,44 @@ def test_aqara_agl011_signature_match(assert_signature_matches_quirk):
                     "0x0012",
                     "0x0702",
                     "0x0b04",
-                    "0xfcc0"
+                    "0xfcc0",
                 ],
-                "out_clusters": [
-                    "0x000a",
-                    "0x0019"
-                ]
+                "out_clusters": ["0x000a", "0x0019"],
             },
             "2": {
                 "profile_id": 0x0104,
                 "device_type": "0x0000",
-                "in_clusters": [
-                    "0xfcc0"
-                ],
-                "out_clusters": []
+                "in_clusters": ["0xfcc0"],
+                "out_clusters": [],
             },
             "3": {
                 "profile_id": 0x0104,
                 "device_type": "0x0000",
-                "in_clusters": [
-                    "0xfcc0"
-                ],
-                "out_clusters": []
+                "in_clusters": ["0xfcc0"],
+                "out_clusters": [],
             },
             "21": {
                 "profile_id": 0x0104,
                 "device_type": "0x0000",
-                "in_clusters": [
-                    "0x000c"
-                ],
-                "out_clusters": []
+                "in_clusters": ["0x000c"],
+                "out_clusters": [],
             },
             "71": {
                 "profile_id": 0x0104,
                 "device_type": "0x0000",
-                "in_clusters": [
-                    "0xfcc0"
-                ],
-                "out_clusters": []
+                "in_clusters": ["0xfcc0"],
+                "out_clusters": [],
             },
             "72": {
                 "profile_id": 0x0104,
                 "device_type": "0x0000",
-                "in_clusters": [
-                    "0xfcc0"
-                ],
-                "out_clusters": []
-            }
+                "in_clusters": ["0xfcc0"],
+                "out_clusters": [],
+            },
         },
         "manufacturer": "Aqara",
         "model": "lumi.switch.agl011",
-        "class": "zigpy.device.Device"
+        "class": "zigpy.device.Device",
     }
 
     assert_signature_matches_quirk(

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2240,59 +2240,117 @@ def test_aqara_agl011_signature_match(assert_signature_matches_quirk):
                     "0x0012",
                     "0x0702",
                     "0x0b04",
-                    "0xfcc0"
+                    "0xfcc0",
                 ],
-                "out_clusters": [
-                    "0x000a",
-                    "0x0019"
-                ]
+                "out_clusters": ["0x000a", "0x0019"],
             },
             "2": {
                 "profile_id": 0x0104,
                 "device_type": "0x0000",
-                "in_clusters": [
-                    "0xfcc0"
-                ],
-                "out_clusters": []
+                "in_clusters": ["0xfcc0"],
+                "out_clusters": [],
             },
             "3": {
                 "profile_id": 0x0104,
                 "device_type": "0x0000",
-                "in_clusters": [
-                    "0xfcc0"
-                ],
-                "out_clusters": []
+                "in_clusters": ["0xfcc0"],
+                "out_clusters": [],
             },
             "21": {
                 "profile_id": 0x0104,
                 "device_type": "0x0000",
-                "in_clusters": [
-                    "0x000c"
-                ],
-                "out_clusters": []
+                "in_clusters": ["0x000c"],
+                "out_clusters": [],
             },
             "71": {
                 "profile_id": 0x0104,
                 "device_type": "0x0000",
-                "in_clusters": [
-                    "0xfcc0"
-                ],
-                "out_clusters": []
+                "in_clusters": ["0xfcc0"],
+                "out_clusters": [],
             },
             "72": {
                 "profile_id": 0x0104,
                 "device_type": "0x0000",
-                "in_clusters": [
-                    "0xfcc0"
-                ],
-                "out_clusters": []
-            }
+                "in_clusters": ["0xfcc0"],
+                "out_clusters": [],
+            },
         },
         "manufacturer": "Aqara",
         "model": "lumi.switch.agl011",
-        "class": "zigpy.device.Device"
+        "class": "zigpy.device.Device",
     }
 
     assert_signature_matches_quirk(
         zhaquirks.xiaomi.aqara.switch_agl011.AqaraDimmerSwitchH2EU, signature
     )
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.xiaomi.aqara.switch_agl011.AqaraDimmerSwitchH2EU,)
+)
+def test_aqara_agl011_opplecluster_sensitivity_enum(zigpy_device_from_quirk, quirk):
+    """Test Sensitivity enum values."""
+
+    device = zigpy_device_from_quirk(quirk)
+    opple_cluster = device.endpoints[1].opple_cluster
+
+    assert opple_cluster.Sensitivity.Low == 0x02D0
+    assert opple_cluster.Sensitivity.Medium == 0x0168
+    assert opple_cluster.Sensitivity.High == 0x00B4
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.xiaomi.aqara.switch_agl011.AqaraDimmerSwitchH2EU,)
+)
+def test_aqara_agl011_opplecluster_update_attribute(zigpy_device_from_quirk, quirk):
+    """Test _update_attribute method."""
+
+    device = zigpy_device_from_quirk(quirk)
+    opple_cluster = device.endpoints[1].opple_cluster
+
+    # Add a ClusterListener to track attribute updates
+    cluster_listener = ClusterListener(opple_cluster)
+
+    # Test updating min_brightness
+    opple_cluster._update_attribute(0x0515, 10)
+    assert len(cluster_listener.attribute_updates) == 1
+    assert cluster_listener.attribute_updates[0] == (0x0515, 10)
+
+    # Test updating max_brightness
+    opple_cluster._update_attribute(0x0516, 80)
+    assert len(cluster_listener.attribute_updates) == 2
+    assert cluster_listener.attribute_updates[1] == (0x0516, 80)
+
+    # Test updating sensitivity
+    opple_cluster._update_attribute(0x0234, opple_cluster.Sensitivity.Medium)
+    assert len(cluster_listener.attribute_updates) == 3
+    assert cluster_listener.attribute_updates[2] == (
+        0x0234,
+        opple_cluster.Sensitivity.Medium,
+    )
+
+    # Test updating phase
+    opple_cluster._update_attribute(0x030A, opple_cluster.Phase.Forward)
+    assert len(cluster_listener.attribute_updates) == 4
+    assert cluster_listener.attribute_updates[3] == (
+        0x030A,
+        opple_cluster.Phase.Forward,
+    )
+
+    # Test updating an invalid attribute
+    opple_cluster._update_attribute(0x9999, 100)  # unknown attribute
+    assert (
+        len(cluster_listener.attribute_updates) == 4
+    )  # No new updates for invalid attribute
+
+    # Test updating min_brightness with an invalid value
+    opple_cluster._update_attribute(0x0515, -1)  # invalid min_brightness
+    assert (
+        len(cluster_listener.attribute_updates) == 4
+    )  # No new updates for invalid value
+
+    # Test updating max_brightness with an invalid value
+    opple_cluster._update_attribute(0x0516, 101)
+    assert (
+        len(cluster_listener.attribute_updates) == 4
+    )  # No new updates for invalid value

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -93,6 +93,7 @@ import zhaquirks.xiaomi.aqara.plug_eu
 import zhaquirks.xiaomi.aqara.roller_curtain_e1
 import zhaquirks.xiaomi.aqara.sensor_ht_agl02
 import zhaquirks.xiaomi.aqara.smoke
+import zhaquirks.xiaomi.aqara.switch_agl011
 import zhaquirks.xiaomi.aqara.switch_t1
 from zhaquirks.xiaomi.aqara.thermostat_agl001 import ScheduleEvent, ScheduleSettings
 import zhaquirks.xiaomi.aqara.weather
@@ -2219,3 +2220,79 @@ def test_h1_wireless_remotes(zigpy_device_from_v2_quirk):
 
     assert MultistateInput.cluster_id in device.endpoints[2].in_clusters
     assert MultistateInput.cluster_id in device.endpoints[3].in_clusters
+
+
+def test_aqara_agl011_signature_match(assert_signature_matches_quirk):
+    """Test signature."""
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4447, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=False, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 0x0104,
+                "device_type": "0x0000",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0003",
+                    "0x0004",
+                    "0x0005",
+                    "0x0006",
+                    "0x0008",
+                    "0x0012",
+                    "0x0702",
+                    "0x0b04",
+                    "0xfcc0"
+                ],
+                "out_clusters": [
+                    "0x000a",
+                    "0x0019"
+                ]
+            },
+            "2": {
+                "profile_id": 0x0104,
+                "device_type": "0x0000",
+                "in_clusters": [
+                    "0xfcc0"
+                ],
+                "out_clusters": []
+            },
+            "3": {
+                "profile_id": 0x0104,
+                "device_type": "0x0000",
+                "in_clusters": [
+                    "0xfcc0"
+                ],
+                "out_clusters": []
+            },
+            "21": {
+                "profile_id": 0x0104,
+                "device_type": "0x0000",
+                "in_clusters": [
+                    "0x000c"
+                ],
+                "out_clusters": []
+            },
+            "71": {
+                "profile_id": 0x0104,
+                "device_type": "0x0000",
+                "in_clusters": [
+                    "0xfcc0"
+                ],
+                "out_clusters": []
+            },
+            "72": {
+                "profile_id": 0x0104,
+                "device_type": "0x0000",
+                "in_clusters": [
+                    "0xfcc0"
+                ],
+                "out_clusters": []
+            }
+        },
+        "manufacturer": "Aqara",
+        "model": "lumi.switch.agl011",
+        "class": "zigpy.device.Device"
+    }
+
+    assert_signature_matches_quirk(
+        zhaquirks.xiaomi.aqara.switch_agl011.AqaraDimmerSwitchH2EU, signature
+    )

--- a/zhaquirks/xiaomi/aqara/switch_agl011.py
+++ b/zhaquirks/xiaomi/aqara/switch_agl011.py
@@ -1,0 +1,208 @@
+"""Aqara H2 EU dimmer switch"""
+
+from zigpy import types as t
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster
+from zigpy.zcl.clusters.general import (
+    AnalogInput,
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    MultistateInput,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.smartenergy import Metering
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    ZHA_SEND_EVENT,
+)
+from zhaquirks.xiaomi import (
+    BasicCluster,
+    ElectricalMeasurementCluster,
+    MeteringCluster,
+    XiaomiAqaraE1Cluster,
+    XiaomiCustomDevice,
+)
+
+
+class OppleCluster(XiaomiAqaraE1Cluster):
+    """Opple cluster."""
+
+    class Sensitivity(t.enum8):
+        """Rotation sensitivity."""
+
+        Low = 0x02D0  # 720
+        Medium = 0x0168  # 360
+        High = 0x00B4  # 180
+
+    class MinBrightness(t.uint8_t):
+        """Minimum brightness."""
+
+        def __init__(self, value: int = 0):
+            """Initialize with a default value."""
+            super().__init__(value)
+            if not (0 <= value <= 99):
+                raise ValueError("Minimum brightness must be between 0 and 100.")
+
+    class MaxBrightness(t.uint8_t):
+        """Maximum brightness."""
+
+        def __init__(self, value: int = 100):
+            """Initialize with a default value."""
+            super().__init__(value)
+            if not (1 <= value <= 100):
+                raise ValueError("Maximum brightness must be between 1 and 100.")
+
+    class Phase(t.enum8):
+        """Startup mode."""
+
+        Forward = 0
+        Reverse = 1
+
+    attributes = {
+        0x0234: ("sensitivity", Sensitivity),
+        0x0515: ("min_brightness", MinBrightness),
+        0x0516: ("max_brightness", MaxBrightness),
+        0x030a: ("phase", t.enum8),
+    }
+
+    def _update_attribute(self, attrid, value):
+        """Handle attribute updates."""
+        super()._update_attribute(attrid, value)
+        if attrid in [0x0234, 0x0515, 0x0516, 0x030a]:
+            self.listener_event(
+                ZHA_SEND_EVENT,
+                {
+                    "type": self.attributes[attrid][0],
+                    "value": value,
+                },
+            )
+
+
+class AqaraDimmerSwitchH2EU(XiaomiCustomDevice):
+    """Aqara H2 EU dimmer switch (KD-R01D)"""
+
+    signature = {
+        MODELS_INFO: [("Aqara", "lumi.switch.agl011")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=0
+            # device_version=1
+            # input_clusters=[0, 3, 4, 5, 6, 8, 12, 1794, 2820, 64704]
+            # output_clusters=[10, 25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    MultistateInput.cluster_id,
+                    Metering.cluster_id,
+                    ElectricalMeasurement.cluster_id,
+                    OppleCluster.cluster_id
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=0
+            # device_version=1
+            # input_clusters=[64704]
+            # output_clusters=[]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [OppleCluster.cluster_id],
+                OUTPUT_CLUSTERS: [],
+            },
+            # <SimpleDescriptor endpoint=3 profile=260 device_type=0
+            # device_version=1
+            # input_clusters=[64704]
+            # output_clusters=[]>
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [OppleCluster.cluster_id],
+                OUTPUT_CLUSTERS: [],
+            },
+            # <SimpleDescriptor endpoint=21 profile=260 device_type=0
+            # device_version=1
+            # input_clusters=[12]
+            # output_clusters=[]>
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [AnalogInput.cluster_id],
+                OUTPUT_CLUSTERS: [],
+            },
+            # <SimpleDescriptor endpoint=71 profile=260 device_type=0
+            # device_version=1
+            # input_clusters=[64704]
+            # output_clusters=[]>
+            71: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [OppleCluster.cluster_id],
+                OUTPUT_CLUSTERS: [],
+            },
+            # <SimpleDescriptor endpoint=72 profile=260 device_type=0
+            # device_version=1
+            # input_clusters=[64704]
+            # output_clusters=[]>
+            72: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [OppleCluster.cluster_id],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    MultistateInput.cluster_id,
+                    MeteringCluster,
+                    ElectricalMeasurementCluster,
+                    AqaraRotationSensitivityCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+        },
+    }
+
+
+# 2025-05-29 21:14:28.721 DEBUG (MainThread) [bellows.ezsp.protocol] Received command incomingMessageHandler: {'type': <EmberIncomingMessageType.INCOMING_UNICAST: 0>, 'apsFrame': EmberApsFrame(profileId=260, clusterId=64704, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=135), 'lastHopLqi': 204, 'lastHopRssi': -60, 'sender': 0xF686, 'bindingIndex': 255, 'addressIndex': 6, 'messageContents': b'\x1c_\x11S\n\x15\x05 A\x16\x05 d'}
+# 2025-05-29 21:14:28.721 DEBUG (MainThread) [bellows.ezsp.protocol] Frame contains trailing data: b'\x04'
+# 2025-05-29 21:14:28.721 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=64704, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=135), 204, -60, 0xF686, 255, 6, b'\x1c_\x11S\n\x15\x05 A\x16\x05 d']
+# 2025-05-29 21:14:28.722 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 5, 29, 19, 14, 28, 722327, tzinfo=datetime.timezone.utc), priority=0, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xF686), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=135, profile_id=260, cluster_id=64704, data=Serialized[b'\x1c_\x11S\n\x15\x05 A\x16\x05 d'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=204, rssi=-60)
+# 2025-05-29 21:14:28.723 DEBUG (MainThread) [zigpy.zcl] [0xF686:1:0xfcc0] Received ZCL frame: b'\x1c_\x11S\n\x15\x05 A\x16\x05 d'
+# 2025-05-29 21:14:28.723 DEBUG (MainThread) [zigpy.zcl] [0xF686:1:0xfcc0] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x1C>(frame_type=<FrameType.GLOBAL_COMMAND: 0>, is_manufacturer_specific=True, direction=<Direction.Server_to_Client: 1>, disable_default_response=1, reserved=0, *is_cluster=False, *is_general=True), manufacturer=4447, tsn=83, command_id=10, *direction=<Direction.Server_to_Client: 1>)
+# 2025-05-29 21:14:28.725 DEBUG (MainThread) [zigpy.zcl] [0xF686:1:0xfcc0] Decoded ZCL frame: ManufacturerSpecificCluster:Report_Attributes(attribute_reports=[Attribute(attrid=0x0515, value=TypeValue(type=uint8_t, value=65)), Attribute(attrid=0x0516, value=TypeValue(type=uint8_t, value=100))])
+# 2025-05-29 21:14:28.725 DEBUG (MainThread) [zigpy.zcl] [0xF686:1:0xfcc0] Received command 0x0A (TSN 83): Report_Attributes(attribute_reports=[Attribute(attrid=0x0515, value=TypeValue(type=uint8_t, value=65)), Attribute(attrid=0x0516, value=TypeValue(type=uint8_t, value=100))])
+# 2025-05-29 21:14:28.729 DEBUG (MainThread) [zigpy.zcl] [0xF686:1:0xfcc0] Attribute report received: 0x0515=65, 0x0516=100
+# 2025-05-29 21:14:28.729 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xF686:1:0xfcc0]: cluster_handler[manufacturer_specific] attribute_updated - cluster[Manufacturer Specific] attr[1301] value[65]
+# 2025-05-29 21:14:28.729 DEBUG (MainThread) [zha] Emitting event cluster_handler_attribute_updated with data ClusterAttributeUpdatedEvent(attribute_id=1301, attribute_name=1301, attribute_value=65, cluster_handler_unique_id='54:ef:44:10:01:1c:6f:78:1:0xfcc0', cluster_id=64704, event_type='cluster_handler_event', event='cluster_handler_attribute_updated') (0 listeners)
+# 2025-05-29 21:14:28.730 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xF686:1:0xfcc0]: cluster_handler[manufacturer_specific] attribute_updated - cluster[Manufacturer Specific] attr[1302] value[100]
+# 2025-05-29 21:14:28.730 DEBUG (MainThread) [zha] Emitting event cluster_handler_attribute_updated with data ClusterAttributeUpdatedEvent(attribute_id=1302, attribute_name=1302, attribute_value=100, cluster_handler_unique_id='54:ef:44:10:01:1c:6f:78:1:0xfcc0', cluster_id=64704, event_type='cluster_handler_event', event='cluster_handler_attribute_updated') (0 listeners)

--- a/zhaquirks/xiaomi/aqara/switch_agl011.py
+++ b/zhaquirks/xiaomi/aqara/switch_agl011.py
@@ -1,4 +1,4 @@
-"""Aqara H2 EU dimmer switch"""
+"""Aqara H2 EU dimmer switch (KD-R01D)."""
 
 from zigpy import types as t
 from zigpy.profiles import zha
@@ -39,12 +39,12 @@ from zhaquirks.xiaomi import (
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Opple cluster."""
 
-    class Sensitivity(t.enum8):
+    class Sensitivity(t.enum16):
         """Rotation sensitivity."""
 
-        Low = 0x02D0  # 720
-        Medium = 0x0168  # 360
-        High = 0x00B4  # 180
+        Low = 0x02D0
+        Medium = 0x0168
+        High = 0x00B4
 
     class Phase(t.enum8):
         """Startup mode."""
@@ -91,7 +91,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
 
 
 class AqaraDimmerSwitchH2EU(XiaomiCustomDevice):
-    """Aqara H2 EU dimmer switch (KD-R01D)"""
+    """Aqara H2 EU dimmer switch (KD-R01D)."""
 
     signature = {
         MODELS_INFO: [("Aqara", "lumi.switch.agl011")],
@@ -113,7 +113,7 @@ class AqaraDimmerSwitchH2EU(XiaomiCustomDevice):
                     MultistateInput.cluster_id,
                     Metering.cluster_id,
                     ElectricalMeasurement.cluster_id,
-                    OppleCluster.cluster_id
+                    OppleCluster.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },

--- a/zhaquirks/xiaomi/aqara/switch_agl011.py
+++ b/zhaquirks/xiaomi/aqara/switch_agl011.py
@@ -27,6 +27,7 @@ from zhaquirks.const import (
     ZHA_SEND_EVENT,
 )
 from zhaquirks.xiaomi import (
+    AnalogInputCluster,
     BasicCluster,
     ElectricalMeasurementCluster,
     MeteringCluster,
@@ -97,7 +98,7 @@ class AqaraDimmerSwitchH2EU(XiaomiCustomDevice):
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0
             # device_version=1
-            # input_clusters=[0, 3, 4, 5, 6, 8, 12, 1794, 2820, 64704]
+            # input_clusters=[0, 3, 4, 5, 6, 8, 18, 1794, 2820, 64704]
             # output_clusters=[10, 25]>
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -173,7 +174,7 @@ class AqaraDimmerSwitchH2EU(XiaomiCustomDevice):
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
@@ -187,6 +188,36 @@ class AqaraDimmerSwitchH2EU(XiaomiCustomDevice):
                     OppleCluster,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [OppleCluster.cluster_id],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [OppleCluster.cluster_id],
+                OUTPUT_CLUSTERS: [],
+            },
+            21: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [AnalogInputCluster],
+                OUTPUT_CLUSTERS: [],
+            },
+            71: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [OppleCluster.cluster_id],
+                OUTPUT_CLUSTERS: [],
+            },
+            72: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [OppleCluster.cluster_id],
+                OUTPUT_CLUSTERS: [],
             },
         },
     }

--- a/zhaquirks/xiaomi/aqara/switch_agl011.py
+++ b/zhaquirks/xiaomi/aqara/switch_agl011.py
@@ -2,7 +2,6 @@
 
 from zigpy import types as t
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster
 from zigpy.zcl.clusters.general import (
     AnalogInput,
     Basic,
@@ -46,6 +45,12 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         Medium = 0x0168  # 360
         High = 0x00B4  # 180
 
+    class Phase(t.enum8):
+        """Startup mode."""
+
+        Forward = 0x0000
+        Reverse = 0x0001
+
     class MinBrightness(t.uint8_t):
         """Minimum brightness."""
 
@@ -64,23 +69,17 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             if not (1 <= value <= 100):
                 raise ValueError("Maximum brightness must be between 1 and 100.")
 
-    class Phase(t.enum8):
-        """Startup mode."""
-
-        Forward = 0
-        Reverse = 1
-
     attributes = {
-        0x0234: ("sensitivity", Sensitivity),
-        0x0515: ("min_brightness", MinBrightness),
-        0x0516: ("max_brightness", MaxBrightness),
-        0x030a: ("phase", t.enum8),
+        0x0234: ("sensitivity", Sensitivity, True),
+        0x030A: ("phase", Phase, True),
+        0x0515: ("min_brightness", MinBrightness, True),
+        0x0516: ("max_brightness", MaxBrightness, True),
     }
 
     def _update_attribute(self, attrid, value):
         """Handle attribute updates."""
         super()._update_attribute(attrid, value)
-        if attrid in [0x0234, 0x0515, 0x0516, 0x030a]:
+        if attrid in self.attributes:
             self.listener_event(
                 ZHA_SEND_EVENT,
                 {
@@ -174,7 +173,7 @@ class AqaraDimmerSwitchH2EU(XiaomiCustomDevice):
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
@@ -185,24 +184,9 @@ class AqaraDimmerSwitchH2EU(XiaomiCustomDevice):
                     MultistateInput.cluster_id,
                     MeteringCluster,
                     ElectricalMeasurementCluster,
-                    AqaraRotationSensitivityCluster,
+                    OppleCluster,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
         },
     }
-
-
-# 2025-05-29 21:14:28.721 DEBUG (MainThread) [bellows.ezsp.protocol] Received command incomingMessageHandler: {'type': <EmberIncomingMessageType.INCOMING_UNICAST: 0>, 'apsFrame': EmberApsFrame(profileId=260, clusterId=64704, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=135), 'lastHopLqi': 204, 'lastHopRssi': -60, 'sender': 0xF686, 'bindingIndex': 255, 'addressIndex': 6, 'messageContents': b'\x1c_\x11S\n\x15\x05 A\x16\x05 d'}
-# 2025-05-29 21:14:28.721 DEBUG (MainThread) [bellows.ezsp.protocol] Frame contains trailing data: b'\x04'
-# 2025-05-29 21:14:28.721 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=64704, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=135), 204, -60, 0xF686, 255, 6, b'\x1c_\x11S\n\x15\x05 A\x16\x05 d']
-# 2025-05-29 21:14:28.722 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 5, 29, 19, 14, 28, 722327, tzinfo=datetime.timezone.utc), priority=0, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xF686), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=135, profile_id=260, cluster_id=64704, data=Serialized[b'\x1c_\x11S\n\x15\x05 A\x16\x05 d'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=204, rssi=-60)
-# 2025-05-29 21:14:28.723 DEBUG (MainThread) [zigpy.zcl] [0xF686:1:0xfcc0] Received ZCL frame: b'\x1c_\x11S\n\x15\x05 A\x16\x05 d'
-# 2025-05-29 21:14:28.723 DEBUG (MainThread) [zigpy.zcl] [0xF686:1:0xfcc0] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x1C>(frame_type=<FrameType.GLOBAL_COMMAND: 0>, is_manufacturer_specific=True, direction=<Direction.Server_to_Client: 1>, disable_default_response=1, reserved=0, *is_cluster=False, *is_general=True), manufacturer=4447, tsn=83, command_id=10, *direction=<Direction.Server_to_Client: 1>)
-# 2025-05-29 21:14:28.725 DEBUG (MainThread) [zigpy.zcl] [0xF686:1:0xfcc0] Decoded ZCL frame: ManufacturerSpecificCluster:Report_Attributes(attribute_reports=[Attribute(attrid=0x0515, value=TypeValue(type=uint8_t, value=65)), Attribute(attrid=0x0516, value=TypeValue(type=uint8_t, value=100))])
-# 2025-05-29 21:14:28.725 DEBUG (MainThread) [zigpy.zcl] [0xF686:1:0xfcc0] Received command 0x0A (TSN 83): Report_Attributes(attribute_reports=[Attribute(attrid=0x0515, value=TypeValue(type=uint8_t, value=65)), Attribute(attrid=0x0516, value=TypeValue(type=uint8_t, value=100))])
-# 2025-05-29 21:14:28.729 DEBUG (MainThread) [zigpy.zcl] [0xF686:1:0xfcc0] Attribute report received: 0x0515=65, 0x0516=100
-# 2025-05-29 21:14:28.729 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xF686:1:0xfcc0]: cluster_handler[manufacturer_specific] attribute_updated - cluster[Manufacturer Specific] attr[1301] value[65]
-# 2025-05-29 21:14:28.729 DEBUG (MainThread) [zha] Emitting event cluster_handler_attribute_updated with data ClusterAttributeUpdatedEvent(attribute_id=1301, attribute_name=1301, attribute_value=65, cluster_handler_unique_id='54:ef:44:10:01:1c:6f:78:1:0xfcc0', cluster_id=64704, event_type='cluster_handler_event', event='cluster_handler_attribute_updated') (0 listeners)
-# 2025-05-29 21:14:28.730 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0xF686:1:0xfcc0]: cluster_handler[manufacturer_specific] attribute_updated - cluster[Manufacturer Specific] attr[1302] value[100]
-# 2025-05-29 21:14:28.730 DEBUG (MainThread) [zha] Emitting event cluster_handler_attribute_updated with data ClusterAttributeUpdatedEvent(attribute_id=1302, attribute_name=1302, attribute_value=100, cluster_handler_unique_id='54:ef:44:10:01:1c:6f:78:1:0xfcc0', cluster_id=64704, event_type='cluster_handler_event', event='cluster_handler_attribute_updated') (0 listeners)

--- a/zhaquirks/xiaomi/aqara/switch_agl011.py
+++ b/zhaquirks/xiaomi/aqara/switch_agl011.py
@@ -24,7 +24,6 @@ from zhaquirks.const import (
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    ZHA_SEND_EVENT,
 )
 from zhaquirks.xiaomi import (
     AnalogInputCluster,
@@ -34,6 +33,11 @@ from zhaquirks.xiaomi import (
     XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
 )
+
+SENSITIVITY = 0x0234
+PHASE = 0x030A
+MIN_BRIGHTNESS = 0x0515
+MAX_BRIGHTNESS = 0x0516
 
 
 class OppleCluster(XiaomiAqaraE1Cluster):
@@ -52,42 +56,24 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         Forward = 0x0000
         Reverse = 0x0001
 
-    class MinBrightness(t.uint8_t):
-        """Minimum brightness."""
-
-        def __init__(self, value: int = 0):
-            """Initialize with a default value."""
-            super().__init__(value)
-            if not (0 <= value <= 99):
-                raise ValueError("Minimum brightness must be between 0 and 100.")
-
-    class MaxBrightness(t.uint8_t):
-        """Maximum brightness."""
-
-        def __init__(self, value: int = 100):
-            """Initialize with a default value."""
-            super().__init__(value)
-            if not (1 <= value <= 100):
-                raise ValueError("Maximum brightness must be between 1 and 100.")
-
     attributes = {
-        0x0234: ("sensitivity", Sensitivity, True),
-        0x030A: ("phase", Phase, True),
-        0x0515: ("min_brightness", MinBrightness, True),
-        0x0516: ("max_brightness", MaxBrightness, True),
+        SENSITIVITY: ("sensitivity", Sensitivity, True),
+        PHASE: ("phase", Phase, True),
+        MIN_BRIGHTNESS: ("min_brightness", t.uint8_t, True),
+        MAX_BRIGHTNESS: ("max_brightness", t.uint8_t, True),
     }
 
     def _update_attribute(self, attrid, value):
-        """Handle attribute updates."""
-        super()._update_attribute(attrid, value)
         if attrid in self.attributes:
-            self.listener_event(
-                ZHA_SEND_EVENT,
-                {
-                    "type": self.attributes[attrid][0],
-                    "value": value,
-                },
-            )
+            if attrid == MIN_BRIGHTNESS and not (0 <= value <= 99):
+                self.debug("Minimum brightness must be between 0 and 100.")
+                return
+            if attrid == MAX_BRIGHTNESS and not (1 <= value <= 100):
+                self.debug("Maximum brightness must be between 1 and 100.")
+                return
+            super()._update_attribute(attrid, value)
+        else:
+            self.debug(f"Attribute {attrid} is not valid for this cluster.")
 
 
 class AqaraDimmerSwitchH2EU(XiaomiCustomDevice):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Add quirk to properly support [Aqara Dimmer Switch H2 EU](https://eu.aqara.com/en-eu/products/aqara-dimmer-switch-h2-eu).

A bit about current state of the device in ZHA:
- Pairing takes a long time (likely because it fails to recognize manufacturer-specific clusters?)
- It exposes a working on/off switch entity
- Power measurement returns constant 0
- On level entity does not seem to do anything
- The 3x transition time entities kind of work, but do not quite make sense
- Level control works if you send zigbee commands, but there is no entity

This PR should have the basic fixes to most of this, and also to expose the settings for rotation sensitivity, phase and min/max brightness, but I see the [z2m implementation](https://www.zigbee2mqtt.io/devices/KD-R01D.html) also includes settings for:
- Turning LED indicator on/off
- Flipping indicator light
- Power on behavior
- Decoupled mode for knob

Additionally, I'm thinking it would make sense for the device to be represented as a dimmable light, but unsure what the precedence is for that. Can I just set the device type in replacement to `DIMMABLE_SWITCH`?

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Fixes #4032.

This is my first attempt at writing a quirk, so bear with me. This is still a draft and will need some more work.

I've used the Zigbee2MQTT implementation as a reference, but have no experience with z2m:
- docs: https://www.zigbee2mqtt.io/devices/KD-R01D.html
- source: https://github.com/Koenkk/zigbee-herdsman-converters/blob/25a00150a482288974870749d6bc28e487d79552/src/devices/lumi.ts#L4452-L4508

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
