### PR TITLE
Move Tuya remote commands to correct cluster

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1065,7 +1065,7 @@ class TuyaSmartRemoteOnOffCluster(OnOff, EventableCluster):
         self.last_tsn = -1
         super().__init__(*args, **kwargs)
 
-    class ServerCommandDefs(OnOff.ServerCommandDefs):
+    class ClientCommandDefs(OnOff.ClientCommandDefs):
         """Server command definitions."""
 
         rotate_type = foundation.ZCLCommandDef(


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Fix command definitions for `_TYZB01_1xktopx6` `TS0041A`. From https://github.com/home-assistant/core/issues/150528, it appears that the definition we have right now is incorrect:

```python
2025-08-13 00:02:10.780 DEBUG (MainThread) [zigpy.zcl] [0xBA95:1:0x0006] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl<0x01>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 0>, disable_default_response=0, reserved=0, *is_cluster=True, *is_general=False), tsn=100, command_id=253, *direction=<Direction.Client_to_Server: 0>)
2025-08-13 00:02:10.785 DEBUG (MainThread) [zigpy.zcl] [0xBA95:1:0x0006] Unknown cluster command 253 b'\x00'
2025-08-13 00:02:10.785 WARNING (MainThread) [zigpy.listeners] Matcher checkin() and command ZCLHeader(frame_control=FrameControl<0x01>(frame_type=<FrameType.CLUSTER_COMMAND: 1>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 0>, disable_default_response=0, reserved=0, *is_cluster=True, *is_general=False), tsn=100, command_id=253, *direction=<Direction.Client_to_Server: 0>) b'\x00' are incompatible
2025-08-13 00:02:10.789 DEBUG (MainThread) [zigpy.zcl] [0xBA95:1:0x0006] Received command 0xFD (TSN 100): b'\x00'
2025-08-13 00:02:10.790 DEBUG (MainThread) [zigpy.zcl] [0xBA95:1:0x0006] No explicit handler for cluster command 0xfd: b'\x00'
```

Whether this change is valid for other devices is debatable. I believe it is, it would make sense for these to be client commands.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->

[zha-9b493435cd2e247b918e1d13f0096c87-_TYZB01_1xktopx6.TS0041A-98ff68bf6f977b05335622602f29deb8.json](https://github.com/user-attachments/files/21746256/zha-9b493435cd2e247b918e1d13f0096c87-_TYZB01_1xktopx6.TS0041A-98ff68bf6f977b05335622602f29deb8.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
