### PR TITLE
Add CentraLite 3400-G keypad quirk with battery fix and motion sensor

### DIFF
--- a/tests/test_centralite.py
+++ b/tests/test_centralite.py
@@ -1,7 +1,8 @@
 """Tests for CentraLite quirks."""
 
-import pytest
 from unittest import mock
+
+import pytest
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.security import IasAce
 

--- a/tests/test_centralite.py
+++ b/tests/test_centralite.py
@@ -1,0 +1,69 @@
+"""Tests for CentraLite quirks."""
+
+import pytest
+from unittest import mock
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.security import IasAce
+
+import zhaquirks
+from zhaquirks.centralite import cl_3400_G
+from zhaquirks.const import MOTION_EVENT
+
+zhaquirks.setup()
+
+CENTRALITE = "CentraLite"
+
+
+@pytest.mark.asyncio
+async def test_centralite_3400g_quirk_loads(zigpy_device_from_v2_quirk):
+    """Test that CentraLite 3400-G quirk loads correctly."""
+    device = zigpy_device_from_v2_quirk(CENTRALITE, "3400-G")
+
+    # Verify device loaded with correct type
+    assert isinstance(device, cl_3400_G.CentraLiteDeviceV2)
+
+    # Verify motion_bus exists
+    assert hasattr(device, "motion_bus")
+
+    # Check endpoint 1 has custom power cluster
+    ep1 = device.endpoints[1]
+    assert ep1.power is not None
+    assert isinstance(ep1.power, cl_3400_G.CustomPowerConfigurationCluster)
+
+    # Check voltage range is set correctly for CR123A batteries
+    assert ep1.power.MIN_VOLTS == 2.1
+    assert ep1.power.MAX_VOLTS == 3.0
+
+    # Verify custom IAS ACE output cluster
+    ias_ace = ep1.out_clusters.get(0x0501)
+    assert ias_ace is not None
+    assert isinstance(ias_ace, cl_3400_G.CustomIasAce)
+
+    # Check endpoint 2 has virtual motion sensor
+    assert 2 in device.endpoints
+    ep2 = device.endpoints[2]
+    assert ep2.ias_zone is not None
+    assert isinstance(ep2.ias_zone, cl_3400_G.MotionCluster)
+
+
+@pytest.mark.asyncio
+async def test_centralite_3400g_motion_trigger(zigpy_device_from_v2_quirk):
+    """Test that GetPanelStatus command triggers motion event."""
+    device = zigpy_device_from_v2_quirk(CENTRALITE, "3400-G")
+
+    # Get the IAS ACE cluster
+    ias_ace = device.endpoints[1].out_clusters[IasAce.cluster_id]
+
+    # Mock the motion_bus listener_event to verify it gets called
+    with mock.patch.object(device.motion_bus, "listener_event") as mock_listener:
+        # Create GetPanelStatus command header
+        hdr = foundation.ZCLHeader.cluster(
+            tsn=1,
+            command_id=IasAce.ServerCommandDefs.get_panel_status.id,
+        )
+
+        # Trigger the command
+        ias_ace.handle_cluster_request(hdr, [])
+
+        # Verify motion event was triggered on the bus
+        mock_listener.assert_called_once_with(MOTION_EVENT)

--- a/zhaquirks/centralite/cl_3400_G.py
+++ b/zhaquirks/centralite/cl_3400_G.py
@@ -1,0 +1,75 @@
+"""Device handler for CentraLite 3400-G."""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.security import IasAce, IasZone
+
+from zhaquirks import Bus, LocalDataCluster, MotionOnEvent, PowerConfigurationCluster
+from zhaquirks.const import MOTION_EVENT
+
+CENTRALITE = "CentraLite"
+ZONE_TYPE = 0x0001
+
+
+class CustomPowerConfigurationCluster(PowerConfigurationCluster):
+    """Custom PowerConfigurationCluster for CR123A batteries."""
+
+    MIN_VOLTS = 2.1
+    MAX_VOLTS = 3.0
+
+
+class MotionCluster(LocalDataCluster, MotionOnEvent, IasZone):
+    """Virtual motion sensor cluster."""
+
+    # Force zone type to Motion Sensor
+    _CONSTANT_ATTRIBUTES = {ZONE_TYPE: IasZone.ZoneType.Motion_Sensor}
+
+    # Reset motion after 90 seconds
+    reset_s = 90
+
+    # Skip configuration for virtual cluster
+    SKIP_CONFIGURATION = True
+
+
+class CustomIasAce(CustomCluster, IasAce):
+    """Custom IAS ACE cluster to detect GetPanelStatus as motion trigger."""
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list,
+        *,
+        dst_addressing: t.Addressing.Group
+        | t.Addressing.IEEE
+        | t.Addressing.NWK
+        | None = None,
+    ):
+        """Handle cluster request - detect GetPanelStatus (0x07) as motion event."""
+        # GetPanelStatus command - keypad sends this when it wakes up from motion
+        if hdr.command_id == IasAce.ServerCommandDefs.get_panel_status.id:
+            self.endpoint.device.motion_bus.listener_event(MOTION_EVENT)
+
+        return super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+
+class CentraLiteDeviceV2(CustomDeviceV2):
+    """Custom device class for CentraLite 3400-G with motion bus."""
+
+    def __init__(self, *args, **kwargs):
+        """Init device with motion bus."""
+        self.motion_bus = Bus()
+        super().__init__(*args, **kwargs)
+
+
+(
+    QuirkBuilder(CENTRALITE, "3400-G")
+    .replaces(CustomPowerConfigurationCluster)
+    .replaces(CustomIasAce, cluster_type="output")
+    .adds_endpoint(2, device_type=zha.DeviceType.OCCUPANCY_SENSOR)
+    .adds(MotionCluster, endpoint_id=2)
+    .device_class(CentraLiteDeviceV2)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

This PR adds a v2 quirk for the CentraLite 3400-G Zigbee keypad that fixes battery reporting and adds virtual motion sensor support.

**Battery Fix:**
- Sets correct voltage range (2.1V-3.0V) for CR123A batteries
- ZHA automatically calculates battery percentage from voltage readings using this range

**Virtual Motion Sensor:**
- The keypad has an internal motion detector but doesn't report motion via standard Zigbee clusters
- When motion is detected, the keypad wakes and sends an IAS ACE GetPanelStatus command (0x07)
- The quirk intercepts this command and triggers a virtual motion sensor on endpoint 2
- Motion automatically clears after 90 seconds
- This matches the behavior implemented in Hubitat's driver for this device

**Implementation:**
- Uses v2 quirk format with `CustomDeviceV2` and `QuirkBuilder`
- Custom device class initializes the Bus system for motion events
- Creates virtual endpoint 2 for the motion sensor
- Preserves IAS Zone on endpoint 1 for tamper detection

**Preserved Features:**
- IAS Zone on endpoint 1 for tamper detection (disabled by default)
- Temperature sensor
- All standard keypad functionality


## Additional information

This quirk has been tested on 3 CentraLite 3400-G devices and confirmed working:
- Battery reporting works correctly
- Motion sensor triggers when walking in front of keypad
- Temperature and tamper detection preserved

No breaking changes. Uses v2 quirk format as recommended, with `CustomDeviceV2` for custom device initialization.


## Device diagnostics
[zha-f8e0b2aa77fdfad9a390fd0edf3af072-CentraLite 3400-G-ec6168d145797b43829512cc58517ee8.json](https://github.com/user-attachments/files/24554822/zha-f8e0b2aa77fdfad9a390fd0edf3af072-CentraLite.3400-G-ec6168d145797b43829512cc58517ee8.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached