### PR TITLE
Add `NimlyPRO24` model variant for Nimly Touch Pro

### DIFF
--- a/zhaquirks/nimly/lock.py
+++ b/zhaquirks/nimly/lock.py
@@ -148,7 +148,8 @@ def last_action_user_converter(value: int) -> int:
 
 
 (
-    QuirkBuilder(NIMLY, "NimlyPRO")
+    QuirkBuilder(NIMLY, "NimlyPRO24")
+    .applies_to(NIMLY, "NimlyPRO")
     .applies_to(NIMLY, "NimlyCode")
     .applies_to(NIMLY, "NimlyTouch")
     .applies_to(NIMLY, "NimlyIn")


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

I bought a new Nimly Touch Pro lock and paired it with ZHA. The pairing worked, but the only entity that appeared was the lock entity.

I did some digging and found out that the standard quirk for Nimly Touch Pro handled the model named "NimlyPRO", "NimlyCode", "NimlyTouch" and "NimlyIn" where as the model my lock have is "NimlyPRO24".


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

I made a custom quirk, a copy of the standard quirk, and added the missing model name and the missing entities appeared in my unit. 



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
