### PR TITLE
Expose Frient EMI LED reset current summation button

### DIFF
--- a/zhaquirks/develco/emi_led.py
+++ b/zhaquirks/develco/emi_led.py
@@ -28,6 +28,7 @@ class ManufacturerMetering(CustomCluster):
         current_summation: Final = ZCLAttributeDef(
             id=0x0301,
             type=t.uint48_t,
+            access="r",
             is_manufacturer_specific=True,
         )
 

--- a/zhaquirks/develco/emi_led.py
+++ b/zhaquirks/develco/emi_led.py
@@ -28,7 +28,7 @@ class ManufacturerMetering(CustomCluster):
         current_summation: Final = ZCLAttributeDef(
             id=0x0301,
             type=t.uint48_t,
-            access="r",
+            access="w",
             is_manufacturer_specific=True,
         )
 

--- a/zhaquirks/develco/emi_led.py
+++ b/zhaquirks/develco/emi_led.py
@@ -48,5 +48,13 @@ class ManufacturerMetering(CustomCluster):
         translation_key="pulse_configuration",
         fallback_name="Pulse configuration",
     )
+    .write_attr_button(
+        attribute_name=ManufacturerMetering.AttributeDefs.current_summation.name,
+        attribute_value=0,
+        cluster_id=ManufacturerMetering.cluster_id,
+        endpoint_id=2,
+        translation_key="reset_summation_delivered",
+        fallback_name="Reset summation delivered",
+    )
     .add_to_registry()
 )

--- a/zhaquirks/develco/emi_led.py
+++ b/zhaquirks/develco/emi_led.py
@@ -25,6 +25,11 @@ class ManufacturerMetering(CustomCluster):
             type=t.uint16_t,
             is_manufacturer_specific=True,
         )
+        current_summation: Final = ZCLAttributeDef(
+            id=0x0301,
+            type=t.uint48_t,
+            is_manufacturer_specific=True,
+        )
 
 
 (


### PR DESCRIPTION
## Proposed change

This exposes the Frient manufacturer-specific `current_summation` attribute.
A write attribute button is also added to easily reset this to `0`.  This is what the user will see.

## Additional information

There will be no number entity to change the value, as the attribute is write-only and we'd duplicate some functionality we have in the sensor.

Advanced users can still set the `current_summation` to a value they want via the debug UI or a service action call.

## Device diagnostics


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
