### PR TITLE
Enable tamper entities for Frient door/window sensors

### DIFF
--- a/zhaquirks/develco/open_close.py
+++ b/zhaquirks/develco/open_close.py
@@ -1,7 +1,8 @@
 """Door/Windows sensors."""
 
-from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2 import BinarySensorDeviceClass, QuirkBuilder
 from zigpy.zcl.clusters.general import BinaryInput
+from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import PowerConfigurationCluster
 
@@ -25,5 +26,14 @@ class DevelcoPowerConfiguration(PowerConfigurationCluster):
     .replaces(DevelcoPowerConfiguration, endpoint_id=35)
     # The binary input cluster is a duplicate
     .prevent_default_entity_creation(endpoint_id=35, cluster_id=BinaryInput.cluster_id)
+    .binary_sensor(
+        endpoint_id=35,
+        cluster_id=IasZone.cluster_id,
+        attribute_name=IasZone.AttributeDefs.zone_status.name,
+        device_class=BinarySensorDeviceClass.TAMPER,
+        attribute_converter=lambda value: bool(value & IasZone.ZoneStatus.Tamper),
+        unique_id_suffix="tamper",
+        fallback_name="Tamper",
+    )
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The Frient sensors report tamper status via IASZone notifications. We should expose it as an entity.

(We should find a way to have ZHA auto create entities at runtime!)

<img width="505" height="422" alt="image" src="https://github.com/user-attachments/assets/23e6f1a7-4f43-4f91-bebe-049b1c82bb10" />


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
