### PR TITLE
Silence swapped direction warning for Aqara devices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy>=0.82.0",
+    "zigpy>=0.82.2",
 ]
 
 [tool.setuptools.packages.find]

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -130,13 +130,13 @@ class XiaomiCustomDevice(CustomDevice):
         # Aqara devices seem to be very lax with their ZCL header's `direction` field,
         # we should try "flipping" it if matching doesn't work normally.
         try:
-            return super()._find_zcl_cluster(hdr, packet)
+            return super()._find_zcl_cluster_strict(hdr, packet)
         except KeyError:
             _LOGGER.debug(
                 "Packet is coming in the wrong direction, swapping direction and trying again",
             )
 
-            return super()._find_zcl_cluster(
+            return super()._find_zcl_cluster_strict(
                 hdr.replace(
                     frame_control=hdr.frame_control.replace(
                         direction=hdr.frame_control.direction.flip()


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Reported here: https://github.com/zigpy/zigpy/issues/1640#issuecomment-3160504392

Currently, Aqara devices emit the "swapped direction" warning because we try to use `_find_zcl_cluster` instead of  `_find_zcl_cluster_strict` when implementing the swapping logic, triggering the zigpy warning.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
