### PR TITLE
Add Aqara T1M ceiling light support

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -79,7 +79,7 @@ from zhaquirks.xiaomi.aqara.feeder_acn001 import (
     AqaraFeederAcn001,
     OppleCluster,
 )
-from zhaquirks.xiaomi.aqara.light_acn import AqaraLightT1M, LumiPowerOnBehaviorMode
+from zhaquirks.xiaomi.aqara.light_acn import AqaraLightT1M, LumiPowerOnStateMode
 import zhaquirks.xiaomi.aqara.magnet_ac01
 import zhaquirks.xiaomi.aqara.magnet_acn001
 import zhaquirks.xiaomi.aqara.magnet_agl02
@@ -2233,25 +2233,18 @@ def test_t1m_ceiling_light(zigpy_device_from_v2_quirk, endpoint):
     aqara_cluster = device.endpoints[endpoint].opple_cluster
     cluster_listener = ClusterListener(aqara_cluster)
 
-    aqara_cluster.update_attribute(
-        AqaraLightT1M.AttributeDefs.power_on_behavior.id, 0x01
-    )
+    aqara_cluster.update_attribute(AqaraLightT1M.AttributeDefs.power_on_state.id, 0x01)
     assert len(cluster_listener.attribute_updates) == 1
     assert (
         cluster_listener.attribute_updates[0][0]
-        == AqaraLightT1M.AttributeDefs.power_on_behavior.id
+        == AqaraLightT1M.AttributeDefs.power_on_state.id
     )
-    assert (
-        cluster_listener.attribute_updates[0][1]
-        == LumiPowerOnBehaviorMode.PreserveState
-    )
+    assert cluster_listener.attribute_updates[0][1] == LumiPowerOnStateMode.LastState
 
-    aqara_cluster.update_attribute(
-        AqaraLightT1M.AttributeDefs.power_on_behavior.id, 0x02
-    )
+    aqara_cluster.update_attribute(AqaraLightT1M.AttributeDefs.power_on_state.id, 0x02)
     assert len(cluster_listener.attribute_updates) == 2
     assert (
         cluster_listener.attribute_updates[1][0]
-        == AqaraLightT1M.AttributeDefs.power_on_behavior.id
+        == AqaraLightT1M.AttributeDefs.power_on_state.id
     )
-    assert cluster_listener.attribute_updates[1][1] == LumiPowerOnBehaviorMode.Off
+    assert cluster_listener.attribute_updates[1][1] == LumiPowerOnStateMode.Off

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2227,7 +2227,8 @@ def test_h1_wireless_remotes(zigpy_device_from_v2_quirk):
 def test_t1m_ceiling_light(zigpy_device_from_v2_quirk, endpoint):
     """Test Aqara T1M ceiling light quirk adds missing endpoints."""
 
