### PR TITLE
Globally allow Aqara devices to handle swapped ZCL header direction

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2257,3 +2257,24 @@ def test_t1m_ceiling_light(zigpy_device_from_v2_quirk, endpoint):
         == AqaraLightT1M.AttributeDefs.power_on_state.id
     )
     assert cluster_listener.attribute_updates[1][1] == LumiPowerOnStateMode.Off
+
+
+async def test_lumi_magnet_sensor_aq2_bad_direction(zigpy_device_from_quirk):
+    """Test Aqara Magnet Sensor AQ2 quirk dealing with bad ZCL command direction."""
+
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.magnet_aq2.MagnetAQ2)
+    listener = ClusterListener(device.endpoints[1].out_clusters[OnOff.cluster_id])
+
+    # The device has a bad ZCL header and reports the incorrect direction for commands
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=6,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(bytes.fromhex("18930A00001001")),
+        )
+    )
+
+    # Our matching logic should be forgiving
+    assert listener.attribute_updates == [(0, t.Bool.true)]

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -12,7 +12,7 @@ import zigpy.device
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy.typing import AddressingMode
-from zigpy.zcl import foundation
+from zigpy.zcl import Cluster, foundation
 from zigpy.zcl.clusters.general import (
     AnalogInput,
     Basic,
@@ -121,6 +121,36 @@ class XiaomiCustomDevice(CustomDevice):
         if not hasattr(self, BATTERY_SIZE):
             self.battery_size = BatterySize.CR2032
         super().__init__(*args, **kwargs)
+
+    def _find_zcl_cluster(
+        self, hdr: foundation.ZCLHeader, packet: t.ZigbeePacket
+    ) -> Cluster:
+        """Find a cluster for the packet."""
+        assert packet.src_ep is not None
+        endpoint = self.endpoints[packet.src_ep]
+
+        # Aqara devices seem to be very lax with their ZCL header's `direction` field
+        if (
+            hdr.frame_control.direction == foundation.Direction.Client_to_Server
+            and packet.cluster_id not in endpoint.out_clusters
+        ) or (
+            hdr.frame_control.direction == foundation.Direction.Server_to_Client
+            and packet.cluster_id not in endpoint.in_clusters
+        ):
+            _LOGGER.debug(
+                "Packet is coming in the wrong direction for cluster %s on endpoint %s,"
+                " swapping direction and trying again"
+            )
+            return super()._find_zcl_cluster(
+                hdr.replace(
+                    frame_control=hdr.frame_control.replace(
+                        direction=hdr.frame_control.direction.flip()
+                    )
+                ),
+                packet,
+            )
+
+        return super()._find_zcl_cluster(hdr, packet)
 
 
 class XiaomiQuickInitDevice(XiaomiCustomDevice, QuickInitDevice):

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -126,21 +126,17 @@ class XiaomiCustomDevice(CustomDevice):
         self, hdr: foundation.ZCLHeader, packet: t.ZigbeePacket
     ) -> Cluster:
         """Find a cluster for the packet."""
-        assert packet.src_ep is not None
-        endpoint = self.endpoints[packet.src_ep]
 
-        # Aqara devices seem to be very lax with their ZCL header's `direction` field
-        if (
-            hdr.frame_control.direction == foundation.Direction.Client_to_Server
-            and packet.cluster_id not in endpoint.out_clusters
-        ) or (
-            hdr.frame_control.direction == foundation.Direction.Server_to_Client
-            and packet.cluster_id not in endpoint.in_clusters
-        ):
+        # Aqara devices seem to be very lax with their ZCL header's `direction` field,
+        # we should try "flipping" it if matching doesn't work normally.
+        try:
+            return super()._find_zcl_cluster(hdr, packet)
+        except KeyError:
             _LOGGER.debug(
                 "Packet is coming in the wrong direction for cluster %s on endpoint %s,"
                 " swapping direction and trying again"
             )
+
             return super()._find_zcl_cluster(
                 hdr.replace(
                     frame_control=hdr.frame_control.replace(
@@ -149,8 +145,6 @@ class XiaomiCustomDevice(CustomDevice):
                 ),
                 packet,
             )
-
-        return super()._find_zcl_cluster(hdr, packet)
 
 
 class XiaomiQuickInitDevice(XiaomiCustomDevice, QuickInitDevice):

--- a/zhaquirks/xiaomi/aqara/magnet_agl02.py
+++ b/zhaquirks/xiaomi/aqara/magnet_agl02.py
@@ -1,8 +1,6 @@
 """Quirk for Aqara T1 door sensor lumi.magnet.agl02."""
 
 from zigpy.profiles import zha
-import zigpy.types as t
-from zigpy.zcl import Cluster, foundation
 from zigpy.zcl.clusters.general import Basic, Identify, OnOff, Ota, PowerConfiguration
 from zigpy.zcl.clusters.security import IasZone
 
@@ -30,20 +28,6 @@ class MagnetT1(XiaomiCustomDevice):
         """Init."""
         self.battery_size = BatterySize.CR1632
         super().__init__(*args, **kwargs)
-
-    def _find_zcl_cluster(
-        self, hdr: foundation.ZCLHeader, packet: t.ZigbeePacket
-    ) -> Cluster:
-        """Find a cluster for the packet."""
-        assert packet.src_ep is not None
-        endpoint = self.endpoints[packet.src_ep]
-
-        # The `direction` field is incorrectly set, we should always route the packet
-        # to client `OnOff` cluster
-        if packet.cluster_id == OnOff.cluster_id:
-            return endpoint.out_clusters[packet.cluster_id]
-
-        return super()._find_zcl_cluster(hdr, packet)
 
     signature = {
         MODELS_INFO: [("LUMI", "lumi.magnet.agl02")],


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
I've received a report of an old Aqara door sensor that doesn't set the ZCL header direction correctly, identifying its attribute report as a server-to-client and not a client-to-server:

```python
2025-08-01 18:57:26.918 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2025, 8, 1, 16, 57, 26, 918827, tzinfo=datetime.timezone.utc), priority=None, src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xF4B3), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=228, profile_id=260, cluster_id=6, data=Serialized[b'\x18\x93\n\x00\x00\x10\x01'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=224, rssi=-55)
2025-08-01 18:57:26.919 DEBUG (MainThread) [zigpy.device] [0xf4b3] Ignoring message on unknown cluster: 0x0006
```

It looks like this problem may affect all Aqara devices, unfortunately. This PR sort of restores our old behavior and tries to flip  the ZCL header before giving up finding a matching cluster.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
