### PR TITLE
Add Tuya cover `_TZE200_fctwhugx` variant

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -380,6 +380,7 @@ class TuyaMoesCover0601(TuyaWindowCover):
             ("_TZE200_gaj531w3", "TS0601"),
             ("_TZE200_icka1clh", "TS0601"),
             ("_TZE200_1vxgqfba", "TS0601"),
+            ("_TZE200_fctwhugx", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
Add new Tuya cover TS0601 _TZE200_fctwhugx variant


## Additional information
<img width="1014" height="969" alt="image" src="https://github.com/user-attachments/assets/5d169c75-1993-4d39-aef5-0c36150fad16" />

Tested works as a custom quirk


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
