### PR TITLE
Pull updated strings from HA Core

### DIFF
--- a/zhaquirks/nimly/lock.py
+++ b/zhaquirks/nimly/lock.py
@@ -131,7 +131,7 @@ def last_action_user_converter(value: int) -> int:
         cluster_id=NimlyDoorLock.cluster_id,
         attribute_name=NimlyDoorLock.AttributeDefs.auto_relock_time.name,
         translation_key="auto_relock",
-        fallback_name="Auto relock",
+        fallback_name="Autorelock",
     )
     .number(
         endpoint_id=11,
@@ -199,7 +199,7 @@ def last_action_user_converter(value: int) -> int:
         cluster_id=NimlyDoorLock.cluster_id,
         attribute_name=NimlyDoorLock.AttributeDefs.auto_relock_time.name,
         translation_key="auto_relock",
-        fallback_name="Auto relock",
+        fallback_name="Autorelock",
     )
     .number(
         endpoint_id=11,

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -723,7 +723,7 @@ class GiexIrrigationStatus(t.enum8):
         step=5,
         unit=PERCENTAGE,
         translation_key="valve_state_auto_shutdown",
-        fallback_name="Valve state auto shutdown",
+        fallback_name="Valve state auto-shutdown",
     )
     .tuya_sensor(
         dp_id=3,

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -686,7 +686,7 @@ class GiexIrrigationStatus(t.enum8):
         attribute_name="auto_clean",
         entity_type=EntityType.CONFIG,
         translation_key="auto_clean",
-        fallback_name="Auto clean",
+        fallback_name="Autoclean",
     )
     .tuya_dp(
         dp_id=21,

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -723,7 +723,7 @@ class GiexIrrigationStatus(t.enum8):
         step=5,
         unit=PERCENTAGE,
         translation_key="valve_state_auto_shutdown",
-        fallback_name="Valve state autoshutdown",
+        fallback_name="Valve state auto shutdown",
     )
     .tuya_sensor(
         dp_id=3,

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -723,7 +723,7 @@ class GiexIrrigationStatus(t.enum8):
         step=5,
         unit=PERCENTAGE,
         translation_key="valve_state_auto_shutdown",
-        fallback_name="Valve state auto shutdown",
+        fallback_name="Valve state autoshutdown",
     )
     .tuya_sensor(
         dp_id=3,


### PR DESCRIPTION
## Proposed change
Pulls in the HA Core string changes, so we're up-to-date as well, from:
- https://github.com/home-assistant/core/pull/148022/
- https://github.com/home-assistant/core/pull/148230/


## Additional information
- "Autoshutdown" is IMO incorrect, so not pulled. EDIT: will change to "auto-shutdown" in HA Core and here.
- "Autoclean" is also used less than both "auto clean" and "auto-clean", though I've updated that, as it seems correct and is used across different HA Core integrations.
- "Autorelock" is fine and commonly used.

Draft until we decided on what to do in HA Core.

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
