### PR TITLE
Add _TZE284_chbyv06x

### DIFF
--- a/zhaquirks/tuya/tuya_gas.py
+++ b/zhaquirks/tuya/tuya_gas.py
@@ -49,6 +49,7 @@ class TuyaIasGasLEL(IasZone, TuyaLocalCluster):
     TuyaQuirkBuilder("_TZE200_hr0tdd47", "TS0601")
     .applies_to("_TZE200_rjxqso4a", "TS0601")
     .applies_to("_TZE284_rjxqso4a", "TS0601")
+    .applies_to("_TZE284_chbyv06x", "TS0601")
     .tuya_gas(dp_id=1)
     .tuya_sensor(
         dp_id=2,


### PR DESCRIPTION
This quirk works with _TZE284_chbyv06x, too

## Proposed change
Add line for _TZE284_chbyv06x gas detector.
<!--
  
-->


## Additional information
I tested this quirk with my new Gas Detector, which now is alive.
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
[zha-01K0FPJ6HBXXHK3YRF7CYD1QCD-_TZE284_chbyv06x TS0601-798452244f4166517c98ec5c019b5732.json](https://github.com/user-attachments/files/22197292/zha-01K0FPJ6HBXXHK3YRF7CYD1QCD-_TZE284_chbyv06x.TS0601-798452244f4166517c98ec5c019b5732.json)
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [X] Tests have been added to verify that the new code works
- [X ] Device diagnostics data has been attached
