### PR TITLE
Add Senoro door sensor alarm

### DIFF
--- a/zhaquirks/tuya/tuya_door.py
+++ b/zhaquirks/tuya/tuya_door.py
@@ -1,9 +1,10 @@
 """Senoro Window Sensor (TS0601)."""
 
-from zigpy.quirks.v2 import EntityPlatform, EntityType
+from zigpy.quirks.v2 import BinarySensorDeviceClass, EntityPlatform, EntityType
 import zigpy.types as t
+from zigpy.zcl import foundation
 
-from zhaquirks.tuya import BatterySize
+from zhaquirks.tuya import TUYA_CLUSTER_ID, BatterySize
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
@@ -30,6 +31,29 @@ class OpeningStateEnum(t.enum8):
         entity_platform=EntityPlatform.SENSOR,
         translation_key="opening",
         fallback_name="Opening",
+    )
+    .tuya_dp_attribute(
+        dp_id=16,
+        attribute_name="alarm",
+        type=t.Bool,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .binary_sensor(
+        attribute_name="alarm",
+        cluster_id=TUYA_CLUSTER_ID,
+        entity_type=EntityType.STANDARD,
+        device_class=BinarySensorDeviceClass.TAMPER,
+        unique_id_suffix="alarm_sensor",
+        fallback_name="Tamper",
+    )
+    .write_attr_button(
+        attribute_name="alarm",
+        attribute_value=0,
+        cluster_id=TUYA_CLUSTER_ID,
+        entity_type=EntityType.STANDARD,
+        unique_id_suffix="alarm_reset",
+        translation_key="reset_alarm",
+        fallback_name="Reset alarm",
     )
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
## Proposed change
This adds a binary sensor entity for the Senoro door sensor that displays the current alarm state.
A button entity is also added that allows for resetting an activated tamper alarm.

**This still needs testing**

## Additional information
Follow-up to:
- https://github.com/zigpy/zha-device-handlers/pull/4086

Implementation details:
- The `tuya_switch` (and so on) methods do three things: (1) map the Tuya DP to a ZCL attribute, (2) create that ZCL attribute, and (3) create the switch entity metadata. Here, we call `tuya_dp_attribute` to (1) map the DP and (2) create the ZCL attribute. We call `binary_sensor` and `write_attr_button` methods directly for the mapped ZCL attribute.
- `translation_key` is omitted for the "Tamper" alarm, as we set the "tamper device class", [defaulting to a translated "Tamper" name in Home Assistant](https://github.com/home-assistant/core/blob/6d28b993444ea93c4d76ae000e46e22c84984ace/homeassistant/components/binary_sensor/strings.json#L293)
- `unique_id_suffix` is only kind of needed for the binary sensor and button entity. The unique ID for the HA entities is based on the `attribute_name` by default, which would conflict. However, unique IDs are still keyed by platform (`binary_sensor` vs `button` in ZHA), so they won't conflict for now. Still, we want to avoid this, so I've given them separate `unique_id_suffix`es.

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
