### PR TITLE
Add Tuya rain sensor variant `_TZ3210_p68kms0l`

### DIFF
--- a/zhaquirks/tuya/tuya_rain.py
+++ b/zhaquirks/tuya/tuya_rain.py
@@ -21,6 +21,7 @@ class TuyaIasZone(IasZone, TuyaLocalCluster):
 
 (
     TuyaQuirkBuilder("_TZ3210_tgvtvdoc", "TS0207")
+    .applies_to("_TZ3210_p68kms0l", "TS0207")
     .tuya_battery(
         dp_id=4, battery_type=BatterySize.Other, battery_qty=1, battery_voltage=30
     )


### PR DESCRIPTION
## Proposed change
My Tuya solar rain sensors did not get the correct quirk since they identified themself as _TZ3210_p68kms0l


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
