### PR TITLE
Add quirk for Bosch RFDL-ZB-MS TriTech motion sensor

### DIFF
--- a/tests/test_bosch.py
+++ b/tests/test_bosch.py
@@ -15,11 +15,10 @@ from zhaquirks.bosch.rbsh_trv0_zb_eu import (
     BoschThermostatCluster as BoschTrvThermostatCluster,
 )
 from zhaquirks.bosch.rfdl_zb_ms import (
+    STUCK_MOTION_THRESHOLD_S,
     BoschIasZone,
     BoschOccupancy,
     BoschRFDLZBMS,
-    MOTION_TIMEOUT_S,
-    STUCK_MOTION_THRESHOLD_S,
 )
 
 zhaquirks.setup()
@@ -794,16 +793,16 @@ async def test_bosch_rfdl_zb_ms_motion_event_sets_occupancy(zigpy_device_from_qu
     assert occupancy_cluster._occupied_since is not None
 
 
-async def test_bosch_rfdl_zb_ms_motion_timeout_clears_occupancy(zigpy_device_from_quirk):
+async def test_bosch_rfdl_zb_ms_motion_timeout_clears_occupancy(
+    zigpy_device_from_quirk,
+):
     """Test that occupancy clears after timeout."""
     device = zigpy_device_from_quirk(BoschRFDLZBMS)
     occupancy_cluster = device.endpoints[1].occupancy
     occupancy_listener = ClusterListener(occupancy_cluster)
 
     # Patch the timeout to be very short for testing
-    with mock.patch.object(
-        zhaquirks.bosch.rfdl_zb_ms, "MOTION_TIMEOUT_S", 0.05
-    ):
+    with mock.patch.object(zhaquirks.bosch.rfdl_zb_ms, "MOTION_TIMEOUT_S", 0.05):
         # Trigger motion event
         occupancy_cluster.motion_event()
 
@@ -914,7 +913,9 @@ async def test_bosch_rfdl_zb_ms_multiple_motion_events_reset_timer(
         assert occupancy_cluster._attr_cache.get(0x0000, 0) == 0
 
 
-async def test_bosch_rfdl_zb_ms_ias_zone_forwards_motion_to_bus(zigpy_device_from_quirk):
+async def test_bosch_rfdl_zb_ms_ias_zone_forwards_motion_to_bus(
+    zigpy_device_from_quirk,
+):
     """Test that IAS Zone cluster forwards motion events to the bus."""
     device = zigpy_device_from_quirk(BoschRFDLZBMS)
     ias_zone_cluster = device.endpoints[1].ias_zone

--- a/tests/test_bosch.py
+++ b/tests/test_bosch.py
@@ -1,15 +1,25 @@
-"""Tests the Bosch thermostats quirk."""
+"""Tests the Bosch quirks."""
 
+import asyncio
+import time
 from unittest import mock
 
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.hvac import ControlSequenceOfOperation, Thermostat
 from zigpy.zcl.foundation import WriteAttributesStatusRecord
 
+from tests.common import ZCL_IAS_MOTION_COMMAND, ClusterListener
 import zhaquirks
 from zhaquirks.bosch.rbsh_trv0_zb_eu import (
     BoschOperatingMode,
     BoschThermostatCluster as BoschTrvThermostatCluster,
+)
+from zhaquirks.bosch.rfdl_zb_ms import (
+    BoschIasZone,
+    BoschOccupancy,
+    BoschRFDLZBMS,
+    MOTION_TIMEOUT_S,
+    STUCK_MOTION_THRESHOLD_S,
 )
 
 zhaquirks.setup()
@@ -712,3 +722,244 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(
             ]
             == ControlSequenceOfOperation.Cooling_Only
         )
+
+
+# =============================================================================
+# Bosch RFDL-ZB-MS TriTech Motion Sensor Tests
+# =============================================================================
+
+
+def test_bosch_rfdl_zb_ms_signature(assert_signature_matches_quirk):
+    """Test that the RFDL-ZB-MS device signature matches the quirk."""
+    signature = {
+        "node_descriptor": "NodeDescriptor(...)",
+        "endpoints": {
+            "1": {
+                "profile_id": 260,
+                "device_type": "0x0402",
+                "in_clusters": [
+                    "0x0000",
+                    "0x0001",
+                    "0x0003",
+                    "0x0020",
+                    "0x0400",
+                    "0x0402",
+                    "0x0500",
+                    "0x0b05",
+                ],
+                "out_clusters": ["0x0019"],
+            }
+        },
+        "manufacturer": "Bosch",
+        "model": "RFDL-ZB-MS",
+    }
+    assert_signature_matches_quirk(BoschRFDLZBMS, signature)
+
+
+def test_bosch_rfdl_zb_ms_device_has_motion_bus(zigpy_device_from_quirk):
+    """Test that the RFDL-ZB-MS device has a motion bus."""
+    device = zigpy_device_from_quirk(BoschRFDLZBMS)
+    assert hasattr(device, "motion_bus")
+    assert device.motion_bus is not None
+
+
+def test_bosch_rfdl_zb_ms_replacement_clusters(zigpy_device_from_quirk):
+    """Test that the RFDL-ZB-MS replacement clusters are present."""
+    device = zigpy_device_from_quirk(BoschRFDLZBMS)
+    ep = device.endpoints[1]
+
+    # Check IAS Zone is our custom cluster
+    assert isinstance(ep.ias_zone, BoschIasZone)
+
+    # Check Occupancy cluster is present and is our custom cluster
+    assert hasattr(ep, "occupancy")
+    assert isinstance(ep.occupancy, BoschOccupancy)
+
+
+async def test_bosch_rfdl_zb_ms_motion_event_sets_occupancy(zigpy_device_from_quirk):
+    """Test that a motion event sets occupancy to 1."""
+    device = zigpy_device_from_quirk(BoschRFDLZBMS)
+    occupancy_cluster = device.endpoints[1].occupancy
+    occupancy_listener = ClusterListener(occupancy_cluster)
+
+    # Initially unoccupied
+    assert occupancy_cluster._attr_cache.get(0x0000, 0) == 0
+
+    # Trigger motion event
+    occupancy_cluster.motion_event()
+
+    # Should be occupied now
+    assert len(occupancy_listener.attribute_updates) == 1
+    assert occupancy_listener.attribute_updates[0] == (0x0000, 1)
+    assert occupancy_cluster._occupied_since is not None
+
+
+async def test_bosch_rfdl_zb_ms_motion_timeout_clears_occupancy(zigpy_device_from_quirk):
+    """Test that occupancy clears after timeout."""
+    device = zigpy_device_from_quirk(BoschRFDLZBMS)
+    occupancy_cluster = device.endpoints[1].occupancy
+    occupancy_listener = ClusterListener(occupancy_cluster)
+
+    # Patch the timeout to be very short for testing
+    with mock.patch.object(
+        zhaquirks.bosch.rfdl_zb_ms, "MOTION_TIMEOUT_S", 0.05
+    ):
+        # Trigger motion event
+        occupancy_cluster.motion_event()
+
+        assert len(occupancy_listener.attribute_updates) == 1
+        assert occupancy_listener.attribute_updates[0] == (0x0000, 1)
+
+        # Wait for timeout
+        await asyncio.sleep(0.1)
+
+        # Should be unoccupied now
+        assert len(occupancy_listener.attribute_updates) == 2
+        assert occupancy_listener.attribute_updates[1] == (0x0000, 0)
+        assert occupancy_cluster._occupied_since is None
+        assert occupancy_cluster._timer_handle is None
+
+
+async def test_bosch_rfdl_zb_ms_clear_when_not_occupied_triggers_motion(
+    zigpy_device_from_quirk,
+):
+    """Test that a clear event when not occupied is treated as motion (stuck sensor)."""
+    device = zigpy_device_from_quirk(BoschRFDLZBMS)
+    occupancy_cluster = device.endpoints[1].occupancy
+    occupancy_listener = ClusterListener(occupancy_cluster)
+
+    # Ensure we're not occupied
+    assert occupancy_cluster._occupied_since is None
+
+    # Send clear event - should trigger motion
+    occupancy_cluster.motion_clear()
+
+    # Should be occupied now (treated as motion)
+    assert len(occupancy_listener.attribute_updates) == 1
+    assert occupancy_listener.attribute_updates[0] == (0x0000, 1)
+    assert occupancy_cluster._occupied_since is not None
+
+
+async def test_bosch_rfdl_zb_ms_clear_after_threshold_triggers_motion(
+    zigpy_device_from_quirk,
+):
+    """Test that a clear after STUCK_MOTION_THRESHOLD_S is treated as new motion."""
+    device = zigpy_device_from_quirk(BoschRFDLZBMS)
+    occupancy_cluster = device.endpoints[1].occupancy
+    occupancy_listener = ClusterListener(occupancy_cluster)
+
+    # Trigger initial motion
+    occupancy_cluster.motion_event()
+    assert len(occupancy_listener.attribute_updates) == 1
+
+    # Simulate time passing beyond threshold
+    occupancy_cluster._occupied_since = time.monotonic() - STUCK_MOTION_THRESHOLD_S - 1
+
+    # Send clear event - should trigger new motion
+    occupancy_cluster.motion_clear()
+
+    # Should have another occupancy update (reset timer)
+    assert len(occupancy_listener.attribute_updates) == 2
+    assert occupancy_listener.attribute_updates[1] == (0x0000, 1)
+
+
+async def test_bosch_rfdl_zb_ms_clear_within_threshold_ignored(zigpy_device_from_quirk):
+    """Test that a clear within STUCK_MOTION_THRESHOLD_S is ignored."""
+    device = zigpy_device_from_quirk(BoschRFDLZBMS)
+    occupancy_cluster = device.endpoints[1].occupancy
+    occupancy_listener = ClusterListener(occupancy_cluster)
+
+    # Trigger initial motion
+    occupancy_cluster.motion_event()
+    assert len(occupancy_listener.attribute_updates) == 1
+
+    # Clear arrives quickly (within threshold) - should be ignored
+    occupancy_cluster.motion_clear()
+
+    # No new updates - the clear was ignored
+    assert len(occupancy_listener.attribute_updates) == 1
+
+
+async def test_bosch_rfdl_zb_ms_multiple_motion_events_reset_timer(
+    zigpy_device_from_quirk,
+):
+    """Test that multiple motion events reset the timer."""
+    device = zigpy_device_from_quirk(BoschRFDLZBMS)
+    occupancy_cluster = device.endpoints[1].occupancy
+
+    with mock.patch.object(zhaquirks.bosch.rfdl_zb_ms, "MOTION_TIMEOUT_S", 0.1):
+        # First motion event
+        occupancy_cluster.motion_event()
+        first_handle = occupancy_cluster._timer_handle
+
+        await asyncio.sleep(0.05)
+
+        # Second motion event should cancel and create new timer
+        occupancy_cluster.motion_event()
+        second_handle = occupancy_cluster._timer_handle
+
+        # Timer handle should be different (new timer)
+        assert first_handle is not second_handle
+
+        # Wait a bit more but not full timeout from second event
+        await asyncio.sleep(0.07)
+
+        # Should still be occupied (timer was reset)
+        assert occupancy_cluster._attr_cache.get(0x0000, 0) == 1
+
+        # Wait for the full timeout from second event
+        await asyncio.sleep(0.05)
+
+        # Now should be unoccupied
+        assert occupancy_cluster._attr_cache.get(0x0000, 0) == 0
+
+
+async def test_bosch_rfdl_zb_ms_ias_zone_forwards_motion_to_bus(zigpy_device_from_quirk):
+    """Test that IAS Zone cluster forwards motion events to the bus."""
+    device = zigpy_device_from_quirk(BoschRFDLZBMS)
+    ias_zone_cluster = device.endpoints[1].ias_zone
+    occupancy_cluster = device.endpoints[1].occupancy
+    occupancy_listener = ClusterListener(occupancy_cluster)
+
+    # Send motion command via IAS Zone
+    hdr, args = ias_zone_cluster.deserialize(ZCL_IAS_MOTION_COMMAND)
+    ias_zone_cluster.handle_message(hdr, args)
+
+    # Occupancy should be set
+    assert len(occupancy_listener.attribute_updates) == 1
+    assert occupancy_listener.attribute_updates[0] == (0x0000, 1)
+
+
+async def test_bosch_rfdl_zb_ms_ias_zone_forwards_clear_to_bus(zigpy_device_from_quirk):
+    """Test that IAS Zone cluster forwards clear events to the bus."""
+    device = zigpy_device_from_quirk(BoschRFDLZBMS)
+    ias_zone_cluster = device.endpoints[1].ias_zone
+    occupancy_cluster = device.endpoints[1].occupancy
+    occupancy_listener = ClusterListener(occupancy_cluster)
+
+    # First trigger motion so we're occupied
+    occupancy_cluster.motion_event()
+    initial_updates = len(occupancy_listener.attribute_updates)
+
+    # Simulate time passing beyond threshold so clear triggers new motion
+    occupancy_cluster._occupied_since = time.monotonic() - STUCK_MOTION_THRESHOLD_S - 1
+
+    # Create a clear command (zone status = 0, no alarm)
+    # ZCL_IAS_MOTION_COMMAND has zone_status = 0x0001 (alarm1 set)
+    # We need zone_status = 0x0000 (no alarm)
+    clear_command = b"\t!\x00\x00\x00\x00\x00\x00\x00"
+
+    hdr, args = ias_zone_cluster.deserialize(clear_command)
+    ias_zone_cluster.handle_message(hdr, args)
+
+    # Should have triggered motion_clear which treats as new motion
+    assert len(occupancy_listener.attribute_updates) == initial_updates + 1
+
+
+def test_bosch_rfdl_zb_ms_occupancy_pir_sensor_type(zigpy_device_from_quirk):
+    """Test that occupancy cluster reports PIR sensor type."""
+    device = zigpy_device_from_quirk(BoschRFDLZBMS)
+    occupancy_cluster = device.endpoints[1].occupancy
+
+    # Attribute 0x0010 is occupancy_sensor_type, should be 0 (PIR)
+    assert occupancy_cluster._CONSTANT_ATTRIBUTES.get(0x0010) == 0

--- a/zhaquirks/bosch/rfdl_zb_ms.py
+++ b/zhaquirks/bosch/rfdl_zb_ms.py
@@ -1,0 +1,227 @@
+"""Quirk for Bosch RFDL-ZB-MS TriTech motion sensor.
+
+This quirk adds a virtual occupancy cluster with configurable timeout
+to ensure reliable motion clear events, addressing an issue where the
+hardware IAS Zone cluster intermittently fails to send clear notifications.
+
+https://github.com/zigpy/zha-device-handlers
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Identify,
+    Ota,
+    PollControl,
+    PowerConfiguration,
+)
+from zigpy.zcl.clusters.homeautomation import Diagnostic
+from zigpy.zcl.clusters.measurement import (
+    IlluminanceMeasurement,
+    OccupancySensing,
+    TemperatureMeasurement,
+)
+from zigpy.zcl.clusters.security import IasZone
+from zigpy.zcl import foundation
+
+from zhaquirks import Bus, LocalDataCluster, PowerConfigurationCluster
+from zhaquirks.bosch import BOSCH
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    MOTION_EVENT,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+MOTION_TIMEOUT_S = 120
+STUCK_MOTION_THRESHOLD_S = (
+    30  # If occupied longer than this when clear arrives, treat as new motion
+)
+MOTION_CLEAR_EVENT = "motion_clear"
+
+
+class BoschPowerConfiguration(PowerConfigurationCluster):
+    """Power configuration with voltage-to-percentage conversion for Bosch sensors."""
+
+    MIN_VOLTS = 1.9  # Minimum voltage (0%)
+    MAX_VOLTS = 3.0  # Maximum voltage (100%)
+
+
+class BoschIasZone(CustomCluster, IasZone):
+    """IAS Zone cluster that forwards motion events to the virtual occupancy cluster."""
+
+    cluster_id = IasZone.cluster_id
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: None = None,
+    ) -> None:
+        """Handle zone status change notifications."""
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+        if hdr.command_id == 0:  # Zone status change notification
+            zone_status = args[0] if args else 0
+            alarm1 = bool(zone_status & 0x01)
+
+            _LOGGER.debug(
+                "Bosch RFDL-ZB-MS zone status: 0x%04X (motion=%s)",
+                zone_status,
+                alarm1,
+            )
+
+            if alarm1:
+                self.endpoint.device.motion_bus.listener_event(MOTION_EVENT)
+            else:
+                # Clear event - let occupancy cluster decide if this is a stuck sensor reset
+                self.endpoint.device.motion_bus.listener_event(MOTION_CLEAR_EVENT)
+
+
+class BoschOccupancy(LocalDataCluster, OccupancySensing):
+    """Virtual occupancy cluster with guaranteed timeout.
+
+    Provides a software-based motion timeout that clears occupancy
+    after MOTION_TIMEOUT_S seconds of no motion, regardless of whether
+    the hardware sends a clear event.
+    """
+
+    cluster_id = OccupancySensing.cluster_id
+
+    _CONSTANT_ATTRIBUTES = {
+        0x0010: 0,  # PIR sensor type
+    }
+
+    def __init__(self, *args, **kwargs):
+        """Initialize cluster and subscribe to motion bus."""
+        super().__init__(*args, **kwargs)
+        self._update_attribute(0x0000, 0)  # occupancy = unoccupied
+        self.endpoint.device.motion_bus.add_listener(self)
+        self._timer_handle = None
+        self._occupied_since = None  # Track when we became occupied
+
+    def motion_event(self):
+        """Handle motion event - set occupied and start/reset timer."""
+        _LOGGER.debug(
+            "Bosch RFDL-ZB-MS: motion detected, starting %ds timer", MOTION_TIMEOUT_S
+        )
+        self._update_attribute(0x0000, 1)  # occupancy = occupied
+        self._occupied_since = time.monotonic()
+
+        if self._timer_handle:
+            self._timer_handle.cancel()
+
+        loop = asyncio.get_event_loop()
+        self._timer_handle = loop.call_later(MOTION_TIMEOUT_S, self._clear_occupancy)
+
+    def motion_clear(self):
+        """Handle clear event from hardware.
+
+        Treats clear as new motion in two scenarios:
+        1. Not currently occupied - sensor was stuck, this clear indicates new activity
+        2. Occupied for longer than STUCK_MOTION_THRESHOLD_S - sensor resetting due to new activity
+        """
+        if self._occupied_since is None:
+            # Not currently occupied but got a clear - sensor was stuck in motion state
+            # and is now resetting due to new activity. Treat as motion.
+            _LOGGER.debug(
+                "Bosch RFDL-ZB-MS: clear received while not occupied, treating as motion (stuck sensor reset)"
+            )
+            self.motion_event()
+            return
+
+        occupied_duration = time.monotonic() - self._occupied_since
+
+        if occupied_duration >= STUCK_MOTION_THRESHOLD_S:
+            _LOGGER.debug(
+                "Bosch RFDL-ZB-MS: clear after %ds (>%ds threshold), treating as new motion",
+                int(occupied_duration),
+                STUCK_MOTION_THRESHOLD_S,
+            )
+            # Treat as new motion - reset the timer
+            self.motion_event()
+        else:
+            _LOGGER.debug(
+                "Bosch RFDL-ZB-MS: clear after %ds (<%ds threshold), ignoring (timer will handle)",
+                int(occupied_duration),
+                STUCK_MOTION_THRESHOLD_S,
+            )
+            # Let the software timer handle the clear
+
+    def _clear_occupancy(self):
+        """Clear occupancy after timeout."""
+        _LOGGER.debug(
+            "Bosch RFDL-ZB-MS: clearing occupancy after %ds timeout", MOTION_TIMEOUT_S
+        )
+        self._update_attribute(0x0000, 0)  # occupancy = unoccupied
+        self._timer_handle = None
+        self._occupied_since = None
+
+
+class BoschRFDLZBMS(CustomDevice):
+    """Bosch RFDL-ZB-MS RADION TriTech motion sensor."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize device with motion bus."""
+        self.motion_bus = Bus()
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        MODELS_INFO: [(BOSCH, "RFDL-ZB-MS")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: 0x0402,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    IlluminanceMeasurement.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    IasZone.cluster_id,
+                    Diagnostic.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: 0x0402,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    BoschPowerConfiguration,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    IlluminanceMeasurement.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    BoschIasZone,
+                    Diagnostic.cluster_id,
+                    BoschOccupancy,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                ],
+            }
+        },
+    }

