### PR TITLE
Fix Frient air quality sensor VOC device class

### DIFF
--- a/zhaquirks/develco/air_quality.py
+++ b/zhaquirks/develco/air_quality.py
@@ -72,7 +72,7 @@ class DevelcoVOCMeasurement(CustomCluster):
         attribute_name=DevelcoVOCMeasurement.AttributeDefs.measured_value.name,
         cluster_id=DevelcoVOCMeasurement.cluster_id,
         endpoint_id=38,
-        device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
+        device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
         state_class=SensorStateClass.MEASUREMENT,
         unit=CONCENTRATION_PARTS_PER_BILLION,
         fallback_name="VOC level",


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Use "VOC parts" device class, not "VOC", for Frient AQ sensor.
Frient air quality sensors report VOC as a concentration, not as a density.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
See https://github.com/home-assistant/core/issues/156444 and https://github.com/home-assistant/core/issues/155785


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
Already present in the ZHA tests.


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