-    device = zigpy_device_from_v2_quirk(AQARA, "lumi.light.acn032")
+    # create the device with 2 endpoints (one for each light on the T1M)
+    device = zigpy_device_from_v2_quirk(AQARA, "lumi.light.acn032", endpoint_ids=[1, 2])
     assert AqaraLightT1M.cluster_id in device.endpoints[endpoint].in_clusters
 
     aqara_cluster = device.endpoints[endpoint].opple_cluster

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -50,6 +50,7 @@ from zhaquirks.const import (
     BatterySize,
 )
 from zhaquirks.xiaomi import (
+    AQARA,
     LUMI,
     XIAOMI_AQARA_ATTRIBUTE,
     XIAOMI_AQARA_ATTRIBUTE_E1,
@@ -78,6 +79,7 @@ from zhaquirks.xiaomi.aqara.feeder_acn001 import (
     AqaraFeederAcn001,
     OppleCluster,
 )
+from zhaquirks.xiaomi.aqara.light_acn import AqaraLightT1M, LumiPowerOnBehaviorMode
 import zhaquirks.xiaomi.aqara.magnet_ac01
 import zhaquirks.xiaomi.aqara.magnet_acn001
 import zhaquirks.xiaomi.aqara.magnet_agl02
@@ -2219,3 +2221,37 @@ def test_h1_wireless_remotes(zigpy_device_from_v2_quirk):
 
     assert MultistateInput.cluster_id in device.endpoints[2].in_clusters
     assert MultistateInput.cluster_id in device.endpoints[3].in_clusters
+
+
+@pytest.mark.parametrize("endpoint", [(1), (2)])
+def test_t1m_ceiling_light(zigpy_device_from_v2_quirk, endpoint):
+    """Test Aqara T1M ceiling light quirk adds missing endpoints."""
+
+    device = zigpy_device_from_v2_quirk(AQARA, "lumi.light.acn032")
+    assert AqaraLightT1M.cluster_id in device.endpoints[endpoint].in_clusters
+
+    aqara_cluster = device.endpoints[endpoint].opple_cluster
+    cluster_listener = ClusterListener(aqara_cluster)
+
+    aqara_cluster.update_attribute(
+        AqaraLightT1M.AttributeDefs.power_on_behavior.id, 0x01
+    )
+    assert len(cluster_listener.attribute_updates) == 1
+    assert (
+        cluster_listener.attribute_updates[0][0]
+        == AqaraLightT1M.AttributeDefs.power_on_behavior.id
+    )
+    assert (
+        cluster_listener.attribute_updates[0][1]
+        == LumiPowerOnBehaviorMode.PreserveState
+    )
+
+    aqara_cluster.update_attribute(
+        AqaraLightT1M.AttributeDefs.power_on_behavior.id, 0x02
+    )
+    assert len(cluster_listener.attribute_updates) == 2
+    assert (
+        cluster_listener.attribute_updates[1][0]
+        == AqaraLightT1M.AttributeDefs.power_on_behavior.id
+    )
+    assert cluster_listener.attribute_updates[1][1] == LumiPowerOnBehaviorMode.Off

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -51,6 +51,7 @@ from zhaquirks.const import (
     BatterySize,
 )
 
+AQARA = "Aqara"
 BATTERY_LEVEL = "battery_level"
 BATTERY_PERCENTAGE_REMAINING = 0x0021
 BATTERY_PERCENTAGE_REMAINING_ATTRIBUTE = "battery_percentage"

--- a/zhaquirks/xiaomi/aqara/light_acn.py
+++ b/zhaquirks/xiaomi/aqara/light_acn.py
@@ -244,9 +244,9 @@ class LumiLightAcn014(XiaomiCustomDevice):
         AqaraLightT1M.AttributeDefs.power_on_state.name,
         LumiPowerOnStateMode,
         AqaraLightT1M.cluster_id,
+        endpoint_id=2,
         translation_key="power_on_state",
         fallback_name="Power on state",
-        endpoint_id=2,
     )
     .add_to_registry()
 )

--- a/zhaquirks/xiaomi/aqara/light_acn.py
+++ b/zhaquirks/xiaomi/aqara/light_acn.py
@@ -40,11 +40,11 @@ from zhaquirks.xiaomi import (
 )
 
 
-class LumiPowerOnBehaviorMode(t.enum8):
-    """Power on behavior mode."""
+class LumiPowerOnStateMode(t.enum8):
+    """Power on state mode."""
 
     On = 0x00
-    PreserveState = 0x01
+    LastState = 0x01
     Off = 0x02
 
 
@@ -57,16 +57,14 @@ class OppleClusterLight(XiaomiAqaraE1Cluster):
 
 
 class AqaraLightT1M(XiaomiAqaraE1Cluster):
-    """Add power on behavior management for Lumi devices."""
-
-    manufacturer_id_override = 4447
+    """Add power on state management for Lumi devices."""
 
     class AttributeDefs(BaseAttributeDefs):
         """Manufacturer specific attributes."""
 
