### PR TITLE
Add Namron 4512783 Floor Heating Thermostat

### DIFF
--- a/tests/test_namron.py
+++ b/tests/test_namron.py
@@ -1,0 +1,70 @@
+"""Tests for Namron quirks."""
+
+import zhaquirks
+import zhaquirks.namron.namron_4512783
+
+zhaquirks.setup()
+
+
+def test_namron_4512783_signature(assert_signature_matches_quirk):
+    """Test signature matching for Namron 4512783 floor heating thermostat."""
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4714, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 260,
+                "device_type": "0x0301",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0003",
+                    "0x0004",
+                    "0x0005",
+                    "0x0006",
+                    "0x0201",
+                    "0x0204",
+                    "0x0405",
+                    "0x0702",
+                    "0x0b04",
+                    "0x1000",
+                    "0xe002",
+                ],
+                "out_clusters": ["0x0003", "0x0019", "0x0406"],
+            },
+            "242": {
+                "profile_id": 41440,
+                "device_type": "0x0061",
+                "in_clusters": [],
+                "out_clusters": ["0x0021"],
+            },
+        },
+        "manufacturer": "Namron AS",
+        "model": "4512783",
+        "class": "zhaquirks.namron.namron_4512783.NamronFloorHeating4512783",
+    }
+    assert_signature_matches_quirk(
+        zhaquirks.namron.namron_4512783.NamronFloorHeating4512783, signature
+    )
+
+
+def test_namron_thermostat_cluster_attributes():
+    """Test that the custom thermostat cluster has the expected manufacturer-specific attributes."""
+    from zhaquirks.namron.namron_4512783 import (
+        NamronOperationMode,
+        NamronThermostatCluster,
+    )
+
+    # Verify manufacturer-specific attributes are defined
+    assert hasattr(NamronThermostatCluster.AttributeDefs, "operation_mode")
+    assert hasattr(NamronThermostatCluster.AttributeDefs, "regulator_percentage")
+
+    # Verify attribute IDs
+    assert NamronThermostatCluster.AttributeDefs.operation_mode.id == 0x8004
+    assert NamronThermostatCluster.AttributeDefs.regulator_percentage.id == 0x801D
+
+    # Verify attributes are marked as manufacturer-specific
+    assert NamronThermostatCluster.AttributeDefs.operation_mode.is_manufacturer_specific
+    assert NamronThermostatCluster.AttributeDefs.regulator_percentage.is_manufacturer_specific
+
+    # Verify operation mode enum values
+    assert NamronOperationMode.Thermostat == 0x00
+    assert NamronOperationMode.Regulator == 0x06

--- a/zhaquirks/namron/__init__.py
+++ b/zhaquirks/namron/__init__.py
@@ -1,0 +1,3 @@
+"""Namron quirks implementations."""
+
+NAMRON = "Namron AS"

--- a/zhaquirks/namron/namron_4512783.py
+++ b/zhaquirks/namron/namron_4512783.py
@@ -40,6 +40,13 @@ class NamronOperationMode(t.enum8):
     Regulator = 0x06
 
 
