### PR TITLE
Adapt battery voltages for Aqara Smoke Alarm JY-GZ-01AQ

### DIFF
--- a/zhaquirks/xiaomi/aqara/smoke.py
+++ b/zhaquirks/xiaomi/aqara/smoke.py
@@ -81,6 +81,13 @@ class LocalIasZone(LocalDataCluster, IasZone):
     }
 
 
+class XiaomiSmokePowerConfiguration(XiaomiPowerConfiguration):
+    """Xiaomi Smoke Power Configuration cluster."""
+
+    MIN_VOLTS_MV = 2475
+    MAX_VOLTS_MV = 3000
+
+
 class LumiSensorSmokeAcn03(CustomDevice):
     """lumi.sensor_smoke.acn03 smoke sensor."""
 
@@ -113,7 +120,7 @@ class LumiSensorSmokeAcn03(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    XiaomiPowerConfiguration,
+                    XiaomiSmokePowerConfiguration,
                     Identify.cluster_id,
                     LocalIasZone,
                     OppleCluster,


### PR DESCRIPTION
## Proposed change
Add a custom battery cluster to the Aqara Smoke Alarm JY-GZ-01AQ with custom voltages for the battery percentage calculation. Currently the percentage is way to low for the given battery voltage.

Same adjustments were done in Z2M, see https://github.com/Koenkk/zigbee-herdsman-converters/pull/9523 and https://github.com/Koenkk/zigbee2mqtt/issues/27374#issuecomment-2984798162

I've tested this change with my device, which went from around 20-22% to around 77-79%

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
