### PR TITLE
Add Legrand devices: Connected Outlet, Micromodule Switch, Shutter Switch, Remote Shutter Switch, Switch and Dimmer

### DIFF
--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -32,35 +32,6 @@ async def test_legrand_battery(zigpy_device_from_quirk, voltage, bpr):
     assert power_cluster["battery_percentage_remaining"] == bpr
 
 
-def test_light_switch_with_neutral_signature(assert_signature_matches_quirk):
-    """Test signature."""
-    signature = {
-        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=1, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4129, maximum_buffer_size=89, maximum_incoming_transfer_size=63, server_mask=10752, maximum_outgoing_transfer_size=63, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
-        "endpoints": {
-            "1": {
-                "profile_id": 260,
-                "device_type": "0x0100",
-                "in_clusters": [
-                    "0x0000",
-                    "0x0003",
-                    "0x0004",
-                    "0x0005",
-                    "0x0006",
-                    "0x000f",
-                    "0xfc01",
-                ],
-                "out_clusters": ["0x0000", "0x0019", "0xfc01"],
-            }
-        },
-        "manufacturer": " Legrand",
-        "model": " Light switch with neutral",
-        "class": "zigpy.device.Device",
-    }
-    assert_signature_matches_quirk(
-        zhaquirks.legrand.switch.LightSwitchWithNeutral, signature
-    )
-
-
 async def test_legrand_wire_pilot_cluster_write_attrs(zigpy_device_from_v2_quirk):
     """Test Legrand cable outlet pilot_wire_mode attr writing."""
 

--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -60,29 +60,29 @@ async def test_legrand_identify_command(zigpy_device_from_v2_quirk):
 
     device = zigpy_device_from_v2_quirk(f" {LEGRAND}", " Light switch with neutral")
     identify_cluster = device.endpoints[1].identify
-    request = identify_cluster.request = mock.AsyncMock()
 
-    # Expected values for the mocked function calls
-    IDENTIFY_TIME = 1234
-    IDENTIFY_COMMAND = 0x00
-    TRIGGER_EFFECT_COMMAND = 0x40
-    EFFECT_ID = 0x00
-    EFFECT_VARIANT = 0x00
+    with mock.patch("zigpy.zcl.Cluster.request") as request:
+        # Expected values for the mocked function calls
+        IDENTIFY_TIME = 1234
+        IDENTIFY_COMMAND = 0x00
+        TRIGGER_EFFECT_COMMAND = 0x40
+        EFFECT_ID = 0x00
+        EFFECT_VARIANT = 0x00
 
-    # Test the identify command
-    await identify_cluster.identify(identify_time=IDENTIFY_TIME)
+        # Test the identify command
+        await identify_cluster.identify(identify_time=IDENTIFY_TIME)
 
-    # The identify command should produce two requests
-    assert request.call_count == 2
+        # The identify command should produce two requests
+        assert request.call_count == 2
 
-    # The first call is for the trigger effect command
-    assert request.call_args_list[0].args[1] == TRIGGER_EFFECT_COMMAND
-    assert request.call_args_list[0].kwargs["effect_id"] == EFFECT_ID
-    assert request.call_args_list[0].kwargs["effect_variant"] == EFFECT_VARIANT
-    assert "identify_time" not in request.call_args_list[0].kwargs
+        # The first call is for the trigger effect command
+        assert request.call_args_list[0].args[1] == TRIGGER_EFFECT_COMMAND
+        assert request.call_args_list[0].kwargs["effect_id"] == EFFECT_ID
+        assert request.call_args_list[0].kwargs["effect_variant"] == EFFECT_VARIANT
+        assert "identify_time" not in request.call_args_list[0].kwargs
 
-    # The second call is for the identify command
-    assert request.call_args_list[1].args[1] == IDENTIFY_COMMAND
-    assert request.call_args_list[1].kwargs["identify_time"] == IDENTIFY_TIME
-    assert "effect_id" not in request.call_args_list[1].kwargs
-    assert "effect_variant" not in request.call_args_list[1].kwargs
+        # The second call is for the identify command
+        assert request.call_args_list[1].args[1] == IDENTIFY_COMMAND
+        assert request.call_args_list[1].kwargs["identify_time"] == IDENTIFY_TIME
+        assert "effect_id" not in request.call_args_list[1].kwargs
+        assert "effect_variant" not in request.call_args_list[1].kwargs

