### PR TITLE
Fix Tuya presence sensitivity config for `_ya4ft0w4`

### DIFF
--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -259,7 +259,6 @@ base_tuya_motion = (
         min_value=0,
         max_value=10,
         step=1,
-        multiplier=0.1,
         translation_key="presence_sensitivity",
         fallback_name="Presence sensitivity",
     )


### PR DESCRIPTION
## Proposed change
The multiplier for the presence sensitivity should be 1, or be deleted like I did.

See https://github.com/zigpy/zha-device-handlers/issues/3990#issuecomment-2902794465

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
