### PR TITLE
Add Third Reality garage door lite sensor settings

### DIFF
--- a/zhaquirks/thirdreality/garage_door_tilt_sensor.py
+++ b/zhaquirks/thirdreality/garage_door_tilt_sensor.py
@@ -18,7 +18,7 @@ class ThirdRealityGarageCluster(CustomCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Define the attributes of a private cluster."""
 
-        undetected_to_detected_delay: Final = ZCLAttributeDef(
+        open_delay_time: Final = ZCLAttributeDef(
             id=0x0000,
             type=t.uint16_t,
             is_manufacturer_specific=True,
@@ -36,14 +36,14 @@ class ThirdRealityGarageCluster(CustomCluster):
     .replaces(ThirdRealityGarageCluster)
     .removes(PollControl.cluster_id)
     .number(
-        attribute_name=ThirdRealityGarageCluster.AttributeDefs.undetected_to_detected_delay.name,
+        attribute_name=ThirdRealityGarageCluster.AttributeDefs.open_delay_time.name,
         cluster_id=ThirdRealityGarageCluster.cluster_id,
         min_value=0,
         max_value=3600,
         unit=UnitOfTime.SECONDS,
         device_class=NumberDeviceClass.DURATION,
-        translation_key="undetected_to_detected_delay",
-        fallback_name="Undetected to detected delay",
+        translation_key="open_delay_time",
+        fallback_name="Open delay time",
     )
     .write_attr_button(
         attribute_name=ThirdRealityGarageCluster.AttributeDefs.z_axis_calibration.name,

--- a/zhaquirks/thirdreality/garage_door_tilt_sensor.py
+++ b/zhaquirks/thirdreality/garage_door_tilt_sensor.py
@@ -6,7 +6,6 @@ from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import NumberDeviceClass, UnitOfTime
 import zigpy.types as t
-from zigpy.zcl.clusters.general import PollControl
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 

--- a/zhaquirks/thirdreality/garage_door_tilt_sensor.py
+++ b/zhaquirks/thirdreality/garage_door_tilt_sensor.py
@@ -1,0 +1,57 @@
+"""Third Reality garage door lite sensor devices."""
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl.clusters.general import PollControl
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+from zigpy.quirks.v2.homeassistant import UnitOfTime, NumberDeviceClass
+
+
+class ThirdRealityGarageCluster(CustomCluster):
+    """Third Reality's garage door lite private cluster."""
+
+    cluster_id = 0xFF01
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Define the attributes of a private cluster."""
+
+        undetected_to_detected_delay: Final = ZCLAttributeDef(
+            id=0x0000,
+            type=t.uint16_t,
+            is_manufacturer_specific=True,
+        )
+
+        z_axis_calibration: Final = ZCLAttributeDef(
+            id=0x0003,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
+
+
+
+(
+    QuirkBuilder("Third Reality, Inc", "3RDTS01056Z")
+    .replaces(ThirdRealityGarageCluster)
+    .removes(PollControl.cluster_id)
+    .number(
+        attribute_name=ThirdRealityGarageCluster.AttributeDefs.undetected_to_detected_delay.name,
+        cluster_id=ThirdRealityGarageCluster.cluster_id,
+        min_value=0,
+        max_value=3600,
+        unit=UnitOfTime.SECONDS,
+        device_class=NumberDeviceClass.DURATION,
+        translation_key="undetected_to_detected_delay",
+        fallback_name="Undetected to detected delay",
+    )
+    .write_attr_button(
+        attribute_name=ThirdRealityGarageCluster.AttributeDefs.z_axis_calibration.name,
+        cluster_id=ThirdRealityGarageCluster.cluster_id,
+		attribute_value=0x01,
+		translation_key="enable_z_axis_calibration",
+        fallback_name="Enable Z axis calibration",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/thirdreality/garage_door_tilt_sensor.py
+++ b/zhaquirks/thirdreality/garage_door_tilt_sensor.py
@@ -4,7 +4,8 @@ from typing import Final
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.quirks.v2.homeassistant import NumberDeviceClass, UnitOfTime
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 

--- a/zhaquirks/thirdreality/garage_door_tilt_sensor.py
+++ b/zhaquirks/thirdreality/garage_door_tilt_sensor.py
@@ -48,8 +48,8 @@ class ThirdRealityGarageCluster(CustomCluster):
         attribute_name=ThirdRealityGarageCluster.AttributeDefs.z_axis_calibration.name,
         cluster_id=ThirdRealityGarageCluster.cluster_id,
         attribute_value=0x01,
-        translation_key="enable_z_axis_calibration",
-        fallback_name="Enable Z axis calibration",
+        translation_key="calibrate_z_axis",
+        fallback_name="Calibrate Z axis",
     )
     .add_to_registry()
 )

--- a/zhaquirks/thirdreality/garage_door_tilt_sensor.py
+++ b/zhaquirks/thirdreality/garage_door_tilt_sensor.py
@@ -34,7 +34,6 @@ class ThirdRealityGarageCluster(CustomCluster):
 (
     QuirkBuilder("Third Reality, Inc", "3RDTS01056Z")
     .replaces(ThirdRealityGarageCluster)
-    .removes(PollControl.cluster_id)
     .number(
         attribute_name=ThirdRealityGarageCluster.AttributeDefs.open_delay_time.name,
         cluster_id=ThirdRealityGarageCluster.cluster_id,

--- a/zhaquirks/thirdreality/garage_door_tilt_sensor.py
+++ b/zhaquirks/thirdreality/garage_door_tilt_sensor.py
@@ -4,10 +4,10 @@ from typing import Final
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import NumberDeviceClass, UnitOfTime
 import zigpy.types as t
 from zigpy.zcl.clusters.general import PollControl
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
-from zigpy.quirks.v2.homeassistant import UnitOfTime, NumberDeviceClass
 
 
 class ThirdRealityGarageCluster(CustomCluster):
@@ -31,7 +31,6 @@ class ThirdRealityGarageCluster(CustomCluster):
         )
 
 
-
 (
     QuirkBuilder("Third Reality, Inc", "3RDTS01056Z")
     .replaces(ThirdRealityGarageCluster)
@@ -49,8 +48,8 @@ class ThirdRealityGarageCluster(CustomCluster):
     .write_attr_button(
         attribute_name=ThirdRealityGarageCluster.AttributeDefs.z_axis_calibration.name,
         cluster_id=ThirdRealityGarageCluster.cluster_id,
-		attribute_value=0x01,
-		translation_key="enable_z_axis_calibration",
+        attribute_value=0x01,
+        translation_key="enable_z_axis_calibration",
         fallback_name="Enable Z axis calibration",
     )
     .add_to_registry()


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR added adaptation code for garage door lite sensor and added 2 additional private cluster

1. open_delay_time： set for 5 seconds, after triggering, display on after 5 seconds
2. z_axis_calibration：When the device is placed flat, the theoretical z-axis angle is 90 degrees, but there is an error, so this attribute needs to be used for calibration to get as close to the theoretical value as possible


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
<img width="1824" height="868" alt="7c0d669c4c0f08f5940c5a052e1fc9d0" src="https://github.com/user-attachments/assets/ce1e473f-a8f8-4cd2-8cc7-61cc7a2a41f0" />


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
