### PR TITLE
Convert Schneider Electric shutters to quirks v2, expose entities

### DIFF
--- a/tests/test_schneiderelectric.py
+++ b/tests/test_schneiderelectric.py
@@ -8,77 +8,19 @@ from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.smartenergy import Metering
 
 from tests.common import ClusterListener
+from zhaquirks.schneiderelectric import SE_MANUF_NAME
 import zhaquirks.schneiderelectric.outlet
-import zhaquirks.schneiderelectric.shutters
 
 zhaquirks.setup()
 
 
-def test_1gang_shutter_1_signature(assert_signature_matches_quirk):
-    """Test signature."""
-    signature = {
-        "node_descriptor": (
-            "NodeDescriptor(logical_type=<LogicalType.Router: 1>, "
-            "complex_descriptor_available=0, user_descriptor_available=0, reserved=0, "
-            "aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, "
-            "mac_capability_flags=<MACCapabilityFlags.FullFunctionDevice|MainsPowered"
-            "|RxOnWhenIdle|AllocateAddress: 142>, manufacturer_code=4190, "
-            "maximum_buffer_size=82, maximum_incoming_transfer_size=82, "
-            "server_mask=10752, maximum_outgoing_transfer_size=82, "
-            "descriptor_capability_field=<DescriptorCapability.NONE: 0>, "
-            "*allocate_address=True, *is_alternate_pan_coordinator=False, "
-            "*is_coordinator=False, *is_end_device=False, "
-            "*is_full_function_device=True, *is_mains_powered=True, "
-            "*is_receiver_on_when_idle=True, *is_router=True, "
-            "*is_security_capable=False)"
-        ),
-        "endpoints": {
-            "5": {
-                "profile_id": 0x0104,
-                "device_type": "0x0202",
-                "in_clusters": [
-                    "0x0000",
-                    "0x0003",
-                    "0x0004",
-                    "0x0005",
-                    "0x0102",
-                    "0x0b05",
-                ],
-                "out_clusters": ["0x0019"],
-            },
-            "21": {
-                "profile_id": 0x0104,
-                "device_type": "0x0104",
-                "in_clusters": [
-                    "0x0000",
-                    "0x0003",
-                    "0x0b05",
-                    "0xff17",
-                ],
-                "out_clusters": [
-                    "0x0003",
-                    "0x0005",
-                    "0x0006",
-                    "0x0008",
-                    "0x0019",
-                    "0x0102",
-                ],
-            },
-        },
-        "manufacturer": "Schneider Electric",
-        "model": "1GANG/SHUTTER/1",
-        "class": "zigpy.device.Device",
-    }
-    assert_signature_matches_quirk(
-        zhaquirks.schneiderelectric.shutters.OneGangShutter1, signature
-    )
-
-
-async def test_1gang_shutter_1_go_to_lift_percentage_cmd(zigpy_device_from_quirk):
+async def test_1gang_shutter_1_go_to_lift_percentage_cmd(zigpy_device_from_v2_quirk):
     """Asserts that the go_to_lift_percentage command inverts the percentage value."""
 
