### PR TITLE
Verify that no quirks do suspicious moves or copy/pastes of clusters

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -901,8 +901,6 @@ def test_no_duplicate_clusters(quirk: CustomDevice) -> None:
             zhaquirks.ikea.twobtnremote.IkeaRodretRemote2BtnNew,
             # remove WindowCovering input cluster (IKEA remote):
             zhaquirks.ikea.twobtnremote.IkeaTradfriRemote2BtnZLL,
-            # add ShortcutV1 cluster as input cluster (IKEA remote) (fixed upstream):
-            zhaquirks.ikea.symfonisk2.IkeaSymfoniskGen2v1,
             #
             # -- other devices --
             # adds DoorLock cluster to output clusters (Yale door locks):

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -865,30 +865,46 @@ def test_suspicious_cluster_moves(quirk: CustomDevice) -> None:
         removed_in_clusters = set(orig_in_clusters) - set(new_in_clusters)
         removed_out_clusters = set(orig_out_clusters) - set(new_out_clusters)
 
+        # Moved clusters
         in_clusters_moved_to_out = added_out_clusters & removed_in_clusters
         out_clusters_moved_to_in = added_in_clusters & removed_out_clusters
 
         if in_clusters_moved_to_out:
             pytest.fail(
-                f"Quirk {quirk!r} moved input to output cluster: {in_clusters_moved_to_out!r}"
+                f"Quirk {quirk!r} moved input to output cluster on EP {ep_id}: {in_clusters_moved_to_out!r}"
             )
 
         if out_clusters_moved_to_in:
             pytest.fail(
-                f"Quirk {quirk!r} moved output to input cluster: {out_clusters_moved_to_in!r}"
+                f"Quirk {quirk!r} moved output to input cluster on EP {ep_id}: {out_clusters_moved_to_in!r}"
             )
 
+        # Mirrored clusters
         out_mirrored_to_in = added_in_clusters & orig_out_clusters
         in_mirrored_to_out = added_out_clusters & orig_in_clusters
 
         if out_mirrored_to_in:
             pytest.fail(
-                f"Quirk {quirk!r} mirrored output to input cluster: {out_mirrored_to_in!r}"
+                f"Quirk {quirk!r} mirrored output to input cluster on EP {ep_id}: {out_mirrored_to_in!r}"
             )
 
         if in_mirrored_to_out:
             pytest.fail(
-                f"Quirk {quirk!r} mirrored input to output cluster: {in_mirrored_to_out!r}"
+                f"Quirk {quirk!r} mirrored input to output cluster on EP {ep_id}: {in_mirrored_to_out!r}"
+            )
+
+        # Removed clusters where one exists of the opposite type
+        removed_duplicate_in_clusters = removed_in_clusters & orig_out_clusters
+        removed_duplicate_out_clusters = removed_out_clusters & orig_in_clusters
+
+        if removed_duplicate_in_clusters:
+            pytest.fail(
+                f"Quirk {quirk!r} removed input cluster that has output cluster with same ID on EP {ep_id}: {removed_duplicate_in_clusters!r}"
+            )
+
+        if removed_duplicate_out_clusters:
+            pytest.fail(
+                f"Quirk {quirk!r} removed output cluster that has input cluster with same ID on EP {ep_id}: {removed_duplicate_out_clusters!r}"
             )
 
 

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -837,6 +837,61 @@ def test_no_duplicate_clusters(quirk: CustomDevice) -> None:
         check_for_duplicate_cluster_ids(ep_data.get(OUTPUT_CLUSTERS, []))
 
 
