### PR TITLE
Add Tuya TRV `_TZE200_4utwozi2` variant

### DIFF
--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -408,6 +408,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     .applies_to("_TZE204_o3x45p96", "TS0601")
     .applies_to("_TZE204_ogx8u5z6", "TS0601")
     .applies_to("_TZE284_ogx8u5z6", "TS0601")
+    .applies_to("_TZE200_4utwozi2", "TS0601")
     .tuya_dp(
         dp_id=2,
         ep_attribute=TuyaThermostatV2.ep_attribute,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This adds `_TZE200_4utwozi2` as an alias for the existing Tuya TS0601 TRV quirk.
The device follows the same DP mapping as the already-supported variants and only requires adding the fingerprint.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Tested locally in a Home Assistant venv; the quirk attaches correctly and the climate entity, setpoint control, and temperature reporting all work as expected.

Fixes #4493

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-31966677aaa64b009b2607fd9d7c2691-_TZE200_4utwozi2 TS0601-838112376b92a6b61f2ae0b591ee2790.json](https://github.com/user-attachments/files/23565699/zha-31966677aaa64b009b2607fd9d7c2691-_TZE200_4utwozi2.TS0601-838112376b92a6b61f2ae0b591ee2790.json)


## Checklist
<!--

  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
