### PR TITLE
Add Tuya TS0601 DIN power meter switch ZCR1-40EM support

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -2040,16 +2040,8 @@ def test_ts0601_din_power_meter_switch_signature(assert_signature_matches_quirk)
             1: {
                 "profile_id": 260,
                 "device_type": "0x0051",
-                "in_clusters": [
-                    "0x0000",
-                    "0x0004",
-                    "0x0005",
-                    "0xEF00"
-                ],
-                "out_clusters": [
-                    "0x0019",
-                    "0x000A"
-                ]
+                "in_clusters": ["0x0000", "0x0004", "0x0005", "0xEF00"],
+                "out_clusters": ["0x0019", "0x000A"],
             },
             # <SimpleDescriptor endpoint=242 profile=41440 device_type=97 device_version=0
             # input_clusters=[] output_clusters=[33]>
@@ -2057,30 +2049,38 @@ def test_ts0601_din_power_meter_switch_signature(assert_signature_matches_quirk)
                 "profile_id": 41440,
                 "device_type": "0x0061",
                 "in_clusters": [],
-                "out_clusters": ["0x0021"]
-            }
+                "out_clusters": ["0x0021"],
+            },
         },
         "manufacturer": "_TZE200_abatw3kj",
-        "model": "TS0601"
+        "model": "TS0601",
     }
 
     assert_signature_matches_quirk(
-        zhaquirks.tuya.ts0601_din_power_meter_switch.TuyaDinPowerMeterSwitch,
-        signature
+        zhaquirks.tuya.ts0601_din_power_meter_switch.TuyaDinPowerMeterSwitch, signature
     )
 
 
 @pytest.mark.parametrize(
     "raw_data, expected_voltage, expected_current, expected_power",
     (
-            ([0x01, 0x2C, 0x00, 0x00, 0x32, 0x00, 0x00, 0x64], 300, 50, 100),  # przykładowe dane
-            ([0x00, 0xFA, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x32], 250, 10, 50),
+        (
+            [0x01, 0x2C, 0x00, 0x00, 0x32, 0x00, 0x00, 0x64],
+            300,
+            50,
+            100,
+        ),  # przykładowe dane
+        ([0x00, 0xFA, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x32], 250, 10, 50),
     ),
 )
-def test_convert_electrical_measurements(raw_data, expected_voltage, expected_current, expected_power):
+def test_convert_electrical_measurements(
+    raw_data, expected_voltage, expected_current, expected_power
+):
     """Test electrical measurements data conversion."""
     voltage, current, power = (
-        zhaquirks.tuya.ts0601_din_power_meter_switch.convert_electrical_measurements(raw_data)
+        zhaquirks.tuya.ts0601_din_power_meter_switch.convert_electrical_measurements(
+            raw_data
+        )
     )
     assert voltage == expected_voltage
     assert current == expected_current

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -38,12 +38,12 @@ import zhaquirks.tuya.ts0042
 import zhaquirks.tuya.ts0043
 import zhaquirks.tuya.ts011f_plug
 import zhaquirks.tuya.ts0501_fan_switch
+import zhaquirks.tuya.ts0601_din_power_meter_switch
 import zhaquirks.tuya.ts0601_electric_heating
 import zhaquirks.tuya.ts0601_trv
 import zhaquirks.tuya.ts1201
 import zhaquirks.tuya.tuya_motion
 import zhaquirks.tuya.tuya_valve
-import zhaquirks.tuya.ts0601_din_power_meter_switch
 
 zhaquirks.setup()
 

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -43,6 +43,7 @@ import zhaquirks.tuya.ts0601_trv
 import zhaquirks.tuya.ts1201
 import zhaquirks.tuya.tuya_motion
 import zhaquirks.tuya.tuya_valve
+import zhaquirks.tuya.ts0601_din_power_meter_switch
 
 zhaquirks.setup()
 