+@pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)
+def test_suspicious_cluster_moves(quirk: CustomDevice) -> None:
+    """Verify that no quirks do suspicious moves or copy/pastes of clusters."""
+    for ep_id, ep_data in quirk.replacement[ENDPOINTS].items():
+        # Originals
+        orig_in_clusters = set(
+            quirk.signature.get(ENDPOINTS, {}).get(ep_id, {}).get(INPUT_CLUSTERS, [])
+        )
+        orig_out_clusters = set(
+            quirk.signature.get(ENDPOINTS, {}).get(ep_id, {}).get(OUTPUT_CLUSTERS, [])
+        )
+
+        # New
+        new_in_clusters = {
+            cluster.cluster_id if isinstance(cluster, zcl.Cluster) else cluster
+            for cluster in ep_data.get(INPUT_CLUSTERS, [])
+        }
+        new_out_clusters = {
+            cluster.cluster_id if isinstance(cluster, zcl.Cluster) else cluster
+            for cluster in ep_data.get(OUTPUT_CLUSTERS, [])
+        }
+
+        added_in_clusters = set(new_in_clusters) - set(orig_in_clusters)
+        added_out_clusters = set(new_out_clusters) - set(orig_out_clusters)
+
+        removed_in_clusters = set(orig_in_clusters) - set(new_in_clusters)
+        removed_out_clusters = set(orig_out_clusters) - set(new_out_clusters)
+
+        in_clusters_moved_to_out = added_out_clusters & removed_in_clusters
+        out_clusters_moved_to_in = added_in_clusters & removed_out_clusters
+
+        if in_clusters_moved_to_out:
+            pytest.fail(
+                f"Quirk {quirk!r} moved input to output cluster: {in_clusters_moved_to_out!r}"
+            )
+
+        if out_clusters_moved_to_in:
+            pytest.fail(
+                f"Quirk {quirk!r} moved output to input cluster: {out_clusters_moved_to_in!r}"
+            )
+
+        out_mirrored_to_in = added_in_clusters & orig_out_clusters
+        in_mirrored_to_out = added_out_clusters & orig_in_clusters
+
+        if out_mirrored_to_in:
+            pytest.fail(
+                f"Quirk {quirk!r} mirrored output to input cluster: {out_mirrored_to_in!r}"
+            )
+
+        if in_mirrored_to_out:
+            pytest.fail(
+                f"Quirk {quirk!r} mirrored input to output cluster: {in_mirrored_to_out!r}"
+            )
+
+
 async def test_local_data_cluster(device_mock) -> None:
     """Ensure reading attributes from a LocalDataCluster works as expected."""
     registry = DeviceRegistry()

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -837,7 +837,87 @@ def test_no_duplicate_clusters(quirk: CustomDevice) -> None:
         check_for_duplicate_cluster_ids(ep_data.get(OUTPUT_CLUSTERS, []))
 
 
