### PR TITLE
Add Avatto Tuya thermostat `_TZE204_gops3slb` variant

### DIFF
--- a/zhaquirks/tuya/tuya_thermostat.py
+++ b/zhaquirks/tuya/tuya_thermostat.py
@@ -418,6 +418,7 @@ base_avatto_quirk = (
 (
     base_avatto_quirk.clone()
     .applies_to("_TZE204_lzriup1j", "TS0601")
+    .applies_to("_TZE204_gops3slb", "TS0601")
     .tuya_enum(
         dp_id=4,
         attribute_name="preset_mode",


### PR DESCRIPTION
_TZE204_gops3slb is the same device as _TZE204_lzriup1j

## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
