### PR TITLE
Expose Tuya TS0001 _TZ3000_iedbgyxt water valve as a switch

### DIFF
--- a/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
+++ b/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
@@ -1,8 +1,8 @@
 """Quirk for Tuya TS0001 (_TZ3000_iedbgyxt) water shutoff valve."""
 
 from zigpy.profiles import zgp, zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (  # Ruff changed this to multi-line in CI
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
     Identify,
@@ -15,10 +15,24 @@ from zigpy.zcl.clusters.general import (  # Ruff changed this to multi-line in C
 MANUFACTURER = "_TZ3000_iedbgyxt"
 MODEL = "TS0001"
 
-TUYA_MFG_CLUSTER_E000 = 0xE000
-TUYA_MFG_CLUSTER_E001 = 0xE001
 GREEN_POWER_CLUSTER_ID = 0x0021
 GREEN_POWER_DEVICE_ID_COMBO_BASIC = 0x0061
+
+
+class TuyaManufClusterE000(CustomCluster):
+    """Tuya manufacturer specific cluster 0xE000."""
+
+    cluster_id = 0xE000
+    name = "Tuya Manufacturer Specific E000"
+    ep_attribute = "tuya_manufacturer_specific_e000"
+
+
+class TuyaManufClusterE001(CustomCluster):
+    """Tuya manufacturer specific cluster 0xE001."""
+
+    cluster_id = 0xE001
+    name = "Tuya Manufacturer Specific E001"
+    ep_attribute = "tuya_manufacturer_specific_e001"
 
 
 class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
@@ -26,7 +40,6 @@ class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
 
     Recognizes the device as a switch instead of a light.
     Includes definition for Green Power endpoint 242.
-    Uses raw IDs for GreenPower cluster and device type to avoid import/attribute issues.
     """
 
     signature = {
@@ -46,8 +59,8 @@ class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     OnOff.cluster_id,
-                    TUYA_MFG_CLUSTER_E000,
-                    TUYA_MFG_CLUSTER_E001,
+                    TuyaManufClusterE000.cluster_id,  # Use the new class
+                    TuyaManufClusterE001.cluster_id,  # Use the new class
                 ],
                 "output_clusters": [
                     Time.cluster_id,
@@ -76,8 +89,8 @@ class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     OnOff.cluster_id,
-                    TUYA_MFG_CLUSTER_E000,
-                    TUYA_MFG_CLUSTER_E001,
+                    TuyaManufClusterE000,  # Use the new class
+                    TuyaManufClusterE001,  # Use the new class
                 ],
                 "output_clusters": [
                     Time.cluster_id,

--- a/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
+++ b/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
@@ -2,7 +2,7 @@
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import ( # Ruff changed this to multi-line in CI
+from zigpy.zcl.clusters.general import (  # Ruff changed this to multi-line in CI
     Basic,
     Groups,
     Identify,

--- a/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
+++ b/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
@@ -2,15 +2,7 @@
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    OnOff,
-    Ota,
-    Scenes,
-    Time,
-)
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
 
 MANUFACTURER = "_TZ3000_iedbgyxt"
 MODEL = "TS0001"

--- a/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
+++ b/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
@@ -1,9 +1,8 @@
-# File: zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
 """Quirk for Tuya TS0001 (_TZ3000_iedbgyxt) water shutoff valve."""
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (  # Bot changed this to single line
+from zigpy.zcl.clusters.general import ( # Ruff changed this to multi-line in CI
     Basic,
     Groups,
     Identify,
@@ -33,7 +32,7 @@ class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
     signature = {
         "manufacturer": MANUFACTURER,
         "model": MODEL,
-        "node_desc": {  # <<< THIS IS THE KEY FIX for the test failure
+        "node_desc": {
             "logical_type": 1,
             "mac_capability_flags": 142,
         },

--- a/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
+++ b/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
@@ -3,7 +3,15 @@
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time # Bot changed this to single line
+from zigpy.zcl.clusters.general import (  # Bot changed this to single line
+    Basic,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
 
 MANUFACTURER = "_TZ3000_iedbgyxt"
 MODEL = "TS0001"

--- a/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
+++ b/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
@@ -1,27 +1,18 @@
-from zigpy.profiles import zha, zgp
+from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    OnOff,
-    Ota,
-    Scenes,
-    Time,
-)
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
 
 MANUFACTURER = "_TZ3000_iedbgyxt"
 MODEL = "TS0001"
 
-TUYA_MFG_CLUSTER_E000 = 0xe000
-TUYA_MFG_CLUSTER_E001 = 0xe001
+TUYA_MFG_CLUSTER_E000 = 0xE000
+TUYA_MFG_CLUSTER_E001 = 0xE001
 GREEN_POWER_CLUSTER_ID = 0x0021
 GREEN_POWER_DEVICE_ID_COMBO_BASIC = 0x0061
 
 
 class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
-    """
-    Custom quirk for Tuya water shutoff valve (TS0001 / _TZ3000_iedbgyxt)
+    """Custom quirk for Tuya water shutoff valve (TS0001 / _TZ3000_iedbgyxt)
     to be recognized as a switch instead of a light.
     Includes definition for Green Power endpoint 242.
     Uses raw IDs for GreenPower cluster and device type to avoid import/attribute issues.
@@ -39,17 +30,21 @@ class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
                 "profile_id": zha.PROFILE_ID,
                 "device_type": zha.DeviceType.ON_OFF_LIGHT,  # 0x0100 (Original)
                 "input_clusters": [
-                    Basic.cluster_id, Identify.cluster_id, Groups.cluster_id,
-                    Scenes.cluster_id, OnOff.cluster_id, TUYA_MFG_CLUSTER_E000,
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    TUYA_MFG_CLUSTER_E000,
                     TUYA_MFG_CLUSTER_E001,
                 ],
                 "output_clusters": [Time.cluster_id, Ota.cluster_id],
             },
             242: {
-                "profile_id": zgp.PROFILE_ID, # 0xa1e0 (Green Power Profile ID)
-                "device_type": GREEN_POWER_DEVICE_ID_COMBO_BASIC, # Use raw ID: 0x0061
+                "profile_id": zgp.PROFILE_ID,  # 0xa1e0 (Green Power Profile ID)
+                "device_type": GREEN_POWER_DEVICE_ID_COMBO_BASIC,  # Use raw ID: 0x0061
                 "input_clusters": [],
-                "output_clusters": [GREEN_POWER_CLUSTER_ID], # Use raw ID: 0x0021
+                "output_clusters": [GREEN_POWER_CLUSTER_ID],  # Use raw ID: 0x0021
             },
         },
     }
@@ -58,19 +53,23 @@ class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
         "endpoints": {
             1: {
                 "profile_id": zha.PROFILE_ID,
-                "device_type": zha.DeviceType.ON_OFF_OUTPUT, # 0x0002
+                "device_type": zha.DeviceType.ON_OFF_OUTPUT,  # 0x0002
                 "input_clusters": [
-                    Basic.cluster_id, Identify.cluster_id, Groups.cluster_id,
-                    Scenes.cluster_id, OnOff.cluster_id, TUYA_MFG_CLUSTER_E000,
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    TUYA_MFG_CLUSTER_E000,
                     TUYA_MFG_CLUSTER_E001,
                 ],
                 "output_clusters": [Time.cluster_id, Ota.cluster_id],
             },
             242: {
                 "profile_id": zgp.PROFILE_ID,
-                "device_type": GREEN_POWER_DEVICE_ID_COMBO_BASIC, # Use raw ID: 0x0061
+                "device_type": GREEN_POWER_DEVICE_ID_COMBO_BASIC,  # Use raw ID: 0x0061
                 "input_clusters": [],
-                "output_clusters": [GREEN_POWER_CLUSTER_ID], # Use raw ID: 0x0021
+                "output_clusters": [GREEN_POWER_CLUSTER_ID],  # Use raw ID: 0x0021
             },
         },
     }

--- a/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
+++ b/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
@@ -1,6 +1,16 @@
+"""Quirk for Tuya TS0001 (_TZ3000_iedbgyxt) water shutoff valve."""
+
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
 
 MANUFACTURER = "_TZ3000_iedbgyxt"
 MODEL = "TS0001"
@@ -12,8 +22,9 @@ GREEN_POWER_DEVICE_ID_COMBO_BASIC = 0x0061
 
 
 class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
-    """Custom quirk for Tuya water shutoff valve (TS0001 / _TZ3000_iedbgyxt)
-    to be recognized as a switch instead of a light.
+    """Custom quirk for Tuya water shutoff valve (TS0001 / _TZ3000_iedbgyxt).
+
+    Recognizes the device as a switch instead of a light. # D205 Fix: Blank line added above.
     Includes definition for Green Power endpoint 242.
     Uses raw IDs for GreenPower cluster and device type to avoid import/attribute issues.
     """
@@ -38,13 +49,18 @@ class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
                     TUYA_MFG_CLUSTER_E000,
                     TUYA_MFG_CLUSTER_E001,
                 ],
-                "output_clusters": [Time.cluster_id, Ota.cluster_id],
+                "output_clusters": [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
             },
             242: {
                 "profile_id": zgp.PROFILE_ID,  # 0xa1e0 (Green Power Profile ID)
                 "device_type": GREEN_POWER_DEVICE_ID_COMBO_BASIC,  # Use raw ID: 0x0061
                 "input_clusters": [],
-                "output_clusters": [GREEN_POWER_CLUSTER_ID],  # Use raw ID: 0x0021
+                "output_clusters": [
+                    GREEN_POWER_CLUSTER_ID,
+                ],
             },
         },
     }
