### PR TITLE
Add Eco-Dim.05 Zigbee dimmer variant

### DIFF
--- a/zhaquirks/hzc/doubledimmerswitch.py
+++ b/zhaquirks/hzc/doubledimmerswitch.py
@@ -18,3 +18,9 @@ class HzcOnOff(NoReplyMixin, CustomCluster, OnOff):
     .replace_cluster_occurrences(HzcOnOff, replace_client_instances=False)
     .add_to_registry()
 )
+
+(
+    QuirkBuilder("EcoDim BV", "Eco-Dim.05 Zigbee")
+    .replace_cluster_occurrences(HzcOnOff, replace_client_instances=False)
+    .add_to_registry()
+)

--- a/zhaquirks/hzc/doubledimmerswitch.py
+++ b/zhaquirks/hzc/doubledimmerswitch.py
@@ -15,12 +15,7 @@ class HzcOnOff(NoReplyMixin, CustomCluster, OnOff):
 
 (
     QuirkBuilder("EcoDim BV", "EcoDim-Zigbee 3.0")
-    .replace_cluster_occurrences(HzcOnOff, replace_client_instances=False)
-    .add_to_registry()
-)
-
-(
-    QuirkBuilder("EcoDim BV", "Eco-Dim.05 Zigbee")
+    .applies_to("EcoDim BV", "Eco-Dim.05 Zigbee")
     .replace_cluster_occurrences(HzcOnOff, replace_client_instances=False)
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
This adds support for a dimmer with a different identifier (Eco-Dim.05 Zigbee).


## Additional information
Fixes: #4369 

## Device diagnostics
Is this really needed?

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
