### PR TITLE
Add HOBEIAN ZG-101ZD rotary dimmer knob

### DIFF
--- a/zhaquirks/hobeian/__init__.py
+++ b/zhaquirks/hobeian/__init__.py
@@ -1,0 +1,1 @@
+"""HOBEIAN quirks."""

--- a/zhaquirks/hobeian/test_zg101zd.py
+++ b/zhaquirks/hobeian/test_zg101zd.py
@@ -3,7 +3,6 @@
 from unittest import mock
 
 import pytest
-import zigpy.types as t
 from zigpy.zcl import foundation
 
 from zhaquirks.hobeian.zg101zd import HobeianOnOffCluster

--- a/zhaquirks/hobeian/test_zg101zd.py
+++ b/zhaquirks/hobeian/test_zg101zd.py
@@ -1,0 +1,115 @@
+"""Tests for HOBEIAN ZG-101ZD rotary dimmer knob quirk."""
+
+from unittest import mock
+
+import pytest
+import zigpy.types as t
+from zigpy.zcl import foundation
+
+from zhaquirks.hobeian.zg101zd import HobeianOnOffCluster
+
+
+@pytest.fixture
+def hobeian_cluster():
+    """Create a HobeianOnOffCluster instance for testing."""
+    cluster = HobeianOnOffCluster(mock.MagicMock())
+    cluster.listener_event = mock.MagicMock()
+    return cluster
+
+
+def _make_hdr(command_id: int) -> foundation.ZCLHeader:
+    """Create a ZCL header with the given command ID."""
+    return foundation.ZCLHeader(
+        frame_control=foundation.FrameControl(
+            frame_type=foundation.FrameType.CLUSTER_COMMAND,
+            is_manufacturer_specific=False,
+            direction=foundation.Direction.Client_to_Server,
+            disable_default_response=True,
+        ),
+        tsn=1,
+        command_id=command_id,
+    )
+
+
+class TestHobeianOnOffCluster:
+    """Tests for HobeianOnOffCluster."""
+
+    def test_rotation_step_right(self, hobeian_cluster):
+        """Test rotation step right command (0x03)."""
+        hdr = _make_hdr(HobeianOnOffCluster.ROTATION_STEP_RIGHT_CMD)
+        hobeian_cluster.handle_cluster_request(hdr, [])
+
+        hobeian_cluster.listener_event.assert_called_once_with(
+            "zha_send_event",
+            "step_with_on_off",
+            {"step_mode": 0, "step_size": 13, "transition_time": 1},
+        )
+
+    def test_rotation_step_left(self, hobeian_cluster):
+        """Test rotation step left command (0x04)."""
+        hdr = _make_hdr(HobeianOnOffCluster.ROTATION_STEP_LEFT_CMD)
+        hobeian_cluster.handle_cluster_request(hdr, [])
+
+        hobeian_cluster.listener_event.assert_called_once_with(
+            "zha_send_event",
+            "step_with_on_off",
+            {"step_mode": 1, "step_size": 13, "transition_time": 1},
+        )
+
+    def test_rotation_direction_right(self, hobeian_cluster):
+        """Test rotation direction right command (0xFC with 0x00)."""
+        hdr = _make_hdr(HobeianOnOffCluster.ROTATION_DIRECTION_CMD)
+        hobeian_cluster.handle_cluster_request(hdr, [b"\x00"])
+
+        hobeian_cluster.listener_event.assert_called_once_with(
+            "zha_send_event",
+            "rotation_direction",
+            {"direction": "right", "direction_raw": 0},
+        )
+
+    def test_rotation_direction_left(self, hobeian_cluster):
+        """Test rotation direction left command (0xFC with 0x01)."""
+        hdr = _make_hdr(HobeianOnOffCluster.ROTATION_DIRECTION_CMD)
+        hobeian_cluster.handle_cluster_request(hdr, [b"\x01"])
+
+        hobeian_cluster.listener_event.assert_called_once_with(
+            "zha_send_event",
+            "rotation_direction",
+            {"direction": "left", "direction_raw": 1},
+        )
+
+    def test_rotation_direction_int_arg(self, hobeian_cluster):
+        """Test rotation direction with int argument."""
+        hdr = _make_hdr(HobeianOnOffCluster.ROTATION_DIRECTION_CMD)
+        hobeian_cluster.handle_cluster_request(hdr, [0])
+
+        hobeian_cluster.listener_event.assert_called_once_with(
+            "zha_send_event",
+            "rotation_direction",
+            {"direction": "right", "direction_raw": 0},
+        )
+
+    def test_rotation_direction_empty_args(self, hobeian_cluster):
+        """Test rotation direction with empty args defaults to right."""
+        hdr = _make_hdr(HobeianOnOffCluster.ROTATION_DIRECTION_CMD)
+        hobeian_cluster.handle_cluster_request(hdr, [])
+
+        hobeian_cluster.listener_event.assert_not_called()
+
+    def test_toggle(self, hobeian_cluster):
+        """Test toggle command (0x02)."""
+        hdr = _make_hdr(HobeianOnOffCluster.TOGGLE_CMD)
+        hobeian_cluster.handle_cluster_request(hdr, [])
+
+        hobeian_cluster.listener_event.assert_called_once_with(
+            "zha_send_event",
+            "toggle",
+            {},
+        )
+
+    def test_button_press_indicator_ignored(self, hobeian_cluster):
+        """Test button press indicator (0xFD) is ignored."""
+        hdr = _make_hdr(HobeianOnOffCluster.BUTTON_PRESS_INDICATOR_CMD)
+        hobeian_cluster.handle_cluster_request(hdr, [])
+
+        hobeian_cluster.listener_event.assert_not_called()

