### PR TITLE
Fix Tuya Hiking power meter "summation received" type

### DIFF
--- a/zhaquirks/tuya/ts0601_din_power.py
+++ b/zhaquirks/tuya/ts0601_din_power.py
@@ -173,7 +173,7 @@ class HikingManufClusterDinPower(TuyaManufClusterAttributes):
         )
         energy_received: Final = ZCLAttributeDef(
             id=HIKING_TOTAL_ENERGY_RECEIVED_ATTR,
-            type=t.uint16_t,
+            type=t.uint32_t,
             is_manufacturer_specific=True,
         )
         voltage_current: Final = ZCLAttributeDef(


### PR DESCRIPTION
Prevent "Summation received" being stuck at 655.36kWh. Side bonus: no more log padding with information about 65537 not being a valid uint16.

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