-    device = zigpy_device_from_quirk(
-        zhaquirks.schneiderelectric.shutters.OneGangShutter1
+    device = zigpy_device_from_v2_quirk(
+        manufacturer=SE_MANUF_NAME,
+        model="1GANG/SHUTTER/1",
+        endpoint_ids=[5, 21],
     )
     window_covering_cluster = device.endpoints[5].window_covering
 
@@ -95,11 +37,13 @@ async def test_1gang_shutter_1_go_to_lift_percentage_cmd(zigpy_device_from_quirk
         assert request_mock.call_args[0][3] == 42  # 100 - 58
 
 
-async def test_1gang_shutter_1_unpatched_cmd(zigpy_device_from_quirk):
+async def test_1gang_shutter_1_unpatched_cmd(zigpy_device_from_v2_quirk):
     """Asserts that unpatched ZCL commands keep working."""
 
-    device = zigpy_device_from_quirk(
-        zhaquirks.schneiderelectric.shutters.OneGangShutter1
+    device = zigpy_device_from_v2_quirk(
+        manufacturer=SE_MANUF_NAME,
+        model="1GANG/SHUTTER/1",
+        endpoint_ids=[5, 21],
     )
     window_covering_cluster = device.endpoints[5].window_covering
 
@@ -115,14 +59,16 @@ async def test_1gang_shutter_1_unpatched_cmd(zigpy_device_from_quirk):
         )
 
 
-async def test_1gang_shutter_1_lift_percentage_updates(zigpy_device_from_quirk):
+async def test_1gang_shutter_1_lift_percentage_updates(zigpy_device_from_v2_quirk):
     """Asserts that updates to the ``current_position_lift_percentage`` attribute.
 
     (e.g., by the device) invert the reported percentage value.
     """
 
-    device = zigpy_device_from_quirk(
-        zhaquirks.schneiderelectric.shutters.OneGangShutter1
+    device = zigpy_device_from_v2_quirk(
+        manufacturer=SE_MANUF_NAME,
+        model="1GANG/SHUTTER/1",
+        endpoint_ids=[5, 21],
     )
     window_covering_cluster = device.endpoints[5].window_covering
     cluster_listener = ClusterListener(window_covering_cluster)

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -7,7 +7,7 @@ from zhaquirks.schneiderelectric import (
     SEBallast,
     SEBasic,
     SEOnOff,
-    SESpecific,
+    SESwitchConfiguration,
 )
 
 (
@@ -19,7 +19,7 @@ from zhaquirks.schneiderelectric import (
     .replaces(SEBallast, endpoint_id=3)
     .replaces(SEOnOff, endpoint_id=3)
     .replaces(SEBasic, endpoint_id=21)
-    .replaces(SESpecific, endpoint_id=21)
+    .replaces(SESwitchConfiguration, endpoint_id=21)
     .add_to_registry()
 )
 
@@ -29,6 +29,6 @@ from zhaquirks.schneiderelectric import (
     .replaces(SEBasic)
     .replaces(SEOnOff)
     .replaces(SEBasic, endpoint_id=21)
-    .replaces(SESpecific, endpoint_id=21)
+    .replaces(SESwitchConfiguration, endpoint_id=21)
     .add_to_registry()
 )

--- a/zhaquirks/schneiderelectric/shutters.py
+++ b/zhaquirks/schneiderelectric/shutters.py
@@ -1,117 +1,131 @@
 """Quirks for Schneider Electric shutters."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.closures import WindowCovering
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    Scenes,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.zcl import ClusterType
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.schneiderelectric import (
     SE_MANUF_NAME,
     SEBasic,
-    SESpecific,
+    SESwitchAction,
+    SESwitchConfiguration,
+    SESwitchIndication,
     SEWindowCovering,
 )
 
+(
+    QuirkBuilder(SE_MANUF_NAME, "1GANG/SHUTTER/1")
+    .applies_to(SE_MANUF_NAME, "NHPB/SHUTTER/1")
+    .replaces(SEBasic, endpoint_id=5)
+    .replaces(SEWindowCovering, endpoint_id=5)
+    .replaces(SEBasic, endpoint_id=21)
+    .replaces(SESwitchConfiguration, endpoint_id=21)
+    .replaces(SEWindowCovering, endpoint_id=21, cluster_type=ClusterType.Client)
+    .enum(
+        endpoint_id=21,
+        cluster_id=SESwitchConfiguration.cluster_id,
+        attribute_name=SESwitchConfiguration.AttributeDefs.se_switch_indication.name,
+        enum_class=SESwitchIndication,
+        translation_key="switch_indication",
+        fallback_name="Switch indication",
+    )
+    .enum(
+        endpoint_id=21,
+        cluster_id=SESwitchConfiguration.cluster_id,
+        attribute_name=SESwitchConfiguration.AttributeDefs.se_switch_actions.name,
+        enum_class=SESwitchAction,
+        translation_key="switch_actions",
+        fallback_name="Switch actions",
+    )
+    .number(
+        endpoint_id=5,
+        cluster_id=SEWindowCovering.cluster_id,
+        attribute_name=SEWindowCovering.AttributeDefs.se_lift_drive_up_time.name,
+        unit=UnitOfTime.SECONDS,
+        multiplier=0.1,
+        min_value=1,
+        max_value=300,
+        step=0.1,
+        translation_key="lift_drive_up_time",
+        fallback_name="Lift drive up time",
+    )
+    .number(
+        endpoint_id=5,
+        cluster_id=SEWindowCovering.cluster_id,
+        attribute_name=SEWindowCovering.AttributeDefs.se_lift_drive_down_time.name,
+        unit=UnitOfTime.SECONDS,
+        multiplier=0.1,
+        min_value=1,
+        max_value=300,
+        step=0.1,
+        translation_key="lift_drive_down_time",
+        fallback_name="Lift drive down time",
+    )
+    .number(
+        endpoint_id=5,
+        cluster_id=SEWindowCovering.cluster_id,
+        attribute_name=SEWindowCovering.AttributeDefs.se_tilt_open_close_and_step_time.name,
+        unit=UnitOfTime.SECONDS,
+        multiplier=0.01,
+        min_value=0,
+        max_value=30,
+        step=0.01,
+        translation_key="tilt_open_close_and_step_time",
+        fallback_name="Tilt open close and step time",
+    )
+    .number(
+        endpoint_id=5,
+        cluster_id=SEWindowCovering.cluster_id,
+        attribute_name=SEWindowCovering.AttributeDefs.se_tilt_position_percentage_after_move_to_level.name,
+        min_value=0,
+        max_value=255,
+        step=1,
+        translation_key="tilt_position_percentage_after_move_to_level",
+        fallback_name="Tilt position percentage after move to level",
+    )
+    .add_to_registry()
+)
 
-class OneGangShutter1(CustomDevice):
-    """1GANG/SHUTTER/1 from Schneider Electric."""
-
-    signature = {
-        MODELS_INFO: [
-            (SE_MANUF_NAME, "1GANG/SHUTTER/1"),
-        ],
-        ENDPOINTS: {
-            # <SimpleDescriptor endpoint=5, profile=260, device_type=514,
-            # device_version=0,
-            # input_clusters=[0, 3, 4, 5, 258, 2821],
-            # output_clusters=[25]>
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    WindowCovering.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-            # <SimpleDescriptor endpoint=21, profile=260, device_type=260,
-            # device_version=0,
-            # input_clusters=[0, 3, 2821, 65303],
-            # output_clusters=[3, 5, 6, 8, 25, 258]>
-            21: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Diagnostic.cluster_id,
-                    SESpecific.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    WindowCovering.cluster_id,
-                ],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
-                INPUT_CLUSTERS: [
-                    SEBasic,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    SEWindowCovering,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-            21: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    SEBasic,
-                    Identify.cluster_id,
-                    Diagnostic.cluster_id,
-                    SESpecific,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    SEWindowCovering,
-                ],
-            },
-        }
-    }
+(
+    QuirkBuilder(SE_MANUF_NAME, "PUCK/SHUTTER/1")
+    .replaces(SEBasic, endpoint_id=5)
+    .replaces(SEWindowCovering, endpoint_id=5)
+    .number(
+        endpoint_id=5,
+        cluster_id=SEWindowCovering.cluster_id,
+        attribute_name=SEWindowCovering.AttributeDefs.se_lift_drive_up_time.name,
+        unit=UnitOfTime.SECONDS,
+        multiplier=0.1,
+        translation_key="lift_drive_up_time",
+        fallback_name="Lift drive up time",
+    )
+    .number(
+        endpoint_id=5,
+        cluster_id=SEWindowCovering.cluster_id,
+        attribute_name=SEWindowCovering.AttributeDefs.se_lift_drive_down_time.name,
+        unit=UnitOfTime.SECONDS,
+        multiplier=0.1,
+        translation_key="lift_drive_down_time",
+        fallback_name="Lift drive down time",
+    )
+    .number(
+        endpoint_id=5,
+        cluster_id=SEWindowCovering.cluster_id,
+        attribute_name=SEWindowCovering.AttributeDefs.se_tilt_open_close_and_step_time.name,
+        unit=UnitOfTime.SECONDS,
+        multiplier=0.01,
+        translation_key="tilt_open_close_and_step_time",
+        fallback_name="Tilt open close and step time",
+    )
+    .number(
+        endpoint_id=5,
+        cluster_id=SEWindowCovering.cluster_id,
+        attribute_name=SEWindowCovering.AttributeDefs.se_tilt_position_percentage_after_move_to_level.name,
+        min_value=0,
+        max_value=255,
+        step=1,
+        translation_key="tilt_position_percentage_after_move_to_level",
+        fallback_name="Tilt position percentage after move to level",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
- Convert to quirks v2
- Define missing attributes using spec doc
- Add support for extra models (NHPB/SHUTTER/1 and PUCK/SHUTTER/1)
- Expose extra entities to home assistant

Fixes #1685
Supersedes #3939

## Additional information
#1705 
[ZB Spec - Micro Module Shutter Blinds - 110422.pdf](https://github.com/user-attachments/files/20774274/ZB.Spec.-.Micro.Module.Shutter.Blinds.-.110422.pdf)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
