### PR TITLE
Allow assigning Tuya datapoints to different endpoints

### DIFF
--- a/tests/test_tuya_builder.py
+++ b/tests/test_tuya_builder.py
@@ -561,3 +561,28 @@ async def test_tuya_override_mcu_command(
 
     assert tuya_listener.attribute_updates[0][0] == 0xEF0A
     assert tuya_listener.attribute_updates[0][1] == TestEnum.B
+
+
+async def test_tuya_quirk_builder_endpoint_id(device_mock):
+    """Test TuyaQuirkBuilder endpoint_id."""
+
+    registry = DeviceRegistry()
+
+    (
+        TuyaQuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
+        .adds_endpoint(2)
+        .tuya_humidity(dp_id=1, endpoint_id=2)
+        .tuya_soil_moisture(dp_id=2)
+        .skip_configuration()
+        .add_to_registry()
+    )
+
+    quirked = registry.get_device(device_mock)
+    assert isinstance(quirked, CustomDeviceV2)
+    assert quirked in registry
+
+    assert not hasattr(quirked.endpoints[1], "humidity")
+    assert hasattr(quirked.endpoints[2], "humidity")
+
+    assert hasattr(quirked.endpoints[1], "soil_moisture")
+    assert not hasattr(quirked.endpoints[2], "soil_moisture")

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -211,6 +211,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         dp_id: int,
         power_cfg: PowerConfiguration,
         scale: float,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya Battery Power Configuration."""
         self.tuya_dp(
@@ -218,8 +219,9 @@ class TuyaQuirkBuilder(QuirkBuilder):
             power_cfg.ep_attribute,
             PowerConfiguration.AttributeDefs.battery_percentage_remaining.name,
             converter=lambda x: x * scale,
+            endpoint_id=endpoint_id,
         )
-        self.adds(power_cfg)
+        self.adds(power_cfg, endpoint_id=endpoint_id)
         return self
 
     def tuya_battery(
@@ -230,11 +232,14 @@ class TuyaQuirkBuilder(QuirkBuilder):
         battery_qty: int | None = 2,
         battery_voltage: int | None = None,
         scale: float = 2,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya Battery Power Configuration."""
 
         if power_cfg:
-            return self._tuya_battery(dp_id=dp_id, power_cfg=power_cfg, scale=scale)
+            return self._tuya_battery(
+                dp_id=dp_id, power_cfg=power_cfg, scale=scale, endpoint_id=endpoint_id
+            )
 
         if not battery_voltage and (battery_type and battery_qty):
             battery_voltage = BATTERY_VOLTAGES.get(battery_type)
@@ -249,7 +254,10 @@ class TuyaQuirkBuilder(QuirkBuilder):
             }
 
         return self._tuya_battery(
-            dp_id=dp_id, power_cfg=TuyaPowerConfigurationClusterBattery, scale=scale
+            dp_id=dp_id,
+            power_cfg=TuyaPowerConfigurationClusterBattery,
+            scale=scale,
+            endpoint_id=endpoint_id,
         )
 
     def tuya_illuminance(
@@ -259,6 +267,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         converter: Callable[[Any], Any] | None = (
             lambda x: 10000 * math.log10(x) + 1 if x != 0 else 0
         ),
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya Illuminance Configuration."""
         self.tuya_dp(
@@ -266,16 +275,18 @@ class TuyaQuirkBuilder(QuirkBuilder):
             illuminance_cfg.ep_attribute,
             IlluminanceMeasurement.AttributeDefs.measured_value.name,
             converter=converter,
+            endpoint_id=endpoint_id,
         )
-        self.adds(illuminance_cfg)
+        self.adds(illuminance_cfg, endpoint_id=endpoint_id)
         return self
 
-    def tuya_contact(self, dp_id: int) -> Self:
+    def tuya_contact(self, dp_id: int, endpoint_id: int = 1) -> Self:
         """Add a Tuya IAS contact sensor."""
         self.tuya_ias(
             dp_id=dp_id,
             ias_cfg=TuyaIasContact,
             converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x != 0 else 0,
+            endpoint_id=endpoint_id,
         )
         return self
 
@@ -284,6 +295,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         dp_id: int,
         co2_cfg: TuyaLocalCluster = TuyaCO2Concentration,
         scale: float = 1e-6,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya CO2 Configuration."""
         self.tuya_dp(
@@ -291,8 +303,9 @@ class TuyaQuirkBuilder(QuirkBuilder):
             co2_cfg.ep_attribute,
             CarbonDioxideConcentration.AttributeDefs.measured_value.name,
             converter=lambda x: x * scale,
+            endpoint_id=endpoint_id,
         )
-        self.adds(co2_cfg)
+        self.adds(co2_cfg, endpoint_id=endpoint_id)
         return self
 
     def tuya_electrical_conductivity(
@@ -300,6 +313,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         dp_id: int,
         ec_cfg: TuyaLocalCluster = TuyaElectricalConductivity,
         scale: float = 1,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya Electrical Conductivity Configuration."""
         self.tuya_dp(
@@ -307,8 +321,9 @@ class TuyaQuirkBuilder(QuirkBuilder):
             ec_cfg.ep_attribute,
             ElectricalConductivity.AttributeDefs.measured_value.name,
             converter=lambda x: x * scale,
+            endpoint_id=endpoint_id,
         )
-        self.adds(ec_cfg)
+        self.adds(ec_cfg, endpoint_id=endpoint_id)
         return self
 
     def tuya_formaldehyde(
@@ -320,6 +335,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
             ((MOL_VOL_AIR_NTP * x) / TuyaFormaldehydeConcentration.MOLECULAR_MASS), 2
         )
         * 1e-6,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya Formaldehyde Configuration."""
         self.tuya_dp(
@@ -327,8 +343,9 @@ class TuyaQuirkBuilder(QuirkBuilder):
             form_cfg.ep_attribute,
             FormaldehydeConcentration.AttributeDefs.measured_value.name,
             converter=converter,
+            endpoint_id=endpoint_id,
         )
-        self.adds(form_cfg)
+        self.adds(form_cfg, endpoint_id=endpoint_id)
         return self
 
     def tuya_pm25(
@@ -336,6 +353,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         dp_id: int,
         pm25_cfg: TuyaLocalCluster = TuyaPM25Concentration,
         scale: float = 1,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya PM25 Configuration."""
         self.tuya_dp(
@@ -343,25 +361,28 @@ class TuyaQuirkBuilder(QuirkBuilder):
             pm25_cfg.ep_attribute,
             PM25.AttributeDefs.measured_value.name,
             converter=lambda x: x * scale,
+            endpoint_id=endpoint_id,
         )
-        self.adds(pm25_cfg)
+        self.adds(pm25_cfg, endpoint_id=endpoint_id)
         return self
 
-    def tuya_gas(self, dp_id: int) -> Self:
+    def tuya_gas(self, dp_id: int, endpoint_id: int = 1) -> Self:
         """Add a Tuya IAS gas sensor."""
         self.tuya_ias(
             dp_id=dp_id,
             ias_cfg=TuyaIasGas,
             converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 0 else 0,
+            endpoint_id=endpoint_id,
         )
         return self
 
-    def tuya_smoke(self, dp_id: int) -> Self:
+    def tuya_smoke(self, dp_id: int, endpoint_id: int = 1) -> Self:
         """Add a Tuya IAS smoke/fire sensor."""
         self.tuya_ias(
             dp_id=dp_id,
             ias_cfg=TuyaIasFire,
             converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 0 else 0,
+            endpoint_id=endpoint_id,
         )
         return self
 
@@ -370,6 +391,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         dp_id: int,
         ias_cfg: TuyaLocalCluster,
         converter: Callable[[Any], Any] | None = None,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya IAS Configuration."""
         self.tuya_dp(
@@ -377,8 +399,9 @@ class TuyaQuirkBuilder(QuirkBuilder):
             ias_cfg.ep_attribute,
             IasZone.AttributeDefs.zone_status.name,
             converter=converter,
+            endpoint_id=endpoint_id,
         )
-        self.adds(ias_cfg)
+        self.adds(ias_cfg, endpoint_id=endpoint_id)
         return self
 
     def tuya_metering(
@@ -386,6 +409,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         dp_id: int,
         metering_cfg: TuyaLocalCluster = TuyaValveWaterConsumedNoInstDemand,
         scale: float = 1,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya Metering Configuration."""
         self.tuya_dp(
@@ -393,22 +417,25 @@ class TuyaQuirkBuilder(QuirkBuilder):
             metering_cfg.ep_attribute,
             attribute_name="current_summ_delivered",
             converter=lambda x: x * scale,
+            endpoint_id=endpoint_id,
         )
-        self.adds(metering_cfg)
+        self.adds(metering_cfg, endpoint_id=endpoint_id)
         return self
 
     def tuya_onoff(
         self,
         dp_id: int,
         onoff_cfg: TuyaLocalCluster = TuyaOnOffNM,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya OnOff Configuration."""
         self.tuya_dp(
             dp_id,
             onoff_cfg.ep_attribute,
             "on_off",
+            endpoint_id=endpoint_id,
         )
-        self.adds(onoff_cfg)
+        self.adds(onoff_cfg, endpoint_id=endpoint_id)
         return self
 
     def tuya_humidity(
@@ -416,6 +443,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         dp_id: int,
         rh_cfg: TuyaLocalCluster = TuyaRelativeHumidity,
         scale: float = 100,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya Relative Humidity Configuration."""
         self.tuya_dp(
@@ -423,8 +451,9 @@ class TuyaQuirkBuilder(QuirkBuilder):
             rh_cfg.ep_attribute,
             "measured_value",
             converter=lambda x: x * scale,
+            endpoint_id=endpoint_id,
         )
-        self.adds(rh_cfg)
+        self.adds(rh_cfg, endpoint_id=endpoint_id)
         return self
 
     def tuya_soil_moisture(
@@ -432,6 +461,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         dp_id: int,
         soil_cfg: TuyaLocalCluster = TuyaSoilMoisture,
         scale: float = 100,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya Soil Moisture Configuration."""
         self.tuya_dp(
@@ -439,8 +469,9 @@ class TuyaQuirkBuilder(QuirkBuilder):
             soil_cfg.ep_attribute,
             "measured_value",
             converter=lambda x: x * scale,
+            endpoint_id=endpoint_id,
         )
-        self.adds(soil_cfg)
+        self.adds(soil_cfg, endpoint_id=endpoint_id)
         return self
 
     def tuya_temperature(
@@ -448,6 +479,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         dp_id: int,
         temp_cfg: TuyaLocalCluster = TuyaTemperatureMeasurement,
         scale: float = 100,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya Temperature Configuration."""
         self.tuya_dp(
@@ -455,16 +487,18 @@ class TuyaQuirkBuilder(QuirkBuilder):
             temp_cfg.ep_attribute,
             "measured_value",
             converter=lambda x: x * scale,
+            endpoint_id=endpoint_id,
         )
-        self.adds(temp_cfg)
+        self.adds(temp_cfg, endpoint_id=endpoint_id)
         return self
 
-    def tuya_vibration(self, dp_id: int) -> Self:
+    def tuya_vibration(self, dp_id: int, endpoint_id: int = 1) -> Self:
         """Add a Tuya IAS vibration sensor."""
         self.tuya_ias(
             dp_id=dp_id,
             ias_cfg=TuyaIasVibration,
             converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x != 0 else 0,
+            endpoint_id=endpoint_id,
         )
         return self
 
@@ -473,6 +507,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         dp_id: int,
         voc_cfg: TuyaLocalCluster = TuyaAirQualityVOC,
         scale: float = 1e-6,
+        endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya VOC Configuration."""
         self.tuya_dp(
@@ -480,8 +515,9 @@ class TuyaQuirkBuilder(QuirkBuilder):
             voc_cfg.ep_attribute,
             TuyaAirQualityVOC.AttributeDefs.measured_value.name,
             converter=lambda x: x * scale,
+            endpoint_id=endpoint_id,
         )
-        self.adds(voc_cfg)
+        self.adds(voc_cfg, endpoint_id=endpoint_id)
         return self
 
     def tuya_attribute(


### PR DESCRIPTION
## Proposed change
TuyaQuirkBuilder did not have the ability to assign data to different endpoints which resulted in some devices not being easily supported as values from the same endpoint are overwritten when they are reported simultaneously by the device.

## Additional information
See https://github.com/zigpy/zha-device-handlers/pull/4510 for more details


## Device diagnostics
N/A


## Checklist
- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
