### PR TITLE
Add Tuya/MOES star ring dimmer variant `_TZE204_1v1dxkck`

### DIFF
--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -288,6 +288,7 @@ class TuyaTripleSwitchDimmerGP(TuyaDimmerSwitch):
     signature = {
         MODELS_INFO: [
             ("_TZE200_vm1gyrso", "TS0601"),
+            ("_TZE204_1v1dxkck", "TS0601"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=0x0100


### PR DESCRIPTION
https://github.com/zigpy/zha-device-handlers/issues/3396#issuecomment-2393283008

## Proposed change
Adds the MOES Star Ring 3 gang zigbee smart dimmer device model to the quirk file 

## Additional information
Basically implements this https://github.com/zigpy/zha-device-handlers/issues/3396#issuecomment-2393283008 action for every HA user going forward

fixes #3396


## Device diagnostics
Not a new quirk, just adding a device.


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
