### PR TITLE
Add Tuya 213E ultrasonic water meter `_TZE200_ajlu4cud`

### DIFF
--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -805,7 +805,7 @@ class TuyaReportingPeriod(t.enum8):
         enum_class=TuyaReportingPeriod,
         entity_type=EntityType.CONFIG,
         translation_key="reporting_interval",
-        fallback_name="Reporting Interval",
+        fallback_name="Reporting interval",
     )
     # Warning - type is bitmap16, TBD.
     # .tuya_dp(

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -827,7 +827,7 @@ class TuyaReportingPeriod(t.enum8):
     )
     # Working temperature
     .tuya_temperature(dp_id=22, scale=1.0)
-    # Power supply volatage
+    # Power supply voltage
     .tuya_sensor(
         dp_id=26,
         attribute_name="voltage",

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -789,6 +789,7 @@ class TuyaReportingPeriod(t.enum8):
 
 (
     TuyaQuirkBuilder("_TZE200_ajlu4cud", "TS0601")
+    .applies_to("_TZE284_ajlu4cud", "TS0601")
     # Total consumption in liters
     .tuya_metering(dp_id=1, metering_cfg=TuyaValveWaterConsumed)
     # Month consumption

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -767,3 +767,77 @@ class GiexIrrigationStatus(t.enum8):
     .skip_configuration()
     .add_to_registry()
 )
+
+# Tuya 213E Ultrasonic water meter 
+# while strictly speaking not a valve, the ultrasonic flow meter is similar to other 
+# devices defined here.
+# Setting the reporting period should also be applicable to other devices (e.g. 214C)
+
+class TuyaReportingPeriod(t.enum8):
+    """Tuya Reporting period enum."""
+
+    reporting_1h = 0x00
+    reporting_2h = 0x01
+    reporting_3h = 0x02
+    reporting_4h = 0x03
+    reporting_6h = 0x04
+    reporting_8h = 0x05
+    reporting_12h = 0x06
+    reporting_24h = 0x07
+
+(
+    TuyaQuirkBuilder("_TZE200_ajlu4cud", "TS0601")
+        # Total consumption in liters
+        .tuya_metering(
+            dp_id=1, metering_cfg=TuyaValveWaterConsumed)
+        # Month consumption
+        #.tuya_metering(
+        #    dp_id=2, scale=0.0001, type=TuyaValveWaterConsumed
+        #)  # per z2m reports in fl oz, convert to liters
+        # Daily consumption
+        #.tuya_metering(
+        #    dp_id=3, scale=0.0001, type=TuyaValveWaterConsumed
+        #)  
+        .tuya_enum(
+            dp_id=4,
+            attribute_name="reporting_interval",
+            enum_class=TuyaReportingPeriod,
+            entity_type=EntityType.CONFIG,
+            translation_key="reporting_interval",
+            fallback_name="Reporting Interval",
+        )        
+        # Warning - type is bitmap16, TBD.
+        #.tuya_dp(
+        #  dp_id=5
+        #) 
+        # DP=16, Meter ID, type string?
+        #.tuya_dp(
+        #  dp_id=18
+        #)
+        # Reverse Water Consumption, Type raw?
+        #.tuya_metering(
+        #    dp_id=18, scale=0.0001, type=TuyaValveWaterConsumed
+        #)  
+        # Flow rate
+        .tuya_dp(
+            dp_id=21,
+            ep_attribute=TuyaValveWaterConsumed.ep_attribute,
+            attribute_name=Metering.AttributeDefs.instantaneous_demand.name,
+        )        
+        # Working temperature
+        .tuya_temperature(dp_id=22, scale=1.)
+        # Power supply volatage
+        .tuya_sensor(
+            dp_id=26,
+            attribute_name="voltage",
+            type=t.uint16_t,
+            converter=lambda x: x / 100,
+            device_class=SensorDeviceClass.VOLTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
+            unit=UnitOfElectricPotential.VOLT,
+            entity_type=EntityType.STANDARD,
+            fallback_name="Voltage",
+        )
+        .skip_configuration()
+        .add_to_registry()
+)

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -768,10 +768,11 @@ class GiexIrrigationStatus(t.enum8):
     .add_to_registry()
 )
 
-# Tuya 213E Ultrasonic water meter 
-# while strictly speaking not a valve, the ultrasonic flow meter is similar to other 
+# Tuya 213E Ultrasonic water meter
+# while strictly speaking not a valve, the ultrasonic flow meter is similar to other
 # devices defined here.
 # Setting the reporting period should also be applicable to other devices (e.g. 214C)
