### PR TITLE
Add device automation triggers for Sunricher ZGRC-KEY-004

### DIFF
--- a/zhaquirks/sunricher/__init__.py
+++ b/zhaquirks/sunricher/__init__.py
@@ -1,0 +1,1 @@
+"""Module for Sunricher devices."""

--- a/zhaquirks/sunricher/button.py
+++ b/zhaquirks/sunricher/button.py
@@ -1,0 +1,30 @@
+"""Sunricher Button device."""
+
+from zigpy.quirks.v2 import QuirkBuilder
+
+from zhaquirks.const import (
+    COMMAND,
+    COMMAND_MOVE_ON_OFF,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_STOP_ON_OFF,
+    LONG_PRESS,
+    LONG_RELEASE,
+    RIGHT,
+    SHORT_PRESS,
+    TURN_OFF,
+    TURN_ON,
+)
+
+(
+    QuirkBuilder("Sunricher", "ZGRC-KEY-004")
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON},
+            (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF},
+            (LONG_PRESS, RIGHT): {COMMAND: COMMAND_MOVE_ON_OFF},
+            (LONG_RELEASE, RIGHT): {COMMAND: COMMAND_STOP_ON_OFF},
+        }
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
Add device automation support for the Sunricher ZGRC-KEY-004. Tested with my device.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