--- a/zhaquirks/hobeian/zg101zd.py
+++ b/zhaquirks/hobeian/zg101zd.py
@@ -1,0 +1,118 @@
+"""Quirk for HOBEIAN ZG-101ZD rotary dimmer knob."""
+
+from typing import Any, Final
+
+import zigpy.types as t
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.general import OnOff
+from zigpy.zcl.foundation import ZCLHeader
+
+
+class HobeianOnOffCluster(OnOff):
+    """Custom OnOff cluster for HOBEIAN rotation commands.
+
+    This device uses proprietary commands on OnOff cluster for rotation:
+    - 0xFC + 0x00/0x01: Rotation direction (right/left)
+    - 0x03: Rotation step right
+    - 0x04: Rotation step left
+    - 0xFD: Button press indicator
+    - 0x02: Standard toggle
+    """
+
+    cluster_id: Final = OnOff.cluster_id
+
+    ROTATION_DIRECTION_CMD: Final = 0xFC
+    ROTATION_STEP_RIGHT_CMD: Final = 0x03
+    ROTATION_STEP_LEFT_CMD: Final = 0x04
+    BUTTON_PRESS_INDICATOR_CMD: Final = 0xFD
+    TOGGLE_CMD: Final = 0x02
+
+    DIRECTION_RIGHT: Final = 0x00
+    DIRECTION_LEFT: Final = 0x01
+
+    def handle_cluster_request(
+        self,
+        hdr: ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: t.Addressing.Group
+        | t.Addressing.IEEE
+        | t.Addressing.NWK
+        | None = None,
+    ) -> None:
+        """Handle incoming cluster commands including proprietary rotation."""
+        command_id = hdr.command_id
+
+        if command_id == self.ROTATION_DIRECTION_CMD:
+            direction = 0
+            if args:
+                raw_data = args[0]
+                if isinstance(raw_data, bytes) and raw_data:
+                    direction = raw_data[0]
+                elif isinstance(raw_data, int):
+                    direction = raw_data
+            self.listener_event(
+                "zha_send_event",
+                "rotation_direction",
+                {
+                    "direction": "right"
+                    if direction == self.DIRECTION_RIGHT
+                    else "left",
+                    "direction_raw": direction,
+                },
+            )
+            return
+
+        if command_id == self.ROTATION_STEP_RIGHT_CMD:
+            self.listener_event(
+                "zha_send_event",
+                "step_with_on_off",
+                {"step_mode": 0, "step_size": 13, "transition_time": 1},
+            )
+            return
+
+        if command_id == self.ROTATION_STEP_LEFT_CMD:
+            self.listener_event(
+                "zha_send_event",
+                "step_with_on_off",
+                {"step_mode": 1, "step_size": 13, "transition_time": 1},
+            )
+            return
+
+        if command_id == self.BUTTON_PRESS_INDICATOR_CMD:
+            return
+
+        if command_id == self.TOGGLE_CMD:
+            self.listener_event("zha_send_event", "toggle", {})
+            return
+
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+
+(
+    QuirkBuilder("HOBEIAN", "ZG-101ZD")
+    .replaces(HobeianOnOffCluster)
+    .replaces(HobeianOnOffCluster, cluster_type="out")
+    .device_automation_triggers(
+        {
+            ("remote_button_short_press", "toggle"): {
+                "command": "toggle",
+                "cluster_id": 6,
+                "endpoint_id": 1,
+            },
+            ("dim_up", "dim_up"): {
+                "command": "step_with_on_off",
+                "cluster_id": 6,
+                "endpoint_id": 1,
+                "args": {"step_mode": 0},
+            },
+            ("dim_down", "dim_down"): {
+                "command": "step_with_on_off",
+                "cluster_id": 6,
+                "endpoint_id": 1,
+                "args": {"step_mode": 1},
+            },
+        }
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/hobeian/zg101zd.py
+++ b/zhaquirks/hobeian/zg101zd.py
@@ -2,13 +2,15 @@
 
 from typing import Any, Final
 
-from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.foundation import ZCLHeader
 
+from zhaquirks import CustomCluster
 
-class HobeianOnOffCluster(OnOff):
+
+class HobeianOnOffCluster(CustomCluster, OnOff):
     """Custom OnOff cluster for HOBEIAN rotation commands.
 
     This device uses proprietary commands on OnOff cluster for rotation:

--- a/zhaquirks/hobeian/zg101zd.py
+++ b/zhaquirks/hobeian/zg101zd.py
@@ -2,8 +2,8 @@
 
 from typing import Any, Final
 
-import zigpy.types as t
 from zigpy.quirks.v2 import QuirkBuilder
+import zigpy.types as t
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.foundation import ZCLHeader
 

--- a/zhaquirks/hobeian/zg101zd.py
+++ b/zhaquirks/hobeian/zg101zd.py
@@ -2,8 +2,8 @@
 
 from typing import Any, Final
 
-from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
+from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.foundation import ZCLHeader
 


### PR DESCRIPTION
## Proposed change

Add quirk for HOBEIAN ZG-101ZD rotary dimmer knob.

This battery-powered Zigbee rotary knob uses proprietary commands on the OnOff cluster (0x0006) instead of standard Level Control (0x0008) for rotation events. Without this quirk, only the button press (toggle) is detected while rotation is ignored.

The quirk intercepts the proprietary commands and converts them to standard ZHA events:

| Command | Data | Converted Event |
|---------|------|-----------------|
| `0x02` | - | `toggle` (button press) |
| `0x03` | - | `step_with_on_off` with `step_mode=0` (rotate right / dim up) |
| `0x04` | - | `step_with_on_off` with `step_mode=1` (rotate left / dim down) |
| `0xFC` | `0x00` | `rotation_direction` right (informational) |
| `0xFC` | `0x01` | `rotation_direction` left (informational) |
| `0xFD` | - | Ignored (button press indicator preceding toggle) |

Device automation triggers are configured for easy use in automations:
- `remote_button_short_press` / `toggle` - Button press
- `dim_up` / `dim_up` - Rotation right
- `dim_down` / `dim_down` - Rotation left

## Additional information

This device appears to be a white-label product that may be sold under other brand names with the same model identifier. The quirk should work for any device reporting manufacturer `HOBEIAN` and model `ZG-101ZD`.

The device has OnOff as an output cluster (client), indicating it's designed to control other devices rather than be controlled. The quirk replaces both server and client OnOff clusters to ensure commands are captured regardless of how the coordinator interprets the cluster direction.

## Device diagnostics

[zha-01JG9SXJ5AMSZAYY67M7Q9G90P-HOBEIAN ZG-101ZD-c297a8f9bc4d673c3fc4588ac6fcc909(1).json](https://github.com/user-attachments/files/24698508/zha-01JG9SXJ5AMSZAYY67M7Q9G90P-HOBEIAN.ZG-101ZD-c297a8f9bc4d673c3fc4588ac6fcc909.1.json)

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached