### PR TITLE
Add quirk for Aqara Curtain Controller C3 (lumi.curtain.acn04)

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -63,6 +63,7 @@ from zhaquirks.xiaomi import (
 )
 import zhaquirks.xiaomi.aqara.cube
 import zhaquirks.xiaomi.aqara.cube_aqgl01
+import zhaquirks.xiaomi.aqara.curtain_c3
 import zhaquirks.xiaomi.aqara.driver_curtain_e1
 from zhaquirks.xiaomi.aqara.feeder_acn001 import (
     FEEDER_ATTR,
@@ -2282,3 +2283,65 @@ async def test_lumi_magnet_sensor_aq2_bad_direction(zigpy_device_from_quirk, cap
 
     # Our matching logic should be forgiving
     assert listener.attribute_updates == [(0, t.Bool.true)]
+
+
+@pytest.mark.parametrize(
+    "command, expected_command_id, expected_args",
+    [
+        (
+            WindowCovering.ServerCommandDefs.up_open.id,
+            WindowCovering.ServerCommandDefs.go_to_lift_percentage.id,
+            (0,),
+        ),
+        (
+            WindowCovering.ServerCommandDefs.down_close.id,
+            WindowCovering.ServerCommandDefs.go_to_lift_percentage.id,
+            (100,),
+        ),
+        (
+            WindowCovering.ServerCommandDefs.stop.id,
+            WindowCovering.ServerCommandDefs.stop.id,
+            (),
+        ),
+    ],
+)
+async def test_xiaomi_curtain_c3_commands(
+    zigpy_device_from_v2_quirk, command, expected_command_id, expected_args
+):
+    """Test Aqara Curtain C3 commands map to go_to_lift_percentage."""
+    device = zigpy_device_from_v2_quirk(AQARA, "lumi.curtain.acn04")
+
+    window_covering_cluster = device.endpoints[1].window_covering
+
+    p = mock.patch.object(window_covering_cluster, "request", mock.AsyncMock())
+
+    with p as request_mock:
+        request_mock.return_value = (foundation.Status.SUCCESS, "done")
+
+        await window_covering_cluster.command(command)
+        assert request_mock.call_count == 1
+        assert request_mock.call_args[0][1] == expected_command_id
+        if expected_args:
+            assert request_mock.call_args[0][3] == expected_args[0]
+
+
+async def test_xiaomi_curtain_c3_position_sync(zigpy_device_from_v2_quirk):
+    """Test Aqara Curtain C3 position sync from manufacturer cluster to WindowCovering."""
+    device = zigpy_device_from_v2_quirk(AQARA, "lumi.curtain.acn04")
+
+    opple_cluster = device.endpoints[1].opple_cluster
+    window_covering_cluster = device.endpoints[1].window_covering
+    wc_listener = ClusterListener(window_covering_cluster)
+
+    curtain_position_attr_id = zhaquirks.xiaomi.aqara.curtain_c3.XiaomiAqaraCurtainC3.AttributeDefs.curtain_position.id
+
+    # Simulate position update from device
+    opple_cluster.update_attribute(curtain_position_attr_id, 75)
+
+    # Verify WindowCovering cluster received the position update
+    assert len(wc_listener.attribute_updates) == 1
+    assert (
+        wc_listener.attribute_updates[0][0]
+        == WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+    assert wc_listener.attribute_updates[0][1] == 75

--- a/zhaquirks/xiaomi/aqara/curtain_c3.py
+++ b/zhaquirks/xiaomi/aqara/curtain_c3.py
@@ -1,0 +1,205 @@
+"""Aqara Curtain Controller C3 (ZNCLDJ01LM)."""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from zigpy import types as t
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import EntityType
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
+
+from zhaquirks import CustomCluster
+from zhaquirks.xiaomi import AQARA, BasicCluster, XiaomiAqaraE1Cluster
+
+
+class AqaraCurtainC3Control(t.enum8):
+    """Aqara C3 curtain control command values."""
+
+    Stop = 0x00
+    Toggle = 0x03
+    Open = 0x07
+    Close = 0x08
+
+
+class XiaomiAqaraCurtainC3(XiaomiAqaraE1Cluster):
+    """Aqara manufacturer cluster for the Curtain Controller C3."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Manufacturer specific attributes."""
+
+        positions_stored: Final = ZCLAttributeDef(
+            id=0x0402,
+            type=t.Bool,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+
+        traverse_time: Final = ZCLAttributeDef(
+            id=0x0403,
+            type=t.uint8_t,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+
+        store_position: Final = ZCLAttributeDef(
+            id=0x0407,
+            type=t.uint8_t,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+        control: Final = ZCLAttributeDef(
+            id=0x0420,
+            type=AqaraCurtainC3Control,
+            zcl_type=DataTypeId.uint8,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+
+        curtain_position: Final = ZCLAttributeDef(
+            id=0x041F,
+            type=t.uint8_t,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+
+        curtain_state: Final = ZCLAttributeDef(
+            id=0x0421,
+            type=t.uint8_t,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+
+        last_manual_operation: Final = ZCLAttributeDef(
+            id=0x0425,
+            type=t.uint8_t,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+
+        calibration_status: Final = ZCLAttributeDef(
+            id=0x0426,
+            type=t.uint8_t,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+
+        hand_open: Final = ZCLAttributeDef(
+            id=0x043A,
+            type=t.Bool,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+        speed: Final = ZCLAttributeDef(
+            id=0x043B,
+            type=t.uint8_t,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+        adaptive_pulling_speed: Final = ZCLAttributeDef(
+            id=0x0442,
+            type=t.uint8_t,
+            access="rwp",
+            is_manufacturer_specific=True,
+        )
+
+        aqara_attributes: Final = ZCLAttributeDef(
+            id=0x00F7,
+            type=t.LVBytes,
+            is_manufacturer_specific=True,
+        )
+
+    def _update_attribute(self, attrid, value):
+        """Handle attribute updates and sync position to WindowCovering cluster."""
+        super()._update_attribute(attrid, value)
+        if attrid == self.AttributeDefs.curtain_position.id:
+            self.endpoint.window_covering.update_attribute(
+                WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+                value,
+            )
+
+
+class WindowCoveringC3(CustomCluster, WindowCovering):
+    """Window covering cluster for the Curtain Controller C3.
+
+    Maps open/close commands to go_to_lift_percentage so the device
+    handles inversion correctly based on window_covering_mode.
+    """
+
+    _CONSTANT_ATTRIBUTES = {
+        WindowCovering.AttributeDefs.window_covering_type.id: WindowCovering.WindowCoveringType.Drapery,
+    }
+
+    async def command(
+        self,
+        command_id: foundation.GeneralCommand | int | t.uint8_t,
+        *args: Any,
+        manufacturer: int | t.uint16_t | None = None,
+        expect_reply: bool = True,
+        tsn: int | t.uint8_t | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Map open/close commands to go_to_lift_percentage."""
+        if command_id == WindowCovering.ServerCommandDefs.up_open.id:
+            command_id = WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
+            args = (0,)
+        elif command_id == WindowCovering.ServerCommandDefs.down_close.id:
+            command_id = WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
+            args = (100,)
+
+        return await super().command(
+            command_id,
+            *args,
+            manufacturer=manufacturer,
+            expect_reply=expect_reply,
+            tsn=tsn,
+            **kwargs,
+        )
+
+
+(
+    QuirkBuilder(AQARA, "lumi.curtain.acn04")
+    .replaces(BasicCluster)
+    .replaces(WindowCoveringC3)
+    .replaces(XiaomiAqaraCurtainC3)
+    .switch(
+        XiaomiAqaraCurtainC3.AttributeDefs.hand_open.name,
+        XiaomiAqaraCurtainC3.cluster_id,
+        translation_key="hand_open",
+        fallback_name="Hand open",
+    )
+    .switch(
+        WindowCovering.AttributeDefs.window_covering_mode.name,
+        WindowCovering.cluster_id,
+        translation_key="reverse_direction",
+        fallback_name="Reverse direction",
+    )
+    .number(
+        XiaomiAqaraCurtainC3.AttributeDefs.speed.name,
+        XiaomiAqaraCurtainC3.cluster_id,
+        min_value=1,
+        max_value=100,
+        step=1,
+        translation_key="speed",
+        fallback_name="Speed",
+    )
+    .binary_sensor(
+        XiaomiAqaraCurtainC3.AttributeDefs.positions_stored.name,
+        XiaomiAqaraCurtainC3.cluster_id,
+        translation_key="calibrated",
+        fallback_name="Calibrated",
+    )
+    .sensor(
+        XiaomiAqaraCurtainC3.AttributeDefs.traverse_time.name,
+        XiaomiAqaraCurtainC3.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="traverse_time",
+        fallback_name="Traverse time",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION

## Proposed change
<!--
  Explain your proposed change below.
-->

Add support for the Aqara Curtain Controller C3 (ZNCLDJ01LM) with:
- Custom WindowCovering cluster mapping open/close/stop commands
- Manufacturer-specific cluster with speed, hand_open, reverse_direction
- Position sync from manufacturer cluster to WindowCovering
- Home Assistant entities for configuration options


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

This is based on the quirk from zigbee2mqtt.
This PR was written by claude. If looks alright to me, but I'm not super familiar with this project...


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[aqara-c3-diagnostics.json](https://github.com/user-attachments/files/24655463/aqara-c3-diagnostics.json)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached



Related: #4661
