### PR TITLE
Fix replacing Inovelli VZM35-SN clusters

### DIFF
--- a/zhaquirks/inovelli/VZM35SN.py
+++ b/zhaquirks/inovelli/VZM35SN.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl import ClusterType
 
 from zhaquirks.inovelli import INOVELLI_AUTOMATION_TRIGGERS, InovelliVZM35SNCluster
 
@@ -9,6 +10,11 @@ from zhaquirks.inovelli import INOVELLI_AUTOMATION_TRIGGERS, InovelliVZM35SNClus
     QuirkBuilder("Inovelli", "VZM35-SN")
     .replaces_endpoint(1, device_type=zha.DeviceType.DIMMABLE_LIGHT)
     .replace_cluster_occurrences(InovelliVZM35SNCluster)
+    # ep 3 is missing in zigpy DB for devices paired with an old fw version, add it:
+    .replaces_endpoint(3, device_type=zha.DeviceType.DIMMER_SWITCH)
+    # these missing clusters are needed for button presses to generate events:
+    .replaces(InovelliVZM35SNCluster, endpoint_id=2, cluster_type=ClusterType.Client)
+    .replaces(InovelliVZM35SNCluster, endpoint_id=3, cluster_type=ClusterType.Client)
     .device_automation_triggers(INOVELLI_AUTOMATION_TRIGGERS)
     .add_to_registry()
 )

--- a/zhaquirks/inovelli/VZM35SN.py
+++ b/zhaquirks/inovelli/VZM35SN.py
@@ -9,8 +9,6 @@ from zhaquirks.inovelli import INOVELLI_AUTOMATION_TRIGGERS, InovelliVZM35SNClus
     QuirkBuilder("Inovelli", "VZM35-SN")
     .replaces_endpoint(1, device_type=zha.DeviceType.DIMMABLE_LIGHT)
     .replace_cluster_occurrences(InovelliVZM35SNCluster)
-    .replaces(InovelliVZM35SNCluster, endpoint_id=2)
-    .replaces(InovelliVZM35SNCluster, endpoint_id=3)
     .device_automation_triggers(INOVELLI_AUTOMATION_TRIGGERS)
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
This fixes an issue where some paired Inovelli VZM35-SN devices, which do not have endpoint 3 present in the zigpy DB due to being paired on older firmware, cause the ZHA integration to fail loading.

This PR now always adds endpoint 3 and then the Inovelli cluster as an output cluster on both endpoint 2 and 3 to catch button press events. See the linked issue below for some more information.

## Additional information
Fixes https://github.com/zigpy/zha-device-handlers/issues/4217
Also addresses https://github.com/home-assistant/core/issues/149843 if bumped in HA

Caused by v2 quirk migration: https://github.com/zigpy/zha-device-handlers/pull/3232

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
