### PR TITLE
Added products support for AduroSmart/AduroLight.

### DIFF
--- a/zhaquirks/aduro/adurolightcsc.py
+++ b/zhaquirks/aduro/adurolightcsc.py
@@ -1,0 +1,204 @@
+"""ADUROLIGHT ADUROLIGHT_CSC device."""
+
+import logging
+from typing import Any, Optional, Union
+
+from zigpy.profiles import zll
+from zigpy.quirks import CustomDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    PowerConfiguration,
+    Scenes,
+)
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.lightlink import LightLink
+from zigpy.zcl.foundation import BaseCommandDefs, ZCLCommandDef, ZCLHeader
+
+from zhaquirks import Bus, EventableCluster
+from zhaquirks.const import (
+    ARGS,
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    CLUSTER_ID,
+    COMMAND,
+    DEVICE_TYPE,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+    TOGGLE,
+    ZHA_SEND_EVENT,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+ADUROLIGHT_REMOTE_CLUSTER_ID = 0xFCCC
+ADUROLIGHT_REMOTE_COMMAND_BUTTON_EVENT = 0x00
+SCENE_NO_GROUP = 0x0000
+
+
+# Adurolight remote cluster implementation
+class AdurolightRemoteCluster(EventableCluster):
+    """Adurolight manufacturer specific cluster for remote."""
+
+    cluster_id = ADUROLIGHT_REMOTE_CLUSTER_ID
+    name = "Adurolight Remote Cluster"
+    ep_attribute = "adurolight_remote_cluster"
+
+    class ClientCommandDefs(BaseCommandDefs):
+        """Client command definitions."""
+
+        button_event = ZCLCommandDef(
+            id=ADUROLIGHT_REMOTE_COMMAND_BUTTON_EVENT,
+            schema={
+                "param1": t.uint8_t,
+                "param2": t.uint8_t,
+                "param3": t.uint8_t,
+            },
+            is_manufacturer_specific=True,
+        )
+
+    def handle_cluster_request(
+        self,
+        hdr: ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: Optional[
+            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
+        ] = None,
+    ):
+        """Handle the cluster command."""
+        if hdr.command_id == ADUROLIGHT_REMOTE_COMMAND_BUTTON_EVENT:
+            _LOGGER.info("Got button press on adurolight remote cluster: %s", args[1])
+            self.endpoint.device.scenes_bus.listener_event(
+                "listener_event", ZHA_SEND_EVENT, "view", [SCENE_NO_GROUP, args[1]]
+            )
+        else:
+            super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+
+class AduroScenesCluster(Scenes, EventableCluster):
+    """Scenes cluster to map preset buttons to the "view" command."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.scenes_bus.add_listener(self)
+
+
+class AdurolightCSC(CustomDevice):
+    """ADUROLIGHT ADUROLIGHT_CSC device."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.scenes_bus = Bus()
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=49246 device_type=2064
+        # device_version=2
+        # input_clusters=[0, 1, 3, 4, 5, 6, 8, 768, 4096, 64716]
+        # output_clusters=[0, 3, 4, 5, 6, 8, 768, 4096, 64716]>
+        MODELS_INFO: [
+            ("ADUROLIGHT", "ADUROLIGHT_CSC"),
+            ("AduroSmart Eria", "ADUROLIGHT_CSC"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                    AdurolightRemoteCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                    AdurolightRemoteCluster.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: 1010,
+                INPUT_CLUSTERS: [
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    LightLink.cluster_id,
+                    AdurolightRemoteCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    AduroScenesCluster,
+                    LightLink.cluster_id,
+                    AdurolightRemoteCluster,
+                ],
+            }
+        }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, TOGGLE): {
+            COMMAND: "view",
+            CLUSTER_ID: 5,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 0x0],
+        },
+        (SHORT_PRESS, BUTTON_1): {
+            COMMAND: "view",
+            CLUSTER_ID: 5,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 0x1],
+        },
+        (SHORT_PRESS, BUTTON_2): {
+            COMMAND: "view",
+            CLUSTER_ID: 5,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 0x2],
+        },
+        (SHORT_PRESS, BUTTON_3): {
+            COMMAND: "view",
+            CLUSTER_ID: 5,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 0x3],
+        },
+    }

