### PR TITLE
Add Tuya motion sensor `_TZE204_gkfbdvyx` variant

### DIFF
--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -237,6 +237,7 @@ base_tuya_motion = (
 (
     base_tuya_motion.clone()
     .applies_to("_TZE200_gkfbdvyx", "TS0601")
+    .applies_to("_TZE204_gkfbdvyx", "TS0601")
     .applies_to("_TZE200_ya4ft0w4", "TS0601")
     .applies_to("_TZE204_ya4ft0w4", "TS0601")
     .tuya_dp(


### PR DESCRIPTION
## Proposed change
Adding support for Tuya motion sensor with new id.

## Additional information
The device doesn't work without this quirk only basic TS0601 data is present(RSSI and LQI)

## Device diagnostics
[zha-84de84c4c581406832f80710b0c58ba8-_TZE204_gkfbdvyx TS0601-e09f6967a8dc5214c3cc2caddb5d3fb2.json](https://github.com/user-attachments/files/23454254/zha-84de84c4c581406832f80710b0c58ba8-_TZE204_gkfbdvyx.TS0601-e09f6967a8dc5214c3cc2caddb5d3fb2.json)

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
