### PR TITLE
Add Tuya TS0601 1 and 2 gang switch variants

### DIFF
--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -202,6 +202,7 @@ class TuyaDoubleSwitchTO(TuyaSwitch):
         MODELS_INFO: [
             ("_TZE200_g1ib5ldv", "TS0601"),
             ("_TZE200_wunufsil", "TS0601"),
+            ("_TZE200_nkjintbl", "TS0601"),
             ("_TZE204_wvovwe9h", "TS0601"),
         ],
         ENDPOINTS: {

--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -89,6 +89,7 @@ class TuyaSingleSwitchTO(TuyaSwitch):
             ("_TZE200_wfxuhoea", "TS0601"),
             ("_TZE200_tviaymwx", "TS0601"),
             ("_TZE204_ptaqh9tk", "TS0601"),  # reported in #3099
+            ("_TZE200_7tdtqgwv", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Add model info keys for 1 and 2 gang (somgoms) tuya switches.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
I've previously tried to add the quirks myself, but that was a long time ago.
The details for the devices can still be found [here](https://github.com/zigpy/zha-device-handlers/pull/899).

Tested locally by adding the classes with added models as a custom quirk.

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-01K5HSH1TTN2PSEN2QWK0RNZ8F-_TZE200_7tdtqgwv TS0601-6f728dec125a6b2ceb1843843764a18c.json](https://github.com/user-attachments/files/22648210/zha-01K5HSH1TTN2PSEN2QWK0RNZ8F-_TZE200_7tdtqgwv.TS0601-6f728dec125a6b2ceb1843843764a18c.json)
[zha-01K5HSH1TTN2PSEN2QWK0RNZ8F-_TZE200_nkjintbl TS0601-663b23194d21583c587d70a1dcccd8d5.json](https://github.com/user-attachments/files/22648211/zha-01K5HSH1TTN2PSEN2QWK0RNZ8F-_TZE200_nkjintbl.TS0601-663b23194d21583c587d70a1dcccd8d5.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