+
 
 class TuyaReportingPeriod(t.enum8):
     """Tuya Reporting period enum."""
@@ -785,59 +786,59 @@ class TuyaReportingPeriod(t.enum8):
     reporting_12h = 0x06
     reporting_24h = 0x07
 
+
 (
     TuyaQuirkBuilder("_TZE200_ajlu4cud", "TS0601")
-        # Total consumption in liters
-        .tuya_metering(
-            dp_id=1, metering_cfg=TuyaValveWaterConsumed)
-        # Month consumption
-        #.tuya_metering(
-        #    dp_id=2, scale=0.0001, type=TuyaValveWaterConsumed
-        #)  # per z2m reports in fl oz, convert to liters
-        # Daily consumption
-        #.tuya_metering(
-        #    dp_id=3, scale=0.0001, type=TuyaValveWaterConsumed
-        #)  
-        .tuya_enum(
-            dp_id=4,
-            attribute_name="reporting_interval",
-            enum_class=TuyaReportingPeriod,
-            entity_type=EntityType.CONFIG,
-            translation_key="reporting_interval",
-            fallback_name="Reporting Interval",
-        )        
-        # Warning - type is bitmap16, TBD.
-        #.tuya_dp(
-        #  dp_id=5
-        #) 
-        # DP=16, Meter ID, type string?
-        #.tuya_dp(
-        #  dp_id=18
-        #)
-        # Reverse Water Consumption, Type raw?
-        #.tuya_metering(
-        #    dp_id=18, scale=0.0001, type=TuyaValveWaterConsumed
-        #)  
-        # Flow rate
-        .tuya_dp(
-            dp_id=21,
-            ep_attribute=TuyaValveWaterConsumed.ep_attribute,
-            attribute_name=Metering.AttributeDefs.instantaneous_demand.name,
-        )        
-        # Working temperature
-        .tuya_temperature(dp_id=22, scale=1.)
-        # Power supply volatage
-        .tuya_sensor(
-            dp_id=26,
-            attribute_name="voltage",
-            type=t.uint16_t,
-            converter=lambda x: x / 100,
-            device_class=SensorDeviceClass.VOLTAGE,
-            state_class=SensorStateClass.MEASUREMENT,
-            unit=UnitOfElectricPotential.VOLT,
-            entity_type=EntityType.STANDARD,
-            fallback_name="Voltage",
-        )
-        .skip_configuration()
-        .add_to_registry()
+    # Total consumption in liters
+    .tuya_metering(dp_id=1, metering_cfg=TuyaValveWaterConsumed)
+    # Month consumption
+    # .tuya_metering(
+    #    dp_id=2, scale=0.0001, type=TuyaValveWaterConsumed
+    # )  # per z2m reports in fl oz, convert to liters
+    # Daily consumption
+    # .tuya_metering(
+    #    dp_id=3, scale=0.0001, type=TuyaValveWaterConsumed
+    # )
+    .tuya_enum(
+        dp_id=4,
+        attribute_name="reporting_interval",
+        enum_class=TuyaReportingPeriod,
+        entity_type=EntityType.CONFIG,
+        translation_key="reporting_interval",
+        fallback_name="Reporting Interval",
+    )
+    # Warning - type is bitmap16, TBD.
+    # .tuya_dp(
+    #  dp_id=5
+    # )
+    # DP=16, Meter ID, type string?
+    # .tuya_dp(
+    #  dp_id=18
+    # )
+    # Reverse Water Consumption, Type raw?
+    # .tuya_metering(
+    #    dp_id=18, scale=0.0001, type=TuyaValveWaterConsumed
+    # )
+    # Flow rate
+    .tuya_dp(
+        dp_id=21,
+        ep_attribute=TuyaValveWaterConsumed.ep_attribute,
+        attribute_name=Metering.AttributeDefs.instantaneous_demand.name,
+    )
+    # Working temperature
+    .tuya_temperature(dp_id=22, scale=1.0)
+    # Power supply volatage
+    .tuya_sensor(
+        dp_id=26,
+        attribute_name="voltage",
+        type=t.uint16_t,
+        converter=lambda x: x / 100,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricPotential.VOLT,
+        entity_type=EntityType.STANDARD,
+        fallback_name="Voltage",
+    )
+    .skip_configuration()
+    .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
while not a valve and just a meter, it is very similar to other devices defined in tuya_valve.py. It allows setting the reporting period, which should also be applicable to 214C, but as I don't have this device I didn't add it to the 214C quirk.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
