### PR TITLE
Add MOES smart curtain switch mini (_TZ3210_zana8d08)

### DIFF
--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -20,11 +20,16 @@ from zhaquirks.const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODEL,
+    MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    MODELS_INFO
 )
-from zhaquirks.tuya import SwitchBackLight, TuyaZBExternalSwitchTypeCluster, TUYA_CLUSTER_E001_ID, TUYA_CLUSTER_E000_ID
+from zhaquirks.tuya import (
+    TUYA_CLUSTER_E000_ID,
+    TUYA_CLUSTER_E001_ID,
+    SwitchBackLight,
+    TuyaZBExternalSwitchTypeCluster,
+)
 
 ATTR_CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
 CMD_GO_TO_LIFT_PERCENTAGE = 0x0005
@@ -359,7 +364,7 @@ class TuyaTS130FZana8d08(CustomDevice):
                     Scenes.cluster_id,
                     TuyaWithBacklightOnOffCluster,
                     TuyaCoveringCluster,
-                    TuyaZBExternalSwitchTypeCluster
+                    TuyaZBExternalSwitchTypeCluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Time.cluster_id,

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -22,8 +22,9 @@ from zhaquirks.const import (
     MODEL,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    MODELS_INFO
 )
-from zhaquirks.tuya import SwitchBackLight, TuyaZBExternalSwitchTypeCluster
+from zhaquirks.tuya import SwitchBackLight, TuyaZBExternalSwitchTypeCluster, TUYA_CLUSTER_E001_ID, TUYA_CLUSTER_E000_ID
 
 ATTR_CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
 CMD_GO_TO_LIFT_PERCENTAGE = 0x0005
@@ -311,6 +312,65 @@ class TuyaTS130FTI2(CustomDevice):
                     Time.cluster_id,
                     Ota.cluster_id,
                 ],
+            },
+        },
+    }
+
+
+class TuyaTS130FZana8d08(CustomDevice):
+    """Tuya smart curtain roller shutter for _TZ3210_zana8d08."""
+
+    signature = {
+        MODELS_INFO: [("_TZ3210_zana8d08", "TS130F")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: 0x0104,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    WindowCovering.cluster_id,
+                    TUYA_CLUSTER_E001_ID,
+                    TUYA_CLUSTER_E000_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaWithBacklightOnOffCluster,
+                    TuyaCoveringCluster,
+                    TuyaZBExternalSwitchTypeCluster
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
             },
         },
     }


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Added a quirk that exposes the TuyaCoveringCluster and TuyaZBExternalSwitchTypeCluster endpoints, allowing for proper calibration of the device (via [this guide](https://community.home-assistant.io/t/zha-curtains-module-calibration/359996/5?u=lmpmatos)) and also switching the switch type via the latter endpoint.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

fixes https://github.com/zigpy/zha-device-handlers/issues/4159

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
