### PR TITLE
Expose entities for Schneider Electric switches/dimmers, add more models

### DIFF
--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -30,8 +30,8 @@ base_micro_dimmer = (
         min_value=1,
         max_value=254,
         step=1,
-        fallback_name="Min light level",
         translation_key="min_level",
+        fallback_name="Min light level",
     )
     .number(
         attribute_name=SEBallast.AttributeDefs.max_level.name,
@@ -40,14 +40,14 @@ base_micro_dimmer = (
         min_value=1,
         max_value=254,
         step=1,
-        fallback_name="Max light level",
         translation_key="max_level",
+        fallback_name="Max light level",
     )
     .number(
         attribute_name=SEOnOff.AttributeDefs.se_on_time_reload.name,
         cluster_id=SEOnOff.cluster_id,
         endpoint_id=3,
-        min_value=0x0,
+        min_value=0,
         max_value=0xFFFFFFFF,
         step=1,
         unit=UnitOfTime.SECONDS,
@@ -59,8 +59,8 @@ base_micro_dimmer = (
         attribute_name=SEOnOff.AttributeDefs.se_pre_warning_time.name,
         cluster_id=SEOnOff.cluster_id,
         endpoint_id=3,
-        min_value=0x0,
-        max_value=0xFFFF,
+        min_value=0,
+        max_value=6553,
         step=1,
         unit=UnitOfTime.SECONDS,
         device_class=NumberDeviceClass.DURATION,
@@ -68,18 +68,18 @@ base_micro_dimmer = (
         fallback_name="Pre warning time",
     )
     .enum(
-        endpoint_id=3,
-        cluster_id=SEOnOff.cluster_id,
         attribute_name=SEOnOff.AttributeDefs.se_on_time_reload_options.name,
         enum_class=SEOnTimeReloadOptions,
+        cluster_id=SEOnOff.cluster_id,
+        endpoint_id=3,
         translation_key="on_time_reload_options",
         fallback_name="On time reload options",
     )
     .enum(
-        endpoint_id=3,
-        cluster_id=SEBallast.cluster_id,
         attribute_name=SEBallast.AttributeDefs.se_control_mode.name,
         enum_class=SEControlMode,
+        cluster_id=SEBallast.cluster_id,
+        endpoint_id=3,
         translation_key="control_mode",
         fallback_name="Control mode",
     )
@@ -90,18 +90,18 @@ base_dimmer = (
     .replaces(SEBasic, endpoint_id=21)
     .replaces(SESwitchConfiguration, endpoint_id=21)
     .enum(
-        endpoint_id=21,
-        cluster_id=SESwitchConfiguration.cluster_id,
         attribute_name=SESwitchConfiguration.AttributeDefs.se_switch_indication.name,
         enum_class=SESwitchIndication,
+        cluster_id=SESwitchConfiguration.cluster_id,
+        endpoint_id=21,
         translation_key="switch_indication",
         fallback_name="Switch indication",
     )
     .enum(
-        endpoint_id=21,
-        cluster_id=SESwitchConfiguration.cluster_id,
         attribute_name=SESwitchConfiguration.AttributeDefs.se_switch_actions.name,
         enum_class=SESwitchAction,
+        cluster_id=SESwitchConfiguration.cluster_id,
+        endpoint_id=21,
         translation_key="switch_actions",
         fallback_name="Switch actions",
     )
@@ -126,20 +126,20 @@ base_dimmer = (
     .applies_to(SE_MANUF_NAME, "NHROTARY/UNIDIM/1")
     .applies_to(SE_MANUF_NAME, "NHPB/UNIDIM/1")
     .enum(
-        endpoint_id=3,
-        cluster_id=SEBallast.cluster_id,
         attribute_name=SEBallast.AttributeDefs.se_wiring_mode.name,
         enum_class=SEWiringMode,
+        cluster_id=SEBallast.cluster_id,
+        endpoint_id=3,
         entity_platform=EntityPlatform.SENSOR,
         entity_type=EntityType.DIAGNOSTIC,
         translation_key="wiring_mode",
         fallback_name="Wiring mode",
     )
     .enum(
-        endpoint_id=3,
-        cluster_id=SEBallast.cluster_id,
         attribute_name=SEBallast.AttributeDefs.se_dimming_curve.name,
         enum_class=SEDimmingCurve,
+        cluster_id=SEBallast.cluster_id,
+        endpoint_id=3,
         translation_key="dimming_curve",
         fallback_name="Dimming curve",
     )

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -18,7 +18,7 @@ from zhaquirks.schneiderelectric import (
     SEWiringMode,
 )
 
-BASE_DIMMER = (
+base_micro_dimmer = (
     QuirkBuilder()
     .replaces(SEBasic, endpoint_id=3)
     .replaces(SEBallast, endpoint_id=3)
@@ -85,8 +85,8 @@ BASE_DIMMER = (
     )
 )
 
-BASE_ROTARY_DIMMER = (
-    BASE_DIMMER.clone()
+base_dimmer = (
+    base_micro_dimmer.clone()
     .replaces(SEBasic, endpoint_id=21)
     .replaces(SESwitchConfiguration, endpoint_id=21)
     .enum(
@@ -107,10 +107,14 @@ BASE_ROTARY_DIMMER = (
     )
 )
 
-(BASE_DIMMER.clone().applies_to(SE_MANUF_NAME, "PUCK/DIMMER/1").add_to_registry())
+(
+    base_micro_dimmer.clone()
+    .applies_to(SE_MANUF_NAME, "PUCK/DIMMER/1")
+    .add_to_registry()
+)  # fmt: skip
 
 (
-    BASE_ROTARY_DIMMER.clone()
+    base_dimmer.clone()
     .applies_to(SE_MANUF_NAME, "NHROTARY/DIMMER/1")
     .applies_to(SE_MANUF_NAME, "NHPB/DIMMER/1")
     .applies_to(SE_MANUF_NAME, "CH/DIMMER/1")
@@ -118,7 +122,7 @@ BASE_ROTARY_DIMMER = (
 )
 
 (
-    BASE_ROTARY_DIMMER.clone()
+    base_dimmer.clone()
     .applies_to(SE_MANUF_NAME, "NHROTARY/UNIDIM/1")
     .applies_to(SE_MANUF_NAME, "NHPB/UNIDIM/1")
     .enum(

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -1,35 +1,147 @@
 """Schneider Electric dimmers and switches quirks."""
 
-from zhaquirks.builder import QuirkBuilder
+from zigpy.quirks.v2 import EntityPlatform, EntityType, QuirkBuilder
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+
 from zhaquirks.schneiderelectric import (
     SE_MANUF_NAME,
     SEBallast,
     SEBasic,
+    SEControlMode,
+    SEDimmingCurve,
     SEOnOff,
+    SEOnTimeReloadOptions,
+    SESwitchAction,
     SESwitchConfiguration,
+    SESwitchIndication,
+    SEWiringMode,
 )
 
-(
-    QuirkBuilder(SE_MANUF_NAME, "NHROTARY/DIMMER/1")
-    .applies_to(SE_MANUF_NAME, "NHROTARY/UNIDIM/1")
-    .applies_to(SE_MANUF_NAME, "NHPB/DIMMER/1")
-    .applies_to(SE_MANUF_NAME, "NHPB/UNIDIM/1")
+BASE_DIMMER = (
+    QuirkBuilder()
     .replaces(SEBasic, endpoint_id=3)
     .replaces(SEBallast, endpoint_id=3)
     .replaces(SEOnOff, endpoint_id=3)
+    .number(
+        attribute_name=SEBallast.AttributeDefs.min_level.name,
+        cluster_id=SEBallast.cluster_id,
+        endpoint_id=3,
+        min_value=1,
+        max_value=254,
+        step=1,
+        fallback_name="Min light level",
+        translation_key="min_level",
+    )
+    .number(
+        attribute_name=SEBallast.AttributeDefs.max_level.name,
+        cluster_id=SEBallast.cluster_id,
+        endpoint_id=3,
+        min_value=1,
+        max_value=254,
+        step=1,
+        fallback_name="Max light level",
+        translation_key="max_level",
+    )
+    .number(
+        attribute_name=SEOnOff.AttributeDefs.se_on_time_reload.name,
+        cluster_id=SEOnOff.cluster_id,
+        endpoint_id=3,
+        min_value=0x0,
+        max_value=0xFFFFFFFF,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        device_class=NumberDeviceClass.DURATION,
+        translation_key="on_time_reload",
+        fallback_name="On time reload",
+    )
+    .number(
+        attribute_name=SEOnOff.AttributeDefs.se_pre_warning_time.name,
+        cluster_id=SEOnOff.cluster_id,
+        endpoint_id=3,
+        min_value=0x0,
+        max_value=0xFFFF,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        device_class=NumberDeviceClass.DURATION,
+        translation_key="pre_warning_time",
+        fallback_name="Pre warning time",
+    )
+    .enum(
+        endpoint_id=3,
+        cluster_id=SEOnOff.cluster_id,
+        attribute_name=SEOnOff.AttributeDefs.se_on_time_reload_options.name,
+        enum_class=SEOnTimeReloadOptions,
+        translation_key="on_time_reload_options",
+        fallback_name="On time reload options",
+    )
+    .enum(
+        endpoint_id=3,
+        cluster_id=SEBallast.cluster_id,
+        attribute_name=SEBallast.AttributeDefs.se_control_mode.name,
+        enum_class=SEControlMode,
+        translation_key="control_mode",
+        fallback_name="Control mode",
+    )
+)
+
+BASE_ROTARY_DIMMER = (
+    BASE_DIMMER.clone()
     .replaces(SEBasic, endpoint_id=21)
     .replaces(SESwitchConfiguration, endpoint_id=21)
+    .enum(
+        endpoint_id=21,
+        cluster_id=SESwitchConfiguration.cluster_id,
+        attribute_name=SESwitchConfiguration.AttributeDefs.se_switch_indication.name,
+        enum_class=SESwitchIndication,
+        translation_key="switch_indication",
+        fallback_name="Switch indication",
+    )
+    .enum(
+        endpoint_id=21,
+        cluster_id=SESwitchConfiguration.cluster_id,
+        attribute_name=SESwitchConfiguration.AttributeDefs.se_switch_actions.name,
+        enum_class=SESwitchAction,
+        translation_key="switch_actions",
+        fallback_name="Switch actions",
+    )
+)
+
+(
+    BASE_DIMMER.clone()
+    .applies_to(SE_MANUF_NAME, "PUCK/DIMMER/1")
     .add_to_registry()
 )
 
+(
+    BASE_ROTARY_DIMMER.clone()
+    .applies_to(SE_MANUF_NAME, "NHROTARY/DIMMER/1")
+    .applies_to(SE_MANUF_NAME, "NHPB/DIMMER/1")
+    .applies_to(SE_MANUF_NAME, "CH/DIMMER/1")
+    .add_to_registry()
+)
 
 (
-    QuirkBuilder(SE_MANUF_NAME, "NHPB/SWITCH/1")
-    .applies_to(SE_MANUF_NAME, "CH2AX/SWITCH/1")
-    .applies_to(SE_MANUF_NAME, "CH10AX/SWITCH/1")
-    .replaces(SEBasic)
-    .replaces(SEOnOff)
-    .replaces(SEBasic, endpoint_id=21)
-    .replaces(SESwitchConfiguration, endpoint_id=21)
+    BASE_ROTARY_DIMMER.clone()
+    .applies_to(SE_MANUF_NAME, "NHROTARY/UNIDIM/1")
+    .applies_to(SE_MANUF_NAME, "NHPB/UNIDIM/1")
+    .enum(
+        endpoint_id=3,
+        cluster_id=SEBallast.cluster_id,
+        attribute_name=SEBallast.AttributeDefs.se_wiring_mode.name,
+        enum_class=SEWiringMode,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="wiring_mode",
+        fallback_name="Wiring mode",
+    )
+    .enum(
+        endpoint_id=3,
+        cluster_id=SEBallast.cluster_id,
+        attribute_name=SEBallast.AttributeDefs.se_dimming_curve.name,
+        enum_class=SEDimmingCurve,
+        translation_key="dimming_curve",
+        fallback_name="Dimming curve",
+    )
     .add_to_registry()
 )

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -11,7 +11,6 @@ from zhaquirks.schneiderelectric import (
     SEControlMode,
     SEDimmingCurve,
     SEOnOff,
-    SEOnTimeReloadOptions,
     SESwitchAction,
     SESwitchConfiguration,
     SESwitchIndication,
@@ -23,26 +22,6 @@ base_micro_dimmer = (
     .replaces(SEBasic, endpoint_id=3)
     .replaces(SEBallast, endpoint_id=3)
     .replaces(SEOnOff, endpoint_id=3)
-    .number(
-        attribute_name=SEBallast.AttributeDefs.min_level.name,
-        cluster_id=SEBallast.cluster_id,
-        endpoint_id=3,
-        min_value=1,
-        max_value=254,
-        step=1,
-        translation_key="min_level",
-        fallback_name="Min light level",
-    )
-    .number(
-        attribute_name=SEBallast.AttributeDefs.max_level.name,
-        cluster_id=SEBallast.cluster_id,
-        endpoint_id=3,
-        min_value=1,
-        max_value=254,
-        step=1,
-        translation_key="max_level",
-        fallback_name="Max light level",
-    )
     .number(
         attribute_name=SEOnOff.AttributeDefs.se_on_time_reload.name,
         cluster_id=SEOnOff.cluster_id,
@@ -66,14 +45,6 @@ base_micro_dimmer = (
         device_class=NumberDeviceClass.DURATION,
         translation_key="pre_warning_time",
         fallback_name="Pre warning time",
-    )
-    .enum(
-        attribute_name=SEOnOff.AttributeDefs.se_on_time_reload_options.name,
-        enum_class=SEOnTimeReloadOptions,
-        cluster_id=SEOnOff.cluster_id,
-        endpoint_id=3,
-        translation_key="on_time_reload_options",
-        fallback_name="On time reload options",
     )
     .enum(
         attribute_name=SEBallast.AttributeDefs.se_control_mode.name,

--- a/zhaquirks/schneiderelectric/dimmers.py
+++ b/zhaquirks/schneiderelectric/dimmers.py
@@ -107,11 +107,7 @@ BASE_ROTARY_DIMMER = (
     )
 )
 
-(
-    BASE_DIMMER.clone()
-    .applies_to(SE_MANUF_NAME, "PUCK/DIMMER/1")
-    .add_to_registry()
-)
+(BASE_DIMMER.clone().applies_to(SE_MANUF_NAME, "PUCK/DIMMER/1").add_to_registry())
 
 (
     BASE_ROTARY_DIMMER.clone()

--- a/zhaquirks/schneiderelectric/switches.py
+++ b/zhaquirks/schneiderelectric/switches.py
@@ -8,7 +8,6 @@ from zhaquirks.schneiderelectric import (
     SE_MANUF_NAME,
     SEBasic,
     SEOnOff,
-    SEOnTimeReloadOptions,
     SESwitchAction,
     SESwitchConfiguration,
     SESwitchIndication,
@@ -41,14 +40,6 @@ base_micro_switch = (
         device_class=NumberDeviceClass.DURATION,
         translation_key="pre_warning_time",
         fallback_name="Pre warning time",
-    )
-    .enum(
-        attribute_name=SEOnOff.AttributeDefs.se_on_time_reload_options.name,
-        enum_class=SEOnTimeReloadOptions,
-        cluster_id=SEOnOff.cluster_id,
-        endpoint_id=1,
-        translation_key="on_time_reload_options",
-        fallback_name="On time reload options",
     )
 )
 

--- a/zhaquirks/schneiderelectric/switches.py
+++ b/zhaquirks/schneiderelectric/switches.py
@@ -14,7 +14,7 @@ from zhaquirks.schneiderelectric import (
     SESwitchIndication,
 )
 
-BASE_SWITCH = (
+base_micro_switch = (
     QuirkBuilder()
     .replaces(SEBasic)
     .replaces(SEOnOff)
@@ -53,7 +53,7 @@ BASE_SWITCH = (
 )
 
 (
-    BASE_SWITCH.clone()
+    base_micro_switch.clone()
     .applies_to(SE_MANUF_NAME, "NHPB/SWITCH/1")
     .applies_to(SE_MANUF_NAME, "CH2AX/SWITCH/1")
     .applies_to(SE_MANUF_NAME, "CH10AX/SWITCH/1")
@@ -78,4 +78,8 @@ BASE_SWITCH = (
     .add_to_registry()
 )
 
-(BASE_SWITCH.clone().applies_to(SE_MANUF_NAME, "PUCK/SWITCH/1").add_to_registry())
+(
+    base_micro_switch.clone()
+    .applies_to(SE_MANUF_NAME, "PUCK/SWITCH/1")
+    .add_to_registry()
+)  # fmt: skip

--- a/zhaquirks/schneiderelectric/switches.py
+++ b/zhaquirks/schneiderelectric/switches.py
@@ -22,7 +22,7 @@ base_micro_switch = (
         attribute_name=SEOnOff.AttributeDefs.se_on_time_reload.name,
         cluster_id=SEOnOff.cluster_id,
         endpoint_id=1,
-        min_value=0x0,
+        min_value=0,
         max_value=0xFFFFFFFF,
         step=1,
         unit=UnitOfTime.SECONDS,
@@ -34,8 +34,8 @@ base_micro_switch = (
         attribute_name=SEOnOff.AttributeDefs.se_pre_warning_time.name,
         cluster_id=SEOnOff.cluster_id,
         endpoint_id=1,
-        min_value=0x0,
-        max_value=0xFFFF,
+        min_value=0,
+        max_value=6553,
         step=1,
         unit=UnitOfTime.SECONDS,
         device_class=NumberDeviceClass.DURATION,
@@ -43,10 +43,10 @@ base_micro_switch = (
         fallback_name="Pre warning time",
     )
     .enum(
-        endpoint_id=1,
-        cluster_id=SEOnOff.cluster_id,
         attribute_name=SEOnOff.AttributeDefs.se_on_time_reload_options.name,
         enum_class=SEOnTimeReloadOptions,
+        cluster_id=SEOnOff.cluster_id,
+        endpoint_id=1,
         translation_key="on_time_reload_options",
         fallback_name="On time reload options",
     )
@@ -60,18 +60,18 @@ base_micro_switch = (
     .replaces(SEBasic, endpoint_id=21)
     .replaces(SESwitchConfiguration, endpoint_id=21)
     .enum(
-        endpoint_id=21,
-        cluster_id=SESwitchConfiguration.cluster_id,
         attribute_name=SESwitchConfiguration.AttributeDefs.se_switch_indication.name,
         enum_class=SESwitchIndication,
+        cluster_id=SESwitchConfiguration.cluster_id,
+        endpoint_id=21,
         translation_key="switch_indication",
         fallback_name="Switch indication",
     )
     .enum(
-        endpoint_id=21,
-        cluster_id=SESwitchConfiguration.cluster_id,
         attribute_name=SESwitchConfiguration.AttributeDefs.se_switch_actions.name,
         enum_class=SESwitchAction,
+        cluster_id=SESwitchConfiguration.cluster_id,
+        endpoint_id=21,
         translation_key="switch_actions",
         fallback_name="Switch actions",
     )

--- a/zhaquirks/schneiderelectric/switches.py
+++ b/zhaquirks/schneiderelectric/switches.py
@@ -1,0 +1,85 @@
+"""Schneider Electric switches quirks."""
+
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+
+from zhaquirks.schneiderelectric import (
+    SE_MANUF_NAME,
+    SEBasic,
+    SEOnOff,
+    SEOnTimeReloadOptions,
+    SESwitchAction,
+    SESwitchConfiguration,
+    SESwitchIndication,
+)
+
+BASE_SWITCH = (
+    QuirkBuilder()
+    .replaces(SEBasic)
+    .replaces(SEOnOff)
+    .number(
+        attribute_name=SEOnOff.AttributeDefs.se_on_time_reload.name,
+        cluster_id=SEOnOff.cluster_id,
+        endpoint_id=1,
+        min_value=0x0,
+        max_value=0xFFFFFFFF,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        device_class=NumberDeviceClass.DURATION,
+        translation_key="on_time_reload",
+        fallback_name="On time reload",
+    )
+    .number(
+        attribute_name=SEOnOff.AttributeDefs.se_pre_warning_time.name,
+        cluster_id=SEOnOff.cluster_id,
+        endpoint_id=1,
+        min_value=0x0,
+        max_value=0xFFFF,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        device_class=NumberDeviceClass.DURATION,
+        translation_key="pre_warning_time",
+        fallback_name="Pre warning time",
+    )
+    .enum(
+        endpoint_id=1,
+        cluster_id=SEOnOff.cluster_id,
+        attribute_name=SEOnOff.AttributeDefs.se_on_time_reload_options.name,
+        enum_class=SEOnTimeReloadOptions,
+        translation_key="on_time_reload_options",
+        fallback_name="On time reload options",
+    )
+)
+
+(
+    BASE_SWITCH.clone()
+    .applies_to(SE_MANUF_NAME, "NHPB/SWITCH/1")
+    .applies_to(SE_MANUF_NAME, "CH2AX/SWITCH/1")
+    .applies_to(SE_MANUF_NAME, "CH10AX/SWITCH/1")
+    .replaces(SEBasic, endpoint_id=21)
+    .replaces(SESwitchConfiguration, endpoint_id=21)
+    .enum(
+        endpoint_id=21,
+        cluster_id=SESwitchConfiguration.cluster_id,
+        attribute_name=SESwitchConfiguration.AttributeDefs.se_switch_indication.name,
+        enum_class=SESwitchIndication,
+        translation_key="switch_indication",
+        fallback_name="Switch indication",
+    )
+    .enum(
+        endpoint_id=21,
+        cluster_id=SESwitchConfiguration.cluster_id,
+        attribute_name=SESwitchConfiguration.AttributeDefs.se_switch_actions.name,
+        enum_class=SESwitchAction,
+        translation_key="switch_actions",
+        fallback_name="Switch actions",
+    )
+    .add_to_registry()
+)
+
+(
+    BASE_SWITCH.clone()
+    .applies_to(SE_MANUF_NAME, "PUCK/SWITCH/1")
+    .add_to_registry()
+)

--- a/zhaquirks/schneiderelectric/switches.py
+++ b/zhaquirks/schneiderelectric/switches.py
@@ -78,8 +78,4 @@ BASE_SWITCH = (
     .add_to_registry()
 )
 
-(
-    BASE_SWITCH.clone()
-    .applies_to(SE_MANUF_NAME, "PUCK/SWITCH/1")
-    .add_to_registry()
-)
+(BASE_SWITCH.clone().applies_to(SE_MANUF_NAME, "PUCK/SWITCH/1").add_to_registry())


### PR DESCRIPTION
## Proposed change

Supersedes: https://github.com/zigpy/zha-device-handlers/pull/3615
Fixes: https://github.com/zigpy/zha-device-handlers/issues/2828, fixes https://github.com/zigpy/zha-device-handlers/issues/2798, fixes https://github.com/zigpy/zha-device-handlers/issues/1696, fixes https://github.com/zigpy/zha-device-handlers/issues/4409
Part of: https://github.com/zigpy/zha-device-handlers/pull/1705

## Additional information
Spec docs:
[ZB Spec - Micro Module Dimmer -110422.pdf](https://github.com/user-attachments/files/22274736/ZB.Spec.-.Micro.Module.Dimmer.-110422.pdf)
[ZB Spec - Micro Module Switch - 110422.pdf](https://github.com/user-attachments/files/22274738/ZB.Spec.-.Micro.Module.Switch.-.110422.pdf)
[ZB Spec - Relay Switch 10A - 110422.pdf](https://github.com/user-attachments/files/22274739/ZB.Spec.-.Relay.Switch.10A.-.110422.pdf)
[ZB Spec - Rotary Dimmer - 110422.pdf](https://github.com/user-attachments/files/22274741/ZB.Spec.-.Rotary.Dimmer.-.110422.pdf)

Switches:
<img width="300" height="1408" alt="image" src="https://github.com/user-attachments/assets/69ab60c6-77fb-41c9-b146-446d55cd3608" />

Dimmers:
<img width="300" height="2044" alt="image" src="https://github.com/user-attachments/assets/be49e11b-63ea-4eca-bb40-a769cbc1ad6c" />



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
