### PR TITLE
Add Tuya TRV variant `_TZE200_py4cm3he`

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1910,7 +1910,7 @@ class ZonnsmartTV01_ZG(TuyaThermostat):
             ("_TZE200_sur6q7ko", "TS0601"),  # LSC Smart Connect 3012732
             ("_TZE200_lllliz3p", "TS0601"),  # tuya TV02-Zigbee2
             ("_TZE200_fsow0qsk", "TS0601"),  # Tesla Smart TV500
-            ("_TZE200_py4cm3he", "TS0601"),  # GIEX Smart TRV TV06 
+            ("_TZE200_py4cm3he", "TS0601"),  # GIEX Smart TRV TV06
         ],
         ENDPOINTS: {
             1: {

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1910,6 +1910,7 @@ class ZonnsmartTV01_ZG(TuyaThermostat):
             ("_TZE200_sur6q7ko", "TS0601"),  # LSC Smart Connect 3012732
             ("_TZE200_lllliz3p", "TS0601"),  # tuya TV02-Zigbee2
             ("_TZE200_fsow0qsk", "TS0601"),  # Tesla Smart TV500
+            ("_TZE200_py4cm3he", "TS0601"),  # GIEX Smart TRV TV06 
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
Add quirk for Tuya TRV _TZE200_py4cm3he (TS0601).


## Additional information
This PR only adds a new device signature for `_TZE200_py4cm3he` (TS0601).  
The device is a new appearance version of Tuya TRV, with identical functionality to the existing TV02.  
No other changes are introduced.

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