--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -53,3 +53,36 @@ async def test_legrand_wire_pilot_cluster_write_attrs(zigpy_device_from_v2_quirk
         [],
         manufacturer=0xFC40,
     )
+
+
+async def test_legrand_identify_command(zigpy_device_from_v2_quirk):
+    """Test Legrand Identify cluster command handling."""
+
+    device = zigpy_device_from_v2_quirk(f" {LEGRAND}", " Light switch with neutral")
+    identify_cluster = device.endpoints[1].identify
+    request = identify_cluster.request = mock.AsyncMock()
+
+    # Expected values for the mocked function calls
+    IDENTIFY_TIME = 1234
+    IDENTIFY_COMMAND = 0x00
+    TRIGGER_EFFECT_COMMAND = 0x40
+    EFFECT_ID = 0x00
+    EFFECT_VARIANT = 0x00
+
+    # Test the identify command
+    await identify_cluster.identify(identify_time=IDENTIFY_TIME)
+
+    # The identify command should produce two requests
+    assert request.call_count == 2
+
+    # The first call is for the trigger effect command
+    assert request.call_args_list[0].args[1] == TRIGGER_EFFECT_COMMAND
+    assert request.call_args_list[0].kwargs["effect_id"] == EFFECT_ID
+    assert request.call_args_list[0].kwargs["effect_variant"] == EFFECT_VARIANT
+    assert "identify_time" not in request.call_args_list[0].kwargs
+
+    # The second call is for the identify command
+    assert request.call_args_list[1].args[1] == IDENTIFY_COMMAND
+    assert request.call_args_list[1].kwargs["identify_time"] == IDENTIFY_TIME
+    assert "effect_id" not in request.call_args_list[1].kwargs
+    assert "effect_variant" not in request.call_args_list[1].kwargs

--- a/zhaquirks/legrand/__init__.py
+++ b/zhaquirks/legrand/__init__.py
@@ -62,29 +62,28 @@ class LegrandIdentify(CustomCluster, Identify):
         self,
         command_id: GeneralCommand | int | t.uint8_t,
         *args: Any,
-        manufacturer: int | t.uint16_t | None = None,
-        expect_reply: bool = True,
-        tsn: int | t.uint8_t | None = None,
         **kwargs: Any,
     ) -> Any:
         """Override the command method to customize the identify command."""
 
         if command_id == Identify.ServerCommandDefs.identify.id:
+            # Remove identify command specific arguments
+            identify_time = kwargs.pop("identify_time", None)
+
             await super().command(
                 command_id=Identify.ServerCommandDefs.trigger_effect.id,
                 effect_id=EffectIdentifier.Blink,
                 effect_variant=EffectVariant.Default,
-                manufacturer=manufacturer,
-                expect_reply=expect_reply,
-                tsn=tsn,
+                **kwargs,
             )
+
+            # Restore identify command specific arguments
+            if identify_time is not None:
+                kwargs["identify_time"] = identify_time
 
         return await super().command(
             command_id,
             *args,
-            manufacturer=manufacturer,
-            expect_reply=expect_reply,
-            tsn=tsn,
             **kwargs,
         )
 

--- a/zhaquirks/legrand/__init__.py
+++ b/zhaquirks/legrand/__init__.py
@@ -1,13 +1,36 @@
 """Module for Legrand devices."""
 
+from typing import Any
+
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
-from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import EffectIdentifier, EffectVariant, Identify
+from zigpy.zcl.foundation import (
+    BaseAttributeDefs,
+    DataTypeId,
+    GeneralCommand,
+    ZCLAttributeDef,
+)
 
 from zhaquirks import PowerConfigurationCluster
 
 LEGRAND = "Legrand"
 MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFC01  # decimal = 64513