@@ -2023,3 +2024,64 @@ async def test_ts601_door_sensor(
     attrs = await cluster.read_attributes(attributes=[attribute])
 
     assert attrs[0].get(attribute) == expected_value
+
+
+def test_ts0601_din_power_meter_switch_signature(assert_signature_matches_quirk):
+    """Test matching of DIN Power Meter Switch ZCR1-40EM signature with quirk."""
+    signature = {
+        # NodeDescriptor: manufacturer_code=4417, max_buffer_size=66, server_mask=10752
+        # device_version=1
+        # input_clusters=[0x0000, 0x0004, 0x0005, 0xef00]
+        # output_clusters=[0x000a, 0x0019]
+        "endpoints": {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=81 device_version=1
+            # input_clusters=[4, 5, 61184, 0] -> [Groups, Scenes, TuyaMCU, Basic]
+            # output_clusters=[25, 10] -> [OTA, Time]>
+            1: {
+                "profile_id": 260,
+                "device_type": "0x0051",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0004",
+                    "0x0005",
+                    "0xEF00"
+                ],
+                "out_clusters": [
+                    "0x0019",
+                    "0x000A"
+                ]
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97 device_version=0
+            # input_clusters=[] output_clusters=[33]>
+            242: {
+                "profile_id": 41440,
+                "device_type": "0x0061",
+                "in_clusters": [],
+                "out_clusters": ["0x0021"]
+            }
+        },
+        "manufacturer": "_TZE200_abatw3kj",
+        "model": "TS0601"
+    }
+
+    assert_signature_matches_quirk(
+        zhaquirks.tuya.ts0601_din_power_meter_switch.TuyaDinPowerMeterSwitch,
+        signature
+    )
+
+
+@pytest.mark.parametrize(
+    "raw_data, expected_voltage, expected_current, expected_power",
+    (
+            ([0x01, 0x2C, 0x00, 0x00, 0x32, 0x00, 0x00, 0x64], 300, 50, 100),  # przykładowe dane
+            ([0x00, 0xFA, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x32], 250, 10, 50),
+    ),
+)
+def test_convert_electrical_measurements(raw_data, expected_voltage, expected_current, expected_power):
+    """Test electrical measurements data conversion."""
+    voltage, current, power = (
+        zhaquirks.tuya.ts0601_din_power_meter_switch.convert_electrical_measurements(raw_data)
+    )
+    assert voltage == expected_voltage
+    assert current == expected_current
+    assert power == expected_power

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -2062,26 +2062,87 @@ def test_ts0601_din_power_meter_switch_signature(assert_signature_matches_quirk)
 
 
 @pytest.mark.parametrize(
-    "raw_data, expected_voltage, expected_current, expected_power",
+    "raw_data, expected_output",
     (
-        (
-            [0x01, 0x2C, 0x00, 0x00, 0x32, 0x00, 0x00, 0x64],
-            300,
-            50,
-            100,
-        ),  # przykładowe dane
-        ([0x00, 0xFA, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x32], 250, 10, 50),
+        ([0x01, 0x2C, 0x00, 0x00, 0x32, 0x00, 0x00, 0x64], (300, 50, 100)),
+        ([0x00, 0xFA, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x32], (250, 10, 50)),
+        ([1, 2, 3], (0, 0, 0)),
+        (None, (0, 0, 0)),
+        ([], (0, 0, 0)),
+        (b"\x01\x02\x03\x04\x05\x06\x07\x08", (258, 1029, 1800)),
     ),
 )
-def test_convert_electrical_measurements(
-    raw_data, expected_voltage, expected_current, expected_power
-):
+def test_convert_electrical_measurements(raw_data, expected_output):
     """Test electrical measurements data conversion."""
-    voltage, current, power = (
+    assert (
         zhaquirks.tuya.ts0601_din_power_meter_switch.convert_electrical_measurements(
             raw_data
         )
+        == expected_output
     )
-    assert voltage == expected_voltage
-    assert current == expected_current
-    assert power == expected_power
+
+
+@pytest.mark.parametrize(
+    "input_data, expected_output",
+    (
+        (123, 123),
+        (123.45, 123),
+        (b"\x00\x00\x00\x64", 100),
+        ([0, 0, 0, 100], 100),
+        (b"\x01\x02\x03", 0),
+        ([1, 2], 0),
+        (None, 0),
+    ),
+)
+def test_convert_energy_data(input_data, expected_output):
+    """Test energy data conversion."""
+    assert (
+        zhaquirks.tuya.ts0601_din_power_meter_switch.convert_energy_data(input_data)
+        == expected_output
+    )
+
+
+async def test_tuya_switch_command(zigpy_device_from_quirk):
+    """Test TuyaDinPowerMeterSwitchOnOff commands."""
+
+    device = zigpy_device_from_quirk(
+        zhaquirks.tuya.ts0601_din_power_meter_switch.TuyaDinPowerMeterSwitch
+    )
+    cluster = device.endpoints[1].tuya_manufacturer
+    onoff_cluster = device.endpoints[1].on_off
+
+    with mock.patch.object(cluster, "request", return_value=foundation.Status.SUCCESS):
+        # Test clear_locking command
+        rsp = await onoff_cluster.command(0x74)
+        assert rsp.status == foundation.Status.SUCCESS
+
+        # Test regular command
+        rsp = await onoff_cluster.command(0x00)  # on command
+        assert rsp.status == foundation.Status.SUCCESS
+
+
+def test_electrical_measurement_updates(zigpy_device_from_quirk):
+    """Test electrical measurement attribute updates."""
+
+    device = zigpy_device_from_quirk(
+        zhaquirks.tuya.ts0601_din_power_meter_switch.TuyaDinPowerMeterSwitch
+    )
+    cluster = device.endpoints[1].electrical_measurement
+
+    # Initialize cluster
+    cluster.update_attribute("apparent_power", 0)
+
+    # Test rms_current update with voltage
+    cluster.update_attribute("rms_voltage", 230)
+    cluster.update_attribute("rms_current", 1000)  # 1A
+    assert cluster.get("apparent_power") == 230  # 230VA
+
+    # Test active_power update with apparent_power
+    cluster.update_attribute("apparent_power", 100)
+    cluster.update_attribute("active_power", 90)  # 90W
+    assert cluster.get("power_factor") == 90  # 90%
+
+    # Test power_factor limiting
+    cluster.update_attribute("apparent_power", 50)
+    cluster.update_attribute("active_power", 100)  # 100W
+    assert cluster.get("power_factor") == 100  # should be limited to 100%

--- a/zhaquirks/tuya/ts0601_din_power_meter_switch.py
+++ b/zhaquirks/tuya/ts0601_din_power_meter_switch.py
@@ -1,0 +1,294 @@
+"""Tuya DIN Power Meter Switch ZCR1-40EM."""
+
+from typing import Optional, Union, Any
+
+import zigpy.types as t
+from zigpy.profiles import zgp, zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Ota,
+    Scenes,
+    Time,
+)
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.smartenergy import Metering
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.tuya import TUYA_MCU_COMMAND, PowerOnState
+from zhaquirks.tuya.mcu import (
+    DPToAttributeMapping,
+    TuyaAttributesCluster,
+    TuyaClusterData,
+    TuyaMCUCluster,
+    TuyaOnOff,
+)
+
+TUYA_DP_ENERGY = 1
+TUYA_DP_MEASUREMENT = 6
+TUYA_DP_STATE = 16
+TUYA_DP_RELAY_STATUS = 27
+
+
+def convert_energy_data(x):
+    """Convert raw Tuya energy data."""
+
+    if isinstance(x, (int, float)):
+        result = int(x)
+        return result
+
+    elif isinstance(x, (bytes, list)) and len(x) >= 4:
+        result = int.from_bytes(
+            x[:4] if isinstance(x, bytes) else bytes(x[:4]), byteorder="big"
+        )
+        return result
+
+    return 0
+
+
+def convert_electrical_measurements(x):
+    """Convert raw Tuya electrical measurement data."""
+    if not (isinstance(x, (bytes, list)) and len(x) >= 8):
+        return 0, 0, 0
+
+    voltage = x[0] << 8 | x[1]
+    current = x[3] << 8 | x[4]
+    power = x[6] << 8 | x[7]
+
+    return voltage, current, power
+
+
+class TuyaDinPowerMeterSwitchBasic(CustomCluster, Basic):
+    """Tuya DIN Power Meter Switch Basic cluster."""
+
+    attributes = Basic.attributes.copy()
+    # noinspection PyTypeChecker
+    attributes.update(
+        {
+            0xFFE2: ("tuya_FFE2", t.uint8_t),
+            0xFFE4: ("tuya_FFE4", t.uint8_t),
+        }
+    )
+
+
+class TuyaDinPowerMeterSwitchOnOff(TuyaOnOff, TuyaAttributesCluster):
+    """Tuya DIN Power Meter Switch OnOff cluster."""
+
+    attributes = TuyaOnOff.attributes.copy()
+    # noinspection PyTypeChecker
+    attributes.update(
+        {
+            0x8002: ("power_on_state", PowerOnState),
+        }
+    )
+
+    server_commands = TuyaOnOff.server_commands.copy()
+    # noinspection PyTypeChecker
+    server_commands.update(
+        {
+            0x74: foundation.ZCLCommandDef("clear_locking", {}, False),
+        }
+    )
+
+    async def command(
+        self,
+        command_id: Union[foundation.GeneralCommand, int, t.uint8_t],
+        *args,
+        manufacturer: Optional[Union[int, t.uint16_t]] = None,
+        expect_reply: bool = True,
+        tsn: Optional[Union[int, t.uint8_t]] = None,
+    ):
+        """Override the default Cluster command."""
+
+        if command_id == 0x74:
+            self.debug(
+                "Sending Tuya Cluster Command... Cluster Command is %x, Arguments are %s",
+                command_id,
+                args,
+            )
+
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_name=self.ep_attribute,
+                cluster_attr="trip",
+                attr_value=True,
+                expect_reply=expect_reply,
+                manufacturer=manufacturer,
+            )
+            # noinspection PyUnresolvedReferences
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cluster_data,
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        return await super().command(command_id, args, manufacturer, expect_reply, tsn)
+
+
+class TuyaDinPowerMeterSwitchElectricalMeasurement(
+    ElectricalMeasurement, TuyaAttributesCluster
+):
+    """Tuya DIN Power Meter Switch Electrical Measurement cluster."""
+
+    AC_VOLTAGE_MULTIPLIER = 0x0600
+    AC_VOLTAGE_DIVISOR = 0x0601
+    AC_CURRENT_MULTIPLIER = 0x0602
+    AC_CURRENT_DIVISOR = 0x0603
+    AC_POWER_MULTIPLIER = 0x0604
+    AC_POWER_DIVISOR = 0x0605
+
+    _CONSTANT_ATTRIBUTES = {
+        AC_VOLTAGE_MULTIPLIER: 1,
+        AC_VOLTAGE_DIVISOR: 10,
+        AC_CURRENT_MULTIPLIER: 1,
+        AC_CURRENT_DIVISOR: 1000,
+        AC_POWER_MULTIPLIER: 1,
+        AC_POWER_DIVISOR: 1,
+    }
+
+    attributes = ElectricalMeasurement.attributes.copy()
+
+    def update_attribute(self, attr_name: str, value: Any) -> None:
+        """Calculate derived attributes."""
+        super().update_attribute(attr_name, value)
+
+        if attr_name == "rms_current":
+            rms_voltage = self.get("rms_voltage")
+            if rms_voltage and rms_voltage > 0:
+                apparent_power = value * rms_voltage / 1000
+                super().update_attribute("apparent_power", int(apparent_power))
+
+        if attr_name == "active_power":
+            apparent_power = self.get("apparent_power")
+            if apparent_power and apparent_power > 0:
+                power_factor = value / apparent_power * 100
+                power_factor = min(power_factor, 100)
+                super().update_attribute("power_factor", round(power_factor))
+
+
+class TuyaDinPowerMeterSwitchMetering(Metering, TuyaAttributesCluster):
+    """Tuya DIN Power Meter Switch Metering cluster."""
+
+    attributes = Metering.attributes.copy()
+
+    # noinspection PyTypeChecker
+    attributes.update(
+        {
+            0x0000: ("current_summ_delivered", t.uint48_t),
+        }
+    )
+
+    _CONSTANT_ATTRIBUTES = {
+        0x0300: 0,  # unit_of_measure (0x00 is kWh)
+        0x0301: 1,  # multiplier for kWh
+        0x0302: 100,  # divisor for kWh
+        0x0306: 0x00,  # metering_device_type (Electric Metering)
+    }
+
+
+class TuyaDinPowerMeterSwitchManufCluster(TuyaMCUCluster):
+    """Tuya DIN Power Meter Switch manufacturer cluster."""
+
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
+        TUYA_DP_STATE: DPToAttributeMapping(
+            TuyaDinPowerMeterSwitchOnOff.ep_attribute,
+            "on_off",
+        ),
+        TUYA_DP_ENERGY: DPToAttributeMapping(
+            TuyaDinPowerMeterSwitchMetering.ep_attribute,
+            "current_summ_delivered",
+            converter=convert_energy_data,
+        ),
+        TUYA_DP_RELAY_STATUS: DPToAttributeMapping(
+            TuyaDinPowerMeterSwitchOnOff.ep_attribute,
+            "power_on_state",
+            converter=lambda x: PowerOnState(x),
+        ),
+        TUYA_DP_MEASUREMENT: DPToAttributeMapping(
+            TuyaDinPowerMeterSwitchElectricalMeasurement.ep_attribute,
+            ("rms_voltage", "rms_current", "active_power"),
+            converter=convert_electrical_measurements,
+        ),
+    }
+
+    data_point_handlers: dict[int, str] = {
+        TUYA_DP_STATE: "_dp_2_attr_update",
+        TUYA_DP_ENERGY: "_dp_2_attr_update",
+        TUYA_DP_MEASUREMENT: "_dp_2_attr_update",
+        TUYA_DP_RELAY_STATUS: "_dp_2_attr_update",
+    }
+
+
+class TuyaDinPowerMeterSwitch(CustomDevice):
+    """Tuya DIN Power Meter Switch device - ZCR1-40EM."""
+
+    signature = {
+        # NodeDescriptor: manufacturer_code=4417, max_buffer_size=66, server_mask=10752
+        # device_version=1
+        # input_clusters=[0x0000, 0x0004, 0x0005, 0xef00]
+        # output_clusters=[0x000a, 0x0019]
+        MODELS_INFO: [
+            ("_TZE200_abatw3kj", "TS0601"),
+        ],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=81 device_version=1
+            # input_clusters=[4, 5, 61184, 0] -> [Groups, Scenes, TuyaMCU, Basic]
+            # output_clusters=[25, 10] -> [OTA, Time]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaMCUCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97 device_version=0
+            # input_clusters=[] output_clusters=[33]>
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    TuyaDinPowerMeterSwitchBasic,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaDinPowerMeterSwitchOnOff,
+                    TuyaDinPowerMeterSwitchElectricalMeasurement,
+                    TuyaDinPowerMeterSwitchMetering,
+                    TuyaDinPowerMeterSwitchManufCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }

--- a/zhaquirks/tuya/ts0601_din_power_meter_switch.py
+++ b/zhaquirks/tuya/ts0601_din_power_meter_switch.py
@@ -1,19 +1,12 @@
 """Tuya DIN Power Meter Switch ZCR1-40EM."""
 
-from typing import Optional, Union, Any
+from typing import Any, Optional, Union
 
-import zigpy.types as t
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import (
-    Basic,
-    GreenPowerProxy,
-    Groups,
-    Ota,
-    Scenes,
-    Time,
-)
+from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Groups, Ota, Scenes, Time
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 


### PR DESCRIPTION
Add support for Tuya DIN Power Meter Switch (`ZCR1-40EM`)
- Model: `TS0601`
- Manufacturer: `_TZE200_abatw3kj`
- Product Link:   
  https://botland.store/smart-controllers/24814-tuya-relay-with-energy-meter-50a-zigbee-androidios-app-rtx-zcr1-40em-5903794124011.html



## Proposed change

This PR adds support for the Tuya DIN Power Meter Switch (ZCR1-40EM). 

Implemented features:
- On/Off control
- Power measurement (W)
- Energy monitoring (kWh)
- Voltage monitoring (V)
- Current monitoring (A)
- Power factor calculation
- Support for power_on_state configuration

Implementation based on:
- Zigbee2MQTT device implementation:   
  https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts#L16141
- Tuya datapoint mapping functions:   
  https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/lib/tuya.ts



## Additional information

- Device physically tested with Home Assistant
- Custom quirk implementation using `TuyaMCUCluster`
- Added unit tests for signature matching and data conversion
- All quirk-specific tests pass

Device specifications:
- Maximum current: 50A
- Voltage range: 110-250V AC
- Power measurement accuracy: ±0.5%

Home Assistant correctly see device:
<img width="1615" height="1646" alt="image" src="https://github.com/user-attachments/assets/9aa45ca1-eff9-4bf2-9ff4-bdfa0bef83b9" />



## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
