### PR TITLE
Add quirk for Sonoff BASICZBR3 device automation triggers

### DIFF
--- a/tests/test_sonoff_basiczbr3.py
+++ b/tests/test_sonoff_basiczbr3.py
@@ -13,30 +13,32 @@ from zhaquirks.sonoff.basiczbr3 import FLASH, POWER_ON
 
 zhaquirks.setup()
 
+
 def test_basiczbr3_quirk_registered():
     """Test that the quirk is properly registered."""
 
-    import zhaquirks.sonoff.basiczbr3  # noqa: F401
-
     from zigpy.quirks import DEVICE_REGISTRY
+
+    import zhaquirks.sonoff.basiczbr3  # noqa: F401
 
     quirks = DEVICE_REGISTRY.registry_v2.get(("SONOFF", "BASICZBR3"))
     assert quirks is not None, "BASICZBR3 quirk not found in registry"
     assert len(quirks) == 1, "Expected exactly one quirk for BASICZBR3"
 
+
 def test_basiczbr3_device_automation_triggers():
     """Test that device automation triggers are correctly defined."""
-    
-    import zhaquirks.sonoff.basiczbr3  # noqa: F401
-    
+
     from zigpy.quirks import DEVICE_REGISTRY
-    
+
+    import zhaquirks.sonoff.basiczbr3  # noqa: F401
+
     quirks = DEVICE_REGISTRY.registry_v2.get(("SONOFF", "BASICZBR3"))
     assert quirks is not None, "BASICZBR3 quirk not found in registry"
-    
+
     quirk_metadata = quirks[0]
     triggers = quirk_metadata.device_automation_triggers_metadata
-    
+
     # Expected triggers
     expected_triggers = {
         (POWER_ON,): {
@@ -52,17 +54,19 @@ def test_basiczbr3_device_automation_triggers():
             PARAMS: {"effect_id": 0x00, "effect_variant": 0x00},
         },
         (FLASH, LONG_PRESS): {
-            COMMAND: "trigger_effect", 
+            COMMAND: "trigger_effect",
             CLUSTER_ID: 3,
             ENDPOINT_ID: 1,
             PARAMS: {"effect_id": 0x00, "effect_variant": 0x01},
         },
     }
-    
+
     # Verify all expected triggers are present
     for trigger_key, expected_trigger in expected_triggers.items():
         assert trigger_key in triggers, f"Missing trigger: {trigger_key}"
         actual_trigger = triggers[trigger_key]
-        
+
         for key, expected_value in expected_trigger.items():
-            assert actual_trigger[key] == expected_value, f"Mismatch in {trigger_key}[{key}]: expected {expected_value}, got {actual_trigger[key]}"
+            assert actual_trigger[key] == expected_value, (
+                f"Mismatch in {trigger_key}[{key}]: expected {expected_value}, got {actual_trigger[key]}"
+            )

--- a/tests/test_sonoff_basiczbr3.py
+++ b/tests/test_sonoff_basiczbr3.py
@@ -1,0 +1,68 @@
+"""Tests for Sonoff BASICZBR3 quirk."""
+
+import zhaquirks
+from zhaquirks.const import (
+    CLUSTER_ID,
+    COMMAND,
+    ENDPOINT_ID,
+    LONG_PRESS,
+    PARAMS,
+    SHORT_PRESS,
+)
+from zhaquirks.sonoff.basiczbr3 import FLASH, POWER_ON
+
+zhaquirks.setup()
+
+def test_basiczbr3_quirk_registered():
+    """Test that the quirk is properly registered."""
+
+    import zhaquirks.sonoff.basiczbr3  # noqa: F401
+
+    from zigpy.quirks import DEVICE_REGISTRY
+
+    quirks = DEVICE_REGISTRY.registry_v2.get(("SONOFF", "BASICZBR3"))
+    assert quirks is not None, "BASICZBR3 quirk not found in registry"
+    assert len(quirks) == 1, "Expected exactly one quirk for BASICZBR3"
+
+def test_basiczbr3_device_automation_triggers():
+    """Test that device automation triggers are correctly defined."""
+    
+    import zhaquirks.sonoff.basiczbr3  # noqa: F401
+    
+    from zigpy.quirks import DEVICE_REGISTRY
+    
+    quirks = DEVICE_REGISTRY.registry_v2.get(("SONOFF", "BASICZBR3"))
+    assert quirks is not None, "BASICZBR3 quirk not found in registry"
+    
+    quirk_metadata = quirks[0]
+    triggers = quirk_metadata.device_automation_triggers_metadata
+    
+    # Expected triggers
+    expected_triggers = {
+        (POWER_ON,): {
+            COMMAND: "identify",
+            CLUSTER_ID: 3,
+            ENDPOINT_ID: 1,
+            PARAMS: {"identify_time": 5},
+        },
+        (FLASH, SHORT_PRESS): {
+            COMMAND: "trigger_effect",
+            CLUSTER_ID: 3,
+            ENDPOINT_ID: 1,
+            PARAMS: {"effect_id": 0x00, "effect_variant": 0x00},
+        },
+        (FLASH, LONG_PRESS): {
+            COMMAND: "trigger_effect", 
+            CLUSTER_ID: 3,
+            ENDPOINT_ID: 1,
+            PARAMS: {"effect_id": 0x00, "effect_variant": 0x01},
+        },
+    }
+    
+    # Verify all expected triggers are present
+    for trigger_key, expected_trigger in expected_triggers.items():
+        assert trigger_key in triggers, f"Missing trigger: {trigger_key}"
+        actual_trigger = triggers[trigger_key]
+        
+        for key, expected_value in expected_trigger.items():
+            assert actual_trigger[key] == expected_value, f"Mismatch in {trigger_key}[{key}]: expected {expected_value}, got {actual_trigger[key]}"

