### PR TITLE
Remove custom Bosch `pi_heating_demand` attr for RBSH-RTH0-ZB-EU

### DIFF
--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -16,9 +16,6 @@ from zigpy.zcl.foundation import ZCLAttributeDef
 # Mode of operation with values BoschOperatingMode.
 OPERATING_MODE_ATTR_ID = 0x4007
 
-# Valve position: 0% - 100%
-VALVE_POSITION_ATTR_ID = 0x4020
-
 # Window open switch (changes to a lower target temperature when on).
 WINDOW_OPEN_ATTR_ID = 0x4042
 
@@ -68,13 +65,6 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         operating_mode = ZCLAttributeDef(
             id=OPERATING_MODE_ATTR_ID,
             type=BoschOperatingMode,
-            is_manufacturer_specific=True,
-        )
-
-        pi_heating_demand = ZCLAttributeDef(
-            id=VALVE_POSITION_ATTR_ID,
-            # Values range from 0-100
-            type=t.uint8_t,
             is_manufacturer_specific=True,
         )
 


### PR DESCRIPTION
## Proposed change
Remove custom Bosch pi_heating_demand attribute for RBSH-RTH0-ZB-EU due to conflicting with thermostat cooling mode.

Fixes https://github.com/home-assistant/core/issues/151763.

This thermostat reports correct status through system_mode and running_mode attributes.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
