### PR TITLE
Add Tuya temperature sensor `_TZE284_9ern5sfh` variant

### DIFF
--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -45,6 +45,7 @@ zhaquirks.setup()
         ("_TZE200_ydrdfkim", "TS0601", 100, 10, False),
         ("_TZE284_locansqn", "TS0601", 100, 10, False),
         ("_TZE200_vvmbj46n", "TS0601", 100, 10, False),
+        ("_TZE284_9ern5sfh", "TS0601", 10, 10, True),
     ],
 )
 async def test_handle_get_data(
@@ -115,6 +116,7 @@ async def test_handle_get_data(
         ("_TZE284_upagmta9", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),
         ("_TZE204_1wnh8bqp", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),
         ("_TZE284_1wnh8bqp", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),
+        ("_TZE284_9ern5sfh", "TS0601", 10, 10, TUYA_TEMP01_HUM02_BAT04),
     ],
 )
 async def test_handle_get_data_enum_batt(

--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -116,7 +116,6 @@ async def test_handle_get_data(
         ("_TZE284_upagmta9", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),
         ("_TZE204_1wnh8bqp", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),
         ("_TZE284_1wnh8bqp", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),
-        ("_TZE284_9ern5sfh", "TS0601", 10, 10, TUYA_TEMP01_HUM02_BAT04),
     ],
 )
 async def test_handle_get_data_enum_batt(

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -51,6 +51,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
 (
     TuyaQuirkBuilder("_TZE200_bjawzodf", "TS0601")
     .applies_to("_TZE200_zl1kmjqx", "TS0601")
+    .applies_to("_TZE284_9ern5sfh", "TS0601")
     # Not using tuya_temperature because device reports negative values incorrectly
     .tuya_dp(
         dp_id=1,


### PR DESCRIPTION
## Proposed change
Add support for the tuya temperature and humidity sensor _TZE284_9ern5sfh

## Additional information
The mapping is identical to the device already present.
As in the other case, the firmware information is reported as unknown.

## Device diagnostics
```
"data": {
    "version": 1,
    "ieee": "**REDACTED**",
    "nwk": "0x0970",
    "manufacturer": "_TZE284_9ern5sfh",
    "model": "TS0601",
    "friendly_manufacturer": "_TZE284_9ern5sfh",
    "friendly_model": "TS0601",
    "name": "_TZE284_9ern5sfh TS0601",
    "quirk_applied": true,
    "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
    "exposes_features": [],
    "manufacturer_code": 4417,
    "power_source": "Battery or Unknown",
    "lqi": 48,
    "rssi": null,
    "last_seen": "2026-01-09T13:43:19.534625+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4417,
      "maximum_buffer_size": 66,
      "maximum_incoming_transfer_size": 66,
      "server_mask": 10752,
      "maximum_outgoing_transfer_size": 66,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "SMART_PLUG",
          "id": 81
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0001",
                "name": "app_version",
                "zcl_type": "uint8",
                "value": 80
              },
              {
                "id": "0x0003",
                "name": "hw_version",
                "zcl_type": "uint8",
                "value": 1
              },
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "_TZE284_9ern5sfh"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "TS0601"
              },
              {
                "id": "0x4000",
                "name": "sw_build_id",
                "zcl_type": "string",
                "unsupported": true
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "zcl_type": "uint8",
                "value": 194
              },
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "value": 2
              },
              {
                "id": "0x0034",
                "name": "battery_rated_voltage",
                "zcl_type": "uint8",
                "value": 15
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "value": 3
              }
            ]
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x0005",
            "endpoint_attribute": "scenes",
            "attributes": []
          },
          {
            "cluster_id": "0x0402",
            "endpoint_attribute": "temperature",
            "attributes": [
              {
                "id": "0x0000",
                "name": "measured_value",
                "zcl_type": "int16",
                "value": 2100
              }
            ]
          },
          {
            "cluster_id": "0x0405",
            "endpoint_attribute": "humidity",
            "attributes": [
              {
                "id": "0x0000",
                "name": "measured_value",
                "zcl_type": "uint16",
                "value": 4350
              }
            ]
          },
          {
            "cluster_id": "0xed00",
            "endpoint_attribute": null,
            "attributes": []
          },
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": "tuya_manufacturer",
            "attributes": [
              {
                "id": "0xef00",
                "name": "mcu_version",
                "zcl_type": "uint48",
                "value": "1.0.0"
              }
            ]
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 80
              }
            ]
          }
        ]
      }
    }
```

Local quirk I'm using in my home assistant is
```
"""Tuya Temperature and Humidity Sensor Quirk V2."""
from zhaquirks.tuya.builder import TuyaQuirkBuilder, TuyaTemperatureMeasurement

(
    TuyaQuirkBuilder("_TZE284_9ern5sfh", "TS0601")
    # Not using tuya_temperature because device reports negative values incorrectly
    .tuya_dp(
        dp_id=1,
        ep_attribute=TuyaTemperatureMeasurement.ep_attribute,
        attribute_name=TuyaTemperatureMeasurement.AttributeDefs.measured_value.name,
        converter=lambda x: ((x - 0xFFFF if x > 0x2000 else x) * 10),
    )
    .adds(TuyaTemperatureMeasurement)
    .tuya_humidity(dp_id=2, scale=10)
    .tuya_battery(dp_id=4)
    .skip_configuration()
    .add_to_registry()
)
```

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
