### PR TITLE
Fix temperature calibration scaling factor

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -575,10 +575,7 @@ class MoesThermostat(TuyaThermostatCluster):
             MOES_MAX_TEMPERATURE_ATTR,
             lambda value: round(value / 100),
         ),
-        "local_temperature_calibration": (
-            MOES_TEMP_CALIBRATION_ATTR,
-            lambda value: round(value / 10),
-        ),
+        "local_temperature_calibration": (MOES_TEMP_CALIBRATION_ATTR, None),
         "work_days": (MOES_WEEK_FORMAT_ATTR, None),
         "operation_preset": (MOES_MODE_ATTR, None),
         "boost_duration_seconds": (MOES_BOOST_TIME_ATTR, None),

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -294,10 +294,7 @@ class MoesManufCluster(TuyaManufClusterAttributes):
         MOES_AWAY_TEMP_ATTR: ("unoccupied_heating_setpoint", lambda value: value * 100),
         MOES_COMFORT_TEMP_ATTR: ("comfort_heating_setpoint", lambda value: value * 100),
         MOES_ECO_TEMP_ATTR: ("eco_heating_setpoint", lambda value: value * 100),
-        MOES_TEMP_CALIBRATION_ATTR: (
-            "local_temperature_calibration",
-            lambda value: value * 1,
-        ),
+        MOES_TEMP_CALIBRATION_ATTR: ("local_temperature_calibration", None),
         MOES_MIN_TEMPERATURE_ATTR: (
             "min_heat_setpoint_limit",
             lambda value: value * 100,

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -296,7 +296,7 @@ class MoesManufCluster(TuyaManufClusterAttributes):
         MOES_ECO_TEMP_ATTR: ("eco_heating_setpoint", lambda value: value * 100),
         MOES_TEMP_CALIBRATION_ATTR: (
             "local_temperature_calibration",
-            lambda value: value * 10,
+            lambda value: value * 1,
         ),
         MOES_MIN_TEMPERATURE_ATTR: (
             "min_heat_setpoint_limit",


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
On my TS0601 by _TZE200_cwnjrr72 Zigbee TRV the value of the local temperature offset entity displayed in decidegress (i.e an offset of `-2.0` degrees showed as `-20`). Making this edit fixed that display value.

However it is possible that the scaling by a factor of 10 error is elsewhere in the stack as when I query the raw endpoints I can see that both the `temperature`  (which reports correctly in HA) and `temperature_calibration` are reported in decidegrees - so it seems odd that the scaling works well for one but not the other - I suspect that scaling is also happening elsewhere (incorrectly)

It is also not clear to me why, for my TRVs the min and max values for the calibration are +2.5 and -2.5. [This is why](https://github.com/zigpy/zha/blob/c6ac89e07dc72b7e7b920fcb4e92d60dd5b270a1/zha/application/platforms/number/__init__.py#L786)


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
