### PR TITLE
Add Tuya smart knob `_TZ3000_gwkzibhs` variant

### DIFF
--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -78,6 +78,7 @@ class TuyaSmartRemote004FROK(EnchantedDevice):
             ("_TZ3000_qja6nq5z", "TS004F"),
             ("_TZ3000_csflgqj2", "TS004F"),
             ("_TZ3000_abrsvsou", "TS004F"),
+            ("_TZ3000_gwkzibhs", "TS004F"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change
Add support to Tuya _TZ3000_gwkzibhs knob.
Tested locally on my HA instance.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Fixes #4301 

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-231c37135385fcc237adea20f78012cb-_TZ3000_gwkzibhs TS004F-9a6332b92aec93042b5ef21a36b526f7.json](https://github.com/user-attachments/files/22854106/zha-231c37135385fcc237adea20f78012cb-_TZ3000_gwkzibhs.TS004F-9a6332b92aec93042b5ef21a36b526f7.json)



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
