### PR TITLE
Add Tuya external switch type cluster to TS0001 switch

### DIFF
--- a/zhaquirks/tuya/ts0001_switch.py
+++ b/zhaquirks/tuya/ts0001_switch.py
@@ -5,7 +5,7 @@ from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
-from zhaquirks.tuya import TuyaZBOnOffAttributeCluster, TuyaZBExternalSwitchTypeCluster
+from zhaquirks.tuya import TuyaZBExternalSwitchTypeCluster, TuyaZBOnOffAttributeCluster
 
 
 class CustomElectricalMeasurement(ElectricalMeasurement, CustomCluster):

--- a/zhaquirks/tuya/ts0001_switch.py
+++ b/zhaquirks/tuya/ts0001_switch.py
@@ -5,7 +5,7 @@ from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
-from zhaquirks.tuya import TuyaZBOnOffAttributeCluster
+from zhaquirks.tuya import TuyaZBOnOffAttributeCluster, TuyaZBExternalSwitchTypeCluster
 
 
 class CustomElectricalMeasurement(ElectricalMeasurement, CustomCluster):
@@ -47,5 +47,6 @@ class CustomMetering(Metering, CustomCluster):
     .replaces(CustomMetering)
     .replaces(CustomElectricalMeasurement)
     .replaces(TuyaZBOnOffAttributeCluster)
+    .replaces(TuyaZBExternalSwitchTypeCluster)
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Closes #4133 

As noted in the linked issue, the Tuya TS0001_switch lacks the `TuyaZBExternalSwitchTypeCluster`. This PR adds that to `ts0001_switch.py`.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

I've already tested this locally on my Home Assistant configuration with a custom quirk and this works.


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
