### PR TITLE
Add support for HOBEIAN ZG-223Z rain sensor

### DIFF
--- a/tests/test_tuya_rain_zg223z.py
+++ b/tests/test_tuya_rain_zg223z.py
@@ -1,0 +1,41 @@
+"""Test for Tuya ZG-223Z rain sensor."""
+
+import pytest
+from zigpy.zcl.clusters.security import IasZone
+
+from tests.common import ClusterListener
+import zhaquirks
+
+zhaquirks.setup()
+
+
+# DP 1: Rain detection (0 = no rain, 1 = raining)
+ZCL_TUYA_RAIN_NONE = b"\t\x00\x02\x00\x00\x01\x04\x00\x01\x00"  # DP 1, value 0
+ZCL_TUYA_RAIN_DETECTED = b"\t\x00\x02\x00\x00\x01\x04\x00\x01\x01"  # DP 1, value 1
+
+
+@pytest.mark.parametrize(
+    "frame, rain_detected",
+    [
+        (ZCL_TUYA_RAIN_NONE, False),
+        (ZCL_TUYA_RAIN_DETECTED, True),
+    ],
+)
+async def test_zg223z_rain_sensor_state_report(
+    zigpy_device_from_v2_quirk, frame, rain_detected
+):
+    """Test HOBEIAN ZG-223Z rain sensor state reporting."""
+
+    rain_dev = zigpy_device_from_v2_quirk("_TZE200_jsaqgakf", "TS0601")
+    tuya_cluster = rain_dev.endpoints[1].tuya_manufacturer
+    ias_listener = ClusterListener(rain_dev.endpoints[1].ias_zone)
+
+    hdr, args = tuya_cluster.deserialize(frame)
+    tuya_cluster.handle_message(hdr, args)
+
+    assert len(ias_listener.cluster_commands) == 0
+    assert len(ias_listener.attribute_updates) == 1
+    assert ias_listener.attribute_updates[0][0] == IasZone.AttributeDefs.zone_status.id
+    assert ias_listener.attribute_updates[0][1] == (
+        IasZone.ZoneStatus.Alarm_1 if rain_detected else 0
+    )

--- a/zhaquirks/tuya/tuya_rain.py
+++ b/zhaquirks/tuya/tuya_rain.py
@@ -1,6 +1,11 @@
 """Quirk for TS0207 rain sensors."""
 
-from zigpy.quirks.v2.homeassistant import LIGHT_LUX, EntityType, UnitOfElectricPotential
+from zigpy.quirks.v2.homeassistant import (
+    LIGHT_LUX,
+    EntityType,
+    UnitOfElectricPotential,
+    UnitOfTime,
+)
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
@@ -83,6 +88,47 @@ class TuyaIasZone(IasZone, TuyaLocalCluster):
         entity_type=EntityType.STANDARD,
         fallback_name="Rain intensity",
     )