+
+
+class DeviceMode(t.enum16):
+    """Device modes for some Legrand devices. To be used in custom cluster.
+
+    Note: some values are taken from the Z2M code.
+    """
+
+    Pilot_Off = 0x0001
+    Pilot_On = 0x0002
+    Switch = 0x0003
+    Auto = 0x0004
+    Dimmer_Off = 0x0100
+    Dimmer_On = 0x0101
 
 
 class LegrandCluster(CustomCluster):
@@ -20,13 +43,73 @@ class LegrandCluster(CustomCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Cluster attributes."""
 
-        dimmer = ZCLAttributeDef(
-            id=0x0000, type=t.data16, is_manufacturer_specific=True
+        device_mode = ZCLAttributeDef(
+            id=0x0000,
+            type=DeviceMode,
+            zcl_type=DataTypeId.data16,
+            is_manufacturer_specific=True,
         )
         led_dark = ZCLAttributeDef(
             id=0x0001, type=t.Bool, is_manufacturer_specific=True
         )
         led_on = ZCLAttributeDef(id=0x0002, type=t.Bool, is_manufacturer_specific=True)
+
+
+class LegrandIdentify(CustomCluster, Identify):
+    """Custom Identify cluster for Legrand devices. Replaces the identify command."""
+
+    async def command(
+        self,
+        command_id: GeneralCommand | int | t.uint8_t,
+        *args: Any,
+        manufacturer: int | t.uint16_t | None = None,
+        expect_reply: bool = True,
+        tsn: int | t.uint8_t | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Override the command method to customize the identify command."""
+
+        if command_id == Identify.ServerCommandDefs.identify.id:
+            await super().command(
+                command_id=Identify.ServerCommandDefs.trigger_effect.id,
+                effect_id=EffectIdentifier.Blink,
+                effect_variant=EffectVariant.Default,
+                manufacturer=manufacturer,
+                expect_reply=expect_reply,
+                tsn=tsn,
+            )
+
+        return await super().command(
+            command_id,
+            *args,
+            manufacturer=manufacturer,
+            expect_reply=expect_reply,
+            tsn=tsn,
+            **kwargs,
+        )
+
+
+class ShutterCalibrationMode(t.enum8):
+    """Shutter calibration modes for Legrand devices."""
+
+    Classic = 0x00
+    Specific = 0x01
+    Up_Down_Stop = 0x02
+    Temporal = 0x03
+    Venetian = 0x04
+
+
+class LegrandShutterCluster(CustomCluster, WindowCovering):
+    """Custom Shutter cluster for Legrand devices. Adds calibration mode."""
+
+    class AttributeDefs(WindowCovering.AttributeDefs):
+        """Cluster attributes."""
+
+        calibration_mode = ZCLAttributeDef(
+            id=0xF002,
+            type=ShutterCalibrationMode,
+            is_manufacturer_specific=True,
+        )
 
 
 class LegrandPowerConfigurationCluster(PowerConfigurationCluster):

--- a/zhaquirks/legrand/connected_outled.py
+++ b/zhaquirks/legrand/connected_outled.py
@@ -1,0 +1,31 @@
+"""Module for Legrand switches (without dimming functionality)."""
+
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.general import BinaryInput, OnOff
+
+from zhaquirks.legrand import LEGRAND, LegrandCluster, LegrandIdentify
+
+(
+    QuirkBuilder(f" {LEGRAND}", " Connected outlet")
+    .replaces(LegrandCluster)
+    .replaces(LegrandIdentify)
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=BinaryInput.cluster_id)
+    .prevent_default_entity_creation(
+        endpoint_id=1,
+        cluster_id=OnOff.cluster_id,
+        function=lambda entity: entity.device_class == "opening",
+    )
+    .switch(
+        attribute_name=LegrandCluster.AttributeDefs.led_dark.name,
+        cluster_id=LegrandCluster.cluster_id,
+        translation_key="turn_on_led_when_off",
+        fallback_name="Turn on LED when off",
+    )
+    .switch(
+        attribute_name=LegrandCluster.AttributeDefs.led_on.name,
+        cluster_id=LegrandCluster.cluster_id,
+        translation_key="turn_on_led_when_on",
+        fallback_name="Turn on LED when on",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/legrand/dimmer.py
+++ b/zhaquirks/legrand/dimmer.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomDevice
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import (
     Basic,
     BinaryInput,
@@ -28,7 +29,9 @@ from zhaquirks.const import (
 from zhaquirks.legrand import (
     LEGRAND,
     MANUFACTURER_SPECIFIC_CLUSTER_ID,
+    DeviceMode,
     LegrandCluster,
+    LegrandIdentify,
     LegrandPowerConfigurationCluster,
 )
 
@@ -278,108 +281,38 @@ class DimmerWithoutNeutralAndBallast(CustomDevice):
     }
 
 
-class DimmerWithNeutral(DimmerWithoutNeutral):
-    """Dimmer switch with neutral."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=256
-        # device_version=1
-        # input_clusters=[0, 3, 4, 8, 6, 5, 15, 64513]
-        # output_clusters=[0, 25, 64513]>
-        MODELS_INFO: [(f" {LEGRAND}", " Dimmer switch with neutral")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Scenes.cluster_id,
-                    BinaryInput.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
-                    Ota.cluster_id,
-                ],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.COMBO_BASIC,
-                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
-    }
-
-
-class DimmerWithNeutral2(CustomDevice):
-    """Dimmer switch with neutral."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=256
-        # device_version=1
-        # input_clusters=[0, 3, 4, 8, 6, 5, 15, 64513]
-        # output_clusters=[0, 64513, 5, 25]>
-        MODELS_INFO: [(f" {LEGRAND}", " Dimmer switch with neutral")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Scenes.cluster_id,
-                    BinaryInput.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
-                    Scenes.cluster_id,
-                    Ota.cluster_id,
-                ],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.COMBO_BASIC,
-                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Scenes.cluster_id,
-                    BinaryInput.cluster_id,
-                    LegrandCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    LegrandCluster,
-                    Scenes.cluster_id,
-                    Ota.cluster_id,
-                ],
-            }
-        }
-    }
+(
+    QuirkBuilder(f" {LEGRAND}", " Dimmer switch with neutral")
+    .replaces(LegrandCluster)
+    .replaces(LegrandIdentify)
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=BinaryInput.cluster_id)
+    .prevent_default_entity_creation(
+        endpoint_id=1,
+        cluster_id=OnOff.cluster_id,
+        function=lambda entity: entity.device_class == "opening",
+    )
+    .switch(
+        attribute_name=LegrandCluster.AttributeDefs.device_mode.name,
+        cluster_id=LegrandCluster.cluster_id,
+        translation_key="dimmer_mode",
+        fallback_name="Dimmer mode",
+        on_value=DeviceMode.Dimmer_On,
+        off_value=DeviceMode.Dimmer_Off,
+    )
+    .switch(
+        attribute_name=LegrandCluster.AttributeDefs.led_dark.name,
+        cluster_id=LegrandCluster.cluster_id,
+        translation_key="turn_on_led_when_off",
+        fallback_name="Turn on LED when off",
+    )
+    .switch(
+        attribute_name=LegrandCluster.AttributeDefs.led_on.name,
+        cluster_id=LegrandCluster.cluster_id,
+        translation_key="turn_on_led_when_on",
+        fallback_name="Turn on LED when on",
+    )
+    .add_to_registry()
+)
 
 
 class RemoteDimmer(CustomDevice):

