### PR TITLE
Add Tuya temperature sensor `_TZE204_navtwmd0`

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -86,6 +86,55 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .add_to_registry()
 )
 
+(
+    TuyaQuirkBuilder("_TZE204_navtwmd0", "TS0601") # Only temperature with alarm, display and external sensor
+    .tuya_temperature(dp_id=1, scale=10)
+    .tuya_enum(
+        dp_id=9,
+        attribute_name="display_unit",
+        enum_class=TuyaTempUnitConvert,
+        entity_type=EntityType.CONFIG,
+        translation_key="display_unit",
+        fallback_name="Display unit",
+    )
+    .tuya_enum(
+        dp_id=14,
+        attribute_name="temperature_alarm",
+        enum_class=TuyaNousTempHumiAlarm,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.STANDARD,
+        translation_key="temperature_alarm",
+        fallback_name="Temperature alarm",
+    )
+    .tuya_number(
+        dp_id=10,
+        attribute_name="alarm_temperature_max",
+        type=t.uint16_t,
+        unit=UnitOfTemperature.CELSIUS,
+        min_value=-20,
+        max_value=60,
+        step=1,
+        multiplier=0.1,
+        entity_type=EntityType.CONFIG,
+        translation_key="alarm_temperature_max",
+        fallback_name="Alarm temperature max",
+    )
+    .tuya_number(
+        dp_id=11,
+        attribute_name="alarm_temperature_min",
+        type=t.uint16_t,
+        unit=UnitOfTemperature.CELSIUS,
+        min_value=-20,
+        max_value=60,
+        step=1,
+        multiplier=0.1,
+        entity_type=EntityType.CONFIG,
+        translation_key="alarm_temperature_min",
+        fallback_name="Alarm temperature min",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)
 
 (
     TuyaQuirkBuilder("_TZE200_a8sdabtg", "TS0601")  # Variant without screen, round
@@ -93,6 +142,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE200_znbl8dj5", "TS0601")
     .applies_to("_TZE200_zppcgbdj", "TS0601")
     .applies_to("_TZE204_s139roas", "TS0601")
+#    .applies_to("_TZE204_navtwmd0", "TS0601")
     .applies_to("_TZE200_s1xgth2u", "TS0601")  # Nedis ZBSC30WT
     .tuya_temperature(dp_id=1, scale=10)
     .adds(TuyaTemperatureMeasurement)

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -87,7 +87,9 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
 )
 
 (
-    TuyaQuirkBuilder("_TZE204_navtwmd0", "TS0601") # Only temperature with alarm, display and external sensor
+    TuyaQuirkBuilder(
+        "_TZE204_navtwmd0", "TS0601"
+    )  # Only temperature with alarm, display and external sensor
     .tuya_temperature(dp_id=1, scale=10)
     .tuya_enum(
         dp_id=9,

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -142,7 +142,6 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE200_znbl8dj5", "TS0601")
     .applies_to("_TZE200_zppcgbdj", "TS0601")
     .applies_to("_TZE204_s139roas", "TS0601")
-#    .applies_to("_TZE204_navtwmd0", "TS0601")
     .applies_to("_TZE200_s1xgth2u", "TS0601")  # Nedis ZBSC30WT
     .tuya_temperature(dp_id=1, scale=10)
     .adds(TuyaTemperatureMeasurement)


### PR DESCRIPTION
## Proposed change
Added the tuya tze204 navtwmd0 temperature sensor to the zha tuya_sensors.py quirks

## Additional information
No additional information available

## Device diagnostics
{
  "node_descriptor": {
    "logical_type": 1,
    "complex_descriptor_available": 0,
    "user_descriptor_available": 0,
    "reserved": 0,
    "aps_flags": 0,
    "frequency_band": 8,
    "mac_capability_flags": 142,
    "manufacturer_code": 4417,
    "maximum_buffer_size": 66,
    "maximum_incoming_transfer_size": 66,
    "server_mask": 10752,
    "maximum_outgoing_transfer_size": 66,
    "descriptor_capability_field": 0
  },
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0051",
      "input_clusters": [
        "0x0000",
        "0x0004",
        "0x0005",
        "0x0402",
        "0xef00"
      ],
      "output_clusters": [
        "0x000a",
        "0x0019"
      ]
    },
    "242": {
      "profile_id": "0xa1e0",
      "device_type": "0x0061",
      "input_clusters": [],
      "output_clusters": [
        "0x0021"
      ]
    }
  },
  "manufacturer": "_TZE204_navtwmd0",
  "model": "TS0601",
  "class": "zigpy.quirks.v2.CustomDeviceV2"
}

## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
