### PR TITLE
Begin migrating simple v1 quirks to v2

### DIFF
--- a/zhaquirks/bitron/thermostat.py
+++ b/zhaquirks/bitron/thermostat.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Basic,
     Identify,
@@ -36,54 +37,8 @@ class Av201032PowerConfigurationCluster(PowerConfigurationCluster):
     MAX_VOLTS = 3.0
 
 
-class Av201032(CustomDevice):
-    """Class for the AV2010/32 thermostat."""
-
-    signature = {
-        # SizePrefixedSimpleDescriptor(
-        #   endpoint=1,
-        #   profile=260,
-        #   device_type=769,
-        #   device_version=0,
-        #   input_clusters=[0, 1, 3, 10, 32, 513, 516, 2821],
-        #   output_clusters=[3, 25]
-        # )
-        MODELS_INFO: [(BITRON, "902010/32")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.THERMOSTAT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Time.cluster_id,
-                    PollControl.cluster_id,
-                    Thermostat.cluster_id,
-                    UserInterface.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.THERMOSTAT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Av201032PowerConfigurationCluster,
-                    Identify.cluster_id,
-                    Time.cluster_id,
-                    PollControl.cluster_id,
-                    Thermostat.cluster_id,
-                    UserInterface.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        },
-    }
+(
+    QuirkBuilder(BITRON, "902010/32")
+    .replaces(replacement_cluster_class=Av201032PowerConfigurationCluster)
+    .add_to_registry()
+)

--- a/zhaquirks/bitron/thermostat.py
+++ b/zhaquirks/bitron/thermostat.py
@@ -1,29 +1,9 @@
 """Module for Bitron/SMaBiT thermostats."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Identify,
-    Ota,
-    PollControl,
-    PowerConfiguration,
-    Time,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 
 from zhaquirks import PowerConfigurationCluster
 from zhaquirks.bitron import BITRON
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 
 
 class Av201032PowerConfigurationCluster(PowerConfigurationCluster):

--- a/zhaquirks/bosch/motion.py
+++ b/zhaquirks/bosch/motion.py
@@ -1,23 +1,9 @@
 """Device handler for Bosch motion sensors."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import Basic, Identify, Ota, PollControl
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.measurement import TemperatureMeasurement
-from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
 from zhaquirks.bosch import BOSCH
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 
 
 class BoschPowerConfiguration(PowerConfigurationCluster):

--- a/zhaquirks/bosch/motion.py
+++ b/zhaquirks/bosch/motion.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PollControl
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
@@ -26,46 +27,8 @@ class BoschPowerConfiguration(PowerConfigurationCluster):
     MIN_VOLTS = 1.9
 
 
-class ISWZPR1WP13(CustomDevice):
-    """Custom device representing Bosch motion sensors."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        #  device_version=0
-        #  input_clusters=[0, 1, 3, 1026, 1280, 32, 2821]
-        #  output_clusters=[25]>
-        MODELS_INFO: [(BOSCH, "ISW-ZPR1-WP13")],
-        ENDPOINTS: {
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            5: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    BoschPowerConfiguration,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(BOSCH, "ISW-ZPR1-WP13")
+    .replaces(replacement_cluster_class=BoschPowerConfiguration, endpoint_id=5)
+    .add_to_registry()
+)

--- a/zhaquirks/centralite/cl_3310S.py
+++ b/zhaquirks/centralite/cl_3310S.py
@@ -1,24 +1,12 @@
 """Centralite 3310S implementation."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, Identify, Ota, PollControl
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 from zhaquirks import PowerConfigurationCluster
 from zhaquirks.centralite import CENTRALITE
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 
 SMRT_THINGS_REL_HUM_CLSTR = 0xFC45
 
@@ -43,7 +31,13 @@ class SmartthingsRelativeHumidityCluster(CustomCluster):
     QuirkBuilder(CENTRALITE, "3310-G")
     .applies_to(CENTRALITE, "3310-S")
     .applies_to(CENTRALITE, "3310")
-    .replaces(replacement_cluster_class=PowerConfigurationCluster, cluster_id=PowerConfigurationCluster.cluster_id)
-    .replaces(replacement_cluster_class=SmartthingsRelativeHumidityCluster, cluster_id=SMRT_THINGS_REL_HUM_CLSTR)
+    .replaces(
+        replacement_cluster_class=PowerConfigurationCluster,
+        cluster_id=PowerConfigurationCluster.cluster_id,
+    )
+    .replaces(
+        replacement_cluster_class=SmartthingsRelativeHumidityCluster,
+        cluster_id=SMRT_THINGS_REL_HUM_CLSTR,
+    )
     .add_to_registry()
 )

--- a/zhaquirks/centralite/cl_3310S.py
+++ b/zhaquirks/centralite/cl_3310S.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PollControl
 from zigpy.zcl.clusters.homeautomation import Diagnostic
@@ -38,50 +39,11 @@ class SmartthingsRelativeHumidityCluster(CustomCluster):
         )
 
 
-class CentraLite3310S(CustomDevice):
-    """CentraLite3310S custom device implementation."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=770
-        #  device_version=0
-        #  input_clusters=[0, 1, 3, 32, 1026, 2821, 64581]
-        #  output_clusters=[3, 25]>
-        MODELS_INFO: [
-            (CENTRALITE, "3310-G"),
-            (CENTRALITE, "3310-S"),
-            (CENTRALITE, "3310"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.TEMPERATURE_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    Diagnostic.cluster_id,
-                    SmartthingsRelativeHumidityCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    Diagnostic.cluster_id,
-                    SmartthingsRelativeHumidityCluster,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(CENTRALITE, "3310-G")
+    .applies_to(CENTRALITE, "3310-S")
+    .applies_to(CENTRALITE, "3310")
+    .replaces(replacement_cluster_class=PowerConfigurationCluster, cluster_id=PowerConfigurationCluster.cluster_id)
+    .replaces(replacement_cluster_class=SmartthingsRelativeHumidityCluster, cluster_id=SMRT_THINGS_REL_HUM_CLSTR)
+    .add_to_registry()
+)

--- a/zhaquirks/centralite/motion.py
+++ b/zhaquirks/centralite/motion.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PollControl
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
@@ -22,75 +23,11 @@ MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFC46  # decimal = 64582
 MANUFACTURER_SPECIFIC_PROFILE_ID = 0xC2DF  # decimal = 49887
 
 
-class CentraLiteMotionSensor(CustomDevice):
-    """Custom device representing centralite motion (only) sensors."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        #  device_version=0
-        #  input_clusters=[0, 1, 3, 1026, 1280, 32, 2821]
-        #  output_clusters=[25]>
-        MODELS_INFO: [
-            (CENTRALITE, "3305-S"),
-            (CENTRALITE, "3325-S"),
-            (CENTRALITE, "3326-L"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-            #  <SimpleDescriptor endpoint=2 profile=49887 device_type=263
-            #  device_version=0
-            #  input_clusters=[0, 1, 3, 2821, 64582]
-            #  output_clusters=[3]>
-            2: {
-                PROFILE_ID: MANUFACTURER_SPECIFIC_PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
-                    Identify.cluster_id,
-                    Diagnostic.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-            2: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Diagnostic.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id],
-            },
-        }
-    }
+(
+    QuirkBuilder(CENTRALITE, "3305-S")
+    .applies_to(CENTRALITE, "3325-S")
+    .applies_to(CENTRALITE, "3326-L")
+    .replaces(replacement_cluster_class=PowerConfigurationCluster, endpoint_id=1)
+    .removes(cluster_id=PowerConfigurationCluster.cluster_id, endpoint_id=2)
+    .add_to_registry()
+)

--- a/zhaquirks/centralite/motion.py
+++ b/zhaquirks/centralite/motion.py
@@ -1,23 +1,9 @@
 """Device handler for centralite motion (only) sensors."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import Basic, Identify, Ota, PollControl
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.measurement import TemperatureMeasurement
-from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
 from zhaquirks.centralite import CENTRALITE
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 
 MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFC46  # decimal = 64582
 MANUFACTURER_SPECIFIC_PROFILE_ID = 0xC2DF  # decimal = 49887

--- a/zhaquirks/echostar/bell.py
+++ b/zhaquirks/echostar/bell.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Alarms,
     Basic,
@@ -33,56 +34,14 @@ MANUFACTURER = " Echostar"
 MODEL = "   Bell"
 
 
-class Bell(CustomDevice):
-    """Echostar Bell device."""
 
-    signature = {
-        # <SimpleDescriptor endpoint=18 profile=260 device_type=260
-        # device_version=0
-        # input_clusters=[0, 3, 9, 1]
-        # output_clusters=[3, 6, 8, 25]>
-        MODELS_INFO: [(MANUFACTURER, MODEL)],
-        ENDPOINTS: {
-            18: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Alarms.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                ],
-            }
-        },
-    }
 
-    replacement = {
-        ENDPOINTS: {
-            18: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Alarms.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                ],
-            }
-        }
-    }
-    device_automation_triggers = {
+(
+    QuirkBuilder(" Echostar", "   Bell")
+    .replaces_endpoint(endpoint_id=18, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.ON_OFF_SWITCH)
+    .device_automation_triggers({
         (SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 18},
         (SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 18},
-    }
+    })
+    .add_to_registry()
+)

--- a/zhaquirks/echostar/bell.py
+++ b/zhaquirks/echostar/bell.py
@@ -1,17 +1,7 @@
 """Echostar Sage Doorbell Sensor Device."""
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import (
-    Alarms,
-    Basic,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    PowerConfiguration,
-)
 
 from zhaquirks.const import (
     BUTTON_1,
@@ -20,13 +10,7 @@ from zhaquirks.const import (
     COMMAND,
     COMMAND_OFF,
     COMMAND_ON,
-    DEVICE_TYPE,
     ENDPOINT_ID,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
     SHORT_PRESS,
 )
 
@@ -34,14 +18,26 @@ MANUFACTURER = " Echostar"
 MODEL = "   Bell"
 
 
-
-
 (
     QuirkBuilder(" Echostar", "   Bell")
-    .replaces_endpoint(endpoint_id=18, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.ON_OFF_SWITCH)
-    .device_automation_triggers({
-        (SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 18},
-        (SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 18},
-    })
+    .replaces_endpoint(
+        endpoint_id=18,
+        profile_id=zha.PROFILE_ID,
+        device_type=zha.DeviceType.ON_OFF_SWITCH,
+    )
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, BUTTON_1): {
+                COMMAND: COMMAND_ON,
+                CLUSTER_ID: 6,
+                ENDPOINT_ID: 18,
+            },
+            (SHORT_PRESS, BUTTON_2): {
+                COMMAND: COMMAND_OFF,
+                CLUSTER_ID: 6,
+                ENDPOINT_ID: 18,
+            },
+        }
+    )
     .add_to_registry()
 )

--- a/zhaquirks/ecolink/contact.py
+++ b/zhaquirks/ecolink/contact.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PollControl
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement

--- a/zhaquirks/ecolink/contact.py
+++ b/zhaquirks/ecolink/contact.py
@@ -1,22 +1,8 @@
 """Ecolink 4655BC0-R device."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import Basic, Identify, Ota, PollControl
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.measurement import TemperatureMeasurement
-from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 
 
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):

