### PR TITLE
Add Tuya NovaDigital ZVL-DUAL valve `_TZE284_iilebqoo`

### DIFF
--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -363,6 +363,7 @@ class GiexIrrigationStatus(t.enum8):
 (
     TuyaQuirkBuilder("_TZE284_8zizsafo", "TS0601")  # Giex GX04
     .applies_to("_TZE284_eaet5qt5", "TS0601")  # Insoma SGW08W
+    .applies_to("_TZE284_iilebqoo", "TS0601")  # NovaDigital ZVL_DUAL
     .tuya_battery(dp_id=59, battery_type=BatterySize.AA, battery_qty=4)
     .tuya_switch(
         dp_id=1,


### PR DESCRIPTION
This PR adds support for the Tuya TS0601 dual valve, sold in Brazil under the "NovaDigital ZVL-DUAL" brand.

The device is a whitelabeled version of the standard Tuya TS0601 dual valve already supported by this quirk. 
It uses the same datapoints and behavior, only the manufacturer string differs:

- Manufacturer: _TZE284_iilebqoo
![WhatsApp Image 2025-08-22 at 14 31 48](https://github.com/user-attachments/assets/706bfe63-d793-4e26-8325-09dcfef099c4)

- Model: TS0601

Adding `.applies_to("_TZE284_iilebqoo", "TS0601")` makes ZHA correctly apply the dual-valve quirk and exposes two switch entities (Valve 1, Valve 2) plus error reporting.

This will help users in Brazil, where the device is distributed under the NovaDigital brand, but is otherwise identical to other Tuya-branded versions.
