### PR TITLE
Fix Tuya TRV local temperature calibration multiplier

### DIFF
--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -209,7 +209,8 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         min_value=-6,
         max_value=6,
         unit=UnitOfTemperature.CELSIUS,
-        step=1,
+        step=0.1,
+        multiplier=0.1,
         translation_key="local_temperature_calibration",
         fallback_name="Local temperature calibration",
     )


### PR DESCRIPTION
## Proposed change
This adds `multiplier=0.1` to the quirks v2 `local_temperature_calibration` on some Tuya TRVs.

TODO: We also need to consider if this needs to be added to others. In Z2M, it doesn't seem entirely clear which ones need this.
TODO: Also check this doesn't break some TRVs included in the same quirk. If it does, it's also an issue in Z2M.


## Additional information
Fixes https://github.com/zigpy/zha-device-handlers/issues/4124


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
