### PR TITLE
Add Avatto N-TRV16 TRV (_TZE204_vjpaih9f)

### DIFF
--- a/tests/test_tuya_avatto_trv16.py
+++ b/tests/test_tuya_avatto_trv16.py
@@ -1,0 +1,193 @@
+"""Tests for the AVATTO N-TRV16 TRV (_TZE204_vjpaih9f)."""
+
+from unittest import mock
+
+import pytest
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.hvac import Thermostat
+
+from tests.common import ClusterListener, wait_for_zigpy_tasks
+import zhaquirks
+from zhaquirks.tuya.mcu import TuyaMCUCluster
+
+zhaquirks.setup()
+
+MANUF = "_TZE204_vjpaih9f"
+MODEL = "TS0601"
+
+ATTR_PRESET_MODE = (0xEF << 8) | 2  # dp 2, exposed on the tuya manufacturer cluster
+ATTR_LOCAL_TEMP_CALIBRATION = (0xEF << 8) | 47  # dp 47
+
+
+@pytest.mark.parametrize(
+    "msg, attr, value",
+    [
+        (
+            b"\t\x01\x02\x00\x01\x02\x04\x00\x01\x00",
+            Thermostat.AttributeDefs.system_mode,
+            Thermostat.SystemMode.Heat,
+        ),  # dp 2, preset Manual (0x00) -> system_mode Heat
+        (
+            b"\t\x01\x02\x00\x01\x02\x04\x00\x01\x06",
+            Thermostat.AttributeDefs.system_mode,
+            Thermostat.SystemMode.Off,
+        ),  # dp 2, preset Off (0x06) -> system_mode Off
+        (
+            b"\t\x01\x02\x00\x01\x03\x01\x00\x01\x01",
+            Thermostat.AttributeDefs.running_state,
+            Thermostat.RunningState.Heat_State_On,
+        ),  # dp 3, valve open
+        (
+            b"\t\x01\x02\x00\x01\x04\x02\x00\x04\x00\x00\x00\xd2",
+            Thermostat.AttributeDefs.occupied_heating_setpoint,
+            2100,
+        ),  # dp 4, setpoint 21.0C
+        (
+            b"\t\x01\x02\x00\x01\x05\x02\x00\x04\x00\x00\x00\xd7",
+            Thermostat.AttributeDefs.local_temperature,
+            2150,
+        ),  # dp 5, current temp 21.5C
+    ],
+)
+async def test_handle_get_data(zigpy_device_from_v2_quirk, msg, attr, value):
+    """Test incoming Tuya datapoints are mapped onto the thermostat cluster."""
+
+    quirked = zigpy_device_from_v2_quirk(MANUF, MODEL)
+    ep = quirked.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+    assert ep.thermostat is not None
+    assert isinstance(ep.thermostat, Thermostat)
+
+    thermostat_listener = ClusterListener(ep.thermostat)
+
+    hdr, data = ep.tuya_manufacturer.deserialize(msg)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+
+    assert len(thermostat_listener.attribute_updates) == 1
+    assert thermostat_listener.attribute_updates[0][0] == attr.id
+    assert thermostat_listener.attribute_updates[0][1] == value
+    assert ep.thermostat.get(attr.id) == value
+
+
+async def test_handle_get_data_preset_mode_raw(zigpy_device_from_v2_quirk):
+    """Dp 2 must also update the raw preset_mode attribute (select entity)."""
+
+    quirked = zigpy_device_from_v2_quirk(MANUF, MODEL)
+    ep = quirked.endpoints[1]
+
+    tmcu_listener = ClusterListener(ep.tuya_manufacturer)
+
+    # dp 2, preset Eco (0x02)
+    msg = b"\t\x01\x02\x00\x01\x02\x04\x00\x01\x02"
+    hdr, data = ep.tuya_manufacturer.deserialize(msg)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+
+    assert (ATTR_PRESET_MODE, 2) in tmcu_listener.attribute_updates
+    assert ep.tuya_manufacturer.get(ATTR_PRESET_MODE) == 2
+
+
+async def test_handle_get_data_local_temperature_calibration(
+    zigpy_device_from_v2_quirk,
+):
+    """Dp 47 (local temperature calibration) is exposed on the tuya cluster."""
+
+    quirked = zigpy_device_from_v2_quirk(MANUF, MODEL)
+    ep = quirked.endpoints[1]
+
+    tmcu_listener = ClusterListener(ep.tuya_manufacturer)
+
+    # dp 47, calibration -1.5C
+    msg = b"\t\x01\x02\x00\x01/\x02\x00\x04\xff\xff\xff\xf1"
+    hdr, data = ep.tuya_manufacturer.deserialize(msg)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+
+    assert (ATTR_LOCAL_TEMP_CALIBRATION, -15) in tmcu_listener.attribute_updates
+    assert ep.tuya_manufacturer.get(ATTR_LOCAL_TEMP_CALIBRATION) == -15
+
+
+@pytest.mark.parametrize(
+    "system_mode, dp_msg",
+    [
+        (
+            Thermostat.SystemMode.Off,
+            b"\x01\x01\x00\x00\x01\x02\x04\x00\x01\x06",
+        ),  # -> preset Off (0x06)
+        (
+            Thermostat.SystemMode.Auto,
+            b"\x01\x01\x00\x00\x01\x02\x04\x00\x01\x01",
+        ),  # -> preset Schedule (0x01)
+        (
+            Thermostat.SystemMode.Heat,
+            b"\x01\x01\x00\x00\x01\x02\x04\x00\x01\x00",
+        ),  # -> preset Manual (0x00)
+    ],
+)
+async def test_write_system_mode(zigpy_device_from_v2_quirk, system_mode, dp_msg):
+    """Writing system_mode (climate on/off) must reach the device via dp 2.
+
+    Regression test: dp 2 is shared between the ZCL `system_mode` attribute
+    and the raw `preset_mode` attribute (tuya_dp_multi with two mappings), so
+    the dp_converter is invoked with one positional value per mapping. A
+    dp_converter that only accepts a single argument raises a TypeError on
+    every write here.
+    """
+
+    quirked = zigpy_device_from_v2_quirk(MANUF, MODEL)
+    ep = quirked.endpoints[1]
+
+    async def async_success(*args, **kwargs):
+        return foundation.Status.SUCCESS
+
+    with mock.patch.object(
+        ep.tuya_manufacturer.endpoint, "request", side_effect=async_success
+    ) as m1:
+        (status,) = await ep.thermostat.write_attributes({"system_mode": system_mode})
+        await wait_for_zigpy_tasks()
+
+        m1.assert_called_once_with(
+            cluster=0xEF00,
+            sequence=1,
+            data=dp_msg,
+            command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
+            priority=None,
+            retries=None,
+            retry_delay=None,
+        )
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
+
+
+async def test_write_preset_mode_does_not_raise(zigpy_device_from_v2_quirk):
+    """Writing preset_mode directly (HA select entity) must not raise.
+
+    Same dp_converter as test_write_system_mode is invoked here, since dp 2
+    is shared by both attributes.
+    """
+
+    quirked = zigpy_device_from_v2_quirk(MANUF, MODEL)
+    ep = quirked.endpoints[1]
+
+    async def async_success(*args, **kwargs):
+        return foundation.Status.SUCCESS
+
+    with mock.patch.object(
+        ep.tuya_manufacturer.endpoint, "request", side_effect=async_success
+    ):
+        (status,) = await ep.tuya_manufacturer.write_attributes(
+            {"preset_mode": 2}  # Eco
+        )
+        await wait_for_zigpy_tasks()
+
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]