+class NamronManufacturerSpecificCluster(CustomCluster):
+    """Namron manufacturer-specific cluster (0xE002)."""
+
+    cluster_id = 0xE002
+    name = "Namron Manufacturer Specific"
+
+
 class NamronThermostatCluster(CustomCluster, Thermostat):
     """Namron manufacturer-specific thermostat cluster.
 
@@ -126,7 +133,7 @@ class NamronFloorHeating4512783(CustomDevice):
                     0x0702,  # Metering
                     ElectricalMeasurement.cluster_id,
                     0x1000,  # Touchlink
-                    0xE002,  # Manufacturer specific
+                    NamronManufacturerSpecificCluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,

--- a/zhaquirks/namron/namron_4512783.py
+++ b/zhaquirks/namron/namron_4512783.py
@@ -1,0 +1,144 @@
+"""Namron 4512783 Floor Heating Thermostat quirk.
+
+This quirk exposes manufacturer-specific attributes for the Namron 4512783
+floor heating thermostat, enabling regulator mode (percentage-based power
+control) in addition to standard thermostat mode.
+
+Manufacturer-specific attributes (Thermostat cluster 0x0201):
+    0x8004 - operation_mode: Controls device operating mode
+             0 = Thermostat mode (temperature-based control)
+             6 = Regulator mode (percentage-based power control)
+    0x801D - regulator_percentage: Power output percentage (0-100) in regulator mode
+"""
+
+from typing import Final
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
+from zigpy.zcl.clusters.measurement import RelativeHumidity
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.namron import NAMRON
+
+
+class NamronOperationMode(t.enum8):
+    """Namron thermostat operation mode."""
+
+    Thermostat = 0x00
+    Regulator = 0x06
+
+
+class NamronThermostatCluster(CustomCluster, Thermostat):
+    """Namron manufacturer-specific thermostat cluster.
+
+    Extends the standard Thermostat cluster with manufacturer-specific
+    attributes for operation mode and regulator percentage control.
+    """
+
+    class AttributeDefs(Thermostat.AttributeDefs):
+        """Manufacturer-specific attribute definitions."""
+
+        operation_mode: Final = ZCLAttributeDef(
+            id=0x8004,
+            type=NamronOperationMode,
+            is_manufacturer_specific=True,
+        )
+        regulator_percentage: Final = ZCLAttributeDef(
+            id=0x801D,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
+
+
+class NamronFloorHeating4512783(CustomDevice):
+    """Namron 4512783 floor heating thermostat."""
+
+    manufacturer_code = 0x126A  # 4714
+
+    signature = {
+        # <NodeDescriptor logical_type=Router manufacturer_code=4714>
+        MODELS_INFO: [(NAMRON, "4512783")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=769
+            # device_version=0
+            # input_clusters=[0, 3, 4, 5, 6, 513, 516, 1029, 1794, 2820, 4096, 57346]
+            # output_clusters=[3, 25, 1030]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.THERMOSTAT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    Thermostat.cluster_id,
+                    UserInterface.cluster_id,
+                    RelativeHumidity.cluster_id,
+                    0x0702,  # Metering
+                    ElectricalMeasurement.cluster_id,
+                    0x1000,  # Touchlink
+                    0xE002,  # Manufacturer specific
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Ota.cluster_id,
+                    0x0406,  # Occupancy Sensing
+                ],
+            },
+            # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+            # device_version=0 input_clusters=[] output_clusters=[33]>
+            242: {
+                PROFILE_ID: 0xA1E0,  # Green Power profile
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [0x0021],  # Green Power
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.THERMOSTAT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    NamronThermostatCluster,
+                    UserInterface.cluster_id,
+                    RelativeHumidity.cluster_id,
+                    0x0702,  # Metering
+                    ElectricalMeasurement.cluster_id,
+                    0x1000,  # Touchlink
+                    0xE002,  # Manufacturer specific
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Ota.cluster_id,
+                    0x0406,  # Occupancy Sensing
+                ],
+            },
+            242: {
+                PROFILE_ID: 0xA1E0,
+                DEVICE_TYPE: 0x0061,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [0x0021],
+            },
+        },
+    }


### PR DESCRIPTION
## Summary
Add support for the Namron 4512783 Floor Heating Thermostat.

## What this quirk does
Exposes manufacturer-specific attributes on the Thermostat cluster (0x0201):
- `operation_mode` (0x8004): Switch between Thermostat mode (0) and Regulator mode (6)
- `regulator_percentage` (0x801D): Set power output percentage (0-100) in regulator mode

## Device Information
- **Manufacturer:** Namron AS
- **Model:** 4512783
- **Manufacturer Code:** 4714 (0x126A)
- **Device Type:** Floor Heating Thermostat

## Device Signature
```
Endpoints:
  1: profile=0x0104, device_type=0x0301 (Thermostat)
     in_clusters: [0x0000, 0x0003, 0x0004, 0x0005, 0x0006, 0x0201, 0x0204, 0x0405, 0x0702, 0x0b04, 0x1000, 0xe002]
     out_clusters: [0x0003, 0x0019, 0x0406]
  242: profile=0xa1e0, device_type=0x0061 (Green Power)
     in_clusters: []
     out_clusters: [0x0021]
```

## Testing
Tested on physical device in Home Assistant 2025.12.3 with ZHA integration.