### PR TITLE
Update issue templates with new diagnostics text

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,10 +57,21 @@ body:
         # Debug information
   - type: textarea
     attributes:
+      label: Diagnostics information
+      placeholder: "Drag-and-drop the diagnostics file here. Do not copy-paste the content."
+      description: >-
+        Diagnostics information is crucial for debugging issues with ZHA devices.
+        
+        You can find the diagnostics information by going to the device page, clicking the three dots, and then by clicking on "Download diagnostics".
+        Drag-and-drop the downloaded file into the textbox below.
+  - type: textarea
+    attributes:
       label: Device signature
       description: |
-        You can find the device signature by going to the device page, clicking the three dots, clicking on "Manage Zigbee device", and then selecting the "Signature" tab at the top.
+        Additionally providing the device signature allows us to quickly get an overview of the device clusters and see if a quirk is already applied to the device.
+        It's optional to provide, since this information is already available in the diagnostics file, but it can help us to quickly identify issues.
         
+        You can find the device signature by going to the device page, clicking the three dots, clicking on "Manage Zigbee device", and then selecting the "Signature" tab at the top.
         Copy the contents and paste your device signature in between the lines with the backticks below.
       value: |
         <details><summary>Device signature</summary>
@@ -68,23 +79,6 @@ body:
         ```json
 
         [Paste the device signature here]
-
-        ```
-
-        </details>
-  - type: textarea
-    attributes:
-      label: Diagnostic information
-      description: |
-        You can find the diagnostic information of the device by going to the device page, clicking the three dots, and then by clicking on "Download diagnostics".
-        
-        Copy the contents of the downloaded text file and paste it in between the lines with the backticks below.
-      value: |
-        <details><summary>Diagnostic information</summary>
-
-        ```json
-
-        [Paste the diagnostic information here]
 
         ```
 

--- a/.github/ISSUE_TEMPLATE/device_support_request.yml
+++ b/.github/ISSUE_TEMPLATE/device_support_request.yml
@@ -46,10 +46,21 @@ body:
         # Debug information
   - type: textarea
     attributes:
+      label: Diagnostics information
+      placeholder: "Drag-and-drop the diagnostics file here. Do not copy-paste the content."
+      description: >-
+        Diagnostics information is crucial for debugging issues with ZHA devices.
+        
+        You can find the diagnostics information by going to the device page, clicking the three dots, and then by clicking on "Download diagnostics".
+        Drag-and-drop the downloaded file into the textbox below.
+  - type: textarea
+    attributes:
       label: Device signature
       description: |
-        You can find the device signature by going to the device page, clicking the three dots, clicking on "Manage Zigbee device", and then selecting the "Signature" tab at the top.
+        Additionally providing the device signature allows us to quickly get an overview of the device clusters and see if a quirk is already applied to the device.
+        It's optional to provide, since this information is already available in the diagnostics file, but it can help us to quickly identify issues.
         
+        You can find the device signature by going to the device page, clicking the three dots, clicking on "Manage Zigbee device", and then selecting the "Signature" tab at the top.
         Copy the contents and paste your device signature in between the lines with the backticks below.
       value: |
         <details><summary>Device signature</summary>
@@ -57,23 +68,6 @@ body:
         ```json
 
         [Paste the device signature here]
-
-        ```
-
-        </details>
-  - type: textarea
-    attributes:
-      label: Diagnostic information
-      description: |
-        You can find the diagnostic information of the device by going to the device page, clicking the three dots, and then by clicking on "Download diagnostics".
-        
-        Copy the contents of the downloaded text file and paste it in between the lines with the backticks below.
-      value: |
-        <details><summary>Diagnostic information</summary>
-
-        ```json
-
-        [Paste the diagnostic information here]
 
         ```
 


### PR DESCRIPTION
## Proposed change
This updates the issue template text for diagnostics information to mention that you need to upload the entire diagnostics file now, instead of just pasting the contents in a textbox.
Additionally, the diagnostics section is now above the device signature section. The text for the device signature now also mentions that it's optional to provide, but still nice if done.


## Additional information
Kind of related discussion in:
- https://github.com/home-assistant/frontend/pull/25849

The text for the diagnostics file is now also more similar to the [HA issue template](https://github.com/home-assistant/core/blob/dev/.github/ISSUE_TEMPLATE/bug_report.yml) text.


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