--- a/zhaquirks/bosch/rfdl_zb_ms.py
+++ b/zhaquirks/bosch/rfdl_zb_ms.py
@@ -14,8 +14,9 @@ import logging
 import time
 from typing import Any
 
-from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
     Identify,
@@ -30,7 +31,6 @@ from zigpy.zcl.clusters.measurement import (
     TemperatureMeasurement,
 )
 from zigpy.zcl.clusters.security import IasZone
-from zigpy.zcl import foundation
 
 from zhaquirks import Bus, LocalDataCluster, PowerConfigurationCluster
 from zhaquirks.bosch import BOSCH


### PR DESCRIPTION
Adds a device handler for the Bosch RFDL-ZB-MS RADION TriTech motion sensor with:

- Virtual Occupancy Sensing cluster (0x0406) with guaranteed 120s timeout
- Handles stuck sensor detection when hardware fails to send clear events
- Custom power configuration for battery voltage conversion

The hardware IAS Zone cluster intermittently fails to send motion clear events. This quirk provides a reliable software-based motion timeout through the occupancy cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Proposed change
<!--
  Explain your proposed change below.
-->
 This quirk adds support for the Bosch RFDL-ZB-MS RADION TriTech motion sensor, which has a hardware issue where the IAS Zone cluster intermittently fails to send motion clear events.
  The solution adds a virtual Occupancy Sensing cluster (0x0406) that:
  1. Sets occupancy ON when motion is detected
  2. Starts a 120-second timer (reset on each motion event)
  3. Guarantees occupancy OFF after timeout, regardless of hardware behavior
  It also handles "stuck" sensors - when the hardware has been stuck in motion-detected state and finally sends a late clear, the quirk treats this as new motion to ensure automations trigger correctly.



## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
  - No breaking changes
  - No dependencies on other PRs
  - Creates two binary sensors: IAS Zone (instant) and Occupancy (reliable timeout)
  - Users should use the occupancy entity for automations requiring guaranteed clear events

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
```json
{
  "home_assistant": {
    "installation_type": "Home Assistant OS",
    "version": "2025.12.4",
    "dev": false,
    "hassio": true,
    "virtualenv": false,
    "python_version": "3.13.9",
    "docker": true,
    "arch": "aarch64",
    "timezone": "America/New_York",
    "os_name": "Linux",
    "os_version": "6.12.47-haos-raspi",
    "container_arch": "aarch64",
    "supervisor": "2025.12.3",
    "host_os": "Home Assistant OS 16.3",
    "docker_version": "28.3.3",
    "chassis": "embedded",
    "run_as_root": true
  },
  "custom_components": {
    "hacs": {
      "documentation": "https://hacs.xyz/docs/use/",
      "version": "2.0.5",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    },
    "bambu_lab": {
      "documentation": "https://github.com/greghesp/ha-bambulab",
      "version": "2.2.18",
      "requirements": [
        "beautifulsoup4"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher"
    ],
    "requirements": [
      "zha==0.0.81"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.00022562919184565544
    },
    "8173f35af2cf9515153fa2d4e7393218": {
      "wait_import_platforms": -0.09561785636469722,
      "wait_base_component": -0.0019555678591132164,
      "config_entry_setup": 18.18183189537376
    }
  },
  "data": {
    "version": 1,
    "ieee": "**REDACTED**",
    "nwk": "0x1C2A",
    "manufacturer": "Bosch",
    "model": "RFDL-ZB-MS",
    "friendly_manufacturer": "Bosch",
    "friendly_model": "RFDL-ZB-MS",
    "name": "Bosch RFDL-ZB-MS",
    "quirk_applied": true,
    "quirk_class": "bosch_tritech.BoschRFDLZBMS",
    "exposes_features": [],
    "manufacturer_code": 4403,
    "power_source": "Battery or Unknown",
    "lqi": 180,
    "rssi": -66,
    "last_seen": "2025-12-22T13:30:18.280085+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4403,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 82,
      "server_mask": 0,
      "maximum_outgoing_transfer_size": 82,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "IAS_ZONE",
          "id": 1026
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "Bosch"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "RFDL-ZB-MS"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "zcl_type": "uint8",
                "value": 200
              },
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "value": 1
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "value": 2
              },
              {
                "id": "0x0020",
                "name": "battery_voltage",
                "zcl_type": "uint8",
                "value": 30
              }
            ]
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0020",
            "endpoint_attribute": "poll_control",
            "attributes": [
              {
                "id": "0x0003",
                "name": "fast_poll_timeout",
                "zcl_type": "uint16",
                "value": 120
              }
            ]
          },
          {
            "cluster_id": "0x0400",
            "endpoint_attribute": "illuminance",
            "attributes": [
              {
                "id": "0x0000",
                "name": "measured_value",
                "zcl_type": "uint16",
                "value": 6976
              }
            ]
          },
          {
            "cluster_id": "0x0402",
            "endpoint_attribute": "temperature",
            "attributes": [
              {
                "id": "0x0000",
                "name": "measured_value",
                "zcl_type": "int16",
                "value": 1763
              }
            ]
          },
          {
            "cluster_id": "0x0406",
            "endpoint_attribute": "occupancy",
            "attributes": [
              {
                "id": "0x0000",
                "name": "occupancy",
                "zcl_type": "map8",
                "value": 0
              },
              {
                "id": "0x0010",
                "name": "pir_o_to_u_delay",
                "zcl_type": "uint16",
                "value": 0
              }
            ]
          },
          {
            "cluster_id": "0x0500",
            "endpoint_attribute": "ias_zone",
            "attributes": [
              {
                "id": "0x0010",
                "name": "cie_addr",
                "zcl_type": "EUI64",
                "value": "6c:5c:b1:ff:fe:ed:64:97"
              },
              {
                "id": "0x0000",
                "name": "zone_state",
                "zcl_type": "enum8",
                "value": 1
              },
              {
                "id": "0x0002",
                "name": "zone_status",
                "zcl_type": "map16",
                "value": 32
              },
              {
                "id": "0x0001",
                "name": "zone_type",
                "zcl_type": "enum16",
                "value": 13
              }
            ]
          },
          {
            "cluster_id": "0x0b05",
            "endpoint_attribute": "diagnostic",
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 588403713
              }
            ]
          }
        ]
      }
    },
    "original_signature": {
      "models_info": [
        [
          "Bosch",
          "RFDL-ZB-MS"
        ]
      ],
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0402",
          "input_clusters": [
            "0x0000",
            "0x0001",
            "0x0003",
            "0x0020",
            "0x0400",
            "0x0402",
            "0x0500",
            "0x0b05"
          ],
          "output_clusters": [
            "0x0019"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "class_name": "Occupancy",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "occupancy",
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OccupancySensingClusterHandler",
                "generic_id": "cluster_handler_0x0406",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1030,
                  "name": "Occupancy Sensing",
                  "type": "server"
                },
                "id": "1:0x0406",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "occupancy"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "occupancy"
          },
          "state": {
            "class_name": "Occupancy",
            "available": true,
            "state": false
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "class_name": "IASZone",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "motion",
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": true,
            "cluster_handlers": [
              {
                "class_name": "IASZoneClusterHandler",
                "generic_id": "cluster_handler_0x0500",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1280,
                  "name": "IAS Zone",
                  "type": "server"
                },
                "id": "1:0x0500",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "zone_status"
          },
          "state": {
            "class_name": "IASZone",
            "available": true,
            "state": false
          }
        }
      ],
      "button": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "button",
            "class_name": "IdentifyButton",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "identify",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "IdentifyClusterHandler",
                "generic_id": "cluster_handler_0x0003",
                "endpoint_id": 1,
                "cluster": {
                  "id": 3,
                  "name": "Identify",
                  "type": "server"
                },
                "id": "1:0x0003",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "command": "identify",
            "args": [
              5
            ],
            "kwargs": {}
          },
          "state": {
            "class_name": "IdentifyButton",
            "available": true
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 180
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -66
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Battery",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "battery",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "PowerConfigurationClusterHandler",
                "generic_id": "cluster_handler_0x0001",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1,
                  "name": "Power Configuration",
                  "type": "server"
                },
                "id": "1:0x0001",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "battery_voltage"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": 0,
            "unit": "%"
          },
          "state": {
            "class_name": "Battery",
            "available": true,
            "state": 100.0,
            "battery_size": "Other",
            "battery_quantity": 1,
            "battery_voltage": 3.0
          },
          "extra_state_attributes": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ]
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Illuminance",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "illuminance",
            "state_class": "measurement",
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "IlluminanceMeasurementClusterHandler",
                "generic_id": "cluster_handler_0x0400",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1024,
                  "name": "Illuminance Measurement",
                  "type": "server"
                },
                "id": "1:0x0400",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "measured_value"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "lx"
          },
          "state": {
            "class_name": "Illuminance",
            "available": true,
            "state": 5
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Temperature",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "temperature",
            "state_class": "measurement",
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TemperatureMeasurementClusterHandler",
                "generic_id": "cluster_handler_0x0402",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1026,
                  "name": "Temperature Measurement",
                  "type": "server"
                },
                "id": "1:0x0402",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "measured_value"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "\u00b0C"
          },
          "state": {
            "class_name": "Temperature",
            "available": true,
            "state": 17.63
          }
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OtaClientClusterHandler",
                "generic_id": "cluster_handler_0x0019_client",
                "endpoint_id": 1,
                "cluster": {
                  "id": 25,
                  "name": "Ota",
                  "type": "client"
                },
                "id": "1:0x0019_client",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x23125401",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
