### PR TITLE
Add more CO2 sensors from herdsman

### DIFF
--- a/zhaquirks/tuya/tuya_co.py
+++ b/zhaquirks/tuya/tuya_co.py
@@ -114,19 +114,12 @@ base_air_quality = (
 
 (
     base_air_quality.clone()  # Tuya NIDR CO2 sensor with GPP.
+    # 18 and 19 from base
     .applies_to("_TZE200_ogkdpgy2", "TS0601")
     .applies_to("_TZE204_ogkdpgy2", "TS0601")
     .applies_to("_TZE200_3ejwxpmu", "TS0601")
     .applies_to("_TZE204_3ejwxpmu", "TS0601")
     .tuya_co2(dp_id=2)
-    .tuya_dp(
-        dp_id=18,
-        ep_attribute=TuyaTemperatureMeasurement.ep_attribute,
-        attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
-        converter=lambda x: CustomTemperature.from_value(x).temperature * 10,
-    )
-    .adds(TuyaTemperatureMeasurement)
-    .tuya_humidity(dp_id=19, scale=10)
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/tuya_co.py
+++ b/zhaquirks/tuya/tuya_co.py
@@ -113,23 +113,10 @@ base_air_quality = (
 
 
 (
-    TuyaQuirkBuilder("_TZE200_3ejwxpmu", "TS0601")  # Tuya NIDR CO2 sensor
-    .tuya_co2(dp_id=2)
-    .tuya_dp(
-        dp_id=18,
-        ep_attribute=TuyaTemperatureMeasurement.ep_attribute,
-        attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
-        converter=lambda x: CustomTemperature.from_value(x).temperature * 10,
-    )
-    .adds(TuyaTemperatureMeasurement)
-    .tuya_humidity(dp_id=19, scale=10)
-    .skip_configuration()
-    .add_to_registry()
-)
-
-(
-    TuyaQuirkBuilder("_TZE200_ogkdpgy2", "TS0601")  # Tuya NIDR CO2 sensor with GPP.
+    base_air_quality.clone()  # Tuya NIDR CO2 sensor with GPP.
     .applies_to("_TZE204_ogkdpgy2", "TS0601")
+    .applies_to("_TZE200_3ejwxpmu", "TS0601")
+    .applies_to("_TZE204_3ejwxpmu", "TS0601")
     .tuya_co2(dp_id=2)
     .tuya_dp(
         dp_id=18,

--- a/zhaquirks/tuya/tuya_co.py
+++ b/zhaquirks/tuya/tuya_co.py
@@ -114,6 +114,7 @@ base_air_quality = (
 
 (
     base_air_quality.clone()  # Tuya NIDR CO2 sensor with GPP.
+    .applies_to("_TZE200_ogkdpgy2", "TS0601")
     .applies_to("_TZE204_ogkdpgy2", "TS0601")
     .applies_to("_TZE200_3ejwxpmu", "TS0601")
     .applies_to("_TZE204_3ejwxpmu", "TS0601")


### PR DESCRIPTION
## Proposed change

I'm not sure how to test this on my HA installation but in herdsman there is a group of three sensors that was previously represented by two identical separate quirks.

This PR attempts to merge their definition to mirror the herdsman listing

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

See https://github.com/Koenkk/zigbee-herdsman-converters/blob/f0039cd8dd6d79e52d3bf3b61b7ecb3f7ae53e95/src/devices/tuya.ts#L1399


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
