### PR TITLE
Fix custom divisor for Innr SP 240 on `0x191E3685`

### DIFF
--- a/zhaquirks/innr/__init__.py
+++ b/zhaquirks/innr/__init__.py
@@ -7,15 +7,29 @@ from zigpy.zcl.clusters.smartenergy import Metering
 INNR = "innr"
 
 
-class MeteringClusterInnr(CustomCluster, Metering):
-    """Provide constant multiplier and divisor.
+class MeteringClusterInnrOld(CustomCluster, Metering):
+    """Provide constant multiplier and divisor for old Innr plug firmware.
 
-    The device seems to supply the summation_formatting attribute correctly, but ZHA doesn't use it for kWh for now.
+    Old firmware provides incorrect values for the divisor, so we override them.
     """
 
     _CONSTANT_ATTRIBUTES = {
         Metering.AttributeDefs.multiplier.id: 1,
         Metering.AttributeDefs.divisor.id: 100,
+    }
+
+
+class MeteringClusterInnrNew(CustomCluster, Metering):
+    """Provide constant multiplier and divisor for new Innr plug firmware.
+
+    New firmware provides already provides correct value, but the old quirk will have
+    persisted the static values in the database, so we need to force the new values
+    to avoid users having to re-pair the device.
+    """
+
+    _CONSTANT_ATTRIBUTES = {
+        Metering.AttributeDefs.multiplier.id: 1,
+        Metering.AttributeDefs.divisor.id: 1000,
     }
 
 

--- a/zhaquirks/innr/innr_sp120_plug.py
+++ b/zhaquirks/innr/innr_sp120_plug.py
@@ -24,7 +24,11 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.innr import INNR, ElectricalMeasurementClusterInnr, MeteringClusterInnr
+from zhaquirks.innr import (
+    INNR,
+    ElectricalMeasurementClusterInnr,
+    MeteringClusterInnrOld,
+)
 
 
 class SP120(CustomDevice):
@@ -75,7 +79,7 @@ class SP120(CustomDevice):
                     Groups.cluster_id,
                     Identify.cluster_id,
                     LevelControl.cluster_id,
-                    MeteringClusterInnr,
+                    MeteringClusterInnrOld,
                     OnOff.cluster_id,
                     Scenes.cluster_id,
                     Time.cluster_id,

--- a/zhaquirks/innr/innr_sp234_plug.py
+++ b/zhaquirks/innr/innr_sp234_plug.py
@@ -24,7 +24,11 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.innr import INNR, ElectricalMeasurementClusterInnr, MeteringClusterInnr
+from zhaquirks.innr import (
+    INNR,
+    ElectricalMeasurementClusterInnr,
+    MeteringClusterInnrOld,
+)
 
 
 class SP234(CustomDevice):
@@ -75,7 +79,7 @@ class SP234(CustomDevice):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     OnOff.cluster_id,
-                    MeteringClusterInnr,
+                    MeteringClusterInnrOld,
                     ElectricalMeasurementClusterInnr,
                     Diagnostic.cluster_id,
                     LightLink.cluster_id,

--- a/zhaquirks/innr/innr_sp240_plug.py
+++ b/zhaquirks/innr/innr_sp240_plug.py
@@ -2,8 +2,9 @@
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.general import LevelControl
 
-from zhaquirks.innr import MeteringClusterInnr
+from zhaquirks.innr import MeteringClusterInnrNew, MeteringClusterInnrOld
 
 
 class InnrCluster(CustomCluster):
@@ -14,9 +15,23 @@ class InnrCluster(CustomCluster):
 
 (
     QuirkBuilder(manufacturer="innr", model="SP 240")
-    # Firmware version `421410437` fixed the divisor and multiplier bug
-    .firmware_version_filter(max_version=0x191E3685)
-    .replaces(MeteringClusterInnr, endpoint_id=1)
+    # Firmware version 421410437 fixed the divisor and multiplier bug,
+    # so only apply this quirk to versions older than that (max_version is exclusive).
+    .firmware_version_filter(max_version=0x191E3685, allow_missing=False)
+    .replaces(MeteringClusterInnrOld, endpoint_id=1)
     .replaces(InnrCluster, endpoint_id=1)
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=LevelControl.cluster_id)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder(manufacturer="innr", model="SP 240")
+    # Firmware version 421410437 fixed the divisor and multiplier bug,
+    # so apply this quirk to that and newer versions to force correct new values,
+    # in case the old quirk persisted the old values into the database.
+    .firmware_version_filter(min_version=0x191E3685, allow_missing=True)
+    .replaces(MeteringClusterInnrNew, endpoint_id=1)
+    .replaces(InnrCluster, endpoint_id=1)
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=LevelControl.cluster_id)
     .add_to_registry()
 )

--- a/zhaquirks/innr/innr_sp240_plug.py
+++ b/zhaquirks/innr/innr_sp240_plug.py
@@ -1,31 +1,9 @@
 """Innr SP 240 plug."""
 
-from zigpy.profiles import zgp, zha
-from zigpy.quirks import CustomCluster, CustomDevice
-from zigpy.zcl.clusters.general import (
-    Basic,
-    GreenPowerProxy,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    Scenes,
-    Time,
-)
-from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
-from zigpy.zcl.clusters.lightlink import LightLink
-from zigpy.zcl.clusters.smartenergy import Metering
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-from zhaquirks.innr import INNR, MeteringClusterInnr
+from zhaquirks.innr import MeteringClusterInnr
 
 
 class InnrCluster(CustomCluster):
@@ -34,72 +12,11 @@ class InnrCluster(CustomCluster):
     cluster_id = 0xE001
 
 
-class SP240(CustomDevice):
-    """Innr SP 240  smart plug."""
-
-    signature = {
-        MODELS_INFO: [(INNR, "SP 240")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Metering.cluster_id,
-                    ElectricalMeasurement.cluster_id,
-                    LightLink.cluster_id,
-                    InnrCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Time.cluster_id,
-                    Ota.cluster_id,
-                ],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [
-                    GreenPowerProxy.cluster_id,
-                ],
-            },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_PLUG_IN_UNIT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    MeteringClusterInnr,
-                    ElectricalMeasurement.cluster_id,
-                    LightLink.cluster_id,
-                    InnrCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Time.cluster_id,
-                    Ota.cluster_id,
-                ],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [
-                    GreenPowerProxy.cluster_id,
-                ],
-            },
-        },
-    }
+(
+    QuirkBuilder(manufacturer="innr", model="SP 240")
+    # Firmware version `421410437` fixed the divisor and multiplier bug
+    .firmware_version_filter(max_version=0x191E3685)
+    .replaces(MeteringClusterInnr, endpoint_id=1)
+    .replaces(InnrCluster, endpoint_id=1)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

This quirk removes changing the divisor for Innr SP 240 plugs on firmware `0x191E3685` and later.

As old divisor values from the quirk may have persisted into zigpy cache, a quirk for newer versions is also added to force the correct `divisor: 1000`. This avoids users needing to re-pair devices to fix the issue and also allows OTA upgrades without re-pairing the device (just needing a ZHA reload or HA restart).

The config entities for the `LevelControl` cluster are also hidden.


## Additional information

Tested with the SP 240 (on a much newer version than the latest OTA).

Fixes:
- Addresses https://github.com/zigpy/zha-device-handlers/issues/3857
- Addresses https://github.com/zigpy/zha-device-handlers/issues/2781


## Device diagnostics

Freshly paired without quirk:
[Innr SP 240 without quirk zha-01KAH6BZ8GBKBJXCPX8V4BB4KP-innr SP 240-40d6d753fef0dfeafea5ce24ed764473.json](https://github.com/user-attachments/files/24413444/Innr.SP.240.without.quirk.zha-01KAH6BZ8GBKBJXCPX8V4BB4KP-innr.SP.240-40d6d753fef0dfeafea5ce24ed764473.json)



## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