--- a/zhaquirks/ecolink/contact.py
+++ b/zhaquirks/ecolink/contact.py
@@ -26,47 +26,8 @@ class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     MAX_VOLTS = 3.0
 
 
-class Ecolink4655BC0R(CustomDevice):
-    """Ecolink 4655BC0-R device."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        # device_version=0
-        # input_clusters=[0, 1, 3, 32, 1026, 1280, 2821]
-        # output_clusters=[25]>
-        MODELS_INFO: [("Ecolink", "4655BC0-R")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    CustomPowerConfigurationCluster.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    CustomPowerConfigurationCluster,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder("Ecolink", "4655BC0-R")
+    .replaces(replacement_cluster_class=CustomPowerConfigurationCluster)
+    .add_to_registry()
+)

--- a/zhaquirks/edpwithus/redy_plug.py
+++ b/zhaquirks/edpwithus/redy_plug.py
@@ -1,26 +1,17 @@
 """EDP WithUs SmartPlug Quirk."""
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import (
-    Alarms,
-    Basic,
-    Groups,
-    Identify,
-    OnOff,
-    Ota,
-    Scenes,
-    Time,
-)
-from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.edpwithus import MeteringCluster
 
-
 (
-    QuirkBuilder("EDP-WITHUS", "REDY")
-    .replaces_endpoint(endpoint_id=85, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.ON_OFF_PLUG_IN_UNIT)
+    QuirkBuilder("EDP-WITHUS", "REDY")  # codespell:ignore
+    .replaces_endpoint(
+        endpoint_id=85,
+        profile_id=zha.PROFILE_ID,
+        device_type=zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
+    )
     .replaces(replacement_cluster_class=MeteringCluster, endpoint_id=85)
     .add_to_registry()
 )

--- a/zhaquirks/edpwithus/redy_plug.py
+++ b/zhaquirks/edpwithus/redy_plug.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Alarms,
     Basic,
@@ -17,49 +18,9 @@ from zigpy.zcl.clusters.smartenergy import Metering
 from zhaquirks.edpwithus import MeteringCluster
 
 
-class EdpWithUsSmartPlug(CustomDevice):
-    """Tradfri Plug."""
-
-    signature = {
-        "endpoints": {
-            # <SimpleDescriptor endpoint=85 profile=260 device_type=9
-            # device_version=0
-            # input_clusters=[0, 3, 4, 5, 6, 9, 10, 1794] output_clusters=[25]>
-            85: {
-                "profile_id": zha.PROFILE_ID,
-                "device_type": zha.DeviceType.MAIN_POWER_OUTLET,
-                "input_clusters": [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    Alarms.cluster_id,
-                    Time.cluster_id,
-                    Metering.cluster_id,
-                ],
-                "output_clusters": [Ota.cluster_id],
-            }
-        },
-        "manufacturer": "EDP-WITHUS",
-    }
-
-    replacement = {
-        "endpoints": {
-            85: {
-                "profile_id": zha.PROFILE_ID,
-                "device_type": zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
-                "input_clusters": [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    Alarms.cluster_id,
-                    Time.cluster_id,
-                    MeteringCluster,
-                ],
-                "output_clusters": [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder("EDP-WITHUS", "REDY")
+    .replaces_endpoint(endpoint_id=85, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.ON_OFF_PLUG_IN_UNIT)
+    .replaces(replacement_cluster_class=MeteringCluster, endpoint_id=85)
+    .add_to_registry()
+)

--- a/zhaquirks/heiman/smoke.py
+++ b/zhaquirks/heiman/smoke.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Alarms,
     Basic,
@@ -26,330 +27,53 @@ from zhaquirks.const import (
 from zhaquirks.heiman import HEIMAN
 
 
-class HeimanSmokYDLV10(CustomDevice):
-    """YDLV10 quirk."""
-
-    # NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=132,
-    # manufacturer_code=48042, maximum_buffer_size=64, maximum_incoming_transfer_size=0,
-    # server_mask=0, maximum_outgoing_transfer_size=0, descriptor_capability_field=3)
-    # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=1026,
-    # device_version=0, input_clusters=[0, 3, 1280, 1, 9, 1282], output_clusters=[25])
-    signature = {
-        MODELS_INFO: [(HEIMAN, "SMOK_YDLV10")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Alarms.cluster_id,
-                    IasZone.cluster_id,
-                    IasWd.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: zigpy.zdo.types.NodeDescriptor(
-            0x02, 0x40, 0x84 & 0b1111_1011, 0xBBAA, 0x40, 0x0000, 0x0000, 0x0000, 0x03
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Alarms.cluster_id,
-                    IasZone.cluster_id,
-                    IasWd.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
 
 
-class HeimanSmokCO_V15(CustomDevice):
-    """CO_V15 quirk."""
-
-    # NodeDescriptor(
-    #     logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0,
-    #     frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|MainsPowered: 132>,
-    #     manufacturer_code=48042, maximum_buffer_size=64, maximum_incoming_transfer_size=0, server_mask=0, maximum_outgoing_transfer_size=0,
-    #     descriptor_capability_field=<DescriptorCapability.ExtendedSimpleDescriptorListAvailable|ExtendedActiveEndpointListAvailable: 3>,
-    #     *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False,
-    #     *is_mains_powered=True, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False
-    # )"
-    signature = {
-        MODELS_INFO: [(HEIMAN, "CO_V15")],
-        ENDPOINTS: {
-            # "profile_id": 260,"device_type": "0x0402",
-            # "in_clusters": ["0x0000","0x0001","0x0003","0x0009","0x0500"],
-            # "out_clusters": ["0x0019"]
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Alarms.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: zigpy.zdo.types.NodeDescriptor(
-            0x02, 0x40, 0x84 & 0b1111_1011, 0xBBAA, 0x40, 0x0000, 0x0000, 0x0000, 0x03
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Alarms.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
 
 
-class HeimanSmokCO_CTPG(CustomDevice):
-    """CO_CTPG quirk."""
-
-    signature = {
-        MODELS_INFO: [(HEIMAN, "CO_CTPG")],
-        ENDPOINTS: {
-            1: {
-                # "profile_id": 260,
-                # "device_type": "0x0402",
-                # "in_clusters": ["0x0000","0x0001","0x0003","0x0009","0x0500"]
-                # "out_clusters": ["0x0019"]
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Alarms.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: zigpy.zdo.types.NodeDescriptor(
-            logical_type=2,
-            complex_descriptor_available=0,
-            user_descriptor_available=0,
-            reserved=0,
-            aps_flags=0,
-            frequency_band=8,
-            mac_capability_flags=132 & 0b1111_1011,
-            manufacturer_code=4627,
-            maximum_buffer_size=64,
-            maximum_incoming_transfer_size=0,
-            server_mask=0,
-            maximum_outgoing_transfer_size=0,
-            descriptor_capability_field=3,
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Alarms.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
 
 
-class HeimanSmokeN30(CustomDevice):
-    """SmokeN30 quirk."""
+# Node descriptor for SMOK_YDLV10 and CO_V15
+node_descriptor_1 = zigpy.zdo.types.NodeDescriptor(
+    0x02, 0x40, 0x84 & 0b1111_1011, 0xBBAA, 0x40, 0x0000, 0x0000, 0x0000, 0x03
+)
 
-    # NodeDescriptor(
-    #     logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0,
-    #     frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>,
-    #     manufacturer_code=4619, maximum_buffer_size=127, maximum_incoming_transfer_size=100, server_mask=11264, maximum_outgoing_transfer_size=100,
-    #     descriptor_capability_field=<DescriptorCapability.NONE: 0>,
-    #     *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False,
-    #     *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)
-    signature = {
-        MODELS_INFO: [("HEIMAN", "SmokeSensor-N-3.0")],
-        ENDPOINTS: {
-            # "profile_id": 260,"device_type": "0x0402",
-            # "in_clusters": ["0x0000","0x0001","0x0003","0x0500","0x0502","0x0b05"],
-            # "out_clusters": ["0x0019"]
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    IasZone.cluster_id,
-                    IasWd.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
+# Node descriptor for CO_CTPG
+node_descriptor_2 = zigpy.zdo.types.NodeDescriptor(
+    logical_type=2,
+    complex_descriptor_available=0,
+    user_descriptor_available=0,
+    reserved=0,
+    aps_flags=0,
+    frequency_band=8,
+    mac_capability_flags=132 & 0b1111_1011,
+    manufacturer_code=4627,
+    maximum_buffer_size=64,
+    maximum_incoming_transfer_size=0,
+    server_mask=0,
+    maximum_outgoing_transfer_size=0,
+    descriptor_capability_field=3,
+)
 
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    IasZone.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
+(
+    QuirkBuilder(HEIMAN, "SMOK_YDLV10")
+    .applies_to(HEIMAN, "CO_V15")
+    .removes(cluster_id=IasWd.cluster_id, endpoint_id=1)
+    .node_descriptor(node_descriptor_1)
+    .add_to_registry()
+)
 
+(
+    QuirkBuilder(HEIMAN, "CO_CTPG")
+    .removes(cluster_id=IasWd.cluster_id, endpoint_id=1)
+    .node_descriptor(node_descriptor_2)
+    .add_to_registry()
+)
 
-class HeimanSmokeEF30(CustomDevice):
-    """SmokeEF30 quirk."""
-
-    # NodeDescriptor(
-    #     logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0,
-    #     frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>,
-    #     manufacturer_code=4619, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82,
-    #     descriptor_capability_field=<DescriptorCapability.NONE: 0>,
-    #     *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False,
-    #     *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)
-    signature = {
-        MODELS_INFO: [("HEIMAN", "SmokeSensor-EF-3.0")],
-        ENDPOINTS: {
-            # "profile_id": "0x0104", "device_type": "0x0402",
-            # "input_clusters": ["0x0000", "0x0001", "0x0003", "0x0020", "0x0500", "0x0502", "0x0b05"],
-            # "output_clusters": ["0x0003", "0x0019"]
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    IasZone.cluster_id,
-                    IasWd.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    IasZone.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
-
-
-class HeimanSmokeEM(CustomDevice):
-    """SmokeEM quirk."""
-
-    signature = {
-        MODELS_INFO: [("HEIMAN", "SmokeSensor-EM")],
-        ENDPOINTS: {
-            # "profile_id": "0x0104", "device_type": "0x0402",
-            # "input_clusters": ["0x0000", "0x0001", "0x0003", "0x0500", "0x0502"],
-            # "output_clusters": ["0x0019"]
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    IasZone.cluster_id,
-                    IasWd.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
+(
+    QuirkBuilder("HEIMAN", "SmokeSensor-N-3.0")
+    .applies_to("HEIMAN", "SmokeSensor-EF-3.0")
+    .applies_to("HEIMAN", "SmokeSensor-EM")
+    .removes(cluster_id=IasWd.cluster_id, endpoint_id=1)
+    .add_to_registry()
+)

--- a/zhaquirks/heiman/smoke.py
+++ b/zhaquirks/heiman/smoke.py
@@ -1,37 +1,10 @@
 """Smoke Sensor."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import (
-    Alarms,
-    Basic,
-    Identify,
-    Ota,
-    PollControl,
-    PowerConfiguration,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.security import IasWd, IasZone
+from zigpy.zcl.clusters.security import IasWd
 import zigpy.zdo.types
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    NODE_DESCRIPTOR,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.heiman import HEIMAN
-
-
-
-
-
-
-
 
 # Node descriptor for SMOK_YDLV10 and CO_V15
 node_descriptor_1 = zigpy.zdo.types.NodeDescriptor(

--- a/zhaquirks/hivehome/mot003V0.py
+++ b/zhaquirks/hivehome/mot003V0.py
@@ -1,31 +1,16 @@
 """Device handler for hivehome.com MOT003 sensors."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Identify,
-    Ota,
-    PollControl,
-    PowerConfiguration,
-)
-from zigpy.zcl.clusters.measurement import OccupancySensing, TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.hivehome import HIVEHOME, MotionCluster
-
 
 (
     QuirkBuilder(HIVEHOME, "MOT003")
-    .replaces(replacement_cluster_class=MotionCluster, cluster_id=IasZone.cluster_id, endpoint_id=6)
+    .replaces(
+        replacement_cluster_class=MotionCluster,
+        cluster_id=IasZone.cluster_id,
+        endpoint_id=6,
+    )
     .add_to_registry()
 )

--- a/zhaquirks/hivehome/mot003V0.py
+++ b/zhaquirks/hivehome/mot003V0.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Basic,
     Identify,
@@ -23,46 +24,8 @@ from zhaquirks.const import (
 from zhaquirks.hivehome import HIVEHOME, MotionCluster
 
 
-class MOT003(CustomDevice):
-    """hivehome.com MOT003."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=6 profile=260 device_type=1026
-        # device_version=0
-        # input_clusters=[0, 1, 3, 32, 1026, 1030, 1280]
-        # output_clusters=[25]>
-        MODELS_INFO: [(HIVEHOME, "MOT003")],
-        ENDPOINTS: {
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    OccupancySensing.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            6: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    OccupancySensing.cluster_id,
-                    MotionCluster,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(HIVEHOME, "MOT003")
+    .replaces(replacement_cluster_class=MotionCluster, cluster_id=IasZone.cluster_id, endpoint_id=6)
+    .add_to_registry()
+)

--- a/zhaquirks/icasa/iczb_kpd12.py
+++ b/zhaquirks/icasa/iczb_kpd12.py
@@ -1,20 +1,6 @@
 """icasa KPD12 device."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    PowerConfiguration,
-    Scenes,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.lighting import Color
-from zigpy.zcl.clusters.lightlink import LightLink
+from zigpy.quirks.v2 import QuirkBuilder
 
 from zhaquirks.const import (
     BUTTON,
@@ -24,104 +10,49 @@ from zhaquirks.const import (
     COMMAND_OFF,
     COMMAND_ON,
     COMMAND_STOP,
-    DEVICE_TYPE,
     DIM_DOWN,
     DIM_UP,
     ENDPOINT_ID,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
     LONG_PRESS,
     LONG_RELEASE,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
     PARAMS,
-    PROFILE_ID,
     SHORT_PRESS,
     TURN_OFF,
     TURN_ON,
 )
 
-
-class IcasaKPD12(CustomDevice):
-    """icasa KPD12 device (looks like a white label Sunricher)."""
-
-    signature = {
-        MODELS_INFO: [("icasa", "ICZB-KPD12")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    Color.cluster_id,
-                    LightLink.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    Color.cluster_id,
-                    LightLink.cluster_id,
-                ],
-            }
+(
+    QuirkBuilder("icasa", "ICZB-KPD12")
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, TURN_ON): {
+                COMMAND: COMMAND_ON,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 6,
+            },
+            (LONG_PRESS, DIM_UP): {
+                COMMAND: COMMAND_MOVE_ON_OFF,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 8,
+                PARAMS: {"move_mode": 0, "rate": 50},
+            },
+            (LONG_RELEASE, BUTTON): {
+                COMMAND: COMMAND_STOP,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 8,
+            },
+            (SHORT_PRESS, TURN_OFF): {
+                COMMAND: COMMAND_OFF,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 6,
+            },
+            (LONG_PRESS, DIM_DOWN): {
+                COMMAND: COMMAND_MOVE_ON_OFF,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 8,
+                PARAMS: {"move_mode": 1, "rate": 50},
+            },
         }
-    }
-
-    device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {
-            COMMAND: COMMAND_ON,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 6,
-        },
-        (LONG_PRESS, DIM_UP): {
-            COMMAND: COMMAND_MOVE_ON_OFF,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 8,
-            PARAMS: {"move_mode": 0, "rate": 50},
-        },
-        (LONG_RELEASE, BUTTON): {
-            COMMAND: COMMAND_STOP,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 8,
-        },
-        (SHORT_PRESS, TURN_OFF): {
-            COMMAND: COMMAND_OFF,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 6,
-        },
-        (LONG_PRESS, DIM_DOWN): {
-            COMMAND: COMMAND_MOVE_ON_OFF,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 8,
-            PARAMS: {"move_mode": 1, "rate": 50},
-        },
-    }
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/icasa/iczb_kpd14s.py
+++ b/zhaquirks/icasa/iczb_kpd14s.py
@@ -1,21 +1,6 @@
 """icasa KPD14S device."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    PowerConfiguration,
-    Scenes,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.lighting import Color
-from zigpy.zcl.clusters.lightlink import LightLink
 
 from zhaquirks.const import (
     BUTTON,
@@ -29,78 +14,73 @@ from zhaquirks.const import (
     COMMAND_RECALL,
     COMMAND_STOP,
     COMMAND_STORE,
-    DEVICE_TYPE,
     DIM_DOWN,
     DIM_UP,
     ENDPOINT_ID,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
     LONG_PRESS,
     LONG_RELEASE,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
     PARAMS,
-    PROFILE_ID,
     SHORT_PRESS,
     TURN_OFF,
     TURN_ON,
 )
 
-
 (
     QuirkBuilder("icasa", "ICZB-KPD14S")
-    .device_automation_triggers({
-        (SHORT_PRESS, TURN_ON): {
-            COMMAND: COMMAND_ON,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 6,
-        },
-        (LONG_PRESS, DIM_UP): {
-            COMMAND: COMMAND_MOVE_ON_OFF,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 8,
-            PARAMS: {"move_mode": 0, "rate": 50},
-        },
-        (LONG_RELEASE, BUTTON): {
-            COMMAND: COMMAND_STOP,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 8,
-        },
-        (SHORT_PRESS, TURN_OFF): {
-            COMMAND: COMMAND_OFF,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 6,
-        },
-        (LONG_PRESS, DIM_DOWN): {
-            COMMAND: COMMAND_MOVE_ON_OFF,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 8,
-            PARAMS: {"move_mode": 1, "rate": 50},
-        },
-        (SHORT_PRESS, BUTTON_1): {
-            COMMAND: COMMAND_RECALL,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 1},
-        },
-        (SHORT_PRESS, BUTTON_2): {
-            COMMAND: COMMAND_RECALL,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 2},
-        },
-        (LONG_PRESS, BUTTON_1): {
-            COMMAND: COMMAND_STORE,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 1},
-        },
-        (LONG_PRESS, BUTTON_2): {
-            COMMAND: COMMAND_STORE,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 2},
-        },
-    })
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, TURN_ON): {
+                COMMAND: COMMAND_ON,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 6,
+            },
+            (LONG_PRESS, DIM_UP): {
+                COMMAND: COMMAND_MOVE_ON_OFF,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 8,
+                PARAMS: {"move_mode": 0, "rate": 50},
+            },
+            (LONG_RELEASE, BUTTON): {
+                COMMAND: COMMAND_STOP,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 8,
+            },
+            (SHORT_PRESS, TURN_OFF): {
+                COMMAND: COMMAND_OFF,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 6,
+            },
+            (LONG_PRESS, DIM_DOWN): {
+                COMMAND: COMMAND_MOVE_ON_OFF,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 8,
+                PARAMS: {"move_mode": 1, "rate": 50},
+            },
+            (SHORT_PRESS, BUTTON_1): {
+                COMMAND: COMMAND_RECALL,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 1},
+            },
+            (SHORT_PRESS, BUTTON_2): {
+                COMMAND: COMMAND_RECALL,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 2},
+            },
+            (LONG_PRESS, BUTTON_1): {
+                COMMAND: COMMAND_STORE,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 1},
+            },
+            (LONG_PRESS, BUTTON_2): {
+                COMMAND: COMMAND_STORE,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 2},
+            },
+        }
+    )
     .add_to_registry()
 )