--- a/zhaquirks/aduro/adurolightncc.py
+++ b/zhaquirks/aduro/adurolightncc.py
@@ -3,7 +3,14 @@
 from zigpy.profiles import zha
 from zigpy.profiles.zha import DeviceType
 from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, LevelControl, OnOff
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    PowerConfiguration,
+)
 from zigpy.zcl.clusters.lightlink import LightLink
 
 from zhaquirks.const import (
@@ -27,7 +34,7 @@ from zhaquirks.const import (
     TURN_ON,
 )
 
-ADUROLIGHT_CLUSTER_ID = 64716
+ADUROLIGHT_REMOTE_CLUSTER_ID = 64716
 
 
 class AdurolightNCC(CustomDevice):
@@ -36,19 +43,23 @@ class AdurolightNCC(CustomDevice):
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=2080
         # device_version=2
-        # input_clusters=[0, 3, 8, 4096, 64716]
+        # input_clusters=[0, 1, 3, 8, 4096, 64716]
         # output_clusters=[3, 4, 6, 8, 4096, 64716]>
-        MODELS_INFO: [("ADUROLIGHT", "Adurolight_NCC")],
+        MODELS_INFO: [
+            ("ADUROLIGHT", "Adurolight_NCC"),
+            ("AduroSmart Eria", "Adurolight_NCC"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
                 DEVICE_TYPE: DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     LevelControl.cluster_id,
                     LightLink.cluster_id,
-                    ADUROLIGHT_CLUSTER_ID,
+                    ADUROLIGHT_REMOTE_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -56,7 +67,7 @@ class AdurolightNCC(CustomDevice):
                     OnOff.cluster_id,
                     LevelControl.cluster_id,
                     LightLink.cluster_id,
-                    ADUROLIGHT_CLUSTER_ID,
+                    ADUROLIGHT_REMOTE_CLUSTER_ID,
                 ],
             }
         },
@@ -69,9 +80,10 @@ class AdurolightNCC(CustomDevice):
                 DEVICE_TYPE: DeviceType.NON_COLOR_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     LightLink.cluster_id,
-                    ADUROLIGHT_CLUSTER_ID,
+                    ADUROLIGHT_REMOTE_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -79,7 +91,7 @@ class AdurolightNCC(CustomDevice):
                     OnOff.cluster_id,
                     LevelControl.cluster_id,
                     LightLink.cluster_id,
-                    ADUROLIGHT_CLUSTER_ID,
+                    ADUROLIGHT_REMOTE_CLUSTER_ID,
                 ],
             }
         }

