### PR TITLE
Change case for Nimly lock "Last PIN code"

### DIFF
--- a/zhaquirks/nimly/lock.py
+++ b/zhaquirks/nimly/lock.py
@@ -124,7 +124,7 @@ def last_action_user_converter(value: int) -> int:
         attribute_converter=lambda value: value.hex(),
         initially_disabled=True,
         translation_key="last_pin_code",
-        fallback_name="Last pin code",
+        fallback_name="Last PIN code",
     )
     .switch(
         endpoint_id=11,
@@ -192,7 +192,7 @@ def last_action_user_converter(value: int) -> int:
         attribute_converter=lambda value: value.hex(),
         initially_disabled=True,
         translation_key="last_pin_code",
-        fallback_name="Last pin code",
+        fallback_name="Last PIN code",
     )
     .switch(
         endpoint_id=11,


### PR DESCRIPTION
## Proposed change
This changes the case from "Last pin code" to "Last PIN code" for the Nimly locks.
Since we use the `fallback_name` to automatically generate (US) English translations/strings, we should correct this here.

## Additional information
Very small follow-up to https://github.com/zigpy/zha-device-handlers/pull/4138


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