+    .adds(TuyaIasZone)
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+# HOBEIAN ZG-223Z Rainwater detection sensor
+(
+    TuyaQuirkBuilder("_TZE200_jsaqgakf", "TS0601")
+    .applies_to("HOBEIAN", "ZG-223Z")
+    .applies_to("_TZE200_u6x1zyv2", "TS0601")
+    .applies_to("_TZE200_2pddnnrk", "TS0601")
+    .tuya_ias(
+        dp_id=1,
+        ias_cfg=TuyaIasZone,
+        converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 1 else 0,
+    )
+    .tuya_number(
+        dp_id=2,
+        attribute_name="sensitivity",
+        type=t.uint8_t,
+        min_value=0,
+        max_value=9,
+        step=1,
+        unit="x",
+        translation_key="sensitivity",
+        fallback_name="Sensitivity",
+    )
+    .tuya_number(
+        dp_id=101,
+        attribute_name="illuminance_sampling",
+        type=t.uint16_t,
+        min_value=1,
+        max_value=480,
+        step=1,
+        unit=UnitOfTime.MINUTES,
+        translation_key="illuminance_sampling",
+        fallback_name="Illuminance sampling",
+    )
+    .tuya_illuminance(dp_id=102)
+    .tuya_battery(dp_id=104)
     .adds(TuyaIasZone)
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
## Proposed change

Add support for HOBEIAN ZG-223Z rain sensor. Based on zigbee-herdsman-converters. Includes manufacturer variants: _TZE200_jsaqgakf, _TZE200_u6x1zyv2, _TZE200_2pddnnrk.

## Additional information

The quirk has been tested and is working in my Home Assistant instance.

## Device diagnostics

<details>
<summary>Device diagnostics</summary>

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Container",
    "version": "2025.11.0b1",
    "dev": false,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.13.9",
    "docker": true,
    "arch": "x86_64",
    "timezone": "Europe/Stockholm",
    "os_name": "Linux",
    "os_version": "6.8.0-87-generic",
    "container_arch": "amd64",
    "run_as_root": true
  },
  "custom_components": {
    "ui_lovelace_minimalist": {
      "documentation": "https://ui-lovelace-minimalist.github.io/UI/",
      "version": "v1.3.18",
      "requirements": [
        "aiofiles>=0.8.0",
        "aiogithubapi>=22.2.4"
      ]
    },
    "robovac": {
      "documentation": "https://github.com/codefoodpixels/robovac",
      "version": "1.0.0",
      "requirements": []
    },
    "config_editor": {
      "documentation": "https://github.com/junkfix/config-editor-card",
      "version": "5.0.0",
      "requirements": []
    },
    "hacs": {
      "documentation": "https://hacs.xyz/docs/use/",
      "version": "2.0.5",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    },
    "zha_toolkit": {
      "documentation": "https://github.com/mdeweerd/zha-toolkit",
      "version": "v1.1.33",
      "requirements": [
        "aiofiles>=0.4.0",
        "pytz>=2016.10"
      ]
    },
    "battery_notes": {
      "documentation": "https://andrew-codechimp.github.io/HA-Battery-Notes/",
      "version": "2.10.11",
      "requirements": []
    },
    "dreame_mower": {
      "documentation": "https://github.com/bhuebschen/dreame-mower",
      "version": "v0.0.5-alpha",
      "requirements": [
        "pillow",
        "numpy",
        "pybase64",
        "requests",
        "pycryptodome",
        "python-miio",
        "py-mini-racer",
        "paho-mqtt"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher"
    ],
    "requirements": [
      "zha==0.0.75"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.00012152899580541998
    },
    "455cfe4e2604a064ef8627b550b9112a": {
      "wait_import_platforms": -0.04668556299293414,
      "wait_base_component": -0.0003402639995329082,
      "config_entry_setup": 17.03706832099124
    }
  },
  "data": {
    "version": 1,
    "ieee": "**REDACTED**",
    "nwk": "0x137F",
    "manufacturer": "HOBEIAN",
    "model": "ZG-223Z",
    "friendly_manufacturer": "HOBEIAN",
    "friendly_model": "ZG-223Z",
    "name": "HOBEIAN ZG-223Z",
    "quirk_applied": true,
    "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
    "quirk_id": null,
    "manufacturer_code": 4742,
    "power_source": "Battery or Unknown",
    "lqi": 120,
    "rssi": -70,
    "last_seen": "2025-10-31T15:47:43.113778+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4742,
      "maximum_buffer_size": 66,
      "maximum_incoming_transfer_size": 66,
      "server_mask": 10752,
      "maximum_outgoing_transfer_size": 66,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "IAS_ZONE",
          "id": 1026
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "HOBEIAN"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "ZG-223Z"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "zcl_type": "uint8",
                "value": 200
              },
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "value": 2
              },
              {
                "id": "0x0034",
                "name": "battery_rated_voltage",
                "zcl_type": "uint8",
                "value": 15
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "value": 3
              },
              {
                "id": "0x0020",
                "name": "battery_voltage",
                "zcl_type": "uint8",
                "value": 30
              }
            ]
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0400",
            "endpoint_attribute": "illuminance",
            "attributes": [
              {
                "id": "0x0004",
                "name": "light_sensor_type",
                "zcl_type": "enum8",
                "value": 0
              },
              {
                "id": "0x0000",
                "name": "measured_value",
                "zcl_type": "uint16",
                "value": 21983
              }
            ]
          },
          {
            "cluster_id": "0x0500",
            "endpoint_attribute": "ias_zone",
            "attributes": [
              {
                "id": "0x0010",
                "name": "cie_addr",
                "zcl_type": "EUI64",
                "value": "2c:11:65:ff:fe:86:e1:a8"
              },
              {
                "id": "0x0000",
                "name": "zone_state",
                "zcl_type": "enum8",
                "value": 1
              },
              {
                "id": "0x0002",
                "name": "zone_status",
                "zcl_type": "map16",
                "value": 0
              },
              {
                "id": "0x0001",
                "name": "zone_type",
                "zcl_type": "enum16",
                "value": 42
              }
            ]
          },
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": "tuya_manufacturer",
            "attributes": [
              {
                "id": "0xef02",
                "name": "sensitivity",
                "zcl_type": "uint8",
                "value": 0
              }
            ]
          }
        ],
        "out_clusters": []
      }
    },
    "original_signature": {},
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "class_name": "IASZone",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "moisture",
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": true,
            "cluster_handlers": [
              {
                "class_name": "IASZoneClusterHandler",
                "generic_id": "cluster_handler_0x0500",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1280,
                  "name": "IAS Zone",
                  "type": "server"
                },
                "id": "1:0x0500",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "zone_status"
          },
          "state": {
            "class_name": "IASZone",
            "available": true,
            "state": false
          }
        }
      ],
      "button": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "button",
            "class_name": "IdentifyButton",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "identify",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "IdentifyClusterHandler",
                "generic_id": "cluster_handler_0x0003",
                "endpoint_id": 1,
                "cluster": {
                  "id": 3,
                  "name": "Identify",
                  "type": "server"
                },
                "id": "1:0x0003",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "command": "identify",
            "args": [
              5
            ],
            "kwargs": {}
          },
          "state": {
            "class_name": "IdentifyButton",
            "available": true
          }
        }
      ],
      "number": [
        {
          "info_object": {
            "fallback_name": "Illuminance sampling",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "NumberConfigurationEntity",
            "translation_key": "illuminance_sampling",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "auto",
            "native_max_value": 480,
            "native_min_value": 1,
            "native_step": 1,
            "native_unit_of_measurement": "min"
          },
          "state": {
            "class_name": "NumberConfigurationEntity",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": "Sensitivity",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "NumberConfigurationEntity",
            "translation_key": "sensitivity",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "auto",
            "native_max_value": 9,
            "native_min_value": 0,
            "native_step": 1,
            "native_unit_of_measurement": "x"
          },
          "state": {
            "class_name": "NumberConfigurationEntity",
            "available": true,
            "state": 0
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 120
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -70
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Battery",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "battery",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "PowerConfigurationClusterHandler",
                "generic_id": "cluster_handler_0x0001",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1,
                  "name": "Power Configuration",
                  "type": "server"
                },
                "id": "1:0x0001",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "battery_voltage"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": 0,
            "unit": "%"
          },
          "state": {
            "class_name": "Battery",
            "available": true,
            "state": 100.0,
            "battery_size": "AA",
            "battery_quantity": 2,
            "battery_voltage": 3.0
          },
          "extra_state_attributes": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ]
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Illuminance",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "illuminance",
            "state_class": "measurement",
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "IlluminanceMeasurementClusterHandler",
                "generic_id": "cluster_handler_0x0400",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1024,
                  "name": "Illuminance Measurement",
                  "type": "server"
                },
                "id": "1:0x0400",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "measured_value"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "lx"
          },
          "state": {
            "class_name": "Illuminance",
            "available": true,
            "state": 158
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached