### PR TITLE
Fix Tuya air sensor SQLite serialization error

### DIFF
--- a/zhaquirks/tuya/tuya_co.py
+++ b/zhaquirks/tuya/tuya_co.py
@@ -13,6 +13,16 @@ from zhaquirks.tuya.builder import (
 )
 
 
+def tuya_air_quality_temperature_converter(value: Any) -> int:
+    """
+    Convert Tuya air quality temperature data to centidegrees.
+
+    Extract temperature from bytes 2-4 of the data payload and convert to centidegrees.
+    The device sends a 4-byte structure: [field_1 (2 bytes), temperature (2 bytes)]
+    """
+    return int.from_bytes(value.serialize()[2:4], byteorder='big', signed=True) * 10
+
+
 class TuyaPM25ConcentrationIgnoreValues(TuyaPM25Concentration):
     """Tuya PM25 concentration measurement cluster that ignores invalid high values."""
 
@@ -29,12 +39,7 @@ base_air_quality = (
         dp_id=18,
         ep_attribute=TuyaTemperatureMeasurement.ep_attribute,
         attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
-        # The device sends a 4-byte structure: [field_1 (2 bytes), temperature (2 bytes)]
-        # Extract temperature from bytes 2-4 of the data payload and convert to centidegrees.
-        converter=lambda x: int.from_bytes(
-            x.serialize()[2:4], byteorder="big", signed=True
-        )
-        * 10,
+        converter=tuya_air_quality_temperature_converter,
     )
     .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=19, scale=10)
@@ -112,12 +117,7 @@ base_air_quality = (
         dp_id=18,
         ep_attribute=TuyaTemperatureMeasurement.ep_attribute,
         attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
-        # The device sends a 4-byte structure: [field_1 (2 bytes), temperature (2 bytes)]
-        # Extract temperature from bytes 2-4 of the data payload and convert to centidegrees.
-        converter=lambda x: int.from_bytes(
-            x.serialize()[2:4], byteorder="big", signed=True
-        )
-        * 10,
+        converter=tuya_air_quality_temperature_converter,
     )
     .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=19, scale=10)
@@ -133,12 +133,7 @@ base_air_quality = (
         dp_id=18,
         ep_attribute=TuyaTemperatureMeasurement.ep_attribute,
         attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
-        # The device sends a 4-byte structure: [field_1 (2 bytes), temperature (2 bytes)]
-        # Extract temperature from bytes 2-4 of the data payload and convert to centidegrees.
-        converter=lambda x: int.from_bytes(
-            x.serialize()[2:4], byteorder="big", signed=True
-        )
-        * 10,
+        converter=tuya_air_quality_temperature_converter,
     )
     .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=19, scale=10)

--- a/zhaquirks/tuya/tuya_co.py
+++ b/zhaquirks/tuya/tuya_co.py
@@ -31,7 +31,10 @@ base_air_quality = (
         attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
         # The device sends a 4-byte structure: [field_1 (2 bytes), temperature (2 bytes)]
         # Extract temperature from bytes 2-4 of the data payload and convert to centidegrees.
-        converter=lambda x: int.from_bytes(x.serialize()[2:4], byteorder='big', signed=True) * 10,
+        converter=lambda x: int.from_bytes(
+            x.serialize()[2:4], byteorder="big", signed=True
+        )
+        * 10,
     )
     .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=19, scale=10)
@@ -111,7 +114,10 @@ base_air_quality = (
         attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
         # The device sends a 4-byte structure: [field_1 (2 bytes), temperature (2 bytes)]
         # Extract temperature from bytes 2-4 of the data payload and convert to centidegrees.
-        converter=lambda x: int.from_bytes(x.serialize()[2:4], byteorder='big', signed=True) * 10,
+        converter=lambda x: int.from_bytes(
+            x.serialize()[2:4], byteorder="big", signed=True
+        )
+        * 10,
     )
     .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=19, scale=10)
@@ -129,7 +135,10 @@ base_air_quality = (
         attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
         # The device sends a 4-byte structure: [field_1 (2 bytes), temperature (2 bytes)]
         # Extract temperature from bytes 2-4 of the data payload and convert to centidegrees.
-        converter=lambda x: int.from_bytes(x.serialize()[2:4], byteorder='big', signed=True) * 10,
+        converter=lambda x: int.from_bytes(
+            x.serialize()[2:4], byteorder="big", signed=True
+        )
+        * 10,
     )
     .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=19, scale=10)

--- a/zhaquirks/tuya/tuya_co.py
+++ b/zhaquirks/tuya/tuya_co.py
@@ -13,18 +13,6 @@ from zhaquirks.tuya.builder import (
 )
 
 
