### PR TITLE
Update Innr SP 240 firmware version for divisor quirk cut-off point

### DIFF
--- a/zhaquirks/innr/innr_sp240_plug.py
+++ b/zhaquirks/innr/innr_sp240_plug.py
@@ -17,7 +17,7 @@ class InnrCluster(CustomCluster):
     QuirkBuilder(manufacturer="innr", model="SP 240")
     # Firmware version 421410437 fixed the divisor and multiplier bug,
     # so only apply this quirk to versions older than that (max_version is exclusive).
-    .firmware_version_filter(max_version=0x191E3685, allow_missing=False)
+    .firmware_version_filter(max_version=0x191B3685, allow_missing=False)
     .replaces(MeteringClusterInnrOld, endpoint_id=1)
     .replaces(InnrCluster, endpoint_id=1)
     .prevent_default_entity_creation(endpoint_id=1, cluster_id=LevelControl.cluster_id)
@@ -29,7 +29,7 @@ class InnrCluster(CustomCluster):
     # Firmware version 421410437 fixed the divisor and multiplier bug,
     # so apply this quirk to that and newer versions to force correct new values,
     # in case the old quirk persisted the old values into the database.
-    .firmware_version_filter(min_version=0x191E3685, allow_missing=True)
+    .firmware_version_filter(min_version=0x191B3685, allow_missing=True)
     .replaces(MeteringClusterInnrNew, endpoint_id=1)
     .replaces(InnrCluster, endpoint_id=1)
     .prevent_default_entity_creation(endpoint_id=1, cluster_id=LevelControl.cluster_id)


### PR DESCRIPTION
## Proposed change
This changes the firmware version we use for deciding which divisor override to apply for the Innr SP 240 smart plug to the correct one `0x191B3685` (slightly older than the version we previously used).

## Additional information
Follow-up to:
- https://github.com/zigpy/zha-device-handlers/pull/4592

For background on why this version is used, see here: https://github.com/zigpy/zha-device-handlers/issues/3857#issuecomment-3710442173

## Device diagnostics
See PR above and https://github.com/zigpy/zha-device-handlers/issues/3857#issuecomment-3719884675.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
