### PR TITLE
Add Third Reality door sensor settings

### DIFF
--- a/zhaquirks/thirdreality/door_sensor_v2.py
+++ b/zhaquirks/thirdreality/door_sensor_v2.py
@@ -1,0 +1,40 @@
+"""Third Reality door sensor devices."""
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+import zigpy.types as t
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+
+class ThirdRealityDoorCluster(CustomCluster):
+    """Third Reality's door sensor private cluster."""
+
+    cluster_id = 0xFF01
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Define the attributes of a private cluster."""
+
+        open_delay_time: Final = ZCLAttributeDef(
+            id=0x0000,
+            type=t.uint16_t,
+            is_manufacturer_specific=True,
+        )
+
+
+(
+    QuirkBuilder("Third Reality, Inc", "3RDS17BZ")
+    .replaces(ThirdRealityDoorCluster)
+    .number(
+        attribute_name=ThirdRealityDoorCluster.AttributeDefs.open_delay_time.name,
+        min_value=0,
+        max_value=3600,
+        unit=UnitOfTime.SECONDS,
+        cluster_id=ThirdRealityDoorCluster.cluster_id,
+        translation_key="open_delay_time",
+        fallback_name="Open Delay Time",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/thirdreality/door_sensor_v2.py
+++ b/zhaquirks/thirdreality/door_sensor_v2.py
@@ -6,6 +6,7 @@ from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 import zigpy.types as t
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 
@@ -32,9 +33,10 @@ class ThirdRealityDoorCluster(CustomCluster):
         min_value=0,
         max_value=3600,
         unit=UnitOfTime.SECONDS,
+        device_class=NumberDeviceClass.DURATION,
         cluster_id=ThirdRealityDoorCluster.cluster_id,
         translation_key="open_delay_time",
-        fallback_name="Open Delay Time",
+        fallback_name="Open delay time",
     )
     .add_to_registry()
 )

--- a/zhaquirks/thirdreality/door_sensor_v2.py
+++ b/zhaquirks/thirdreality/door_sensor_v2.py
@@ -30,11 +30,11 @@ class ThirdRealityDoorCluster(CustomCluster):
     .replaces(ThirdRealityDoorCluster)
     .number(
         attribute_name=ThirdRealityDoorCluster.AttributeDefs.open_delay_time.name,
+        cluster_id=ThirdRealityDoorCluster.cluster_id,
         min_value=0,
         max_value=3600,
         unit=UnitOfTime.SECONDS,
         device_class=NumberDeviceClass.DURATION,
-        cluster_id=ThirdRealityDoorCluster.cluster_id,
         translation_key="open_delay_time",
         fallback_name="Open delay time",
     )

--- a/zhaquirks/thirdreality/door_sensor_v2.py
+++ b/zhaquirks/thirdreality/door_sensor_v2.py
@@ -5,8 +5,8 @@ from typing import Final
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
-import zigpy.types as t
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR added adaptation code for door_sensor and added 1 additional private cluster

1. open_delay_time: set for 5 seconds, after triggering, display on after 5 seconds

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
<img width="1076" height="677" alt="2f8a7a35c0428774d368d5c20bbb7729" src="https://github.com/user-attachments/assets/a0d0e418-3338-4a73-9a18-43005f276539" />


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
