### PR TITLE
Migrate MLI tint remote to v2 and add tint-Remote-white

### DIFF
--- a/zhaquirks/mli/tint.py
+++ b/zhaquirks/mli/tint.py
@@ -4,6 +4,8 @@ from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import Basic, Scenes
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.lightlink import LightLink
 from zigpy.zcl.foundation import GeneralCommand
 from zhaquirks import LocalDataCluster
 from zhaquirks.const import (
@@ -204,8 +206,11 @@ DAT = {
 
 (
     QuirkBuilder("MLI", "tint-Remote-white")
-    .replaces(TintRemoteBasicCluster)
+    .replaces(TintRemoteBasicCluster, cluster_type=ClusterType.Server)
+    .adds(LightLink, cluster_type=ClusterType.Server)
+    .adds(TintRemoteBasicCluster, cluster_type=ClusterType.Client)
     .adds(TintRemoteScenesCluster, cluster_type=ClusterType.Client)
+    .adds(Color, cluster_type=ClusterType.Client)
     .device_automation_triggers(DAT.copy())
     .add_to_registry()
 )

--- a/zhaquirks/mli/tint.py
+++ b/zhaquirks/mli/tint.py
@@ -1,28 +1,30 @@
 """Tint remote."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    Scenes,
-)
-from zigpy.zcl.clusters.lighting import Color
-from zigpy.zcl.clusters.lightlink import LightLink
-
-from zhaquirks import Bus, LocalDataCluster
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl import ClusterType
+from zigpy.zcl.clusters.general import Basic, Scenes
+from zigpy.zcl.foundation import GeneralCommand
+from zhaquirks import LocalDataCluster
 from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
+    ARGS,
+    ATTRIBUTE_ID,
+    ATTRIBUTE_NAME,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_ATTRIBUTE_UPDATED,
+    COMMAND_MOVE,
+    COMMAND_ON,
+    COMMAND_OFF,
+    COMMAND_STEP,
+    COMMAND_STOP,
+    DIM_DOWN,
+    DIM_UP,
+    ENDPOINT_ID,
+    SHORT_PRESS,
+    LONG_PRESS,
+    LONG_RELEASE,
+    VALUE,
 )
 
 TINT_SCENE_ATTR = 0x4005
@@ -35,7 +37,7 @@ class TintRemoteScenesCluster(LocalDataCluster, Scenes):
         """Init."""
         super().__init__(*args, **kwargs)
 
-        self.endpoint.device.scene_bus.add_listener(self)
+        self.endpoint.device.add_listener(self)
 
     def change_scene(self, value):
         """Change scene attribute to new value."""
@@ -47,7 +49,7 @@ class TintRemoteBasicCluster(CustomCluster, Basic):
 
     def handle_cluster_general_request(self, hdr, args, *, dst_addressing=None):
         """Send write_attributes value to TintRemoteSceneCluster."""
-        if hdr.command_id != foundation.GeneralCommand.Write_Attributes:
+        if hdr.command_id != GeneralCommand.Write_Attributes:
             return
 
         attr = args[0][0]
@@ -55,65 +57,155 @@ class TintRemoteBasicCluster(CustomCluster, Basic):
             return
 
         value = attr.value.value
-        self.endpoint.device.scene_bus.listener_event("change_scene", value)
+        self.endpoint.device.listener_event("change_scene", value)
 
 
-class TintRemote(CustomDevice):
-    """Tint remote quirk."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.scene_bus = Bus()
-        super().__init__(*args, **kwargs)
-
-    signature = {
-        # endpoint=1 profile=260 device_type=2048 device_version=1 input_clusters=[0, 3, 4096]
-        # output_clusters=[0, 3, 4, 5, 8, 25, 768, 4096]
-        MODELS_INFO: [("MLI", "ZBT-Remote-ALL-RGBW")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_CONTROLLER,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    LightLink.cluster_id,  # 4096
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Ota.cluster_id,  # 25
-                    Color.cluster_id,  # 768
-                    LightLink.cluster_id,  # 4096
-                ],
-            },
+DAT = {
+    # ON / OFF BUTTON
+    (SHORT_PRESS, "BUTTON_ON"): {
+        COMMAND: COMMAND_ON,
+        CLUSTER_ID: 6,
+        ENDPOINT_ID: 1,
+        ARGS: [],
+    },
+    (SHORT_PRESS, "BUTTON_OFF"): {
+        COMMAND: COMMAND_OFF,
+        CLUSTER_ID: 6,
+        ENDPOINT_ID: 1,
+        ARGS: [],
+    },
+    # COLOR WHEEL
+    # todo:  validate correct handling for dynamic color values sent by color wheel
+    # WARMER
+    (SHORT_PRESS, "COLOR_WHEEL"): {
+        COMMAND: "move_to_color",
+        CLUSTER_ID: 768,
+        ENDPOINT_ID: 1,
+        ARGS: [24420, 38570, 0],  # sample values
+    },
+    # COLOR TEMPERATURE BUTTONS
+    # todo:  validate correct handling for cycling through available values
+    # WARMER
+    (SHORT_PRESS, "BUTTON_COLOR_TEMP_WARM"): {
+        COMMAND: "move_to_color_temp",
+        CLUSTER_ID: 768,
+        ENDPOINT_ID: 1,
+        ARGS: [370, 10],
+    },
+    # COLDER
+    (SHORT_PRESS, "BUTTON_COLOR_TEMP_COLD"): {
+        COMMAND: "move_to_color_temp",
+        CLUSTER_ID: 768,
+        ENDPOINT_ID: 1,
+        ARGS: [153, 10],
+    },
+    # BRIGHTNESS UP/DOWN BUTTONS
+    (SHORT_PRESS, DIM_DOWN): {
+        COMMAND: COMMAND_STEP,
+        CLUSTER_ID: 8,
+        ENDPOINT_ID: 1,
+        ARGS: [1, 43, 10],
+    },
+    (LONG_PRESS, DIM_DOWN): {
+        COMMAND: COMMAND_MOVE,
+        CLUSTER_ID: 8,
+        ENDPOINT_ID: 1,
+        ARGS: [1, 100],
+    },
+    (SHORT_PRESS, DIM_UP): {
+        COMMAND: COMMAND_STEP,
+        CLUSTER_ID: 8,
+        ENDPOINT_ID: 1,
+        ARGS: [0, 43, 10],
+    },
+    (LONG_PRESS, DIM_UP): {
+        COMMAND: COMMAND_MOVE,
+        CLUSTER_ID: 8,
+        ENDPOINT_ID: 1,
+        ARGS: [0, 100],
+    },
+    # todo: check for correct definition, because stop command is being sent for up and down equally
+    (LONG_RELEASE): {
+        COMMAND: COMMAND_STOP,
+        CLUSTER_ID: 8,
+        ENDPOINT_ID: 1,
+        ARGS: [],
+    },
+    # SCENE BUTTONS
+    (SHORT_PRESS, "worklight"): {
+        COMMAND: COMMAND_ATTRIBUTE_UPDATED,
+        CLUSTER_ID: 5,
+        ENDPOINT_ID: 1,
+        ARGS: {
+            ATTRIBUTE_ID: 1,
+            ATTRIBUTE_NAME: "current_scene",
+            VALUE: 3,
         },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_CONTROLLER,
-                INPUT_CLUSTERS: [
-                    TintRemoteBasicCluster,  # 0
-                    Identify.cluster_id,  # 3
-                    LightLink.cluster_id,  # 4096
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    TintRemoteScenesCluster,  # 5
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Ota.cluster_id,  # 25
-                    Color.cluster_id,  # 768
-                    LightLink.cluster_id,  # 4096
-                ],
-            },
+    },
+    (SHORT_PRESS, "sunset"): {
+        COMMAND: COMMAND_ATTRIBUTE_UPDATED,
+        CLUSTER_ID: 5,
+        ENDPOINT_ID: 1,
+        ARGS: {
+            ATTRIBUTE_ID: 1,
+            ATTRIBUTE_NAME: "current_scene",
+            VALUE: 1,
         },
-    }
+    },
+    (SHORT_PRESS, "party"): {
+        COMMAND: COMMAND_ATTRIBUTE_UPDATED,
+        CLUSTER_ID: 5,
+        ENDPOINT_ID: 1,
+        ARGS: {
+            ATTRIBUTE_ID: 1,
+            ATTRIBUTE_NAME: "current_scene",
+            VALUE: 2,
+        },
+    },
+    (SHORT_PRESS, "nightlight"): {
+        COMMAND: COMMAND_ATTRIBUTE_UPDATED,
+        CLUSTER_ID: 5,
+        ENDPOINT_ID: 1,
+        ARGS: {
+            ATTRIBUTE_ID: 1,
+            ATTRIBUTE_NAME: "current_scene",
+            VALUE: 6,
+        },
+    },
+    (SHORT_PRESS, "campfire"): {
+        COMMAND: COMMAND_ATTRIBUTE_UPDATED,
+        CLUSTER_ID: 5,
+        ENDPOINT_ID: 1,
+        ARGS: {
+            ATTRIBUTE_ID: 1,
+            ATTRIBUTE_NAME: "current_scene",
+            VALUE: 4,
+        },
+    },
+    (SHORT_PRESS, "romance"): {
+        COMMAND: COMMAND_ATTRIBUTE_UPDATED,
+        CLUSTER_ID: 5,
+        ENDPOINT_ID: 1,
+        ARGS: {
+            ATTRIBUTE_ID: 1,
+            ATTRIBUTE_NAME: "current_scene",
+            VALUE: 5,
+        },
+    },
+}
+
+(
+    QuirkBuilder("MLI", "ZBT-Remote-ALL-RGBW")
+    .replace_cluster_occurrences(TintRemoteBasicCluster)
+    .adds(TintRemoteScenesCluster, cluster_type=ClusterType.Client)
+    .device_automation_triggers(DAT.copy())
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder("MLI", "tint-Remote-white")
+    .replaces(TintRemoteBasicCluster)
+    .adds(TintRemoteScenesCluster, cluster_type=ClusterType.Client)
+    .device_automation_triggers(DAT.copy())
+    .add_to_registry()
+)

