### PR TITLE
Move XBee replacement endpoints to ZHA profile

### DIFF
--- a/zhaquirks/xbee/xbee3_io.py
+++ b/zhaquirks/xbee/xbee3_io.py
@@ -29,105 +29,105 @@ class XBee3Sensor(XBeeCommon):
             0xD0: {
                 # AD0/DIO0/Commissioning
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                 OUTPUT_CLUSTERS: [],
             },
             0xD1: {
                 # AD1/DIO1/SPI_nATTN
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                 OUTPUT_CLUSTERS: [],
             },
             0xD2: {
                 # AD2/DIO2/SPI_CLK
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                 OUTPUT_CLUSTERS: [],
             },
             0xD3: {
                 # AD3/DIO3
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                 OUTPUT_CLUSTERS: [],
             },
             0xD4: {
                 # DIO4/SPI_MOSI
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xD5: {
                 # DIO5/Assoc
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xD6: {
                 # DIO6/RTS
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xD7: {
                 # DIO7/CTS
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                 OUTPUT_CLUSTERS: [],
             },
             0xD8: {
                 # DIO8
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xD9: {
                 # DIO9
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xDA: {
                 # DIO10/PWM0
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff, XBeePWM],
                 OUTPUT_CLUSTERS: [],
             },
             0xDB: {
                 # DIO11/PWM1
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff, XBeePWM],
                 OUTPUT_CLUSTERS: [],
             },
             0xDC: {
                 # DIO12/SPI_MISO
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xDD: {
                 # DIO13/DOUT
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xDE: {
                 # DIO14/DIN
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },

--- a/zhaquirks/xbee/xbee_io.py
+++ b/zhaquirks/xbee/xbee_io.py
@@ -23,105 +23,105 @@ class XBeeSensor(XBeeCommon):
             0xD0: {
                 # AD0/DIO0/Commissioning
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                 OUTPUT_CLUSTERS: [],
             },
             0xD1: {
                 # AD1/DIO1/SPI_nATTN
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                 OUTPUT_CLUSTERS: [],
             },
             0xD2: {
                 # AD2/DIO2/SPI_CLK
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                 OUTPUT_CLUSTERS: [],
             },
             0xD3: {
                 # AD3/DIO3
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                 OUTPUT_CLUSTERS: [],
             },
             0xD4: {
                 # DIO4/SPI_MOSI
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xD5: {
                 # DIO5/Assoc
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xD6: {
                 # DIO6/RTS
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xD7: {
                 # DIO7/CTS
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff, XBeeAnalogInput],
                 OUTPUT_CLUSTERS: [],
             },
             0xD8: {
                 # DIO8
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xD9: {
                 # DIO9
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xDA: {
                 # DIO10/PWM0
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xDB: {
                 # DIO11/PWM1
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xDC: {
                 # DIO12/SPI_MISO
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xDD: {
                 # DIO13/DOUT
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },
             0xDE: {
                 # DIO14/DIN
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
-                PROFILE_ID: XBEE_PROFILE_ID,
+                PROFILE_ID: zha.PROFILE_ID,
                 INPUT_CLUSTERS: [XBeeOnOff],
                 OUTPUT_CLUSTERS: [],
             },


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
ZHA now ignores all endpoints which are neither with ZLL nor ZHA profile.
This PR moves XBee replacement endpoints to ZHA profile.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
