### PR TITLE
Restore BinaryInput entity in Legrand Switch with Neutral

### DIFF
--- a/zhaquirks/legrand/switch.py
+++ b/zhaquirks/legrand/switch.py
@@ -1,7 +1,7 @@
 """Module for Legrand switches (without dimming functionality)."""
 
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.general import BinaryInput, OnOff
+from zigpy.zcl.clusters.general import OnOff
 
 from zhaquirks.legrand import LEGRAND, LegrandCluster, LegrandIdentify
 
@@ -9,7 +9,9 @@ from zhaquirks.legrand import LEGRAND, LegrandCluster, LegrandIdentify
     QuirkBuilder(f" {LEGRAND}", " Light switch with neutral")
     .replaces(LegrandCluster)
     .replaces(LegrandIdentify)
-    .prevent_default_entity_creation(endpoint_id=1, cluster_id=BinaryInput.cluster_id)
+    # It seems that the binary input is mostly non-functional. However some users report
+    # that the BinaryInput is actually working for them. So we leave it commented out for now.
+    # .prevent_default_entity_creation(endpoint_id=1, cluster_id=BinaryInput.cluster_id)
     .prevent_default_entity_creation(
         endpoint_id=1,
         cluster_id=OnOff.cluster_id,


### PR DESCRIPTION
While the binary input seems to be non functional to the majority of the users, someone has reported that it displays the "switch pressed" state (see issue #4337). For now we restore it here.

I have tried everything to make it work for me, but could not do it, so I could not test it directly. The code has been tested by @Blakko, who is actually using this functionality.

I have a comment in the code to leave some info for future users.

This PR closes issue #4337

## Proposed change

* Restore `BinaryInput` cluster in `Legrand Switch with Neutral`

## Additional information

## Device diagnostics

See issue #4337

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly (tested by @Blakko)
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works (not applicable I think)
- [x] Device diagnostics data has been attached