--- a/zhaquirks/mli/tint.py
+++ b/zhaquirks/mli/tint.py
@@ -5,6 +5,7 @@ from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import Basic, Scenes
 from zigpy.zcl.foundation import GeneralCommand
+
 from zhaquirks import LocalDataCluster
 from zhaquirks.const import (
     ARGS,
@@ -14,16 +15,16 @@ from zhaquirks.const import (
     COMMAND,
     COMMAND_ATTRIBUTE_UPDATED,
     COMMAND_MOVE,
-    COMMAND_ON,
     COMMAND_OFF,
+    COMMAND_ON,
     COMMAND_STEP,
     COMMAND_STOP,
     DIM_DOWN,
     DIM_UP,
     ENDPOINT_ID,
-    SHORT_PRESS,
     LONG_PRESS,
     LONG_RELEASE,
+    SHORT_PRESS,
     VALUE,
 )
 


### PR DESCRIPTION
## Proposed change
Migrates 'MLI ZBT-Remote-ALL-RGBW' to Quirks v2 and adds quirk for very similar 'MLI tint-Remote-white'


## Additional information
Fixes #4298
implemented device automation triggers from @SimpleUserHA (https://github.com/SimpleUserHA/zha-device-handlers/commit/4e85a04163a9f46dca020fa517782efdc8192b1e)

## Device diagnostics
[zha-65b0bd4fb9032284773ce41e2eb4988b-MLI ZBT-ExtendedColor-b2f69fe517daa41d33f24c597985c03d.json](https://github.com/user-attachments/files/24422390/zha-65b0bd4fb9032284773ce41e2eb4988b-MLI.ZBT-ExtendedColor-b2f69fe517daa41d33f24c597985c03d.json)
[zha-65b0bd4fb9032284773ce41e2eb4988b-MLI tint-Remote-white-e56878a1f4dc08b174a959879490054a(1).json](https://github.com/user-attachments/files/24422392/zha-65b0bd4fb9032284773ce41e2eb4988b-MLI.tint-Remote-white-e56878a1f4dc08b174a959879490054a.1.json)

## Checklist
- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
