### PR TITLE
Added Woox R7305 (_TZE284_btsuytky) support

### DIFF
--- a/zhaquirks/tuya/tuya_smoke.py
+++ b/zhaquirks/tuya/tuya_smoke.py
@@ -81,6 +81,7 @@ class TuyaSmokeDetectorCluster(TuyaManufClusterAttributes):
     .applies_to("_TZE284_rccxox8p", "TS0601")
     .applies_to("_TZE200_vzekyi4c", "TS0601")
     .applies_to("_TZE204_vawy74yh", "TS0601")
+    .applies_to("_TZE284_btsuytky", "TS0601")
     .tuya_smoke(dp_id=1)
     .skip_configuration()
     .add_to_registry()
@@ -89,6 +90,7 @@ class TuyaSmokeDetectorCluster(TuyaManufClusterAttributes):
 (
     TuyaQuirkBuilder("TZE200_0zaf1cr8", "TS0601")
     .applies_to("_TZE284_0zaf1cr8", "TS0601")
+    .applies_to("_TZE284_btsuytky", "TS0601")
     .tuya_smoke(dp_id=1)
     .tuya_binary_sensor(
         dp_id=14,


### PR DESCRIPTION
## Proposed change
<!--
Add Support For WOOX R7305 Smart Smoke Detector (_TZE284_btsuytky)
-->


## Additional information
<!--
None, just added it to the list
-->


## Device diagnostics
<!--
{
  "home_assistant": {
    "installation_type": "Home Assistant OS",
    "version": "2025.11.3",
    "dev": false,
    "hassio": true,
    "virtualenv": false,
    "python_version": "3.13.9",
    "docker": true,
    "arch": "aarch64",
    "timezone": "Europe/Amsterdam",
    "os_name": "Linux",
    "os_version": "6.12.47-haos-raspi",
    "container_arch": "aarch64",
    "supervisor": "2025.11.5",
    "host_os": "Home Assistant OS 16.3",
    "docker_version": "28.3.3",
    "chassis": "embedded",
    "run_as_root": true
  },
  "custom_components": {
    "hacs": {
      "documentation": "https://hacs.xyz/docs/configuration/start",
      "version": "2.0.1",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    },
    "p2000": {
      "documentation": "https://github.com/cyberjunky/home-assistant-p2000",
      "version": "1.0.23",
      "requirements": [
        "feedparser"
      ]
    },
    "waterinfo": {
      "documentation": "https://github.com/physje/waterinfo",
      "version": "1.1.0",
      "requirements": [
        "rws-ddlpy==0.6.0"
      ]
    },
    "mikrotik_router": {
      "documentation": "https://github.com/tomaae/homeassistant-mikrotik_router",
      "version": "0.0.0",
      "requirements": [
        "librouteros>=3.2.0",
        "mac-vendor-lookup>=0.1.12"
      ]
    },
    "flightradar24": {
      "documentation": "https://github.com/AlexandrErohin/home-assistant-flightradar24",
      "version": "v1.23.0",
      "requirements": [
        "FlightRadarAPI==1.3.34",
        "pycountry==23.12.11"
      ]
    },
    "hvac_group": {
      "documentation": "https://github.com/tetele/hvac_group",
      "version": "0.2.0",
      "requirements": []
    },
    "network_scanner": {
      "documentation": "https://github.com/parvez/network_scanner",
      "version": "1.0.7",
      "requirements": [
        "python-nmap"
      ]
    },
    "truenas": {
      "documentation": "https://github.com/tomaae/homeassistant-truenas",
      "version": "0.0.0",
      "requirements": []
    },
    "localtuya": {
      "documentation": "https://github.com/rospogrigio/localtuya/",
      "version": "5.2.1",
      "requirements": []
    },
    "mitsubishi_wf_rac": {
      "documentation": "https://github.com/jeatheak/Mitsubishi-WF-RAC-Integration/",
      "version": "2024.7",
      "requirements": [
        "aenum>=3.1.11"
      ]
    },
    "bambu_lab": {
      "documentation": "https://github.com/greghesp/ha-bambulab",
      "version": "2.0.39",
      "requirements": [
        "cloudscraper"
      ]
    },
    "browser_mod": {
      "documentation": "https://github.com/thomasloven/hass-browser_mod/blob/master/README.md",
      "version": "2.3.1",
      "requirements": []
    },
    "afvalbeheer": {
      "documentation": "https://github.com/pippyn/Home-Assistant-Sensor-Afvalbeheer",
      "version": "5.5.4",
      "requirements": [
        "rsa",
        "pycryptodome"
      ]
    },
    "dirigera_platform": {
      "documentation": "https://github.com/sanjoyg/dirigera_platform",
      "version": "0.0.1",
      "requirements": [
        "dirigera==1.2.1"
      ]
    },
    "afvalwijzer": {
      "documentation": "https://github.com/xirixiz/homeassistant-afvalwijzer/blob/main/README.md",
      "version": "2024.12.06",
      "requirements": []
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher"
    ],
    "requirements": [
      "zha==0.0.79"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.00012003490701317787
    },
    "01JEV0NAKDSA2HZWHG1AYXB5BS": {
      "wait_import_platforms": -0.013875456992536783,
      "config_entry_setup": 4.526944338111207
    }
  },
  "data": {
    "version": 1,
    "ieee": "**REDACTED**",
    "nwk": "0xB803",
    "manufacturer": "_TZE284_btsuytky",
    "model": "TS0601",
    "friendly_manufacturer": "_TZE284_btsuytky",
    "friendly_model": "TS0601",
    "name": "_TZE284_btsuytky TS0601",
    "quirk_applied": true,
    "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
    "quirk_id": null,
    "manufacturer_code": 4098,
    "power_source": "Battery or Unknown",
    "lqi": 214,
    "rssi": -42,
    "last_seen": "2025-12-01T17:25:05.305620+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4098,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 82,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 82,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "SMART_PLUG",
          "id": 81
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0001",
                "name": "app_version",
                "zcl_type": "uint8",
                "value": 67
              },
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "_TZE284_btsuytky"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "TS0601"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "value": 1
              },
              {
                "id": "0x0034",
                "name": "battery_rated_voltage",
                "zcl_type": "uint8",
                "value": 30
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "value": 8
              }
            ]
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x0005",
            "endpoint_attribute": "scenes",
            "attributes": []
          },
          {
            "cluster_id": "0x0500",
            "endpoint_attribute": "ias_zone",
            "attributes": [
              {
                "id": "0x0001",
                "name": "zone_type",
                "zcl_type": "enum16",
                "value": 40
              }
            ]
          },
          {
            "cluster_id": "0xed00",
            "endpoint_attribute": null,
            "attributes": []
          },
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": "tuya_manufacturer",
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 67
              }
            ]
          }
        ]
      }
    },
    "original_signature": {},
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "class_name": "IASZone",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "smoke",
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": true,
            "cluster_handlers": [
              {
                "class_name": "IASZoneClusterHandler",
                "generic_id": "cluster_handler_0x0500",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1280,
                  "name": "IAS Zone",
                  "type": "server"
                },
                "id": "1:0x0500",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "zone_status"
          },
          "state": {
            "class_name": "IASZone",
            "available": true,
            "state": false
          }
        },
        {
          "info_object": {
            "fallback_name": "Battery low",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "class_name": "BinarySensor",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "battery",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "battery_low"
          },
          "state": {
            "class_name": "BinarySensor",
            "available": true,
            "state": false
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 214
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -42
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Battery",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "battery",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "PowerConfigurationClusterHandler",
                "generic_id": "cluster_handler_0x0001",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1,
                  "name": "Power Configuration",
                  "type": "server"
                },
                "id": "1:0x0001",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "battery_voltage"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": 0,
            "unit": "%"
          },
          "state": {
            "class_name": "Battery",
            "available": true,
            "state": null,
            "battery_size": "CR123A",
            "battery_quantity": 1
          },
          "extra_state_attributes": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ]
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OtaClientClusterHandler",
                "generic_id": "cluster_handler_0x0019_client",
                "endpoint_id": 1,
                "cluster": {
                  "id": 25,
                  "name": "Ota",
                  "type": "client"
                },
                "id": "1:0x0019_client",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x00000043",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [X] Device diagnostics data has been attached
