### PR TITLE
Fix SYMFONISK v2 remote quirk automation triggers

### DIFF
--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -61,7 +61,7 @@ class ShortcutV1Cluster(EventableCluster):
     class ServerCommandDefs(BaseCommandDefs):
         """Server command definitions."""
 
-        shortcut_v1 = foundation.ZCLCommandDef(
+        shortcut_v1_event = foundation.ZCLCommandDef(
             id=0x01,
             schema={
                 "shortcut_button": t.int8s,

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -19,7 +19,6 @@ WWAH_CLUSTER_ID = 0xFC57  # decimal = 64599 ('Works with all Hubs' cluster)
 
 IKEA_SHORTCUT_CLUSTER_V1_ID = 0xFC7F  # decimal = 64639 Shortcut V1 commands
 IKEA_MATTER_SWITCH_CLUSTER_ID = 0xFC80  # decimal = 64640 Shortcut V2 commands
-COMMAND_SHORTCUT_V1 = "shortcut_v1_events"
 
 # PowerConfiguration cluster attributes
 BATTERY_VOLTAGE = PowerConfiguration.attributes_by_name["battery_voltage"].id

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -60,7 +60,7 @@ class ShortcutV1Cluster(EventableCluster):
     class ServerCommandDefs(BaseCommandDefs):
         """Server command definitions."""
 
-        shortcut_v1_event = foundation.ZCLCommandDef(
+        shortcut_v1_events = foundation.ZCLCommandDef(
             id=0x01,
             schema={
                 "shortcut_button": t.int8s,

--- a/zhaquirks/ikea/symfonisk2.py
+++ b/zhaquirks/ikea/symfonisk2.py
@@ -152,7 +152,6 @@ class IkeaSymfoniskGen2v1(CustomDevice):
                     PollControl.cluster_id,
                     LightLink.cluster_id,
                     WWAH_CLUSTER_ID,
-                    ShortcutV1Cluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,

--- a/zhaquirks/ikea/symfonisk2.py
+++ b/zhaquirks/ikea/symfonisk2.py
@@ -48,7 +48,6 @@ from zhaquirks.const import (
     TOGGLE,
 )
 from zhaquirks.ikea import (
-    COMMAND_SHORTCUT_V1,
     IKEA,
     IKEA_CLUSTER_ID,
     WWAH_CLUSTER_ID,
@@ -174,27 +173,27 @@ class IkeaSymfoniskGen2v1(CustomDevice):
     device_automation_triggers.update(
         {
             (SHORT_PRESS, BUTTON_1): {
-                COMMAND: COMMAND_SHORTCUT_V1,
+                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_event.name,
                 PARAMS: {"shortcut_button": 1, "shortcut_event": 1},
             },
             (DOUBLE_PRESS, BUTTON_1): {
-                COMMAND: COMMAND_SHORTCUT_V1,
+                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_event.name,
                 PARAMS: {"shortcut_button": 1, "shortcut_event": 2},
             },
             (LONG_PRESS, BUTTON_1): {
-                COMMAND: COMMAND_SHORTCUT_V1,
+                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_event.name,
                 PARAMS: {"shortcut_button": 1, "shortcut_event": 3},
             },
             (SHORT_PRESS, BUTTON_2): {
-                COMMAND: COMMAND_SHORTCUT_V1,
+                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_event.name,
                 PARAMS: {"shortcut_button": 2, "shortcut_event": 1},
             },
             (DOUBLE_PRESS, BUTTON_2): {
-                COMMAND: COMMAND_SHORTCUT_V1,
+                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_event.name,
                 PARAMS: {"shortcut_button": 2, "shortcut_event": 2},
             },
             (LONG_PRESS, BUTTON_2): {
-                COMMAND: COMMAND_SHORTCUT_V1,
+                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_event.name,
                 PARAMS: {"shortcut_button": 2, "shortcut_event": 3},
             },
         },

--- a/zhaquirks/ikea/symfonisk2.py
+++ b/zhaquirks/ikea/symfonisk2.py
@@ -172,27 +172,27 @@ class IkeaSymfoniskGen2v1(CustomDevice):
     device_automation_triggers.update(
         {
             (SHORT_PRESS, BUTTON_1): {
-                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_event.name,
+                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_events.name,
                 PARAMS: {"shortcut_button": 1, "shortcut_event": 1},
             },
             (DOUBLE_PRESS, BUTTON_1): {
-                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_event.name,
+                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_events.name,
                 PARAMS: {"shortcut_button": 1, "shortcut_event": 2},
             },
             (LONG_PRESS, BUTTON_1): {
-                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_event.name,
+                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_events.name,
                 PARAMS: {"shortcut_button": 1, "shortcut_event": 3},
             },
             (SHORT_PRESS, BUTTON_2): {
-                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_event.name,
+                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_events.name,
                 PARAMS: {"shortcut_button": 2, "shortcut_event": 1},
             },
             (DOUBLE_PRESS, BUTTON_2): {
-                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_event.name,
+                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_events.name,
                 PARAMS: {"shortcut_button": 2, "shortcut_event": 2},
             },
             (LONG_PRESS, BUTTON_2): {
-                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_event.name,
+                COMMAND: ShortcutV1Cluster.ServerCommandDefs.shortcut_v1_events.name,
                 PARAMS: {"shortcut_button": 2, "shortcut_event": 3},
             },
         },


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The recent migration to the new ZCL command schemas introduced a bug: I renamed the `shortcut_v1_event` command to `shortcut_v1` by accident. This causes the automation trigger to not match the real event emitted by the device.

The quirk also added the `ShortcutV1Cluster` to the input cluster list, despite the device not having this functionality before. This has been removed.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Core issue: https://github.com/home-assistant/core/issues/150360


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-ee9746238c3623e7c7bc5c90dff96841-IKEA.of.Sweden.SYMFONISK.sound.remote.gen2-547fdd3833766f26e6bb75152ff42e1a.json](https://github.com/user-attachments/files/21758585/zha-ee9746238c3623e7c7bc5c90dff96841-IKEA.of.Sweden.SYMFONISK.sound.remote.gen2-547fdd3833766f26e6bb75152ff42e1a.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
