### PR TITLE
Add devcontainer configuration for zha-device-handlers project

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install common build dependencies required for compiling Python packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libffi-dev \
+        libssl-dev \
+        cargo \
+        git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip/setuptools to a modern version
+RUN python3 -m pip install --upgrade pip setuptools wheel
+
+USER vscode
+
+WORKDIR /workspaces/zha-device-handlers

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,32 @@
+# Devcontainer for `zha-device-handlers`
+
+This folder contains the VS Code Dev Container configuration for this repository.
+Using the devcontainer is optional, but it is a convenient way to get a consistent setup quickly.
+
+## Why use it
+
+- Fast onboarding for new contributors
+- Isolated environment (keeps your host setup clean)
+- Same base tooling across machines and Codespaces
+
+## Quick start
+
+1. Open this repository in VS Code.
+2. Click "Reopen in Container" when VS Code prompts you.
+3. Wait until container creation and `postCreateCommand` finish.
+4. Start working.
+
+## What happens automatically
+
+- Base image: `mcr.microsoft.com/devcontainers/python:1-3.12`
+- Workspace path: `/workspaces/zha-device-handlers`
+- Initial setup command: `bash script/setup`
+
+If setup fails, run `bash script/setup` manually in the container terminal.
+
+## Project docs
+
+For day-to-day commands and contribution guidance, please use:
+
+- Main contributor docs: [../README.md](../README.md)
+- Agent-specific guidance: [../AGENTS.md](../AGENTS.md)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "zha-device-handlers (Dev)",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  },
+  "postCreateCommand": "bash script/setup",
+  "remoteUser": "vscode",
+  "workspaceFolder": "/workspaces/zha-device-handlers",
+  "containerEnv": {
+    "PIP_NO_CACHE_DIR": "off",
+    "DEBIAN_FRONTEND": "noninteractive"
+  }
+}


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Add a VS Code devcontainer configuration for `zha-device-handlers` to make local development and testing easier and more reproducible:

- Add a `.devcontainer/Dockerfile` based on `mcr.microsoft.com/devcontainers/python:1-3.12` with common build dependencies for Python packages.
- Add `.devcontainer/devcontainer.json` to configure the workspace, recommended extensions and a `postCreateCommand` that runs `script/setup` to create the virtualenv and install dev dependencies.
- Add `.devcontainer/README.md` documenting what the devcontainer does and how to use it with VS Code / Dev Containers.

This change is purely for development workflow convenience and does not affect any runtime code, quirks, or released packages.  
Motivation: make onboarding easier for contributors, have a reproducible dev environment, and keep the local development environment of contributors (including mine) clean and less cluttered.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

- No functional changes to ZHA quirks or device handling.
- No impact on Home Assistant users; this only affects contributors who opt into using the devcontainer / GitHub Codespaces.
- The intention of this PR is to improve the contributor experience and provide a clean, isolated environment for development without polluting the host system with additional tooling and dependencies.
- I’m not sure if adding a `.devcontainer` setup is desired in this repository; if this is not welcome or does not fit the maintainers' preferences, I’m happy to adjust the PR or close it again.


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->

Not applicable – this PR does not add or modify any device quirks and only introduces development tooling (.devcontainer).


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
