### PR TITLE
Add support for Sonoff MINI DUO (ZB2GS) 2-channel switch

### DIFF
--- a/zhaquirks/sonoff/minizb2gs.py
+++ b/zhaquirks/sonoff/minizb2gs.py
@@ -19,6 +19,7 @@ class SonoffExternalSwitchTriggerType(types.enum8):
 
 class SonoffDetachRelayMode2Type(types.enum8):
     """Detach Relay Mode 2 type."""
+
     Detach_none = 0x00
     Detach_relay_l1 = 0x01
     Detach_relay_l2 = 0x02

--- a/zhaquirks/sonoff/minizb2gs.py
+++ b/zhaquirks/sonoff/minizb2gs.py
@@ -18,8 +18,7 @@ class SonoffExternalSwitchTriggerType(types.enum8):
 
 
 class SonoffDetachRelayMode2Type(types.enum8):
-    """Detach Relay Mode 2 type"""
-
+    """Detach Relay Mode 2 type."""
     Detach_none = 0x00
     Detach_relay_l1 = 0x01
     Detach_relay_l2 = 0x02

--- a/zhaquirks/sonoff/minizb2gs.py
+++ b/zhaquirks/sonoff/minizb2gs.py
@@ -10,13 +10,16 @@ from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 class SonoffExternalSwitchTriggerType(types.enum8):
     """extern switch trigger type."""
+
     Edge_trigger = 0x00
     Pulse_trigger = 0x01
     Normally_on_follow_trigger = 0x02
     Normally_off_follow_trigger = 0x82
 
+
 class SonoffDetachRelayMode2Type(types.enum8):
     """Detach Relay Mode 2 type"""
+
     Detach_none = 0x00
     Detach_relay_l1 = 0x01
     Detach_relay_l2 = 0x02
@@ -48,6 +51,7 @@ class SonoffCluster(CustomCluster):
             type=t.int16s,
             is_manufacturer_specific=True,
         )
+
 
 (
     QuirkBuilder("SONOFF", "MINI-ZB2GS")

--- a/zhaquirks/sonoff/minizb2gs.py
+++ b/zhaquirks/sonoff/minizb2gs.py
@@ -1,0 +1,90 @@
+"""Sonoff MINI-ZB2GS - Zigbee Switch."""
+
+from zigpy import types
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+
+class SonoffExternalSwitchTriggerType(types.enum8):
+    """extern switch trigger type."""
+    Edge_trigger = 0x00
+    Pulse_trigger = 0x01
+    Normally_on_follow_trigger = 0x02
+    Normally_off_follow_trigger = 0x82
+
+class SonoffDetachRelayMode2Type(types.enum8):
+    """Detach Relay Mode 2 type"""
+    Detach_none = 0x00
+    Detach_relay_l1 = 0x01
+    Detach_relay_l2 = 0x02
+    Detach_relay_l1_l2 = 0x03
+
+
+class SonoffCluster(CustomCluster):
+    """Custom Sonoff cluster."""
+
+    cluster_id = 0xFC11
+
+    manufacturer_id_override = foundation.ZCLHeader.NO_MANUFACTURER_ID
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        external_trigger_mode = ZCLAttributeDef(
+            id=0x0016,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
+        detach_relay_mode2 = ZCLAttributeDef(
+            id=0x0019,
+            type=t.bitmap8,
+            is_manufacturer_specific=True,
+        )
+        rf_turbo_mode = ZCLAttributeDef(
+            id=0x0012,
+            type=t.int16s,
+            is_manufacturer_specific=True,
+        )
+
+(
+    QuirkBuilder("SONOFF", "MINI-ZB2GS")
+    .replaces(SonoffCluster, endpoint_id=1)
+    .replaces(SonoffCluster, endpoint_id=2)
+    .enum(
+        SonoffCluster.AttributeDefs.external_trigger_mode.name,
+        SonoffExternalSwitchTriggerType,
+        SonoffCluster.cluster_id,
+        translation_key="external_trigger_mode_l1",
+        fallback_name="External trigger mode L1",
+        endpoint_id=1,
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.external_trigger_mode.name,
+        SonoffExternalSwitchTriggerType,
+        SonoffCluster.cluster_id,
+        translation_key="external_trigger_mode_l2",
+        fallback_name="External trigger mode L2",
+        endpoint_id=2,
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.detach_relay_mode2.name,
+        SonoffDetachRelayMode2Type,
+        SonoffCluster.cluster_id,
+        translation_key="detach_relay_mode2_l1",
+        fallback_name="Detach relay mode L1",
+        endpoint_id=1,
+    )
+    .switch(
+        SonoffCluster.AttributeDefs.rf_turbo_mode.name,
+        SonoffCluster.cluster_id,
+        off_value=9,
+        on_value=20,
+        translation_key="rf_turbo_mode",
+        fallback_name="RF turbo mode",
+        endpoint_id=1,
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
Quirk adding support for Sonoff MINI DUO (ZB2GS) 2-channel switch.
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[SONOFF MINI-ZB2GS.json](https://github.com/user-attachments/files/24440778/SONOFF.MINI-ZB2GS.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
