### PR TITLE
Fix Tuya Hiking power meter "momentary power" type

### DIFF
--- a/zhaquirks/tuya/ts0601_din_power.py
+++ b/zhaquirks/tuya/ts0601_din_power.py
@@ -182,7 +182,7 @@ class HikingManufClusterDinPower(TuyaManufClusterAttributes):
             is_manufacturer_specific=True,
         )
         power: Final = ZCLAttributeDef(
-            id=HIKING_POWER_ATTR, type=t.uint16_t, is_manufacturer_specific=True
+            id=HIKING_POWER_ATTR, type=t.int32s, is_manufacturer_specific=True
         )
         frequency: Final = ZCLAttributeDef(
             id=HIKING_FREQUENCY_ATTR, type=t.uint16_t, is_manufacturer_specific=True


### PR DESCRIPTION
Power can go into negative, as these meters are bi-directional. Switch uint16_t to int32s.

- [x] The changes are tested and work correctly
