### PR TITLE
Fix Schneider Electric thermostat number limits

### DIFF
--- a/zhaquirks/schneiderelectric/thermostat.py
+++ b/zhaquirks/schneiderelectric/thermostat.py
@@ -643,7 +643,7 @@ class SEHeatingCoolingOutput(CustomCluster):
         device_class=NumberDeviceClass.TEMPERATURE,
         unit=UnitOfTemperature.CELSIUS,
         min_value=0,
-        max_value=12,
+        max_value=1.2,
         multiplier=0.1,
         step=0.1,
     )
@@ -691,7 +691,7 @@ class SEHeatingCoolingOutput(CustomCluster):
         fallback_name="Boost amount",
         device_class=NumberDeviceClass.TEMPERATURE,
         unit=UnitOfTemperature.CELSIUS,
-        min_value=0,
+        min_value=0.5,
         max_value=10,
         multiplier=0.01,
         step=0.5,


### PR DESCRIPTION
## Proposed change
This fixes limits for "Open window detection threshold" and "Boost amount" numbers according to the spec doc.


## Additional information
#3575 


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
