### PR TITLE
Fix Tuya presence sensor "distance tracking" for `_ya4ft0w4`

### DIFF
--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -247,10 +247,10 @@ base_tuya_motion = (
     # 2, 3, 4, and 9 from base
     .tuya_switch(
         dp_id=101,
-        attribute_name="find_switch",
-        entity_type=EntityType.STANDARD,
-        translation_key="led_indicator",
-        fallback_name="LED indicator",
+        attribute_name="distance_tracking",
+        entity_type=EntityType.CONFIG,
+        translation_key="distance_tracking",
+        fallback_name="Distance tracking",
     )
     .tuya_number(
         dp_id=102,


### PR DESCRIPTION
The switch actually enables/disables distance tracking instead of a LED indicator. Renaming the switch to what it actually does prevents a lot of confusion.

## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
