### PR TITLE
Add HOBEIAN ZG-204ZV mmWave presence sensor

### DIFF
--- a/tests/test_tuya_motion.py
+++ b/tests/test_tuya_motion.py
@@ -3,6 +3,7 @@
 import asyncio
 
 import pytest
+from zigpy.types import Bool
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement, OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
@@ -20,6 +21,29 @@ ZCL_TUYA_MOTION_V5 = b"\tL\x01\x00\x05\x01\x01\x00\x01\x04"  # DP 1, motion is 0
 ZCL_TUYA_MOTION_V6 = b"\tL\x01\x00\x05\x01\x04\x00\x01\x02"  # DP 1, enum
 ZCL_TUYA_MOTION_V7 = b"\tL\x01\x00\x05\x01\x01\x00\x01\x00"  # DP 1, Inv
 ZCL_TUYA_MOTION_V8 = b"\tL\x01\x00\x05\x65\x01\x00\x01\x00"  # DP 101, Inv
+
+# ZG-204ZV configuration datapoint messages
+ZCL_ZG204ZV_SENSITIVITY = (
+    b"\tL\x01\x00\x05\x02\x02\x00\x04\x00\x00\x00\x0a"  # DP 2, sensitivity=10
+)
+ZCL_ZG204ZV_FADING_TIME = (
+    b"\tL\x01\x00\x05\x66\x02\x00\x04\x00\x00\x00\x3c"  # DP 102, fading_time=60s
+)
+ZCL_ZG204ZV_HUMIDITY_OFFSET = (
+    b"\tL\x01\x00\x05\x68\x02\x00\x04\x00\x00\x00\x05"  # DP 104, humidity_offset=5
+)
+ZCL_ZG204ZV_TEMP_OFFSET = (
+    b"\tL\x01\x00\x05\x69\x02\x00\x04\x00\x00\x00\x0a"  # DP 105, temp_offset=10 (1.0°C)
+)
+ZCL_ZG204ZV_ILLUM_INTERVAL = (
+    b"\tL\x01\x00\x05\x6b\x02\x00\x04\x00\x00\x00\x0a"  # DP 107, illum_interval=10min
+)
+ZCL_ZG204ZV_LED_ON = b"\tL\x01\x00\x05\x6c\x01\x00\x01\x01"  # DP 108, LED indicator ON
+ZCL_ZG204ZV_LED_OFF = (
+    b"\tL\x01\x00\x05\x6c\x01\x00\x01\x00"  # DP 108, LED indicator OFF
+)
+ZCL_ZG204ZV_TEMP_UNIT_C = b"\tL\x01\x00\x05\x6d\x04\x00\x01\x00"  # DP 109, Celsius
+ZCL_ZG204ZV_TEMP_UNIT_F = b"\tL\x01\x00\x05\x6d\x04\x00\x01\x01"  # DP 109, Fahrenheit
 
 
 zhaquirks.setup()
@@ -67,6 +91,11 @@ zhaquirks.setup()
         ("_TZE200_2aaelwxk", "TS0601", ZCL_TUYA_MOTION),
         ("_TZE200_kb5noeto", "TS0601", ZCL_TUYA_MOTION),
         ("_TZE204_ex3rcdha", "TS0601", ZCL_TUYA_MOTION_V8),
+        ("HOBEIAN", "ZG-204ZV", ZCL_TUYA_MOTION),
+        ("_TZE200_uli8wasj", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE200_grgol3xp", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE200_rhgsbacq", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE200_y8jijhba", "TS0601", ZCL_TUYA_MOTION),
     ],
 )
 async def test_tuya_motion_quirk_occ(zigpy_device_from_v2_quirk, model, manuf, occ_msg):
