### PR TITLE
Add Tuya dimmable LED controller `_TZ3210_syh4kuef` variant

### DIFF
--- a/zhaquirks/tuya/ts0501bs.py
+++ b/zhaquirks/tuya/ts0501bs.py
@@ -40,6 +40,7 @@ class DimmableLedController(CustomDevice):
             ("_TZ3210_dbilpfqk", "TS0501B"),
             ("_TZ3210_agjx0pxt", "TS0501B"),
             ("_TZ3210_d062rv7j", "TS0501B"),
+            ("_TZ3210_syh4kuef", "TS0501B"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=257


### PR DESCRIPTION
## Proposed change
This is a one-line change that adds support for the `_TZ3210_syh4kuef` device. This is listed on e.g. AliExpress as:

[Zigbee 3.0 12 Watts 12V Dimmable LED Driver Dimming LED Power Supply Voice APP Smart Control Suitable for downlight spotlight
](https://www.aliexpress.com/item/1005006630186296.html)

The device works fine, but lists a color dimmer instead of a regular one. This quirk fixes it.