--- a/zhaquirks/legrand/dimmer.py
+++ b/zhaquirks/legrand/dimmer.py
@@ -294,10 +294,10 @@ class DimmerWithoutNeutralAndBallast(CustomDevice):
     .switch(
         attribute_name=LegrandCluster.AttributeDefs.device_mode.name,
         cluster_id=LegrandCluster.cluster_id,
-        translation_key="dimmer_mode",
-        fallback_name="Dimmer mode",
         on_value=DeviceMode.Dimmer_On,
         off_value=DeviceMode.Dimmer_Off,
+        translation_key="dimmer_mode",
+        fallback_name="Dimmer mode",
     )
     .switch(
         attribute_name=LegrandCluster.AttributeDefs.led_dark.name,

--- a/zhaquirks/legrand/micromodule.py
+++ b/zhaquirks/legrand/micromodule.py
@@ -1,0 +1,31 @@
+"""Module for Legrand micromodule switches."""
+
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.general import BinaryInput, OnOff
+
+from zhaquirks.legrand import LEGRAND, LegrandCluster, LegrandIdentify
+
+(
+    QuirkBuilder(f" {LEGRAND}", " Micromodule switch")
+    .replaces(LegrandCluster)
+    .replaces(LegrandIdentify)
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=BinaryInput.cluster_id)
+    .prevent_default_entity_creation(
+        endpoint_id=1,
+        cluster_id=OnOff.cluster_id,
+        function=lambda entity: entity.device_class == "opening",
+    )
+    .switch(
+        attribute_name=LegrandCluster.AttributeDefs.led_dark.name,
+        cluster_id=LegrandCluster.cluster_id,
+        translation_key="turn_on_led_when_off",
+        fallback_name="Turn on LED when off",
+    )
+    .switch(
+        attribute_name=LegrandCluster.AttributeDefs.led_on.name,
+        cluster_id=LegrandCluster.cluster_id,
+        translation_key="turn_on_led_when_on",
+        fallback_name="Turn on LED when on",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/legrand/shutter.py
+++ b/zhaquirks/legrand/shutter.py
@@ -1,0 +1,45 @@
+"""Module for Legrand shutter switches."""
+
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.general import BinaryInput, OnOff
+
+from zhaquirks.legrand import (
+    LEGRAND,
+    LegrandCluster,
+    LegrandIdentify,
+    LegrandShutterCluster,
+    ShutterCalibrationMode,
+)
+
+(
+    QuirkBuilder(f" {LEGRAND}", " Shutter SW with level control")
+    .replaces(LegrandCluster)
+    .replaces(LegrandIdentify)
+    .replaces(LegrandShutterCluster)
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=BinaryInput.cluster_id)
+    .prevent_default_entity_creation(
+        endpoint_id=1,
+        cluster_id=OnOff.cluster_id,
+        function=lambda entity: entity.device_class == "opening",
+    )
+    .switch(
+        attribute_name=LegrandCluster.AttributeDefs.led_dark.name,
+        cluster_id=LegrandCluster.cluster_id,
+        translation_key="turn_on_led_when_off",
+        fallback_name="Turn on LED when off",
+    )
+    .switch(
+        attribute_name=LegrandCluster.AttributeDefs.led_on.name,
+        cluster_id=LegrandCluster.cluster_id,
+        translation_key="turn_on_led_when_on",
+        fallback_name="Turn on LED when on",
+    )
+    .enum(
+        attribute_name=LegrandShutterCluster.AttributeDefs.calibration_mode.name,
+        cluster_id=LegrandShutterCluster.cluster_id,
+        translation_key="calibration_mode",
+        fallback_name="Calibration mode",
+        enum_class=ShutterCalibrationMode,
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/legrand/shutter.py
+++ b/zhaquirks/legrand/shutter.py
@@ -37,9 +37,9 @@ from zhaquirks.legrand import (
     .enum(
         attribute_name=LegrandShutterCluster.AttributeDefs.calibration_mode.name,
         cluster_id=LegrandShutterCluster.cluster_id,
+        enum_class=ShutterCalibrationMode,
         translation_key="calibration_mode",
         fallback_name="Calibration mode",
-        enum_class=ShutterCalibrationMode,
     )
     .add_to_registry()
 )

--- a/zhaquirks/legrand/switch.py
+++ b/zhaquirks/legrand/switch.py
@@ -1,77 +1,31 @@
 """Module for Legrand switches (without dimming functionality)."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    BinaryInput,
-    Groups,
-    Identify,
-    OnOff,
-    Ota,
-    Scenes,
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.general import BinaryInput, OnOff
+
+from zhaquirks.legrand import LEGRAND, LegrandCluster, LegrandIdentify
+
+(
+    QuirkBuilder(f" {LEGRAND}", " Light switch with neutral")
+    .replaces(LegrandCluster)
+    .replaces(LegrandIdentify)
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=BinaryInput.cluster_id)
+    .prevent_default_entity_creation(
+        endpoint_id=1,
+        cluster_id=OnOff.cluster_id,
+        function=lambda entity: entity.device_class == "opening",
+    )
+    .switch(
+        attribute_name=LegrandCluster.AttributeDefs.led_dark.name,
+        cluster_id=LegrandCluster.cluster_id,
+        translation_key="turn_on_led_when_off",
+        fallback_name="Turn on LED when off",
+    )
+    .switch(
+        attribute_name=LegrandCluster.AttributeDefs.led_on.name,
+        cluster_id=LegrandCluster.cluster_id,
+        translation_key="turn_on_led_when_on",
+        fallback_name="Turn on LED when on",
+    )
+    .add_to_registry()
 )
-
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-from zhaquirks.legrand import LEGRAND, MANUFACTURER_SPECIFIC_CLUSTER_ID, LegrandCluster
-
-
-class LightSwitchWithNeutral(CustomDevice):
-    """Light switch with neutral wire."""
-
-    signature = {
-        #  <SimpleDescriptor endpoint=1 profile=260 device_type=256
-        # input_clusters=[0, 3, 4, 5, 6, 15, 64513]
-        # output_clusters=[0, 25, 64513]>
-        MODELS_INFO: [(f" {LEGRAND}", " Light switch with neutral")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    BinaryInput.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Ota.cluster_id,
-                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    BinaryInput.cluster_id,
-                    LegrandCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Ota.cluster_id,
-                    LegrandCluster,
-                ],
-            }
-        }
-    }

--- a/zhaquirks/legrand/wirelessshutter.py
+++ b/zhaquirks/legrand/wirelessshutter.py
@@ -1,0 +1,13 @@
+"""Module for Legrand remote wireless shutter switches."""
+
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.general import BinaryInput
+
+from zhaquirks.legrand import LEGRAND, LegrandPowerConfigurationCluster
+
+(
+    QuirkBuilder(f" {LEGRAND}", " Shutters central remote switch")
+    .replaces(LegrandPowerConfigurationCluster)
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=BinaryInput.cluster_id)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Add some custom Legrand clusters:
* `LegrandIdentify` which extends the `Identify` cluster to support the custom `identify` command needed for Legrand devices, which requires sending a `trigger_effect` command before.
* `LegrandShutterCluster` which extends the `Shutter` cluster adding a `calibration_mode` enum attribute

Support the new following Legrand devices:
* Connected Outlet (I own [this](https://catalogo.bticino.it/prodotto/soluzioni-per-edifici-residenziali-e-nel-terziario/livinglight/livinglight-smart/BTI-N4531C-IT) equivalent by BTicino)
* Micromodule Switch (I own [this](https://catalogo.bticino.it/prodotto/soluzioni-per-edifici-residenziali-e-nel-terziario/livinglight/livinglight-smart/BTI-3584C-IT) equivalent by BTicino)
* Shutter Switches (I own [this](https://catalogo.bticino.it/prodotto/soluzioni-per-edifici-residenziali-e-nel-terziario/livinglight/livinglight-smart/BTI-N4027C-IT) equivalent by BTicino)
* Remote Shutter Switches (I own [this](https://catalogo.bticino.it/prodotto/soluzioni-per-edifici-residenziali-e-nel-terziario/livinglight/livinglight-smart/comandi-wireless-per-gestione-luci-e-tapparelle/BTI-LN4027CWI-IT) equivalent by BTicino)

Convert to quirk V2 the following Legrand devices:
* Switch (I own [this](https://catalogo.bticino.it/prodotto/soluzioni-per-edifici-residenziali-e-nel-terziario/livinglight/livinglight-smart/BTI-N4003C-IT) equivalent by BTcino)
* Dimmer with Neutral (I own [this](https://catalogo.bticino.it/prodotto/soluzioni-per-edifici-residenziali-e-nel-terziario/livinglight/livinglight-smart/BTI-N4411C-IT) equivalent by BTcino)

## Additional information

* The `LegrandCluster` manufacturer specific cluster has been slightly refactored renaming the `dimmer` attribute to `device_mode` and adding some values to be consistent with the Z2M implementation (see [here](https://github.com/Koenkk/zigbee-herdsman-converters/blob/8e9404b28c6b4ee032bb29d6528695e3d260d38f/src/lib/legrand.ts#L205)) 
* I removed from all devices I implemented, the binary input entity (which is non functional)
* I removed from all devices the "opening" entity associated with the OnOff cluster (which is also non functional)
* I added toggle entities to control the LED behavior (led_on_when_on and led_on_when_off, which turn on the integrated LED respectively when the device is in the on or off state)

Information has been derived from the [Legrand developer portal](https://developer.legrand.com/local-interoperability/#Products%20cluster%20list) and the Z2M implementation.

Commits have been separated by domain for easier review, but only tested as a whole (single commits might not be functional)

## Device diagnostics

* Connected outlet: [zha-01K1JQT83XMY0X6WTRD4FQQ602- Legrand  Connected outlet-529ebe0364e3213c61a16076c44cc0c9.json](https://github.com/user-attachments/files/21822953/zha-01K1JQT83XMY0X6WTRD4FQQ602-.Legrand.Connected.outlet-529ebe0364e3213c61a16076c44cc0c9.json)
* Micromodule switch: [zha-01K1JQT83XMY0X6WTRD4FQQ602- Legrand  Micromodule switch-088bf7986cfa77914a6928421d9cbdb6.json](https://github.com/user-attachments/files/21822963/zha-01K1JQT83XMY0X6WTRD4FQQ602-.Legrand.Micromodule.switch-088bf7986cfa77914a6928421d9cbdb6.json)
* Shutter switch: [zha-01K1JQT83XMY0X6WTRD4FQQ602- Legrand  Shutter SW with level control-2069c9719e8762c86d12a52448a28351.json](https://github.com/user-attachments/files/21822966/zha-01K1JQT83XMY0X6WTRD4FQQ602-.Legrand.Shutter.SW.with.level.control-2069c9719e8762c86d12a52448a28351.json)
* Remote shutter switch: [zha-01K1JQT83XMY0X6WTRD4FQQ602- Legrand  Shutters central remote switch-5b1504d6d6f62e29083617f5f6db65ea.json](https://github.com/user-attachments/files/21822969/zha-01K1JQT83XMY0X6WTRD4FQQ602-.Legrand.Shutters.central.remote.switch-5b1504d6d6f62e29083617f5f6db65ea.json)
* Switch: [zha-01K1JQT83XMY0X6WTRD4FQQ602- Legrand  Light switch with neutral-b82c9674f6a570bf286e0c4a803b2328.json](https://github.com/user-attachments/files/21822972/zha-01K1JQT83XMY0X6WTRD4FQQ602-.Legrand.Light.switch.with.neutral-b82c9674f6a570bf286e0c4a803b2328.json)
* Dimmer: [zha-01K1JQT83XMY0X6WTRD4FQQ602- Legrand  Dimmer switch with neutral-1957f2f675e97488d01ee2abd9d9a068 (2).json](https://github.com/user-attachments/files/21822973/zha-01K1JQT83XMY0X6WTRD4FQQ602-.Legrand.Dimmer.switch.with.neutral-1957f2f675e97488d01ee2abd9d9a068.2.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly (**NOTE**: I could not test _exactly_ the files uploaded here, for example i cannot put a `__init__.py` file in the custom_zha_quirks folder so I had to modify them slightly. Any help on how to test the entire quirks package for example by replacing it is appreciated - consider I am using a HA Green HW) 
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works (**NOTE**: More than happy to write some, I just need some guidance on what to test and how)
- [x] Device diagnostics data has been attached
