### PR TITLE
Fix tamper sensor showing for wrong Frient entry sensors

### DIFF
--- a/zhaquirks/develco/open_close.py
+++ b/zhaquirks/develco/open_close.py
@@ -24,20 +24,20 @@ base_quirk = (
     .prevent_default_entity_creation(endpoint_id=35, cluster_id=BinaryInput.cluster_id)
 )
 
-# Entry Sensor 2 Pro + Entry Sensor (basic), no tamper
+# Entry Sensor 2 Pro, no tamper
 (
     base_quirk.clone()
     .applies_to("frient A/S", "WISZB-131")
-    .applies_to("Develco Products A/S", "WISZB-121")
-    .applies_to("frient A/S", "WISZB-121")
     .add_to_registry()
 )
 
-# Entry Sensor Pro, with tamper
+# Entry Sensor Pro + Entry Sensor (basic), with tamper
 (
     base_quirk.clone()
     .applies_to("Develco Products A/S", "WISZB-120")
     .applies_to("frient A/S", "WISZB-120")
+    .applies_to("Develco Products A/S", "WISZB-121")
+    .applies_to("frient A/S", "WISZB-121")
     .binary_sensor(
         endpoint_id=35,
         cluster_id=IasZone.cluster_id,

--- a/zhaquirks/develco/open_close.py
+++ b/zhaquirks/develco/open_close.py
@@ -16,16 +16,28 @@ class DevelcoPowerConfiguration(PowerConfigurationCluster):
     MAX_VOLTS = 3.0
 
 
-(
-    QuirkBuilder("frient A/S", "WISZB-131")
-    .applies_to("Develco Products A/S", "WISZB-120")
-    .applies_to("frient A/S", "WISZB-120")
-    .applies_to("Develco Products A/S", "WISZB-121")
-    .applies_to("frient A/S", "WISZB-121")
+base_quirk = (
+    QuirkBuilder()
     .replaces(DevelcoIasZone, endpoint_id=35)
     .replaces(DevelcoPowerConfiguration, endpoint_id=35)
     # The binary input cluster is a duplicate
     .prevent_default_entity_creation(endpoint_id=35, cluster_id=BinaryInput.cluster_id)
+)
+
+# Entry Sensor 2 Pro + Entry Sensor (basic), no tamper
+(
+    base_quirk.clone()
+    .applies_to("frient A/S", "WISZB-131")
+    .applies_to("Develco Products A/S", "WISZB-121")
+    .applies_to("frient A/S", "WISZB-121")
+    .add_to_registry()
+)
+
+# Entry Sensor Pro, with tamper
+(
+    base_quirk.clone()
+    .applies_to("Develco Products A/S", "WISZB-120")
+    .applies_to("frient A/S", "WISZB-120")
     .binary_sensor(
         endpoint_id=35,
         cluster_id=IasZone.cluster_id,

--- a/zhaquirks/develco/open_close.py
+++ b/zhaquirks/develco/open_close.py
@@ -25,7 +25,11 @@ base_quirk = (
 )
 
 # Entry Sensor 2 Pro, no tamper
-(base_quirk.clone().applies_to("frient A/S", "WISZB-131").add_to_registry())
+(
+    base_quirk.clone()
+    .applies_to("frient A/S", "WISZB-131")
+    .add_to_registry()
+)  # fmt: skip
 
 # Entry Sensor Pro + Entry Sensor (basic), with tamper
 (

--- a/zhaquirks/develco/open_close.py
+++ b/zhaquirks/develco/open_close.py
@@ -25,11 +25,7 @@ base_quirk = (
 )
 
 # Entry Sensor 2 Pro, no tamper
-(
-    base_quirk.clone()
-    .applies_to("frient A/S", "WISZB-131")
-    .add_to_registry()
-)
+(base_quirk.clone().applies_to("frient A/S", "WISZB-131").add_to_registry())
 
 # Entry Sensor Pro + Entry Sensor (basic), with tamper
 (


### PR DESCRIPTION
## Proposed change

This fixes an issue where the binary tamper sensor is shown for the Frient Entry Sensor 2 Pro and Entry Sensor (basic) which both do not support the tamper sensor according to specifications.
It's only supported by the 1st Gen Frient Entry Sensor Pro.

## Additional information

Follow-up to:
- https://github.com/zigpy/zha-device-handlers/pull/4246


## Device diagnostics

Should already be in ZHA diagnostics. ~~I don't have the devices anyway.~~ -> I have the Entry Sensor 2 Pro now.

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
