### PR TITLE
Replace ByteString

### DIFF
--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -1,6 +1,5 @@
 """Tests for TuyaQuirkBuilder."""
 
-from collections.abc import ByteString
 import datetime
 from unittest import mock
 
@@ -166,13 +165,13 @@ async def test_tuya_quirkbuilder(device_mock):
     class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
         """Tuya Electrical Measurement cluster."""
 
-    def dpToPower(data: ByteString) -> int:
+    def dpToPower(data: bytes) -> int:
         return data[0]
 
-    def dpToCurrent(data: ByteString) -> int:
+    def dpToCurrent(data: bytes) -> int:
         return data[1]
 
-    def dpToVoltage(data: ByteString) -> int:
+    def dpToVoltage(data: bytes) -> int:
         return data[2]
 
     entry = (

--- a/zhaquirks/tuya/ts0601_power.py
+++ b/zhaquirks/tuya/ts0601_power.py
@@ -1,7 +1,5 @@
 """Tuya Power Meter."""
 
-from collections.abc import ByteString
-
 from zigpy.quirks.v2 import EntityType, SensorDeviceClass, SensorStateClass
 from zigpy.quirks.v2.homeassistant import (
     PERCENTAGE,
@@ -18,7 +16,7 @@ from zhaquirks.tuya import DPToAttributeMapping, TuyaLocalCluster
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
-def dp_to_power(data: ByteString) -> int:
+def dp_to_power(data: bytes) -> int:
     """Convert DP data to power value."""
     # From https://github.com/Koenkk/zigbee2mqtt/issues/18603#issuecomment-2277697295
     power = int(data)
@@ -27,7 +25,7 @@ def dp_to_power(data: ByteString) -> int:
     return power
 
 
-def multi_dp_to_power(data: ByteString) -> int:
+def multi_dp_to_power(data: bytes) -> int:
     """Convert DP data to power value."""
     # Support negative power readings
     # From https://github.com/Koenkk/zigbee2mqtt/issues/18603#issuecomment-2277697295
@@ -37,12 +35,12 @@ def multi_dp_to_power(data: ByteString) -> int:
     return power
 
 
-def multi_dp_to_current(data: ByteString) -> int:
+def multi_dp_to_current(data: bytes) -> int:
     """Convert DP data to current value."""
     return data[4] | (data[3] << 8)
 
 
-def multi_dp_to_voltage(data: ByteString) -> int:
+def multi_dp_to_voltage(data: bytes) -> int:
     """Convert DP data to voltage value."""
     return data[1] | (data[0] << 8)
 


### PR DESCRIPTION
## Proposed change
`typing.ByteString` and `collections.abc.ByteString` will be removed in Python `3.14`.
AFAICT the actual data type is `bytes` anyway, so just use that instead.
_The alternative would be the full type `bytes | bytearray | memoryview`._

Originally added in #3644 by @abmantis.

https://docs.python.org/3.13/library/typing.html#typing.ByteString


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