-@pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)
+@pytest.mark.parametrize(
+    "quirk",
+    [
+        quirk_cls
+        for quirk_cls in ALL_QUIRK_CLASSES
+        if quirk_cls
+        not in (
+            # -- Tuya devices --
+            # remove duplicated OnOff from input cluster (Tuya remotes):
+            zhaquirks.tuya.ts004f.TuyaSmartRemote004F,
+            zhaquirks.tuya.ts004f.TuyaSmartRemote004FROK,
+            zhaquirks.tuya.ts004f.TuyaSmartRemote004FDMS,
+            zhaquirks.tuya.ts004f.TuyaSmartRemote004FSK,
+            zhaquirks.tuya.ts004f.TuyaSmartRemote004FSK_v2,
+            # swap OnOff from input to output cluster (Tuya remotes):
+            zhaquirks.tuya.ts0041.TuyaSmartRemote0041TOPlusA,
+            zhaquirks.tuya.ts0042.TuyaSmartRemote0042TOPlusA,
+            zhaquirks.tuya.ts0043.TuyaSmartRemote0043TOPlusB,
+            zhaquirks.tuya.ts0044.TuyaSmartRemote0044TOPlusB,
+            zhaquirks.tuya.ts0046.TuyaSmartRemote0046,
+            # swap TuyaZBExternalSwitchTypeCluster input to output cluster (Tuya plug):
+            zhaquirks.tuya.ts011f_plug.Plug_v6,
+            #
+            # -- Xiaomi/Aqara devices --
+            # swap OnOff from input to output cluster (binary sensor):
+            zhaquirks.xiaomi.aqara.magnet_aq2.MagnetAQ2,
+            # swap OnOff from input to output cluster (Aqara remotes):
+            zhaquirks.xiaomi.aqara.sensor_switch_aq3.SwitchAQ3,
+            zhaquirks.xiaomi.aqara.switch_aq2.SwitchAQ2,
+            # remove MultistateInput output cluster (Xiaomi cube):
+            zhaquirks.xiaomi.aqara.cube.Cube,
+            zhaquirks.xiaomi.aqara.cube_aqgl01.CubeAQGL01,
+            # also add OTA input cluster (Aqara cube):
+            zhaquirks.xiaomi.aqara.cube_aqgl01.CubeCAGL02,
+            # remove custom Xiaomi output cluster (E1 curtain driver):
+            zhaquirks.xiaomi.aqara.driver_curtain_e1.DriverE1,
+            # remove random AnalogInput input cluster (Aqara remote + temp sensor):
+            zhaquirks.xiaomi.aqara.remote_b186acn01.RemoteB186ACN01,
+            zhaquirks.xiaomi.aqara.remote_b286acn01.RemoteB286ACN01,
+            zhaquirks.xiaomi.mija.sensor_ht.Weather,
+            # remove Time input cluster (Aqara switch):
+            zhaquirks.xiaomi.aqara.switch_t1.SwitchT1Alt2,
+            zhaquirks.xiaomi.aqara.switch_t1.SwitchT1,
+            # remove OnOff output cluster (Aqara switch):
+            zhaquirks.xiaomi.aqara.switch_t1.SwitchT1Alt3,
+            # remove OTA input cluster (Aqara remote + motion sensor):
+            zhaquirks.xiaomi.mija.motion.Motion,
+            zhaquirks.xiaomi.mija.sensor_switch.MijaButton,
+            # remove a bunch of incorrect output clusters (LUMI/Keen temp sensor):
+            zhaquirks.keenhome.weather.TemperatureHumidtyPressureSensor,
+            # this just exposed all ZCL clusters, remove a lot (Aqara light):
+            zhaquirks.xiaomi.aqara.light_aqcn2.LightAqcn02,
+            # DoorLock cluster that's actually a MultistateInput cluster
+            # removed as output cluster (Aqara vibration sensor):
+            zhaquirks.xiaomi.aqara.vibration_aq1.VibrationAQ1,
+            #
+            # -- IKEA devices --
+            # swap PM25 cluster from output to input cluster (IKEA Starkvind):
+            zhaquirks.ikea.starkvind.IkeaSTARKVIND,
+            zhaquirks.ikea.starkvind.IkeaSTARKVIND_v2,
+            # removes Group input cluster (IKEA remote):
+            zhaquirks.ikea.twobtnremote.IkeaRodretRemote2BtnNew,
+            # remove WindowCovering input cluster (IKEA remote):
+            zhaquirks.ikea.twobtnremote.IkeaTradfriRemote2BtnZLL,
+            # add ShortcutV1 cluster as input cluster (IKEA remote) (fixed upstream):
+            zhaquirks.ikea.symfonisk2.IkeaSymfoniskGen2v1,
+            #
+            # -- other devices --
+            # adds DoorLock cluster to output clusters (Yale door locks):
+            zhaquirks.yale.realliving.YRD210PBDB220TSLL,
+            zhaquirks.yale.realliving.YRD220240TSDB,
+            # remove LevelControl input cluster (Adurolight remote):
+            zhaquirks.aduro.adurolightncc.AdurolightNCC,
+            # add a bunch of output clusters (Zhongxing motion sensor):
+            zhaquirks.zhongxing.motion.SN10ZW,
+            # remove Tuya clusters from input and output clusters (ZLinky):
+            zhaquirks.lixee.zlinky.ZLinkyTICFWV14,
+            zhaquirks.lixee.zlinky.ZLinkyTICFWV15,
+        )
+    ],
+)
 def test_suspicious_cluster_moves(quirk: CustomDevice) -> None:
     """Verify that no quirks do suspicious moves or copy/pastes of clusters."""
     for ep_id, ep_data in quirk.replacement[ENDPOINTS].items():

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -851,11 +851,11 @@ def test_suspicious_cluster_moves(quirk: CustomDevice) -> None:
 
         # New
         new_in_clusters = {
-            cluster.cluster_id if isinstance(cluster, zcl.Cluster) else cluster
+            cluster if isinstance(cluster, int) else cluster.cluster_id
             for cluster in ep_data.get(INPUT_CLUSTERS, [])
         }
         new_out_clusters = {
-            cluster.cluster_id if isinstance(cluster, zcl.Cluster) else cluster
+            cluster if isinstance(cluster, int) else cluster.cluster_id
             for cluster in ep_data.get(OUTPUT_CLUSTERS, [])
         }
 


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This is a unit test only PR that checks all existing quirks for "suspicious" cluster moves:
- input to output (and vice versa)
- copy an input to an output (or vice versa)
- remove an input cluster on an endpoint where an identical output cluster exists (...)

Current outliers:

```python
keenhome.weather.TemperatureHumidtyPressureSensor  moved output to input cluster: {TemperatureMeasurement, RelativeHumidity}
xiaomi.aqara.magnet_aq2.MagnetAQ2                  moved input to output cluster: {OnOff}
xiaomi.aqara.sensor_switch_aq3.SwitchAQ3           moved input to output cluster: {OnOff}
xiaomi.aqara.switch_aq2.SwitchAQ2                  moved input to output cluster: {OnOff}
zhongxing.motion.SN10ZW                            moved input to output cluster: {PowerConfiguration}

xiaomi.aqara.cube_aqgl01.CubeCAGL02                mirrored output to input cluster: {Ota}
xiaomi.aqara.switch_t1.SwitchT1Alt3                mirrored input to output cluster: {Time}
xiaomi.aqara.switch_t1.SwitchT1                    mirrored input to output cluster: {Time}
yale.realliving.YRD210PBDB220TSLL                  mirrored input to output cluster: {DoorLock}
yale.realliving.YRD220240TSDB                      mirrored input to output cluster: {DoorLock}
```

The "removed input cluster that has output cluster with same ID" test flags a ton of devices (48/441 😓), including https://github.com/zigpy/zha-device-handlers/pull/4258 and https://github.com/zigpy/zha/pull/515.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