--- a/zhaquirks/sonoff/__init__.py
+++ b/zhaquirks/sonoff/__init__.py
@@ -1,1 +1,3 @@
 """Quirks for Sonoff devices."""
+
+from . import basiczbr3  # noqa: F401

--- a/zhaquirks/sonoff/basiczbr3.py
+++ b/zhaquirks/sonoff/basiczbr3.py
@@ -1,0 +1,46 @@
+"""Device handler for Sonoff BASICZBR3."""
+
+from zigpy.quirks.v2 import QuirkBuilder
+
+from zhaquirks.const import (
+    CLUSTER_ID,
+    COMMAND,
+    ENDPOINT_ID,
+    LONG_PRESS,
+    PARAMS,
+    SHORT_PRESS,
+)
+
+# Define action types for the BASICZBR3
+POWER_ON = "power_on"
+FLASH = "flash"
+
+(
+    QuirkBuilder("SONOFF", "BASICZBR3")
+    .device_automation_triggers(
+        {
+            # Power On action - uses identify command without parameters
+            (POWER_ON,): {
+                COMMAND: "identify",
+                CLUSTER_ID: 3,  # Identify cluster
+                ENDPOINT_ID: 1,
+                PARAMS: {"identify_time": 5},
+            },
+            # Flash Short action - uses trigger_effect command with short flash
+            (FLASH, SHORT_PRESS): {
+                COMMAND: "trigger_effect",
+                CLUSTER_ID: 3,  # Identify cluster
+                ENDPOINT_ID: 1,
+                PARAMS: {"effect_id": 0x00, "effect_variant": 0x00},  # Short flash
+            },
+            # Flash Long action - uses trigger_effect command with long flash
+            (FLASH, LONG_PRESS): {
+                COMMAND: "trigger_effect",
+                CLUSTER_ID: 3,  # Identify cluster
+                ENDPOINT_ID: 1,
+                PARAMS: {"effect_id": 0x00, "effect_variant": 0x01},  # Long flash
+            },
+        }
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
Fix device automation actions showing incorrect options in Home Assistant UI. Power On action no longer shows Short/Long options, Flash action now shows correct Short/Long variants using trigger_effect command.

Fixes #4163

## Proposed change
This PR adds a device-specific quirk for the Sonoff BASICZBR3 to fix incorrect device automation action options in Home Assistant.

The problems in the issue are:
- The "Power On" action incorrectly shows Short/Long options in the UI
- The "Flash" action doesn't show the Short/Long options it should have

The proposed solution:
- Created a v2 quirk (`zhaquirks/sonoff/basiczbr3.py`) with proper `device_automation_triggers`
- The power on action uses `identify` command (cluster 0x0003) with `identify_time` parameter - no Short/Long options
- The flash short action uses `trigger_effect` command with `effect_id=0x00, effect_variant=0x00`
- The flash long action uses `trigger_effect` command with `effect_id=0x00, effect_variant=0x01`

## Additional information
- This is a non-breaking change that only affects the Sonoff BASICZBR3 device
- Comprehensive tests have been added to verify quirk registration and device automation triggers
- The fix is based on analysis of the device diagnostics showing the device supports the Identify cluster with both required commands

Fixes #4163


## Device diagnostics
The device diagnostics data from the original issue shows:
- Device: SONOFF BASICZBR3 (manufacturer: "SONOFF", model: "BASICZBR3")
- `quirk_applied: false` (before this fix)
- Identify cluster (0x0003) present with `IdentifyButton` already working
- Supports both `identify` and `trigger_effect` commands as confirmed by existing `IdentifyClusterHandler`

Original diagnostics: https://github.com/user-attachments/files/21059916/zha-sonoff_basiczbr3.json

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