--- a/zhaquirks/aduro/csw_82909.py
+++ b/zhaquirks/aduro/csw_82909.py
@@ -1,0 +1,156 @@
+"""AduroSmart multi contact sensor devices."""
+
+import logging
+import math
+from typing import Any, Final, Optional, Union
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import (
+    QuirkBuilder,
+    ReportingConfig,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+import zigpy.types as t
+from zigpy.zcl.foundation import (
+    BaseAttributeDefs,
+    BaseCommandDefs,
+    ZCLAttributeDef,
+    ZCLCommandDef,
+    ZCLHeader,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+ADUROLIGHT_ACCEL_CLUSTER_ID = 0xFCC1
+ADUROLIGHT_ACCEL_COMMAND_REPORT_DATA = 0x0A
+
+
+# Adurolight accel cluster implementation
+class AduroSmartAccelCluster(CustomCluster):
+    """AduroSmart multi contact sensor private cluster."""
+
+    cluster_id = ADUROLIGHT_ACCEL_CLUSTER_ID
+    name = "Adurolight Accel Cluster"
+    ep_attribute = "adurolight_accel_cluster"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Define the attributes of a private cluster."""
+
+        x_axis: Final = ZCLAttributeDef(
+            id=0x0000,
+            type=t.int16s,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+        y_axis: Final = ZCLAttributeDef(
+            id=0x0001,
+            type=t.int16s,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+        z_axis: Final = ZCLAttributeDef(
+            id=0x0002,
+            type=t.int16s,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+
+    class ClientCommandDefs(BaseCommandDefs):
+        """Client command definitions."""
+
+        button_event = ZCLCommandDef(
+            id=ADUROLIGHT_ACCEL_COMMAND_REPORT_DATA,
+            schema={
+                "x_axis_id": t.uint16_t,
+                "x_axis_type": t.uint8_t,
+                "x_axis_value": t.int16s,
+                "y_axis_id": t.uint16_t,
+                "y_axis_type": t.uint8_t,
+                "y_axis_value": t.int16s,
+                "z_axis_id": t.uint16_t,
+                "z_axis_type": t.uint8_t,
+                "z_axis_value": t.int16s,
+            },
+            is_manufacturer_specific=True,
+        )
+
+    def get_accel_value(self, attrid, value):
+        """Check for a valid accel value."""
+        shifted_val = value >> 2
+        result_float = (shifted_val * 977 / 1000) + 1
+        value = math.floor(result_float)
+        super()._update_attribute(attrid, value)
+
+    def handle_cluster_request(
+        self,
+        hdr: ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: Optional[
+            Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
+        ] = None,
+    ):
+        """Handle the cluster command."""
+        if hdr.command_id == ADUROLIGHT_ACCEL_COMMAND_REPORT_DATA:
+            if len(args) == 9:
+                attrid_1 = args[0]
+                value_1 = args[2]
+                attrid_2 = args[3]
+                value_2 = args[5]
+                attrid_3 = args[6]
+                value_3 = args[8]
+                if attrid_1 == 0x0000:
+                    self.get_accel_value(attrid_1, value_1)
+                if attrid_2 == 0x0001:
+                    self.get_accel_value(attrid_2, value_2)
+                if attrid_3 == 0x0002:
+                    self.get_accel_value(attrid_3, value_3)
+        else:
+            super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+
+(
+    QuirkBuilder("AduroSmart ERIA", "CSW_81909")
+    .replaces(AduroSmartAccelCluster)
+    .sensor(
+        AduroSmartAccelCluster.AttributeDefs.x_axis.name,
+        AduroSmartAccelCluster.cluster_id,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.ACCELERATION,
+        translation_key="x_axis",
+        fallback_name="X-Axis",
+        reporting_config=ReportingConfig(
+            min_interval=1,
+            max_interval=65535,
+            reportable_change=0,
+        ),
+    )
+    .sensor(
+        AduroSmartAccelCluster.AttributeDefs.y_axis.name,
+        AduroSmartAccelCluster.cluster_id,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.ACCELERATION,
+        translation_key="y_axis",
+        fallback_name="Y-Axis",
+        reporting_config=ReportingConfig(
+            min_interval=1,
+            max_interval=65535,
+            reportable_change=0,
+        ),
+    )
+    .sensor(
+        AduroSmartAccelCluster.AttributeDefs.z_axis.name,
+        AduroSmartAccelCluster.cluster_id,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.ACCELERATION,
+        translation_key="z_axis",
+        fallback_name="Z-Axis",
+        reporting_config=ReportingConfig(
+            min_interval=1,
+            max_interval=65535,
+            reportable_change=0,
+        ),
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/aduro/dimmer_m3002.py
+++ b/zhaquirks/aduro/dimmer_m3002.py
@@ -1,0 +1,196 @@
+"""AduroSmart M3002 dimmer devices."""
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTime
+import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+
+class LoadControlMode(t.enum8):
+    """Load control modes for AduroSmart devices."""
+
+    LeadingEdgeControl = 0x00
+    TrailingEdgeControl = 0x01
+
+
+class SwitchMode(t.enum8):
+    """Switch modes for AduroSmart devices."""
+
+    MomentarySwitch = 0x00
+    ToggleSwitch = 0x01
+    RollerBlindSwitch = 0x02
+
+
+class DoubleClickScene(t.enum8):
+    """Double click scenes for AduroSmart devices."""
+
+    Disabled = 0x00
+    On = 0x01
+    Off = 0x02
+    DimmingUp = 0x03
+    DimmingDown = 0x04
+    DimmingToBrightest = 0x05
+    DimmingToDarkest = 0x06
+
+
+class AduroDimmerBasicCluster(CustomCluster, Basic):
+    """Aduro Dimmer Basic cluster."""
+
+    class AttributeDefs(Basic.AttributeDefs):
+        """Attribute definitions."""
+
+        load_control_mode: Final = ZCLAttributeDef(
+            id=0x7600,
+            type=t.uint8_t,
+            access="rw",
+        )
+
+        switch_mode: Final = ZCLAttributeDef(
+            id=0x7700,
+            type=t.uint8_t,
+            access="rw",
+        )
+
+        invert_switch: Final = ZCLAttributeDef(
+            id=0x7701,
+            type=t.Bool,
+            access="rw",
+        )
+
+        scene_activation: Final = ZCLAttributeDef(
+            id=0x7702,
+            type=t.Bool,
+            access="rw",
+        )
+
+        s1_double_click_scene: Final = ZCLAttributeDef(
+            id=0x7703,
+            type=t.uint8_t,
+            access="rw",
+        )
+
+        s2_double_click_scene: Final = ZCLAttributeDef(
+            id=0x7704,
+            type=t.uint8_t,
+            access="rw",
+        )
+
+        min_brightness_level: Final = ZCLAttributeDef(
+            id=0x7800,
+            type=t.uint8_t,
+            access="rw",
+        )
+
+        max_brightness_level: Final = ZCLAttributeDef(
+            id=0x7801,
+            type=t.uint8_t,
+            access="rw",
+        )
+
+        manual_dimming_step_size: Final = ZCLAttributeDef(
+            id=0x7802,
+            type=t.uint8_t,
+            access="rw",
+        )
+
+        manual_dimming_time: Final = ZCLAttributeDef(
+            id=0x7803,
+            type=t.uint16_t,
+            access="rw",
+        )
+
+
+(
+    QuirkBuilder("AduroSmart ERIA", "DimmerM3002")
+    .applies_to("Robb Smarrt", "DimmerM3002")
+    .replaces(AduroDimmerBasicCluster)
+    .enum(
+        attribute_name=AduroDimmerBasicCluster.AttributeDefs.load_control_mode.name,
+        cluster_id=AduroDimmerBasicCluster.cluster_id,
+        enum_class=LoadControlMode,
+        translation_key="load_control_mode",
+        fallback_name="Load Control Mode",
+    )
+    .enum(
+        attribute_name=AduroDimmerBasicCluster.AttributeDefs.switch_mode.name,
+        cluster_id=AduroDimmerBasicCluster.cluster_id,
+        enum_class=SwitchMode,
+        translation_key="switch_mode",
+        fallback_name="Switch Mode",
+    )
+    .switch(
+        attribute_name=AduroDimmerBasicCluster.AttributeDefs.invert_switch.name,
+        cluster_id=AduroDimmerBasicCluster.cluster_id,
+        translation_key="invert_switch",
+        fallback_name="Invert Switch",
+    )
+    .switch(
+        attribute_name=AduroDimmerBasicCluster.AttributeDefs.scene_activation.name,
+        cluster_id=AduroDimmerBasicCluster.cluster_id,
+        translation_key="scene_activation",
+        fallback_name="Scene Activation",
+    )
+    .enum(
+        attribute_name=AduroDimmerBasicCluster.AttributeDefs.s1_double_click_scene.name,
+        cluster_id=AduroDimmerBasicCluster.cluster_id,
+        enum_class=DoubleClickScene,
+        translation_key="s1_double_click_scene",
+        fallback_name="S1 Double Click Scene",
+    )
+    .enum(
+        attribute_name=AduroDimmerBasicCluster.AttributeDefs.s2_double_click_scene.name,
+        cluster_id=AduroDimmerBasicCluster.cluster_id,
+        enum_class=DoubleClickScene,
+        translation_key="s2_double_click_scene",
+        fallback_name="S2 Double Click Scene",
+    )
+    .number(
+        attribute_name=AduroDimmerBasicCluster.AttributeDefs.min_brightness_level.name,
+        cluster_id=AduroDimmerBasicCluster.cluster_id,
+        min_value=1,
+        max_value=100,
+        step=1,
+        unit=PERCENTAGE,
+        translation_key="min_brightness_level",
+        fallback_name="Min Brightness Level",
+        mode="box",
+    )
+    .number(
+        attribute_name=AduroDimmerBasicCluster.AttributeDefs.max_brightness_level.name,
+        cluster_id=AduroDimmerBasicCluster.cluster_id,
+        min_value=1,
+        max_value=100,
+        step=1,
+        unit=PERCENTAGE,
+        translation_key="max_brightness_level",
+        fallback_name="Max Brightness Level",
+        mode="box",
+    )
+    .number(
+        attribute_name=AduroDimmerBasicCluster.AttributeDefs.manual_dimming_step_size.name,
+        cluster_id=AduroDimmerBasicCluster.cluster_id,
+        min_value=1,
+        max_value=25,
+        step=1,
+        unit=PERCENTAGE,
+        translation_key="manual_dimming_step_size",
+        fallback_name="Manual Dimming Step Size",
+        mode="box",
+    )
+    .number(
+        attribute_name=AduroDimmerBasicCluster.AttributeDefs.manual_dimming_time.name,
+        cluster_id=AduroDimmerBasicCluster.cluster_id,
+        min_value=100,
+        max_value=10000,
+        step=100,
+        unit=UnitOfTime.MILLISECONDS,
+        translation_key="manual_dimming_time",
+        fallback_name="Manual Dimming Time",
+        mode="box",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
- 81910  5-in-1 Multi Contact Sensor
- 81825  Wireless Dimming Remote
- 81847  Wireless Scene Remote
- 81883  Mini Built-in Dimmer

## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
