### PR TITLE
Loosen duplicate v2 quirks test for firmware filter

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -56,7 +56,7 @@ def test_translation_key_and_fallback_name_match() -> None:
 
 def test_manufacturer_model_metadata_unique() -> None:
     """Ensure that each manufacturer-model pair is unique across all v2 quirks."""
-    # quirk_locations are a list and not a set below,
+    # quirk_locations is a list and not a set below,
     # as they are not guaranteed to be unique when set up incorrectly
 
     # (manufacturer, model) -> {quirk_location}
@@ -65,6 +65,9 @@ def test_manufacturer_model_metadata_unique() -> None:
     )
 
     for quirk in ALL_QUIRK_V2_CLASSES:
+        if quirk.fw_version_filter is not None:
+            # skip quirks with firmware filter, as they can share manufacturer/model
+            continue
         for metadata in quirk.manufacturer_model_metadata:
             man_model_quirk_map[(metadata.manufacturer, metadata.model)].append(
                 f"{quirk.quirk_file}:{quirk.quirk_file_line}"


### PR DESCRIPTION
## Proposed change

This loosens the quirks v2 test for detecting duplicate manufacturer/model information across v2 quirks to ignore v2 quirks with a firmware version filter.


## Additional information

The test isn't actually necessary for zigpy to work correctly. zigpy already uses the quirk that's added later to the v2 registry (IIRC). Still, we want to keep this test around, as we've sometimes seen multiple Tuya (v2) quirks include the same manufacturer/model information.

One version of https://github.com/zigpy/zha-device-handlers/pull/4425 added firmware version filters, so this issue came up there.


## Checklist


- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
