### PR TITLE
Add Tuya MOES temp sensor ZTH-01 `_TZE284_9yapgbuv` variant

### DIFF
--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -104,6 +104,7 @@ async def test_handle_get_data(
         ("_TZE204_yjjdcqsq", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),
         ("_TZE200_9yapgbuv", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),
         ("_TZE204_9yapgbuv", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),
+        ("_TZE284_9yapgbuv", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),
         ("_TZE200_utkemkbs", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),
         ("_TZE204_utkemkbs", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),
         ("_TZE204_ksz749x8", "TS0601", 100, 10, TUYA_TEMP01_HUM02_BAT03),

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -305,6 +305,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE284_yjjdcqsq", "TS0601")
     .applies_to("_TZE200_9yapgbuv", "TS0601")
     .applies_to("_TZE204_9yapgbuv", "TS0601")
+    .applies_to("_TZE284_9yapgbuv", "TS0601")
     .applies_to("_TZE200_utkemkbs", "TS0601")
     .applies_to("_TZE204_utkemkbs", "TS0601")
     .applies_to("_TZE284_utkemkbs", "TS0601")


### PR DESCRIPTION
## Proposed change
Add support for device `TS0601` - `_TZE284_9yapgbuv` sold as [MOES Temperature and humidity probe, ZigBee](https://www.alza.cz/moes-temperature-and-humidity-probe-zigbee-d12938972.htm), labeled as `ZTH-01` on the device itself.


## Additional information
None


## Device diagnostics

[moes_diagnostics.json](https://github.com/user-attachments/files/24690638/moes_diagnostics.json)


## Checklist

- [ X ] The changes are tested and work correctly
- [ X ] `pre-commit` checks pass / the code has been formatted using Black
- [ X ] Tests have been added to verify that the new code works
- [ X ] Device diagnostics data has been attached
