### PR TITLE
Add support for Nous E10 CO2, Temperature and Humidity Detector

### DIFF
--- a/tests/test_nous.py
+++ b/tests/test_nous.py
@@ -1,0 +1,12 @@
+"""Tests for Nous quirks."""
+
+import zhaquirks
+
+zhaquirks.setup()
+
+
+def test_nous_e10_quirk_loads():
+    """Test that the Nous E10 CO2 sensor quirk file loads and registers without errors."""
+    # The quirk is auto-registered when the module is imported
+    # This test ensures the file has no syntax/import errors and registers successfully
+    import zhaquirks.tuya.nous_e10_co2  # noqa: F401

--- a/zhaquirks/tuya/nous_e10_co2.py
+++ b/zhaquirks/tuya/nous_e10_co2.py
@@ -1,0 +1,46 @@
+"""Nous E10 CO2, Temperature, and Humidity Detector.
+
+Manufacturer: _TZE284_xpvamyfz
+Model: TS0601
+"""
+
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
+import zigpy.types as t
+
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+(
+    TuyaQuirkBuilder("_TZE284_xpvamyfz", "TS0601")
+    .tuya_sensor(
+        dp_id=2,
+        attribute_name="carbon_dioxide_concentration",
+        type=t.uint32_t,
+        divisor=1,
+        device_class=SensorDeviceClass.CO2,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit="ppm",
+        fallback_name="CO2",
+    )
+    .tuya_sensor(
+        dp_id=18,
+        attribute_name="temperature",
+        type=t.int32s,
+        divisor=1,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit="°C",
+        fallback_name="Temperature",
+    )
+    .tuya_sensor(
+        dp_id=19,
+        attribute_name="humidity",
+        type=t.uint32_t,
+        divisor=1,
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit="%",
+        fallback_name="Humidity",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
Add quirk for the Nous E10 (_TZE284_xpvamyfz / TS0601) which provides CO2, temperature, and humidity measurements using the TuyaQuirkBuilder v2 API.

Sensors:
- CO2 concentration (DP 2, ppm)
- Temperature (DP 18, °C, signed for negative values)
- Humidity (DP 19, %)

## Additional information
- This is my first time trying to do this - feedback welcome and appreciated.
- Tests are minimal but it isn't clear to me what else to test - examples welcome
- This code is working in my HA instance with the device

## Device diagnostics
[zha-2b5da96179570b3038c5dfdb61f698d8-_TZE284_xpvamyfz TS0601-9eae19e47cbad4e60c376b24b5c0679b.json](https://github.com/user-attachments/files/24311493/zha-2b5da96179570b3038c5dfdb61f698d8-_TZE284_xpvamyfz.TS0601-9eae19e47cbad4e60c376b24b5c0679b.json)


## Checklist
- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [X] Tests have been added to verify that the new code works
- [X] Device diagnostics data has been attached