--- a/zhaquirks/icasa/iczb_kpd14s.py
+++ b/zhaquirks/icasa/iczb_kpd14s.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -46,61 +47,9 @@ from zhaquirks.const import (
 )
 
 
-class IcasaKPD14S(CustomDevice):
-    """icasa KPD14S device (looks like a white label Sunricher)."""
-
-    signature = {
-        MODELS_INFO: [("icasa", "ICZB-KPD14S")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    Color.cluster_id,
-                    LightLink.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    Color.cluster_id,
-                    LightLink.cluster_id,
-                ],
-            }
-        }
-    }
-
-    device_automation_triggers = {
+(
+    QuirkBuilder("icasa", "ICZB-KPD14S")
+    .device_automation_triggers({
         (SHORT_PRESS, TURN_ON): {
             COMMAND: COMMAND_ON,
             ENDPOINT_ID: 1,
@@ -152,4 +101,6 @@ class IcasaKPD14S(CustomDevice):
             CLUSTER_ID: 5,
             PARAMS: {"group_id": 0, "scene_id": 2},
         },
-    }
+    })
+    .add_to_registry()
+)

--- a/zhaquirks/icasa/iczb_kpd18s.py
+++ b/zhaquirks/icasa/iczb_kpd18s.py
@@ -1,20 +1,6 @@
 """icasa KPD18S device."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    PowerConfiguration,
-    Scenes,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.lighting import Color
-from zigpy.zcl.clusters.lightlink import LightLink
+from zigpy.quirks.v2 import QuirkBuilder
 
 from zhaquirks.const import (
     BUTTON,
@@ -32,176 +18,121 @@ from zhaquirks.const import (
     COMMAND_RECALL,
     COMMAND_STOP,
     COMMAND_STORE,
-    DEVICE_TYPE,
     DIM_DOWN,
     DIM_UP,
     ENDPOINT_ID,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
     LONG_PRESS,
     LONG_RELEASE,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
     PARAMS,
-    PROFILE_ID,
     SHORT_PRESS,
     TURN_OFF,
     TURN_ON,
 )
 
-
-class IcasaKPD18S(CustomDevice):
-    """icasa KPD18S device (looks like a white label Sunricher)."""
-
-    signature = {
-        MODELS_INFO: [("icasa", "ICZB-KPD18S")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    Color.cluster_id,
-                    LightLink.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                    Color.cluster_id,
-                    LightLink.cluster_id,
-                ],
-            }
+(
+    QuirkBuilder("icasa", "ICZB-KPD18S")
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, TURN_ON): {
+                COMMAND: COMMAND_ON,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 6,
+            },
+            (LONG_PRESS, DIM_UP): {
+                COMMAND: COMMAND_MOVE_ON_OFF,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 8,
+                PARAMS: {"move_mode": 0, "rate": 50},
+            },
+            (LONG_RELEASE, BUTTON): {
+                COMMAND: COMMAND_STOP,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 8,
+            },
+            (SHORT_PRESS, TURN_OFF): {
+                COMMAND: COMMAND_OFF,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 6,
+            },
+            (LONG_PRESS, DIM_DOWN): {
+                COMMAND: COMMAND_MOVE_ON_OFF,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 8,
+                PARAMS: {"move_mode": 1, "rate": 50},
+            },
+            (SHORT_PRESS, BUTTON_1): {
+                COMMAND: COMMAND_RECALL,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 1},
+            },
+            (SHORT_PRESS, BUTTON_2): {
+                COMMAND: COMMAND_RECALL,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 2},
+            },
+            (SHORT_PRESS, BUTTON_3): {
+                COMMAND: COMMAND_RECALL,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 3},
+            },
+            (SHORT_PRESS, BUTTON_4): {
+                COMMAND: COMMAND_RECALL,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 4},
+            },
+            (SHORT_PRESS, BUTTON_5): {
+                COMMAND: COMMAND_RECALL,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 5},
+            },
+            (SHORT_PRESS, BUTTON_6): {
+                COMMAND: COMMAND_RECALL,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 6},
+            },
+            (LONG_PRESS, BUTTON_1): {
+                COMMAND: COMMAND_STORE,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 1},
+            },
+            (LONG_PRESS, BUTTON_2): {
+                COMMAND: COMMAND_STORE,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 2},
+            },
+            (LONG_PRESS, BUTTON_3): {
+                COMMAND: COMMAND_STORE,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 3},
+            },
+            (LONG_PRESS, BUTTON_4): {
+                COMMAND: COMMAND_STORE,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 4},
+            },
+            (LONG_PRESS, BUTTON_5): {
+                COMMAND: COMMAND_STORE,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 5},
+            },
+            (LONG_PRESS, BUTTON_6): {
+                COMMAND: COMMAND_STORE,
+                ENDPOINT_ID: 1,
+                CLUSTER_ID: 5,
+                PARAMS: {"group_id": 0, "scene_id": 6},
+            },
         }
-    }
-
-    device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {
-            COMMAND: COMMAND_ON,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 6,
-        },
-        (LONG_PRESS, DIM_UP): {
-            COMMAND: COMMAND_MOVE_ON_OFF,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 8,
-            PARAMS: {"move_mode": 0, "rate": 50},
-        },
-        (LONG_RELEASE, BUTTON): {
-            COMMAND: COMMAND_STOP,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 8,
-        },
-        (SHORT_PRESS, TURN_OFF): {
-            COMMAND: COMMAND_OFF,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 6,
-        },
-        (LONG_PRESS, DIM_DOWN): {
-            COMMAND: COMMAND_MOVE_ON_OFF,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 8,
-            PARAMS: {"move_mode": 1, "rate": 50},
-        },
-        (SHORT_PRESS, BUTTON_1): {
-            COMMAND: COMMAND_RECALL,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 1},
-        },
-        (SHORT_PRESS, BUTTON_2): {
-            COMMAND: COMMAND_RECALL,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 2},
-        },
-        (SHORT_PRESS, BUTTON_3): {
-            COMMAND: COMMAND_RECALL,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 3},
-        },
-        (SHORT_PRESS, BUTTON_4): {
-            COMMAND: COMMAND_RECALL,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 4},
-        },
-        (SHORT_PRESS, BUTTON_5): {
-            COMMAND: COMMAND_RECALL,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 5},
-        },
-        (SHORT_PRESS, BUTTON_6): {
-            COMMAND: COMMAND_RECALL,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 6},
-        },
-        (LONG_PRESS, BUTTON_1): {
-            COMMAND: COMMAND_STORE,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 1},
-        },
-        (LONG_PRESS, BUTTON_2): {
-            COMMAND: COMMAND_STORE,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 2},
-        },
-        (LONG_PRESS, BUTTON_3): {
-            COMMAND: COMMAND_STORE,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 3},
-        },
-        (LONG_PRESS, BUTTON_4): {
-            COMMAND: COMMAND_STORE,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 4},
-        },
-        (LONG_PRESS, BUTTON_5): {
-            COMMAND: COMMAND_STORE,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 5},
-        },
-        (LONG_PRESS, BUTTON_6): {
-            COMMAND: COMMAND_STORE,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 5,
-            PARAMS: {"group_id": 0, "scene_id": 6},
-        },
-    }
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/keenhome/sv02612mp13.py
+++ b/zhaquirks/keenhome/sv02612mp13.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -29,72 +30,18 @@ KEEN1_CLUSTER_ID = 0xFC01  # decimal = 64513
 KEEN2_CLUSTER_ID = 0xFC02  # decimal = 64514
 
 
-class KeenHomeSmartVent(CustomDevice):
-    """Custom device representing Keen Home Smart Vent."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=3
-        # device_version=0
-        # input_clusters=[
-        #   0, 1, 3, 4, 5, 6, 8, 32, 1026, 1027, 2821, 64513, 64514]
-        # output_clusters=[25]>
-        MODELS_INFO: [
-            ("Keen Home Inc", "SV01-410-MP-1.0"),
-            ("Keen Home Inc", "SV01-410-MP-1.1"),
-            ("Keen Home Inc", "SV01-410-MP-1.4"),
-            ("Keen Home Inc", "SV01-410-MP-1.5"),
-            ("Keen Home Inc", "SV02-410-MP-1.2"),
-            ("Keen Home Inc", "SV02-410-MP-1.3"),
-            ("Keen Home Inc", "SV01-412-MP-1.0"),
-            ("Keen Home Inc", "SV01-610-MP-1.0"),
-            ("Keen Home Inc", "SV02-610-MP-1.3"),
-            ("Keen Home Inc", "SV01-612-MP-1.0"),
-            ("Keen Home Inc", "SV02-612-MP-1.3"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROLLABLE_OUTPUT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    DoublingPowerConfigurationCluster.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    PressureMeasurement.cluster_id,
-                    Diagnostic.cluster_id,
-                    KEEN1_CLUSTER_ID,
-                    KEEN2_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    DoublingPowerConfigurationCluster,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    PressureMeasurement.cluster_id,
-                    Diagnostic.cluster_id,
-                    KEEN1_CLUSTER_ID,
-                    KEEN2_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder("Keen Home Inc", "SV01-410-MP-1.0")
+    .applies_to("Keen Home Inc", "SV01-410-MP-1.1")
+    .applies_to("Keen Home Inc", "SV01-410-MP-1.4")
+    .applies_to("Keen Home Inc", "SV01-410-MP-1.5")
+    .applies_to("Keen Home Inc", "SV02-410-MP-1.2")
+    .applies_to("Keen Home Inc", "SV02-410-MP-1.3")
+    .applies_to("Keen Home Inc", "SV01-412-MP-1.0")
+    .applies_to("Keen Home Inc", "SV01-610-MP-1.0")
+    .applies_to("Keen Home Inc", "SV02-610-MP-1.3")
+    .applies_to("Keen Home Inc", "SV01-612-MP-1.0")
+    .applies_to("Keen Home Inc", "SV02-612-MP-1.3")
+    .replaces(replacement_cluster_class=DoublingPowerConfigurationCluster, cluster_id=DoublingPowerConfigurationCluster.cluster_id)
+    .add_to_registry()
+)

--- a/zhaquirks/keenhome/sv02612mp13.py
+++ b/zhaquirks/keenhome/sv02612mp13.py
@@ -1,30 +1,8 @@
 """Smart vent quirk."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    PollControl,
-    Scenes,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.measurement import PressureMeasurement, TemperatureMeasurement
 
 from zhaquirks import DoublingPowerConfigurationCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 
 KEEN1_CLUSTER_ID = 0xFC01  # decimal = 64513
 KEEN2_CLUSTER_ID = 0xFC02  # decimal = 64514
@@ -42,6 +20,9 @@ KEEN2_CLUSTER_ID = 0xFC02  # decimal = 64514
     .applies_to("Keen Home Inc", "SV02-610-MP-1.3")
     .applies_to("Keen Home Inc", "SV01-612-MP-1.0")
     .applies_to("Keen Home Inc", "SV02-612-MP-1.3")
-    .replaces(replacement_cluster_class=DoublingPowerConfigurationCluster, cluster_id=DoublingPowerConfigurationCluster.cluster_id)
+    .replaces(
+        replacement_cluster_class=DoublingPowerConfigurationCluster,
+        cluster_id=DoublingPowerConfigurationCluster.cluster_id,
+    )
     .add_to_registry()
 )

--- a/zhaquirks/kof/kof_mr101z.py
+++ b/zhaquirks/kof/kof_mr101z.py
@@ -77,56 +77,15 @@ class KofLevelControl(NoReplyMixin, CustomCluster, LevelControl):
     void_input_commands = {cmd.id for cmd in LevelControl.commands_by_name.values()}
 
 
-class CeilingFan(CustomDevice):
-    """Ceiling Fan Device."""
-
-    signature = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: 14,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Fan.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        },
-        MANUFACTURER: "King Of Fans,  Inc.",
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
-                INPUT_CLUSTERS: [
-                    KofBasic,
-                    KofIdentify,
-                    KofGroups,
-                    KofScenes,
-                    KofOnOff,
-                    KofLevelControl,
-                    Fan,
-                ],
-                OUTPUT_CLUSTERS: [Identify, Ota],
-            }
-        }
-    }
-
 
 (
     QuirkBuilder("King Of Fans,  Inc.", "MR101Z")
-    .replaces_endpoint(1, zha.PROFILE_ID, zha.DeviceType.DIMMABLE_LIGHT)
-    .replaces(KofBasic)
-    .replaces(KofIdentify)
-    .replaces(KofGroups)
-    .replaces(KofScenes)
-    .replaces(KofOnOff)
-    .replaces(KofLevelControl)
+    .replaces_endpoint(endpoint_id=1, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.DIMMABLE_LIGHT)
+    .replaces(replacement_cluster_class=KofBasic, cluster_id=Basic.cluster_id)
+    .replaces(replacement_cluster_class=KofIdentify, cluster_id=Identify.cluster_id)
+    .replaces(replacement_cluster_class=KofGroups, cluster_id=Groups.cluster_id)
+    .replaces(replacement_cluster_class=KofScenes, cluster_id=Scenes.cluster_id)
+    .replaces(replacement_cluster_class=KofOnOff, cluster_id=OnOff.cluster_id)
+    .replaces(replacement_cluster_class=KofLevelControl, cluster_id=LevelControl.cluster_id)
     .add_to_registry()
 )

--- a/zhaquirks/kof/kof_mr101z.py
+++ b/zhaquirks/kof/kof_mr101z.py
@@ -8,7 +8,7 @@ expect replies at all.
 from __future__ import annotations
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -16,20 +16,10 @@ from zigpy.zcl.clusters.general import (
     Identify,
     LevelControl,
     OnOff,
-    Ota,
     Scenes,
 )
-from zigpy.zcl.clusters.hvac import Fan
 
 from zhaquirks import NoReplyMixin
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MANUFACTURER,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 
 
 class KofBasic(NoReplyMixin, CustomCluster, Basic):
@@ -77,15 +67,20 @@ class KofLevelControl(NoReplyMixin, CustomCluster, LevelControl):
     void_input_commands = {cmd.id for cmd in LevelControl.commands_by_name.values()}
 
 
-
 (
     QuirkBuilder("King Of Fans,  Inc.", "MR101Z")
-    .replaces_endpoint(endpoint_id=1, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.DIMMABLE_LIGHT)
+    .replaces_endpoint(
+        endpoint_id=1,
+        profile_id=zha.PROFILE_ID,
+        device_type=zha.DeviceType.DIMMABLE_LIGHT,
+    )
     .replaces(replacement_cluster_class=KofBasic, cluster_id=Basic.cluster_id)
     .replaces(replacement_cluster_class=KofIdentify, cluster_id=Identify.cluster_id)
     .replaces(replacement_cluster_class=KofGroups, cluster_id=Groups.cluster_id)
     .replaces(replacement_cluster_class=KofScenes, cluster_id=Scenes.cluster_id)
     .replaces(replacement_cluster_class=KofOnOff, cluster_id=OnOff.cluster_id)
-    .replaces(replacement_cluster_class=KofLevelControl, cluster_id=LevelControl.cluster_id)
+    .replaces(
+        replacement_cluster_class=KofLevelControl, cluster_id=LevelControl.cluster_id
+    )
     .add_to_registry()
 )

--- a/zhaquirks/kof/kof_mr101z.py
+++ b/zhaquirks/kof/kof_mr101z.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -116,3 +117,16 @@ class CeilingFan(CustomDevice):
             }
         }
     }
+
+
+(
+    QuirkBuilder("King Of Fans,  Inc.", "MR101Z")
+    .replaces_endpoint(1, zha.PROFILE_ID, zha.DeviceType.DIMMABLE_LIGHT)
+    .replaces(KofBasic)
+    .replaces(KofIdentify)
+    .replaces(KofGroups)
+    .replaces(KofScenes)
+    .replaces(KofOnOff)
+    .replaces(KofLevelControl)
+    .add_to_registry()
+)

--- a/zhaquirks/konke/button.py
+++ b/zhaquirks/konke/button.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -33,108 +34,20 @@ from zhaquirks.quirk_ids import KONKE_BUTTON
 KONKE_CLUSTER_ID = 0xFCC0
 
 
-class KonkeButtonRemote1(CustomDevice):
-    """Konke 1-button remote device."""
 
-    quirk_id = KONKE_BUTTON
 
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=2
-        # device_version=0
-        # input_clusters=[0, 1, 3, 6, 64704]
-        # output_clusters=[3, 64704]>
-        MODELS_INFO: [(KONKE, "3AFE280100510001")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_OUTPUT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    KONKE_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, KONKE_CLUSTER_ID],
-            },
-        },
-    }
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster,
-                    Identify.cluster_id,
-                    KonkeOnOffCluster,
-                    KONKE_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    KONKE_CLUSTER_ID,
-                ],
-            },
-        },
-    }
-
-    device_automation_triggers = {
+(
+    QuirkBuilder(KONKE, "3AFE280100510001")
+    .applies_to(KONKE, "3AFE170100510001")
+    .replaces_endpoint(endpoint_id=1, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.REMOTE_CONTROL)
+    .replaces(replacement_cluster_class=PowerConfigurationCluster)
+    .replaces(replacement_cluster_class=KonkeOnOffCluster)
+    .device_automation_triggers({
         (DOUBLE_PRESS, DOUBLE_PRESS): {COMMAND: COMMAND_DOUBLE},
         (SHORT_PRESS, SHORT_PRESS): {COMMAND: COMMAND_SINGLE},
         (LONG_PRESS, LONG_PRESS): {COMMAND: COMMAND_HOLD},
-    }
+    })
+    .add_to_registry()
+)
 
 
-class KonkeButtonRemote2(CustomDevice):
-    """Konke 1-button remote device 2nd variant."""
-
-    quirk_id = KONKE_BUTTON
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=2
-        # device_version=0
-        # input_clusters=[0, 1, 3, 4, 5, 6]
-        # output_clusters=[3]>
-        MODELS_INFO: [(KONKE, "3AFE170100510001")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_OUTPUT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id],
-            },
-        },
-    }
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    KonkeOnOffCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                ],
-            },
-        },
-    }
-
-    device_automation_triggers = {
-        (DOUBLE_PRESS, DOUBLE_PRESS): {COMMAND: COMMAND_DOUBLE},
-        (SHORT_PRESS, SHORT_PRESS): {COMMAND: COMMAND_SINGLE},
-        (LONG_PRESS, LONG_PRESS): {COMMAND: COMMAND_HOLD},
-    }

--- a/zhaquirks/konke/button.py
+++ b/zhaquirks/konke/button.py
@@ -1,16 +1,7 @@
 """Konke Button Remote."""
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    OnOff,
-    PowerConfiguration,
-    Scenes,
-)
 
 from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
@@ -18,36 +9,31 @@ from zhaquirks.const import (
     COMMAND_DOUBLE,
     COMMAND_HOLD,
     COMMAND_SINGLE,
-    DEVICE_TYPE,
     DOUBLE_PRESS,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
     LONG_PRESS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
     SHORT_PRESS,
 )
 from zhaquirks.konke import KONKE, KonkeOnOffCluster
-from zhaquirks.quirk_ids import KONKE_BUTTON
 
 KONKE_CLUSTER_ID = 0xFCC0
-
-
 
 
 (
     QuirkBuilder(KONKE, "3AFE280100510001")
     .applies_to(KONKE, "3AFE170100510001")
-    .replaces_endpoint(endpoint_id=1, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.REMOTE_CONTROL)
+    .replaces_endpoint(
+        endpoint_id=1,
+        profile_id=zha.PROFILE_ID,
+        device_type=zha.DeviceType.REMOTE_CONTROL,
+    )
     .replaces(replacement_cluster_class=PowerConfigurationCluster)
     .replaces(replacement_cluster_class=KonkeOnOffCluster)
-    .device_automation_triggers({
-        (DOUBLE_PRESS, DOUBLE_PRESS): {COMMAND: COMMAND_DOUBLE},
-        (SHORT_PRESS, SHORT_PRESS): {COMMAND: COMMAND_SINGLE},
-        (LONG_PRESS, LONG_PRESS): {COMMAND: COMMAND_HOLD},
-    })
+    .device_automation_triggers(
+        {
+            (DOUBLE_PRESS, DOUBLE_PRESS): {COMMAND: COMMAND_DOUBLE},
+            (SHORT_PRESS, SHORT_PRESS): {COMMAND: COMMAND_SINGLE},
+            (LONG_PRESS, LONG_PRESS): {COMMAND: COMMAND_HOLD},
+        }
+    )
     .add_to_registry()
 )
-
-

--- a/zhaquirks/ledvance/a19rgbw.py
+++ b/zhaquirks/ledvance/a19rgbw.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,
@@ -25,51 +26,8 @@ from zhaquirks.const import (
 from zhaquirks.ledvance import LEDVANCE, LedvanceLightCluster
 
 
-class LedvanceA19RGBW(CustomDevice):
-    """Ledvance A19 RGBW device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=258
-        # device_version=2 input_clusters=[0, 3, 4, 5, 6, 8, 768, 2821, 64513]
-        # output_clusters=[25]>
-        MODELS_INFO: [(LEDVANCE, "A19 RGBW")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMABLE_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                    Diagnostic.cluster_id,
-                    LedvanceLightCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMABLE_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                    Diagnostic.cluster_id,
-                    LedvanceLightCluster,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(LEDVANCE, "A19 RGBW")
+    .replaces(replacement_cluster_class=LedvanceLightCluster, cluster_id=LedvanceLightCluster.cluster_id)
+    .add_to_registry()
+)

--- a/zhaquirks/ledvance/a19rgbw.py
+++ b/zhaquirks/ledvance/a19rgbw.py
@@ -1,33 +1,14 @@
 """Ledvance A19 RGBW device."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    Scenes,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.lighting import Color
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.ledvance import LEDVANCE, LedvanceLightCluster
-
 
 (
     QuirkBuilder(LEDVANCE, "A19 RGBW")
-    .replaces(replacement_cluster_class=LedvanceLightCluster, cluster_id=LedvanceLightCluster.cluster_id)
+    .replaces(
+        replacement_cluster_class=LedvanceLightCluster,
+        cluster_id=LedvanceLightCluster.cluster_id,
+    )
     .add_to_registry()
 )

--- a/zhaquirks/ledvance/flexrgbw.py
+++ b/zhaquirks/ledvance/flexrgbw.py
@@ -1,75 +1,15 @@
 """Ledvance flex rgbw device."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    Scenes,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.lighting import Color
+from zigpy.quirks.v2 import QuirkBuilder
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.ledvance import LEDVANCE, LedvanceLightCluster
 
-
-class FlexRGBW(CustomDevice):
-    """Ledvance Flex RGBW LED strip."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=258
-        # device_version=2 input_clusters=[0, 3, 4, 5, 6, 8, 768, 2821, 64527]
-        # output_clusters=[25]>
-        MODELS_INFO: [(LEDVANCE, "FLEX RGBW")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMABLE_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                    LedvanceLightCluster.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMABLE_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                    LedvanceLightCluster,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(LEDVANCE, "FLEX RGBW")
+    .replaces(
+        replacement_cluster_class=LedvanceLightCluster,
+        cluster_id=LedvanceLightCluster.cluster_id,
+        endpoint_id=1,
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/legrand/switch.py
+++ b/zhaquirks/legrand/switch.py
@@ -1,77 +1,15 @@
 """Module for Legrand switches (without dimming functionality)."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    BinaryInput,
-    Groups,
-    Identify,
-    OnOff,
-    Ota,
-    Scenes,
-)
+from zigpy.quirks.v2 import QuirkBuilder
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.legrand import LEGRAND, MANUFACTURER_SPECIFIC_CLUSTER_ID, LegrandCluster
 
