### PR TITLE
Add Philips Hue Flux Gradient lightstrip

### DIFF
--- a/zhaquirks/philips/hue_light.py
+++ b/zhaquirks/philips/hue_light.py
@@ -7,7 +7,7 @@ from zhaquirks.philips import PHILIPS, SIGNIFY, PhilipsHueLightCluster
 (
     QuirkBuilder()
     .applies_to(SIGNIFY, "929004610402")
-    .friendly_name(model="Hue Flux Gradient lightstrip", manufacturer="Philips")
+    .friendly_name(model="Hue Flux gradient lightstrip", manufacturer="Philips",)
     .replaces(PhilipsHueLightCluster, endpoint_id=11)
     .add_to_registry()
 )

--- a/zhaquirks/philips/hue_light.py
+++ b/zhaquirks/philips/hue_light.py
@@ -6,6 +6,17 @@ from zhaquirks.philips import PHILIPS, SIGNIFY, PhilipsHueLightCluster
 
 (
     QuirkBuilder()
+    .applies_to(SIGNIFY, "929004610402")
+    .friendly_name(
+        model="Hue Flux Gradient lightstrip",
+        manufacturer="Philips"
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder()
     .applies_to(SIGNIFY, "LCX001")
     .applies_to(SIGNIFY, "LCX002")
     .applies_to(SIGNIFY, "LCX003")

--- a/zhaquirks/philips/hue_light.py
+++ b/zhaquirks/philips/hue_light.py
@@ -7,10 +7,7 @@ from zhaquirks.philips import PHILIPS, SIGNIFY, PhilipsHueLightCluster
 (
     QuirkBuilder()
     .applies_to(SIGNIFY, "929004610402")
-    .friendly_name(
-        model="Hue Flux Gradient lightstrip",
-        manufacturer="Philips"
-    )
+    .friendly_name(model="Hue Flux Gradient lightstrip", manufacturer="Philips")
     .replaces(PhilipsHueLightCluster, endpoint_id=11)
     .add_to_registry()
 )

--- a/zhaquirks/philips/hue_light.py
+++ b/zhaquirks/philips/hue_light.py
@@ -7,7 +7,10 @@ from zhaquirks.philips import PHILIPS, SIGNIFY, PhilipsHueLightCluster
 (
     QuirkBuilder()
     .applies_to(SIGNIFY, "929004610402")
-    .friendly_name(model="Hue Flux gradient lightstrip", manufacturer="Philips",)
+    .friendly_name(
+        model="Hue Flux gradient lightstrip",
+        manufacturer="Philips",
+    )
     .replaces(PhilipsHueLightCluster, endpoint_id=11)
     .add_to_registry()
 )


### PR DESCRIPTION
Philips has added a new Hue Flux Gradient lightstrip

## Proposed change
Add support for for 'multicolor' using PhilipsHueLightCluster for the new Philips Hue Flux Gradient lightstrip


## Additional information


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-07612e9e757e2fb0fa90d82e3c089c6d-Philips Hue Flux Gradient lightstrip-d65fcf00044ceb0b6a43a8f0de0bf373.json](https://github.com/user-attachments/files/22871159/zha-07612e9e757e2fb0fa90d82e3c089c6d-Philips.Hue.Flux.Gradient.lightstrip-d65fcf00044ceb0b6a43a8f0de0bf373.json)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
