### PR TITLE
Fix Tuya illuminance/valve enum sensor entity type, add test

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -4,7 +4,12 @@ import collections
 import itertools
 
 import zigpy.quirks
-from zigpy.quirks.v2 import QuirksV2RegistryEntry
+from zigpy.quirks.v2 import (
+    EntityPlatform,
+    EntityType,
+    QuirksV2RegistryEntry,
+    ZCLEnumMetadata,
+)
 
 import zhaquirks
 
@@ -70,3 +75,21 @@ def test_manufacturer_model_metadata_unique() -> None:
         assert len(quirk_locations) == 1, (
             f"Manufacturer-model pair '{manufacturer}' '{model}' is shared by multiple quirks: {quirk_locations}"
         )
+
+
+def test_enum_sensor_category() -> None:
+    """Ensure enum metadata with sensor entity platform has valid entity category."""
+    for quirk in ALL_QUIRK_V2_CLASSES:
+        for entity_metadata in quirk.entity_metadata:
+            if (
+                isinstance(entity_metadata, ZCLEnumMetadata)
+                and entity_metadata.entity_platform is EntityPlatform.SENSOR
+            ):
+                assert entity_metadata.entity_type in (
+                    EntityType.STANDARD,
+                    EntityType.DIAGNOSTIC,
+                ), (
+                    f"Enum sensor '{entity_metadata.translation_key}' in "
+                    f"{quirk.quirk_file}:{quirk.quirk_file_line} "
+                    f"has invalid entity type '{entity_metadata.entity_type}'"
+                )

--- a/zhaquirks/tuya/tuya_illuminance.py
+++ b/zhaquirks/tuya/tuya_illuminance.py
@@ -1,6 +1,6 @@
 """Tuya illuminance sensors."""
 
-from zigpy.quirks.v2 import EntityPlatform
+from zigpy.quirks.v2 import EntityPlatform, EntityType
 from zigpy.types import t
 
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
@@ -23,6 +23,7 @@ class BrightnessLevel(t.enum8):
         dp_id=1,
         attribute_name="brightness_level",
         enum_class=BrightnessLevel,
+        entity_type=EntityType.STANDARD,
         entity_platform=EntityPlatform.SENSOR,
         translation_key="brightness_level",
         fallback_name="Brightness level",

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -510,6 +510,7 @@ class GiexIrrigationStatus(t.enum8):
         dp_id=3,
         attribute_name="valve_status",
         enum_class=TuyaValveStatus,
+        entity_type=EntityType.STANDARD,
         entity_platform=EntityPlatform.SENSOR,
         translation_key="valve_status",
         fallback_name="Valve status",


### PR DESCRIPTION
## Proposed change

This fixes an issue where a Tuya illuminance enum sensor entity and a Tuya valve status enum sensor entity had the incorrect default of `EntityType.CONFIG`, due to this being the default for the `sensor` quirks v2 method in zigpy.

Normally, this is correct, but since the entity platform is set to `SENSOR` (instead of the default `SELECT`), we also need a different entity category/type. This was done correctly, except in these two quirks.

A test is also added to make sure existing enum sensor entities and future ones have the correct entity category.
For now, it only makes sense to validate this platform, since this mistake can't really happen elsewhere, as the entity platform is only switched from `SELECT` to `SENSOR` for enum metadata, with it having the `CONFIG` entity category default for quirks v2 entities.

## Additional information

In the future, we may want to consider directly validating/enforcing this in zigpy, depending on the provided platform
Alternatively, we may also want to consider adding a separate `enum_sensor`/`sensor_enum` method for enum sensor entities, since this better aligns with other platforms and would avoid this mistake in the first place, with a correct default.

Trace reported in Discord:
```python
Error adding entity sensor.front_hallway_luminance_brightness_level for domain sensor with platform zha
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 657, in _async_add_entities
    await self._async_add_entity(
        entity, False, entity_registry, config_subentry_id
    )
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 979, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1368, in add_to_platform_finish
    await self.async_internal_added_to_hass()
  File "/usr/src/homeassistant/homeassistant/helpers/restore_state.py", line 276, in async_internal_added_to_hass
    await super().async_internal_added_to_hass()
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 284, in async_internal_added_to_hass
    raise HomeAssistantError(
        f"Entity {self.entity_id} cannot be added as the entity category is set to config"
    )
homeassistant.exceptions.HomeAssistantError: Entity sensor.front_hallway_luminance_brightness_level cannot be added as the entity category is set to config
```

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
