### PR TITLE
Add Arteco ZS-304Z soil moisture sensor

### DIFF
--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -178,3 +178,54 @@ def test_valid_attributes(zigpy_device_from_v2_quirk):
     assert {temperature_attr_id} == temperature_cluster._VALID_ATTRIBUTES
     assert {humidity_attr_id} == humidity_cluster._VALID_ATTRIBUTES
     assert {power_attr_id} == power_config_cluster._VALID_ATTRIBUTES
+
+
+async def test_handle_get_data_soil_sensor(zigpy_device_from_v2_quirk):
+    """Test handle_get_data for Arteco ZS-304Z soil sensor."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_o9ofysmo", "TS0601")
+    ep = quirked.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+
+    # DP 3: Soil Moisture (50%) -> 50
+    # DP 5: Temperature (25.0 C) -> 250
+    # DP 14: Battery (High) -> 2
+    # DP 101: Humidity (60%) -> 60
+    # DP 102: Illuminance (1000 lux) -> 1000
+
+    # Payload construction
+    # ZCL Header: 09 (FC) e0 (Seq) 02 (Cmd)
+    # Tuya Header in payload: 00 00 (Trans ID?)
+    # DPs
+    dps = (
+        b"\x03\x02\x00\x04\x00\x00\x00\x32"  # DP 3: 50 (0x32)
+        b"\x05\x02\x00\x04\x00\x00\x00\xfa"  # DP 5: 250 (0xFA)
+        b"\x0e\x04\x00\x01\x02"  # DP 14: 2 (0x02)
+        b"\x65\x02\x00\x04\x00\x00\x00\x3c"  # DP 101: 60 (0x3C)
+        b"\x66\x02\x00\x04\x00\x00\x03\xe8"  # DP 102: 1000 (0x03E8)
+    )
+
+    message = b"\x09\xe0\x02\x00\x00" + dps
+
+    hdr, data = ep.tuya_manufacturer.deserialize(message)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+
+    # Verify attributes
+
+    # Soil Moisture: DP 3 * 100 = 50 * 100 = 5000
+    assert ep.soil_moisture.get("measured_value") == 5000
+
+    # Temperature: DP 5 * 10 = 250 * 10 = 2500
+    assert ep.temperature.get("measured_value") == 2500
+
+    # Battery: DP 14=2 -> 200 (100% * 2)
+    assert ep.power.get("battery_percentage_remaining") == 200
+
+    # Humidity: DP 101 * 100 = 60 * 100 = 6000
+    assert ep.humidity.get("measured_value") == 6000
+
+    # Illuminance: 10000 * log10(1000) + 1 = 10000 * 3 + 1 = 30001
+    assert ep.illuminance.get("measured_value") == 30001

--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -180,10 +180,17 @@ def test_valid_attributes(zigpy_device_from_v2_quirk):
     assert {power_attr_id} == power_config_cluster._VALID_ATTRIBUTES
 
 
-async def test_handle_get_data_soil_sensor(zigpy_device_from_v2_quirk):
+@pytest.mark.parametrize(
+    "model,manuf",
+    [
+        ("_TZE284_o9ofysmo", "TS0601"),
+        ("Arteco", "ZS-304Z"),
+    ],
+)
+async def test_handle_get_data_soil_sensor(zigpy_device_from_v2_quirk, model, manuf):
     """Test handle_get_data for Arteco ZS-304Z soil sensor."""
 
-    quirked = zigpy_device_from_v2_quirk("_TZE284_o9ofysmo", "TS0601")
+    quirked = zigpy_device_from_v2_quirk(model, manuf)
     ep = quirked.endpoints[1]
 
     assert ep.tuya_manufacturer is not None

--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -215,8 +215,8 @@ async def test_handle_get_data_soil_sensor(zigpy_device_from_v2_quirk):
 
     # Verify attributes
 
-    # Soil Moisture: DP 3 * 100 = 50 * 100 = 5000
-    assert ep.soil_moisture.get("measured_value") == 5000
+    # Soil Moisture: DP 3 -> 50
+    assert ep.tuya_manufacturer.get("soil_moisture") == 50
 
     # Temperature: DP 5 * 10 = 250 * 10 = 2500
     assert ep.temperature.get("measured_value") == 2500

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -372,3 +372,81 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .skip_configuration()
     .add_to_registry()
 )
+
+(
+    TuyaQuirkBuilder("_TZE284_o9ofysmo", "TS0601")  # Arteco ZS-304Z
+    .tuya_soil_moisture(dp_id=3)
+    .tuya_temperature(dp_id=5, scale=10)
+    # DP 14 is Battery State (Enum: 0=Low, 1=Middle, 2=High).
+    # We convert it to Zigbee percentage (0-200) for standard integration.
+    # 0 -> 20 (10%), 1 -> 100 (50%), 2 -> 200 (100%)
+    .tuya_dp(
+        dp_id=14,
+        ep_attribute=TuyaPowerConfigurationCluster2AAA.ep_attribute,
+        attribute_name="battery_percentage_remaining",
+        converter=lambda x: {0: 20, 1: 100, 2: 200}.get(x, 200),
+    )
+    .adds(TuyaPowerConfigurationCluster2AAA)
+    .tuya_humidity(dp_id=101)
+    .tuya_illuminance(dp_id=102)
+    # Calibration and configuration
+    .tuya_number(
+        dp_id=103,
+        attribute_name="soil_sampling",
+        type=t.uint16_t,
+        entity_type=EntityType.CONFIG,
+        translation_key="soil_sampling",
+        fallback_name="Soil sampling interval",
+    )
+    .tuya_number(
+        dp_id=104,
+        attribute_name="soil_calibration",
+        type=t.int16s,
+        entity_type=EntityType.CONFIG,
+        translation_key="soil_calibration",
+        fallback_name="Soil calibration",
+    )
+    .tuya_number(
+        dp_id=105,
+        attribute_name="humidity_calibration",
+        type=t.int16s,
+        entity_type=EntityType.CONFIG,
+        translation_key="humidity_calibration",
+        fallback_name="Humidity calibration",
+    )
+    .tuya_number(
+        dp_id=106,
+        attribute_name="illuminance_calibration",
+        type=t.int16s,
+        entity_type=EntityType.CONFIG,
+        translation_key="illuminance_calibration",
+        fallback_name="Illuminance calibration",
+    )
+    .tuya_number(
+        dp_id=107,
+        attribute_name="temperature_calibration",
+        type=t.int16s,
+        multiplier=0.1,
+        step=0.1,
+        entity_type=EntityType.CONFIG,
+        translation_key="temperature_calibration",
+        fallback_name="Temperature calibration",
+    )
+    .tuya_number(
+        dp_id=110,
+        attribute_name="soil_warning",
+        type=t.uint16_t,
+        entity_type=EntityType.CONFIG,
+        translation_key="soil_warning",
+        fallback_name="Soil warning threshold",
+    )
+    # DP 111: Water warning (0: none, 1: alarm)
+    .tuya_binary_sensor(
+        dp_id=111,
+        attribute_name="water_warning",
+        translation_key="water_warning",
+        fallback_name="Water warning",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -375,7 +375,16 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
 
 (
     TuyaQuirkBuilder("_TZE284_o9ofysmo", "TS0601")  # Arteco ZS-304Z
-    .tuya_soil_moisture(dp_id=3)
+    .tuya_sensor(
+        dp_id=3,
+        type=t.uint16_t,
+        attribute_name="soil_moisture",
+        unit=PERCENTAGE,
+        device_class=SensorDeviceClass.MOISTURE,
+        entity_type=EntityType.STANDARD,
+        translation_key="soil_moisture",
+        fallback_name="Soil moisture",
+    )
     .tuya_temperature(dp_id=5, scale=10)
     # DP 14 is Battery State (Enum: 0=Low, 1=Middle, 2=High).
     # We convert it to Zigbee percentage (0-200) for standard integration.

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -3,7 +3,13 @@
 import datetime
 
 from zigpy.quirks.v2 import EntityPlatform, EntityType
-from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTemperature, UnitOfTime
+from zigpy.quirks.v2.homeassistant import (
+    LIGHT_LUX,
+    PERCENTAGE,
+    UnitOfTemperature,
+    UnitOfTime,
+)
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass
 import zigpy.types as t
 from zigpy.zcl import foundation
@@ -404,23 +410,38 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
         dp_id=103,
         attribute_name="soil_sampling",
         type=t.uint16_t,
+        unit=UnitOfTime.SECONDS,
+        min_value=5,
+        max_value=3600,
+        step=1,
         entity_type=EntityType.CONFIG,
+        device_class=NumberDeviceClass.DURATION,
         translation_key="soil_sampling",
         fallback_name="Soil sampling interval",
     )
     .tuya_number(
         dp_id=104,
-        attribute_name="soil_calibration",
+        attribute_name="soil_moisture_calibration",
         type=t.int16s,
+        unit=PERCENTAGE,
+        min_value=-30,
+        max_value=30,
+        step=1,
         entity_type=EntityType.CONFIG,
-        translation_key="soil_calibration",
-        fallback_name="Soil calibration",
+        device_class=NumberDeviceClass.MOISTURE,
+        translation_key="soil_moisture_calibration",
+        fallback_name="Soil moisture calibration",
     )
     .tuya_number(
         dp_id=105,
         attribute_name="humidity_calibration",
         type=t.int16s,
+        unit=PERCENTAGE,
+        min_value=-30,
+        max_value=30,
+        step=1,
         entity_type=EntityType.CONFIG,
+        device_class=NumberDeviceClass.HUMIDITY,
         translation_key="humidity_calibration",
         fallback_name="Humidity calibration",
     )
@@ -428,7 +449,12 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
         dp_id=106,
         attribute_name="illuminance_calibration",
         type=t.int16s,
+        unit=LIGHT_LUX,
+        min_value=-1000,
+        max_value=1000,
+        step=1,
         entity_type=EntityType.CONFIG,
+        device_class=NumberDeviceClass.ILLUMINANCE,
         translation_key="illuminance_calibration",
         fallback_name="Illuminance calibration",
     )
@@ -436,9 +462,13 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
         dp_id=107,
         attribute_name="temperature_calibration",
         type=t.int16s,
+        unit=UnitOfTemperature.CELSIUS,
         multiplier=0.1,
         step=0.1,
+        min_value=-2,
+        max_value=2,
         entity_type=EntityType.CONFIG,
+        device_class=NumberDeviceClass.TEMPERATURE_DELTA,
         translation_key="temperature_calibration",
         fallback_name="Temperature calibration",
     )
@@ -446,7 +476,12 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
         dp_id=110,
         attribute_name="soil_warning",
         type=t.uint16_t,
+        unit=PERCENTAGE,
+        min_value=0,
+        max_value=100,
+        step=1,
         entity_type=EntityType.CONFIG,
+        device_class=NumberDeviceClass.MOISTURE,
         translation_key="soil_warning",
         fallback_name="Soil warning threshold",
     )

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -375,6 +375,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
 
 (
     TuyaQuirkBuilder("_TZE284_o9ofysmo", "TS0601")  # Arteco ZS-304Z
+    .applies_to("Arteco", "ZS-304Z")
     .tuya_sensor(
         dp_id=3,
         type=t.uint16_t,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Adds support for the Arteco ZS-304Z (TS0601) soil moisture sensor (_TZE284_o9ofysmo).

This device provides:
- Soil moisture (DP 3)
- Temperature (DP 5)
- Humidity (DP 101)
- Illuminance (DP 102)
- Battery state (DP 14, mapped to percentage remaining)

It also includes various configuration parameters:
- Soil sampling interval (DP 103)
- Calibration for soil, humidity, illuminance, and temperature (DPs 104-107)
- Soil warning threshold (DP 110)
- Water warning binary sensor (DP 111)


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

<img width="1019" height="881" alt="image" src="https://github.com/user-attachments/assets/899f0917-891f-4dc1-a0cc-f68c4c564e8f" />

- Fixes #4541

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->

[zha-01KCVF5Y1M7D1DM1GHG4QQPBW9-_TZE284_o9ofysmo TS0601-dab25e8a31cf620cc69fcf8ffc1d34ce.json](https://github.com/user-attachments/files/24361061/zha-01KCVF5Y1M7D1DM1GHG4QQPBW9-_TZE284_o9ofysmo.TS0601-dab25e8a31cf620cc69fcf8ffc1d34ce.json)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