@@ -63,13 +79,18 @@ class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
                     TUYA_MFG_CLUSTER_E000,
                     TUYA_MFG_CLUSTER_E001,
                 ],
-                "output_clusters": [Time.cluster_id, Ota.cluster_id],
+                "output_clusters": [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
             },
             242: {
                 "profile_id": zgp.PROFILE_ID,
                 "device_type": GREEN_POWER_DEVICE_ID_COMBO_BASIC,  # Use raw ID: 0x0061
                 "input_clusters": [],
-                "output_clusters": [GREEN_POWER_CLUSTER_ID],  # Use raw ID: 0x0021
+                "output_clusters": [
+                    GREEN_POWER_CLUSTER_ID,
+                ],
             },
         },
     }

--- a/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
+++ b/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
@@ -1,0 +1,76 @@
+from zigpy.profiles import zha, zgp
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+
+MANUFACTURER = "_TZ3000_iedbgyxt"
+MODEL = "TS0001"
+
+TUYA_MFG_CLUSTER_E000 = 0xe000
+TUYA_MFG_CLUSTER_E001 = 0xe001
+GREEN_POWER_CLUSTER_ID = 0x0021
+GREEN_POWER_DEVICE_ID_COMBO_BASIC = 0x0061
+
+
+class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
+    """
+    Custom quirk for Tuya water shutoff valve (TS0001 / _TZ3000_iedbgyxt)
+    to be recognized as a switch instead of a light.
+    Includes definition for Green Power endpoint 242.
+    Uses raw IDs for GreenPower cluster and device type to avoid import/attribute issues.
+    """
+
+    signature = {
+        "manufacturer": MANUFACTURER,
+        "model": MODEL,
+        "node_descriptor": {
+            "logical_type": 1,
+            "mac_capability_flags": 142,
+        },
+        "endpoints": {
+            1: {
+                "profile_id": zha.PROFILE_ID,
+                "device_type": zha.DeviceType.ON_OFF_LIGHT,  # 0x0100 (Original)
+                "input_clusters": [
+                    Basic.cluster_id, Identify.cluster_id, Groups.cluster_id,
+                    Scenes.cluster_id, OnOff.cluster_id, TUYA_MFG_CLUSTER_E000,
+                    TUYA_MFG_CLUSTER_E001,
+                ],
+                "output_clusters": [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                "profile_id": zgp.PROFILE_ID, # 0xa1e0 (Green Power Profile ID)
+                "device_type": GREEN_POWER_DEVICE_ID_COMBO_BASIC, # Use raw ID: 0x0061
+                "input_clusters": [],
+                "output_clusters": [GREEN_POWER_CLUSTER_ID], # Use raw ID: 0x0021
+            },
+        },
+    }
+
+    replacement = {
+        "endpoints": {
+            1: {
+                "profile_id": zha.PROFILE_ID,
+                "device_type": zha.DeviceType.ON_OFF_OUTPUT, # 0x0002
+                "input_clusters": [
+                    Basic.cluster_id, Identify.cluster_id, Groups.cluster_id,
+                    Scenes.cluster_id, OnOff.cluster_id, TUYA_MFG_CLUSTER_E000,
+                    TUYA_MFG_CLUSTER_E001,
+                ],
+                "output_clusters": [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                "profile_id": zgp.PROFILE_ID,
+                "device_type": GREEN_POWER_DEVICE_ID_COMBO_BASIC, # Use raw ID: 0x0061
+                "input_clusters": [],
+                "output_clusters": [GREEN_POWER_CLUSTER_ID], # Use raw ID: 0x0021
+            },
+        },
+    }

--- a/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
+++ b/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
@@ -2,15 +2,7 @@
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    OnOff,
-    Ota,
-    Scenes,
-    Time,
-)
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
 
 MANUFACTURER = "_TZ3000_iedbgyxt"
 MODEL = "TS0001"

--- a/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
+++ b/zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
@@ -1,8 +1,9 @@
+# File: zhaquirks/tuya/tuya_valve_tz3000_iedbgyxt.py
 """Quirk for Tuya TS0001 (_TZ3000_iedbgyxt) water shutoff valve."""
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time # Bot changed this to single line
 
 MANUFACTURER = "_TZ3000_iedbgyxt"
 MODEL = "TS0001"
@@ -16,7 +17,7 @@ GREEN_POWER_DEVICE_ID_COMBO_BASIC = 0x0061
 class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
     """Custom quirk for Tuya water shutoff valve (TS0001 / _TZ3000_iedbgyxt).
 
-    Recognizes the device as a switch instead of a light. # D205 Fix: Blank line added above.
+    Recognizes the device as a switch instead of a light.
     Includes definition for Green Power endpoint 242.
     Uses raw IDs for GreenPower cluster and device type to avoid import/attribute issues.
     """
@@ -24,7 +25,7 @@ class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
     signature = {
         "manufacturer": MANUFACTURER,
         "model": MODEL,
-        "node_descriptor": {
+        "node_desc": {  # <<< THIS IS THE KEY FIX for the test failure
             "logical_type": 1,
             "mac_capability_flags": 142,
         },
@@ -47,8 +48,8 @@ class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
                 ],
             },
             242: {
-                "profile_id": zgp.PROFILE_ID,  # 0xa1e0 (Green Power Profile ID)
-                "device_type": GREEN_POWER_DEVICE_ID_COMBO_BASIC,  # Use raw ID: 0x0061
+                "profile_id": zgp.PROFILE_ID,
+                "device_type": GREEN_POWER_DEVICE_ID_COMBO_BASIC,
                 "input_clusters": [],
                 "output_clusters": [
                     GREEN_POWER_CLUSTER_ID,
@@ -78,7 +79,7 @@ class TuyaValve_TZ3000_iedbgyxt(CustomDevice):
             },
             242: {
                 "profile_id": zgp.PROFILE_ID,
-                "device_type": GREEN_POWER_DEVICE_ID_COMBO_BASIC,  # Use raw ID: 0x0061
+                "device_type": GREEN_POWER_DEVICE_ID_COMBO_BASIC,
                 "input_clusters": [],
                 "output_clusters": [
                     GREEN_POWER_CLUSTER_ID,


### PR DESCRIPTION
https://github.com/zigpy/zha-device-handlers/issues/4103#issuecomment-2925755868

This quirk is working here.  It might not be the cleanest so I understand if you all decline and modify/add yourselves.

## Proposed change
Adds switch/valve functionality to a device that was mismatched as a light.


## Additional information
Should fix https://github.com/zigpy/zha-device-handlers/issues/4103


## Checklist
- [X] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
