### PR TITLE
Add Third Reality 60g radar VOC level

### DIFF
--- a/zhaquirks/thirdreality/60g_radar.py
+++ b/zhaquirks/thirdreality/60g_radar.py
@@ -1,0 +1,40 @@
+"""Third Reality formaldehyde sensor devices."""
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder, SensorDeviceClass, SensorStateClass
+from zigpy.quirks.v2.homeassistant import CONCENTRATION_PARTS_PER_BILLION
+import zigpy.types as t
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+
+class ThirdRealityRadarCluster(CustomCluster):
+    """Third Reality's plug private cluster."""
+
+    cluster_id = 0x042e
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Define the attributes of a private cluster."""
+
+        # measure the value of voc
+        volatile_organic_compounds: Final = ZCLAttributeDef(
+            id=0x0000,
+            type=t.Single,
+            is_manufacturer_specific=True,
+        )
+
+(
+    QuirkBuilder("Third Reality, Inc", "3RPL01084Z")
+    .replaces(ThirdRealityRadarCluster)
+    .sensor(
+        endpoint_id=1,
+        attribute_name=ThirdRealityRadarCluster.AttributeDefs.volatile_organic_compounds.name,
+        cluster_id=ThirdRealityRadarCluster.cluster_id,
+        device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=CONCENTRATION_PARTS_PER_BILLION,
+        fallback_name="Volatile organic compounds",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/thirdreality/60g_radar.py
+++ b/zhaquirks/thirdreality/60g_radar.py
@@ -12,7 +12,7 @@ from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 class ThirdRealityRadarCluster(CustomCluster):
     """Third Reality's plug private cluster."""
 
-    cluster_id = 0x042e
+    cluster_id = 0x042E
 
     class AttributeDefs(BaseAttributeDefs):
         """Define the attributes of a private cluster."""
@@ -23,6 +23,7 @@ class ThirdRealityRadarCluster(CustomCluster):
             type=t.Single,
             is_manufacturer_specific=True,
         )
+
 
 (
     QuirkBuilder("Third Reality, Inc", "3RPL01084Z")

--- a/zhaquirks/thirdreality/60g_radar.py
+++ b/zhaquirks/thirdreality/60g_radar.py
@@ -1,4 +1,4 @@
-"""Third Reality formaldehyde sensor devices."""
+"""Third Reality 60g radar devices."""
 
 from typing import Final
 
@@ -10,7 +10,7 @@ from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 
 class ThirdRealityRadarCluster(CustomCluster):
-    """Third Reality's plug private cluster."""
+    """Third Reality's 60g radar private cluster."""
 
     cluster_id = 0x042E
 

--- a/zhaquirks/thirdreality/60g_radar.py
+++ b/zhaquirks/thirdreality/60g_radar.py
@@ -35,7 +35,7 @@ class ThirdRealityRadarCluster(CustomCluster):
         device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
         state_class=SensorStateClass.MEASUREMENT,
         unit=CONCENTRATION_PARTS_PER_BILLION,
-        fallback_name="Volatile organic compounds",
+        fallback_name="Volatile organic compounds parts",
     )
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR added adaptation code for 60g radar and added 1 additional private clusters
volatile_organic_compounds：Measure the value of VOC
## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
