### PR TITLE
Fix Xiaomi Aqara vibration sensor angle signed conversion

### DIFF
--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -109,6 +109,9 @@ class VibrationAQ1(XiaomiQuickInitDevice):
                 x = value & 0xFFFF
                 y = (value >> 16) & 0xFFFF
                 z = (value >> 32) & 0xFFFF
+                x = x - 0x10000 if x & 0x8000 else x
+                y = y - 0x10000 if y & 0x8000 else y
+                z = z - 0x10000 if z & 0x8000 else z
                 X = 0.0 + x
                 Y = 0.0 + y
                 Z = 0.0 + z


### PR DESCRIPTION
This PR addresses an issue with how the Xiaomi Aqara  vibration angle (specifically for devices like the DJT11LM) is converted from bytes to an integer. Previously, the conversion was unsigned, limiting the range to 0-90 degrees.

By changing the conversion to use signed values, the device can now correctly report and interpret angles within the full -90 to 90 degree range. This ensures accurate control and reporting for devices utilizing this angle measurement.

This change particularly benefits devices like the DJT11LM that operate with both positive and negative angle values for full range motion.