### PR TITLE
Add Aqara W600 thermostat

### DIFF
--- a/zhaquirks/xiaomi/aqara/thermostat_aeu005.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_aeu005.py
@@ -1,0 +1,312 @@
+"""Aqara W600 Radiator Thermostat Quirk."""
+
+from typing import Any, Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import PERCENTAGE, EntityPlatform, EntityType
+import zigpy.types as t
+from zigpy.zcl.clusters.hvac import Thermostat
+from zigpy.zcl.foundation import DataTypeId, ZCLAttributeAccess, ZCLAttributeDef
+
+ZCL_SYSTEM_MODE = Thermostat.AttributeDefs.system_mode
+ZCL_RUNNING_STATE = Thermostat.AttributeDefs.running_state
+
+
+THERMOSTAT_ENABLED_TO_SYSTEM_MODE_MAP = {
+    0: Thermostat.SystemMode.Off,
+    1: Thermostat.SystemMode.Heat,
+}
+
+SYSTEM_MODE_TO_THERMOSTAT_ENABLED_MAP = {
+    Thermostat.SystemMode.Off: 0,
+    Thermostat.SystemMode.Heat: 1,
+    Thermostat.SystemMode.Auto: 1,
+}
+
+
+def valve_position_to_running_state(valve_position):
+    """Convert the current valve position / pi heating demand to a ZCL running state."""
+
+    if valve_position > 0:
+        return Thermostat.RunningState.Heat_State_On
+
+    return Thermostat.RunningState.Idle
+
+
+def get_attribute_id_or_name(
+    attribute: ZCLAttributeDef,
+    attributes: dict[str | int, Any] | list[int | str],
+) -> int | str | None:
+    """Return the attribute id/name when the id/name of the attribute is in the attributes list or None otherwise."""
+
+    if attribute.id in attributes:
+        return attribute.id
+    elif attribute.name in attributes:
+        return attribute.name
+    else:
+        return None
+
+
+class ThermostatCluster(CustomCluster, Thermostat):
+    """Aqara W600 thermostat cluster."""
+
+    # remove cooling mode
+    _CONSTANT_ATTRIBUTES = {
+        Thermostat.AttributeDefs.ctrl_sequence_of_oper.id: Thermostat.ControlSequenceOfOperation.Heating_Only
+    }
+
+    async def read_attributes(
+        self,
+        attributes: list[int | str],
+        allow_cache: bool = False,
+        only_cache: bool = False,
+        manufacturer: int | t.uint16_t | None = None,
+        **kwargs,
+    ) -> Any:
+        """Redirect system_mode and running_state reads to vendor-specific cluster."""
+
+        successful_r, failed_r = {}, {}
+        remaining_attributes = attributes.copy()
+
+        system_mode = get_attribute_id_or_name(ZCL_SYSTEM_MODE, attributes)
+        if system_mode is not None:
+            remaining_attributes.remove(system_mode)
+
+            thermostat_id = CustomAqaraCluster.AttributeDefs.thermostat_enabled.id
+
+            result = await self.endpoint.aqara_custom.read_attributes(
+                [thermostat_id],
+                allow_cache,
+                only_cache,
+                manufacturer,
+            )
+
+            failed_r.update(result[1])
+
+            thermostat_enabled = result[0].get(thermostat_id)
+            if thermostat_enabled is not None:
+                successful_r[ZCL_SYSTEM_MODE.id] = (
+                    THERMOSTAT_ENABLED_TO_SYSTEM_MODE_MAP[thermostat_enabled]
+                )
+
+        running_state = get_attribute_id_or_name(ZCL_RUNNING_STATE, attributes)
+        if running_state is not None:
+            remaining_attributes.remove(running_state)
+
+            valve_position_id = CustomAqaraCluster.AttributeDefs.valve_position.id
+
+            result = await self.endpoint.aqara_custom.read_attributes(
+                [valve_position_id],
+                allow_cache,
+                only_cache,
+                manufacturer,
+            )
+
+            failed_r.update(result[1])
+
+            valve_position = result[0].get(valve_position_id)
+            if valve_position is not None:
+                successful_r[ZCL_RUNNING_STATE.id] = valve_position_to_running_state(
+                    valve_position
+                )
+
+        if remaining_attributes:
+            result = await super().read_attributes(
+                remaining_attributes,
+                allow_cache,
+                only_cache,
+                manufacturer,
+                **kwargs,
+            )
+
+            successful_r.update(result[0])
+            failed_r.update(result[1])
+
+        return successful_r, failed_r
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int, Any],
+        manufacturer: int | None = None,
+        **kwargs,
+    ) -> list:
+        """Redirect system_mode writes to vendor-specific cluster."""
+
+        result = []
+        remaining_attributes = attributes.copy()
+
+        system_mode = get_attribute_id_or_name(ZCL_SYSTEM_MODE, attributes)
+        system_mode_value = None
+        if system_mode is not None:
+            remaining_attributes.pop(system_mode)
+            system_mode_value = attributes.get(system_mode)
+
+        thermostat_enabled = None
+        if system_mode_value is not None:
+            thermostat_enabled = SYSTEM_MODE_TO_THERMOSTAT_ENABLED_MAP.get(
+                system_mode_value
+            )
+
+        if thermostat_enabled is not None:
+            result += await self.endpoint.aqara_custom.write_attributes(
+                {
+                    CustomAqaraCluster.AttributeDefs.thermostat_enabled.id: thermostat_enabled
+                }
+            )
+
+        if remaining_attributes:
+            result += await super().write_attributes(attributes, manufacturer, **kwargs)
+
+        return result
+
+    def _update_attribute(self, attrid: int | t.uint16_t, value: Any) -> None:
+        """Prevent bad system_mode attribute reports from device."""
+
+        if attrid == ThermostatCluster.AttributeDefs.system_mode.id:
+            return
+
+        return super()._update_attribute(attrid, value)
+
+
+class AqaraDisplayOrientation(t.enum8):
+    """Aqara display orientation attribute values."""
+
+    Normal = 0x00
+    Flipped = 0x01
+
+
+class AqaraValveAdaptStatus(t.enum8):
+    """Aqara valve adapt status attribute values."""
+
+    NotReady = 0x00
+    ReadyToCalibrate = 0x01
+    Error = 0x02
+    CalibrationInProgress = 0x03
+
+
+class CustomAqaraCluster(CustomCluster):
+    """Custom Aqara W600 cluster."""
+
+    cluster_id = t.uint16_t(0xFCC0)
+    ep_attribute = "aqara_custom"
+
+    class AttributeDefs(CustomCluster.AttributeDefs):
+        """Aqara W600 manufacturer-specific attributes."""
+
+        calibrate_valve: Final = ZCLAttributeDef(
+            id=t.uint16_t(0x0270),
+            type=t.uint8_t,
+        )
+
+        calibrate_state: Final = ZCLAttributeDef(
+            id=t.uint16_t(0x027B),
+            type=AqaraValveAdaptStatus,
+            access=ZCLAttributeAccess.Read | ZCLAttributeAccess.Report,
+        )
+
+        thermostat_enabled: Final = ZCLAttributeDef(
+            id=t.uint16_t(0x0271),
+            type=t.Bool,
+            zcl_type=DataTypeId.uint8,
+        )
+
+        window_detection: Final = ZCLAttributeDef(
+            id=t.uint16_t(0x0273),
+            type=t.Bool,
+            zcl_type=DataTypeId.uint8,
+        )
+
+        valve_detection: Final = ZCLAttributeDef(
+            id=t.uint16_t(0x0274),
+            type=t.Bool,
+            zcl_type=DataTypeId.uint8,
+        )
+
+        child_lock: Final = ZCLAttributeDef(
+            id=t.uint16_t(0x0277),
+            type=t.Bool,
+            zcl_type=DataTypeId.uint8,
+        )
+
+        display_orientation: Final = ZCLAttributeDef(
+            id=t.uint16_t(0x0330),
+            type=AqaraDisplayOrientation,
+            zcl_type=DataTypeId.uint8,
+        )
+
+        valve_position: Final = ZCLAttributeDef(
+            id=t.uint16_t(0x0360),
+            type=t.uint16_t,
+            access=ZCLAttributeAccess.Read | ZCLAttributeAccess.Report,
+        )
+
+    def _update_attribute(self, attrid: int | t.uint16_t, value: Any) -> None:
+        """Redirect custom cluster reports to the thermostat cluster."""
+
+        if attrid == CustomAqaraCluster.AttributeDefs.thermostat_enabled.id:
+            self.endpoint.thermostat.update_attribute(
+                ZCL_SYSTEM_MODE.id,
+                THERMOSTAT_ENABLED_TO_SYSTEM_MODE_MAP[value],
+            )
+
+        if attrid == CustomAqaraCluster.AttributeDefs.valve_position.id:
+            self.endpoint.thermostat.update_attribute(
+                ZCL_RUNNING_STATE.id,
+                valve_position_to_running_state(value),
+            )
+
+        super()._update_attribute(attrid, value)
+
+
+(
+    QuirkBuilder("Aqara", "lumi.airrtc.aeu005")
+    .firmware_version_filter(min_version=0x0000192B)
+    .replaces(ThermostatCluster)
+    .replaces(CustomAqaraCluster)
+    .write_attr_button(
+        CustomAqaraCluster.AttributeDefs.calibrate_valve.name,
+        1,
+        CustomAqaraCluster.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="calibrate_valve",
+        fallback_name="Calibrate valve",
+    )
+    .enum(
+        CustomAqaraCluster.AttributeDefs.calibrate_state.name,
+        AqaraValveAdaptStatus,
+        CustomAqaraCluster.cluster_id,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="valve_adapt_status",
+        fallback_name="Valve adaptation status",
+    )
+    .switch(
+        CustomAqaraCluster.AttributeDefs.window_detection.name,
+        CustomAqaraCluster.cluster_id,
+        translation_key="window_detection",
+        fallback_name="Open window detection",
+    )
+    .switch(
+        CustomAqaraCluster.AttributeDefs.child_lock.name,
+        CustomAqaraCluster.cluster_id,
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    .enum(
+        CustomAqaraCluster.AttributeDefs.display_orientation.name,
+        AqaraDisplayOrientation,
+        CustomAqaraCluster.cluster_id,
+        translation_key="display_orientation",
+        fallback_name="Display orientation",
+    )
+    .sensor(
+        CustomAqaraCluster.AttributeDefs.valve_position.name,
+        CustomAqaraCluster.cluster_id,
+        unit=PERCENTAGE,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="pi_heating_demand",
+        fallback_name="Pi heating demand",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

This PR adds a quirk for the [Aqara  Radiator Thermostat W600](https://www.aqara.com/eu/product/radiator-thermostat-w600/) in Zigbee Mode.

The device has the following quirks:

- Some attributes in the Thermostat cluster are wrong: `ctrl_sequence_of_oper`, `system_mode` and `running_state` do not reflect actual thermostat operation. The actual value of these attributes are part of a different, vendor-specific cluster.
- There is additional functionality in a vendor-specific cluster, e.g. setting the display orientation.

This PR implements correct Thermostat operation and additional attributes. It is based on previous work by other authors, namely:

- https://community.home-assistant.io/t/aqara-w600/962367
- https://gitlab.com/joerg.hampel/my-personal-ha-setup/-/blob/develop/homeassistant/custom_zha_quirks/aqara_w600_trv.py
- https://github.com/Koenkk/zigbee-herdsman-converters/blob/0ec2707ae3b886ff5c3b0344ade30521f8c1382f/src/devices/lumi.ts#L4954

Also, I drew some inspiration from the existing quirks for the Bosch Thermostat and Aqara E1.

## Additional information

This PR fixes #4518.

The quirk requires the device to have at least firmware version 0x0000192B, as there seems to be a change in attribute values in this release: https://github.com/Koenkk/zigbee-herdsman-converters/pull/11296.

The latest firmware can be obtained from [zigbee-OTA](https://github.com/Koenkk/zigbee-OTA/tree/master/images/Aqara), or directly from Aqara:

```
https://cdn.aqara.com/cdn/opencloud-product/mainland/product-firmware/prd/lumi.airrtc.aeu005/20251229111353_OTA_lumi.airrtc.aeu005_0.0.0_2543_20251229_14D78A.ota
```

The device is known under the following names:

- Aqara W600
- Aqara WT-A03D
- Aqara WT-A03E
- lumi.airrtc.aeu005

There is a lot of information on the device in the Aqara forum. A good starting point is the recent thread [W600 thermostat: Collection of infos and open issues](https://forum.aqara.com/t/w600-thermostat-collection-of-infos-and-open-issues/188010).

## Device diagnostics

<details>

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant OS",
    "version": "2026.1.2",
    "dev": false,
    "hassio": true,
    "virtualenv": false,
    "python_version": "3.13.11",
    "docker": true,
    "arch": "aarch64",
    "timezone": "Europe/Berlin",
    "os_name": "Linux",
    "os_version": "6.12.47-haos-raspi",
    "container_arch": "aarch64",
    "supervisor": "2026.01.1",
    "host_os": "Home Assistant OS 16.3",
    "docker_version": "28.3.3",
    "chassis": "embedded",
    "run_as_root": true
  },
  "custom_components": {
    "myskoda": {
      "documentation": "https://github.com/skodaconnect/homeassistant-myskoda/blob/main/README.md",
      "version": "1.29.2",
      "requirements": [
        "myskoda==2.5.1"
      ]
    },
    "zha_toolkit": {
      "documentation": "https://github.com/mdeweerd/zha-toolkit",
      "version": "v1.1.35",
      "requirements": [
        "aiofiles>=0.4.0",
        "pytz>=2016.10"
      ]
    },
    "hacs": {
      "documentation": "https://hacs.xyz/docs/use/",
      "version": "2.0.5",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    },
    "dreame_vacuum": {
      "documentation": "https://github.com/Tasshack/dreame-vacuum/tree/dev?tab=readme-ov-file#features",
      "version": "v2.0.0b19",
      "requirements": [
        "pillow",
        "numpy",
        "pybase64",
        "requests",
        "pycryptodome",
        "python-miio",
        "py-mini-racer",
        "paho-mqtt"
      ]
    },
    "versatile_thermostat": {
      "documentation": "https://github.com/jmcollin78/versatile_thermostat",
      "version": "8.5.0",
      "requirements": [
        "numpy",
        "scipy"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==0.0.84",
      "serialx==0.6.2"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.00010320404544472694
    },
    "01JEDWNW42RSX0G8XY1EQPRR00": {
      "wait_import_platforms": -0.020369477104395628,
      "wait_base_component": -0.0009117457084357738,
      "config_entry_setup": 4.9410415510647
    }
  },
  "data": {
    "version": 1,
    "ieee": "**REDACTED**",
    "nwk": "0x5D08",
    "manufacturer": "Aqara",
    "model": "lumi.airrtc.aeu005",
    "friendly_manufacturer": "Aqara",
    "friendly_model": "lumi.airrtc.aeu005",
    "name": "Aqara lumi.airrtc.aeu005",
    "quirk_applied": true,
    "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
    "exposes_features": [],
    "manufacturer_code": 4447,
    "power_source": "Battery or Unknown",
    "lqi": 218,
    "rssi": -38,
    "last_seen": "2026-01-19T21:55:05.048055+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4447,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 82,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 82,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "WINDOW_COVERING_CONTROLLER",
          "id": 515
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0001",
                "name": "app_version",
                "zcl_type": "uint8",
                "value": 43
              },
              {
                "id": "0xfffd",
                "name": "cluster_revision",
                "zcl_type": "uint16",
                "value": 2
              },
              {
                "id": "0x0006",
                "name": "date_code",
                "zcl_type": "string",
                "value": "20251229"
              },
              {
                "id": "0x0003",
                "name": "hw_version",
                "zcl_type": "uint8",
                "value": 1
              },
              {
                "id": "0x0010",
                "name": "location_desc",
                "zcl_type": "string",
                "value": "\u9ed8\u8ba4\u623f\u95f4"
              },
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "Aqara"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "lumi.airrtc.aeu005"
              },
              {
                "id": "0x0007",
                "name": "power_source",
                "zcl_type": "enum8",
                "value": 3
              },
              {
                "id": "0x000a",
                "name": "product_code",
                "zcl_type": "octstr",
                "value": {
                  "__type": "<class 'bytes'>",
                  "repr": "b''"
                }
              },
              {
                "id": "0x000d",
                "name": "serial_number",
                "zcl_type": "string",
                "value": ""
              },
              {
                "id": "0x0002",
                "name": "stack_version",
                "zcl_type": "uint8",
                "value": 27
              },
              {
                "id": "0x0000",
                "name": "zcl_version",
                "zcl_type": "uint8",
                "value": 3
              }
            ]
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": [
              {
                "id": "0xfffd",
                "name": "cluster_revision",
                "zcl_type": "uint16",
                "value": 1
              },
              {
                "id": "0x0000",
                "name": "identify_time",
                "zcl_type": "uint16",
                "value": 0
              }
            ]
          },
          {
            "cluster_id": "0x0201",
            "endpoint_attribute": "thermostat",
            "attributes": [
              {
                "id": "0x0006",
                "name": "abs_max_cool_setpoint_limit",
                "zcl_type": "int16",
                "unsupported": true
              },
              {
                "id": "0x0004",
                "name": "abs_max_heat_setpoint_limit",
                "zcl_type": "int16",
                "value": 3000
              },
              {
                "id": "0x0005",
                "name": "abs_min_cool_setpoint_limit",
                "zcl_type": "int16",
                "unsupported": true
              },
              {
                "id": "0x0003",
                "name": "abs_min_heat_setpoint_limit",
                "zcl_type": "int16",
                "value": 700
              },
              {
                "id": "0x001b",
                "name": "ctrl_sequence_of_oper",
                "zcl_type": "enum8",
                "value": 2
              },
              {
                "id": "0x0000",
                "name": "local_temperature",
                "zcl_type": "int16",
                "value": 2100
              },
              {
                "id": "0x0010",
                "name": "local_temperature_calibration",
                "zcl_type": "int8",
                "value": 0
              },
              {
                "id": "0x0018",
                "name": "max_cool_setpoint_limit",
                "zcl_type": "int16",
                "unsupported": true
              },
              {
                "id": "0x0016",
                "name": "max_heat_setpoint_limit",
                "zcl_type": "int16",
                "value": 3000
              },
              {
                "id": "0x0017",
                "name": "min_cool_setpoint_limit",
                "zcl_type": "int16",
                "unsupported": true
              },
              {
                "id": "0x0015",
                "name": "min_heat_setpoint_limit",
                "zcl_type": "int16",
                "value": 500
              },
              {
                "id": "0x0002",
                "name": "occupancy",
                "zcl_type": "map8",
                "unsupported": true
              },
              {
                "id": "0x0011",
                "name": "occupied_cooling_setpoint",
                "zcl_type": "int16",
                "unsupported": true
              },
              {
                "id": "0x0012",
                "name": "occupied_heating_setpoint",
                "zcl_type": "int16",
                "value": 1800
              },
              {
                "id": "0x0007",
                "name": "pi_cooling_demand",
                "zcl_type": "uint8",
                "unsupported": true
              },
              {
                "id": "0x0008",
                "name": "pi_heating_demand",
                "zcl_type": "uint8",
                "unsupported": true
              },
              {
                "id": "0x001e",
                "name": "running_mode",
                "zcl_type": "enum8",
                "value": 0
              },
              {
                "id": "0x0029",
                "name": "running_state",
                "zcl_type": "map16",
                "value": 0
              },
              {
                "id": "0x0030",
                "name": "setpoint_change_source",
                "zcl_type": "enum8",
                "unsupported": true
              },
              {
                "id": "0x001c",
                "name": "system_mode",
                "zcl_type": "enum8",
                "value": 4
              },
              {
                "id": "0x0009",
                "name": "system_type_config",
                "zcl_type": "map8",
                "unsupported": true
              },
              {
                "id": "0x0023",
                "name": "temp_setpoint_hold",
                "zcl_type": "enum8",
                "value": 1
              },
              {
                "id": "0x0024",
                "name": "temp_setpoint_hold_duration",
                "zcl_type": "uint16",
                "value": 120
              },
              {
                "id": "0x0013",
                "name": "unoccupied_cooling_setpoint",
                "zcl_type": "int16",
                "unsupported": true
              },
              {
                "id": "0x0014",
                "name": "unoccupied_heating_setpoint",
                "zcl_type": "int16",
                "unsupported": true
              }
            ]
          },
          {
            "cluster_id": "0xfcc0",
            "endpoint_attribute": "aqara_custom",
            "attributes": [
              {
                "id": "0x027b",
                "name": "calibrate_state",
                "zcl_type": "enum8",
                "value": 1
              },
              {
                "id": "0x0270",
                "name": "calibrate_valve",
                "zcl_type": "uint8",
                "value": 1
              },
              {
                "id": "0x0277",
                "name": "child_lock",
                "zcl_type": "uint8",
                "value": 0
              },
              {
                "id": "0x0330",
                "name": "display_orientation",
                "zcl_type": "uint8",
                "value": 1
              },
              {
                "id": "0x0271",
                "name": "thermostat_enabled",
                "zcl_type": "uint8",
                "value": 1
              },
              {
                "id": "0x0274",
                "name": "valve_detection",
                "zcl_type": "uint8",
                "value": 0
              },
              {
                "id": "0x0360",
                "name": "valve_position",
                "zcl_type": "uint16",
                "value": 0
              },
              {
                "id": "0x0273",
                "name": "window_detection",
                "zcl_type": "uint8",
                "value": 0
              }
            ]
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": [
              {
                "id": "0xfffd",
                "name": "cluster_revision",
                "zcl_type": "uint16",
                "value": 1
              },
              {
                "id": "0x0005",
                "name": "dst_shift",
                "zcl_type": "int32",
                "value": 3600
              },
              {
                "id": "0x0007",
                "name": "local_time",
                "zcl_type": "uint32",
                "unsupported": true
              },
              {
                "id": "0x0000",
                "name": "time",
                "zcl_type": "UTC",
                "value": 822056203
              },
              {
                "id": "0x0002",
                "name": "time_zone",
                "zcl_type": "int32",
                "value": 3600
              }
            ]
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0xfffd",
                "name": "cluster_revision",
                "zcl_type": "uint16",
                "value": 3
              },
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 6443
              },
              {
                "id": "0x0003",
                "name": "current_zigbee_stack_version",
                "zcl_type": "uint16",
                "value": 27
              },
              {
                "id": "0x0004",
                "name": "downloaded_file_version",
                "zcl_type": "uint32",
                "value": 0
              },
              {
                "id": "0x0005",
                "name": "downloaded_zigbee_stack_version",
                "zcl_type": "uint16",
                "value": 27
              },
              {
                "id": "0x0001",
                "name": "file_offset",
                "zcl_type": "uint32",
                "value": 0
              },
              {
                "id": "0x0008",
                "name": "image_type_id",
                "zcl_type": "uint16",
                "value": 5120
              },
              {
                "id": "0x0006",
                "name": "image_upgrade_status",
                "zcl_type": "enum8",
                "value": 0
              },
              {
                "id": "0x0007",
                "name": "manufacturer_id",
                "zcl_type": "uint16",
                "value": 4447
              },
              {
                "id": "0x0000",
                "name": "upgrade_server_id",
                "zcl_type": "EUI64",
                "value": "00:00:00:00:00:00:00:00"
              }
            ]
          }
        ]
      }
    },
    "original_signature": {},
    "zha_lib_entities": {
      "button": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "button",
            "class_name": "IdentifyButton",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "identify",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "IdentifyClusterHandler",
                "generic_id": "cluster_handler_0x0003",
                "endpoint_id": 1,
                "cluster": {
                  "id": 3,
                  "name": "Identify",
                  "type": "server"
                },
                "id": "1:0x0003",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "command": "identify",
            "args": [
              5
            ],
            "kwargs": {}
          },
          "state": {
            "class_name": "IdentifyButton",
            "available": true
          }
        },
        {
          "info_object": {
            "fallback_name": "Calibrate valve",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "button",
            "class_name": "WriteAttributeButton",
            "translation_key": "calibrate_valve",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OppleRemoteClusterHandler",
                "generic_id": "cluster_handler_0xfcc0",
                "endpoint_id": 1,
                "cluster": {
                  "id": 64704,
                  "name": "CustomAqaraCluster",
                  "type": "server"
                },
                "id": "1:0xfcc0",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "calibrate_valve",
            "attribute_value": 1
          },
          "state": {
            "class_name": "WriteAttributeButton",
            "available": true
          }
        }
      ],
      "climate": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "climate",
            "class_name": "Thermostat",
            "translation_key": "thermostat",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": true,
            "cluster_handlers": [
              {
                "class_name": "ThermostatClusterHandler",
                "generic_id": "cluster_handler_0x0201",
                "endpoint_id": 1,
                "cluster": {
                  "id": 513,
                  "name": "ThermostatCluster",
                  "type": "server"
                },
                "id": "1:0x0201",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "local_temperature"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "max_temp": 30.0,
            "min_temp": 5.0,
            "supported_features": 385,
            "fan_modes": null,
            "preset_modes": [],
            "hvac_modes": [
              "off",
              "heat"
            ]
          },
          "state": {
            "class_name": "Thermostat",
            "available": true,
            "current_temperature": 21.0,
            "outdoor_temperature": null,
            "target_temperature": 18.0,
            "target_temperature_high": null,
            "target_temperature_low": null,
            "hvac_action": "idle",
            "hvac_mode": "heat",
            "preset_mode": "none",
            "fan_mode": "auto",
            "system_mode": "[4]/heat",
            "occupancy": null,
            "occupied_cooling_setpoint": null,
            "occupied_heating_setpoint": 1800,
            "pi_heating_demand": null,
            "pi_cooling_demand": null,
            "unoccupied_cooling_setpoint": null,
            "unoccupied_heating_setpoint": null
          },
          "extra_state_attributes": [
            "occupancy",
            "occupied_cooling_setpoint",
            "occupied_heating_setpoint",
            "pi_cooling_demand",
            "pi_heating_demand",
            "system_mode",
            "unoccupied_cooling_setpoint",
            "unoccupied_heating_setpoint"
          ]
        }
      ],
      "number": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "ThermostatLocalTempCalibration",
            "translation_key": "local_temperature_calibration",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "ThermostatClusterHandler",
                "generic_id": "cluster_handler_0x0201",
                "endpoint_id": 1,
                "cluster": {
                  "id": 513,
                  "name": "ThermostatCluster",
                  "type": "server"
                },
                "id": "1:0x0201",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "local_temperature"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "box",
            "native_max_value": 2.5,
            "native_min_value": -2.5,
            "native_step": 0.1,
            "native_unit_of_measurement": "\u00b0C"
          },
          "state": {
            "class_name": "ThermostatLocalTempCalibration",
            "available": true,
            "state": 0.0
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "MaxHeatSetpointLimit",
            "translation_key": "max_heat_setpoint_limit",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "ThermostatClusterHandler",
                "generic_id": "cluster_handler_0x0201",
                "endpoint_id": 1,
                "cluster": {
                  "id": 513,
                  "name": "ThermostatCluster",
                  "type": "server"
                },
                "id": "1:0x0201",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "local_temperature"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "box",
            "native_max_value": 30.0,
            "native_min_value": 5.0,
            "native_step": 0.5,
            "native_unit_of_measurement": "\u00b0C"
          },
          "state": {
            "class_name": "MaxHeatSetpointLimit",
            "available": true,
            "state": 30.0
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "MinHeatSetpointLimit",
            "translation_key": "min_heat_setpoint_limit",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "ThermostatClusterHandler",
                "generic_id": "cluster_handler_0x0201",
                "endpoint_id": 1,
                "cluster": {
                  "id": 513,
                  "name": "ThermostatCluster",
                  "type": "server"
                },
                "id": "1:0x0201",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "local_temperature"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "box",
            "native_max_value": 30.0,
            "native_min_value": 7.0,
            "native_step": 0.5,
            "native_unit_of_measurement": "\u00b0C"
          },
          "state": {
            "class_name": "MinHeatSetpointLimit",
            "available": true,
            "state": 5.0
          }
        }
      ],
      "select": [
        {
          "info_object": {
            "fallback_name": "Display Orientation",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "select",
            "class_name": "ZCLEnumSelectEntity",
            "translation_key": "display_orientation",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OppleRemoteClusterHandler",
                "generic_id": "cluster_handler_0xfcc0",
                "endpoint_id": 1,
                "cluster": {
                  "id": 64704,
                  "name": "CustomAqaraCluster",
                  "type": "server"
                },
                "id": "1:0xfcc0",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "enum": "AqaraDisplayOrientation",
            "options": [
              "Normal",
              "Flipped"
            ]
          },
          "state": {
            "class_name": "ZCLEnumSelectEntity",
            "available": true,
            "state": "Flipped"
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 218
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -38
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "ThermostatHVACAction",
            "translation_key": "hvac_action",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "ThermostatClusterHandler",
                "generic_id": "cluster_handler_0x0201",
                "endpoint_id": 1,
                "cluster": {
                  "id": 513,
                  "name": "ThermostatCluster",
                  "type": "server"
                },
                "id": "1:0x0201",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "local_temperature"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "ThermostatHVACAction",
            "available": true,
            "state": "idle"
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "SetpointChangeSourceTimestamp",
            "translation_key": "setpoint_change_source_timestamp",
            "translation_placeholders": null,
            "device_class": "timestamp",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "ThermostatClusterHandler",
                "generic_id": "cluster_handler_0x0201",
                "endpoint_id": 1,
                "cluster": {
                  "id": 513,
                  "name": "ThermostatCluster",
                  "type": "server"
                },
                "id": "1:0x0201",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "local_temperature"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "SetpointChangeSourceTimestamp",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": "Valve adaptation status",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "EnumSensor",
            "translation_key": "valve_adapt_status",
            "translation_placeholders": null,
            "device_class": "enum",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OppleRemoteClusterHandler",
                "generic_id": "cluster_handler_0xfcc0",
                "endpoint_id": 1,
                "cluster": {
                  "id": 64704,
                  "name": "CustomAqaraCluster",
                  "type": "server"
                },
                "id": "1:0xfcc0",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "EnumSensor",
            "available": true,
            "state": "ReadyToCalibrate"
          }
        },
        {
          "info_object": {
            "fallback_name": "Pi heating demand",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Sensor",
            "translation_key": "pi_heating_demand",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OppleRemoteClusterHandler",
                "generic_id": "cluster_handler_0xfcc0",
                "endpoint_id": 1,
                "cluster": {
                  "id": 64704,
                  "name": "CustomAqaraCluster",
                  "type": "server"
                },
                "id": "1:0xfcc0",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "%"
          },
          "state": {
            "class_name": "Sensor",
            "available": true,
            "state": 0
          }
        }
      ],
      "switch": [
        {
          "info_object": {
            "fallback_name": "Child lock",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "switch",
            "class_name": "ConfigurableAttributeSwitch",
            "translation_key": "child_lock",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OppleRemoteClusterHandler",
                "generic_id": "cluster_handler_0xfcc0",
                "endpoint_id": 1,
                "cluster": {
                  "id": 64704,
                  "name": "CustomAqaraCluster",
                  "type": "server"
                },
                "id": "1:0xfcc0",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "child_lock",
            "invert_attribute_name": null,
            "force_inverted": false,
            "off_value": 0,
            "on_value": 1
          },
          "state": {
            "class_name": "ConfigurableAttributeSwitch",
            "available": true,
            "state": false,
            "inverted": false
          }
        },
        {
          "info_object": {
            "fallback_name": "Open window detection",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "switch",
            "class_name": "ConfigurableAttributeSwitch",
            "translation_key": "window_detection",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OppleRemoteClusterHandler",
                "generic_id": "cluster_handler_0xfcc0",
                "endpoint_id": 1,
                "cluster": {
                  "id": 64704,
                  "name": "CustomAqaraCluster",
                  "type": "server"
                },
                "id": "1:0xfcc0",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "window_detection",
            "invert_attribute_name": null,
            "force_inverted": false,
            "off_value": 0,
            "on_value": 1
          },
          "state": {
            "class_name": "ConfigurableAttributeSwitch",
            "available": true,
            "state": false,
            "inverted": false
          }
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OtaClientClusterHandler",
                "generic_id": "cluster_handler_0x0019_client",
                "endpoint_id": 1,
                "cluster": {
                  "id": 25,
                  "name": "Ota",
                  "type": "client"
                },
                "id": "1:0x0019_client",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x0000192b",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```

</details>


## Checklist

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [X] Device diagnostics data has been attached
