### PR TITLE
Add Third Reality temperature and humidity sensor lite settings

### DIFF
--- a/zhaquirks/thirdreality/temperature_and_humidity_sensor_lite_v2.py
+++ b/zhaquirks/thirdreality/temperature_and_humidity_sensor_lite_v2.py
@@ -4,10 +4,11 @@ from typing import Final
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTemperature
 import zigpy.types as t
 from zigpy.zcl.clusters.general import PollControl
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
-from zigpy.quirks.v2.homeassistant import UnitOfTemperature, PERCENTAGE
+
 
 class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
     """Third Reality's temperature and humidity sensor lite private cluster."""

--- a/zhaquirks/thirdreality/temperature_and_humidity_sensor_lite_v2.py
+++ b/zhaquirks/thirdreality/temperature_and_humidity_sensor_lite_v2.py
@@ -1,0 +1,77 @@
+"""Third Reality temperature and humidity sensor devices."""
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl.clusters.general import PollControl
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+from zigpy.quirks.v2.homeassistant import UnitOfTemperature, PERCENTAGE
+
+class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
+    """Third Reality's temperature and humidity sensor lite private cluster."""
+
+    cluster_id = 0xFF01
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Define the attributes of a private cluster."""
+
+        temperature_correction_fahrenheit: Final = ZCLAttributeDef(
+            id=0x0033,
+            type=t.int16s,
+            is_manufacturer_specific=True,
+        )
+
+        temperature_correction_celsius: Final = ZCLAttributeDef(
+            id=0x0031,
+            type=t.int16s,
+            is_manufacturer_specific=True,
+        )
+
+        humidity_correction: Final = ZCLAttributeDef(
+            id=0x0032,
+            type=t.int16s,
+            is_manufacturer_specific=True,
+        )
+
+
+(
+    QuirkBuilder("Third Reality, Inc", "3RTHS0224Z")
+    .replaces(ThirdRealityTemperatureAndHumidityCluster)
+    .removes(PollControl.cluster_id)
+    .number(
+        attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.temperature_correction_celsius.name,
+        min_value=-10000,
+        max_value=10000,
+        multiplier=0.01,
+        step=0.1,
+        unit=UnitOfTemperature.CELSIUS,
+        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
+        translation_key="temperature_correction_celsius",
+        fallback_name="Celsius correction",
+    )
+    .number(
+        attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.temperature_correction_fahrenheit.name,
+        min_value=-10000,
+        max_value=10000,
+        multiplier=0.01,
+        step=0.1,
+        unit=UnitOfTemperature.FAHRENHEIT,
+        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
+        translation_key="temperature_correction_fahrenheit",
+        fallback_name="Fahrenheit correction",
+    )
+    .number(
+        attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.humidity_correction.name,
+        min_value=-10000,
+        max_value=10000,
+        multiplier=0.01,
+        step=0.1,
+        unit=PERCENTAGE,
+        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
+        translation_key="humidity_correction",
+        fallback_name="Humidity Correction",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/thirdreality/temperature_and_humidity_sensor_lite_v2.py
+++ b/zhaquirks/thirdreality/temperature_and_humidity_sensor_lite_v2.py
@@ -3,7 +3,7 @@
 from typing import Final
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2 import NumberDeviceClass, QuirkBuilder
 from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTemperature
 import zigpy.types as t
 from zigpy.zcl.clusters.general import PollControl
@@ -48,6 +48,7 @@ class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
         max_value=10000,
         multiplier=0.01,
         step=0.1,
+        device_class=NumberDeviceClass.TEMPERATURE,
         unit=UnitOfTemperature.CELSIUS,
         translation_key="temperature_correction_celsius",
         fallback_name="Celsius correction",
@@ -59,6 +60,7 @@ class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
         max_value=10000,
         multiplier=0.01,
         step=0.1,
+        device_class=NumberDeviceClass.TEMPERATURE,
         unit=UnitOfTemperature.FAHRENHEIT,
         translation_key="temperature_correction_fahrenheit",
         fallback_name="Fahrenheit correction",
@@ -70,6 +72,7 @@ class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
         max_value=10000,
         multiplier=0.01,
         step=0.1,
+        device_class=NumberDeviceClass.HUMIDITY,
         unit=PERCENTAGE,
         translation_key="humidity_correction",
         fallback_name="Humidity Correction",

--- a/zhaquirks/thirdreality/temperature_and_humidity_sensor_lite_v2.py
+++ b/zhaquirks/thirdreality/temperature_and_humidity_sensor_lite_v2.py
@@ -50,8 +50,8 @@ class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
         step=0.1,
         device_class=NumberDeviceClass.TEMPERATURE,
         unit=UnitOfTemperature.CELSIUS,
-        translation_key="temperature_correction_celsius",
-        fallback_name="Celsius correction",
+        translation_key="temperature_offset_celsius",
+        fallback_name="Celsius offset",
     )
     .number(
         attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.temperature_correction_fahrenheit.name,
@@ -62,8 +62,8 @@ class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
         step=0.1,
         device_class=NumberDeviceClass.TEMPERATURE,
         unit=UnitOfTemperature.FAHRENHEIT,
-        translation_key="temperature_correction_fahrenheit",
-        fallback_name="Fahrenheit correction",
+        translation_key="temperature_offset_fahrenheit",
+        fallback_name="Fahrenheit offset",
     )
     .number(
         attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.humidity_correction.name,
@@ -74,8 +74,8 @@ class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
         step=0.1,
         device_class=NumberDeviceClass.HUMIDITY,
         unit=PERCENTAGE,
-        translation_key="humidity_correction",
-        fallback_name="Humidity Correction",
+        translation_key="humidity_offset",
+        fallback_name="Humidity offset",
     )
     .add_to_registry()
 )

--- a/zhaquirks/thirdreality/temperature_and_humidity_sensor_lite_v2.py
+++ b/zhaquirks/thirdreality/temperature_and_humidity_sensor_lite_v2.py
@@ -43,34 +43,34 @@ class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
     .removes(PollControl.cluster_id)
     .number(
         attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.temperature_correction_celsius.name,
+        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
         min_value=-10000,
         max_value=10000,
         multiplier=0.01,
         step=0.1,
         unit=UnitOfTemperature.CELSIUS,
-        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
         translation_key="temperature_correction_celsius",
         fallback_name="Celsius correction",
     )
     .number(
         attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.temperature_correction_fahrenheit.name,
+        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
         min_value=-10000,
         max_value=10000,
         multiplier=0.01,
         step=0.1,
         unit=UnitOfTemperature.FAHRENHEIT,
-        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
         translation_key="temperature_correction_fahrenheit",
         fallback_name="Fahrenheit correction",
     )
     .number(
         attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.humidity_correction.name,
+        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
         min_value=-10000,
         max_value=10000,
         multiplier=0.01,
         step=0.1,
         unit=PERCENTAGE,
-        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
         translation_key="humidity_correction",
         fallback_name="Humidity Correction",
     )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR added adaptation code for T_H sensor lite and added 3 additional private clusters

1. temperature_correction_fahrenheit: Calibrate Fahrenheit
2. temperature_correction_celsius: Calibrate Celsius
3. humidity_correction: Calibrate humidity

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
<img width="1083" height="622" alt="10ffc084fc46bc38d2395d562f68b406" src="https://github.com/user-attachments/assets/07d42e76-b14f-4325-b03e-cbf48ee624e4" />


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
