### PR TITLE
Add Tuya write attribute button method

### DIFF
--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -211,6 +211,13 @@ async def test_tuya_quirkbuilder(device_mock):
             translation_key="test_enum",
             fallback_name="Test enum",
         )
+        .tuya_write_attr_button(
+            dp_id=12,
+            attribute_name="test_button",
+            attribute_value=1,
+            translation_key="test_button",
+            fallback_name="Test button",
+        )
         .tuya_dp_multi(
             dp_id=11,
             attribute_mapping=[
@@ -261,6 +268,7 @@ async def test_tuya_quirkbuilder(device_mock):
     assert tuya_cluster.attributes_by_name["test_binary"].id == 0xEF08
     assert tuya_cluster.attributes_by_name["test_sensor"].id == 0xEF09
     assert tuya_cluster.attributes_by_name["test_enum"].id == 0xEF0A
+    assert tuya_cluster.attributes_by_name["test_button"].id == 0xEF0C
 
     with mock.patch.object(
         tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -810,6 +810,47 @@ class TuyaQuirkBuilder(QuirkBuilder):
 
         return self
 
+    def tuya_write_attr_button(
+        self,
+        dp_id: int,
+        attribute_name: str,
+        attribute_value: int,
+        endpoint_id: int = 1,
+        entity_type: EntityType = EntityType.CONFIG,
+        initially_disabled: bool = False,
+        attribute_initialized_from_cache: bool = True,
+        unique_id_suffix: str | None = None,
+        translation_key: str | None = None,
+        fallback_name: str | None = None,
+        primary: bool | None = None,
+    ) -> QuirkBuilder:
+        """Add an EntityMetadata containing WriteAttributeButtonMetadata and return self.
+
+        This method allows exposing a button entity in Home Assistant that writes
+        a value to a Tuya datapoint when pressed.
+        """
+        self.tuya_dp_attribute(
+            dp_id=dp_id,
+            attribute_name=attribute_name,
+            type=t.Bool,
+            access=foundation.ZCLAttributeAccess.Read
+            | foundation.ZCLAttributeAccess.Write,
+        )
+        self.write_attr_button(
+            attribute_name=attribute_name,
+            cluster_id=TUYA_CLUSTER_ID,
+            endpoint_id=endpoint_id,
+            attribute_value=attribute_value,
+            entity_type=entity_type,
+            initially_disabled=initially_disabled,
+            attribute_initialized_from_cache=attribute_initialized_from_cache,
+            unique_id_suffix=unique_id_suffix,
+            translation_key=translation_key,
+            fallback_name=fallback_name,
+            primary=primary,
+        )
+        return self
+
     def tuya_enchantment(
         self, read_attr_spell: bool = True, data_query_spell: bool = False
     ) -> QuirkBuilder:


### PR DESCRIPTION
## Proposed change
This adds a `tuya_write_attr_button` method to the `TuyaQuirkBuilder` to allow both mapping a Tuya DP to a (fake) ZCL attribute as well as adding a normal `write_attr_button` for that ZCL attribute.


## Additional information
Related:
- https://github.com/zigpy/zha-device-handlers/pull/4086

Semi-related TODOs:
- add `primary` and `unique_id` to other Tuya methods
- return `Self` type in `TuyaQuirkBuilder` and zigpy `QuirkBuilder` 

## Checklist
- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