--- a/zhaquirks/tuya/ts0601_tze204_avatto_n-trv16
+++ b/zhaquirks/tuya/ts0601_tze204_avatto_n-trv16
@@ -1,0 +1,169 @@
+from zigpy.quirks.v2 import EntityType, EntityPlatform
+from zigpy.quirks.v2.homeassistant import UnitOfTemperature
+from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
+from zigpy.zcl.clusters.hvac import RunningState, Thermostat
+from zhaquirks.tuya import (
+    PowerConfiguration,
+    TuyaLocalCluster,
+    TuyaPowerConfigurationCluster3AA
+)
+from zhaquirks.tuya.mcu import TuyaAttributesCluster
+import zigpy.types as t
+
+class PresetMode(t.enum8):
+    """PresetMode Enum."""
+
+    Manual = 0x00
+    Schedule = 0x01
+    Eco = 0x02
+    Comfort = 0x03
+    FrostProtection = 0x04
+    Holiday = 0x05
+    Off = 0x06
+
+class TuyaThermostat(Thermostat, TuyaAttributesCluster):
+    """Tuya local thermostat cluster."""
+
+    _CONSTANT_ATTRIBUTES = {
+        Thermostat.AttributeDefs.ctrl_sequence_of_oper.id: Thermostat.ControlSequenceOfOperation.Heating_Only
+    }
+
+    def __init__(self, *args, **kwargs):
+        """Init a TuyaThermostat cluster."""
+        super().__init__(*args, **kwargs)
+        self.add_unsupported_attribute(
+            Thermostat.AttributeDefs.setpoint_change_source.id
+        )
+        self.add_unsupported_attribute(
+            Thermostat.AttributeDefs.setpoint_change_source_timestamp.id
+        )
+        self.add_unsupported_attribute(Thermostat.AttributeDefs.pi_heating_demand.id)
+
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+(
+    TuyaQuirkBuilder("_TZE204_vjpaih9f", "TS0601")
+    .tuya_enum(
+        dp_id=2,
+        attribute_name="preset_mode",
+        enum_class=PresetMode,
+        translation_key="preset_mode",
+        fallback_name="Preset mode",
+    )
+    .tuya_dp(
+        dp_id=3,
+        ep_attribute=TuyaThermostat.ep_attribute,
+        attribute_name=TuyaThermostat.AttributeDefs.running_state.name,
+        converter=lambda x: RunningState.Heat_State_On if x else RunningState.Idle,
+    )
+    .tuya_dp(
+        dp_id=4,
+        ep_attribute=TuyaThermostat.ep_attribute,
+        attribute_name=TuyaThermostat.AttributeDefs.occupied_heating_setpoint.name,
+        converter=lambda x: x * 10,
+        dp_converter=lambda x: x // 10,
+    )
+    .tuya_dp(
+        dp_id=5,
+        ep_attribute=TuyaThermostat.ep_attribute,
+        attribute_name=TuyaThermostat.AttributeDefs.local_temperature.name,
+        converter=lambda x: x * 10,
+    )
+    .tuya_battery(dp_id=6, power_cfg=TuyaPowerConfigurationCluster3AA)
+    .tuya_switch(
+        dp_id=7,
+        attribute_name="child_lock",
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    .tuya_switch(
+        dp_id=14,
+        attribute_name="window_detection",
+        translation_key="window_detection",
+        fallback_name="Window Detection",
+    )
+    .tuya_binary_sensor(
+        dp_id=15, 
+        attribute_name="window_open", 
+        translation_key="window_open", 
+        fallback_name="Window Open",
+        entity_type=EntityType.STANDARD,
+        device_class=BinarySensorDeviceClass.WINDOW,
+    )
+    .tuya_number(
+        dp_id=21,
+        attribute_name="holiday_temperature",
+        type=t.int32s,
+        min_value=5,
+        max_value=35,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.5,
+        multiplier=0.1,
+        translation_key="holiday_temperature",
+        fallback_name="Holiday Temperature",
+    )
+    .tuya_binary_sensor(
+        dp_id=35, 
+        attribute_name="battery_low", 
+        translation_key="battery_low", 
+        fallback_name="Battery Low",
+        entity_type=EntityType.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.BATTERY,
+    )
+    .tuya_switch(
+        dp_id=36,
+        attribute_name="frost_protection",
+        translation_key="frost_protection",
+        fallback_name="Frost protection",
+    )
+    .tuya_number(
+        dp_id=47,
+        attribute_name=TuyaThermostat.AttributeDefs.local_temperature_calibration.name,
+        type=t.int32s,
+        min_value=-9.5,
+        max_value=9.5,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.5,
+        multiplier=0.1,
+        translation_key="local_temperature_calibration",
+        fallback_name="Local temperature calibration",
+    )
+    .tuya_number(
+        dp_id=103,
+        attribute_name="eco_temperature",
+        type=t.int32s,
+        min_value=5,
+        max_value=35,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.5,
+        multiplier=0.1,
+        translation_key="eco_temperature",
+        fallback_name="Eco Temperature",
+    )
+    .tuya_number(
+        dp_id=104,
+        attribute_name="comfort_temperature",
+        type=t.int32s,
+        min_value=5,
+        max_value=35,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.5,
+        multiplier=0.1,
+        translation_key="comfort_temperature",
+        fallback_name="Comfort Temperature",
+    )
+    .tuya_number(
+        dp_id=105,
+        attribute_name="frost_protection_temperature",
+        type=t.int32s,
+        min_value=5,
+        max_value=35,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.5,
+        multiplier=0.1,
+        translation_key="frost_protection_temperature",
+        fallback_name="Frost Protection Temperature",
+    )
+    .adds(TuyaThermostat)
+    .skip_configuration()
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0601_tze204_avatto_n-trv16
+++ b/zhaquirks/tuya/ts0601_tze204_avatto_n-trv16
@@ -5,10 +5,11 @@ from zigpy.zcl.clusters.hvac import RunningState, Thermostat
 from zhaquirks.tuya import (
     PowerConfiguration,
     TuyaLocalCluster,
-    TuyaPowerConfigurationCluster3AA
+    TuyaPowerConfigurationCluster3AA,
 )
 from zhaquirks.tuya.mcu import TuyaAttributesCluster
 import zigpy.types as t
+
 
 class PresetMode(t.enum8):
     """PresetMode Enum."""
@@ -20,6 +21,7 @@ class PresetMode(t.enum8):
     FrostProtection = 0x04
     Holiday = 0x05
     Off = 0x06
+
 
 class TuyaThermostat(Thermostat, TuyaAttributesCluster):
     """Tuya local thermostat cluster."""
@@ -39,7 +41,9 @@ class TuyaThermostat(Thermostat, TuyaAttributesCluster):
         )
         self.add_unsupported_attribute(Thermostat.AttributeDefs.pi_heating_demand.id)
 
+
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
 (
     TuyaQuirkBuilder("_TZE204_vjpaih9f", "TS0601")
     .tuya_enum(
@@ -82,9 +86,9 @@ from zhaquirks.tuya.builder import TuyaQuirkBuilder
         fallback_name="Window Detection",
     )
     .tuya_binary_sensor(
-        dp_id=15, 
-        attribute_name="window_open", 
-        translation_key="window_open", 
+        dp_id=15,
+        attribute_name="window_open",
+        translation_key="window_open",
         fallback_name="Window Open",
         entity_type=EntityType.STANDARD,
         device_class=BinarySensorDeviceClass.WINDOW,
@@ -102,9 +106,9 @@ from zhaquirks.tuya.builder import TuyaQuirkBuilder
         fallback_name="Holiday Temperature",
     )
     .tuya_binary_sensor(
-        dp_id=35, 
-        attribute_name="battery_low", 
-        translation_key="battery_low", 
+        dp_id=35,
+        attribute_name="battery_low",
+        translation_key="battery_low",
         fallback_name="Battery Low",
         entity_type=EntityType.DIAGNOSTIC,
         device_class=BinarySensorDeviceClass.BATTERY,

--- a/zhaquirks/tuya/ts0601_tze204_avatto_n-trv16.py
+++ b/zhaquirks/tuya/ts0601_tze204_avatto_n-trv16.py
@@ -1,0 +1,243 @@
+"""Quirk for AVATTO N-TRV16 TRV (_TZE204_vjpaih9f).
+
+Fixed version with proper system_mode <-> preset_mode mapping.
+"""
+
+import zigpy.types as t
+from zigpy.zcl.clusters.hvac import RunningState, Thermostat
+
+from zhaquirks.builder import BinarySensorDeviceClass, EntityType, UnitOfTemperature
+from zhaquirks.tuya import TUYA_CLUSTER_ID, TuyaPowerConfigurationCluster3AA
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.mcu import (
+    DPToAttributeMapping,
+    TuyaAttributesCluster,
+    TuyaMCUCluster,
+)
+
+
+class AvattoPresetMode(t.enum8):
+    """AVATTO TRV Preset Mode Enum.
+
+    Maps to Tuya dp_id=2 values.
+    """
+
+    Manual = 0x00
+    Schedule = 0x01
+    Eco = 0x02
+    Comfort = 0x03
+    FrostProtection = 0x04
+    Holiday = 0x05
+    Off = 0x06
+
+
+class AvattoThermostat(Thermostat, TuyaAttributesCluster):
+    """AVATTO TRV thermostat cluster."""
+
+    _CONSTANT_ATTRIBUTES = {
+        Thermostat.AttributeDefs.ctrl_sequence_of_oper.id: (
+            Thermostat.ControlSequenceOfOperation.Heating_Only
+        ),
+        Thermostat.AttributeDefs.abs_min_heat_setpoint_limit.id: 500,  # 5°C
+        Thermostat.AttributeDefs.abs_max_heat_setpoint_limit.id: 3500,  # 35°C
+    }
+
+    def __init__(self, *args, **kwargs):
+        """Init the thermostat cluster."""
+        super().__init__(*args, **kwargs)
+        self.add_unsupported_attribute(
+            Thermostat.AttributeDefs.setpoint_change_source.id
+        )
+        self.add_unsupported_attribute(
+            Thermostat.AttributeDefs.setpoint_change_source_timestamp.id
+        )
+        self.add_unsupported_attribute(Thermostat.AttributeDefs.pi_heating_demand.id)
+
+
+(
+    TuyaQuirkBuilder("_TZE204_vjpaih9f", "TS0601")
+    # DP 2: Preset mode - maps to BOTH system_mode AND preset_mode
+    # This is the key fix: tuya_dp_multi allows one DP to update multiple attributes
+    .tuya_dp_multi(
+        dp_id=2,
+        attribute_mapping=[
+            # First mapping: Tuya preset → ZCL system_mode (for HA climate entity)
+            DPToAttributeMapping(
+                ep_attribute=AvattoThermostat.ep_attribute,
+                attribute_name=AvattoThermostat.AttributeDefs.system_mode.name,
+                # Incoming: Tuya preset value → ZCL SystemMode
+                converter=lambda x: {
+                    AvattoPresetMode.Manual: Thermostat.SystemMode.Heat,
+                    AvattoPresetMode.Schedule: Thermostat.SystemMode.Auto,
+                    AvattoPresetMode.Eco: Thermostat.SystemMode.Auto,
+                    AvattoPresetMode.Comfort: Thermostat.SystemMode.Heat,
+                    AvattoPresetMode.FrostProtection: Thermostat.SystemMode.Heat,
+                    AvattoPresetMode.Holiday: Thermostat.SystemMode.Auto,
+                    AvattoPresetMode.Off: Thermostat.SystemMode.Off,
+                }.get(AvattoPresetMode(x), Thermostat.SystemMode.Heat),
+            ),
+            # Second mapping: Also store raw preset_mode on TuyaMCUCluster
+            # This allows the preset_mode entity to work
+            DPToAttributeMapping(
+                ep_attribute=TuyaMCUCluster.ep_attribute,
+                attribute_name="preset_mode",
+            ),
+        ],
+        # Outgoing: ZCL SystemMode (arg 1) / raw preset_mode (arg 2, unused here)
+        # → Tuya preset value. Both attributes share dp_id=2, so the converter
+        # must accept one positional value per mapping above (see tuya_trv.py
+        # for the reference pattern this mirrors).
+        dp_converter=lambda system_mode, _preset_mode: {
+            Thermostat.SystemMode.Off: AvattoPresetMode.Off,
+            Thermostat.SystemMode.Auto: AvattoPresetMode.Schedule,
+            Thermostat.SystemMode.Heat: AvattoPresetMode.Manual,
+        }.get(system_mode, AvattoPresetMode.Manual),
+    )
+    # Register the preset_mode attribute on the Tuya cluster
+    .tuya_attribute(
+        dp_id=2,
+        attribute_name="preset_mode",
+        type=t.uint16_t,
+        is_manufacturer_specific=True,
+    )
+    # Expose preset_mode as a selectable enum entity
+    .enum(
+        attribute_name="preset_mode",
+        cluster_id=TUYA_CLUSTER_ID,
+        enum_class=AvattoPresetMode,
+        translation_key="preset_mode",
+        fallback_name="Preset mode",
+    )
+    # DP 3: Running state (valve open/closed, i.e., heating or idle)
+    .tuya_dp(
+        dp_id=3,
+        ep_attribute=AvattoThermostat.ep_attribute,
+        attribute_name=AvattoThermostat.AttributeDefs.running_state.name,
+        converter=lambda x: RunningState.Heat_State_On if x else RunningState.Idle,
+    )
+    # DP 4: Heating setpoint (target temperature)
+    .tuya_dp(
+        dp_id=4,
+        ep_attribute=AvattoThermostat.ep_attribute,
+        attribute_name=AvattoThermostat.AttributeDefs.occupied_heating_setpoint.name,
+        converter=lambda x: x * 10,  # Tuya sends decidegrees, ZCL uses centidegrees
+        dp_converter=lambda x: x // 10,
+    )
+    # DP 5: Local temperature (current temperature reading)
+    .tuya_dp(
+        dp_id=5,
+        ep_attribute=AvattoThermostat.ep_attribute,
+        attribute_name=AvattoThermostat.AttributeDefs.local_temperature.name,
+        converter=lambda x: x * 10,
+    )
+    # DP 6: Battery percentage
+    .tuya_battery(dp_id=6, power_cfg=TuyaPowerConfigurationCluster3AA)
+    # DP 7: Child lock
+    .tuya_switch(
+        dp_id=7,
+        attribute_name="child_lock",
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    # DP 14: Window detection enable/disable
+    .tuya_switch(
+        dp_id=14,
+        attribute_name="window_detection",
+        translation_key="window_detection",
+        fallback_name="Open window detection",
+    )
+    # DP 15: Window open status (binary sensor)
+    .tuya_binary_sensor(
+        dp_id=15,
+        attribute_name="window_open",
+        translation_key="window_open",
+        fallback_name="Window open",
+        entity_type=EntityType.STANDARD,
+        device_class=BinarySensorDeviceClass.WINDOW,
+    )
+    # DP 21: Holiday temperature setpoint
+    .tuya_number(
+        dp_id=21,
+        attribute_name="holiday_temperature",
+        type=t.int32s,
+        min_value=5,
+        max_value=35,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.5,
+        multiplier=0.1,
+        translation_key="holiday_temperature",
+        fallback_name="Holiday temperature",
+    )
+    # DP 35: Battery low indicator
+    .tuya_binary_sensor(
+        dp_id=35,
+        attribute_name="battery_low",
+        translation_key="battery_low",
+        fallback_name="Battery low",
+        entity_type=EntityType.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.BATTERY,
+    )
+    # DP 36: Frost protection enable/disable
+    .tuya_switch(
+        dp_id=36,
+        attribute_name="frost_protection",
+        translation_key="frost_protection",
+        fallback_name="Frost protection",
+    )
+    # DP 47: Local temperature calibration (offset)
+    .tuya_number(
+        dp_id=47,
+        attribute_name=AvattoThermostat.AttributeDefs.local_temperature_calibration.name,
+        type=t.int32s,
+        min_value=-9.5,
+        max_value=9.5,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.5,
+        multiplier=0.1,
+        translation_key="local_temperature_calibration",
+        fallback_name="Local temperature calibration",
+    )
+    # DP 103: Eco mode temperature
+    .tuya_number(
+        dp_id=103,
+        attribute_name="eco_temperature",
+        type=t.int32s,
+        min_value=5,
+        max_value=35,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.5,
+        multiplier=0.1,
+        translation_key="eco_temperature",
+        fallback_name="Eco temperature",
+    )
+    # DP 104: Comfort mode temperature
+    .tuya_number(
+        dp_id=104,
+        attribute_name="comfort_temperature",
+        type=t.int32s,
+        min_value=5,
+        max_value=35,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.5,
+        multiplier=0.1,
+        translation_key="comfort_temperature",
+        fallback_name="Comfort temperature",
+    )
+    # DP 105: Frost protection temperature
+    .tuya_number(
+        dp_id=105,
+        attribute_name="frost_protection_temperature",
+        type=t.int32s,
+        min_value=5,
+        max_value=35,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.5,
+        multiplier=0.1,
+        translation_key="frost_protection_temperature",
+        fallback_name="Frost protection temperature",
+    )
+    # Add our custom thermostat cluster
+    .adds(AvattoThermostat)
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
Adds support for Avatto N-TRV16 Tuya TS0601 Thermostat
<img width="661" height="1064" alt="image" src="https://github.com/user-attachments/assets/40296010-4449-44e2-b251-45e298f15e1d" />



## Additional information
I used the DP from zigbee2mqtt as a baseline: https://github.com/Koenkk/zigbee-herdsman-converters/blob/f963b918211305f63b7a35c3f847b55cc926cd83/src/devices/tuya.ts#L20684-L20750


## Device diagnostics
[zha-01J9PF144WNVNQYSX5HWT0ZHEW-_TZE204_vjpaih9f TS0601-ce9a45da3e81d362d04138e0044a53f4.json](https://github.com/user-attachments/files/23697348/zha-01J9PF144WNVNQYSX5HWT0ZHEW-_TZE204_vjpaih9f.TS0601-ce9a45da3e81d362d04138e0044a53f4.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly (I was unable to trigger the window detection)
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached



Closes #4471
