### PR TITLE
Add Tuya 2 gang no neutral switch `TS0012` `_TZ3000_rbl8c85w`

### DIFF
--- a/zhaquirks/tuya/ts001x.py
+++ b/zhaquirks/tuya/ts001x.py
@@ -727,6 +727,73 @@ class Tuya_Double_Var05(EnchantedDevice, TuyaSwitch):
     }
 
 
+class Tuya_Double_Var06(EnchantedDevice, TuyaSwitch):
+    """Tuya 2 gang no neutral light switch (variation 06)."""
+
+    signature = {
+        MODEL: "TS0012",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaZBOnOffAttributeCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+
 class Tuya_Triple_No_N(EnchantedDevice, TuyaSwitch):
     """Tuya 3 gang no neutral light switch."""
 


### PR DESCRIPTION
## Proposed change
Add variation for `_TZ3000_rbl8c85w` Tuya device.

`_TZ3000_rbl8c85w` needs to be an `EnchantedDevice` or it'll detect it's not connected to a Tuya hub, causing it to toggle both relays at the same time.


## Additional information
Fixes https://github.com/zigpy/zha-device-handlers/issues/4106

`Tuya_Double_Var06` is not an ideal name, but follows the `Var05` variant that's in that class.
It should be cleaned up at some point. It's the same as `TuyaDoubleNoNeutralSwitch`, except for added `Identify` clusters on ep 1 and ep 2.

We use v1 quirks instead of v2 quirks for the wildcard "manufacturer" matching.


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