-        power_on_behavior = ZCLAttributeDef(
+        power_on_state = ZCLAttributeDef(
             id=0x0517,
-            type=LumiPowerOnBehaviorMode,
+            type=LumiPowerOnStateMode,
             zcl_type=DataTypeId.uint8,
             access="rw",
             is_manufacturer_specific=True,
@@ -233,22 +231,22 @@ class LumiLightAcn014(XiaomiCustomDevice):
 (
     QuirkBuilder(AQARA, "lumi.light.acn032")
     .friendly_name(manufacturer="Aqara", model="Ceiling Light T1M")
-    .adds_endpoint(2, device_type=zha.DeviceType.COLOR_DIMMABLE_LIGHT)
+    .replaces_endpoint(2, device_type=zha.DeviceType.COLOR_DIMMABLE_LIGHT)
     .replaces(AqaraLightT1M)
     .replaces(AqaraLightT1M, endpoint_id=2)
     .enum(
-        AqaraLightT1M.AttributeDefs.power_on_behavior.name,
-        LumiPowerOnBehaviorMode,
+        AqaraLightT1M.AttributeDefs.power_on_state.name,
+        LumiPowerOnStateMode,
         AqaraLightT1M.cluster_id,
-        translation_key="power_on_behavior",
-        fallback_name="Power on behavior",
+        translation_key="power_on_state",
+        fallback_name="Power on state",
     )
     .enum(
-        AqaraLightT1M.AttributeDefs.power_on_behavior.name,
-        LumiPowerOnBehaviorMode,
+        AqaraLightT1M.AttributeDefs.power_on_state.name,
+        LumiPowerOnStateMode,
         AqaraLightT1M.cluster_id,
-        translation_key="power_on_behavior",
-        fallback_name="Power on behavior",
+        translation_key="power_on_state",
+        fallback_name="Power on state",
         endpoint_id=2,
     )
     .add_to_registry()

--- a/zhaquirks/xiaomi/aqara/light_acn.py
+++ b/zhaquirks/xiaomi/aqara/light_acn.py
@@ -2,6 +2,7 @@
 
 from zigpy import types as t
 from zigpy.profiles import zgp, zha
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Alarms,
     AnalogInput,
@@ -20,6 +21,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.smartenergy import Metering
+from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -30,11 +32,20 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.xiaomi import (
+    AQARA,
     LUMI,
     BasicCluster,
     XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
 )
+
+
+class LumiPowerOnBehaviorMode(t.enum8):
+    """Power on behavior mode."""
+
+    On = 0x00
+    PreserveState = 0x01
+    Off = 0x02
 
 
 class OppleClusterLight(XiaomiAqaraE1Cluster):
@@ -43,6 +54,23 @@ class OppleClusterLight(XiaomiAqaraE1Cluster):
     attributes = {
         0x0201: ("power_outage_memory", t.Bool, True),
     }
+
+
+class AqaraLightT1M(XiaomiAqaraE1Cluster):
+    """Add power on behavior management for Lumi devices."""
+
+    manufacturer_id_override = 4447
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Manufacturer specific attributes."""
+
+        power_on_behavior = ZCLAttributeDef(
+            id=0x0517,
+            type=LumiPowerOnBehaviorMode,
+            zcl_type=DataTypeId.uint8,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
 
 
 class LumiLightAcn003(XiaomiCustomDevice):
@@ -200,3 +228,28 @@ class LumiLightAcn014(XiaomiCustomDevice):
             },
         }
     }
+
+
+(
+    QuirkBuilder(AQARA, "lumi.light.acn032")
+    .friendly_name(manufacturer="Aqara", model="Ceiling Light T1M")
+    .adds_endpoint(2, device_type=zha.DeviceType.COLOR_DIMMABLE_LIGHT)
+    .replaces(AqaraLightT1M)
+    .replaces(AqaraLightT1M, endpoint_id=2)
+    .enum(
+        AqaraLightT1M.AttributeDefs.power_on_behavior.name,
+        LumiPowerOnBehaviorMode,
+        AqaraLightT1M.cluster_id,
+        translation_key="power_on_behavior",
+        fallback_name="Power on behavior",
+    )
+    .enum(
+        AqaraLightT1M.AttributeDefs.power_on_behavior.name,
+        LumiPowerOnBehaviorMode,
+        AqaraLightT1M.cluster_id,
+        translation_key="power_on_behavior",
+        fallback_name="Power on behavior",
+        endpoint_id=2,
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/xiaomi/aqara/light_acn.py
+++ b/zhaquirks/xiaomi/aqara/light_acn.py
@@ -231,7 +231,6 @@ class LumiLightAcn014(XiaomiCustomDevice):
 (
     QuirkBuilder(AQARA, "lumi.light.acn032")
     .friendly_name(manufacturer="Aqara", model="Ceiling Light T1M")
-    .replaces_endpoint(2, device_type=zha.DeviceType.COLOR_DIMMABLE_LIGHT)
     .replaces(AqaraLightT1M)
     .replaces(AqaraLightT1M, endpoint_id=2)
     .enum(


### PR DESCRIPTION
## Proposed change
This quirk adds support for power on behavior configuration to Aqara Light T1M (ceiling light with RGB ring).
This device identifies itself as lumi.light.acn032.


## Additional information
This is an updated pull request based on #3070 and #3066 but updated to the new Quirks v2
This also allows the new option to be exposed in Home Assistant Configuration.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