-
-class LightSwitchWithNeutral(CustomDevice):
-    """Light switch with neutral wire."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=256
-        # input_clusters=[0, 3, 4, 5, 6, 15, 64513]
-        # output_clusters=[0, 25, 64513]>
-        MODELS_INFO: [(f" {LEGRAND}", " Light switch with neutral")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    BinaryInput.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Ota.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    BinaryInput.cluster_id,
-                    LegrandCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Ota.cluster_id,
-                    LegrandCluster,
-                ],
-            }
-        }
-    }
+(
+    QuirkBuilder(f" {LEGRAND}", " Light switch with neutral")
+    .replaces(
+        replacement_cluster_class=LegrandCluster,
+        cluster_id=MANUFACTURER_SPECIFIC_CLUSTER_ID,
+        endpoint_id=1,
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/nue/auwz02000.py
+++ b/zhaquirks/nue/auwz02000.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes
 from zigpy.zcl.clusters.lightlink import LightLink
 
@@ -15,74 +16,9 @@ from ..const import (
 )
 
 
-class auwz02000(CustomDevice):
-    """Model NUE-AUWZ02-000 Double GPO - Australia plug."""
-
-    signature = {
-        MODELS_INFO: [("3A Smart Home DE", "LXN56-TS27LX1.2")],
-        ENDPOINTS: {
-            #  <SimpleDescriptor endpoint=1 profile=260 device_type=256
-            #  device_version=1
-            #  input_clusters=[0, 3, 4, 5, 6, 4096]
-            #  output_clusters=[25]>
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LightLink.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-            #  <SimpleDescriptor endpoint=2 profile=260 device_type=256
-            #  device_version=1
-            #  input_clusters=[0, 3, 4, 5, 6]
-            #  output_clusters=[25]>
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,  # 0x0009
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LightLink.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,  # 0x0009
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-        }
-    }
+(
+    QuirkBuilder("3A Smart Home DE", "LXN56-TS27LX1.2")
+    .replaces_endpoint(endpoint_id=1, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.MAIN_POWER_OUTLET)
+    .replaces_endpoint(endpoint_id=2, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.MAIN_POWER_OUTLET)
+    .add_to_registry()
+)

--- a/zhaquirks/nue/auwz02000.py
+++ b/zhaquirks/nue/auwz02000.py
@@ -1,24 +1,19 @@
 """Nue / 3A Smart Home - Double GPO Quirk."""
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes
-from zigpy.zcl.clusters.lightlink import LightLink
-
-from ..const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-
 
 (
     QuirkBuilder("3A Smart Home DE", "LXN56-TS27LX1.2")
-    .replaces_endpoint(endpoint_id=1, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.MAIN_POWER_OUTLET)
-    .replaces_endpoint(endpoint_id=2, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.MAIN_POWER_OUTLET)
+    .replaces_endpoint(
+        endpoint_id=1,
+        profile_id=zha.PROFILE_ID,
+        device_type=zha.DeviceType.MAIN_POWER_OUTLET,
+    )
+    .replaces_endpoint(
+        endpoint_id=2,
+        profile_id=zha.PROFILE_ID,
+        device_type=zha.DeviceType.MAIN_POWER_OUTLET,
+    )
     .add_to_registry()
 )

--- a/zhaquirks/philio/pst03a.py
+++ b/zhaquirks/philio/pst03a.py
@@ -2,6 +2,8 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import (
     Alarms,
     Basic,
@@ -30,64 +32,17 @@ from zhaquirks.const import (
 from zhaquirks.philio import PHILIO, MotionCluster
 
 
-class Pst03a(CustomDevice):
-    """Custom device representing PST03A 4in1 motion/opening/temperature/illuminance sensors."""
-
-    signature = {
-        MODEL: "PST03A-v2.2.5",
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Alarms.cluster_id,
-                    OccupancySensing.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id, Ota.cluster_id],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Alarms.cluster_id,
-                    BinaryInput.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-        },
-    }
-
-    replacement = {
-        SKIP_CONFIGURATION: True,
-        MANUFACTURER: PHILIO,
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Alarms.cluster_id,
-                    MotionCluster,
-                    TemperatureMeasurement.cluster_id,
-                    IlluminanceMeasurement.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Alarms.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-        },
-    }
+(
+    QuirkBuilder(PHILIO, "PST03A-v2.2.5")
+    .skip_configuration()
+    .removes(cluster_id=PowerConfiguration.cluster_id, endpoint_id=1)
+    .removes(cluster_id=OccupancySensing.cluster_id, endpoint_id=1)
+    .removes(cluster_id=IasZone.cluster_id, endpoint_id=1)
+    .removes(cluster_id=OnOff.cluster_id, cluster_type=ClusterType.Client, endpoint_id=1)
+    .adds(cluster=MotionCluster, endpoint_id=1)
+    .adds(cluster=TemperatureMeasurement.cluster_id, endpoint_id=1)
+    .adds(cluster=IlluminanceMeasurement.cluster_id, endpoint_id=1)
+    .removes(cluster_id=PowerConfiguration.cluster_id, endpoint_id=2)
+    .removes(cluster_id=BinaryInput.cluster_id, endpoint_id=2)
+    .add_to_registry()
+)

--- a/zhaquirks/philio/pst03a.py
+++ b/zhaquirks/philio/pst03a.py
@@ -1,17 +1,8 @@
 """Device handler for Philio PST03A-v2.2.5."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl import ClusterType
