### PR TITLE
Require device diagnostics for all issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -64,6 +64,8 @@ body:
         
         You can find the diagnostics information by going to the device page, clicking the three dots, and then by clicking on "Download diagnostics".
         Drag-and-drop the downloaded file into the textbox below.
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Device signature

--- a/.github/ISSUE_TEMPLATE/device_support_request.yml
+++ b/.github/ISSUE_TEMPLATE/device_support_request.yml
@@ -53,6 +53,8 @@ body:
         
         You can find the diagnostics information by going to the device page, clicking the three dots, and then by clicking on "Download diagnostics".
         Drag-and-drop the downloaded file into the textbox below.
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Device signature

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@
 
   You can find the diagnostics information by going to the device page, clicking the
   three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
-  downloaded into this section.
+  downloaded file into this section.
 -->
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,4 +34,4 @@
 - [ ] The changes are tested and work correctly
 - [ ] `pre-commit` checks pass / the code has been formatted using Black
 - [ ] Tests have been added to verify that the new code works
-- [ ] Device diagnostics data has been attached.
+- [ ] Device diagnostics data has been attached

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,18 @@
 -->
 
 
+## Device diagnostics
+<!--
+  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
+  entities and we do not have regressions. For all new quirks, we require device
+  diagnostics.
+
+  You can find the diagnostics information by going to the device page, clicking the
+  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
+  downloaded into this section.
+-->
+
+
 ## Checklist
 <!--
   Put an 'x' in all boxes that apply.
@@ -22,3 +34,4 @@
 - [ ] The changes are tested and work correctly
 - [ ] `pre-commit` checks pass / the code has been formatted using Black
 - [ ] Tests have been added to verify that the new code works
+- [ ] Device diagnostics data has been attached.


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
We should require device diagnostics for all new device PRs and issues. This helps grow the ZHA unit testing database and avoids an unnecessary back-and-forth where we inevitably ask for this information anyways.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached.
