### PR TITLE
Add Centralite thermostat 3157100 "-E" variant

### DIFF
--- a/zhaquirks/centralite/cl_3157100.py
+++ b/zhaquirks/centralite/cl_3157100.py
@@ -26,7 +26,12 @@ class CentraLite3157100(CustomDevice):
         #  device_version=0
         #  input_clusters=[0, 1, 3, 513, 514, 516, 32, 2821]
         #  output_clusters=[10, 25]>
-        MODELS_INFO: [(CENTRALITE, "3157100"), ("Centralite", "3157100")],
+        MODELS_INFO: [
+            (CENTRALITE, "3157100"),
+            ("Centralite", "3157100"),
+            (CENTRALITE, "3157100-E"),
+            ("Centralite", "3157100-E"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
## Proposed change
Add Centralite 3157100-E thermostat alongside 3157100

## Additional information
I have a 3157100 and a -E. The -E doesn't get picked up by the quirk, so Home Assistant doesn't know about the battery level.

## Device diagnostics
[zha-eaf2163c01fde964b1753fdcb151fa5d-Centralite 3157100-E-07fab7d5a4de438ba149ae483a2865e9.json](https://github.com/user-attachments/files/24094478/zha-eaf2163c01fde964b1753fdcb151fa5d-Centralite.3157100-E-07fab7d5a4de438ba149ae483a2865e9.json)

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
