### PR TITLE
Fix Frient EMI Norwegian HAN divisor

### DIFF
--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -141,24 +141,9 @@ async def test_frient_emi(zigpy_device_from_v2_quirk):
         assert result == (foundation.Status.SUCCESS, "done")
 
 
-def _get_packet_data(
-    command: foundation.GeneralCommand,
-    attr: foundation.Attribute | None = None,
-    dirc: foundation.Direction = foundation.Direction.Server_to_Client,
-) -> bytes:
-    hdr = foundation.ZCLHeader.general(1, command, 0, dirc).serialize()
-    if attr is not None:
-        cmd = foundation.GENERAL_COMMANDS[command].schema([attr]).serialize()
-    else:
-        cmd = b""
-    return t.SerializableBytes(hdr + cmd).serialize()
-
-
 async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
     """Test Frient EMI Norwegian HAN ignoring incorrect divisor attribute reports."""
     device = zigpy_device_from_v2_quirk("frient A/S", "EMIZB-132", endpoint_ids=[1, 2])
-
-    # TODO: maybe get data from real device
 
     metering_cluster = device.endpoints[2].smartenergy_metering
     metering_listener = ClusterListener(metering_cluster)
@@ -173,6 +158,7 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
             cluster_id=Metering.cluster_id,
             src_ep=2,
             dst_ep=2,
+            # XXX: get data from real device
             data=t.SerializableBytes(b'\x1c\x00\x00\x01\n\x02\x03"\x00\x02\x00'),
         )
     )

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -2,9 +2,11 @@
 
 from unittest import mock
 
+import zigpy.types as t
 from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.smartenergy import Metering
 
+from tests.common import ClusterListener
 import zhaquirks
 
 zhaquirks.setup()
@@ -137,3 +139,65 @@ async def test_frient_emi(zigpy_device_from_v2_quirk):
         assert attr_data == b"\x00\x00%d\x00\x00\x00\x00\x00"
 
         assert result == (foundation.Status.SUCCESS, "done")
+
+
+def _get_packet_data(
+    command: foundation.GeneralCommand,
+    attr: foundation.Attribute | None = None,
+    dirc: foundation.Direction = foundation.Direction.Server_to_Client,
+) -> bytes:
+    hdr = foundation.ZCLHeader.general(1, command, 0, dirc).serialize()
+    if attr is not None:
+        cmd = foundation.GENERAL_COMMANDS[command].schema([attr]).serialize()
+    else:
+        cmd = b""
+    return t.SerializableBytes(hdr + cmd).serialize()
+
+
+async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
+    """Test Frient EMI Norwegian HAN ignoring incorrect divisor attribute reports."""
+    device = zigpy_device_from_v2_quirk("frient A/S", "EMIZB-132", endpoint_ids=[1, 2])
+
+    # TODO: maybe get data from real device
+
+    metering_cluster = device.endpoints[2].smartenergy_metering
+    metering_listener = ClusterListener(metering_cluster)
+
+    # divisor already fixed at 1000
+    assert metering_cluster.get(Metering.AttributeDefs.divisor.id) == 1000
+
+    # send incorrect divisor attribute report
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=Metering.cluster_id,
+            src_ep=2,
+            dst_ep=2,
+            data=t.SerializableBytes(b'\x1c\x00\x00\x01\n\x02\x03"\x00\x02\x00'),
+        )
+    )
+
+    # attribute_updated event should not be emitted
+    assert len(metering_listener.attribute_updates) == 0
+
+    # divisor should still be fixed at 1000
+    assert metering_cluster.get(Metering.AttributeDefs.divisor.id) == 1000
+
+    # send current_summ_delivered attribute report
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=Metering.cluster_id,
+            src_ep=2,
+            dst_ep=2,
+            data=t.SerializableBytes(
+                b"\x1c\x00\x00\x01\n\x00\x00%\xd2\x04\x00\x00\x00\x00"
+            ),
+        )
+    )
+
+    # attribute_updated event should be emitted
+    assert len(metering_listener.attribute_updates) == 1
+    assert (
+        metering_cluster.get(Metering.AttributeDefs.current_summ_delivered.id) == 1234
+    )

--- a/zhaquirks/develco/emi_han.py
+++ b/zhaquirks/develco/emi_han.py
@@ -25,9 +25,7 @@ class FrientMetering(CustomCluster, Metering):
 
 
 (
-    # TODO: check which manufacturer name is used by the device
     QuirkBuilder("frient A/S", "EMIZB-132")
-    .applies_to("Develco Products A/S", "EMIZB-132")
-    .replaces(FrientMetering, endpoint_id=2)  # TODO: check endpoint
+    .replaces(FrientMetering, endpoint_id=2)
     .add_to_registry()
 )

--- a/zhaquirks/develco/emi_han.py
+++ b/zhaquirks/develco/emi_han.py
@@ -1,0 +1,33 @@
+"""Frient Electricity Meter Interface Norwegian HAN."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl.clusters.smartenergy import Metering
+
+
+class FrientMetering(CustomCluster, Metering):
+    """Frient EMI Norwegian HAN Metering cluster definition."""
+
+    # fix device issue
+    _CONSTANT_ATTRIBUTES = {Metering.AttributeDefs.divisor.id: 1000}
+
+    def _update_attribute(self, attrid: int | t.uint16_t, value: Any) -> None:
+        """Update attribute with value."""
+        # prevent attribute_updated events for divisor
+        if attrid == Metering.AttributeDefs.divisor.id:
+            return
+        super()._update_attribute(attrid, value)
+
+
+(
+    # TODO: check which manufacturer name is used by the device
+    QuirkBuilder("frient A/S", "EMIZB-132")
+    .applies_to("Develco Products A/S", "EMIZB-132")
+    .replaces(FrientMetering, endpoint_id=2)  # TODO: check endpoint
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

This fixes the Metering divisor for the Frient EMI Norwegian HAN to a value of `1000` and ignores all attribute updates for that attribute, as the device apparently sends attribute reports with a value of `512` randomly.


TODO:
- add tests
- address TODOs in quirk
- get device diagnostics
- get invalid device report data (turn on debug logs for this)
 

## Additional information

See Z2M issue for reference:
- https://github.com/Koenkk/zigbee-herdsman-converters/issues/3066

## Testing

This is an experimental and untested quirk. We need device diagnostics to make sure this fixes the issue.

If you want to test this as a custom quirk, you can do the following:
1. Install an addon that allows you to modify files in Home Assistant's `/config` directory.
The "Samba share" addon or VSCode addon can be used for this.
2. Create a `zha_custom_quirks` folder in Home Assistant's `/config` directory. So, in the folder where HA's `configuration.yaml` is.
3. Use the download button on the [linked GitHub page](https://github.com/TheJulianJES/zha-device-handlers/blob/tjj/frient_emi_norw_han/zhaquirks/develco/emi_han.py) to get the custom quirk as a `.py` file.
4. Copy the custom quirk file you've just downloaded into the newly created `zha_custom_quirks`.
5. Now, add the following to HA's `configuration.yaml`:
```yaml
zha:
  custom_quirks_path: /config/zha_custom_quirks
```
(Make sure you only have one `zha:` entry in your `configuration.yaml`. If you modified other ZHA YAML settings, you may need to merge your modifications with the one above.)

6. Restart Home Assistant.
7. Check if ZHA still works. if not, check the logs and post any errors.
8. Check if the custom quirk works as expected.

If you search the web, you should also be able to find some more info on installing custom quirks.

## Device diagnostics
We ideally need these before merging:
> You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
