### PR TITLE
Fix Tuya remotes not generating events due to swapped cluster

### DIFF
--- a/zhaquirks/tuya/ts0041.py
+++ b/zhaquirks/tuya/ts0041.py
@@ -221,10 +221,10 @@ class TuyaSmartRemote0041_var04(CustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
-                    TuyaSmartRemoteOnOffCluster,
+                    OnOff.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
-                    OnOff.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
                     Time.cluster_id,
                     Ota.cluster_id,
                 ],


### PR DESCRIPTION
## Proposed change

This fixes an issue for Tuya remotes, where the `TuyaSmartRemoteOnOffCluster` was used as an input/server cluster, instead of an output/client cluster, causing events to not be generated with the new strict ZCL (command) matching in zigpy.

#### TODO: Also fix for other Tuya remotes, possibly look into Z2M.


## Additional information

Addresses:
- https://github.com/home-assistant/core/issues/150528

Related:
- https://github.com/zigpy/zha-device-handlers/pull/4255


## Device diagnostics

Copied from [HA issue](https://github.com/home-assistant/core/issues/150528#issuecomment-3181216968): [zha-9b493435cd2e247b918e1d13f0096c87-_TYZB01_1xktopx6.TS0041A-98ff68bf6f977b05335622602f29deb8.json](https://github.com/user-attachments/files/21759698/zha-9b493435cd2e247b918e1d13f0096c87-_TYZB01_1xktopx6.TS0041A-98ff68bf6f977b05335622602f29deb8.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly -> see https://github.com/home-assistant/core/issues/150528#issuecomment-3183377984
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