-class CustomTemperature(t.Struct):
-    """Custom temperature wrapper."""
-
-    field_1: t.int16s_be
-    temperature: t.int16s_be
-
-    @classmethod
-    def from_value(cls, value):
-        """Convert from a raw value to a Struct data."""
-        return cls.deserialize(value.serialize())[0]
-
-
 class TuyaPM25ConcentrationIgnoreValues(TuyaPM25Concentration):
     """Tuya PM25 concentration measurement cluster that ignores invalid high values."""
 
@@ -41,7 +29,9 @@ base_air_quality = (
         dp_id=18,
         ep_attribute=TuyaTemperatureMeasurement.ep_attribute,
         attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
-        converter=lambda x: CustomTemperature.from_value(x).temperature * 10,
+        # The device sends a 4-byte structure: [field_1 (2 bytes), temperature (2 bytes)]
+        # Extract temperature from bytes 2-4 of the data payload and convert to centidegrees.
+        converter=lambda x: int.from_bytes(x.serialize()[2:4], byteorder='big', signed=True) * 10,
     )
     .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=19, scale=10)
@@ -119,7 +109,9 @@ base_air_quality = (
         dp_id=18,
         ep_attribute=TuyaTemperatureMeasurement.ep_attribute,
         attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
-        converter=lambda x: CustomTemperature.from_value(x).temperature * 10,
+        # The device sends a 4-byte structure: [field_1 (2 bytes), temperature (2 bytes)]
+        # Extract temperature from bytes 2-4 of the data payload and convert to centidegrees.
+        converter=lambda x: int.from_bytes(x.serialize()[2:4], byteorder='big', signed=True) * 10,
     )
     .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=19, scale=10)
@@ -135,7 +127,9 @@ base_air_quality = (
         dp_id=18,
         ep_attribute=TuyaTemperatureMeasurement.ep_attribute,
         attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
-        converter=lambda x: CustomTemperature.from_value(x).temperature * 10,
+        # The device sends a 4-byte structure: [field_1 (2 bytes), temperature (2 bytes)]
+        # Extract temperature from bytes 2-4 of the data payload and convert to centidegrees.
+        converter=lambda x: int.from_bytes(x.serialize()[2:4], byteorder='big', signed=True) * 10,
     )
     .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=19, scale=10)

--- a/zhaquirks/tuya/tuya_co.py
+++ b/zhaquirks/tuya/tuya_co.py
@@ -14,13 +14,12 @@ from zhaquirks.tuya.builder import (
 
 
 def tuya_air_quality_temperature_converter(value: Any) -> int:
-    """
-    Convert Tuya air quality temperature data to centidegrees.
+    """Convert Tuya air quality temperature data to centidegrees.
 
     Extract temperature from bytes 2-4 of the data payload and convert to centidegrees.
     The device sends a 4-byte structure: [field_1 (2 bytes), temperature (2 bytes)]
     """
-    return int.from_bytes(value.serialize()[2:4], byteorder='big', signed=True) * 10
+    return int.from_bytes(value.serialize()[2:4], byteorder="big", signed=True) * 10
 
 
 class TuyaPM25ConcentrationIgnoreValues(TuyaPM25Concentration):


### PR DESCRIPTION
fix: resolve SQLite serialization error for tuya air quality sensors (#3671)

Remove CustomTemperature class that caused SQLite binding errors when saving device attributes. Replace with direct byte parsing to extract temperature values without creating non-serializable objects to avoid "type 'CustomTemperature' is not supported" SQLite binding errors.

Fixes #3671

## Proposed change
This PR fixes SQLite serialization errors that occur with Tuya air quality sensors (specifically `_TZE204_c2fmom5z` and related devices) when ZHA attempts to save device attributes to the database.
The root cause was that the quirk was using a `CustomTemperature` struct to parse temperature data from dp_id=18. When the Tuya MCU system processed this data point, it automatically created a `custom_temperature` attribute containing the `CustomTemperature` object. SQLite cannot serialize this custom Python objects, causing the error: `Error binding parameter 6: type 'CustomTemperature' is not supported`.
The proposed solution is:
- Replace the converter with direct byte parsing: `int.from_bytes(x.serialize()[2:4], byteorder='big', signed=True) * 10`
- This extracts the temperature value (bytes 2-4) from the 4-byte data structure without creating intermediate objects


## Additional information
Affected devices: 
- `_TZE200_c2fmom5z` / `_TZE204_c2fmom5z` (reported in issue)
- `_TZE200_3ejwxpmu` 
- `_TZE200_ogkdpgy2` / `_TZE204_ogkdpgy2`
- All other Tuya air quality sensors using the `base_air_quality` builder

This change is fully backward compatible. All existing functionality is preserved:
- Same temperature values are reported (e.g., 288 → 2880 centidegrees)
- All test cases continue to pass

## Device diagnostics


## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
