### PR TITLE
Add battery reporting and _TZE200_vexa5o82 to Tuya TS0601 covers

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -54,6 +54,7 @@ TUYA_MCU_VERSION_REQ = 0x10
 TUYA_MCU_VERSION_RSP = 0x11
 TUYA_LEVEL_COMMAND = 514
 
+BATTERY_CHANGE = "battery_change"
 LEVEL_EVENT = "level_event"
 TUYA_MCU_COMMAND = "tuya_mcu_command"
 
@@ -1235,6 +1236,16 @@ class TuyaManufacturerWindowCover(TuyaManufCluster):
                     ATTR_COVER_INVERTED,
                     tuya_payload.data[1],  # Check this
                 )
+            elif (
+                self.endpoint.device.tuya_battery_attr is not None
+                and tuya_payload.command_id
+                == TUYA_DP_TYPE_VALUE + self.endpoint.device.tuya_battery_attr
+            ):
+                self.endpoint.device.battery_bus.listener_event(
+                    BATTERY_CHANGE,
+                    tuya_payload.data[4],
+                )
+
         elif hdr.command_id == TUYA_SET_TIME:
             """Time event call super"""
             super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
@@ -1377,9 +1388,13 @@ class TuyaWindowCover(CustomDevice):
     # Don't invert _TZE200_cowvfni3: https://github.com/Koenkk/zigbee2mqtt/issues/6043
     tuya_cover_inverted_by_default = False
 
+    # For covers which report battery, this sets the battery report attribute id
+    tuya_battery_attr = None
+
     def __init__(self, *args, **kwargs):
         """Init device."""
         self.cover_bus = Bus()
+        self.battery_bus = Bus()
         super().__init__(*args, **kwargs)
 
 

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -14,12 +14,13 @@ from zhaquirks.const import (
 from zhaquirks.tuya import (
     TuyaManufacturerWindowCover,
     TuyaManufCluster,
+    TuyaPowerConfigurationCluster,
     TuyaWindowCover,
     TuyaWindowCoverControl,
-    TuyaPowerConfigurationCluster,
 )
 
 ZEMISMART_BATTERY_ATTR = 0x0D
+
 
 class TuyaZemismartSmartCover0601(TuyaWindowCover):
     """Tuya Zemismart blind cover motor."""

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -381,6 +381,7 @@ class TuyaMoesCover0601(TuyaWindowCover):
             ("_TZE200_icka1clh", "TS0601"),
             ("_TZE200_1vxgqfba", "TS0601"),
             ("_TZE200_fctwhugx", "TS0601"),
+            ("_TZE200_vexa5o82", "TS0601"),
         ],
         ENDPOINTS: {
             1: {

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -16,8 +16,10 @@ from zhaquirks.tuya import (
     TuyaManufCluster,
     TuyaWindowCover,
     TuyaWindowCoverControl,
+    TuyaPowerConfigurationCluster,
 )
 
+ZEMISMART_BATTERY_ATTR = 0x0D
 
 class TuyaZemismartSmartCover0601(TuyaWindowCover):
     """Tuya Zemismart blind cover motor."""
@@ -352,6 +354,8 @@ class TuyaZemismartSmartCover0601_2_inv_position(TuyaWindowCover):
 class TuyaMoesCover0601(TuyaWindowCover):
     """Tuya blind controller device."""
 
+    tuya_battery_attr = ZEMISMART_BATTERY_ATTR
+
     signature = {
         # "node_descriptor": "NodeDescriptor(byte1=2, byte2=64, mac_capability_flags=128, manufacturer_code=4098,
         #                    maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264,
@@ -408,6 +412,7 @@ class TuyaMoesCover0601(TuyaWindowCover):
                     Scenes.cluster_id,
                     TuyaManufacturerWindowCover,
                     TuyaWindowCoverControl,
+                    TuyaPowerConfigurationCluster,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             }


### PR DESCRIPTION
## Proposed change

The _TZE200_vexa5o82 is yet another variant of the Tuya Smart Blinds, which I recently purchased on Ali Express. With this change the blind works well for me.


## Additional information

This is a trivial change.

## Device diagnostics
[zha-b306388cd2e1e0bd754134eb9054ec01-_TZE200_vexa5o82 TS0601-cb537191b46c1acdf65eb481be6456c1.json](https://github.com/user-attachments/files/22787078/zha-b306388cd2e1e0bd754134eb9054ec01-_TZE200_vexa5o82.TS0601-cb537191b46c1acdf65eb481be6456c1.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
