### PR TITLE
Add Tuya plantation shutter `_TZE284_myikb7qz`

### DIFF
--- a/tests/test_tuya_shutter.py
+++ b/tests/test_tuya_shutter.py
@@ -1,0 +1,34 @@
+"""Tests for Tuya Shutter quirks."""
+
+from zigpy.zcl.clusters.general import PowerConfiguration
+
+import zhaquirks
+from zhaquirks.tuya import TuyaLocalCluster
+from zhaquirks.tuya.mcu import TuyaMCUCluster
+
+zhaquirks.setup()
+
+
+def test_valid_attributes(zigpy_device_from_v2_quirk):
+    """Test that valid attributes on virtual clusters are populated by Tuya datapoints mappings."""
+    quirked = zigpy_device_from_v2_quirk("_TZE284_myikb7qz", "TS0601")
+    ep = quirked.endpoints[1]
+
+    power_attr_id = PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
+
+    power_config_cluster = ep.power
+
+    assert isinstance(power_config_cluster, TuyaLocalCluster)
+
+    # check that the virtual clusters have expected valid attributes
+    assert {power_attr_id} == power_config_cluster._VALID_ATTRIBUTES
+
+
+async def test_tuya(zigpy_device_from_v2_quirk):
+    """Example Tuya Test."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_myikb7qz", "TS0601")
+    ep = quirked.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)

--- a/zhaquirks/tuya/tuya_shutter.py
+++ b/zhaquirks/tuya/tuya_shutter.py
@@ -1,13 +1,11 @@
-from zigpy.quirks.v2 import BinarySensorDeviceClass, EntityPlatform, EntityType
-from zhaquirks.tuya.builder import TuyaQuirkBuilder
-from zhaquirks.const import BatterySize
+"""Tuya Plantation Shutter."""
+
+from zigpy.quirks.v2 import EntityPlatform, EntityType
+from zigpy.quirks.v2.homeassistant import PERCENTAGE
 import zigpy.types as t
-from zigpy.quirks.v2.homeassistant import (
-    PERCENTAGE,
-    UnitOfElectricPotential,
-    UnitOfTime,
-    UnitOfVolume,
-)
+
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
 
 class OpeningStateEnum(t.enum8):
     """Enum for opening state."""
@@ -17,17 +15,30 @@ class OpeningStateEnum(t.enum8):
     Close = 0x02
     Continue = 0x03
 
-#class SituationSetEnum(t.enum8):
-#    """Enum for Situation Set."""
-#
-#    fully_open = 0
-#    fully_close = 1
 
-#class MotorDirectionEnum(t.enum8):
-#    """Enum for Motor Direction."""
-#
-#    Forward = 0
-#    Backward = 1
+class SituationSetEnum(t.enum8):
+    """Enum for Situation Set."""
+
+    fully_open = 0x00
+    fully_close = 0x01
+
+
+class MotorDirectionEnum(t.enum8):
+    """Enum for Motor Direction."""
+
+    Forward = 0x00
+    Backward = 0x01
+
+
+class BorderLimitEnum(t.enum8):
+    """Enum for Border Limit Setting."""
+
+    up = 0x00
+    down = 0x01
+    up_delete = 0x02
+    down_delete = 0x03
+    remove_top_bottom = 0x04
+
 
 (
     TuyaQuirkBuilder("_TZE284_myikb7qz", "TS0601")
@@ -40,6 +51,7 @@ class OpeningStateEnum(t.enum8):
         translation_key="control",
         fallback_name="Control",
     )
+    # Working
     .tuya_number(
         dp_id=2,
         attribute_name="curtain_target_setting",
@@ -51,6 +63,7 @@ class OpeningStateEnum(t.enum8):
         translation_key="curtain_target_setting",
         fallback_name="Curtain Target Setting",
     )
+    # Working
     .tuya_number(
         dp_id=3,
         attribute_name="curtain_postion",
@@ -62,32 +75,58 @@ class OpeningStateEnum(t.enum8):
         translation_key="curtain_position",
         fallback_name="Curtain Position",
     )
-    #.tuya_enum(
-    #    dp_id=5,
-    #    attribute_name="motor_direction",
-    #    enum_class=MotorDirectionEnum,
-    #    entity_type=EntityType.STANDARD,
-    #    entity_platform=EntityPlatform.SENSOR,
-    #    translation_key="motor_direction",
-    #    fallback_name="Motor Direction",
-    #)
-    #.tuya_enum(
-    #    dp_id=11,
-    #    attribute_name="situation_set",
-    #    enum_class=SituationSetEnum,
-    #    entity_type=EntityType.STANDARD,
-    #    entity_platform=EntityPlatform.SENSOR,
-    #    translation_key="situation_set",
-    #    fallback_name="Situation Set",
-    #)
-    .tuya_battery(dp_id=13, battery_qty=1)
-    #.tuya_switch(
-    #    dp_id=101,
-    #    attribute_name="child_lock",
-    #    translation_key="child_lock",
-    #    fallback_name="Child lock",
-    #)
+    # Working Needs to be manually triggered to pick up sensor
+    .tuya_enum(
+        dp_id=5,
+        attribute_name="motor_direction",
+        enum_class=MotorDirectionEnum,
+        entity_type=EntityType.STANDARD,
+        entity_platform=EntityPlatform.SENSOR,
+        translation_key="motor_direction",
+        fallback_name="Motor Direction",
+    )
+    # Not Working
+    .tuya_enum(
+        dp_id=11,
+        attribute_name="situation_set",
+        enum_class=SituationSetEnum,
+        entity_type=EntityType.STANDARD,
+        entity_platform=EntityPlatform.SENSOR,
+        translation_key="situation_set",
+        fallback_name="Situation Set",
+    )
+    # power_cfg=PowerConfiguration does not work
+    .tuya_battery(
+        dp_id=13,
+    )
+    # Not working
+    .tuya_enum(
+        dp_id=16,
+        attribute_name="border_limit",
+        enum_class=BorderLimitEnum,
+        entity_type=EntityType.STANDARD,
+        entity_platform=EntityPlatform.SENSOR,
+        translation_key="border_limit",
+        fallback_name="Border Limit Setting",
+    )
+    # Not working
+    .tuya_number(
+        dp_id=19,
+        attribute_name="position_best",
+        type=t.uint32_t,
+        min_value=0,
+        max_value=100,
+        step=1,
+        unit=PERCENTAGE,
+        translation_key="position_best",
+        fallback_name="Best Position",
+    )
+    .tuya_switch(
+        dp_id=101,
+        attribute_name="child_lock",
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
     .skip_configuration()
     .add_to_registry()
 )
-

--- a/zhaquirks/tuya/tuya_shutter.py
+++ b/zhaquirks/tuya/tuya_shutter.py
@@ -54,26 +54,26 @@ class BorderLimitEnum(t.enum8):
     # Working
     .tuya_number(
         dp_id=2,
-        attribute_name="curtain_target_setting",
+        attribute_name="shutter_target_setting",
         type=t.uint32_t,
         min_value=0,
         max_value=100,
         step=1,
         unit=PERCENTAGE,
-        translation_key="curtain_target_setting",
-        fallback_name="Curtain Target Setting",
+        translation_key="shutter_target_setting",
+        fallback_name="Shutter Target Setting",
     )
     # Working
     .tuya_number(
         dp_id=3,
-        attribute_name="curtain_postion",
+        attribute_name="shutter_postion",
         type=t.uint32_t,
         min_value=0,
         max_value=100,
         step=1,
         unit=PERCENTAGE,
-        translation_key="curtain_position",
-        fallback_name="Curtain Position",
+        translation_key="shutter_position",
+        fallback_name="Shutter Position",
     )
     # Working Needs to be manually triggered to pick up sensor
     .tuya_enum(

--- a/zhaquirks/tuya/tuya_shutter.py
+++ b/zhaquirks/tuya/tuya_shutter.py
@@ -1,0 +1,93 @@
+from zigpy.quirks.v2 import BinarySensorDeviceClass, EntityPlatform, EntityType
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.const import BatterySize
+import zigpy.types as t
+from zigpy.quirks.v2.homeassistant import (
+    PERCENTAGE,
+    UnitOfElectricPotential,
+    UnitOfTime,
+    UnitOfVolume,
+)
+
+class OpeningStateEnum(t.enum8):
+    """Enum for opening state."""
+
+    Open = 0x00
+    Stop = 0x01
+    Close = 0x02
+    Continue = 0x03
+
+#class SituationSetEnum(t.enum8):
+#    """Enum for Situation Set."""
+#
+#    fully_open = 0
+#    fully_close = 1
+
+#class MotorDirectionEnum(t.enum8):
+#    """Enum for Motor Direction."""
+#
+#    Forward = 0
+#    Backward = 1
+
+(
+    TuyaQuirkBuilder("_TZE284_myikb7qz", "TS0601")
+    .tuya_enum(
+        dp_id=1,
+        attribute_name="control_state",
+        enum_class=OpeningStateEnum,
+        entity_type=EntityType.STANDARD,
+        entity_platform=EntityPlatform.SENSOR,
+        translation_key="control",
+        fallback_name="Control",
+    )
+    .tuya_number(
+        dp_id=2,
+        attribute_name="curtain_target_setting",
+        type=t.uint32_t,
+        min_value=0,
+        max_value=100,
+        step=1,
+        unit=PERCENTAGE,
+        translation_key="curtain_target_setting",
+        fallback_name="Curtain Target Setting",
+    )
+    .tuya_number(
+        dp_id=3,
+        attribute_name="curtain_postion",
+        type=t.uint32_t,
+        min_value=0,
+        max_value=100,
+        step=1,
+        unit=PERCENTAGE,
+        translation_key="curtain_position",
+        fallback_name="Curtain Position",
+    )
+    #.tuya_enum(
+    #    dp_id=5,
+    #    attribute_name="motor_direction",
+    #    enum_class=MotorDirectionEnum,
+    #    entity_type=EntityType.STANDARD,
+    #    entity_platform=EntityPlatform.SENSOR,
+    #    translation_key="motor_direction",
+    #    fallback_name="Motor Direction",
+    #)
+    #.tuya_enum(
+    #    dp_id=11,
+    #    attribute_name="situation_set",
+    #    enum_class=SituationSetEnum,
+    #    entity_type=EntityType.STANDARD,
+    #    entity_platform=EntityPlatform.SENSOR,
+    #    translation_key="situation_set",
+    #    fallback_name="Situation Set",
+    #)
+    .tuya_battery(dp_id=13, battery_qty=1)
+    #.tuya_switch(
+    #    dp_id=101,
+    #    attribute_name="child_lock",
+    #    translation_key="child_lock",
+    #    fallback_name="Child lock",
+    #)
+    .skip_configuration()
+    .add_to_registry()
+)
+


### PR DESCRIPTION
## Proposed change
Add support for tuya plantation shutter.
https://www.amazon.com/Blindsmart-Plantation-Shutters-Automatic-Rechargeable/dp/B0B74SQQ43

DP pulled from here: 
https://community.hubitat.com/t/release-zemismart-zigbee-blind-driver/67525/508?u=kkossev

Confirmed DP from here:
https://raw.githubusercontent.com/amosyuen/hubitat-zemismart-zigbee/development/Zemismart%20Zigbee%20Blind.groovy


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--

-->
```
{
  "node_descriptor": {
    "logical_type": 2,
    "complex_descriptor_available": 0,
    "user_descriptor_available": 0,
    "reserved": 0,
    "aps_flags": 0,
    "frequency_band": 8,
    "mac_capability_flags": 128,
    "manufacturer_code": 4417,
    "maximum_buffer_size": 66,
    "maximum_incoming_transfer_size": 66,
    "server_mask": 10752,
    "maximum_outgoing_transfer_size": 66,
    "descriptor_capability_field": 0
  },
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0051",
      "input_clusters": [
        "0x0000",
        "0x0001",
        "0x0004",
        "0x0005",
        "0xed00",
        "0xef00"
      ],
      "output_clusters": [
        "0x000a",
        "0x0019"
      ]
    }
  },
  "manufacturer": "_TZE284_myikb7qz",
  "model": "TS0601",
  "class": "zigpy.quirks.v2.CustomDeviceV2"
}
````
<img width="1033" height="892" alt="Screenshot From 2025-08-27 15-36-45" src="https://github.com/user-attachments/assets/37c6180b-d614-4208-96de-12fc7db9e02e" />



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
