### PR TITLE
Add Tuya Zemismart cover `_TZE200_sq6affpe` variant

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -176,6 +176,7 @@ class TuyaZemismartSmartCover0601_3(TuyaWindowCover):
             ("_TZE200_iossyxra", "TS0601"),
             ("_TZE200_pw7mji0l", "TS0601"),
             ("_TZE200_9vpe3fl1", "TS0601"),
+            ("_TZE200_sq6affpe", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
Add quirk for Tuya _TZE200_sq6affpe (TS0601).

## Additional information
Only added signature to existing class.
This was tested with Zemismart ZM25R3

## Device diagnostics

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