-from zigpy.zcl.clusters.general import (
-    Alarms,
-    Basic,
-    BinaryInput,
-    OnOff,
-    Ota,
-    PowerConfiguration,
-)
+from zigpy.zcl.clusters.general import BinaryInput, OnOff, PowerConfiguration
 from zigpy.zcl.clusters.measurement import (
     IlluminanceMeasurement,
     OccupancySensing,
@@ -19,18 +10,7 @@ from zigpy.zcl.clusters.measurement import (
 )
 from zigpy.zcl.clusters.security import IasZone
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MANUFACTURER,
-    MODEL,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-    SKIP_CONFIGURATION,
-)
 from zhaquirks.philio import PHILIO, MotionCluster
-
 
 (
     QuirkBuilder(PHILIO, "PST03A-v2.2.5")
@@ -38,7 +18,9 @@ from zhaquirks.philio import PHILIO, MotionCluster
     .removes(cluster_id=PowerConfiguration.cluster_id, endpoint_id=1)
     .removes(cluster_id=OccupancySensing.cluster_id, endpoint_id=1)
     .removes(cluster_id=IasZone.cluster_id, endpoint_id=1)
-    .removes(cluster_id=OnOff.cluster_id, cluster_type=ClusterType.Client, endpoint_id=1)
+    .removes(
+        cluster_id=OnOff.cluster_id, cluster_type=ClusterType.Client, endpoint_id=1
+    )
     .adds(cluster=MotionCluster, endpoint_id=1)
     .adds(cluster=TemperatureMeasurement.cluster_id, endpoint_id=1)
     .adds(cluster=IlluminanceMeasurement.cluster_id, endpoint_id=1)

--- a/zhaquirks/philips/motion.py
+++ b/zhaquirks/philips/motion.py
@@ -4,6 +4,7 @@ from typing import Final
 
 from zigpy.profiles import zha, zll
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -45,129 +46,22 @@ class BasicCluster(CustomCluster, Basic):
         )
 
 
-class PhilipsMotion(CustomDevice):
-    """Old Philips motion sensor devices."""
-
-    signature = {
-        MODELS_INFO: [(PHILIPS, "SML001"), (PHILIPS, "SML002")],
-        ENDPOINTS: {
-            #  <SimpleDescriptor endpoint=1 profile=49246 device_type=2128
-            #  device_version=?
-            #  input_clusters=[0]
-            #  output_clusters=[0, 3, 4, 5, 6, 8, 768]>
-            1: {
-                PROFILE_ID: zll.PROFILE_ID,
-                DEVICE_TYPE: zll.DeviceType.ON_OFF_SENSOR,
-                INPUT_CLUSTERS: [Basic.cluster_id],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            #  <SimpleDescriptor endpoint=2 profile=260 device_type=0x0107
-            #  device_version=?
-            #  input_clusters=[0, 1, 3, 1024, 1026, 1030]
-            #  output_clusters=[25]>
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    IlluminanceMeasurement.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    OccupancySensing.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zll.PROFILE_ID,
-                DEVICE_TYPE: zll.DeviceType.ON_OFF_SENSOR,
-                INPUT_CLUSTERS: [Basic.cluster_id],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    IlluminanceMeasurement.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    PhilipsOccupancySensing,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-        }
-    }
 
 
-class SignifyMotion(CustomDevice):
-    """New Philips motion sensor devices."""
+# Old Philips motion sensors (SML001, SML002) with dual endpoints
+(
+    QuirkBuilder(PHILIPS, "SML001")
+    .applies_to(PHILIPS, "SML002")
+    .replaces(replacement_cluster_class=BasicCluster, endpoint_id=2)
+    .replaces(replacement_cluster_class=PhilipsOccupancySensing, endpoint_id=2)
+    .add_to_registry()
+)
 
-    signature = {
-        MODELS_INFO: [(SIGNIFY, "SML003"), (SIGNIFY, "SML004")],
-        ENDPOINTS: {
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    IlluminanceMeasurement.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    OccupancySensing.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    IlluminanceMeasurement.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    PhilipsOccupancySensing,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    Ota.cluster_id,
-                ],
-            },
-        }
-    }
+# New Signify motion sensors (SML003, SML004) with single endpoint
+(
+    QuirkBuilder(SIGNIFY, "SML003")
+    .applies_to(SIGNIFY, "SML004")
+    .replaces(replacement_cluster_class=BasicCluster, endpoint_id=2)
+    .replaces(replacement_cluster_class=PhilipsOccupancySensing, endpoint_id=2)
+    .add_to_registry()
+)

--- a/zhaquirks/philips/motion.py
+++ b/zhaquirks/philips/motion.py
@@ -2,36 +2,12 @@
 
 from typing import Final
 
-from zigpy.profiles import zha, zll
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    PowerConfiguration,
-    Scenes,
-)
-from zigpy.zcl.clusters.lighting import Color
-from zigpy.zcl.clusters.measurement import (
-    IlluminanceMeasurement,
-    OccupancySensing,
-    TemperatureMeasurement,
-)
+from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.foundation import ZCLAttributeDef
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.philips import PHILIPS, SIGNIFY, PhilipsOccupancySensing
 
 
@@ -44,8 +20,6 @@ class BasicCluster(CustomCluster, Basic):
         trigger_indicator: Final = ZCLAttributeDef(
             id=0x0033, type=t.Bool, is_manufacturer_specific=True
         )
-
-
 
 
 # Old Philips motion sensors (SML001, SML002) with dual endpoints

--- a/zhaquirks/samjin/button.py
+++ b/zhaquirks/samjin/button.py
@@ -1,17 +1,6 @@
 """Samjin button device."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Identify,
-    Ota,
-    PollControl,
-    PowerConfiguration,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks.const import (
@@ -20,18 +9,11 @@ from zhaquirks.const import (
     COMMAND_BUTTON_DOUBLE,
     COMMAND_BUTTON_HOLD,
     COMMAND_BUTTON_SINGLE,
-    DEVICE_TYPE,
     DOUBLE_PRESS,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
     LONG_PRESS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
     SHORT_PRESS,
 )
 from zhaquirks.samjin import SAMJIN, SamjinIASCluster
-
 
 SAMJIN_BUTTON_TRIGGERS = {
     (DOUBLE_PRESS, DOUBLE_PRESS): {COMMAND: COMMAND_BUTTON_DOUBLE},

--- a/zhaquirks/samjin/button.py
+++ b/zhaquirks/samjin/button.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Basic,
     Identify,
@@ -32,97 +33,19 @@ from zhaquirks.const import (
 from zhaquirks.samjin import SAMJIN, SamjinIASCluster
 
 
-class SamjinButton(CustomDevice):
-    """Samjin button device."""
+SAMJIN_BUTTON_TRIGGERS = {
+    (DOUBLE_PRESS, DOUBLE_PRESS): {COMMAND: COMMAND_BUTTON_DOUBLE},
+    (SHORT_PRESS, SHORT_PRESS): {COMMAND: COMMAND_BUTTON_SINGLE},
+    (LONG_PRESS, LONG_PRESS): {COMMAND: COMMAND_BUTTON_HOLD},
+}
 
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        # device_version=0
-        # input_clusters=[0, 1, 3, 32, 1026, 1280, 2821]
-        # output_clusters=[3, 25]>
-        MODELS_INFO: [(SAMJIN, BUTTON)],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    SamjinIASCluster,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        }
-    }
-
-    device_automation_triggers = {
-        (DOUBLE_PRESS, DOUBLE_PRESS): {COMMAND: COMMAND_BUTTON_DOUBLE},
-        (SHORT_PRESS, SHORT_PRESS): {COMMAND: COMMAND_BUTTON_SINGLE},
-        (LONG_PRESS, LONG_PRESS): {COMMAND: COMMAND_BUTTON_HOLD},
-    }
+(
+    QuirkBuilder(SAMJIN, BUTTON)
+    .replaces(replacement_cluster_class=SamjinIASCluster, cluster_id=IasZone.cluster_id)
+    .device_automation_triggers(SAMJIN_BUTTON_TRIGGERS)
+    .add_to_registry()
+)
 
 
-class SamjinButton2(SamjinButton):
-    """Samjin button device variation without Diagnostic cluster."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        # device_version=0
-        # input_clusters=[0, 1, 3, 32, 1026, 1280]
-        # output_clusters=[3, 25]>
-        MODELS_INFO: [(SAMJIN, BUTTON)],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    SamjinIASCluster,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        }
-    }
+# Note: SamjinButton2 variation without Diagnostic cluster is handled by the same v2 quirk above
+# since v2 API only replaces the IasZone cluster, other differences are handled automatically

--- a/zhaquirks/samjin/multi2.py
+++ b/zhaquirks/samjin/multi2.py
@@ -1,71 +1,16 @@
 """Samjin Multi 2019 Refresh Quirk."""
 
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Identify,
-    Ota,
-    PollControl,
-    PowerConfiguration,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.measurement import TemperatureMeasurement
-from zigpy.zcl.clusters.security import IasZone
+from zigpy.quirks.v2 import QuirkBuilder
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.samjin import SAMJIN
 from zhaquirks.smartthings import SmartThingsAccelCluster
 
