### PR TITLE
Remove Fahrenheit temperature offset for Third Reality sensors

### DIFF
--- a/zhaquirks/thirdreality/temperature_sensor.py
+++ b/zhaquirks/thirdreality/temperature_sensor.py
@@ -10,7 +10,7 @@ from zigpy.zcl.clusters.general import PollControl
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 
-class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
+class ThirdRealityCluster(CustomCluster):
     """Third Reality's temperature and humidity sensor private cluster."""
 
     cluster_id = 0xFF01
@@ -18,20 +18,21 @@ class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Define the attributes of a private cluster."""
 
-        temperature_correction_fahrenheit: Final = ZCLAttributeDef(
-            id=0x0033,
-            type=t.int16s,
-            is_manufacturer_specific=True,
-        )
-
-        temperature_correction_celsius: Final = ZCLAttributeDef(
+        temperature_offset_celsius: Final = ZCLAttributeDef(
             id=0x0031,
             type=t.int16s,
             is_manufacturer_specific=True,
         )
 
-        humidity_correction: Final = ZCLAttributeDef(
+        humidity_offset: Final = ZCLAttributeDef(
             id=0x0032,
+            type=t.int16s,
+            is_manufacturer_specific=True,
+        )
+
+        # intentionally not exposed as an entity
+        temperature_offset_fahrenheit: Final = ZCLAttributeDef(
+            id=0x0033,
             type=t.int16s,
             is_manufacturer_specific=True,
         )
@@ -39,34 +40,22 @@ class ThirdRealityTemperatureAndHumidityCluster(CustomCluster):
 
 base_quirk = (
     QuirkBuilder()
-    .replaces(ThirdRealityTemperatureAndHumidityCluster)
+    .replaces(ThirdRealityCluster)
     .number(
-        attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.temperature_correction_celsius.name,
-        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
+        attribute_name=ThirdRealityCluster.AttributeDefs.temperature_offset_celsius.name,
+        cluster_id=ThirdRealityCluster.cluster_id,
         min_value=-10000,
         max_value=10000,
         multiplier=0.01,
         step=0.1,
         device_class=NumberDeviceClass.TEMPERATURE,
         unit=UnitOfTemperature.CELSIUS,
-        translation_key="temperature_offset_celsius",
-        fallback_name="Celsius offset",
+        translation_key="temperature_offset",
+        fallback_name="Temperature offset",
     )
     .number(
-        attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.temperature_correction_fahrenheit.name,
-        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
-        min_value=-10000,
-        max_value=10000,
-        multiplier=0.01,
-        step=0.1,
-        device_class=NumberDeviceClass.TEMPERATURE,
-        unit=UnitOfTemperature.FAHRENHEIT,
-        translation_key="temperature_offset_fahrenheit",
-        fallback_name="Fahrenheit offset",
-    )
-    .number(
-        attribute_name=ThirdRealityTemperatureAndHumidityCluster.AttributeDefs.humidity_correction.name,
-        cluster_id=ThirdRealityTemperatureAndHumidityCluster.cluster_id,
+        attribute_name=ThirdRealityCluster.AttributeDefs.humidity_offset.name,
+        cluster_id=ThirdRealityCluster.cluster_id,
         min_value=-10000,
         max_value=10000,
         multiplier=0.01,


### PR DESCRIPTION
## Proposed change

This no longer exposes the Fahrenheit temperature offset for Third Reality temperature and humidity sensors.

HA should automatically present the unit the user prefers when the temperature device class is set for a temperature entity, which I added in the initial PRs, where the sensors where added, making the additional Fahrenheit entity unnecessary.

For the LCD sensors at least, it makes sense to expose the temperature offset that the device offers, as all template options in HA wouldn't change the temperature displayed on the device.

### Why this was merged in the first place

Initially, I thought that this was just a weird device implementation, where the "Fahrenheit offset" only applies to the LCD sensor if it's in "Fahrenheit" mode (can be switched with the side button on the device).
But from the fact that non-LCD sensors also include the Fahrenheit correction and by interpreting more into existing PR descriptions, I think the "Fahrenheit" offset is just to make it easier for the user.

But we don't need to rely on the device doing this with two separate entities, as HA already does this with device classes changing the unit per user preference.

### Other change

- This PR also renames the attributes from "correction" to "offset" to match other quirks. If you were previously using the custom quirks, you might need to delete the old/stale entities.
- The `ThirdRealityTemperatureAndHumidityCluster` cluster class is also renamed to `ThirdRealityCluster`. Both names aren't ideal, but this is a pure manufacturer/private cluster. The latter is at least much shorter.

## Additional information

Follow-up to (PRs which added both Celsius and Fahrenheit offset):
- https://github.com/zigpy/zha-device-handlers/pull/4387 (initial PR for non-LCD sensor)
- https://github.com/zigpy/zha-device-handlers/pull/4386 (initial PR for LCD sensor)
- https://github.com/zigpy/zha-device-handlers/pull/4441 (PR combining above quirks)

Related (soil sensor with similar offset attributes):
- https://github.com/zigpy/zha-device-handlers/pull/4380

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
