### PR TITLE
Add Third Reality temperature and humidity sensor settings

### DIFF
--- a/zhaquirks/thirdreality/temperature_and_humidity_sensor_v2.py
+++ b/zhaquirks/thirdreality/temperature_and_humidity_sensor_v2.py
@@ -3,7 +3,7 @@
 from typing import Final
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2 import NumberDeviceClass, QuirkBuilder
 from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTemperature
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
@@ -41,36 +41,39 @@ class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
     .replaces(ThirdRealityTemperatureAndHumidityCluster)
     .number(
         attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.temperature_correction_celsius.name,
+        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
         min_value=-10000,
         max_value=10000,
         multiplier=0.01,
         step=0.1,
+        device_class=NumberDeviceClass.TEMPERATURE,
         unit=UnitOfTemperature.CELSIUS,
-        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
-        translation_key="temperature_correction_celsius",
-        fallback_name="Celsius correction",
+        translation_key="temperature_offset_celsius",
+        fallback_name="Celsius offset",
     )
     .number(
         attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.temperature_correction_fahrenheit.name,
+        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
         min_value=-10000,
         max_value=10000,
         multiplier=0.01,
         step=0.1,
+        device_class=NumberDeviceClass.TEMPERATURE,
         unit=UnitOfTemperature.FAHRENHEIT,
-        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
-        translation_key="temperature_correction_fahrenheit",
-        fallback_name="Fahrenheit correction",
+        translation_key="temperature_offset_fahrenheit",
+        fallback_name="Fahrenheit offset",
     )
     .number(
         attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.humidity_correction.name,
+        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
         min_value=-10000,
         max_value=10000,
         multiplier=0.01,
         step=0.1,
+        device_class=NumberDeviceClass.HUMIDITY,
         unit=PERCENTAGE,
-        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
-        translation_key="humidity_correction",
-        fallback_name="Humidity correction",
+        translation_key="humidity_offset",
+        fallback_name="Humidity offset",
     )
     .add_to_registry()
 )

--- a/zhaquirks/thirdreality/temperature_and_humidity_sensor_v2.py
+++ b/zhaquirks/thirdreality/temperature_and_humidity_sensor_v2.py
@@ -4,9 +4,9 @@ from typing import Final
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTemperature
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
-from zigpy.quirks.v2.homeassistant import UnitOfTemperature, PERCENTAGE
 
 
 class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):

--- a/zhaquirks/thirdreality/temperature_and_humidity_sensor_v2.py
+++ b/zhaquirks/thirdreality/temperature_and_humidity_sensor_v2.py
@@ -1,0 +1,76 @@
+"""Third Reality temperature and humidity sensor devices."""
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+from zigpy.quirks.v2.homeassistant import UnitOfTemperature, PERCENTAGE
+
+
+class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
+    """Third Reality's temperature and humidity sensor private cluster."""
+
+    cluster_id = 0xFF01
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Define the attributes of a private cluster."""
+
+        temperature_correction_fahrenheit: Final = ZCLAttributeDef(
+            id=0x0033,
+            type=t.int16s,
+            is_manufacturer_specific=True,
+        )
+
+        temperature_correction_celsius: Final = ZCLAttributeDef(
+            id=0x0031,
+            type=t.int16s,
+            is_manufacturer_specific=True,
+        )
+
+        humidity_correction: Final = ZCLAttributeDef(
+            id=0x0032,
+            type=t.int16s,
+            is_manufacturer_specific=True,
+        )
+
+
+(
+    QuirkBuilder("Third Reality, Inc", "3RTHS24BZ")
+    .replaces(ThirdRealityTemperatureAndHumidityCluster)
+    .number(
+        attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.temperature_correction_celsius.name,
+        min_value=-10000,
+        max_value=10000,
+        multiplier=0.01,
+        step=0.1,
+        unit=UnitOfTemperature.CELSIUS,
+        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
+        translation_key="temperature_correction_celsius",
+        fallback_name="Celsius correction",
+    )
+    .number(
+        attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.temperature_correction_fahrenheit.name,
+        min_value=-10000,
+        max_value=10000,
+        multiplier=0.01,
+        step=0.1,
+        unit=UnitOfTemperature.FAHRENHEIT,
+        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
+        translation_key="temperature_correction_fahrenheit",
+        fallback_name="Fahrenheit correction",
+    )
+    .number(
+        attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.humidity_correction.name,
+        min_value=-10000,
+        max_value=10000,
+        multiplier=0.01,
+        step=0.1,
+        unit=PERCENTAGE,
+        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
+        translation_key="humidity_correction",
+        fallback_name="Humidity correction",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR added adaptation code for T_H sensor and added 3 additional private clusters

1. temperature_correction_fahrenheit: Calibrate Fahrenheit
2. temperature_correction_celsius: Calibrate Celsius
3. humidity_correction: Calibrate humidity

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
<img width="1148" height="713" alt="8d0fef7efb0f9e50279a95f0d18095a5" src="https://github.com/user-attachments/assets/2f31a1d9-b76b-4429-bb39-284f65f1a581" />


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
