### PR TITLE
Add Third Reality switch settings

### DIFF
--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -1,0 +1,61 @@
+"""Third Reality Blind Gen2 devices."""
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+
+
+
+class THIRD_REALITY_Switch_CLUSTER(CustomCluster):
+    """Third Reality's Switch private cluster."""
+
+    cluster_id = 0xFF02
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Define the attributes of a private cluster."""
+		
+        
+        on_to_off_delay: Final = ZCLAttributeDef(
+            id=0x0001,
+            type=t.uint16_t,
+            is_manufacturer_specific=True,
+        )
+          
+        off_to_on_delay: Final = ZCLAttributeDef(
+            id=0x0002,
+            type=t.uint16_t,
+            is_manufacturer_specific=True,
+        )
+
+
+(
+    QuirkBuilder("Third Reality, Inc", "3RSS009Z")
+    .replaces(THIRD_REALITY_Switch_CLUSTER)
+    .number(
+        attribute_name=THIRD_REALITY_Switch_CLUSTER.AttributeDefs.on_to_off_delay.name,
+        cluster_id=THIRD_REALITY_Switch_CLUSTER.cluster_id,
+        endpoint_id=1,
+        min_value=0,
+        max_value=65535,
+        unit=UnitOfTime.SECONDS,
+        step=1,
+        translation_key="on_to_off_delay",
+        fallback_name="on_to_off_delay",
+    )
+    .number(
+        attribute_name=THIRD_REALITY_Switch_CLUSTER.AttributeDefs.off_to_on_delay.name,
+        cluster_id=THIRD_REALITY_Switch_CLUSTER.cluster_id,
+        endpoint_id=1,
+        min_value=0,
+        max_value=65535,
+        unit=UnitOfTime.SECONDS,
+        step=1,
+        translation_key="off_to_on_delay",
+        fallback_name="off_to_on_delay",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -42,7 +42,7 @@ class THIRD_REALITY_Switch_CLUSTER(CustomCluster):
         unit=UnitOfTime.SECONDS,
         step=1,
         translation_key="on_to_off_delay",
-        fallback_name="on_to_off_delay",
+        fallback_name="On to off delay",
     )
     .number(
         attribute_name=THIRD_REALITY_Switch_CLUSTER.AttributeDefs.off_to_on_delay.name,

--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -5,6 +5,7 @@ from typing import Final
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 

--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -8,6 +8,7 @@ from zigpy.quirks.v2.homeassistant import UnitOfTime
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
+
 class THIRD_REALITY_Switch_CLUSTER(CustomCluster):
     """Third Reality's Switch private cluster."""
 

--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -6,6 +6,7 @@ from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 import zigpy.types as t
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 

--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -55,7 +55,7 @@ class THIRD_REALITY_Switch_CLUSTER(CustomCluster):
         device_class=NumberDeviceClass.DURATION,
         step=1,
         translation_key="off_to_on_delay",
-        fallback_name="off_to_on_delay",
+        fallback_name="Off to on delay",
     )
     .add_to_registry()
 )

--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -1,4 +1,4 @@
-"""Third Reality Blind Gen2 devices."""
+"""Third Reality Switch Gen2 devices."""
 
 from typing import Final
 

--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -5,7 +5,6 @@ from typing import Final
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
-from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 

--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -4,10 +4,9 @@ from typing import Final
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import UnitOfTime
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
-from zigpy.quirks.v2.homeassistant import UnitOfTime
-
 
 
 class THIRD_REALITY_Switch_CLUSTER(CustomCluster):
@@ -17,14 +16,13 @@ class THIRD_REALITY_Switch_CLUSTER(CustomCluster):
 
     class AttributeDefs(BaseAttributeDefs):
         """Define the attributes of a private cluster."""
-		
-        
+
         on_to_off_delay: Final = ZCLAttributeDef(
             id=0x0001,
             type=t.uint16_t,
             is_manufacturer_specific=True,
         )
-          
+
         off_to_on_delay: Final = ZCLAttributeDef(
             id=0x0002,
             type=t.uint16_t,

--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -40,6 +40,7 @@ class THIRD_REALITY_Switch_CLUSTER(CustomCluster):
         min_value=0,
         max_value=65535,
         unit=UnitOfTime.SECONDS,
+        device_class=NumberDeviceClass.DURATION,
         step=1,
         translation_key="on_to_off_delay",
         fallback_name="On to off delay",

--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -8,7 +8,6 @@ from zigpy.quirks.v2.homeassistant import UnitOfTime
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
-
 class THIRD_REALITY_Switch_CLUSTER(CustomCluster):
     """Third Reality's Switch private cluster."""
 

--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -51,6 +51,7 @@ class THIRD_REALITY_Switch_CLUSTER(CustomCluster):
         min_value=0,
         max_value=65535,
         unit=UnitOfTime.SECONDS,
+        device_class=NumberDeviceClass.DURATION,
         step=1,
         translation_key="off_to_on_delay",
         fallback_name="off_to_on_delay",

--- a/zhaquirks/thirdreality/switch_v2.py
+++ b/zhaquirks/thirdreality/switch_v2.py
@@ -5,8 +5,8 @@ from typing import Final
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
-import zigpy.types as t
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR added adaptation code for dual_plug and added 2 additional private clusters

1. on_to_off_delay---off delay, when you set the attribute to 10 and the current status is on, it will change to off after 10 seconds
2. off_to_on_delay---on delay, similar to the above

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
<img width="1138" height="725" alt="9cebdaa5-95ab-46be-8b48-5dccfc5d02fe" src="https://github.com/user-attachments/assets/ccefe475-9924-45a7-b0b2-6dc68bb9a54d" />

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
