### PR TITLE
Add advanced features to Aqara E1 TRV (heartbeat, running_state, calibrate)

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1330,6 +1330,48 @@ async def test_xiaomi_e1_thermostat_heartbeat_unknown_type(zigpy_device_from_qui
     assert 2 not in parsed
 
 
+async def test_xiaomi_e1_thermostat_heartbeat_truncated(zigpy_device_from_quirk):
+    """Test heartbeat parsing with truncated data triggers exception handling."""
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import _parse_heartbeat
+
+    # uint16 type (0x21) requires 2 bytes, but we only provide 1
+    # This should trigger IndexError in int.from_bytes
+    truncated_data = bytes([1, 0x21, 0x42])  # Missing second byte for uint16
+    parsed = _parse_heartbeat(truncated_data)
+    # Should return empty dict or partial result, not crash
+    assert isinstance(parsed, dict)
+
+    # Float type (0x39) requires 4 bytes, but we only provide 2
+    truncated_float = bytes([1, 0x39, 0x00, 0x00])  # Missing 2 bytes for float
+    parsed = _parse_heartbeat(truncated_float)
+    assert isinstance(parsed, dict)
+
+
+async def test_xiaomi_e1_thermostat_write_unknown_attribute_name(
+    zigpy_device_from_quirk,
+):
+    """Test writing with unknown attribute name is skipped."""
+    from unittest import mock
+
+    from zigpy.zcl import foundation
+
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    opple_cluster = device.endpoints[1].opple_cluster
+
+    async def async_success(*args, **kwargs):
+        return [foundation.Status.SUCCESS]
+
+    with mock.patch.object(opple_cluster, "request", side_effect=async_success) as m:
+        # Try to write an unknown attribute name - should be skipped
+        await opple_cluster.write_attributes({"nonexistent_attribute": 123})
+
+        # Request is called but with empty attributes list
+        assert m.call_count == 1
+        args = m.call_args[0]
+        # The attributes list (args[3]) should be empty since unknown attr was skipped
+        assert len(args[3]) == 0
+
+
 async def test_xiaomi_e1_thermostat_heartbeat_valve_alarm(zigpy_device_from_quirk):
     """Test heartbeat updates valve alarm attribute."""
     from zhaquirks.xiaomi.aqara.thermostat_agl001 import (

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1421,7 +1421,11 @@ async def test_xiaomi_e1_thermostat_write_calibrate(zigpy_device_from_quirk):
 
 
 async def test_xiaomi_e1_thermostat_write_away_temperature(zigpy_device_from_quirk):
-    """Test writing away_preset_temperature converts to centidegrees."""
+    """Test writing away_preset_temperature passes value as uint32.
+
+    Note: ZHA Number entity sends value already in centidegrees,
+    so no multiplication is needed in write_attributes.
+    """
     from unittest import mock
 
     from zigpy.zcl import foundation
@@ -1435,12 +1439,13 @@ async def test_xiaomi_e1_thermostat_write_away_temperature(zigpy_device_from_qui
         return [foundation.Status.SUCCESS]
 
     with mock.patch.object(opple_cluster, "request", side_effect=async_success) as m:
-        await opple_cluster.write_attributes({AWAY_PRESET_TEMPERATURE: 18.5})
+        # Value comes from ZHA Number entity already in centidegrees
+        await opple_cluster.write_attributes({AWAY_PRESET_TEMPERATURE: 1850})
 
         assert m.call_count == 1
         args = m.call_args[0]
         attr = next(attr for attr in args[3] if attr.attrid == AWAY_PRESET_TEMPERATURE)
-        # 18.5 * 100 = 1850 centidegrees
+        # Value should be passed through as uint32
         assert attr.value.value == 1850
 
 

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1181,6 +1181,113 @@ async def test_xiaomi_e1_thermostat_schedule_settings_deserialization(
     assert str(s) == expected_string
 
 
+async def test_xiaomi_e1_thermostat_heartbeat_parsing(zigpy_device_from_quirk):
+    """Test heartbeat parsing on Xiaomi E1 thermostat."""
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import HEARTBEAT, _parse_heartbeat
+
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+
+    opple_cluster = device.endpoints[1].opple_cluster
+    thermostat_cluster = device.endpoints[1].thermostat
+    thermostat_listener = ClusterListener(thermostat_cluster)
+
+    device_temp_cluster = device.endpoints[1].device_temperature
+    device_temp_listener = ClusterListener(device_temp_cluster)
+
+    power_config_cluster = device.endpoints[1].power
+    power_config_listener = ClusterListener(power_config_cluster)
+
+    # Test heartbeat TLV parsing function directly
+    # Format: key (1 byte) + type (1 byte) + value (N bytes)
+    # Type 0x20 = uint8, 0x21 = uint16, 0x23 = uint32
+
+    # Create a test heartbeat with:
+    # - key 3 (device_temperature): uint8 = 25 (25°C)
+    # - key 5 (power_outage_count): uint8 = 3
+    # - key 101 (preset): uint8 = 1 (auto)
+    # - key 102 (local_temperature): uint16 = 2150 (21.50°C in centidegrees)
+    # - key 105 (battery): uint8 = 85 (85%)
+    heartbeat_data = bytes(
+        [
+            3,
+            0x20,
+            25,  # device_temperature = 25
+            5,
+            0x20,
+            3,  # power_outage_count = 3
+            101,
+            0x20,
+            1,  # preset = auto
+            102,
+            0x21,
+            0x66,
+            0x08,  # local_temperature = 2150 (little-endian)
+            105,
+            0x20,
+            85,  # battery = 85%
+        ]
+    )
+
+    parsed = _parse_heartbeat(heartbeat_data)
+    assert parsed[3] == 25  # device_temperature
+    assert parsed[5] == 3  # power_outage_count
+    assert parsed[101] == 1  # preset
+    assert parsed[102] == 2150  # local_temperature
+    assert parsed[105] == 85  # battery
+
+    # Now test that the cluster correctly updates related attributes
+    opple_cluster.update_attribute(HEARTBEAT, heartbeat_data)
+
+    # Check device temperature was updated (value * 100 for centidegrees)
+    assert len(device_temp_listener.attribute_updates) >= 1
+    device_temp_update = next(
+        (
+            u
+            for u in device_temp_listener.attribute_updates
+            if u[0] == DeviceTemperature.AttributeDefs.current_temperature.id
+        ),
+        None,
+    )
+    assert device_temp_update is not None
+    assert device_temp_update[1] == 2500  # 25°C * 100
+
+    # Check local temperature was updated on thermostat
+    assert len(thermostat_listener.attribute_updates) >= 1
+    local_temp_update = next(
+        (
+            u
+            for u in thermostat_listener.attribute_updates
+            if u[0] == Thermostat.AttributeDefs.local_temperature.id
+        ),
+        None,
+    )
+    assert local_temp_update is not None
+    assert local_temp_update[1] == 2150  # already in centidegrees
+
+    # Check battery percentage was updated
+    assert len(power_config_listener.attribute_updates) >= 1
+    battery_update = next(
+        (
+            u
+            for u in power_config_listener.attribute_updates
+            if u[0] == PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
+        ),
+        None,
+    )
+    assert battery_update is not None
+    assert battery_update[1] == 170  # 85% * 2
+
+
+async def test_xiaomi_e1_thermostat_heartbeat_empty(zigpy_device_from_quirk):
+    """Test heartbeat parsing with empty/invalid data."""
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import _parse_heartbeat
+
+    # Test empty data
+    assert _parse_heartbeat(b"") == {}
+    assert _parse_heartbeat(None) == {}
+    assert _parse_heartbeat(bytes([0])) == {}  # Only 1 byte, can't parse
+
+
 @pytest.mark.parametrize(
     "quirk, invalid_iilluminance_report",
     (

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1557,6 +1557,60 @@ async def test_xiaomi_e1_thermostat_heartbeat_running_state(zigpy_device_from_v2
     assert running_state_update[1] == 0  # Idle because system is off
 
 
+async def test_xiaomi_e1_thermostat_read_running_state(zigpy_device_from_v2_quirk):
+    """Test reading running_state returns cached value (simulated from heartbeat)."""
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import (
+        HEARTBEAT,
+        HEARTBEAT_HEATING_SETPOINT,
+        HEARTBEAT_LOCAL_TEMPERATURE,
+        SYSTEM_MODE,
+        SystemMode,
+    )
+
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
+    opple_cluster = device.endpoints[1].opple_cluster
+    thermostat_cluster = device.endpoints[1].thermostat
+
+    # Test 1: Read running_state before any heartbeat - should return default (0 = Idle)
+    result = await thermostat_cluster.read_attributes(["running_state"])
+    assert Thermostat.AttributeDefs.running_state.id in result[0]
+    assert result[0][Thermostat.AttributeDefs.running_state.id] == 0  # Default Idle
+
+    # Test 2: Send heartbeat that triggers heating, then read running_state
+    opple_cluster._attr_cache[SYSTEM_MODE] = SystemMode.Heat
+    heartbeat_data = bytes(
+        [
+            HEARTBEAT_LOCAL_TEMPERATURE,
+            0x21,
+            0xD0,
+            0x07,  # 2000 = 20.00°C
+            HEARTBEAT_HEATING_SETPOINT,
+            0x21,
+            0x98,
+            0x08,  # 2200 = 22.00°C (setpoint > local = heating)
+        ]
+    )
+    opple_cluster.update_attribute(HEARTBEAT, heartbeat_data)
+
+    # Now read running_state - should return Heat_State_On from cache
+    result = await thermostat_cluster.read_attributes(["running_state"])
+    assert Thermostat.AttributeDefs.running_state.id in result[0]
+    assert (
+        result[0][Thermostat.AttributeDefs.running_state.id]
+        == Thermostat.RunningState.Heat_State_On
+    )
+
+    # Test 3: Also test reading by attribute ID
+    result = await thermostat_cluster.read_attributes(
+        [Thermostat.AttributeDefs.running_state.id]
+    )
+    assert Thermostat.AttributeDefs.running_state.id in result[0]
+    assert (
+        result[0][Thermostat.AttributeDefs.running_state.id]
+        == Thermostat.RunningState.Heat_State_On
+    )
+
+
 async def test_xiaomi_e1_thermostat_write_calibrate(zigpy_device_from_v2_quirk):
     """Test writing calibrate attribute triggers calibration."""
     from unittest import mock

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1420,7 +1420,9 @@ async def test_xiaomi_e1_thermostat_heartbeat_setup_mode(zigpy_device_from_v2_qu
     assert preset_update[1] == Preset.Setup
 
 
-async def test_xiaomi_e1_thermostat_heartbeat_firmware_version(zigpy_device_from_v2_quirk):
+async def test_xiaomi_e1_thermostat_heartbeat_firmware_version(
+    zigpy_device_from_v2_quirk,
+):
     """Test heartbeat updates firmware version on Basic cluster."""
     from zigpy.zcl.clusters.general import Basic
 

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1288,6 +1288,163 @@ async def test_xiaomi_e1_thermostat_heartbeat_empty(zigpy_device_from_quirk):
     assert _parse_heartbeat(bytes([0])) == {}  # Only 1 byte, can't parse
 
 
+async def test_xiaomi_e1_thermostat_heartbeat_float_and_signed(zigpy_device_from_quirk):
+    """Test heartbeat parsing with float and signed integer types."""
+    # Test float (type 0x39) - single precision IEEE 754
+    # Value 23.5 = 0x41BC0000 in big-endian, 0x0000BC41 in little-endian
+    import struct
+
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import _parse_heartbeat
+
+    float_bytes = struct.pack("<f", 23.5)
+    heartbeat_with_float = bytes([1, 0x39]) + float_bytes
+    parsed = _parse_heartbeat(heartbeat_with_float)
+    assert abs(parsed[1] - 23.5) < 0.01
+
+    # Test signed int8 (type 0x28) with negative value
+    heartbeat_with_signed = bytes([2, 0x28, 0xFB])  # -5 in signed int8
+    parsed = _parse_heartbeat(heartbeat_with_signed)
+    assert parsed[2] == -5
+
+    # Test signed int16 (type 0x29) with negative value
+    # -100 = 0xFF9C in little-endian
+    heartbeat_with_int16 = bytes([3, 0x29, 0x9C, 0xFF])
+    parsed = _parse_heartbeat(heartbeat_with_int16)
+    assert parsed[3] == -100
+
+    # Test signed int32 (type 0x2B)
+    heartbeat_with_int32 = bytes([4, 0x2B, 0x00, 0x00, 0x00, 0x80])  # -2147483648
+    parsed = _parse_heartbeat(heartbeat_with_int32)
+    assert parsed[4] == -2147483648
+
+
+async def test_xiaomi_e1_thermostat_heartbeat_unknown_type(zigpy_device_from_quirk):
+    """Test heartbeat parsing with unknown data type stops parsing."""
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import _parse_heartbeat
+
+    # First entry is valid uint8, second is unknown type 0xFF
+    heartbeat_data = bytes([1, 0x20, 42, 2, 0xFF, 0x00])
+    parsed = _parse_heartbeat(heartbeat_data)
+    # Should parse first entry but stop at unknown type
+    assert parsed[1] == 42
+    assert 2 not in parsed
+
+
+async def test_xiaomi_e1_thermostat_heartbeat_valve_alarm(zigpy_device_from_quirk):
+    """Test heartbeat updates valve alarm attribute."""
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import (
+        HEARTBEAT,
+        HEARTBEAT_VALVE_ALARM,
+        VALVE_ALARM,
+    )
+
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    opple_cluster = device.endpoints[1].opple_cluster
+    opple_listener = ClusterListener(opple_cluster)
+
+    # Heartbeat with valve_alarm = 1 (key 104, type uint8)
+    heartbeat_data = bytes([HEARTBEAT_VALVE_ALARM, 0x20, 1])
+    opple_cluster.update_attribute(HEARTBEAT, heartbeat_data)
+
+    # Check valve_alarm was updated
+    valve_alarm_update = next(
+        (u for u in opple_listener.attribute_updates if u[0] == VALVE_ALARM), None
+    )
+    assert valve_alarm_update is not None
+    assert valve_alarm_update[1] == 1
+
+
+async def test_xiaomi_e1_thermostat_write_calibrate(zigpy_device_from_quirk):
+    """Test writing calibrate attribute triggers calibration."""
+    from unittest import mock
+
+    from zigpy.zcl import foundation
+
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import CALIBRATE
+
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    opple_cluster = device.endpoints[1].opple_cluster
+
+    async def async_success(*args, **kwargs):
+        return [foundation.Status.SUCCESS]
+
+    with mock.patch.object(opple_cluster, "request", side_effect=async_success) as m:
+        await opple_cluster.write_attributes({CALIBRATE: 0})
+
+        # Verify calibrate is always written as 1
+        assert m.call_count == 1
+        args = m.call_args[0]
+        attr = next(attr for attr in args[3] if attr.attrid == CALIBRATE)
+        assert attr.value.value == 1
+
+
+async def test_xiaomi_e1_thermostat_write_away_temperature(zigpy_device_from_quirk):
+    """Test writing away_preset_temperature converts to centidegrees."""
+    from unittest import mock
+
+    from zigpy.zcl import foundation
+
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import AWAY_PRESET_TEMPERATURE
+
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    opple_cluster = device.endpoints[1].opple_cluster
+
+    async def async_success(*args, **kwargs):
+        return [foundation.Status.SUCCESS]
+
+    with mock.patch.object(opple_cluster, "request", side_effect=async_success) as m:
+        await opple_cluster.write_attributes({AWAY_PRESET_TEMPERATURE: 18.5})
+
+        assert m.call_count == 1
+        args = m.call_args[0]
+        attr = next(attr for attr in args[3] if attr.attrid == AWAY_PRESET_TEMPERATURE)
+        # 18.5 * 100 = 1850 centidegrees
+        assert attr.value.value == 1850
+
+
+async def test_xiaomi_e1_thermostat_write_by_name(zigpy_device_from_quirk):
+    """Test writing attribute by name."""
+    from unittest import mock
+
+    from zigpy.zcl import foundation
+
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import CHILD_LOCK
+
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    opple_cluster = device.endpoints[1].opple_cluster
+
+    async def async_success(*args, **kwargs):
+        return [foundation.Status.SUCCESS]
+
+    with mock.patch.object(opple_cluster, "request", side_effect=async_success) as m:
+        await opple_cluster.write_attributes({"child_lock": True})
+
+        assert m.call_count == 1
+        args = m.call_args[0]
+        attr = next(attr for attr in args[3] if attr.attrid == CHILD_LOCK)
+        # t.Bool returns an enum, check truthiness
+        assert bool(attr.value.value)
+
+
+async def test_xiaomi_e1_thermostat_preset_setup_mode(zigpy_device_from_quirk):
+    """Test preset setup mode detection."""
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import PRESET, Preset
+
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    opple_cluster = device.endpoints[1].opple_cluster
+    opple_listener = ClusterListener(opple_cluster)
+
+    # Update preset to Setup (3) - should trigger debug log
+    opple_cluster.update_attribute(PRESET, Preset.Setup)
+
+    # Verify attribute was updated
+    preset_update = next(
+        (u for u in opple_listener.attribute_updates if u[0] == PRESET), None
+    )
+    assert preset_update is not None
+    assert preset_update[1] == Preset.Setup
+
+
 @pytest.mark.parametrize(
     "quirk, invalid_iilluminance_report",
     (

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -921,13 +921,13 @@ async def test_aqara_smoke_sensor_xiaomi_attribute_report(
     ],
 )
 async def test_xiaomi_e1_thermostat_rw_redirection(
-    zigpy_device_from_quirk,
+    zigpy_device_from_v2_quirk,
     attr_redirect,
     attr_no_redirect,
 ):
     """Test system_mode rw redirection to OppleCluster on Xiaomi E1 thermostat with id and named reads/writes."""
 
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
 
     opple_cluster = device.endpoints[1].opple_cluster
     opple_listener = ClusterListener(opple_cluster)
@@ -1037,11 +1037,10 @@ async def test_xiaomi_e1_thermostat_rw_redirection(
         assert len(opple_cluster._write_attributes.mock_calls) == 0
 
 
-@pytest.mark.parametrize("quirk", (zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001,))
-async def test_xiaomi_e1_thermostat_attribute_update(zigpy_device_from_quirk, quirk):
+async def test_xiaomi_e1_thermostat_attribute_update(zigpy_device_from_v2_quirk):
     """Test update_attribute on Xiaomi E1 thermostat."""
 
-    device = zigpy_device_from_quirk(quirk)
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
 
     opple_cluster = device.endpoints[1].opple_cluster
     opple_listener = ClusterListener(opple_cluster)
@@ -1181,11 +1180,11 @@ async def test_xiaomi_e1_thermostat_schedule_settings_deserialization(
     assert str(s) == expected_string
 
 
-async def test_xiaomi_e1_thermostat_heartbeat_parsing(zigpy_device_from_quirk):
+async def test_xiaomi_e1_thermostat_heartbeat_parsing(zigpy_device_from_v2_quirk):
     """Test heartbeat parsing on Xiaomi E1 thermostat."""
     from zhaquirks.xiaomi.aqara.thermostat_agl001 import HEARTBEAT, _parse_heartbeat
 
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
 
     opple_cluster = device.endpoints[1].opple_cluster
     thermostat_cluster = device.endpoints[1].thermostat
@@ -1348,14 +1347,14 @@ async def test_xiaomi_e1_thermostat_heartbeat_truncated(zigpy_device_from_quirk)
 
 
 async def test_xiaomi_e1_thermostat_write_unknown_attribute_name(
-    zigpy_device_from_quirk,
+    zigpy_device_from_v2_quirk,
 ):
     """Test writing with unknown attribute name is skipped."""
     from unittest import mock
 
     from zigpy.zcl import foundation
 
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
     opple_cluster = device.endpoints[1].opple_cluster
 
     async def async_success(*args, **kwargs):
@@ -1372,7 +1371,7 @@ async def test_xiaomi_e1_thermostat_write_unknown_attribute_name(
         assert len(args[3]) == 0
 
 
-async def test_xiaomi_e1_thermostat_heartbeat_valve_alarm(zigpy_device_from_quirk):
+async def test_xiaomi_e1_thermostat_heartbeat_valve_alarm(zigpy_device_from_v2_quirk):
     """Test heartbeat updates valve alarm attribute."""
     from zhaquirks.xiaomi.aqara.thermostat_agl001 import (
         HEARTBEAT,
@@ -1380,7 +1379,7 @@ async def test_xiaomi_e1_thermostat_heartbeat_valve_alarm(zigpy_device_from_quir
         VALVE_ALARM,
     )
 
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
     opple_cluster = device.endpoints[1].opple_cluster
     opple_listener = ClusterListener(opple_cluster)
 
@@ -1396,7 +1395,7 @@ async def test_xiaomi_e1_thermostat_heartbeat_valve_alarm(zigpy_device_from_quir
     assert valve_alarm_update[1] == 1
 
 
-async def test_xiaomi_e1_thermostat_heartbeat_setup_mode(zigpy_device_from_quirk):
+async def test_xiaomi_e1_thermostat_heartbeat_setup_mode(zigpy_device_from_v2_quirk):
     """Test heartbeat detects setup mode (preset=3)."""
     from zhaquirks.xiaomi.aqara.thermostat_agl001 import (
         HEARTBEAT,
@@ -1405,7 +1404,7 @@ async def test_xiaomi_e1_thermostat_heartbeat_setup_mode(zigpy_device_from_quirk
         Preset,
     )
 
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
     opple_cluster = device.endpoints[1].opple_cluster
     opple_listener = ClusterListener(opple_cluster)
 
@@ -1421,7 +1420,7 @@ async def test_xiaomi_e1_thermostat_heartbeat_setup_mode(zigpy_device_from_quirk
     assert preset_update[1] == Preset.Setup
 
 
-async def test_xiaomi_e1_thermostat_heartbeat_firmware_version(zigpy_device_from_quirk):
+async def test_xiaomi_e1_thermostat_heartbeat_firmware_version(zigpy_device_from_v2_quirk):
     """Test heartbeat updates firmware version on Basic cluster."""
     from zigpy.zcl.clusters.general import Basic
 
@@ -1430,7 +1429,7 @@ async def test_xiaomi_e1_thermostat_heartbeat_firmware_version(zigpy_device_from
         HEARTBEAT_FIRMWARE_VERSION,
     )
 
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
     opple_cluster = device.endpoints[1].opple_cluster
     basic_cluster = device.endpoints[1].basic
     basic_listener = ClusterListener(basic_cluster)
@@ -1453,7 +1452,7 @@ async def test_xiaomi_e1_thermostat_heartbeat_firmware_version(zigpy_device_from
     assert sw_build_update[1] == "2073"
 
 
-async def test_xiaomi_e1_thermostat_write_calibrate(zigpy_device_from_quirk):
+async def test_xiaomi_e1_thermostat_write_calibrate(zigpy_device_from_v2_quirk):
     """Test writing calibrate attribute triggers calibration."""
     from unittest import mock
 
@@ -1461,7 +1460,7 @@ async def test_xiaomi_e1_thermostat_write_calibrate(zigpy_device_from_quirk):
 
     from zhaquirks.xiaomi.aqara.thermostat_agl001 import CALIBRATE
 
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
     opple_cluster = device.endpoints[1].opple_cluster
 
     async def async_success(*args, **kwargs):
@@ -1477,7 +1476,7 @@ async def test_xiaomi_e1_thermostat_write_calibrate(zigpy_device_from_quirk):
         assert attr.value.value == 1
 
 
-async def test_xiaomi_e1_thermostat_write_away_temperature(zigpy_device_from_quirk):
+async def test_xiaomi_e1_thermostat_write_away_temperature(zigpy_device_from_v2_quirk):
     """Test writing away_preset_temperature passes value as uint32.
 
     Note: ZHA Number entity sends value already in centidegrees,
@@ -1489,7 +1488,7 @@ async def test_xiaomi_e1_thermostat_write_away_temperature(zigpy_device_from_qui
 
     from zhaquirks.xiaomi.aqara.thermostat_agl001 import AWAY_PRESET_TEMPERATURE
 
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
     opple_cluster = device.endpoints[1].opple_cluster
 
     async def async_success(*args, **kwargs):
@@ -1506,7 +1505,7 @@ async def test_xiaomi_e1_thermostat_write_away_temperature(zigpy_device_from_qui
         assert attr.value.value == 1850
 
 
-async def test_xiaomi_e1_thermostat_write_by_name(zigpy_device_from_quirk):
+async def test_xiaomi_e1_thermostat_write_by_name(zigpy_device_from_v2_quirk):
     """Test writing attribute by name."""
     from unittest import mock
 
@@ -1514,7 +1513,7 @@ async def test_xiaomi_e1_thermostat_write_by_name(zigpy_device_from_quirk):
 
     from zhaquirks.xiaomi.aqara.thermostat_agl001 import CHILD_LOCK
 
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
     opple_cluster = device.endpoints[1].opple_cluster
 
     async def async_success(*args, **kwargs):
@@ -1530,11 +1529,11 @@ async def test_xiaomi_e1_thermostat_write_by_name(zigpy_device_from_quirk):
         assert bool(attr.value.value)
 
 
-async def test_xiaomi_e1_thermostat_preset_setup_mode(zigpy_device_from_quirk):
+async def test_xiaomi_e1_thermostat_preset_setup_mode(zigpy_device_from_v2_quirk):
     """Test preset setup mode detection."""
     from zhaquirks.xiaomi.aqara.thermostat_agl001 import PRESET, Preset
 
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
     opple_cluster = device.endpoints[1].opple_cluster
     opple_listener = ClusterListener(opple_cluster)
 

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1396,6 +1396,63 @@ async def test_xiaomi_e1_thermostat_heartbeat_valve_alarm(zigpy_device_from_quir
     assert valve_alarm_update[1] == 1
 
 
+async def test_xiaomi_e1_thermostat_heartbeat_setup_mode(zigpy_device_from_quirk):
+    """Test heartbeat detects setup mode (preset=3)."""
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import (
+        HEARTBEAT,
+        HEARTBEAT_PRESET,
+        PRESET,
+        Preset,
+    )
+
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    opple_cluster = device.endpoints[1].opple_cluster
+    opple_listener = ClusterListener(opple_cluster)
+
+    # Heartbeat with preset = 3 (Setup mode, key 101, type uint8)
+    heartbeat_data = bytes([HEARTBEAT_PRESET, 0x20, Preset.Setup])
+    opple_cluster.update_attribute(HEARTBEAT, heartbeat_data)
+
+    # Check preset was updated to Setup mode
+    preset_update = next(
+        (u for u in opple_listener.attribute_updates if u[0] == PRESET), None
+    )
+    assert preset_update is not None
+    assert preset_update[1] == Preset.Setup
+
+
+async def test_xiaomi_e1_thermostat_heartbeat_firmware_version(zigpy_device_from_quirk):
+    """Test heartbeat updates firmware version on Basic cluster."""
+    from zigpy.zcl.clusters.general import Basic
+
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import (
+        HEARTBEAT,
+        HEARTBEAT_FIRMWARE_VERSION,
+    )
+
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+    opple_cluster = device.endpoints[1].opple_cluster
+    basic_cluster = device.endpoints[1].basic
+    basic_listener = ClusterListener(basic_cluster)
+
+    # Heartbeat with firmware version = 2073 (0x819) (key 13, type uint32)
+    # 2073 in little-endian bytes: 0x19 0x08 0x00 0x00
+    heartbeat_data = bytes([HEARTBEAT_FIRMWARE_VERSION, 0x23, 0x19, 0x08, 0x00, 0x00])
+    opple_cluster.update_attribute(HEARTBEAT, heartbeat_data)
+
+    # Check firmware version was updated on Basic cluster
+    sw_build_update = next(
+        (
+            u
+            for u in basic_listener.attribute_updates
+            if u[0] == Basic.AttributeDefs.sw_build_id.id
+        ),
+        None,
+    )
+    assert sw_build_update is not None
+    assert sw_build_update[1] == "2073"
+
+
 async def test_xiaomi_e1_thermostat_write_calibrate(zigpy_device_from_quirk):
     """Test writing calibrate attribute triggers calibration."""
     from unittest import mock

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1454,6 +1454,109 @@ async def test_xiaomi_e1_thermostat_heartbeat_firmware_version(
     assert sw_build_update[1] == "2073"
 
 
+async def test_xiaomi_e1_thermostat_heartbeat_running_state(zigpy_device_from_v2_quirk):
+    """Test heartbeat simulates running_state based on temperature."""
+    from zhaquirks.xiaomi.aqara.thermostat_agl001 import (
+        HEARTBEAT,
+        HEARTBEAT_HEATING_SETPOINT,
+        HEARTBEAT_LOCAL_TEMPERATURE,
+        SYSTEM_MODE,
+        SystemMode,
+    )
+
+    device = zigpy_device_from_v2_quirk(manufacturer="LUMI", model="lumi.airrtc.agl001")
+    opple_cluster = device.endpoints[1].opple_cluster
+    thermostat_cluster = device.endpoints[1].thermostat
+    thermostat_listener = ClusterListener(thermostat_cluster)
+
+    # Set system_mode to Heat (default)
+    opple_cluster._attr_cache[SYSTEM_MODE] = SystemMode.Heat
+
+    # Test case 1: setpoint > local_temp -> heating
+    # local_temp = 2000 (20.00°C), setpoint = 2200 (22.00°C)
+    heartbeat_data = bytes(
+        [
+            HEARTBEAT_LOCAL_TEMPERATURE,
+            0x21,
+            0xD0,
+            0x07,  # 2000 little-endian
+            HEARTBEAT_HEATING_SETPOINT,
+            0x21,
+            0x98,
+            0x08,  # 2200 little-endian
+        ]
+    )
+    opple_cluster.update_attribute(HEARTBEAT, heartbeat_data)
+
+    running_state_update = next(
+        (
+            u
+            for u in thermostat_listener.attribute_updates
+            if u[0] == Thermostat.AttributeDefs.running_state.id
+        ),
+        None,
+    )
+    assert running_state_update is not None
+    assert running_state_update[1] == Thermostat.RunningState.Heat_State_On
+
+    # Test case 2: setpoint <= local_temp -> idle
+    thermostat_listener.attribute_updates.clear()
+    # local_temp = 2200 (22.00°C), setpoint = 2000 (20.00°C)
+    heartbeat_data = bytes(
+        [
+            HEARTBEAT_LOCAL_TEMPERATURE,
+            0x21,
+            0x98,
+            0x08,  # 2200 little-endian
+            HEARTBEAT_HEATING_SETPOINT,
+            0x21,
+            0xD0,
+            0x07,  # 2000 little-endian
+        ]
+    )
+    opple_cluster.update_attribute(HEARTBEAT, heartbeat_data)
+
+    running_state_update = next(
+        (
+            u
+            for u in thermostat_listener.attribute_updates
+            if u[0] == Thermostat.AttributeDefs.running_state.id
+        ),
+        None,
+    )
+    assert running_state_update is not None
+    assert running_state_update[1] == 0  # Idle
+
+    # Test case 3: system_mode = Off -> idle regardless of temperatures
+    thermostat_listener.attribute_updates.clear()
+    opple_cluster._attr_cache[SYSTEM_MODE] = SystemMode.Off
+    # local_temp = 2000, setpoint = 2200 (would be heating if on)
+    heartbeat_data = bytes(
+        [
+            HEARTBEAT_LOCAL_TEMPERATURE,
+            0x21,
+            0xD0,
+            0x07,
+            HEARTBEAT_HEATING_SETPOINT,
+            0x21,
+            0x98,
+            0x08,
+        ]
+    )
+    opple_cluster.update_attribute(HEARTBEAT, heartbeat_data)
+
+    running_state_update = next(
+        (
+            u
+            for u in thermostat_listener.attribute_updates
+            if u[0] == Thermostat.AttributeDefs.running_state.id
+        ),
+        None,
+    )
+    assert running_state_update is not None
+    assert running_state_update[1] == 0  # Idle because system is off
+
+
 async def test_xiaomi_e1_thermostat_write_calibrate(zigpy_device_from_v2_quirk):
     """Test writing calibrate attribute triggers calibration."""
     from unittest import mock

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from functools import reduce
+import logging
 import math
 import struct
 from typing import Any, Final
@@ -10,10 +11,11 @@ from typing import Any, Final
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, Identify, Ota, Time
+from zigpy.zcl.clusters.general import Basic, DeviceTemperature, Identify, Ota, Time
 from zigpy.zcl.clusters.hvac import Thermostat
 from zigpy.zcl.foundation import ZCLAttributeDef
 
+from zhaquirks import LocalDataCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -29,6 +31,8 @@ from zhaquirks.xiaomi import (
     XiaomiPowerConfiguration,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 ZCL_SYSTEM_MODE = Thermostat.attributes_by_name["system_mode"].id
 
 XIAOMI_SYSTEM_MODE_MAP = {
@@ -36,11 +40,23 @@ XIAOMI_SYSTEM_MODE_MAP = {
     1: Thermostat.SystemMode.Heat,
 }
 
+
+class SystemMode(t.enum8):
+    """Xiaomi TRV system mode.
+
+    Maps to ZCL Thermostat.SystemMode but with Xiaomi-specific values.
+    """
+
+    Off = 0x00  # Heating disabled
+    Heat = 0x01  # Heating enabled
+
+
 SYSTEM_MODE = 0x0271
 PRESET = 0x0272
 WINDOW_DETECTION = 0x0273
 VALVE_DETECTION = 0x0274
 VALVE_ALARM = 0x0275
+CALIBRATE = 0x0270
 CHILD_LOCK = 0x0277
 AWAY_PRESET_TEMPERATURE = 0x0279
 WINDOW_OPEN = 0x027A
@@ -49,8 +65,43 @@ SCHEDULE = 0x027D
 SCHEDULE_SETTINGS = 0x0276
 SENSOR = 0x027E
 BATTERY_PERCENTAGE = 0x040A
+HEARTBEAT = 0x00F7
 
-XIAOMI_CLUSTER_ID = 0xFCC0
+XIAOMI_MANUFACTURER_CODE = 0x115F
+
+# Heartbeat data keys (from TLV structure)
+HEARTBEAT_DEVICE_TEMPERATURE = 3
+HEARTBEAT_POWER_OUTAGE_COUNT = 5
+HEARTBEAT_FIRMWARE_VERSION = 13
+HEARTBEAT_PRESET = 101
+HEARTBEAT_LOCAL_TEMPERATURE = 102
+HEARTBEAT_HEATING_SETPOINT = 103
+HEARTBEAT_VALVE_ALARM = 104
+HEARTBEAT_BATTERY = 105
+
+
+class Preset(t.enum8):
+    """TRV operating preset.
+
+    Determines the operating mode of the thermostat.
+    """
+
+    Manual = 0x00  # Manual temperature control
+    Auto = 0x01  # Automatic schedule-based control
+    Away = 0x02  # Away/vacation mode with reduced temperature
+    Setup = 0x03  # Initial setup mode after powering ("E11" on display)
+
+
+class SensorMode(t.enum8):
+    """Temperature sensor mode.
+
+    Determines which temperature source the TRV uses for regulation.
+    """
+
+    Internal = 0x00  # Use internal temperature sensor (at the radiator)
+    ExternalPaired = 0x01  # External Aqara sensor paired via Aqara Hub (automatic)
+    ExternalInput = 0x02  # External temperature input via automation (manual updates)
+
 
 DAYS_MAP = {
     "mon": 0x02,
@@ -370,47 +421,120 @@ class ScheduleSettings(t.LVBytes):
         return result
 
 
+class LocalDeviceTemperatureCluster(LocalDataCluster, DeviceTemperature):
+    """Device temperature cluster for internal TRV temperature."""
+
+    _CONSTANT_ATTRIBUTES = {
+        DeviceTemperature.AttributeDefs.min_temp_experienced.id: -4000,
+        DeviceTemperature.AttributeDefs.max_temp_experienced.id: 12500,
+    }
+
+
+# ZCL data type sizes for heartbeat parsing (type_id: (size, signed))
+_ZCL_TYPE_SIZES: dict[int, tuple[int, bool]] = {
+    0x10: (1, False),  # Bool
+    0x20: (1, False),  # uint8
+    0x21: (2, False),  # uint16
+    0x22: (3, False),  # uint24
+    0x23: (4, False),  # uint32
+    0x24: (5, False),  # uint40
+    0x25: (6, False),  # uint48
+    0x28: (1, True),  # int8
+    0x29: (2, True),  # int16
+    0x2B: (4, True),  # int32
+}
+
+
+def _parse_heartbeat(value: bytes) -> dict[int, Any]:
+    """Parse Xiaomi TLV heartbeat structure.
+
+    The heartbeat is a TLV-encoded structure where each entry consists of:
+    - 1 byte: key/index
+    - 1 byte: data type (ZCL type)
+    - N bytes: value (length depends on type)
+
+    Returns a dictionary mapping keys to their parsed values.
+    """
+    result: dict[int, Any] = {}
+    if not value or not isinstance(value, (bytes, bytearray)):
+        return result
+
+    i = 0
+    while i < len(value) - 1:
+        key = value[i]
+        data_type = value[i + 1]
+
+        try:
+            if data_type in _ZCL_TYPE_SIZES:
+                size, signed = _ZCL_TYPE_SIZES[data_type]
+                result[key] = int.from_bytes(
+                    value[i + 2 : i + 2 + size], "little", signed=signed
+                )
+                i += 2 + size
+            elif data_type == 0x39:  # float (single precision)
+                result[key] = struct.unpack("<f", value[i + 2 : i + 6])[0]
+                i += 6
+            else:
+                _LOGGER.debug(
+                    "Unknown data type 0x%02x at position %d in heartbeat",
+                    data_type,
+                    i,
+                )
+                break
+        except (IndexError, struct.error):
+            _LOGGER.debug("Error parsing heartbeat at position %d", i)
+            break
+
+    return result
+
+
 class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
     """Aqara manufacturer specific settings."""
 
     class AttributeDefs(XiaomiAqaraE1Cluster.AttributeDefs):
         """Attribute definitions."""
 
+        heartbeat: Final = ZCLAttributeDef(
+            id=HEARTBEAT, type=t.LVBytes, is_manufacturer_specific=True
+        )
+        calibrate: Final = ZCLAttributeDef(
+            id=CALIBRATE, type=t.uint8_t, is_manufacturer_specific=True
+        )
         system_mode: Final = ZCLAttributeDef(
-            id=SYSTEM_MODE, type=t.uint8_t, is_manufacturer_specific=True
+            id=SYSTEM_MODE, type=SystemMode, is_manufacturer_specific=True
         )
         preset: Final = ZCLAttributeDef(
-            id=PRESET, type=t.uint8_t, is_manufacturer_specific=True
+            id=PRESET, type=Preset, is_manufacturer_specific=True
         )
         window_detection: Final = ZCLAttributeDef(
-            id=WINDOW_DETECTION, type=t.uint8_t, is_manufacturer_specific=True
+            id=WINDOW_DETECTION, type=t.Bool, is_manufacturer_specific=True
         )
         valve_detection: Final = ZCLAttributeDef(
-            id=VALVE_DETECTION, type=t.uint8_t, is_manufacturer_specific=True
+            id=VALVE_DETECTION, type=t.Bool, is_manufacturer_specific=True
         )
         valve_alarm: Final = ZCLAttributeDef(
-            id=VALVE_ALARM, type=t.uint8_t, is_manufacturer_specific=True
+            id=VALVE_ALARM, type=t.Bool, is_manufacturer_specific=True
         )
         child_lock: Final = ZCLAttributeDef(
-            id=CHILD_LOCK, type=t.uint8_t, is_manufacturer_specific=True
+            id=CHILD_LOCK, type=t.Bool, is_manufacturer_specific=True
         )
         away_preset_temperature: Final = ZCLAttributeDef(
             id=AWAY_PRESET_TEMPERATURE, type=t.uint32_t, is_manufacturer_specific=True
         )
         window_open: Final = ZCLAttributeDef(
-            id=WINDOW_OPEN, type=t.uint8_t, is_manufacturer_specific=True
+            id=WINDOW_OPEN, type=t.Bool, is_manufacturer_specific=True
         )
         calibrated: Final = ZCLAttributeDef(
-            id=CALIBRATED, type=t.uint8_t, is_manufacturer_specific=True
+            id=CALIBRATED, type=t.Bool, is_manufacturer_specific=True
         )
         schedule: Final = ZCLAttributeDef(
-            id=SCHEDULE, type=t.uint8_t, is_manufacturer_specific=True
+            id=SCHEDULE, type=t.Bool, is_manufacturer_specific=True
         )
         schedule_settings: Final = ZCLAttributeDef(
             id=SCHEDULE_SETTINGS, type=ScheduleSettings, is_manufacturer_specific=True
         )
         sensor: Final = ZCLAttributeDef(
-            id=SENSOR, type=t.uint8_t, is_manufacturer_specific=True
+            id=SENSOR, type=SensorMode, is_manufacturer_specific=True
         )
         battery_percentage: Final = ZCLAttributeDef(
             id=BATTERY_PERCENTAGE, type=t.uint8_t, is_manufacturer_specific=True
@@ -425,7 +549,102 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
             self.endpoint.thermostat.update_attribute(
                 ZCL_SYSTEM_MODE, XIAOMI_SYSTEM_MODE_MAP[value]
             )
+        elif attrid == HEARTBEAT:
+            self._handle_heartbeat(value)
+        elif attrid == PRESET:
+            # Check for setup mode (preset=3)
+            if value == Preset.Setup:
+                self.debug("Device is in setup mode (E11)")
         super()._update_attribute(attrid, value)
+
+    def _handle_heartbeat(self, value: bytes) -> None:
+        """Handle heartbeat message and update related clusters."""
+        heartbeat_data = _parse_heartbeat(value)
+        self.debug("Parsed heartbeat data: %s", heartbeat_data)
+
+        # Update device temperature
+        if HEARTBEAT_DEVICE_TEMPERATURE in heartbeat_data:
+            device_temp = heartbeat_data[HEARTBEAT_DEVICE_TEMPERATURE]
+            # Device temperature is in degrees Celsius, ZCL expects centidegrees
+            self.endpoint.device_temperature.update_attribute(
+                DeviceTemperature.AttributeDefs.current_temperature.id,
+                device_temp * 100,
+            )
+
+        # Update local temperature on thermostat
+        if HEARTBEAT_LOCAL_TEMPERATURE in heartbeat_data:
+            local_temp = heartbeat_data[HEARTBEAT_LOCAL_TEMPERATURE]
+            # Temperature is already in centidegrees from heartbeat
+            self.endpoint.thermostat.update_attribute(
+                Thermostat.AttributeDefs.local_temperature.id,
+                local_temp,
+            )
+
+        # Update battery
+        if HEARTBEAT_BATTERY in heartbeat_data:
+            battery = heartbeat_data[HEARTBEAT_BATTERY]
+            self.endpoint.power.battery_percent_reported(battery)
+
+        # Update preset (and detect setup mode)
+        if HEARTBEAT_PRESET in heartbeat_data:
+            preset = heartbeat_data[HEARTBEAT_PRESET]
+            if preset == Preset.Setup:
+                self.debug("Device is in setup mode (E11) from heartbeat")
+            self.update_attribute(PRESET, preset)
+
+        # Update valve alarm
+        if HEARTBEAT_VALVE_ALARM in heartbeat_data:
+            valve_alarm = heartbeat_data[HEARTBEAT_VALVE_ALARM]
+            self.update_attribute(VALVE_ALARM, 1 if valve_alarm == 1 else 0)
+
+        # Store power outage count for reference
+        if HEARTBEAT_POWER_OUTAGE_COUNT in heartbeat_data:
+            power_outage_count = heartbeat_data[HEARTBEAT_POWER_OUTAGE_COUNT] - 1
+            self.debug("Power outage count: %s", power_outage_count)
+
+    async def read_attributes(
+        self,
+        attributes: list[int | str],
+        allow_cache: bool = False,
+        only_cache: bool = False,
+        manufacturer: int | t.uint16_t | None = None,
+    ):
+        """Read attributes with Xiaomi manufacturer code."""
+        if manufacturer is None:
+            manufacturer = XIAOMI_MANUFACTURER_CODE
+        return await super().read_attributes(
+            attributes, allow_cache, only_cache, manufacturer
+        )
+
+    async def write_attributes(
+        self, attributes: dict[str | int, Any], manufacturer: int | None = None
+    ) -> list:
+        """Write attributes with Xiaomi manufacturer code."""
+        if manufacturer is None:
+            manufacturer = XIAOMI_MANUFACTURER_CODE
+
+        attrs_to_write = {}
+        for attr, value in attributes.items():
+            # Resolve attribute name to ID if needed
+            if isinstance(attr, str):
+                attr_def = self.attributes_by_name.get(attr)
+                if attr_def:
+                    attr = attr_def.id
+                else:
+                    self.debug("Unknown attribute name: %s", attr)
+                    continue
+
+            # Handle calibrate trigger specially - writing 1 triggers calibration
+            if attr == CALIBRATE:
+                attrs_to_write[attr] = t.uint8_t(1)
+            # Handle away_preset_temperature - needs to be multiplied by 100
+            elif attr == AWAY_PRESET_TEMPERATURE:
+                # Value comes in as degrees, needs to be in centidegrees
+                attrs_to_write[attr] = t.uint32_t(int(value * 100))
+            else:
+                attrs_to_write[attr] = value
+
+        return await super().write_attributes(attrs_to_write, manufacturer)
 
 
 class AGL001(XiaomiCustomDevice):
@@ -468,6 +687,7 @@ class AGL001(XiaomiCustomDevice):
                     Time.cluster_id,
                     XiaomiPowerConfiguration,
                     AqaraThermostatSpecificCluster,
+                    LocalDeviceTemperatureCluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -115,6 +115,9 @@ class ThermostatCluster(CustomCluster, Thermostat):
         ].id: Thermostat.ControlSequenceOfOperation.Heating_Only
     }
 
+    # Attribute IDs for special handling
+    _RUNNING_STATE_ATTR = Thermostat.AttributeDefs.running_state.id
+
     async def read_attributes(
         self,
         attributes: list[int | str],
@@ -125,6 +128,20 @@ class ThermostatCluster(CustomCluster, Thermostat):
         """Pass reading attributes to Xiaomi cluster if applicable."""
         successful_r, failed_r = {}, {}
         remaining_attributes = attributes.copy()
+
+        # Handle running_state - device doesn't support it natively, we simulate it
+        # from heartbeat data. Return cached value or default to Idle.
+        running_state_requested = (
+            self._RUNNING_STATE_ATTR in attributes or "running_state" in attributes
+        )
+        if running_state_requested:
+            if self._RUNNING_STATE_ATTR in attributes:
+                remaining_attributes.remove(self._RUNNING_STATE_ATTR)
+            if "running_state" in attributes:
+                remaining_attributes.remove("running_state")
+            # Return cached value (set by heartbeat) or default to Idle (0)
+            cached_state = self._attr_cache.get(self._RUNNING_STATE_ATTR, 0)
+            successful_r[self._RUNNING_STATE_ATTR] = cached_state
 
         # read system_mode from Xiaomi cluster (can be numeric or string)
         if ZCL_SYSTEM_MODE in attributes or "system_mode" in attributes:

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -705,28 +705,28 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="child_lock",
         fallback_name="Child lock",
-        unique_id_suffix="child_lock",
+        unique_id_suffix="64704-child_lock",
     )
     .switch(
         AqaraThermostatSpecificCluster.AttributeDefs.window_detection.name,
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="window_detection",
         fallback_name="Open window detection",
-        unique_id_suffix="window_detection",
+        unique_id_suffix="64704-window_detection",
     )
     .switch(
         AqaraThermostatSpecificCluster.AttributeDefs.valve_detection.name,
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="valve_detection",
         fallback_name="Valve detection",
-        unique_id_suffix="valve_detection",
+        unique_id_suffix="64704-valve_detection",
     )
     .switch(
         AqaraThermostatSpecificCluster.AttributeDefs.schedule.name,
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="schedule",
         fallback_name="Schedule",
-        unique_id_suffix="schedule",
+        unique_id_suffix="64704-schedule",
     )
     # Binary sensors
     .binary_sensor(
@@ -735,7 +735,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         device_class=BinarySensorDeviceClass.PROBLEM,
         translation_key="valve_alarm",
         fallback_name="Valve alarm",
-        unique_id_suffix="valve_alarm",
+        unique_id_suffix="64704-valve_alarm",
     )
     .binary_sensor(
         AqaraThermostatSpecificCluster.AttributeDefs.window_open.name,
@@ -743,7 +743,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         device_class=BinarySensorDeviceClass.WINDOW,
         translation_key="window_open",
         fallback_name="Window open",
-        unique_id_suffix="window_open",
+        unique_id_suffix="64704-window_open",
     )
     .binary_sensor(
         AqaraThermostatSpecificCluster.AttributeDefs.calibrated.name,
@@ -751,7 +751,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         entity_type=EntityType.DIAGNOSTIC,
         translation_key="calibrated",
         fallback_name="Calibrated",
-        unique_id_suffix="calibrated",
+        unique_id_suffix="64704-calibrated",
     )
     # Selects (enums)
     .enum(
@@ -760,7 +760,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="preset",
         fallback_name="Preset",
-        unique_id_suffix="preset",
+        unique_id_suffix="64704-preset",
     )
     .enum(
         AqaraThermostatSpecificCluster.AttributeDefs.sensor.name,
@@ -768,7 +768,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="sensor_mode",
         fallback_name="Sensor mode",
-        unique_id_suffix="sensor",
+        unique_id_suffix="64704-sensor",
     )
     # Number
     .number(
@@ -782,7 +782,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         device_class=NumberDeviceClass.TEMPERATURE,
         translation_key="away_preset_temperature",
         fallback_name="Away preset temperature",
-        unique_id_suffix="away_preset_temperature",
+        unique_id_suffix="64704-away_preset_temperature",
     )
     # Button
     .write_attr_button(

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -8,28 +8,18 @@ import math
 import struct
 from typing import Any, Final
 
-from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import EntityType, UnitOfTemperature
+from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, DeviceTemperature, Identify, Ota, Time
+from zigpy.zcl.clusters.general import Basic, DeviceTemperature
 from zigpy.zcl.clusters.hvac import Thermostat
 from zigpy.zcl.foundation import ZCLAttributeDef
 
 from zhaquirks import LocalDataCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-from zhaquirks.xiaomi import (
-    LUMI,
-    XiaomiAqaraE1Cluster,
-    XiaomiCustomDevice,
-    XiaomiPowerConfiguration,
-)
+from zhaquirks.xiaomi import LUMI, XiaomiAqaraE1Cluster, XiaomiPowerConfiguration
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -602,10 +592,9 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
             power_outage_count = heartbeat_data[HEARTBEAT_POWER_OUTAGE_COUNT] - 1
             self.debug("Power outage count: %s", power_outage_count)
 
-        # Update firmware version on Basic cluster
+        # Update firmware version on Basic cluster (standard ZCL attribute)
         if HEARTBEAT_FIRMWARE_VERSION in heartbeat_data:
             fw_version = heartbeat_data[HEARTBEAT_FIRMWARE_VERSION]
-            # Use raw version number as string (consistent with Z2M)
             version_str = str(fw_version)
             self.debug("Firmware version: %s", version_str)
             self.endpoint.basic.update_attribute(
@@ -657,54 +646,99 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         return await super().write_attributes(attrs_to_write, manufacturer)
 
 
-class AGL001(XiaomiCustomDevice):
-    """Aqara E1 Radiator Thermostat (AGL001) Device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=769
-        # device_version=1
-        # input_clusters=[0, 1, 3, 513, 64704]
-        # output_clusters=[3, 513, 64704]>
-        MODELS_INFO: [(LUMI, "lumi.airrtc.agl001")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.THERMOSTAT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Thermostat.cluster_id,
-                    Time.cluster_id,
-                    XiaomiPowerConfiguration.cluster_id,
-                    AqaraThermostatSpecificCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Thermostat.cluster_id,
-                    AqaraThermostatSpecificCluster.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    ThermostatCluster,
-                    Time.cluster_id,
-                    XiaomiPowerConfiguration,
-                    AqaraThermostatSpecificCluster,
-                    LocalDeviceTemperatureCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    ThermostatCluster,
-                    AqaraThermostatSpecificCluster,
-                    Ota.cluster_id,
-                ],
-            }
-        }
-    }
+(
+    QuirkBuilder(LUMI, "lumi.airrtc.agl001")
+    .replaces(ThermostatCluster)
+    .replaces(AqaraThermostatSpecificCluster)
+    .replaces(XiaomiPowerConfiguration)
+    .adds(LocalDeviceTemperatureCluster)
+    # Complete entity definitions for this device.
+    # Note: ZHA currently has legacy hardcoded entities for this device which may
+    # cause duplicates. Those should be removed from ZHA in a follow-up PR.
+    #
+    # Switches
+    .switch(
+        AqaraThermostatSpecificCluster.AttributeDefs.child_lock.name,
+        AqaraThermostatSpecificCluster.cluster_id,
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    .switch(
+        AqaraThermostatSpecificCluster.AttributeDefs.window_detection.name,
+        AqaraThermostatSpecificCluster.cluster_id,
+        translation_key="window_detection",
+        fallback_name="Window detection",
+    )
+    .switch(
+        AqaraThermostatSpecificCluster.AttributeDefs.valve_detection.name,
+        AqaraThermostatSpecificCluster.cluster_id,
+        translation_key="valve_detection",
+        fallback_name="Valve detection",
+    )
+    .switch(
+        AqaraThermostatSpecificCluster.AttributeDefs.schedule.name,
+        AqaraThermostatSpecificCluster.cluster_id,
+        translation_key="schedule",
+        fallback_name="Schedule",
+    )
+    # Binary sensors
+    .binary_sensor(
+        AqaraThermostatSpecificCluster.AttributeDefs.valve_alarm.name,
+        AqaraThermostatSpecificCluster.cluster_id,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        translation_key="valve_alarm",
+        fallback_name="Valve alarm",
+    )
+    .binary_sensor(
+        AqaraThermostatSpecificCluster.AttributeDefs.window_open.name,
+        AqaraThermostatSpecificCluster.cluster_id,
+        device_class=BinarySensorDeviceClass.WINDOW,
+        translation_key="window_open",
+        fallback_name="Window open",
+    )
+    .binary_sensor(
+        AqaraThermostatSpecificCluster.AttributeDefs.calibrated.name,
+        AqaraThermostatSpecificCluster.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="calibrated",
+        fallback_name="Calibrated",
+    )
+    # Selects (enums)
+    .enum(
+        AqaraThermostatSpecificCluster.AttributeDefs.preset.name,
+        Preset,
+        AqaraThermostatSpecificCluster.cluster_id,
+        translation_key="preset",
+        fallback_name="Preset",
+    )
+    .enum(
+        AqaraThermostatSpecificCluster.AttributeDefs.sensor.name,
+        SensorMode,
+        AqaraThermostatSpecificCluster.cluster_id,
+        translation_key="sensor_mode",
+        fallback_name="Sensor mode",
+    )
+    # Number
+    .number(
+        AqaraThermostatSpecificCluster.AttributeDefs.away_preset_temperature.name,
+        AqaraThermostatSpecificCluster.cluster_id,
+        min_value=5,
+        max_value=30,
+        step=0.5,
+        unit=UnitOfTemperature.CELSIUS,
+        multiplier=0.01,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        translation_key="away_preset_temperature",
+        fallback_name="Away preset temperature",
+    )
+    # Button
+    .write_attr_button(
+        AqaraThermostatSpecificCluster.AttributeDefs.calibrate.name,
+        1,
+        AqaraThermostatSpecificCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="calibrate",
+        fallback_name="Calibrate",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -696,8 +696,8 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
     .replaces(XiaomiPowerConfiguration)
     .adds(LocalDeviceTemperatureCluster)
     # Complete entity definitions for this device.
-    # Note: ZHA currently has legacy hardcoded entities for this device which may
-    # cause duplicates. Those should be removed from ZHA in a follow-up PR.
+    # unique_id_suffix values match legacy ZHA entity IDs for seamless migration
+    # (prevents duplicate entities and preserves automations/dashboards).
     #
     # Switches
     .switch(
@@ -705,24 +705,28 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="child_lock",
         fallback_name="Child lock",
+        unique_id_suffix="child_lock",
     )
     .switch(
         AqaraThermostatSpecificCluster.AttributeDefs.window_detection.name,
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="window_detection",
         fallback_name="Open window detection",
+        unique_id_suffix="window_detection",
     )
     .switch(
         AqaraThermostatSpecificCluster.AttributeDefs.valve_detection.name,
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="valve_detection",
         fallback_name="Valve detection",
+        unique_id_suffix="valve_detection",
     )
     .switch(
         AqaraThermostatSpecificCluster.AttributeDefs.schedule.name,
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="schedule",
         fallback_name="Schedule",
+        unique_id_suffix="schedule",
     )
     # Binary sensors
     .binary_sensor(
@@ -731,6 +735,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         device_class=BinarySensorDeviceClass.PROBLEM,
         translation_key="valve_alarm",
         fallback_name="Valve alarm",
+        unique_id_suffix="valve_alarm",
     )
     .binary_sensor(
         AqaraThermostatSpecificCluster.AttributeDefs.window_open.name,
@@ -738,6 +743,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         device_class=BinarySensorDeviceClass.WINDOW,
         translation_key="window_open",
         fallback_name="Window open",
+        unique_id_suffix="window_open",
     )
     .binary_sensor(
         AqaraThermostatSpecificCluster.AttributeDefs.calibrated.name,
@@ -745,6 +751,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         entity_type=EntityType.DIAGNOSTIC,
         translation_key="calibrated",
         fallback_name="Calibrated",
+        unique_id_suffix="calibrated",
     )
     # Selects (enums)
     .enum(
@@ -753,6 +760,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="preset",
         fallback_name="Preset",
+        unique_id_suffix="preset",
     )
     .enum(
         AqaraThermostatSpecificCluster.AttributeDefs.sensor.name,
@@ -760,6 +768,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="sensor_mode",
         fallback_name="Sensor mode",
+        unique_id_suffix="sensor",
     )
     # Number
     .number(
@@ -773,6 +782,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         device_class=NumberDeviceClass.TEMPERATURE,
         translation_key="away_preset_temperature",
         fallback_name="Away preset temperature",
+        unique_id_suffix="away_preset_temperature",
     )
     # Button
     .write_attr_button(

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -602,6 +602,32 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
                 version_str,
             )
 
+        # Simulate running_state based on temperature difference
+        # The device doesn't report running_state, but we can derive it
+        if (
+            HEARTBEAT_LOCAL_TEMPERATURE in heartbeat_data
+            and HEARTBEAT_HEATING_SETPOINT in heartbeat_data
+        ):
+            local_temp = heartbeat_data[HEARTBEAT_LOCAL_TEMPERATURE]
+            setpoint = heartbeat_data[HEARTBEAT_HEATING_SETPOINT]
+            # Get current system_mode from cluster cache
+            system_mode = self._attr_cache.get(SYSTEM_MODE, SystemMode.Heat)
+
+            if system_mode == SystemMode.Off:
+                # System is off, not heating
+                running_state = 0  # Idle
+            elif setpoint > local_temp:
+                # Need to heat - setpoint higher than current temperature
+                running_state = Thermostat.RunningState.Heat_State_On
+            else:
+                # At or above setpoint, not heating
+                running_state = 0  # Idle
+
+            self.endpoint.thermostat.update_attribute(
+                Thermostat.AttributeDefs.running_state.id,
+                running_state,
+            )
+
     async def read_attributes(
         self,
         attributes: list[int | str],

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -693,7 +693,7 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         AqaraThermostatSpecificCluster.AttributeDefs.window_detection.name,
         AqaraThermostatSpecificCluster.cluster_id,
         translation_key="window_detection",
-        fallback_name="Window detection",
+        fallback_name="Open window detection",
     )
     .switch(
         AqaraThermostatSpecificCluster.AttributeDefs.valve_detection.name,

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -501,40 +501,40 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
             id=CALIBRATE, type=t.uint8_t, is_manufacturer_specific=True
         )
         system_mode: Final = ZCLAttributeDef(
-            id=SYSTEM_MODE, type=SystemMode, is_manufacturer_specific=True
+            id=SYSTEM_MODE, type=t.uint8_t, is_manufacturer_specific=True
         )
         preset: Final = ZCLAttributeDef(
-            id=PRESET, type=Preset, is_manufacturer_specific=True
+            id=PRESET, type=t.uint8_t, is_manufacturer_specific=True
         )
         window_detection: Final = ZCLAttributeDef(
-            id=WINDOW_DETECTION, type=t.Bool, is_manufacturer_specific=True
+            id=WINDOW_DETECTION, type=t.uint8_t, is_manufacturer_specific=True
         )
         valve_detection: Final = ZCLAttributeDef(
-            id=VALVE_DETECTION, type=t.Bool, is_manufacturer_specific=True
+            id=VALVE_DETECTION, type=t.uint8_t, is_manufacturer_specific=True
         )
         valve_alarm: Final = ZCLAttributeDef(
-            id=VALVE_ALARM, type=t.Bool, is_manufacturer_specific=True
+            id=VALVE_ALARM, type=t.uint8_t, is_manufacturer_specific=True
         )
         child_lock: Final = ZCLAttributeDef(
-            id=CHILD_LOCK, type=t.Bool, is_manufacturer_specific=True
+            id=CHILD_LOCK, type=t.uint8_t, is_manufacturer_specific=True
         )
         away_preset_temperature: Final = ZCLAttributeDef(
             id=AWAY_PRESET_TEMPERATURE, type=t.uint32_t, is_manufacturer_specific=True
         )
         window_open: Final = ZCLAttributeDef(
-            id=WINDOW_OPEN, type=t.Bool, is_manufacturer_specific=True
+            id=WINDOW_OPEN, type=t.uint8_t, is_manufacturer_specific=True
         )
         calibrated: Final = ZCLAttributeDef(
-            id=CALIBRATED, type=t.Bool, is_manufacturer_specific=True
+            id=CALIBRATED, type=t.uint8_t, is_manufacturer_specific=True
         )
         schedule: Final = ZCLAttributeDef(
-            id=SCHEDULE, type=t.Bool, is_manufacturer_specific=True
+            id=SCHEDULE, type=t.uint8_t, is_manufacturer_specific=True
         )
         schedule_settings: Final = ZCLAttributeDef(
             id=SCHEDULE_SETTINGS, type=ScheduleSettings, is_manufacturer_specific=True
         )
         sensor: Final = ZCLAttributeDef(
-            id=SENSOR, type=SensorMode, is_manufacturer_specific=True
+            id=SENSOR, type=t.uint8_t, is_manufacturer_specific=True
         )
         battery_percentage: Final = ZCLAttributeDef(
             id=BATTERY_PERCENTAGE, type=t.uint8_t, is_manufacturer_specific=True
@@ -602,6 +602,17 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
             power_outage_count = heartbeat_data[HEARTBEAT_POWER_OUTAGE_COUNT] - 1
             self.debug("Power outage count: %s", power_outage_count)
 
+        # Update firmware version on Basic cluster
+        if HEARTBEAT_FIRMWARE_VERSION in heartbeat_data:
+            fw_version = heartbeat_data[HEARTBEAT_FIRMWARE_VERSION]
+            # Use raw version number as string (consistent with Z2M)
+            version_str = str(fw_version)
+            self.debug("Firmware version: %s", version_str)
+            self.endpoint.basic.update_attribute(
+                Basic.AttributeDefs.sw_build_id.id,
+                version_str,
+            )
+
     async def read_attributes(
         self,
         attributes: list[int | str],
@@ -637,10 +648,9 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
             # Handle calibrate trigger specially - writing 1 triggers calibration
             if attr == CALIBRATE:
                 attrs_to_write[attr] = t.uint8_t(1)
-            # Handle away_preset_temperature - needs to be multiplied by 100
+            # Handle away_preset_temperature - value already in centidegrees from Number entity
             elif attr == AWAY_PRESET_TEMPERATURE:
-                # Value comes in as degrees, needs to be in centidegrees
-                attrs_to_write[attr] = t.uint32_t(int(value * 100))
+                attrs_to_write[attr] = t.uint32_t(int(value))
             else:
                 attrs_to_write[attr] = value
 


### PR DESCRIPTION
## Summary

Adds advanced features to the Aqara E1 TRV quirk:

- **Heartbeat parsing**: Parse TLV-encoded heartbeat messages to extract device temperature, battery, firmware version, and more
- **Running state simulation**: Derive HVAC action (heating/idle) from temperature comparison since device doesn't report it natively
- **Calibrate button**: Expose valve calibration as a button entity in Home Assistant
- **Device temperature sensor**: Add internal device temperature cluster  
- **Setup mode detection**: Log when device is in setup mode (E11 error)

## Changes

### New Features
- `_parse_heartbeat()`: TLV parser for Xiaomi heartbeat messages
- `_handle_heartbeat()`: Process heartbeat data and update related clusters
- `LocalDeviceTemperatureCluster`: Device temperature sensor
- `running_state` simulation based on setpoint vs local temperature
- Calibrate button entity
- `Preset.Setup` enum value (0x03) for setup mode detection

### Updated Clusters
- `ThermostatCluster.read_attributes()`: Intercept `running_state` reads to return cached simulated value
- `AqaraThermostatSpecificCluster.write_attributes()`: Handle calibrate trigger and manufacturer code

## Dependencies

⚠️ **This PR builds on top of #4604** (v1→v2 migration). It should be reviewed/merged **after** #4604 is merged.

Related: zigpy/zha#621 (removes legacy hardcoded entities)

## Testing

All tests pass. Tested on real hardware.

## Notes

Per @TheJulianJES's feedback, this PR was split from #4604 to keep the migration PR focused on just the v1→v2 conversion. This PR adds the new features separately.