### PR TITLE
Add Tuya TS0501B dimmer `_TZB210_rkgngb5o` variant

### DIFF
--- a/zhaquirks/tuya/ts0501bs.py
+++ b/zhaquirks/tuya/ts0501bs.py
@@ -41,6 +41,7 @@ class DimmableLedController(CustomDevice):
             ("_TZ3210_agjx0pxt", "TS0501B"),
             ("_TZ3210_d062rv7j", "TS0501B"),
             ("_TZ3210_syh4kuef", "TS0501B"),
+            ("_TZB210_rkgngb5o", "TS0501B"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=257


### PR DESCRIPTION
## Proposed change
Add another manufacturer code to the single-color version of  TS051B: `_TZB210_rkgngb5o`.


## Additional information
N/A


## Device diagnostics
[zha-b39a9d7cb9e02f7f243f5b92df2e0c8a-_TZB210_rkgngb5o TS0501B-567135d93c6c99e933f03be28df8851b.json](https://github.com/user-attachments/files/24361682/zha-b39a9d7cb9e02f7f243f5b92df2e0c8a-_TZB210_rkgngb5o.TS0501B-567135d93c6c99e933f03be28df8851b.json)



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
