### PR TITLE
Add guide on testing custom quirks in ZHA

### DIFF
--- a/how_to_test_custom_quirks_in_zha.md
+++ b/how_to_test_custom_quirks_in_zha.md
@@ -1,10 +1,10 @@
-The intruction-guide below is written with the assumed premises that you are and end-user of Home Assistant's [ZHA integration](https://www.home-assistant.io/integrations/zha), however please note that this guide is meant to be useful regardless if you are an ZHA end-user or first-time zha-quirk developer.
+The instruction-guide below is written with the assumed premises that you are and end-user of Home Assistant's [ZHA integration](https://www.home-assistant.io/integrations/zha), however please note that this guide is meant to be useful regardless if you are an ZHA end-user or first-time zha-quirk developer.
 
 # How to test a not yet merged custom quirk in ZHA
 
 If you have bought a non-standard Zigbee device that is not yet supported in Home Assistant's ZHA integration but someone have already written and shared a experimental "custom quirk" (ZHA Device Handler) that not get been merged into a "[ZHA Device Handlers"](https://github.com/zigpy/zha-device-handlers)" library release then you as an end-user can still manually add that to your Home Assistant instance for testing using something like File Editor or Samba share add-ons in Home Assistant.
 
-1. Get a copy of an existing "custom quirk" that is meant for your speific decive (or code your own custom quirks). Tip is to search for the specific Zigbee device signature among open issues and open pull requests as those might contain experimental custom quirk that have not yet been merged for your Zigbee device, see https://github.com/zigpy/zha-device-handlers/issues?q=is%3Aissue+is%3Aopen and https://github.com/zigpy/zha-device-handlers/pulls?q=is%3Aopen+is%3Apr
+1. Get a copy of an existing "custom quirk" that is meant for your specific Zigbee device (or code your own custom quirks). Tip is to search for the specific Zigbee device signature among open issues and open pull requests as those might contain experimental custom quirk that have not yet been merged for your Zigbee device, see https://github.com/zigpy/zha-device-handlers/issues?q=is%3Aissue+is%3Aopen and https://github.com/zigpy/zha-device-handlers/pulls?q=is%3Aopen+is%3Apr
 2. Inside your Home Assistant instance, create a directory/folder for your custom quirks (for example `/config/zha_quirks/`)
 3. Copy or create a quirk file in this directory (called it for example “`devicemodelzyz_devicetypexyz.py`”). This file should contain the Python script for the quirk and its specific Zigbee device signature unique to it. 
 4. Add configuration with the full path to the directory that now containing custom quirk module(s) that will override and take precedence over any built-in quirks matching any device that has the same Zigbee device signature. to Home Assistant's config.yaml
@@ -14,6 +14,6 @@ zha:
   custom_quirks_path: /config/zha_quirks/
 ```
 5. Restart Home Assistant to make the quirk take effect.
-6. If and when a better ZHA Device Handler quirk is merged into the zha-quirks package then remove the custom quirk you added and possibly the whole folder if it is the last one. Make sure to revert at least `enable_quirks: true` to `false` in the settings then reboot Home Assistant.
+6. If and when a better ZHA Device Handler quirk is merged into the zha-quirks package then remove the custom quirk you added and possibly the whole folder if it was the last custom quirk that you added.
 
-Note! If your Home Assistant is running inside a container then you must then you must edit and add or remove the file inside that container, see https://github.com/zigpy/zha-device-handlers/discussions/693
+Note! If your Home Assistant is running inside a container then you must then you must edit and add or remove the file inside that container, see the community discussion thread at https://github.com/zigpy/zha-device-handlers/discussions/693

--- a/how_to_test_custom_quirks_in_zha.md
+++ b/how_to_test_custom_quirks_in_zha.md
@@ -1,0 +1,19 @@
+The intruction-guide below is written with the assumed premises that you are and end-user of Home Assistant's [ZHA integration](https://www.home-assistant.io/integrations/zha), however please note that this guide is meant to be useful regardless if you are an ZHA end-user or first-time zha-quirk developer.
+
+# How to test a not yet merged custom quirk in ZHA
+
+If you have bought a non-standard Zigbee device that is not yet supported in Home Assistant's ZHA integration but someone have already written and shared a experimental "custom quirk" (ZHA Device Handler) that not get been merged into a "[ZHA Device Handlers"](https://github.com/zigpy/zha-device-handlers)" library release then you as an end-user can still manually add that to your Home Assistant instance for testing using something like File Editor or Samba share add-ons in Home Assistant.
+
+1. Get a copy of an existing "custom quirk" that is meant for your speific decive (or code your own custom quirks). Tip is to search for the specific Zigbee device signature among open issues and open pull requests as those might contain experimental custom quirk that have not yet been merged for your Zigbee device, see https://github.com/zigpy/zha-device-handlers/issues?q=is%3Aissue+is%3Aopen and https://github.com/zigpy/zha-device-handlers/pulls?q=is%3Aopen+is%3Apr
+2. Inside your Home Assistant instance, create a directory/folder for your custom quirks (for example `/config/zha_quirks/`)
+3. Copy or create a quirk file in this directory (called it for example “`devicemodelzyz_devicetypexyz.py`”). This file should contain the Python script for the quirk and its specific Zigbee device signature unique to it. 
+4. Add configuration with the full path to the directory that now containing custom quirk module(s) that will override and take precedence over any built-in quirks matching any device that has the same Zigbee device signature. to Home Assistant's config.yaml
+```
+zha:
+  database_path: /config/zigbee.db
+  custom_quirks_path: /config/zha_quirks/
+```
+5. Restart Home Assistant to make the quirk take effect.
+6. If and when a better ZHA Device Handler quirk is merged into the zha-quirks package then remove the custom quirk you added and possibly the whole folder if it is the last one. Make sure to revert at least `enable_quirks: true` to `false` in the settings then reboot Home Assistant.
+
+Note! If your Home Assistant is running inside a container then you must then you must edit and add or remove the file inside that container, see https://github.com/zigpy/zha-device-handlers/discussions/693


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Added a step-by-step guide for how users can manually add a not yet merged  work-in-progress custom zha quirk for testing.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

New https://github.com/zigpy/zha-device-handlers/pull/4355 PR could also replace old PR -> https://github.com/zigpy/zha-device-handlers/pull/2419

This also compliments the guide for writting quirks -> https://github.com/zigpy/zha-device-handlers/pull/4349

Hoping both PRs can be addded as-is, as at least this can be used as a starting point and then others can improvide it.


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->

Not applicable for this context.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