-
-class SmartthingsMultiPurposeSensor2019(CustomDevice):
-    """Samjin multi device."""
-
-    signature = {
-        MODELS_INFO: [(SAMJIN, "multi")],
-        ENDPOINTS: {
-            # <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-            # device_version=0 input_clusters=[0, 1, 3, 32, 1026, 1280,
-            # 2821, 64514]
-            # output_clusters=[3, 25]>
-            1: {
-                PROFILE_ID: 0x0104,
-                DEVICE_TYPE: 0x0402,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    Diagnostic.cluster_id,
-                    SmartThingsAccelCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    Diagnostic.cluster_id,
-                    SmartThingsAccelCluster,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(SAMJIN, "multi")
+    .replaces(
+        replacement_cluster_class=SmartThingsAccelCluster,
+        cluster_id=SmartThingsAccelCluster.cluster_id,
+        endpoint_id=1,
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/schneiderelectric/outlet.py
+++ b/zhaquirks/schneiderelectric/outlet.py
@@ -1,28 +1,9 @@
 """Schneider Electric (Wiser) Outlet Quirks."""
 
-from zigpy.profiles import zgp, zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import (
-    Basic,
-    GreenPowerProxy,
-    Groups,
-    Identify,
-    OnOff,
-    Ota,
-    Scenes,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic, ElectricalMeasurement
-from zigpy.zcl.clusters.smartenergy import DeviceManagement, Metering
+from zigpy.zcl.clusters.smartenergy import Metering
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.schneiderelectric import SE_MANUF_NAME
 
 
@@ -38,6 +19,10 @@ class MeteringCluster(CustomCluster, Metering):
 (
     QuirkBuilder(SE_MANUF_NAME, "SOCKET/OUTLET/1")
     .applies_to(SE_MANUF_NAME, "SOCKET/OUTLET/2")
-    .replaces(replacement_cluster_class=MeteringCluster, cluster_id=Metering.cluster_id, endpoint_id=6)
+    .replaces(
+        replacement_cluster_class=MeteringCluster,
+        cluster_id=Metering.cluster_id,
+        endpoint_id=6,
+    )
     .add_to_registry()
 )

--- a/zhaquirks/schneiderelectric/outlet.py
+++ b/zhaquirks/schneiderelectric/outlet.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
@@ -34,76 +35,9 @@ class MeteringCluster(CustomCluster, Metering):
         super()._update_attribute(attrid, value)
 
 
-class SocketOutlet(CustomDevice):
-    """Schneider Electric Socket outlet WDE002182, WDE002172."""
-
-    signature = {
-        MODELS_INFO: [
-            (SE_MANUF_NAME, "SOCKET/OUTLET/1"),
-            (SE_MANUF_NAME, "SOCKET/OUTLET/2"),
-        ],
-        ENDPOINTS: {
-            # <SimpleDescriptor endpoint=1 profile=260 device_type=9
-            # device_version=0
-            # input_clusters=[0, 3, 4, 5, 6, 1794, 1800, 2820, 2821, 64516] output_clusters=[25]>
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    Metering.cluster_id,
-                    DeviceManagement.cluster_id,
-                    ElectricalMeasurement.cluster_id,
-                    Diagnostic.cluster_id,
-                    0xFC04,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [
-                    GreenPowerProxy.cluster_id,
-                ],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.MAIN_POWER_OUTLET,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    MeteringCluster,
-                    DeviceManagement.cluster_id,
-                    ElectricalMeasurement.cluster_id,
-                    Diagnostic.cluster_id,
-                    0xFC04,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [
-                    GreenPowerProxy.cluster_id,
-                ],
-            },
-        },
-    }
+(
+    QuirkBuilder(SE_MANUF_NAME, "SOCKET/OUTLET/1")
+    .applies_to(SE_MANUF_NAME, "SOCKET/OUTLET/2")
+    .replaces(replacement_cluster_class=MeteringCluster, cluster_id=Metering.cluster_id, endpoint_id=6)
+    .add_to_registry()
+)

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -8,23 +8,11 @@ import logging
 from typing import Any, Final, Optional, Union
 
 import zigpy.profiles.zha as zha_p
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import (
-    Basic,
-    DeviceTemperature,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    Scenes,
-    Time,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic, ElectricalMeasurement
-from zigpy.zcl.clusters.smartenergy import Metering
+from zigpy.zcl.clusters.general import DeviceTemperature
 from zigpy.zcl.foundation import BaseCommandDefs
 
 from zhaquirks import EventableCluster
@@ -37,12 +25,6 @@ from zhaquirks.const import (
     COMMAND_M_MULTI_PRESS_COMPLETE,
     COMMAND_M_SHORT_RELEASE,
     DESCRIPTION,
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
     TURN_OFF,
     TURN_ON,
     VALUE,
@@ -243,9 +225,19 @@ class LightManufacturerCluster(EventableCluster, SinopeTechnologiesManufacturerC
 (
     QuirkBuilder(SINOPE, "SW2500ZB")
     .applies_to(SINOPE, "SW2500ZB-G2")
-    .replaces_endpoint(endpoint_id=1, profile_id=zha_p.PROFILE_ID, device_type=zha_p.DeviceType.ON_OFF_LIGHT)
-    .replaces(replacement_cluster_class=CustomDeviceTemperatureCluster, cluster_id=DeviceTemperature.cluster_id)
-    .replaces(replacement_cluster_class=LightManufacturerCluster, cluster_id=SINOPE_MANUFACTURER_CLUSTER_ID)
+    .replaces_endpoint(
+        endpoint_id=1,
+        profile_id=zha_p.PROFILE_ID,
+        device_type=zha_p.DeviceType.ON_OFF_LIGHT,
+    )
+    .replaces(
+        replacement_cluster_class=CustomDeviceTemperatureCluster,
+        cluster_id=DeviceTemperature.cluster_id,
+    )
+    .replaces(
+        replacement_cluster_class=LightManufacturerCluster,
+        cluster_id=SINOPE_MANUFACTURER_CLUSTER_ID,
+    )
     .device_automation_triggers(LIGHT_DEVICE_TRIGGERS)
     .add_to_registry()
 )
@@ -254,9 +246,19 @@ class LightManufacturerCluster(EventableCluster, SinopeTechnologiesManufacturerC
 (
     QuirkBuilder(SINOPE, "DM2500ZB")
     .applies_to(SINOPE, "DM2500ZB-G2")
-    .replaces_endpoint(endpoint_id=1, profile_id=zha_p.PROFILE_ID, device_type=zha_p.DeviceType.DIMMABLE_LIGHT)
-    .replaces(replacement_cluster_class=CustomDeviceTemperatureCluster, cluster_id=DeviceTemperature.cluster_id)
-    .replaces(replacement_cluster_class=LightManufacturerCluster, cluster_id=SINOPE_MANUFACTURER_CLUSTER_ID)
+    .replaces_endpoint(
+        endpoint_id=1,
+        profile_id=zha_p.PROFILE_ID,
+        device_type=zha_p.DeviceType.DIMMABLE_LIGHT,
+    )
+    .replaces(
+        replacement_cluster_class=CustomDeviceTemperatureCluster,
+        cluster_id=DeviceTemperature.cluster_id,
+    )
+    .replaces(
+        replacement_cluster_class=LightManufacturerCluster,
+        cluster_id=SINOPE_MANUFACTURER_CLUSTER_ID,
+    )
     .device_automation_triggers(LIGHT_DEVICE_TRIGGERS)
     .add_to_registry()
 )
@@ -265,9 +267,19 @@ class LightManufacturerCluster(EventableCluster, SinopeTechnologiesManufacturerC
 (
     QuirkBuilder(SINOPE, "DM2550ZB")
     .applies_to(SINOPE, "DM2550ZB-G2")
-    .replaces_endpoint(endpoint_id=1, profile_id=zha_p.PROFILE_ID, device_type=zha_p.DeviceType.DIMMABLE_LIGHT)
-    .replaces(replacement_cluster_class=CustomDeviceTemperatureCluster, cluster_id=DeviceTemperature.cluster_id)
-    .replaces(replacement_cluster_class=LightManufacturerCluster, cluster_id=SINOPE_MANUFACTURER_CLUSTER_ID)
+    .replaces_endpoint(
+        endpoint_id=1,
+        profile_id=zha_p.PROFILE_ID,
+        device_type=zha_p.DeviceType.DIMMABLE_LIGHT,
+    )
+    .replaces(
+        replacement_cluster_class=CustomDeviceTemperatureCluster,
+        cluster_id=DeviceTemperature.cluster_id,
+    )
+    .replaces(
+        replacement_cluster_class=LightManufacturerCluster,
+        cluster_id=SINOPE_MANUFACTURER_CLUSTER_ID,
+    )
     .device_automation_triggers(LIGHT_DEVICE_TRIGGERS)
     .add_to_registry()
 )

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -9,6 +9,7 @@ from typing import Any, Final, Optional, Union
 
 import zigpy.profiles.zha as zha_p
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
@@ -239,198 +240,34 @@ class LightManufacturerCluster(EventableCluster, SinopeTechnologiesManufacturerC
     """LightManufacturerCluster: fire events corresponding to press type."""
 
 
-class SinopeTechnologieslight(CustomDevice):
-    """SinopeTechnologiesLight custom device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=259
-        # device_version=0 input_clusters=[0, 2, 3, 4, 5, 6, 1794, 2821, 65281]
-        # output_clusters=[3, 4, 25]>
-        MODELS_INFO: [
-            (SINOPE, "SW2500ZB"),
-            (SINOPE, "SW2500ZB-G2"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha_p.PROFILE_ID,
-                DEVICE_TYPE: zha_p.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    DeviceTemperature.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    Metering.cluster_id,
-                    Diagnostic.cluster_id,
-                    SINOPE_MANUFACTURER_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Ota.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha_p.PROFILE_ID,
-                DEVICE_TYPE: zha_p.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    CustomDeviceTemperatureCluster,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    Metering.cluster_id,
-                    Diagnostic.cluster_id,
-                    LightManufacturerCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Ota.cluster_id,
-                ],
-            }
-        }
-    }
-
-    device_automation_triggers = LIGHT_DEVICE_TRIGGERS
+(
+    QuirkBuilder(SINOPE, "SW2500ZB")
+    .applies_to(SINOPE, "SW2500ZB-G2")
+    .replaces_endpoint(endpoint_id=1, profile_id=zha_p.PROFILE_ID, device_type=zha_p.DeviceType.ON_OFF_LIGHT)
+    .replaces(replacement_cluster_class=CustomDeviceTemperatureCluster, cluster_id=DeviceTemperature.cluster_id)
+    .replaces(replacement_cluster_class=LightManufacturerCluster, cluster_id=SINOPE_MANUFACTURER_CLUSTER_ID)
+    .device_automation_triggers(LIGHT_DEVICE_TRIGGERS)
+    .add_to_registry()
+)
 
 
-class SinopeDM2500ZB(CustomDevice):
-    """DM2500ZB, DM2500ZB-G2 Dimmers."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=260 device_version=1
-        # input_clusters=[0, 2, 3, 4, 5, 6, 8, 1794, 2821, 65281]
-        # output_clusters=[3, 4, 25]>
-        MODELS_INFO: [
-            (SINOPE, "DM2500ZB"),
-            (SINOPE, "DM2500ZB-G2"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha_p.PROFILE_ID,
-                DEVICE_TYPE: zha_p.DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    DeviceTemperature.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Metering.cluster_id,
-                    Diagnostic.cluster_id,
-                    SINOPE_MANUFACTURER_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Ota.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha_p.PROFILE_ID,
-                DEVICE_TYPE: zha_p.DeviceType.DIMMABLE_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    CustomDeviceTemperatureCluster,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Metering.cluster_id,
-                    Diagnostic.cluster_id,
-                    LightManufacturerCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Ota.cluster_id,
-                ],
-            }
-        }
-    }
-
-    device_automation_triggers = LIGHT_DEVICE_TRIGGERS
+(
+    QuirkBuilder(SINOPE, "DM2500ZB")
+    .applies_to(SINOPE, "DM2500ZB-G2")
+    .replaces_endpoint(endpoint_id=1, profile_id=zha_p.PROFILE_ID, device_type=zha_p.DeviceType.DIMMABLE_LIGHT)
+    .replaces(replacement_cluster_class=CustomDeviceTemperatureCluster, cluster_id=DeviceTemperature.cluster_id)
+    .replaces(replacement_cluster_class=LightManufacturerCluster, cluster_id=SINOPE_MANUFACTURER_CLUSTER_ID)
+    .device_automation_triggers(LIGHT_DEVICE_TRIGGERS)
+    .add_to_registry()
+)
 
 
-class SinopeDM2550ZB(CustomDevice):
-    """DM2550ZB, DM2550ZB-G2 Dimmers."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=260 device_version=1
-        # input_clusters=[0, 2, 3, 4, 5, 6, 8, 1794, 2820, 2821, 65281]
-        # output_clusters=[3, 4, 10, 25]>
-        MODELS_INFO: [
-            (SINOPE, "DM2550ZB"),
-            (SINOPE, "DM2550ZB-G2"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha_p.PROFILE_ID,
-                DEVICE_TYPE: zha_p.DeviceType.DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    DeviceTemperature.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Metering.cluster_id,
-                    ElectricalMeasurement.cluster_id,
-                    Diagnostic.cluster_id,
-                    SINOPE_MANUFACTURER_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Time.cluster_id,
-                    Ota.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha_p.PROFILE_ID,
-                DEVICE_TYPE: zha_p.DeviceType.DIMMABLE_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    CustomDeviceTemperatureCluster,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Metering.cluster_id,
-                    ElectricalMeasurement.cluster_id,
-                    Diagnostic.cluster_id,
-                    LightManufacturerCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Time.cluster_id,
-                    Ota.cluster_id,
-                ],
-            }
-        }
-    }
-
-    device_automation_triggers = LIGHT_DEVICE_TRIGGERS
+(
+    QuirkBuilder(SINOPE, "DM2550ZB")
+    .applies_to(SINOPE, "DM2550ZB-G2")
+    .replaces_endpoint(endpoint_id=1, profile_id=zha_p.PROFILE_ID, device_type=zha_p.DeviceType.DIMMABLE_LIGHT)
+    .replaces(replacement_cluster_class=CustomDeviceTemperatureCluster, cluster_id=DeviceTemperature.cluster_id)
+    .replaces(replacement_cluster_class=LightManufacturerCluster, cluster_id=SINOPE_MANUFACTURER_CLUSTER_ID)
+    .device_automation_triggers(LIGHT_DEVICE_TRIGGERS)
+    .add_to_registry()
+)

--- a/zhaquirks/smartthings/moisturev4.py
+++ b/zhaquirks/smartthings/moisturev4.py
@@ -1,21 +1,11 @@
 """Device handler for smartthings moistureV4 sensor."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
-from zigpy.zcl.clusters.general import Basic, BinaryInput, Identify, Ota, PollControl
-from zigpy.zcl.clusters.measurement import TemperatureMeasurement
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-    ZONE_TYPE,
-)
+from zhaquirks.const import ZONE_TYPE
 from zhaquirks.smartthings import SMART_THINGS
 
 
@@ -25,46 +15,17 @@ class CustomIasZone(CustomCluster, IasZone):
     _CONSTANT_ATTRIBUTES = {ZONE_TYPE: IasZone.ZoneType.Water_Sensor}
 
 
-class SmartThingsMoistureV4(CustomDevice):
-    """SmartThingsMoistureV4."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        #  device_version=0
-        #  input_clusters=[0, 1, 3, 15, 1026, 1280, 32]
-        #  output_clusters=[25]>
-        MODELS_INFO: [(SMART_THINGS, "moisturev4")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
-                    Identify.cluster_id,
-                    BinaryInput.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster,
-                    Identify.cluster_id,
-                    BinaryInput.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    CustomIasZone,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(SMART_THINGS, "moisturev4")
+    .replaces(
+        replacement_cluster_class=PowerConfigurationCluster,
+        cluster_id=PowerConfigurationCluster.cluster_id,
+        endpoint_id=1,
+    )
+    .replaces(
+        replacement_cluster_class=CustomIasZone,
+        cluster_id=IasZone.cluster_id,
+        endpoint_id=1,
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/smartthings/motion.py
+++ b/zhaquirks/smartthings/motion.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import Basic, BinaryInput, Identify, Ota, PollControl
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
@@ -18,46 +19,9 @@ from zhaquirks.const import (
 from zhaquirks.smartthings import SMART_THINGS
 
 
-class SmartThingsMotion(CustomDevice):
-    """SmartThingsMotionV4 or V5."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        #  device_version=0
-        #  input_clusters=[0, 1, 3, 15, 1026, 1280, 32]
-        #  output_clusters=[25]>
-        MODELS_INFO: [(SMART_THINGS, "motionv4"), (SMART_THINGS, "motionv5")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
-                    Identify.cluster_id,
-                    BinaryInput.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster,
-                    Identify.cluster_id,
-                    BinaryInput.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(SMART_THINGS, "motionv4")
+    .applies_to(SMART_THINGS, "motionv5")
+    .replaces(PowerConfigurationCluster)
+    .add_to_registry()
+)

--- a/zhaquirks/smartthings/motion.py
+++ b/zhaquirks/smartthings/motion.py
@@ -1,23 +1,9 @@
 """Device handler for smartthings motionV4 sensors."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import Basic, BinaryInput, Identify, Ota, PollControl
-from zigpy.zcl.clusters.measurement import TemperatureMeasurement
-from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.smartthings import SMART_THINGS
-
 
 (
     QuirkBuilder(SMART_THINGS, "motionv4")

--- a/zhaquirks/smartthings/multiv4.py
+++ b/zhaquirks/smartthings/multiv4.py
@@ -1,66 +1,22 @@
 """Device handler for smartthings multiV4 sensors."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Basic, BinaryInput, Identify, Ota, PollControl
-from zigpy.zcl.clusters.measurement import TemperatureMeasurement
-from zigpy.zcl.clusters.security import IasZone
+from zigpy.quirks.v2 import QuirkBuilder
 
 from zhaquirks import PowerConfigurationCluster
 from zhaquirks.centralite import CentraLiteAccelCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.smartthings import SMART_THINGS
 
-
-class SmartThingsMultiV4(CustomDevice):
-    """SmartThingsMultiV4."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        # device_version=0
-        # input_clusters=[0, 1, 3, 15, 32, 1026, 1280, 64514]
-        # output_clusters=[25]>
-        MODELS_INFO: [(SMART_THINGS, "multiv4")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
-                    Identify.cluster_id,
-                    BinaryInput.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    CentraLiteAccelCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfigurationCluster,
-                    Identify.cluster_id,
-                    BinaryInput.cluster_id,
-                    PollControl.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    CentraLiteAccelCluster,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(SMART_THINGS, "multiv4")
+    .replaces(
+        replacement_cluster_class=PowerConfigurationCluster,
+        cluster_id=PowerConfigurationCluster.cluster_id,
+        endpoint_id=1,
+    )
+    .replaces(
+        replacement_cluster_class=CentraLiteAccelCluster,
+        cluster_id=CentraLiteAccelCluster.cluster_id,
+        endpoint_id=1,
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/smartthings/pgc313.py
+++ b/zhaquirks/smartthings/pgc313.py
@@ -1,19 +1,9 @@
 """SmartThings SmartSense Multi Sensor quirk."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Basic, Ota
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.security import IasZone
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-    ZONE_TYPE,
-)
+from zhaquirks.const import ZONE_TYPE
 from zhaquirks.smartthings import SMART_THINGS, SmartThingsIasZone
 
 SMARTSENSE_MULTI_DEVICE_TYPE = 0x0139  # decimal = 313
@@ -25,36 +15,9 @@ class IasZoneContactSwitchCluster(SmartThingsIasZone):
     _CONSTANT_ATTRIBUTES = {ZONE_TYPE: IasZone.ZoneType.Contact_Switch}
 
 
-class SmartthingsSmartSenseMultiSensor(CustomDevice):
-    """Multipurpose sensor."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=313
-        #  device_version=0 input_clusters=[0] output_clusters=[25]>
-        MODELS_INFO: [(SMART_THINGS, "PGC313")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: SMARTSENSE_MULTI_DEVICE_TYPE,
-                INPUT_CLUSTERS: [Basic.cluster_id],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-            #  <SimpleDescriptor endpoint=2 profile=64513 device_type=313
-            #  device_version=0 input_clusters=[] output_clusters=[]>
-            2: {
-                PROFILE_ID: 0xFC01,  # decimal = 64513
-                DEVICE_TYPE: SMARTSENSE_MULTI_DEVICE_TYPE,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [Basic.cluster_id, IasZoneContactSwitchCluster],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(SMART_THINGS, "PGC313")
+    .adds(IasZoneContactSwitchCluster, endpoint_id=1)
+    .removes_endpoint(endpoint_id=2)
+    .add_to_registry()
+)

--- a/zhaquirks/smartthings/pgc314.py
+++ b/zhaquirks/smartthings/pgc314.py
@@ -1,17 +1,7 @@
 """SmartThings SmartSense Motion quirk."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Basic, Ota
+from zigpy.quirks.v2 import QuirkBuilder
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.smartthings import SMART_THINGS, SmartThingsIasZone
 
 SMARTSENSE_MOTION_DEVICE_TYPE = 0x013A  # decimal = 314
@@ -25,36 +15,9 @@ class IasZoneMotionCluster(SmartThingsIasZone):
     _CONSTANT_ATTRIBUTES = {ZONE_TYPE: MOTION_TYPE}
 
 
-class SmartthingsSmartSenseMotionSensor(CustomDevice):
-    """SmartSense Motion Sensor."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=314
-        #  device_version=0 input_clusters=[0] output_clusters=[25]>
-        MODELS_INFO: [(SMART_THINGS, "PGC314")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: SMARTSENSE_MOTION_DEVICE_TYPE,
-                INPUT_CLUSTERS: [Basic.cluster_id],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-            #  <SimpleDescriptor endpoint=2 profile=64513 device_type=314
-            #  device_version=0 input_clusters=[] output_clusters=[]>
-            2: {
-                PROFILE_ID: 0xFC01,  # decimal = 64513
-                DEVICE_TYPE: SMARTSENSE_MOTION_DEVICE_TYPE,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [Basic.cluster_id, IasZoneMotionCluster],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(SMART_THINGS, "PGC314")
+    .adds(IasZoneMotionCluster, endpoint_id=1)
+    .removes_endpoint(endpoint_id=2)
+    .add_to_registry()
+)

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -5,30 +5,14 @@ from __future__ import annotations
 from collections.abc import Coroutine
 from typing import Any
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    Ota,
-    PowerConfiguration,
-    Scenes,
-)
+from zigpy.zcl.clusters.general import PowerConfiguration
 
 from zhaquirks import DoublingPowerConfigurationCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 
 
 class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
@@ -65,7 +49,13 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
 
 (
     QuirkBuilder("Smartwings", "WM25/L-Z")
-    .replaces(replacement_cluster_class=DoublingPowerConfigurationCluster, cluster_id=PowerConfiguration.cluster_id)
-    .replaces(replacement_cluster_class=InvertedWindowCoveringCluster, cluster_id=WindowCovering.cluster_id)
+    .replaces(
+        replacement_cluster_class=DoublingPowerConfigurationCluster,
+        cluster_id=PowerConfiguration.cluster_id,
+    )
+    .replaces(
+        replacement_cluster_class=InvertedWindowCoveringCluster,
+        cluster_id=WindowCovering.cluster_id,
+    )
     .add_to_registry()
 )

--- a/zhaquirks/smartwings/wm25lz.py
+++ b/zhaquirks/smartwings/wm25lz.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
@@ -62,48 +63,9 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
         )
 
 
-class WM25LBlinds(CustomDevice):
-    """Custom device representing Smartwings WM25LZ blinds."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=514
-        # device_version=1
-        # input_clusters=[0, 1, 3, 4, 5, 258]
-        # output_clusters=[3, 25]>
-        MODELS_INFO: [
-            ("Smartwings", "WM25/L-Z"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    WindowCovering.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    DoublingPowerConfigurationCluster,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    InvertedWindowCoveringCluster,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder("Smartwings", "WM25/L-Z")
+    .replaces(replacement_cluster_class=DoublingPowerConfigurationCluster, cluster_id=PowerConfiguration.cluster_id)
+    .replaces(replacement_cluster_class=InvertedWindowCoveringCluster, cluster_id=WindowCovering.cluster_id)
+    .add_to_registry()
+)

--- a/zhaquirks/sonoff/snzb06p.py
+++ b/zhaquirks/sonoff/snzb06p.py
@@ -1,20 +1,9 @@
 """Sonoff SNZB-06 - Zigbee presence sensor."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, Identify, Ota
-from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
-
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 
 SONOFF_CLUSTER_FC11_ID = 0xFC11
 SONOFF_CLUSTER_FC57_ID = 0xFC57
@@ -38,52 +27,16 @@ class SonoffFC11Cluster(CustomCluster):
     }
 
 
-class SonoffPresenceSenorSNZB06P(CustomDevice):
-    """Sonoff human presence senor - model SNZB-06P."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1, profile=260, device_type=263
-        # device_version=1
-        # input_clusters=[0, 3, 1030, 1280, 64599, 64529]
-        # output_clusters=[3, 25]>
-        MODELS_INFO: [
-            ("SONOFF", "SNZB-06P"),
-        ],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    OccupancySensing.cluster_id,
-                    IasZone.cluster_id,
-                    SONOFF_CLUSTER_FC11_ID,
-                    SONOFF_CLUSTER_FC57_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    OccupancySensing.cluster_id,
-                    SonoffFC11Cluster,
-                    SONOFF_CLUSTER_FC57_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Ota.cluster_id,
-                ],
-            },
-        },
-    }
+(
+    QuirkBuilder("SONOFF", "SNZB-06P")
+    .replaces(
+        replacement_cluster_class=SonoffFC11Cluster,
+        cluster_id=SONOFF_CLUSTER_FC11_ID,
+        endpoint_id=1,
+    )
+    .removes(
+        cluster_id=IasZone.cluster_id,
+        endpoint_id=1,
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/sourcingandcreation/smart_button.py
+++ b/zhaquirks/sourcingandcreation/smart_button.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Basic,
     Groups,

--- a/zhaquirks/sourcingandcreation/smart_button.py
+++ b/zhaquirks/sourcingandcreation/smart_button.py
@@ -1,20 +1,6 @@
 """Device handler for Sourcing & Creation EB-SB-1B (Boulanger Essentielb 8009289) smart button."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    PowerConfiguration,
-)
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.lighting import Color
-from zigpy.zcl.clusters.lightlink import LightLink
 
 from zhaquirks.const import (
     CLUSTER_ID,
@@ -22,99 +8,38 @@ from zhaquirks.const import (
     COMMAND_STEP,
     COMMAND_STEP_COLOR_TEMP,
     COMMAND_STOP,
-    DEVICE_TYPE,
     DOUBLE_PRESS,
     ENDPOINT_ID,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
     LONG_PRESS,
     LONG_RELEASE,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
     SHORT_PRESS,
     TURN_ON,
 )
 
-
-class SourcingAndCreationSmartButton(CustomDevice):
-    """Custom device representing Sourcing & Creation smart button."""
-
-    signature = {
-        #  <SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=2048,
-        #  device_version=1,
-        #  input_clusters=[0, 1, 3, 2821, 4096, 64769],
-        #  output_clusters=[3, 4, 6, 8, 25, 768, 4096])>
-        MODELS_INFO: [("Sourcing & Creation", "EB-SB-1B")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,  # 260
-                DEVICE_TYPE: zha.DeviceType.COLOR_CONTROLLER,  # 2048
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    PowerConfiguration.cluster_id,  # 1
-                    Identify.cluster_id,  # 3
-                    Diagnostic.cluster_id,  # 2821
-                    LightLink.cluster_id,  # 4096
-                    0xFD01,  # 64769
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Ota.cluster_id,  # 25
-                    Color.cluster_id,  # 768
-                    LightLink.cluster_id,  # 4096
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_CONTROLLER,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    PowerConfiguration.cluster_id,  # 1
-                    Identify.cluster_id,  # 3
-                    Diagnostic.cluster_id,  # 2821
-                    LightLink.cluster_id,  # 4096
-                    0xFD01,  # 64769
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Ota.cluster_id,  # 25
-                    Color.cluster_id,  # 768
-                    LightLink.cluster_id,  # 4096
-                ],
-            }
-        },
-    }
-
-    device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {
-            CLUSTER_ID: 6,  # OnOff.cluster_id
-            ENDPOINT_ID: 1,
-        },
-        (LONG_PRESS, TURN_ON): {
-            COMMAND: COMMAND_STEP,
-            CLUSTER_ID: 8,  # LevelControl.cluster_id
-            ENDPOINT_ID: 1,
-        },
-        (LONG_RELEASE, TURN_ON): {
-            COMMAND: COMMAND_STOP,
-            CLUSTER_ID: 8,  # LevelControl.cluster_id
-            ENDPOINT_ID: 1,
-        },
-        (DOUBLE_PRESS, TURN_ON): {
-            COMMAND: COMMAND_STEP_COLOR_TEMP,
-            CLUSTER_ID: 768,  # Color.cluster_id
-            ENDPOINT_ID: 1,
-        },
-    }
+(
+    QuirkBuilder("Sourcing & Creation", "EB-SB-1B")
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, TURN_ON): {
+                CLUSTER_ID: 6,  # OnOff.cluster_id
+                ENDPOINT_ID: 1,
+            },
+            (LONG_PRESS, TURN_ON): {
+                COMMAND: COMMAND_STEP,
+                CLUSTER_ID: 8,  # LevelControl.cluster_id
+                ENDPOINT_ID: 1,
+            },
+            (LONG_RELEASE, TURN_ON): {
+                COMMAND: COMMAND_STOP,
+                CLUSTER_ID: 8,  # LevelControl.cluster_id
+                ENDPOINT_ID: 1,
+            },
+            (DOUBLE_PRESS, TURN_ON): {
+                COMMAND: COMMAND_STEP_COLOR_TEMP,
+                CLUSTER_ID: 768,  # Color.cluster_id
+                ENDPOINT_ID: 1,
+            },
+        }
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/texasinstruments/router.py
+++ b/zhaquirks/texasinstruments/router.py
@@ -2,21 +2,11 @@
 
 from typing import Final
 
-from zigpy.profiles import zgp, zha
-from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Identify
+from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.foundation import ZCLAttributeDef
-
-from zhaquirks import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 
 
 class BasicCluster(CustomCluster, Basic):
@@ -32,7 +22,16 @@ class BasicCluster(CustomCluster, Basic):
 
 (
     QuirkBuilder("TexasInstruments", "ti.router")
-    .replaces(replacement_cluster_class=BasicCluster, cluster_id=Basic.cluster_id, endpoint_id=8)
-    .replaces(replacement_cluster_class=BasicCluster, cluster_id=Basic.cluster_id, endpoint_id=8, cluster_type="output")
+    .replaces(
+        replacement_cluster_class=BasicCluster,
+        cluster_id=Basic.cluster_id,
+        endpoint_id=8,
+    )
+    .replaces(
+        replacement_cluster_class=BasicCluster,
+        cluster_id=Basic.cluster_id,
+        endpoint_id=8,
+        cluster_type="output",
+    )
     .add_to_registry()
 )

--- a/zhaquirks/texasinstruments/router.py
+++ b/zhaquirks/texasinstruments/router.py
@@ -4,6 +4,7 @@ from typing import Final
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Identify
 from zigpy.zcl.foundation import ZCLAttributeDef
@@ -29,49 +30,9 @@ class BasicCluster(CustomCluster, Basic):
         )
 
 
-class TiRouter(CustomDevice):
-    """Texas Instruments Z-Stack router device."""
-
-    signature = {
-        MODELS_INFO: [("TexasInstruments", "ti.router")],
-        ENDPOINTS: {
-            8: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: 0x00FF,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                ],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
-    }
-    replacement = {
-        ENDPOINTS: {
-            8: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: 0x00FF,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    BasicCluster,
-                ],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
-    }
+(
+    QuirkBuilder("TexasInstruments", "ti.router")
+    .replaces(replacement_cluster_class=BasicCluster, cluster_id=Basic.cluster_id, endpoint_id=8)
+    .replaces(replacement_cluster_class=BasicCluster, cluster_id=Basic.cluster_id, endpoint_id=8, cluster_type="output")
+    .add_to_registry()
+)

--- a/zhaquirks/thirdreality/button.py
+++ b/zhaquirks/thirdreality/button.py
@@ -1,9 +1,8 @@
 """Third Reality button devices."""
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import Basic, LevelControl, MultistateInput, OnOff, Ota
+from zigpy.zcl.clusters.general import MultistateInput
 
 from zhaquirks import CustomCluster, PowerConfigurationCluster
 from zhaquirks.const import (
@@ -12,17 +11,10 @@ from zhaquirks.const import (
     COMMAND_HOLD,
     COMMAND_RELEASE,
     COMMAND_SINGLE,
-    DEVICE_TYPE,
     DOUBLE_PRESS,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
     LONG_PRESS,
     LONG_RELEASE,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
     SHORT_PRESS,
-    SKIP_CONFIGURATION,
     VALUE,
     ZHA_SEND_EVENT,
 )
@@ -66,15 +58,25 @@ class MultistateInputCluster(CustomCluster, MultistateInput):
 
 (
     QuirkBuilder(THIRD_REALITY, "3RSB22BZ")
-    .replaces_endpoint(endpoint_id=1, profile_id=0x0104, device_type=zha.DeviceType.REMOTE_CONTROL)
-    .replaces(replacement_cluster_class=CustomPowerConfigurationCluster, cluster_id=CustomPowerConfigurationCluster.cluster_id)
-    .replaces(replacement_cluster_class=MultistateInputCluster, cluster_id=MultistateInput.cluster_id)
+    .replaces_endpoint(
+        endpoint_id=1, profile_id=0x0104, device_type=zha.DeviceType.REMOTE_CONTROL
+    )
+    .replaces(
+        replacement_cluster_class=CustomPowerConfigurationCluster,
+        cluster_id=CustomPowerConfigurationCluster.cluster_id,
+    )
+    .replaces(
+        replacement_cluster_class=MultistateInputCluster,
+        cluster_id=MultistateInput.cluster_id,
+    )
     .skip_configuration()
-    .device_automation_triggers({
-        (DOUBLE_PRESS, DOUBLE_PRESS): {COMMAND: COMMAND_DOUBLE},
-        (SHORT_PRESS, SHORT_PRESS): {COMMAND: COMMAND_SINGLE},
-        (LONG_PRESS, LONG_PRESS): {COMMAND: COMMAND_HOLD},
-        (LONG_RELEASE, LONG_RELEASE): {COMMAND: COMMAND_RELEASE},
-    })
+    .device_automation_triggers(
+        {
+            (DOUBLE_PRESS, DOUBLE_PRESS): {COMMAND: COMMAND_DOUBLE},
+            (SHORT_PRESS, SHORT_PRESS): {COMMAND: COMMAND_SINGLE},
+            (LONG_PRESS, LONG_PRESS): {COMMAND: COMMAND_HOLD},
+            (LONG_RELEASE, LONG_RELEASE): {COMMAND: COMMAND_RELEASE},
+        }
+    )
     .add_to_registry()
 )

--- a/zhaquirks/thirdreality/button.py
+++ b/zhaquirks/thirdreality/button.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import Basic, LevelControl, MultistateInput, OnOff, Ota
 
 from zhaquirks import CustomCluster, PowerConfigurationCluster
@@ -63,50 +64,17 @@ class MultistateInputCluster(CustomCluster, MultistateInput):
             super()._update_attribute(0, action)
 
 
-class Button(CustomDevice):
-    """thirdreality button device - alternate version."""
-
-    signature = {
-        MODELS_INFO: [(THIRD_REALITY, "3RSB22BZ")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: 0x0104,
-                DEVICE_TYPE: 0x0006,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    MultistateInput.cluster_id,
-                    CustomPowerConfigurationCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                ],
-            }
-        },
-    }
-    replacement = {
-        SKIP_CONFIGURATION: True,
-        ENDPOINTS: {
-            1: {
-                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    CustomPowerConfigurationCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Ota.cluster_id,
-                ],
-            }
-        },
-    }
-
-    device_automation_triggers = {
+(
+    QuirkBuilder(THIRD_REALITY, "3RSB22BZ")
+    .replaces_endpoint(endpoint_id=1, profile_id=0x0104, device_type=zha.DeviceType.REMOTE_CONTROL)
+    .replaces(replacement_cluster_class=CustomPowerConfigurationCluster, cluster_id=CustomPowerConfigurationCluster.cluster_id)
+    .replaces(replacement_cluster_class=MultistateInputCluster, cluster_id=MultistateInput.cluster_id)
+    .skip_configuration()
+    .device_automation_triggers({
         (DOUBLE_PRESS, DOUBLE_PRESS): {COMMAND: COMMAND_DOUBLE},
         (SHORT_PRESS, SHORT_PRESS): {COMMAND: COMMAND_SINGLE},
         (LONG_PRESS, LONG_PRESS): {COMMAND: COMMAND_HOLD},
         (LONG_RELEASE, LONG_RELEASE): {COMMAND: COMMAND_RELEASE},
-    }
+    })
+    .add_to_registry()
+)

--- a/zhaquirks/thirdreality/switch.py
+++ b/zhaquirks/thirdreality/switch.py
@@ -1,19 +1,8 @@
 """Third Reality switch devices."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes
-from zigpy.zcl.clusters.homeautomation import Diagnostic
+from zigpy.quirks.v2 import QuirkBuilder
 
 from zhaquirks import PowerConfigurationCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.thirdreality import THIRD_REALITY
 
 
@@ -24,95 +13,13 @@ class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     MAX_VOLTS = 3.0
 
 
-class Switch(CustomDevice):
-    """3RSS008Z device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260
-        # device_type=2 device_version=1
-        # input_clusters=[0, 4, 3, 6, 5, 25, 1]
-        # output_clusters=[1]>
-        MODELS_INFO: [(THIRD_REALITY, "3RSS007Z"), (THIRD_REALITY, "3RSS008Z")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_OUTPUT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    Ota.cluster_id,
-                    CustomPowerConfigurationCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [CustomPowerConfigurationCluster.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_OUTPUT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    Ota.cluster_id,
-                    CustomPowerConfigurationCluster,
-                ],
-                OUTPUT_CLUSTERS: [CustomPowerConfigurationCluster.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(THIRD_REALITY, "3RSS007Z")
+    .applies_to(THIRD_REALITY, "3RSS008Z")
+    .replaces(CustomPowerConfigurationCluster)
+    .add_to_registry()
+)
 
 
-class SwitchPlus(Switch):
-    """RealitySwitch Plus (3RSS008Z) device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260
-        # device_type=2 device_version=1
-        # input_clusters=[0, 4, 3, 6, 5, 1, 2821]
-        # output_clusters=[25]>
-        MODELS_INFO: [(THIRD_REALITY, "3RSS008Z")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_OUTPUT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    Diagnostic.cluster_id,
-                    CustomPowerConfigurationCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_OUTPUT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    Diagnostic.cluster_id,
-                    CustomPowerConfigurationCluster,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+# Note: SwitchPlus (3RSS008Z) with Diagnostic cluster is handled by the main quirk above
+# The v2 API only replaces the power configuration, other cluster differences are handled automatically

--- a/zhaquirks/thirdreality/vibrate.py
+++ b/zhaquirks/thirdreality/vibrate.py
@@ -4,6 +4,7 @@ from typing import Final
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic, Ota, PowerConfiguration
 from zigpy.zcl.clusters.security import IasZone
@@ -42,41 +43,8 @@ class ThirdRealityAccelCluster(CustomCluster):
         )
 
 
-class Vibrate(CustomDevice):
-    """ThirdReality vibrate device."""
-
-    signature = {
-        MODELS_INFO: [(THIRD_REALITY, "3RVS01031Z")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    IasZone.cluster_id,
-                    ThirdRealityAccelCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            }
-        },
-    }
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    IasZone.cluster_id,
-                    ThirdRealityAccelCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            }
-        },
-    }
+(
+    QuirkBuilder(THIRD_REALITY, "3RVS01031Z")
+    .replaces(replacement_cluster_class=ThirdRealityAccelCluster, cluster_id=MANUFACTURER_SPECIFIC_CLUSTER_ID)
+    .add_to_registry()
+)

--- a/zhaquirks/thirdreality/vibrate.py
+++ b/zhaquirks/thirdreality/vibrate.py
@@ -2,23 +2,11 @@
 
 from typing import Final
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, Ota, PowerConfiguration
-from zigpy.zcl.clusters.security import IasZone
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 from zhaquirks import CustomCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.thirdreality import THIRD_REALITY
 
 MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFFF1
@@ -45,6 +33,9 @@ class ThirdRealityAccelCluster(CustomCluster):
 
 (
     QuirkBuilder(THIRD_REALITY, "3RVS01031Z")
-    .replaces(replacement_cluster_class=ThirdRealityAccelCluster, cluster_id=MANUFACTURER_SPECIFIC_CLUSTER_ID)
+    .replaces(
+        replacement_cluster_class=ThirdRealityAccelCluster,
+        cluster_id=MANUFACTURER_SPECIFIC_CLUSTER_ID,
+    )
     .add_to_registry()
 )

--- a/zhaquirks/trust/zpir8000.py
+++ b/zhaquirks/trust/zpir8000.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
 from zigpy.zcl.clusters.security import IasZone
 
@@ -18,41 +19,8 @@ from zhaquirks.trust import MotionCluster
 MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFFFF
 
 
-class ZPIR8000(CustomDevice):
-    """Trust ZPIR-8000."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        # device_version=1
-        # input_clusters=[0, 3, 1280, 65535, 1]
-        # output_clusters=[]>
-        MODELS_INFO: [("ADUROLIGHT", "VMS_ADUROLIGHT")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    IasZone.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    MotionCluster,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
-                ]
-            }
-        }
-    }
+(
+    QuirkBuilder("ADUROLIGHT", "VMS_ADUROLIGHT")
+    .replaces(replacement_cluster_class=MotionCluster, cluster_id=IasZone.cluster_id)
+    .add_to_registry()
+)

--- a/zhaquirks/trust/zpir8000.py
+++ b/zhaquirks/trust/zpir8000.py
@@ -1,19 +1,8 @@
 """Device handler for Trust ZPIR-8000 sensors."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
 from zigpy.zcl.clusters.security import IasZone
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.trust import MotionCluster
 
 MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFFFF

--- a/zhaquirks/universalelectronics/contact_sensor.py
+++ b/zhaquirks/universalelectronics/contact_sensor.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PollControl
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
@@ -25,47 +26,8 @@ class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     MAX_VOLTS = 3.0
 
 
-class ContactSensor(CustomDevice):
-    """XHS2-UE Door/Window Sensor."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        # device_version=0
-        # input_clusters=[0, 1, 3, 1026, 1280, 32, 2821]
-        # output_clusters=[25]>
-        MODELS_INFO: [("Universal Electronics Inc", "URC4460BC0-X-R")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    CustomPowerConfigurationCluster.cluster_id,
-                    Identify.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    PollControl.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    CustomPowerConfigurationCluster,
-                    Identify.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    PollControl.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder("Universal Electronics Inc", "URC4460BC0-X-R")
+    .replaces(replacement_cluster_class=CustomPowerConfigurationCluster)
+    .add_to_registry()
+)

--- a/zhaquirks/universalelectronics/contact_sensor.py
+++ b/zhaquirks/universalelectronics/contact_sensor.py
@@ -1,22 +1,8 @@
 """XHS2-UE Door/Window Sensor."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import Basic, Identify, Ota, PollControl
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.measurement import TemperatureMeasurement
-from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 
 
 class CustomPowerConfigurationCluster(PowerConfigurationCluster):

--- a/zhaquirks/visonic/mct340.py
+++ b/zhaquirks/visonic/mct340.py
@@ -1,22 +1,8 @@
 """Visonic MCT340 device."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import Basic, Identify, Ota, PollControl
-from zigpy.zcl.clusters.homeautomation import Diagnostic
-from zigpy.zcl.clusters.measurement import TemperatureMeasurement
-from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 
 OSRAM_DEVICE = 0x0810  # 2064 base 10
 OSRAM_CLUSTER = 0xFD00  # 64768 base 10
@@ -27,8 +13,6 @@ class CustomPowerConfigurationCluster(PowerConfigurationCluster):
 
     MIN_VOLTS = 2.1
     MAX_VOLTS = 3.0
-
-
 
 
 (

--- a/zhaquirks/visonic/mct340.py
+++ b/zhaquirks/visonic/mct340.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PollControl
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
@@ -28,47 +29,11 @@ class CustomPowerConfigurationCluster(PowerConfigurationCluster):
     MAX_VOLTS = 3.0
 
 
-class MCT340(CustomDevice):
-    """Visonic MCT340 device."""
 
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
-        # device_version=0
-        # input_clusters=[0, 1, 3, 1026, 1280, 32, 2821]
-        # output_clusters=[25]>
-        MODELS_INFO: [("Visonic", "MCT-340 E"), ("Visonic", "MCT-340 SMA")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    CustomPowerConfigurationCluster.cluster_id,
-                    Identify.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    PollControl.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
 
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    CustomPowerConfigurationCluster,
-                    Identify.cluster_id,
-                    TemperatureMeasurement.cluster_id,
-                    IasZone.cluster_id,
-                    PollControl.cluster_id,
-                    Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder("Visonic", "MCT-340 E")
+    .applies_to("Visonic", "MCT-340 SMA")
+    .replaces(replacement_cluster_class=CustomPowerConfigurationCluster)
+    .add_to_registry()
+)

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, Union
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -5,7 +5,6 @@ from typing import Any, Optional, Union
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
-from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (

--- a/zhaquirks/zbeacon/doorsensor.py
+++ b/zhaquirks/zbeacon/doorsensor.py
@@ -1,71 +1,13 @@
 """Doorsensors."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Identify,
-    Ota,
-    PollControl,
-    PowerConfiguration,
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.general import PollControl
+
+(
+    QuirkBuilder("zbeacon", "DS01")
+    .removes(
+        cluster_id=PollControl.cluster_id,
+        endpoint_id=1,
+    )
+    .add_to_registry()
 )
-from zigpy.zcl.clusters.security import IasZone
-
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-
-
-class DS01DoorSensor(CustomDevice):
-    """One of the long rectangular Doorsensors working on 2xAAA.
-
-    It doesn't correctly implement the PollControl Cluster.
-    The device will send "PollControl:checkin()" on PollControl cluster,
-        but doesn't respond when checkin_response is sent after that from the coordinator
-
-    The model zbeacon DS01 sounds a lot like ("eWeLink", "DS01") from Sonoff sold as Sonoff SNZB-04
-    The device tested is sold as Elivco and IHseno IH-MC01 and uses a TuYa ZTU module as described here:
-        https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7415
-    """
-
-    signature = {
-        MODELS_INFO: [("zbeacon", "DS01")],
-        ENDPOINTS: {
-            # SizePrefixedSimpleDescriptor(
-            # endpoint=1, profile=260, device_type=1026, device_version=0,
-            # input_clusters=[0, 3, 1, 1280, 32], output_clusters=[25])
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    PollControl.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    IasZone.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Ota.cluster_id,
-                ],
-            }
-        }
-    }