@@ -172,3 +201,111 @@ async def test_tuya_motion_quirk_enum_illum(
     assert len(illum_listener.attribute_updates) == 1
     assert illum_listener.attribute_updates[0][0] == zcl_illum_id
     assert illum_listener.attribute_updates[0][1] == exp_value
+
+
+@pytest.mark.parametrize(
+    "model,manuf",
+    [
+        ("HOBEIAN", "ZG-204ZV"),
+        ("_TZE200_uli8wasj", "TS0601"),
+        ("_TZE200_grgol3xp", "TS0601"),
+        ("_TZE200_rhgsbacq", "TS0601"),
+        ("_TZE200_y8jijhba", "TS0601"),
+    ],
+)
+async def test_zg204zv_tuya_config_datapoints(zigpy_device_from_v2_quirk, model, manuf):
+    """Test ZG-204ZV Tuya configuration datapoints.
+
+    Note: ZG-204ZV reports sensor data (battery, temperature, humidity, illuminance)
+    via standard Zigbee clusters (0x0001, 0x0402, 0x0405, 0x0400) natively.
+    This test focuses on Tuya datapoints used for occupancy detection and device
+    configuration (sensitivity, fading time, offsets, intervals, LED, temp unit).
+    """
+    quirked_device = zigpy_device_from_v2_quirk(model, manuf)
+    ep = quirked_device.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+
+    tmcu_listener = ClusterListener(ep.tuya_manufacturer)
+    assert len(tmcu_listener.attribute_updates) == 0
+
+    # Test DP 2: motion_detection_sensitivity (0-19)
+    hdr, data = ep.tuya_manufacturer.deserialize(ZCL_ZG204ZV_SENSITIVITY)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    assert ep.tuya_manufacturer.get((0xEF << 8) | 2) == 10
+    assert len(tmcu_listener.attribute_updates) == 1
+    assert tmcu_listener.attribute_updates[0][0] == (0xEF << 8) | 2
+    assert tmcu_listener.attribute_updates[0][1] == 10
+
+    # Test DP 102: fading_time (0-28800 seconds)
+    hdr, data = ep.tuya_manufacturer.deserialize(ZCL_ZG204ZV_FADING_TIME)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    assert ep.tuya_manufacturer.get((0xEF << 8) | 102) == 60
+    assert len(tmcu_listener.attribute_updates) == 2
+    assert tmcu_listener.attribute_updates[1][0] == (0xEF << 8) | 102
+    assert tmcu_listener.attribute_updates[1][1] == 60
+
+    # Test DP 104: humidity_offset (-30 to 30)
+    hdr, data = ep.tuya_manufacturer.deserialize(ZCL_ZG204ZV_HUMIDITY_OFFSET)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    assert ep.tuya_manufacturer.get((0xEF << 8) | 104) == 5
+    assert len(tmcu_listener.attribute_updates) == 3
+    assert tmcu_listener.attribute_updates[2][0] == (0xEF << 8) | 104
+    assert tmcu_listener.attribute_updates[2][1] == 5
+
+    # Test DP 105: temperature_offset (-2.0 to 2.0°C, step 0.1, multiplier 0.1)
+    hdr, data = ep.tuya_manufacturer.deserialize(ZCL_ZG204ZV_TEMP_OFFSET)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    # Device sends raw value 10, which with multiplier 0.1 = 1.0°C
+    assert ep.tuya_manufacturer.get((0xEF << 8) | 105) == 10
+    assert len(tmcu_listener.attribute_updates) == 4
+    assert tmcu_listener.attribute_updates[3][0] == (0xEF << 8) | 105
+    assert tmcu_listener.attribute_updates[3][1] == 10
+
+    # Test DP 107: illuminance_interval (1-720 minutes)
+    hdr, data = ep.tuya_manufacturer.deserialize(ZCL_ZG204ZV_ILLUM_INTERVAL)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    assert ep.tuya_manufacturer.get((0xEF << 8) | 107) == 10
+    assert len(tmcu_listener.attribute_updates) == 5
+    assert tmcu_listener.attribute_updates[4][0] == (0xEF << 8) | 107
+    assert tmcu_listener.attribute_updates[4][1] == 10
+
+    # Test DP 108: led_indicator (bool)
+    hdr, data = ep.tuya_manufacturer.deserialize(ZCL_ZG204ZV_LED_ON)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    assert ep.tuya_manufacturer.get((0xEF << 8) | 108) == 1
+    assert len(tmcu_listener.attribute_updates) == 6
+    assert tmcu_listener.attribute_updates[5][0] == (0xEF << 8) | 108
+    assert tmcu_listener.attribute_updates[5][1] == Bool.true
+
+    hdr, data = ep.tuya_manufacturer.deserialize(ZCL_ZG204ZV_LED_OFF)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    assert ep.tuya_manufacturer.get((0xEF << 8) | 108) == 0
+    assert len(tmcu_listener.attribute_updates) == 7
+    assert tmcu_listener.attribute_updates[6][0] == (0xEF << 8) | 108
+    assert tmcu_listener.attribute_updates[6][1] == Bool.false
+
+    # Test DP 109: temperature_unit_convert (enum: 0=Celsius, 1=Fahrenheit)
+    hdr, data = ep.tuya_manufacturer.deserialize(ZCL_ZG204ZV_TEMP_UNIT_C)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    assert ep.tuya_manufacturer.get((0xEF << 8) | 109) == 0
+    assert len(tmcu_listener.attribute_updates) == 8
+    assert tmcu_listener.attribute_updates[7][0] == (0xEF << 8) | 109
+    assert tmcu_listener.attribute_updates[7][1] == 0
+
+    hdr, data = ep.tuya_manufacturer.deserialize(ZCL_ZG204ZV_TEMP_UNIT_F)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    assert ep.tuya_manufacturer.get((0xEF << 8) | 109) == 1
+    assert len(tmcu_listener.attribute_updates) == 9
+    assert tmcu_listener.attribute_updates[8][0] == (0xEF << 8) | 109
+    assert tmcu_listener.attribute_updates[8][1] == 1

--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -13,6 +13,7 @@ from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks.tuya import TuyaLocalCluster
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.tuya_sensor import TuyaTempUnitConvert
 
 
 class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
@@ -1513,6 +1514,98 @@ base_tuya_motion = (
         step=1,
         translation_key="motion_detection_sensitivity",
         fallback_name="Motion detection sensitivity",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+# HOBEIAN ZG-204ZV, 10GHz mmWave presence sensor with temp/humidity/illuminance
+# Sensor data (battery, temperature, humidity, illuminance) reported via standard
+# Zigbee clusters (0x0001, 0x0402, 0x0405, 0x0400) by the device itself
+# Tuya datapoints used for: occupancy detection (DP 1) and device configuration
+# (sensitivity, fading time, sensor offsets, illuminance interval, LED, temp unit)
+(
+    TuyaQuirkBuilder("HOBEIAN", "ZG-204ZV")
+    .applies_to("_TZE200_uli8wasj", "TS0601")
+    .applies_to("_TZE200_grgol3xp", "TS0601")
+    .applies_to("_TZE200_rhgsbacq", "TS0601")
+    .applies_to("_TZE200_y8jijhba", "TS0601")
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=TuyaOccupancySensing.ep_attribute,
+        attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
+        converter=lambda x: x == 1,
+    )
+    .adds(TuyaOccupancySensing)
+    .tuya_number(
+        dp_id=2,
+        attribute_name="motion_detection_sensitivity",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=19,
+        step=1,
+        translation_key="motion_detection_sensitivity",
+        fallback_name="Motion detection sensitivity",
+    )
+    .tuya_number(
+        dp_id=102,
+        attribute_name="fading_time",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        min_value=0,
+        max_value=28800,
+        step=1,
+        translation_key="fading_time",
+        fallback_name="Motion keep time",
+    )
+    .tuya_number(
+        dp_id=104,
+        attribute_name="humidity_offset",
+        type=t.int16s,
+        min_value=-30,
+        max_value=30,
+        step=1,
+        translation_key="humidity_offset",
+        fallback_name="Humidity offset",
+    )
+    .tuya_number(
+        dp_id=105,
+        attribute_name="temperature_offset",
+        type=t.int16s,
+        min_value=-2,
+        max_value=2,
+        step=0.1,
+        multiplier=0.1,
+        translation_key="temperature_offset",
+        fallback_name="Temperature offset",
+    )
+    .tuya_number(
+        dp_id=107,
+        attribute_name="illuminance_interval",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.MINUTES,
+        min_value=1,
+        max_value=720,
+        step=1,
+        translation_key="illuminance_interval",
+        fallback_name="Illuminance interval",
+    )
+    .tuya_switch(
+        dp_id=108,
+        attribute_name="led_indicator",
+        entity_type=EntityType.STANDARD,
+        translation_key="led_indicator",
+        fallback_name="LED indicator",
+    )
+    .tuya_enum(
+        dp_id=109,
+        attribute_name="temperature_unit_convert",
+        enum_class=TuyaTempUnitConvert,
+        translation_key="temperature_unit_convert",
+        fallback_name="Temperature unit",
     )
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
## Proposed change
Add support for HOBEIAN ZG-204ZV 10GHz mmWave presence sensor with temperature, humidity, and illuminance sensors.

## Additional information
Additional supported manufacturers:
- _TZE200_uli8wasj
- _TZE200_grgol3xp
- _TZE200_rhgsbacq
- _TZE200_y8jijhba

Configuration options:
- Motion detection sensitivity (0-19)
- Motion keep time / fading time (0-28800 seconds)
- Temperature offset calibration (-2 to 2°C, step 0.1)
- Humidity offset calibration (-30 to 30%)
- Illuminance interval (1-720 minutes)
- LED indicator (on/off)
- Temperature unit (Celsius/Fahrenheit)

Environmental sensors (temperature, humidity, illuminance) report via standard Zigbee clusters. Occupancy detection and configuration settings use Tuya datapoints.

Implementation matches Z2M converter for this device.

Fixes #4268

## Device diagnostics

<details>
<summary>Device diagnostics JSON</summary>

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Container",
    "version": "2025.11.0b1",
    "dev": false,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.13.9",
    "docker": true,
    "arch": "x86_64",
    "timezone": "Europe/Stockholm",
    "os_name": "Linux",
    "os_version": "6.8.0-87-generic",
    "container_arch": "amd64",
    "run_as_root": true
  },
  "custom_components": {
    "ui_lovelace_minimalist": {
      "documentation": "https://ui-lovelace-minimalist.github.io/UI/",
      "version": "v1.3.18",
      "requirements": [
        "aiofiles>=0.8.0",
        "aiogithubapi>=22.2.4"
      ]
    },
    "robovac": {
      "documentation": "https://github.com/codefoodpixels/robovac",
      "version": "1.0.0",
      "requirements": []
    },
    "config_editor": {
      "documentation": "https://github.com/junkfix/config-editor-card",
      "version": "5.0.0",
      "requirements": []
    },
    "hacs": {
      "documentation": "https://hacs.xyz/docs/use/",
      "version": "2.0.5",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    },
    "zha_toolkit": {
      "documentation": "https://github.com/mdeweerd/zha-toolkit",
      "version": "v1.1.33",
      "requirements": [
        "aiofiles>=0.4.0",
        "pytz>=2016.10"
      ]
    },
    "battery_notes": {
      "documentation": "https://andrew-codechimp.github.io/HA-Battery-Notes/",
      "version": "2.10.11",
      "requirements": []
    },
    "dreame_mower": {
      "documentation": "https://github.com/bhuebschen/dreame-mower",
      "version": "v0.0.5-alpha",
      "requirements": [
        "pillow",
        "numpy",
        "pybase64",
        "requests",
        "pycryptodome",
        "python-miio",
        "py-mini-racer",
        "paho-mqtt"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher"
    ],
    "requirements": [
      "zha==0.0.75"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.00010930598364211619
    },
    "455cfe4e2604a064ef8627b550b9112a": {
      "wait_import_platforms": -0.36058925901306793,
      "wait_base_component": -0.0003673690080177039,
      "config_entry_setup": 17.58184719501878
    }
  },
  "data": {
    "version": 1,
    "ieee": "**REDACTED**",
    "nwk": "0x242D",
    "manufacturer": "HOBEIAN",
    "model": "ZG-204ZV",
    "friendly_manufacturer": "HOBEIAN",
    "friendly_model": "ZG-204ZV",
    "name": "HOBEIAN ZG-204ZV",
    "quirk_applied": true,
    "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
    "quirk_id": null,
    "manufacturer_code": 4742,
    "power_source": "Battery or Unknown",
    "lqi": 100,
    "rssi": -75,
    "last_seen": "2025-11-01T19:35:36.877617+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4742,
      "maximum_buffer_size": 66,
      "maximum_incoming_transfer_size": 66,
      "server_mask": 10752,
      "maximum_outgoing_transfer_size": 66,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "IAS_ZONE",
          "id": 1026
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "HOBEIAN"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "ZG-204ZV"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": []
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0400",
            "endpoint_attribute": "illuminance",
            "attributes": [
              {
                "id": "0x0000",
                "name": "measured_value",
                "zcl_type": "uint16",
                "value": 1
              }
            ]
          },
          {
            "cluster_id": "0x0402",
            "endpoint_attribute": "temperature",
            "attributes": [
              {
                "id": "0x0000",
                "name": "measured_value",
                "zcl_type": "int16",
                "value": 2470
              }
            ]
          },
          {
            "cluster_id": "0x0405",
            "endpoint_attribute": "humidity",
            "attributes": [
              {
                "id": "0x0000",
                "name": "measured_value",
                "zcl_type": "uint16",
                "value": 3740
              }
            ]
          },
          {
            "cluster_id": "0x0406",
            "endpoint_attribute": "occupancy",
            "attributes": [
              {
                "id": "0x0000",
                "name": "occupancy",
                "zcl_type": "map8",
                "value": true
              }
            ]
          },
          {
            "cluster_id": "0x0500",
            "endpoint_attribute": "ias_zone",
            "attributes": [
              {
                "id": "0x0002",
                "name": "zone_status",
                "zcl_type": "map16",
                "value": 1
              },
              {
                "id": "0x0001",
                "name": "zone_type",
                "zcl_type": "enum16",
                "value": 13
              }
            ]
          },
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": "tuya_manufacturer",
            "attributes": [
              {
                "id": "0xef66",
                "name": "fading_time",
                "zcl_type": "uint16",
                "value": 30
              },
              {
                "id": "0xef68",
                "name": "humidity_offset",
                "zcl_type": "int16",
                "value": 0
              },
              {
                "id": "0xef6b",
                "name": "illuminance_interval",
                "zcl_type": "uint16",
                "value": 2
              },
              {
                "id": "0xef6c",
                "name": "led_indicator",
                "zcl_type": "bool",
                "value": 0
              },
              {
                "id": "0xef02",
                "name": "motion_detection_sensitivity",
                "zcl_type": "uint16",
                "value": 10
              },
              {
                "id": "0xef69",
                "name": "temperature_offset",
                "zcl_type": "int16",
                "value": 0
              },
              {
                "id": "0xef6d",
                "name": "temperature_unit_convert",
                "zcl_type": "enum8",
                "value": 0
              }
            ]
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          }
        ]
      }
    },
    "original_signature": {},
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "class_name": "Occupancy",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "occupancy",
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OccupancySensingClusterHandler",
                "generic_id": "cluster_handler_0x0406",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1030,
                  "name": "Occupancy Sensing",
                  "type": "server"
                },
                "id": "1:0x0406",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "occupancy"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "occupancy"
          },
          "state": {
            "class_name": "Occupancy",
            "available": true,
            "state": true
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "class_name": "IASZone",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "motion",
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": true,
            "cluster_handlers": [
              {
                "class_name": "IASZoneClusterHandler",
                "generic_id": "cluster_handler_0x0500",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1280,
                  "name": "IAS Zone",
                  "type": "server"
                },
                "id": "1:0x0500",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "zone_status"
          },
          "state": {
            "class_name": "IASZone",
            "available": true,
            "state": true
          }
        }
      ],
      "button": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "button",
            "class_name": "IdentifyButton",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "identify",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "IdentifyClusterHandler",
                "generic_id": "cluster_handler_0x0003",
                "endpoint_id": 1,
                "cluster": {
                  "id": 3,
                  "name": "Identify",
                  "type": "server"
                },
                "id": "1:0x0003",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "command": "identify",
            "args": [
              5
            ],
            "kwargs": {}
          },
          "state": {
            "class_name": "IdentifyButton",
            "available": true
          }
        }
      ],
      "number": [
        {
          "info_object": {
            "fallback_name": "Motion keep time",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "NumberConfigurationEntity",
            "translation_key": "fading_time",
            "translation_placeholders": null,
            "device_class": "duration",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "auto",
            "native_max_value": 28800,
            "native_min_value": 0,
            "native_step": 1,
            "native_unit_of_measurement": "s"
          },
          "state": {
            "class_name": "NumberConfigurationEntity",
            "available": true,
            "state": 30
          }
        },
        {
          "info_object": {
            "fallback_name": "Humidity offset",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "NumberConfigurationEntity",
            "translation_key": "humidity_offset",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "auto",
            "native_max_value": 30,
            "native_min_value": -30,
            "native_step": 1,
            "native_unit_of_measurement": null
          },
          "state": {
            "class_name": "NumberConfigurationEntity",
            "available": true,
            "state": 0
          }
        },
        {
          "info_object": {
            "fallback_name": "Illuminance interval",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "NumberConfigurationEntity",
            "translation_key": "illuminance_interval",
            "translation_placeholders": null,
            "device_class": "duration",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "auto",
            "native_max_value": 720,
            "native_min_value": 1,
            "native_step": 1,
            "native_unit_of_measurement": "min"
          },
          "state": {
            "class_name": "NumberConfigurationEntity",
            "available": true,
            "state": 2
          }
        },
        {
          "info_object": {
            "fallback_name": "Motion detection sensitivity",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "NumberConfigurationEntity",
            "translation_key": "motion_detection_sensitivity",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "auto",
            "native_max_value": 19,
            "native_min_value": 0,
            "native_step": 1,
            "native_unit_of_measurement": null
          },
          "state": {
            "class_name": "NumberConfigurationEntity",
            "available": true,
            "state": 10
          }
        },
        {
          "info_object": {
            "fallback_name": "Temperature offset",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "NumberConfigurationEntity",
            "translation_key": "temperature_offset",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "auto",
            "native_max_value": 2,
            "native_min_value": -2,
            "native_step": 0.1,
            "native_unit_of_measurement": null
          },
          "state": {
            "class_name": "NumberConfigurationEntity",
            "available": true,
            "state": 0.0
          }
        }
      ],
      "select": [
        {
          "info_object": {
            "fallback_name": "Temperature unit",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "select",
            "class_name": "ZCLEnumSelectEntity",
            "translation_key": "temperature_unit_convert",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "enum": "TuyaTempUnitConvert",
            "options": [
              "Celsius",
              "Fahrenheit"
            ]
          },
          "state": {
            "class_name": "ZCLEnumSelectEntity",
            "available": true,
            "state": "Celsius"
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 100
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -75
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Battery",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "battery",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "PowerConfigurationClusterHandler",
                "generic_id": "cluster_handler_0x0001",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1,
                  "name": "Power Configuration",
                  "type": "server"
                },
                "id": "1:0x0001",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "battery_voltage"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": 0,
            "unit": "%"
          },
          "state": {
            "class_name": "Battery",
            "available": true,
            "state": null
          },
          "extra_state_attributes": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ]
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Illuminance",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "illuminance",
            "state_class": "measurement",
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "IlluminanceMeasurementClusterHandler",
                "generic_id": "cluster_handler_0x0400",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1024,
                  "name": "Illuminance Measurement",
                  "type": "server"
                },
                "id": "1:0x0400",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "measured_value"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "lx"
          },
          "state": {
            "class_name": "Illuminance",
            "available": true,
            "state": 1
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Temperature",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "temperature",
            "state_class": "measurement",
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TemperatureMeasurementClusterHandler",
                "generic_id": "cluster_handler_0x0402",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1026,
                  "name": "Temperature Measurement",
                  "type": "server"
                },
                "id": "1:0x0402",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "measured_value"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "\u00b0C"
          },
          "state": {
            "class_name": "Temperature",
            "available": true,
            "state": 24.7
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Humidity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "humidity",
            "state_class": "measurement",
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "RelativeHumidityClusterHandler",
                "generic_id": "cluster_handler_0x0405",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1029,
                  "name": "Relative Humidity Measurement",
                  "type": "server"
                },
                "id": "1:0x0405",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "measured_value"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "%"
          },
          "state": {
            "class_name": "Humidity",
            "available": true,
            "state": 37.4
          }
        }
      ],
      "switch": [
        {
          "info_object": {
            "fallback_name": "LED indicator",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "switch",
            "class_name": "ConfigurableAttributeSwitch",
            "translation_key": "led_indicator",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "led_indicator",
            "invert_attribute_name": null,
            "force_inverted": false,
            "off_value": 0,
            "on_value": 1
          },
          "state": {
            "class_name": "ConfigurableAttributeSwitch",
            "available": true,
            "state": false,
            "inverted": false
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```

</details>

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass with `pytest tests` for the affected device. (`pytest tests/test_tuya_motion.py`)
- [x] Tests added/updated for the changes.
- [x] Device diagnostics attached.