--- a/zhaquirks/zen/thermostat.py
+++ b/zhaquirks/zen/thermostat.py
@@ -1,20 +1,8 @@
 """Module to handle quirks of the  Zen Within thermostat."""
 
-import zigpy.profiles.zha as zha_p
-from zigpy.quirks import CustomDevice
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters import general, homeautomation, hvac
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
 from zhaquirks.zen import ZEN, ZenPowerConfiguration
-
 
 (
     QuirkBuilder(ZEN, "Zen-01")

--- a/zhaquirks/zen/thermostat.py
+++ b/zhaquirks/zen/thermostat.py
@@ -2,6 +2,7 @@
 
 import zigpy.profiles.zha as zha_p
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters import general, homeautomation, hvac
 
 from zhaquirks.const import (
@@ -15,55 +16,8 @@ from zhaquirks.const import (
 from zhaquirks.zen import ZEN, ZenPowerConfiguration
 
 
-class ZenThermostat(CustomDevice):
-    """Zen Within Thermostat custom device."""
-
-    signature = {
-        # Node Descriptor: <Optional byte1=2 byte2=64 mac_capability_flags=128
-        # manufacturer_code=4440 maximum_buffer_size=82
-        # maximum_incoming_transfer_size=128 server_mask=0
-        # maximum_outgoing_transfer_size=128 descriptor_capability_field=0>
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=769 device_version=0
-        # input_clusters=[0, 1, 3, 4, 5, 32, 513, 514, 516, 2821]
-        # output_clusters=[10, 25]>
-        MODELS_INFO: [(ZEN, "Zen-01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha_p.PROFILE_ID,
-                DEVICE_TYPE: zha_p.DeviceType.THERMOSTAT,
-                INPUT_CLUSTERS: [
-                    general.Basic.cluster_id,
-                    general.PowerConfiguration.cluster_id,
-                    general.Identify.cluster_id,
-                    general.Groups.cluster_id,
-                    general.Scenes.cluster_id,
-                    general.PollControl.cluster_id,
-                    hvac.Thermostat.cluster_id,
-                    hvac.Fan.cluster_id,
-                    hvac.UserInterface.cluster_id,
-                    homeautomation.Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [general.Time.cluster_id, general.Ota.cluster_id],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    general.Basic.cluster_id,
-                    ZenPowerConfiguration,
-                    general.Identify.cluster_id,
-                    general.Groups.cluster_id,
-                    general.Scenes.cluster_id,
-                    general.PollControl.cluster_id,
-                    hvac.Thermostat.cluster_id,
-                    hvac.Fan.cluster_id,
-                    hvac.UserInterface.cluster_id,
-                    homeautomation.Diagnostic.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [general.Time.cluster_id, general.Ota.cluster_id],
-            }
-        }
-    }
+(
+    QuirkBuilder(ZEN, "Zen-01")
+    .replaces(replacement_cluster_class=ZenPowerConfiguration)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR migrates a handful of very simple v1 quirks to v2 quirks: only those that replace clusters, modify the device type, add automation triggers, etc. We can do more in a future pass. My goal is to get rid of v1 quirks entirely and build out the APIs we need for v2 quirks to do that.

These quirks have *not* been tested and many will be broken. This is more or less a test that will be brought into a working state *eventually*.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
