### PR TITLE
Add Aqara Display Switch (lumi.switch.aeu001)

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import math
+import struct
 from unittest import mock
 
 import pytest
@@ -97,10 +98,18 @@ import zhaquirks.xiaomi.aqara.roller_curtain_e1
 import zhaquirks.xiaomi.aqara.sensor_ht_agl02
 import zhaquirks.xiaomi.aqara.smoke
 from zhaquirks.xiaomi.aqara.switch_aeu001 import (
+    ButtonLayout,
     ButtonOperationMode,
+    ButtonRelay,
+    ElderMode,
+    LVBytesString,
     OppleCluster as DisplaySwitchOppleCluster,
+    ProximitySensitivity,
+    ScreensaverStyle,
+    ShowMode,
     StartupOnOff,
     Theme,
+    WeatherCondition,
 )
 import zhaquirks.xiaomi.aqara.switch_t1
 from zhaquirks.xiaomi.aqara.thermostat_agl001 import ScheduleEvent, ScheduleSettings
@@ -2391,3 +2400,437 @@ def test_aqara_display_switch_opple_cluster(zigpy_device_from_v2_quirk):
         == DisplaySwitchOppleCluster.AttributeDefs.theme.id
     )
     assert cluster_listener.attribute_updates[2][1] == Theme.Option2
+
+
+def test_lvbytes_string_from_string():
+    """Test LVBytesString converts string to UTF-8 bytes."""
+    result = LVBytesString("hello")
+    assert result == b"hello"
+    assert isinstance(result, LVBytesString)
+
+
+def test_lvbytes_string_from_bytes():
+    """Test LVBytesString accepts bytes directly."""
+    result = LVBytesString(b"hello")
+    assert result == b"hello"
+
+
+def test_lvbytes_string_empty():
+    """Test LVBytesString with empty string."""
+    result = LVBytesString("")
+    assert result == b""
+
+
+def test_lvbytes_string_unicode():
+    """Test LVBytesString with unicode characters."""
+    result = LVBytesString("héllo")
+    assert result == "héllo".encode()
+
+
+def test_display_switch_enums():
+    """Test all enum classes have expected values."""
+    # StartupOnOff
+    assert StartupOnOff.On == 0x00
+    assert StartupOnOff.RestorePrevious == 0x01
+    assert StartupOnOff.Off == 0x02
+    assert StartupOnOff.ReversePrevious == 0x03
+
+    # ButtonOperationMode
+    assert ButtonOperationMode.Disabled == 0x00
+    assert ButtonOperationMode.ControlRelay == 0x01
+    assert ButtonOperationMode.Decoupled == 0x02
+    assert ButtonOperationMode.WirelessButton == 0x04
+
+    # Theme
+    assert Theme.Option1 == 0x00
+    assert Theme.Option2 == 0x01
+
+    # ShowMode
+    assert ShowMode.IconAndText == 0x01
+    assert ShowMode.IconOnly == 0x02
+    assert ShowMode.TextOnly == 0x03
+
+    # ScreensaverStyle
+    assert ScreensaverStyle.DigitalClock == 0x01
+    assert ScreensaverStyle.WeatherConditions == 0x02
+    assert ScreensaverStyle.IndoorEnvironment == 0x03
+
+    # ProximitySensitivity
+    assert ProximitySensitivity.Near == 0x01
+    assert ProximitySensitivity.Far == 0x05
+
+    # ElderMode
+    assert ElderMode.Off == 0x03
+    assert ElderMode.On == 0x05
+
+    # ButtonRelay
+    assert ButtonRelay.Relay1 == 0x01
+    assert ButtonRelay.Relay2 == 0x02
+
+    # ButtonLayout
+    assert ButtonLayout.Button1 == 0x01
+    assert ButtonLayout.Button2 == 0x02
+    assert ButtonLayout.Button3 == 0x04
+    assert ButtonLayout.Button4 == 0x08
+
+
+def test_weather_condition_enum():
+    """Test WeatherCondition enum values."""
+    assert WeatherCondition.Sunny == 0x00
+    assert WeatherCondition.Clear == 0x01
+    assert WeatherCondition.Cloudy == 0x04
+    assert WeatherCondition.LightRain == 0x0D
+    assert WeatherCondition.Foggy == 0x1E
+    assert WeatherCondition.Tornado == 0x24
+    assert WeatherCondition.Unknown == 0x25
+
+
+def test_multistate_input_cluster_single_press(zigpy_device_from_v2_quirk):
+    """Test MultistateInputCluster only fires event for single press (value=1)."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    multistate_cluster = device.endpoints[1].multistate_input
+    listener = mock.MagicMock()
+    multistate_cluster.add_listener(listener)
+
+    # Value != 1 should NOT trigger event
+    multistate_cluster.update_attribute(
+        MultistateInput.AttributeDefs.present_value.id, 0
+    )
+    assert listener.zha_send_event.call_count == 0
+
+    # Value = 1 should trigger event
+    multistate_cluster.update_attribute(
+        MultistateInput.AttributeDefs.present_value.id, 1
+    )
+    assert listener.zha_send_event.call_count == 1
+
+    # Other values should not trigger event
+    multistate_cluster.update_attribute(
+        MultistateInput.AttributeDefs.present_value.id, 2
+    )
+    assert listener.zha_send_event.call_count == 1
+
+
+def test_opple_cluster_instance_weather_seq(zigpy_device_from_v2_quirk):
+    """Test OppleCluster uses instance-level weather sequence counter."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    # Verify instance has _weather_seq initialized to 0
+    assert hasattr(opple_cluster, "_weather_seq")
+    assert opple_cluster._weather_seq == 0
+
+
+def test_opple_cluster_build_condition_packet(zigpy_device_from_v2_quirk):
+    """Test OppleCluster builds correct weather condition packets."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    # Build a condition packet for Cloudy (code 4)
+    packet = opple_cluster._build_condition_packet(4)
+
+    # Check packet structure
+    assert len(packet) == 25  # 22 bytes base + 3 extra in our struct
+    assert packet[0:4] == bytes([0xAA, 0x71, 0x13, 0x44])  # Header
+    assert packet[4] == 1  # First sequence number
+    assert packet[5] == (0x8E - 1) & 0xFF  # Checksum
+    assert packet[-4:] == bytes([0x00, 0x00, 0x00, 0x04])  # Payload: condition code 4
+
+    # Build another packet to verify sequence increments
+    packet2 = opple_cluster._build_condition_packet(0)
+    assert packet2[4] == 2  # Second sequence number
+    assert packet2[5] == (0x8E - 2) & 0xFF  # Updated checksum
+
+
+def test_opple_cluster_build_null_packet(zigpy_device_from_v2_quirk):
+    """Test OppleCluster builds correct null packets."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    packet = opple_cluster._build_null_packet()
+
+    # Check null packet payload is all zeros
+    assert packet[-4:] == bytes([0x00, 0x00, 0x00, 0x00])
+
+
+def test_opple_cluster_build_temperature_packet(zigpy_device_from_v2_quirk):
+    """Test OppleCluster builds correct temperature packets."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    # Build packet for 22.5 degrees
+    packet = opple_cluster._build_temperature_packet(22.5)
+
+    # Verify temperature is encoded as IEEE 754 big-endian float
+    expected_temp_bytes = struct.pack(">f", 22.5)
+    assert packet[-4:] == expected_temp_bytes
+
+
+def test_opple_cluster_get_ieee_bytes(zigpy_device_from_v2_quirk):
+    """Test OppleCluster extracts last 6 bytes of IEEE address."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    ieee_bytes = opple_cluster._get_ieee_bytes()
+
+    # Should be 6 bytes (last 6 of 8-byte IEEE address)
+    assert len(ieee_bytes) == 6
+
+
+@pytest.mark.parametrize(
+    "condition_input",
+    [
+        WeatherCondition.Sunny,
+        WeatherCondition.Cloudy,
+        4,  # Integer input
+        "Sunny",  # String name input
+    ],
+)
+async def test_opple_cluster_write_attributes_weather_condition(
+    zigpy_device_from_v2_quirk, condition_input
+):
+    """Test OppleCluster.write_attributes handles weather_condition virtual attribute."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    # Mock the parent write_attributes to capture calls
+    mock_write = mock.AsyncMock(return_value=[0])
+
+    with mock.patch.object(
+        DisplaySwitchOppleCluster.__bases__[0], "write_attributes", mock_write
+    ):
+        result = await opple_cluster.write_attributes(
+            {"weather_condition": condition_input}
+        )
+
+    # Should have called write_attributes twice (condition + null packet)
+    assert mock_write.call_count == 2
+    assert result == [0]
+
+
+async def test_opple_cluster_write_attributes_weather_condition_by_id(
+    zigpy_device_from_v2_quirk,
+):
+    """Test OppleCluster.write_attributes handles weather_condition by attribute ID."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    mock_write = mock.AsyncMock(return_value=[0])
+
+    weather_condition_id = DisplaySwitchOppleCluster.AttributeDefs.weather_condition.id
+
+    with mock.patch.object(
+        DisplaySwitchOppleCluster.__bases__[0], "write_attributes", mock_write
+    ):
+        result = await opple_cluster.write_attributes({weather_condition_id: 4})
+
+    # Should have called write_attributes twice (condition + null packet)
+    assert mock_write.call_count == 2
+    assert result == [0]
+
+
+async def test_opple_cluster_write_attributes_weather_temperature(
+    zigpy_device_from_v2_quirk,
+):
+    """Test OppleCluster.write_attributes handles weather_temperature virtual attribute."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    mock_write = mock.AsyncMock(return_value=[0])
+
+    with mock.patch.object(
+        DisplaySwitchOppleCluster.__bases__[0], "write_attributes", mock_write
+    ):
+        result = await opple_cluster.write_attributes({"weather_temperature": 22})
+
+    # Should have called write_attributes once for temperature
+    assert mock_write.call_count == 1
+    assert result == [0]
+
+
+async def test_opple_cluster_write_attributes_weather_temperature_by_id(
+    zigpy_device_from_v2_quirk,
+):
+    """Test OppleCluster.write_attributes handles weather_temperature by attribute ID."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    mock_write = mock.AsyncMock(return_value=[0])
+
+    weather_temp_id = DisplaySwitchOppleCluster.AttributeDefs.weather_temperature.id
+
+    with mock.patch.object(
+        DisplaySwitchOppleCluster.__bases__[0], "write_attributes", mock_write
+    ):
+        result = await opple_cluster.write_attributes({weather_temp_id: -5})
+
+    assert mock_write.call_count == 1
+    assert result == [0]
+
+
+async def test_opple_cluster_write_attributes_invalid_weather_condition(
+    zigpy_device_from_v2_quirk,
+):
+    """Test OppleCluster.write_attributes raises error for invalid weather condition name."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    with pytest.raises(ValueError, match="Invalid weather condition"):
+        await opple_cluster.write_attributes({"weather_condition": "InvalidCondition"})
+
+
+async def test_opple_cluster_write_attributes_normal_passthrough(
+    zigpy_device_from_v2_quirk,
+):
+    """Test OppleCluster.write_attributes passes through normal attributes."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    mock_write = mock.AsyncMock(return_value=[0])
+
+    display_brightness_id = (
+        DisplaySwitchOppleCluster.AttributeDefs.display_brightness.id
+    )
+
+    with mock.patch.object(
+        DisplaySwitchOppleCluster.__bases__[0], "write_attributes", mock_write
+    ):
+        await opple_cluster.write_attributes({display_brightness_id: 50})
+
+    # Should pass through to parent
+    assert mock_write.call_count == 1
+    # Check that brightness attribute was passed through
+    # call_args is (args, kwargs) - the attrs dict is passed as first positional arg after self
+    call_args = mock_write.call_args
+    attrs_dict = call_args[0][
+        0
+    ]  # First positional arg is self, skip it; second is attrs dict
+    assert display_brightness_id in attrs_dict
+    assert attrs_dict[display_brightness_id] == 50
+
+
+async def test_opple_cluster_write_attributes_empty(zigpy_device_from_v2_quirk):
+    """Test OppleCluster.write_attributes returns success for empty attributes."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    # Write attributes with None value (should be popped and result in empty dict)
+    result = await opple_cluster.write_attributes({"weather_condition": None})
+    assert result == [0]
+
+
+async def test_opple_cluster_write_attributes_combined(zigpy_device_from_v2_quirk):
+    """Test OppleCluster.write_attributes handles both weather and normal attributes."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    mock_write = mock.AsyncMock(return_value=[0])
+
+    display_brightness_id = (
+        DisplaySwitchOppleCluster.AttributeDefs.display_brightness.id
+    )
+
+    with mock.patch.object(
+        DisplaySwitchOppleCluster.__bases__[0], "write_attributes", mock_write
+    ):
+        await opple_cluster.write_attributes(
+            {
+                "weather_condition": WeatherCondition.Sunny,
+                "weather_temperature": 20,
+                display_brightness_id: 80,
+            }
+        )
+
+    # Should have: condition packet, null packet, temperature packet, and normal attr
+    assert mock_write.call_count == 4
+
+
+def test_opple_cluster_weather_seq_wraps(zigpy_device_from_v2_quirk):
+    """Test OppleCluster weather sequence counter wraps at 255."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
+
+    # Set sequence to 255
+    opple_cluster._weather_seq = 255
+
+    # Build a packet - should wrap to 0, then increment to 1 in the method
+    # Actually the method does: _weather_seq = (_weather_seq + 1) & 0xFF
+    # So 255 + 1 = 256 & 0xFF = 0
+    packet = opple_cluster._build_condition_packet(0)
+
+    # Sequence should have wrapped to 0
+    assert packet[4] == 0
+    assert opple_cluster._weather_seq == 0

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2282,3 +2282,110 @@ async def test_lumi_magnet_sensor_aq2_bad_direction(zigpy_device_from_quirk, cap
 
     # Our matching logic should be forgiving
     assert listener.attribute_updates == [(0, t.Bool.true)]
+
+
+def test_aqara_display_switch_endpoints(zigpy_device_from_v2_quirk):
+    """Test Aqara Display Switch V1 EU quirk creates all expected endpoints."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    # Verify all endpoints exist
+    assert 1 in device.endpoints
+    assert 2 in device.endpoints
+    assert 3 in device.endpoints
+    assert 4 in device.endpoints
+    assert 21 in device.endpoints
+
+    # Endpoint 1: Primary switch with metering
+    assert OnOff.cluster_id in device.endpoints[1].in_clusters
+    assert MultistateInput.cluster_id in device.endpoints[1].in_clusters
+
+    # Endpoint 2: Secondary switch
+    assert OnOff.cluster_id in device.endpoints[2].in_clusters
+    assert MultistateInput.cluster_id in device.endpoints[2].in_clusters
+
+    # Endpoint 3: Button 1 (decoupled mode)
+    assert MultistateInput.cluster_id in device.endpoints[3].in_clusters
+
+    # Endpoint 4: Button 2 (decoupled mode)
+    assert MultistateInput.cluster_id in device.endpoints[4].in_clusters
+
+    # Endpoint 21: Analog input
+    assert AnalogInput.cluster_id in device.endpoints[21].in_clusters
+
+
+@pytest.mark.parametrize("endpoint_id", [1, 2, 3, 4])
+def test_aqara_display_switch_button_events(zigpy_device_from_v2_quirk, endpoint_id):
+    """Test Aqara Display Switch button press events."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    multistate_cluster = device.endpoints[endpoint_id].multistate_input
+    listener = mock.MagicMock()
+    multistate_cluster.add_listener(listener)
+
+    # Simulate single press (value=1)
+    multistate_cluster.update_attribute(
+        MultistateInput.AttributeDefs.present_value.id, 1
+    )
+
+    # Verify ZHA send event was called with correct action
+    assert listener.zha_send_event.call_count == 1
+    expected_action = f"button_{endpoint_id}_single"
+    assert listener.zha_send_event.call_args[0][0] == expected_action
+    assert listener.zha_send_event.call_args[0][1]["endpoint_id"] == endpoint_id
+    assert listener.zha_send_event.call_args[0][1]["value"] == 1
+
+
+def test_aqara_display_switch_opple_cluster(zigpy_device_from_v2_quirk):
+    """Test Aqara Display Switch OppleCluster attribute definitions."""
+    from zhaquirks.xiaomi.aqara.switch_aeu001 import (
+        ButtonOperationMode,
+        OppleCluster,
+        StartupOnOff,
+        Theme,
+    )
+
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
+    )
+
+    opple_cluster = device.endpoints[1].in_clusters[OppleCluster.cluster_id]
+    cluster_listener = ClusterListener(opple_cluster)
+
+    # Test startup_on_off attribute update
+    opple_cluster.update_attribute(
+        OppleCluster.AttributeDefs.startup_on_off.id,
+        StartupOnOff.RestorePrevious,
+    )
+    assert len(cluster_listener.attribute_updates) == 1
+    assert (
+        cluster_listener.attribute_updates[0][0]
+        == OppleCluster.AttributeDefs.startup_on_off.id
+    )
+    assert cluster_listener.attribute_updates[0][1] == StartupOnOff.RestorePrevious
+
+    # Test button_operation_mode attribute update
+    opple_cluster.update_attribute(
+        OppleCluster.AttributeDefs.button_operation_mode.id,
+        ButtonOperationMode.Decoupled,
+    )
+    assert len(cluster_listener.attribute_updates) == 2
+    assert (
+        cluster_listener.attribute_updates[1][0]
+        == OppleCluster.AttributeDefs.button_operation_mode.id
+    )
+    assert cluster_listener.attribute_updates[1][1] == ButtonOperationMode.Decoupled
+
+    # Test theme attribute update
+    opple_cluster.update_attribute(
+        OppleCluster.AttributeDefs.theme.id,
+        Theme.Option2,
+    )
+    assert len(cluster_listener.attribute_updates) == 3
+    assert (
+        cluster_listener.attribute_updates[2][0] == OppleCluster.AttributeDefs.theme.id
+    )
+    assert cluster_listener.attribute_updates[2][1] == Theme.Option2

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -96,6 +96,12 @@ import zhaquirks.xiaomi.aqara.plug_eu
 import zhaquirks.xiaomi.aqara.roller_curtain_e1
 import zhaquirks.xiaomi.aqara.sensor_ht_agl02
 import zhaquirks.xiaomi.aqara.smoke
+from zhaquirks.xiaomi.aqara.switch_aeu001 import (
+    ButtonOperationMode,
+    OppleCluster as DisplaySwitchOppleCluster,
+    StartupOnOff,
+    Theme,
+)
 import zhaquirks.xiaomi.aqara.switch_t1
 from zhaquirks.xiaomi.aqara.thermostat_agl001 import ScheduleEvent, ScheduleSettings
 import zhaquirks.xiaomi.aqara.weather
@@ -2341,51 +2347,47 @@ def test_aqara_display_switch_button_events(zigpy_device_from_v2_quirk, endpoint
 
 def test_aqara_display_switch_opple_cluster(zigpy_device_from_v2_quirk):
     """Test Aqara Display Switch OppleCluster attribute definitions."""
-    from zhaquirks.xiaomi.aqara.switch_aeu001 import (
-        ButtonOperationMode,
-        OppleCluster,
-        StartupOnOff,
-        Theme,
-    )
-
     device = zigpy_device_from_v2_quirk(
         "Aqara", "lumi.switch.aeu001", endpoint_ids=[1, 2, 3, 4, 21]
     )
 
-    opple_cluster = device.endpoints[1].in_clusters[OppleCluster.cluster_id]
+    opple_cluster = device.endpoints[1].in_clusters[
+        DisplaySwitchOppleCluster.cluster_id
+    ]
     cluster_listener = ClusterListener(opple_cluster)
 
     # Test startup_on_off attribute update
     opple_cluster.update_attribute(
-        OppleCluster.AttributeDefs.startup_on_off.id,
+        DisplaySwitchOppleCluster.AttributeDefs.startup_on_off.id,
         StartupOnOff.RestorePrevious,
     )
     assert len(cluster_listener.attribute_updates) == 1
     assert (
         cluster_listener.attribute_updates[0][0]
-        == OppleCluster.AttributeDefs.startup_on_off.id
+        == DisplaySwitchOppleCluster.AttributeDefs.startup_on_off.id
     )
     assert cluster_listener.attribute_updates[0][1] == StartupOnOff.RestorePrevious
 
     # Test button_operation_mode attribute update
     opple_cluster.update_attribute(
-        OppleCluster.AttributeDefs.button_operation_mode.id,
+        DisplaySwitchOppleCluster.AttributeDefs.button_operation_mode.id,
         ButtonOperationMode.Decoupled,
     )
     assert len(cluster_listener.attribute_updates) == 2
     assert (
         cluster_listener.attribute_updates[1][0]
-        == OppleCluster.AttributeDefs.button_operation_mode.id
+        == DisplaySwitchOppleCluster.AttributeDefs.button_operation_mode.id
     )
     assert cluster_listener.attribute_updates[1][1] == ButtonOperationMode.Decoupled
 
     # Test theme attribute update
     opple_cluster.update_attribute(
-        OppleCluster.AttributeDefs.theme.id,
+        DisplaySwitchOppleCluster.AttributeDefs.theme.id,
         Theme.Option2,
     )
     assert len(cluster_listener.attribute_updates) == 3
     assert (
-        cluster_listener.attribute_updates[2][0] == OppleCluster.AttributeDefs.theme.id
+        cluster_listener.attribute_updates[2][0]
+        == DisplaySwitchOppleCluster.AttributeDefs.theme.id
     )
     assert cluster_listener.attribute_updates[2][1] == Theme.Option2

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -8,7 +8,7 @@ from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.zcl.clusters.general import Groups, Identify, MultistateInput, OnOff, Scenes
-from zigpy.zcl.foundation import ZCLAttributeDef
+from zigpy.zcl.foundation import DataTypeId, ZCLAttributeDef
 
 from zhaquirks.const import (
     BUTTON_1,
@@ -172,21 +172,25 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         startup_on_off: Final = ZCLAttributeDef(
             id=0x0517,
             type=StartupOnOff,
+            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         button_operation_mode: Final = ZCLAttributeDef(
             id=0x0269,
             type=ButtonOperationMode,
+            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         button_relay: Final = ZCLAttributeDef(
             id=0x0235,
             type=ButtonRelay,
+            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         button_layout: Final = ZCLAttributeDef(
             id=0x0300,
             type=ButtonLayout,
+            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
 
@@ -194,11 +198,13 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         theme: Final = ZCLAttributeDef(
             id=0x0215,
             type=Theme,
+            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         show_mode: Final = ZCLAttributeDef(
             id=0x026A,
             type=ShowMode,
+            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         display_brightness: Final = ZCLAttributeDef(
@@ -216,6 +222,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         screensaver_style: Final = ZCLAttributeDef(
             id=0x0214,
             type=ScreensaverStyle,
+            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         # weather_data and color_button are complex byte arrays with device-specific
@@ -235,6 +242,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         proximity_sensitivity: Final = ZCLAttributeDef(
             id=0x0268,
             type=ProximitySensitivity,
+            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
 
@@ -242,6 +250,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         elder_mode: Final = ZCLAttributeDef(
             id=0x0217,
             type=ElderMode,
+            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         double_tap_override: Final = ZCLAttributeDef(
@@ -267,6 +276,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         weather_condition: Final = ZCLAttributeDef(
             id=0xFFF0,  # Virtual ID (not a real device attribute)
             type=WeatherCondition,
+            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         weather_temperature: Final = ZCLAttributeDef(

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -114,15 +114,12 @@ class ButtonRelay(t.enum8):
 
 
 class ButtonLayout(t.enum8):
-    """Button layout assignment enum."""
+    """Button layout assignment enum (only used when button_operation_mode = WirelessButton)."""
 
-    Empty = 0x00
-    Switch1 = 0x01
-    Switch2 = 0x02
-    Button1 = 0x03
-    Button2 = 0x04
-    Button3 = 0x05
-    Button4 = 0x06
+    Button1 = 0x01
+    Button2 = 0x02
+    Button3 = 0x04
+    Button4 = 0x08
 
 
 class MultistateInputCluster(CustomCluster, MultistateInput):
@@ -505,12 +502,18 @@ class OppleCluster(XiaomiAqaraE1Cluster):
 
 
 # Example service call to set button/switch names or icons:
+#
+# The device uses DIFFERENT attributes depending on the button's operation mode:
+#   - Switch mode (button_operation_mode = ControlRelay): use switch_name/switch_icon
+#   - Button mode (button_operation_mode = WirelessButton): use button_name/button_icon
+#
 # service: zha.set_zigbee_cluster_attribute
 # data:
 #   ieee: "your:device:ieee:address"
-#   endpoint_id: 1        # 1-4 for buttons, 1-2 for switches
+#   endpoint_id: 1        # Display position 1-4
 #   cluster_id: 64704     # 0xfcc0
 #   cluster_type: in
-#   attribute: 619        # button_name (619), button_icon (620), switch_name (622), switch_icon (623)
-#   value: "My Label"
+#   attribute: 623        # switch_icon (623) or switch_name (622) for switch mode
+#                         # button_icon (620) or button_name (619) for button mode
+#   value: "light_bulb"   # Icon name or custom text label
 #   manufacturer: 4447    # 0x115f (Aqara)

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -539,17 +539,8 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         OppleCluster.AttributeDefs.startup_on_off.name,
         StartupOnOff,
         OppleCluster.cluster_id,
-        endpoint_id=1,
-        translation_key="startup_on_off_1",
-        fallback_name="Switch 1 power-on behavior",
-    )
-    .enum(
-        OppleCluster.AttributeDefs.startup_on_off.name,
-        StartupOnOff,
-        OppleCluster.cluster_id,
-        endpoint_id=2,
-        translation_key="startup_on_off_2",
-        fallback_name="Switch 2 power-on behavior",
+        translation_key="startup_on_off",
+        fallback_name="Power-on behavior",
     )
     .enum(
         OppleCluster.AttributeDefs.button_operation_mode.name,

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -6,15 +6,8 @@ from zigpy import types as t
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
-from zigpy.zcl.clusters.general import (
-    DeviceTemperature,
-    Groups,
-    Identify,
-    MultistateInput,
-    OnOff,
-    Scenes,
-)
-from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
+from zigpy.zcl.clusters.general import Groups, Identify, MultistateInput, OnOff, Scenes
+from zigpy.zcl.foundation import DataTypeId, ZCLAttributeDef
 
 from zhaquirks.const import (
     BUTTON_1,
@@ -140,7 +133,7 @@ class MultistateInputCluster(CustomCluster, MultistateInput):
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Opple cluster for Aqara Display Switch."""
 
-    class AttributeDefs(BaseAttributeDefs):
+    class AttributeDefs(XiaomiAqaraE1Cluster.AttributeDefs):
         """Attribute definitions."""
 
         # Switch configuration
@@ -200,6 +193,9 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
+        # weather_data and color_button are complex byte arrays with device-specific
+        # encoding. They are defined for attribute discovery but not exposed as
+        # Home Assistant entities since their format is not fully documented.
         weather_data: Final = ZCLAttributeDef(
             id=0xFFF2, type=t.LVBytes, is_manufacturer_specific=True
         )
@@ -248,7 +244,6 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     QuirkBuilder("Aqara", "lumi.switch.aeu001")
     # Endpoint 1: Primary switch with metering
     .replaces(BasicCluster)
-    .adds(DeviceTemperature)
     .adds(Identify)
     .adds(Groups)
     .adds(Scenes)

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -3,34 +3,17 @@
 from typing import Final
 
 from zigpy import types as t
-from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.zcl.clusters.general import (
     DeviceTemperature,
     Groups,
     Identify,
-    MultistateInput,
     OnOff,
     Scenes,
 )
 from zigpy.zcl.foundation import ZCLAttributeDef
 
-from zhaquirks.const import (
-    ATTR_ID,
-    BUTTON_1,
-    BUTTON_2,
-    BUTTON_3,
-    BUTTON_4,
-    COMMAND,
-    DOUBLE_PRESS,
-    ENDPOINT_ID,
-    LONG_PRESS,
-    PRESS_TYPE,
-    SHORT_PRESS,
-    VALUE,
-    ZHA_SEND_EVENT,
-)
 from zhaquirks.xiaomi import (
     AnalogInputCluster,
     BasicCluster,
@@ -38,37 +21,6 @@ from zhaquirks.xiaomi import (
     MeteringCluster,
     XiaomiAqaraE1Cluster,
 )
-
-# Press type mapping from device values to human-readable strings
-PRESS_TYPES = {0: "hold", 1: "single", 2: "double"}
-STATUS_TYPE_ATTR = 0x0055  # decimal = 85
-
-
-class MultistateInputCluster(CustomCluster, MultistateInput):
-    """Multistate input cluster for button events."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self._current_state = None
-        super().__init__(*args, **kwargs)
-
-    def _update_attribute(self, attrid, value):
-        super()._update_attribute(attrid, value)
-        if attrid == STATUS_TYPE_ATTR:
-            # Map value to press type
-            self._current_state = PRESS_TYPES.get(value)
-            if self._current_state:
-                # Generate event with format: "{endpoint_id}_{press_type}"
-                event_args = {
-                    ENDPOINT_ID: self.endpoint.endpoint_id,
-                    PRESS_TYPE: self._current_state,
-                    ATTR_ID: attrid,
-                    VALUE: value,
-                }
-                action = f"{self.endpoint.endpoint_id}_{self._current_state}"
-                self.listener_event(ZHA_SEND_EVENT, action, event_args)
-                # Update attribute 0 for display in Home Assistant
-                super()._update_attribute(0, action)
 
 
 class OppleCluster(XiaomiAqaraE1Cluster):
@@ -191,7 +143,6 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     .adds(Groups)
     .adds(Scenes)
     .adds(OnOff)
-    .replaces(MultistateInputCluster)
     .replaces(MeteringCluster)
     .replaces(ElectricalMeasurementCluster)
     .replaces(OppleCluster, cluster_id=0xFCC0)
@@ -200,79 +151,9 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     .adds(Groups, endpoint_id=2)
     .adds(Scenes, endpoint_id=2)
     .adds(OnOff, endpoint_id=2)
-    .replaces(MultistateInputCluster, endpoint_id=2)
     .replaces(OppleCluster, cluster_id=0xFCC0, endpoint_id=2)
-    # Endpoint 3: Button 1 (decoupled mode)
-    .adds(Identify, endpoint_id=3)
-    .adds(Groups, endpoint_id=3)
-    .adds(Scenes, endpoint_id=3)
-    .replaces(MultistateInputCluster, endpoint_id=3)
-    .replaces(OppleCluster, cluster_id=0xFCC0, endpoint_id=3)
-    # Endpoint 4: Button 2 (decoupled mode)
-    .adds(Identify, endpoint_id=4)
-    .adds(Groups, endpoint_id=4)
-    .adds(Scenes, endpoint_id=4)
-    .replaces(MultistateInputCluster, endpoint_id=4)
-    .replaces(OppleCluster, cluster_id=0xFCC0, endpoint_id=4)
     # Endpoint 21: Analog input
     .replaces(AnalogInputCluster, endpoint_id=21)
-    # Device automation triggers for all button events
-    .device_automation_triggers(
-        {
-            # Button 1 (Endpoint 1)
-            (SHORT_PRESS, BUTTON_1): {
-                ENDPOINT_ID: 1,
-                COMMAND: "1_single",
-            },
-            (DOUBLE_PRESS, BUTTON_1): {
-                ENDPOINT_ID: 1,
-                COMMAND: "1_double",
-            },
-            (LONG_PRESS, BUTTON_1): {
-                ENDPOINT_ID: 1,
-                COMMAND: "1_hold",
-            },
-            # Button 2 (Endpoint 2)
-            (SHORT_PRESS, BUTTON_2): {
-                ENDPOINT_ID: 2,
-                COMMAND: "2_single",
-            },
-            (DOUBLE_PRESS, BUTTON_2): {
-                ENDPOINT_ID: 2,
-                COMMAND: "2_double",
-            },
-            (LONG_PRESS, BUTTON_2): {
-                ENDPOINT_ID: 2,
-                COMMAND: "2_hold",
-            },
-            # Button 3 (Endpoint 3 - decoupled mode)
-            (SHORT_PRESS, BUTTON_3): {
-                ENDPOINT_ID: 3,
-                COMMAND: "3_single",
-            },
-            (DOUBLE_PRESS, BUTTON_3): {
-                ENDPOINT_ID: 3,
-                COMMAND: "3_double",
-            },
-            (LONG_PRESS, BUTTON_3): {
-                ENDPOINT_ID: 3,
-                COMMAND: "3_hold",
-            },
-            # Button 4 (Endpoint 4 - decoupled mode)
-            (SHORT_PRESS, BUTTON_4): {
-                ENDPOINT_ID: 4,
-                COMMAND: "4_single",
-            },
-            (DOUBLE_PRESS, BUTTON_4): {
-                ENDPOINT_ID: 4,
-                COMMAND: "4_double",
-            },
-            (LONG_PRESS, BUTTON_4): {
-                ENDPOINT_ID: 4,
-                COMMAND: "4_hold",
-            },
-        }
-    )
     # Display configuration entities
     .number(
         OppleCluster.AttributeDefs.display_brightness.name,

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -8,7 +8,7 @@ from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.zcl.clusters.general import Groups, Identify, MultistateInput, OnOff, Scenes
-from zigpy.zcl.foundation import DataTypeId, ZCLAttributeDef
+from zigpy.zcl.foundation import ZCLAttributeDef
 
 from zhaquirks.const import (
     BUTTON_1,
@@ -172,25 +172,21 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         startup_on_off: Final = ZCLAttributeDef(
             id=0x0517,
             type=StartupOnOff,
-            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         button_operation_mode: Final = ZCLAttributeDef(
             id=0x0269,
             type=ButtonOperationMode,
-            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         button_relay: Final = ZCLAttributeDef(
             id=0x0235,
             type=ButtonRelay,
-            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         button_layout: Final = ZCLAttributeDef(
             id=0x0300,
             type=ButtonLayout,
-            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
 
@@ -198,13 +194,11 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         theme: Final = ZCLAttributeDef(
             id=0x0215,
             type=Theme,
-            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         show_mode: Final = ZCLAttributeDef(
             id=0x026A,
             type=ShowMode,
-            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         display_brightness: Final = ZCLAttributeDef(
@@ -222,7 +216,6 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         screensaver_style: Final = ZCLAttributeDef(
             id=0x0214,
             type=ScreensaverStyle,
-            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         # weather_data and color_button are complex byte arrays with device-specific
@@ -242,7 +235,6 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         proximity_sensitivity: Final = ZCLAttributeDef(
             id=0x0268,
             type=ProximitySensitivity,
-            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
 
@@ -250,7 +242,6 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         elder_mode: Final = ZCLAttributeDef(
             id=0x0217,
             type=ElderMode,
-            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         double_tap_override: Final = ZCLAttributeDef(
@@ -276,7 +267,6 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         weather_condition: Final = ZCLAttributeDef(
             id=0xFFF0,  # Virtual ID (not a real device attribute)
             type=WeatherCondition,
-            zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
         weather_temperature: Final = ZCLAttributeDef(
@@ -285,8 +275,10 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             is_manufacturer_specific=True,
         )
 
-    # Class-level sequence counter for weather packets
-    _weather_seq: int = 0
+    def __init__(self, *args, **kwargs):
+        """Initialize the cluster with instance-level weather sequence counter."""
+        super().__init__(*args, **kwargs)
+        self._weather_seq = 0
 
     def _get_ieee_bytes(self) -> bytes:
         """Extract last 6 bytes of device IEEE address for weather packets."""
@@ -310,8 +302,8 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         - Payload: 4 bytes
         """
         # Increment and wrap sequence counter
-        OppleCluster._weather_seq = (OppleCluster._weather_seq + 1) & 0xFF
-        seq = OppleCluster._weather_seq
+        self._weather_seq = (self._weather_seq + 1) & 0xFF
+        seq = self._weather_seq
         checksum = (0x8E - seq) & 0xFF
 
         ieee_bytes = self._get_ieee_bytes()
@@ -384,7 +376,12 @@ class OppleCluster(XiaomiAqaraE1Cluster):
                     condition_code = value
                 else:
                     # Try to look up by name
-                    condition_code = WeatherCondition[value].value
+                    try:
+                        condition_code = WeatherCondition[value].value
+                    except KeyError as exc:
+                        raise ValueError(
+                            f"Invalid weather condition: {value!r}"
+                        ) from exc
 
                 # Build and send condition packet
                 condition_packet = self._build_condition_packet(condition_code)
@@ -428,26 +425,26 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     .replaces(MultistateInputCluster)
     .replaces(MeteringCluster)
     .replaces(ElectricalMeasurementCluster)
-    .replaces(OppleCluster, cluster_id=OppleCluster.cluster_id)
+    .replaces(OppleCluster)
     # Endpoint 2: Secondary switch
     .adds(Identify, endpoint_id=2)
     .adds(Groups, endpoint_id=2)
     .adds(Scenes, endpoint_id=2)
     .adds(OnOff, endpoint_id=2)
     .replaces(MultistateInputCluster, endpoint_id=2)
-    .replaces(OppleCluster, cluster_id=OppleCluster.cluster_id, endpoint_id=2)
+    .replaces(OppleCluster, endpoint_id=2)
     # Endpoint 3: Button 1 (decoupled mode)
     .adds(Identify, endpoint_id=3)
     .adds(Groups, endpoint_id=3)
     .adds(Scenes, endpoint_id=3)
     .replaces(MultistateInputCluster, endpoint_id=3)
-    .replaces(OppleCluster, cluster_id=OppleCluster.cluster_id, endpoint_id=3)
+    .replaces(OppleCluster, endpoint_id=3)
     # Endpoint 4: Button 2 (decoupled mode)
     .adds(Identify, endpoint_id=4)
     .adds(Groups, endpoint_id=4)
     .adds(Scenes, endpoint_id=4)
     .replaces(MultistateInputCluster, endpoint_id=4)
-    .replaces(OppleCluster, cluster_id=OppleCluster.cluster_id, endpoint_id=4)
+    .replaces(OppleCluster, endpoint_id=4)
     # Endpoint 21: Analog input
     .replaces(AnalogInputCluster, endpoint_id=21)
     # Device automation triggers for single press events

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -99,6 +99,32 @@ class ProximitySensitivity(t.enum8):
     Far = 0x05
 
 
+class ElderMode(t.enum8):
+    """Elder mode enum (larger interface elements)."""
+
+    Off = 0x03
+    On = 0x05
+
+
+class ButtonRelay(t.enum8):
+    """Button relay assignment enum."""
+
+    Relay1 = 0x01
+    Relay2 = 0x02
+
+
+class ButtonLayout(t.enum8):
+    """Button layout assignment enum."""
+
+    Empty = 0x00
+    Switch1 = 0x01
+    Switch2 = 0x02
+    Button1 = 0x03
+    Button2 = 0x04
+    Button3 = 0x05
+    Button4 = 0x06
+
+
 class MultistateInputCluster(CustomCluster, MultistateInput):
     """Multistate input cluster for button events (single press only)."""
 
@@ -134,10 +160,16 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             is_manufacturer_specific=True,
         )
         button_relay: Final = ZCLAttributeDef(
-            id=0x0235, type=t.uint8_t, is_manufacturer_specific=True
+            id=0x0235,
+            type=ButtonRelay,
+            zcl_type=DataTypeId.uint8,
+            is_manufacturer_specific=True,
         )
         button_layout: Final = ZCLAttributeDef(
-            id=0x0300, type=t.uint8_t, is_manufacturer_specific=True
+            id=0x0300,
+            type=ButtonLayout,
+            zcl_type=DataTypeId.uint8,
+            is_manufacturer_specific=True,
         )
 
         # Display configuration
@@ -191,7 +223,10 @@ class OppleCluster(XiaomiAqaraE1Cluster):
 
         # Other features
         elder_mode: Final = ZCLAttributeDef(
-            id=0x0217, type=t.uint8_t, is_manufacturer_specific=True
+            id=0x0217,
+            type=ElderMode,
+            zcl_type=DataTypeId.uint8,
+            is_manufacturer_specific=True,
         )
         double_tap_override: Final = ZCLAttributeDef(
             id=0x0236, type=t.uint8_t, is_manufacturer_specific=True
@@ -328,15 +363,123 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         OppleCluster.AttributeDefs.startup_on_off.name,
         StartupOnOff,
         OppleCluster.cluster_id,
+        endpoint_id=1,
         translation_key="startup_on_off",
-        fallback_name="Power-on behavior",
+        fallback_name="Switch 1 power-on behavior",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.startup_on_off.name,
+        StartupOnOff,
+        OppleCluster.cluster_id,
+        endpoint_id=2,
+        translation_key="startup_on_off",
+        fallback_name="Switch 2 power-on behavior",
     )
     .enum(
         OppleCluster.AttributeDefs.button_operation_mode.name,
         ButtonOperationMode,
         OppleCluster.cluster_id,
+        endpoint_id=1,
         translation_key="button_operation_mode",
-        fallback_name="Button operation mode",
+        fallback_name="Button 1 operation mode",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.button_operation_mode.name,
+        ButtonOperationMode,
+        OppleCluster.cluster_id,
+        endpoint_id=2,
+        translation_key="button_operation_mode",
+        fallback_name="Button 2 operation mode",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.button_operation_mode.name,
+        ButtonOperationMode,
+        OppleCluster.cluster_id,
+        endpoint_id=3,
+        translation_key="button_operation_mode",
+        fallback_name="Button 3 operation mode",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.button_operation_mode.name,
+        ButtonOperationMode,
+        OppleCluster.cluster_id,
+        endpoint_id=4,
+        translation_key="button_operation_mode",
+        fallback_name="Button 4 operation mode",
+    )
+    # Button relay assignment (which relay each button controls)
+    .enum(
+        OppleCluster.AttributeDefs.button_relay.name,
+        ButtonRelay,
+        OppleCluster.cluster_id,
+        endpoint_id=1,
+        translation_key="button_relay",
+        fallback_name="Button 1 relay",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.button_relay.name,
+        ButtonRelay,
+        OppleCluster.cluster_id,
+        endpoint_id=2,
+        translation_key="button_relay",
+        fallback_name="Button 2 relay",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.button_relay.name,
+        ButtonRelay,
+        OppleCluster.cluster_id,
+        endpoint_id=3,
+        translation_key="button_relay",
+        fallback_name="Button 3 relay",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.button_relay.name,
+        ButtonRelay,
+        OppleCluster.cluster_id,
+        endpoint_id=4,
+        translation_key="button_relay",
+        fallback_name="Button 4 relay",
+    )
+    # Button layout assignment (what each button position shows)
+    .enum(
+        OppleCluster.AttributeDefs.button_layout.name,
+        ButtonLayout,
+        OppleCluster.cluster_id,
+        endpoint_id=1,
+        translation_key="button_layout",
+        fallback_name="Button 1 layout",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.button_layout.name,
+        ButtonLayout,
+        OppleCluster.cluster_id,
+        endpoint_id=2,
+        translation_key="button_layout",
+        fallback_name="Button 2 layout",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.button_layout.name,
+        ButtonLayout,
+        OppleCluster.cluster_id,
+        endpoint_id=3,
+        translation_key="button_layout",
+        fallback_name="Button 3 layout",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.button_layout.name,
+        ButtonLayout,
+        OppleCluster.cluster_id,
+        endpoint_id=4,
+        translation_key="button_layout",
+        fallback_name="Button 4 layout",
+    )
+    # Elder mode (larger interface elements)
+    .enum(
+        OppleCluster.AttributeDefs.elder_mode.name,
+        ElderMode,
+        OppleCluster.cluster_id,
+        translation_key="elder_mode",
+        fallback_name="Elder mode",
     )
     # Switch entities for boolean settings
     .switch(
@@ -359,3 +502,15 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     )
     .add_to_registry()
 )
+
+
+# Example service call to set button/switch names or icons:
+# service: zha.set_zigbee_cluster_attribute
+# data:
+#   ieee: "your:device:ieee:address"
+#   endpoint_id: 1        # 1-4 for buttons, 1-2 for switches
+#   cluster_id: 64704     # 0xfcc0
+#   cluster_type: in
+#   attribute: 619        # button_name (619), button_icon (620), switch_name (622), switch_icon (623)
+#   value: "My Label"
+#   manufacturer: 4447    # 0x115f (Aqara)

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -1,0 +1,367 @@
+"""Aqara Display Switch V1 EU (lumi.switch.aeu001)."""
+
+from typing import Final
+
+from zigpy import types as t
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.zcl.clusters.general import (
+    DeviceTemperature,
+    Groups,
+    Identify,
+    MultistateInput,
+    OnOff,
+    Scenes,
+)
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+from zhaquirks.const import (
+    ATTR_ID,
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    BUTTON_4,
+    COMMAND,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    LONG_PRESS,
+    PRESS_TYPE,
+    SHORT_PRESS,
+    VALUE,
+    ZHA_SEND_EVENT,
+)
+from zhaquirks.xiaomi import (
+    AnalogInputCluster,
+    BasicCluster,
+    ElectricalMeasurementCluster,
+    MeteringCluster,
+    XiaomiAqaraE1Cluster,
+)
+
+# Press type mapping from device values to human-readable strings
+PRESS_TYPES = {0: "hold", 1: "single", 2: "double"}
+STATUS_TYPE_ATTR = 0x0055  # decimal = 85
+
+
+class MultistateInputCluster(CustomCluster, MultistateInput):
+    """Multistate input cluster for button events."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self._current_state = None
+        super().__init__(*args, **kwargs)
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == STATUS_TYPE_ATTR:
+            # Map value to press type
+            self._current_state = PRESS_TYPES.get(value)
+            if self._current_state:
+                # Generate event with format: "{endpoint_id}_{press_type}"
+                event_args = {
+                    ENDPOINT_ID: self.endpoint.endpoint_id,
+                    PRESS_TYPE: self._current_state,
+                    ATTR_ID: attrid,
+                    VALUE: value,
+                }
+                action = f"{self.endpoint.endpoint_id}_{self._current_state}"
+                self.listener_event(ZHA_SEND_EVENT, action, event_args)
+                # Update attribute 0 for display in Home Assistant
+                super()._update_attribute(0, action)
+
+
+class OppleCluster(XiaomiAqaraE1Cluster):
+    """Opple cluster for Aqara Display Switch."""
+
+    class StartupOnOff(t.enum8):
+        """Startup behavior enum."""
+
+        On = 0x00
+        RestorePrevious = 0x01
+        Off = 0x02
+        ReversePrevious = 0x03
+
+    class ButtonOperationMode(t.enum8):
+        """Button operation mode enum."""
+
+        Disabled = 0x00
+        ControlRelay = 0x01
+        Decoupled = 0x02
+        WirelessButton = 0x04
+
+    class Theme(t.enum8):
+        """Display theme enum."""
+
+        Option1 = 0x00
+        Option2 = 0x01
+
+    class ShowMode(t.enum8):
+        """Button display mode enum."""
+
+        IconAndText = 0x01
+        IconOnly = 0x02
+        TextOnly = 0x03
+
+    class ScreensaverStyle(t.enum8):
+        """Screensaver style enum."""
+
+        DigitalClock = 0x01
+        WeatherConditions = 0x02
+        IndoorEnvironment = 0x03
+
+    class ProximitySensitivity(t.enum8):
+        """Proximity sensitivity enum."""
+
+        Near = 0x01
+        LessNear = 0x02
+        Medium = 0x03
+        LessFar = 0x04
+        Far = 0x05
+
+    class AttributeDefs(XiaomiAqaraE1Cluster.AttributeDefs):
+        """Attribute definitions."""
+
+        # Switch configuration
+        startup_on_off: Final = ZCLAttributeDef(
+            id=0x0517, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        button_operation_mode: Final = ZCLAttributeDef(
+            id=0x0269, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        button_relay: Final = ZCLAttributeDef(
+            id=0x0235, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        button_layout: Final = ZCLAttributeDef(
+            id=0x0300, type=t.uint8_t, is_manufacturer_specific=True
+        )
+
+        # Display configuration
+        theme: Final = ZCLAttributeDef(
+            id=0x0215, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        show_mode: Final = ZCLAttributeDef(
+            id=0x026A, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        display_brightness: Final = ZCLAttributeDef(
+            id=0x0211, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        standby_time: Final = ZCLAttributeDef(
+            id=0x0216, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        standby_screen_saver: Final = ZCLAttributeDef(
+            id=0x0221, type=t.Bool, is_manufacturer_specific=True
+        )
+        standby_brightness: Final = ZCLAttributeDef(
+            id=0x0222, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        screensaver_style: Final = ZCLAttributeDef(
+            id=0x0214, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        weather_data: Final = ZCLAttributeDef(
+            id=0xFFF2, type=t.LVBytes, is_manufacturer_specific=True
+        )
+        color_button: Final = ZCLAttributeDef(
+            id=0x0266, type=t.LVBytes, is_manufacturer_specific=True
+        )
+
+        # Proximity sensor
+        proximity_activation: Final = ZCLAttributeDef(
+            id=0x026D, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        proximity_sensitivity: Final = ZCLAttributeDef(
+            id=0x0268, type=t.uint8_t, is_manufacturer_specific=True
+        )
+
+        # Other features
+        elder_mode: Final = ZCLAttributeDef(
+            id=0x0217, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        double_tap_override: Final = ZCLAttributeDef(
+            id=0x0236, type=t.uint8_t, is_manufacturer_specific=True
+        )
+
+
+(
+    QuirkBuilder("Aqara", "lumi.switch.aeu001")
+    # Endpoint 1: Primary switch with metering
+    .replaces(BasicCluster)
+    .adds(DeviceTemperature)
+    .adds(Identify)
+    .adds(Groups)
+    .adds(Scenes)
+    .adds(OnOff)
+    .replaces(MultistateInputCluster)
+    .replaces(MeteringCluster)
+    .replaces(ElectricalMeasurementCluster)
+    .replaces(OppleCluster, cluster_id=0xFCC0)
+    # Endpoint 2: Secondary switch
+    .adds(Identify, endpoint_id=2)
+    .adds(Groups, endpoint_id=2)
+    .adds(Scenes, endpoint_id=2)
+    .adds(OnOff, endpoint_id=2)
+    .replaces(MultistateInputCluster, endpoint_id=2)
+    .replaces(OppleCluster, cluster_id=0xFCC0, endpoint_id=2)
+    # Endpoint 3: Button 1 (decoupled mode)
+    .adds(Identify, endpoint_id=3)
+    .adds(Groups, endpoint_id=3)
+    .adds(Scenes, endpoint_id=3)
+    .replaces(MultistateInputCluster, endpoint_id=3)
+    .replaces(OppleCluster, cluster_id=0xFCC0, endpoint_id=3)
+    # Endpoint 4: Button 2 (decoupled mode)
+    .adds(Identify, endpoint_id=4)
+    .adds(Groups, endpoint_id=4)
+    .adds(Scenes, endpoint_id=4)
+    .replaces(MultistateInputCluster, endpoint_id=4)
+    .replaces(OppleCluster, cluster_id=0xFCC0, endpoint_id=4)
+    # Endpoint 21: Analog input
+    .replaces(AnalogInputCluster, endpoint_id=21)
+    # Device automation triggers for all button events
+    .device_automation_triggers(
+        {
+            # Button 1 (Endpoint 1)
+            (SHORT_PRESS, BUTTON_1): {
+                ENDPOINT_ID: 1,
+                COMMAND: "1_single",
+            },
+            (DOUBLE_PRESS, BUTTON_1): {
+                ENDPOINT_ID: 1,
+                COMMAND: "1_double",
+            },
+            (LONG_PRESS, BUTTON_1): {
+                ENDPOINT_ID: 1,
+                COMMAND: "1_hold",
+            },
+            # Button 2 (Endpoint 2)
+            (SHORT_PRESS, BUTTON_2): {
+                ENDPOINT_ID: 2,
+                COMMAND: "2_single",
+            },
+            (DOUBLE_PRESS, BUTTON_2): {
+                ENDPOINT_ID: 2,
+                COMMAND: "2_double",
+            },
+            (LONG_PRESS, BUTTON_2): {
+                ENDPOINT_ID: 2,
+                COMMAND: "2_hold",
+            },
+            # Button 3 (Endpoint 3 - decoupled mode)
+            (SHORT_PRESS, BUTTON_3): {
+                ENDPOINT_ID: 3,
+                COMMAND: "3_single",
+            },
+            (DOUBLE_PRESS, BUTTON_3): {
+                ENDPOINT_ID: 3,
+                COMMAND: "3_double",
+            },
+            (LONG_PRESS, BUTTON_3): {
+                ENDPOINT_ID: 3,
+                COMMAND: "3_hold",
+            },
+            # Button 4 (Endpoint 4 - decoupled mode)
+            (SHORT_PRESS, BUTTON_4): {
+                ENDPOINT_ID: 4,
+                COMMAND: "4_single",
+            },
+            (DOUBLE_PRESS, BUTTON_4): {
+                ENDPOINT_ID: 4,
+                COMMAND: "4_double",
+            },
+            (LONG_PRESS, BUTTON_4): {
+                ENDPOINT_ID: 4,
+                COMMAND: "4_hold",
+            },
+        }
+    )
+    # Display configuration entities
+    .number(
+        OppleCluster.AttributeDefs.display_brightness.name,
+        OppleCluster.cluster_id,
+        min_value=0,
+        max_value=100,
+        step=1,
+        translation_key="display_brightness",
+        fallback_name="Display brightness",
+    )
+    .number(
+        OppleCluster.AttributeDefs.standby_brightness.name,
+        OppleCluster.cluster_id,
+        min_value=0,
+        max_value=100,
+        step=1,
+        translation_key="standby_brightness",
+        fallback_name="Standby brightness",
+    )
+    .number(
+        OppleCluster.AttributeDefs.standby_time.name,
+        OppleCluster.cluster_id,
+        min_value=5,
+        max_value=65535,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        translation_key="standby_time",
+        fallback_name="Standby time",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.theme.name,
+        OppleCluster.Theme,
+        OppleCluster.cluster_id,
+        translation_key="theme",
+        fallback_name="Display theme",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.show_mode.name,
+        OppleCluster.ShowMode,
+        OppleCluster.cluster_id,
+        translation_key="show_mode",
+        fallback_name="Button display mode",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.screensaver_style.name,
+        OppleCluster.ScreensaverStyle,
+        OppleCluster.cluster_id,
+        translation_key="screensaver_style",
+        fallback_name="Screensaver style",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.proximity_sensitivity.name,
+        OppleCluster.ProximitySensitivity,
+        OppleCluster.cluster_id,
+        translation_key="proximity_sensitivity",
+        fallback_name="Proximity sensitivity",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.startup_on_off.name,
+        OppleCluster.StartupOnOff,
+        OppleCluster.cluster_id,
+        translation_key="startup_on_off",
+        fallback_name="Power-on behavior",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.button_operation_mode.name,
+        OppleCluster.ButtonOperationMode,
+        OppleCluster.cluster_id,
+        translation_key="button_operation_mode",
+        fallback_name="Button operation mode",
+    )
+    # Switch entities for boolean settings
+    .switch(
+        OppleCluster.AttributeDefs.standby_screen_saver.name,
+        OppleCluster.cluster_id,
+        translation_key="standby_screen_saver",
+        fallback_name="Standby screensaver",
+    )
+    .switch(
+        OppleCluster.AttributeDefs.proximity_activation.name,
+        OppleCluster.cluster_id,
+        translation_key="proximity_activation",
+        fallback_name="Proximity wake",
+    )
+    .switch(
+        OppleCluster.AttributeDefs.double_tap_override.name,
+        OppleCluster.cluster_id,
+        translation_key="double_tap_override",
+        fallback_name="Double tap override",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -361,7 +361,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         StartupOnOff,
         OppleCluster.cluster_id,
         endpoint_id=1,
-        translation_key="startup_on_off",
+        translation_key="startup_on_off_1",
         fallback_name="Switch 1 power-on behavior",
     )
     .enum(
@@ -369,7 +369,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         StartupOnOff,
         OppleCluster.cluster_id,
         endpoint_id=2,
-        translation_key="startup_on_off",
+        translation_key="startup_on_off_2",
         fallback_name="Switch 2 power-on behavior",
     )
     .enum(
@@ -377,7 +377,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         ButtonOperationMode,
         OppleCluster.cluster_id,
         endpoint_id=1,
-        translation_key="button_operation_mode",
+        translation_key="button_operation_mode_1",
         fallback_name="Button 1 operation mode",
     )
     .enum(
@@ -385,7 +385,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         ButtonOperationMode,
         OppleCluster.cluster_id,
         endpoint_id=2,
-        translation_key="button_operation_mode",
+        translation_key="button_operation_mode_2",
         fallback_name="Button 2 operation mode",
     )
     .enum(
@@ -393,7 +393,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         ButtonOperationMode,
         OppleCluster.cluster_id,
         endpoint_id=3,
-        translation_key="button_operation_mode",
+        translation_key="button_operation_mode_3",
         fallback_name="Button 3 operation mode",
     )
     .enum(
@@ -401,7 +401,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         ButtonOperationMode,
         OppleCluster.cluster_id,
         endpoint_id=4,
-        translation_key="button_operation_mode",
+        translation_key="button_operation_mode_4",
         fallback_name="Button 4 operation mode",
     )
     # Button relay assignment (which relay each button controls)
@@ -410,7 +410,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         ButtonRelay,
         OppleCluster.cluster_id,
         endpoint_id=1,
-        translation_key="button_relay",
+        translation_key="button_relay_1",
         fallback_name="Button 1 relay",
     )
     .enum(
@@ -418,7 +418,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         ButtonRelay,
         OppleCluster.cluster_id,
         endpoint_id=2,
-        translation_key="button_relay",
+        translation_key="button_relay_2",
         fallback_name="Button 2 relay",
     )
     .enum(
@@ -426,7 +426,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         ButtonRelay,
         OppleCluster.cluster_id,
         endpoint_id=3,
-        translation_key="button_relay",
+        translation_key="button_relay_3",
         fallback_name="Button 3 relay",
     )
     .enum(
@@ -434,7 +434,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         ButtonRelay,
         OppleCluster.cluster_id,
         endpoint_id=4,
-        translation_key="button_relay",
+        translation_key="button_relay_4",
         fallback_name="Button 4 relay",
     )
     # Button layout assignment (what each button position shows)
@@ -443,7 +443,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         ButtonLayout,
         OppleCluster.cluster_id,
         endpoint_id=1,
-        translation_key="button_layout",
+        translation_key="button_layout_1",
         fallback_name="Button 1 layout",
     )
     .enum(
@@ -451,7 +451,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         ButtonLayout,
         OppleCluster.cluster_id,
         endpoint_id=2,
-        translation_key="button_layout",
+        translation_key="button_layout_2",
         fallback_name="Button 2 layout",
     )
     .enum(
@@ -459,7 +459,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         ButtonLayout,
         OppleCluster.cluster_id,
         endpoint_id=3,
-        translation_key="button_layout",
+        translation_key="button_layout_3",
         fallback_name="Button 3 layout",
     )
     .enum(
@@ -467,7 +467,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         ButtonLayout,
         OppleCluster.cluster_id,
         endpoint_id=4,
-        translation_key="button_layout",
+        translation_key="button_layout_4",
         fallback_name="Button 4 layout",
     )
     # Elder mode (larger interface elements)

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -3,17 +3,29 @@
 from typing import Final
 
 from zigpy import types as t
+from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.zcl.clusters.general import (
     DeviceTemperature,
     Groups,
     Identify,
+    MultistateInput,
     OnOff,
     Scenes,
 )
-from zigpy.zcl.foundation import ZCLAttributeDef
+from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
 
+from zhaquirks.const import (
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    BUTTON_4,
+    COMMAND,
+    ENDPOINT_ID,
+    SHORT_PRESS,
+    ZHA_SEND_EVENT,
+)
 from zhaquirks.xiaomi import (
     AnalogInputCluster,
     BasicCluster,
@@ -22,64 +34,94 @@ from zhaquirks.xiaomi import (
     XiaomiAqaraE1Cluster,
 )
 
+# Attribute for present_value in MultistateInput cluster
+PRESENT_VALUE_ATTR = MultistateInput.AttributeDefs.present_value.id
+
+
+class StartupOnOff(t.enum8):
+    """Startup behavior enum."""
+
+    On = 0x00
+    RestorePrevious = 0x01
+    Off = 0x02
+    ReversePrevious = 0x03
+
+
+class ButtonOperationMode(t.enum8):
+    """Button operation mode enum."""
+
+    Disabled = 0x00
+    ControlRelay = 0x01
+    Decoupled = 0x02
+    WirelessButton = 0x04
+
+
+class Theme(t.enum8):
+    """Display theme enum."""
+
+    Option1 = 0x00
+    Option2 = 0x01
+
+
+class ShowMode(t.enum8):
+    """Button display mode enum."""
+
+    IconAndText = 0x01
+    IconOnly = 0x02
+    TextOnly = 0x03
+
+
+class ScreensaverStyle(t.enum8):
+    """Screensaver style enum."""
+
+    DigitalClock = 0x01
+    WeatherConditions = 0x02
+    IndoorEnvironment = 0x03
+
+
+class ProximitySensitivity(t.enum8):
+    """Proximity sensitivity enum."""
+
+    Near = 0x01
+    LessNear = 0x02
+    Medium = 0x03
+    LessFar = 0x04
+    Far = 0x05
+
+
+class MultistateInputCluster(CustomCluster, MultistateInput):
+    """Multistate input cluster for button events (single press only)."""
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == PRESENT_VALUE_ATTR and value == 1:
+            # Single press detected (value=1)
+            action = f"button_{self.endpoint.endpoint_id}_single"
+            event_args = {
+                "endpoint_id": self.endpoint.endpoint_id,
+                "value": value,
+            }
+            self.listener_event(ZHA_SEND_EVENT, action, event_args)
+
 
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Opple cluster for Aqara Display Switch."""
 
-    class StartupOnOff(t.enum8):
-        """Startup behavior enum."""
-
-        On = 0x00
-        RestorePrevious = 0x01
-        Off = 0x02
-        ReversePrevious = 0x03
-
-    class ButtonOperationMode(t.enum8):
-        """Button operation mode enum."""
-
-        Disabled = 0x00
-        ControlRelay = 0x01
-        Decoupled = 0x02
-        WirelessButton = 0x04
-
-    class Theme(t.enum8):
-        """Display theme enum."""
-
-        Option1 = 0x00
-        Option2 = 0x01
-
-    class ShowMode(t.enum8):
-        """Button display mode enum."""
-
-        IconAndText = 0x01
-        IconOnly = 0x02
-        TextOnly = 0x03
-
-    class ScreensaverStyle(t.enum8):
-        """Screensaver style enum."""
-
-        DigitalClock = 0x01
-        WeatherConditions = 0x02
-        IndoorEnvironment = 0x03
-
-    class ProximitySensitivity(t.enum8):
-        """Proximity sensitivity enum."""
-
-        Near = 0x01
-        LessNear = 0x02
-        Medium = 0x03
-        LessFar = 0x04
-        Far = 0x05
-
-    class AttributeDefs(XiaomiAqaraE1Cluster.AttributeDefs):
+    class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
 
         # Switch configuration
         startup_on_off: Final = ZCLAttributeDef(
-            id=0x0517, type=t.uint8_t, is_manufacturer_specific=True
+            id=0x0517,
+            type=StartupOnOff,
+            zcl_type=DataTypeId.uint8,
+            is_manufacturer_specific=True,
         )
         button_operation_mode: Final = ZCLAttributeDef(
-            id=0x0269, type=t.uint8_t, is_manufacturer_specific=True
+            id=0x0269,
+            type=ButtonOperationMode,
+            zcl_type=DataTypeId.uint8,
+            is_manufacturer_specific=True,
         )
         button_relay: Final = ZCLAttributeDef(
             id=0x0235, type=t.uint8_t, is_manufacturer_specific=True
@@ -90,10 +132,16 @@ class OppleCluster(XiaomiAqaraE1Cluster):
 
         # Display configuration
         theme: Final = ZCLAttributeDef(
-            id=0x0215, type=t.uint8_t, is_manufacturer_specific=True
+            id=0x0215,
+            type=Theme,
+            zcl_type=DataTypeId.uint8,
+            is_manufacturer_specific=True,
         )
         show_mode: Final = ZCLAttributeDef(
-            id=0x026A, type=t.uint8_t, is_manufacturer_specific=True
+            id=0x026A,
+            type=ShowMode,
+            zcl_type=DataTypeId.uint8,
+            is_manufacturer_specific=True,
         )
         display_brightness: Final = ZCLAttributeDef(
             id=0x0211, type=t.uint8_t, is_manufacturer_specific=True
@@ -108,7 +156,10 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             id=0x0222, type=t.uint8_t, is_manufacturer_specific=True
         )
         screensaver_style: Final = ZCLAttributeDef(
-            id=0x0214, type=t.uint8_t, is_manufacturer_specific=True
+            id=0x0214,
+            type=ScreensaverStyle,
+            zcl_type=DataTypeId.uint8,
+            is_manufacturer_specific=True,
         )
         weather_data: Final = ZCLAttributeDef(
             id=0xFFF2, type=t.LVBytes, is_manufacturer_specific=True
@@ -122,7 +173,10 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             id=0x026D, type=t.uint8_t, is_manufacturer_specific=True
         )
         proximity_sensitivity: Final = ZCLAttributeDef(
-            id=0x0268, type=t.uint8_t, is_manufacturer_specific=True
+            id=0x0268,
+            type=ProximitySensitivity,
+            zcl_type=DataTypeId.uint8,
+            is_manufacturer_specific=True,
         )
 
         # Other features
@@ -143,17 +197,52 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     .adds(Groups)
     .adds(Scenes)
     .adds(OnOff)
+    .replaces(MultistateInputCluster)
     .replaces(MeteringCluster)
     .replaces(ElectricalMeasurementCluster)
-    .replaces(OppleCluster, cluster_id=0xFCC0)
+    .replaces(OppleCluster, cluster_id=OppleCluster.cluster_id)
     # Endpoint 2: Secondary switch
     .adds(Identify, endpoint_id=2)
     .adds(Groups, endpoint_id=2)
     .adds(Scenes, endpoint_id=2)
     .adds(OnOff, endpoint_id=2)
-    .replaces(OppleCluster, cluster_id=0xFCC0, endpoint_id=2)
+    .replaces(MultistateInputCluster, endpoint_id=2)
+    .replaces(OppleCluster, cluster_id=OppleCluster.cluster_id, endpoint_id=2)
+    # Endpoint 3: Button 1 (decoupled mode)
+    .adds(Identify, endpoint_id=3)
+    .adds(Groups, endpoint_id=3)
+    .adds(Scenes, endpoint_id=3)
+    .replaces(MultistateInputCluster, endpoint_id=3)
+    .replaces(OppleCluster, cluster_id=OppleCluster.cluster_id, endpoint_id=3)
+    # Endpoint 4: Button 2 (decoupled mode)
+    .adds(Identify, endpoint_id=4)
+    .adds(Groups, endpoint_id=4)
+    .adds(Scenes, endpoint_id=4)
+    .replaces(MultistateInputCluster, endpoint_id=4)
+    .replaces(OppleCluster, cluster_id=OppleCluster.cluster_id, endpoint_id=4)
     # Endpoint 21: Analog input
     .replaces(AnalogInputCluster, endpoint_id=21)
+    # Device automation triggers for single press events
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, BUTTON_1): {
+                ENDPOINT_ID: 1,
+                COMMAND: "button_1_single",
+            },
+            (SHORT_PRESS, BUTTON_2): {
+                ENDPOINT_ID: 2,
+                COMMAND: "button_2_single",
+            },
+            (SHORT_PRESS, BUTTON_3): {
+                ENDPOINT_ID: 3,
+                COMMAND: "button_3_single",
+            },
+            (SHORT_PRESS, BUTTON_4): {
+                ENDPOINT_ID: 4,
+                COMMAND: "button_4_single",
+            },
+        }
+    )
     # Display configuration entities
     .number(
         OppleCluster.AttributeDefs.display_brightness.name,
@@ -185,42 +274,42 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     )
     .enum(
         OppleCluster.AttributeDefs.theme.name,
-        OppleCluster.Theme,
+        Theme,
         OppleCluster.cluster_id,
         translation_key="theme",
         fallback_name="Display theme",
     )
     .enum(
         OppleCluster.AttributeDefs.show_mode.name,
-        OppleCluster.ShowMode,
+        ShowMode,
         OppleCluster.cluster_id,
         translation_key="show_mode",
         fallback_name="Button display mode",
     )
     .enum(
         OppleCluster.AttributeDefs.screensaver_style.name,
-        OppleCluster.ScreensaverStyle,
+        ScreensaverStyle,
         OppleCluster.cluster_id,
         translation_key="screensaver_style",
         fallback_name="Screensaver style",
     )
     .enum(
         OppleCluster.AttributeDefs.proximity_sensitivity.name,
-        OppleCluster.ProximitySensitivity,
+        ProximitySensitivity,
         OppleCluster.cluster_id,
         translation_key="proximity_sensitivity",
         fallback_name="Proximity sensitivity",
     )
     .enum(
         OppleCluster.AttributeDefs.startup_on_off.name,
-        OppleCluster.StartupOnOff,
+        StartupOnOff,
         OppleCluster.cluster_id,
         translation_key="startup_on_off",
         fallback_name="Power-on behavior",
     )
     .enum(
         OppleCluster.AttributeDefs.button_operation_mode.name,
-        OppleCluster.ButtonOperationMode,
+        ButtonOperationMode,
         OppleCluster.cluster_id,
         translation_key="button_operation_mode",
         fallback_name="Button operation mode",

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -1,6 +1,7 @@
 """Aqara Display Switch V1 EU (lumi.switch.aeu001)."""
 
-from typing import Final
+import struct
+from typing import Any, Final
 
 from zigpy import types as t
 from zigpy.quirks import CustomCluster
@@ -113,6 +114,37 @@ class ButtonLayout(t.enum8):
     Button2 = 0x02
     Button3 = 0x04
     Button4 = 0x08
+
+
+class WeatherCondition(t.enum8):
+    """Weather condition codes for the display screensaver."""
+
+    Sunny = 0x00
+    Clear = 0x01
+    Fair = 0x03
+    Cloudy = 0x04
+    PartlyCloudy = 0x05
+    MostlyCloudy = 0x07
+    Overcast = 0x09
+    LightRain = 0x0D
+    ModerateRain = 0x0E
+    Storm = 0x10
+    HeavyStorm = 0x11
+    SevereStorm = 0x12
+    FreezingRain = 0x13
+    Sleet = 0x14
+    SnowFlurry = 0x15
+    LightSnow = 0x16
+    ModerateSnow = 0x17
+    HeavySnow = 0x18
+    Snowstorm = 0x19
+    Foggy = 0x1E
+    Windy = 0x20
+    Blustery = 0x21
+    Hurricane = 0x22
+    TropicalStorm = 0x23
+    Tornado = 0x24
+    Unknown = 0x25
 
 
 class MultistateInputCluster(CustomCluster, MultistateInput):
@@ -238,6 +270,151 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         switch_icon: Final = ZCLAttributeDef(
             id=0x026F, type=LVBytesString, is_manufacturer_specific=True
         )
+
+        # Weather display attributes (write-only, used with screensaver_style=WeatherConditions)
+        # These are virtual attributes that encode data into weather_data packets.
+        weather_condition: Final = ZCLAttributeDef(
+            id=0xFFF0,  # Virtual ID (not a real device attribute)
+            type=WeatherCondition,
+            zcl_type=DataTypeId.uint8,
+            is_manufacturer_specific=True,
+        )
+        weather_temperature: Final = ZCLAttributeDef(
+            id=0xFFF1,  # Virtual ID (not a real device attribute)
+            type=t.int16s,  # Temperature in Celsius (e.g., -10 to 50)
+            is_manufacturer_specific=True,
+        )
+
+    # Class-level sequence counter for weather packets
+    _weather_seq: int = 0
+
+    def _get_ieee_bytes(self) -> bytes:
+        """Extract last 6 bytes of device IEEE address for weather packets."""
+        ieee = self.endpoint.device.ieee
+        # IEEE address is 8 bytes, we need the last 6
+        ieee_bytes = ieee.serialize()
+        return ieee_bytes[2:8]  # Skip first 2 bytes
+
+    def _build_weather_packet(self, msg_type: tuple[int, int], payload: bytes) -> bytes:
+        """Build a weather data packet for the display.
+
+        Packet format (22 bytes):
+        - Header: 0xAA 0x71 0x13 0x44 (4 bytes)
+        - Sequence: 1 byte (incrementing counter)
+        - Checksum: 1 byte (0x8E - sequence)
+        - Type marker: 0x08 0x41 0x10 (3 bytes)
+        - Reserved: 0x00 0x00 (2 bytes)
+        - IEEE address: 6 bytes (last 6 bytes of device address)
+        - Message type: 2 bytes (e.g., 0x0D 0x02 for condition)
+        - Data marker: 0x00 0x55 (2 bytes)
+        - Payload: 4 bytes
+        """
+        # Increment and wrap sequence counter
+        OppleCluster._weather_seq = (OppleCluster._weather_seq + 1) & 0xFF
+        seq = OppleCluster._weather_seq
+        checksum = (0x8E - seq) & 0xFF
+
+        ieee_bytes = self._get_ieee_bytes()
+
+        packet = (
+            bytes(
+                [
+                    0xAA,
+                    0x71,
+                    0x13,
+                    0x44,  # Header
+                    seq,  # Sequence number
+                    checksum,  # Checksum (seq + checksum = 0x8E)
+                    0x08,
+                    0x41,
+                    0x10,  # Type marker (Octet String, Length 16)
+                    0x00,
+                    0x00,  # Reserved
+                ]
+            )
+            + ieee_bytes
+            + bytes(
+                [
+                    msg_type[0],
+                    msg_type[1],  # Message type
+                    0x00,
+                    0x55,  # Data marker
+                ]
+            )
+            + payload
+        )
+
+        return packet
+
+    def _build_condition_packet(self, condition_code: int) -> bytes:
+        """Build weather condition packet (message type 0x0D, 0x02)."""
+        payload = bytes([0x00, 0x00, 0x00, condition_code])
+        return self._build_weather_packet((0x0D, 0x02), payload)
+
+    def _build_null_packet(self) -> bytes:
+        """Build null packet required after some weather conditions (message type 0x00, 0x06)."""
+        payload = bytes([0x00, 0x00, 0x00, 0x00])
+        return self._build_weather_packet((0x00, 0x06), payload)
+
+    def _build_temperature_packet(self, temperature: float) -> bytes:
+        """Build weather temperature packet (message type 0x00, 0x04)."""
+        # Convert temperature to IEEE 754 single-precision float (big-endian)
+        payload = struct.pack(">f", temperature)
+        return self._build_weather_packet((0x00, 0x04), payload)
+
+    async def write_attributes(
+        self, attributes: dict[str | int, Any], manufacturer: int | None = None
+    ) -> list:
+        """Override write_attributes to handle weather virtual attributes."""
+        # Check for weather virtual attributes
+        weather_condition_id = self.AttributeDefs.weather_condition.id
+        weather_temperature_id = self.AttributeDefs.weather_temperature.id
+        weather_data_id = self.AttributeDefs.weather_data.id
+
+        # Process weather_condition
+        if weather_condition_id in attributes or "weather_condition" in attributes:
+            value = attributes.pop(weather_condition_id, None) or attributes.pop(
+                "weather_condition", None
+            )
+            if value is not None:
+                # Convert enum value if needed
+                if isinstance(value, WeatherCondition):
+                    condition_code = value.value
+                elif isinstance(value, int):
+                    condition_code = value
+                else:
+                    # Try to look up by name
+                    condition_code = WeatherCondition[value].value
+
+                # Build and send condition packet
+                condition_packet = self._build_condition_packet(condition_code)
+                await super().write_attributes(
+                    {weather_data_id: condition_packet}, manufacturer=manufacturer
+                )
+
+                # Send null packet (required for some conditions like fog)
+                null_packet = self._build_null_packet()
+                await super().write_attributes(
+                    {weather_data_id: null_packet}, manufacturer=manufacturer
+                )
+
+        # Process weather_temperature
+        if weather_temperature_id in attributes or "weather_temperature" in attributes:
+            value = attributes.pop(weather_temperature_id, None) or attributes.pop(
+                "weather_temperature", None
+            )
+            if value is not None:
+                temperature = float(value)
+                temp_packet = self._build_temperature_packet(temperature)
+                await super().write_attributes(
+                    {weather_data_id: temp_packet}, manufacturer=manufacturer
+                )
+
+        # Process remaining attributes normally
+        if attributes:
+            return await super().write_attributes(attributes, manufacturer=manufacturer)
+
+        return [0]  # Success
 
 
 (
@@ -506,9 +683,41 @@ class OppleCluster(XiaomiAqaraE1Cluster):
 # data:
 #   ieee: "your:device:ieee:address"
 #   endpoint_id: 1        # Display position 1-4
-#   cluster_id: 64704     # 0xfcc0
+#   cluster_id: 64704     # 0xFCC0
 #   cluster_type: in
-#   attribute: 623        # switch_icon (623) or switch_name (622) for switch mode
-#                         # button_icon (620) or button_name (619) for button mode
+#   attribute: 0x026F     # switch_icon (0x026F) or switch_name (0x026E) for switch mode
+#                         # button_icon (0x026C) or button_name (0x026B) for button mode
 #   value: "light_bulb"   # Icon name or custom text label
-#   manufacturer: 4447    # 0x115f (Aqara)
+#   manufacturer: 4447    # 0x115F (Aqara)
+#
+#
+# Example service calls to set weather display (for screensaver_style = WeatherConditions):
+#
+# Set weather condition:
+# service: zha.set_zigbee_cluster_attribute
+# data:
+#   ieee: "your:device:ieee:address"
+#   endpoint_id: 1
+#   cluster_id: 64704     # 0xFCC0
+#   cluster_type: in
+#   attribute: 0xFFF0     # weather_condition (virtual attribute)
+#   value: 4              # WeatherCondition enum value (see below)
+#   manufacturer: 4447    # 0x115F (Aqara)
+#
+# Set weather temperature:
+# service: zha.set_zigbee_cluster_attribute
+# data:
+#   ieee: "your:device:ieee:address"
+#   endpoint_id: 1
+#   cluster_id: 64704     # 0xFCC0
+#   cluster_type: in
+#   attribute: 0xFFF1     # weather_temperature (virtual attribute)
+#   value: 22             # Temperature in Celsius
+#   manufacturer: 4447    # 0x115F (Aqara)
+#
+# WeatherCondition values:
+#   Sunny=0, Clear=1, Fair=3, Cloudy=4, PartlyCloudy=5, MostlyCloudy=7,
+#   Overcast=9, LightRain=13, ModerateRain=14, Storm=16, HeavyStorm=17,
+#   SevereStorm=18, FreezingRain=19, Sleet=20, SnowFlurry=21, LightSnow=22,
+#   ModerateSnow=23, HeavySnow=24, Snowstorm=25, Foggy=30, Windy=32,
+#   Blustery=33, Hurricane=34, TropicalStorm=35, Tornado=36, Unknown=37

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -38,6 +38,16 @@ from zhaquirks.xiaomi import (
 PRESENT_VALUE_ATTR = MultistateInput.AttributeDefs.present_value.id
 
 
+class LVBytesString(t.LVBytes):
+    """LVBytes type that accepts string input and encodes to UTF-8."""
+
+    def __new__(cls, value=b""):
+        """Create new instance, converting string to bytes if needed."""
+        if isinstance(value, str):
+            value = value.encode("utf-8")
+        return super().__new__(cls, value)
+
+
 class StartupOnOff(t.enum8):
     """Startup behavior enum."""
 
@@ -185,6 +195,20 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         )
         double_tap_override: Final = ZCLAttributeDef(
             id=0x0236, type=t.uint8_t, is_manufacturer_specific=True
+        )
+
+        # Button/Switch labels (writable via zha.set_zigbee_cluster_attribute service)
+        button_name: Final = ZCLAttributeDef(
+            id=0x026B, type=LVBytesString, is_manufacturer_specific=True
+        )
+        button_icon: Final = ZCLAttributeDef(
+            id=0x026C, type=LVBytesString, is_manufacturer_specific=True
+        )
+        switch_name: Final = ZCLAttributeDef(
+            id=0x026E, type=LVBytesString, is_manufacturer_specific=True
+        )
+        switch_icon: Final = ZCLAttributeDef(
+            id=0x026F, type=LVBytesString, is_manufacturer_specific=True
         )
 
 

--- a/zhaquirks/xiaomi/aqara/switch_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu001.py
@@ -427,6 +427,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
 (
     QuirkBuilder("Aqara", "lumi.switch.aeu001")
     # Endpoint 1: Primary switch with metering
+    .replaces_endpoint(1, device_type=0x010A)
     .replaces(BasicCluster)
     .adds(Identify)
     .adds(Groups)
@@ -437,6 +438,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     .replaces(ElectricalMeasurementCluster)
     .replaces(OppleCluster)
     # Endpoint 2: Secondary switch
+    .replaces_endpoint(2, device_type=0x010A)
     .adds(Identify, endpoint_id=2)
     .adds(Groups, endpoint_id=2)
     .adds(Scenes, endpoint_id=2)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This is a complex zigbee device so I only managed to get most options working. ~~Couldn't figure out how to make the most important features work, like setting icons and text for the buttons. At least this can be used as a starting point if someone else wants to give it a try.~~
The only thing not working AFAIK is setting a sensor for IndoorEnvironment but you can use the Weather Conditions for the same thing.
Based on the Z2M converter in https://github.com/Koenkk/zigbee2mqtt/issues/26407

@N0Klu3 FYI

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
<details>
{
  "version": 1,
  "ieee": "**REDACTED**",
  "nwk": "0x5D49",
  "manufacturer": "Aqara",
  "model": "lumi.switch.aeu001",
  "friendly_manufacturer": "Aqara",
  "friendly_model": "lumi.switch.aeu001",
  "name": "Aqara lumi.switch.aeu001",
  "quirk_applied": false,
  "quirk_class": "zigpy.device.Device",
  "exposes_features": [],
  "manufacturer_code": 4447,
  "power_source": "Mains",
  "lqi": 100,
  "rssi": -75,
  "last_seen": "2026-01-19T09:25:50.840209+00:00",
  "available": true,
  "device_type": "Router",
  "active_coordinator": false,
  "node_descriptor": {
    "logical_type": "Router",
    "complex_descriptor_available": false,
    "user_descriptor_available": false,
    "reserved": 0,
    "aps_flags": 0,
    "frequency_band": 8,
    "mac_capability_flags": 142,
    "manufacturer_code": 4447,
    "maximum_buffer_size": 82,
    "maximum_incoming_transfer_size": 82,
    "server_mask": 11264,
    "maximum_outgoing_transfer_size": 82,
    "descriptor_capability_field": 0
  },
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": {
        "name": "COLOR_DIMMABLE_LIGHT",
        "id": 258
      },
      "in_clusters": [
        {
          "cluster_id": "0x0000",
          "endpoint_attribute": "basic",
          "attributes": [
            {
              "id": "0x0001",
              "name": "app_version",
              "zcl_type": "uint8",
              "value": 37
            },
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 2
            },
            {
              "id": "0x0006",
              "name": "date_code",
              "zcl_type": "string",
              "value": "20241106"
            },
            {
              "id": "0x0003",
              "name": "hw_version",
              "zcl_type": "uint8",
              "value": 1
            },
            {
              "id": "0x0010",
              "name": "location_desc",
              "zcl_type": "string",
              "value": "\u9ed8\u8ba4\u623f\u95f4"
            },
            {
              "id": "0x0004",
              "name": "manufacturer",
              "zcl_type": "string",
              "value": "Aqara"
            },
            {
              "id": "0x0005",
              "name": "model",
              "zcl_type": "string",
              "value": "lumi.switch.aeu001"
            },
            {
              "id": "0x0007",
              "name": "power_source",
              "zcl_type": "enum8",
              "value": 4
            },
            {
              "id": "0x000a",
              "name": "product_code",
              "zcl_type": "octstr",
              "value": {
                "__type": "<class 'bytes'>",
                "repr": "b''"
              }
            },
            {
              "id": "0x000d",
              "name": "serial_number",
              "zcl_type": "string",
              "value": ""
            },
            {
              "id": "0x0002",
              "name": "stack_version",
              "zcl_type": "uint8",
              "value": 27
            },
            {
              "id": "0x0000",
              "name": "zcl_version",
              "zcl_type": "uint8",
              "value": 3
            }
          ]
        },
        {
          "cluster_id": "0x0003",
          "endpoint_attribute": "identify",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 1
            },
            {
              "id": "0x0000",
              "name": "identify_time",
              "zcl_type": "uint16",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0004",
          "endpoint_attribute": "groups",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 2
            },
            {
              "id": "0x0000",
              "name": "name_support",
              "zcl_type": "map8",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0005",
          "endpoint_attribute": "scenes",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 2
            },
            {
              "id": "0x0000",
              "name": "count",
              "zcl_type": "uint8",
              "value": 0
            },
            {
              "id": "0x0002",
              "name": "current_group",
              "zcl_type": "uint16",
              "value": 0
            },
            {
              "id": "0x0001",
              "name": "current_scene",
              "zcl_type": "uint8",
              "value": 0
            },
            {
              "id": "0x0004",
              "name": "name_support",
              "zcl_type": "map8",
              "value": 0
            },
            {
              "id": "0x0003",
              "name": "scene_valid",
              "zcl_type": "bool",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0006",
          "endpoint_attribute": "on_off",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 2
            },
            {
              "id": "0x0000",
              "name": "on_off",
              "zcl_type": "bool",
              "value": 0
            },
            {
              "id": "0x4003",
              "name": "start_up_on_off",
              "zcl_type": "enum8",
              "unsupported": true
            }
          ]
        },
        {
          "cluster_id": "0x0012",
          "endpoint_attribute": "multistate_input",
          "attributes": [
            {
              "id": "0x0100",
              "name": "application_type",
              "zcl_type": "uint32",
              "unsupported": true
            },
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x001c",
              "name": "description",
              "zcl_type": "string",
              "unsupported": true
            },
            {
              "id": "0x004a",
              "name": "number_of_states",
              "zcl_type": "uint16",
              "value": 1
            },
            {
              "id": "0x0051",
              "name": "out_of_service",
              "zcl_type": "bool",
              "value": 0
            },
            {
              "id": "0x0055",
              "name": "present_value",
              "zcl_type": "uint16",
              "value": 0
            },
            {
              "id": "0x0067",
              "name": "reliability",
              "zcl_type": "enum8",
              "unsupported": true
            },
            {
              "id": "0xfffe",
              "name": "reporting_status",
              "zcl_type": "enum8",
              "unsupported": true
            },
            {
              "id": "0x000e",
              "name": "state_text",
              "zcl_type": "unk",
              "unsupported": true
            },
            {
              "id": "0x006f",
              "name": "status_flags",
              "zcl_type": "map8",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0702",
          "endpoint_attribute": "smartenergy_metering",
          "attributes": [
            {
              "id": "0x0000",
              "name": "current_summ_delivered",
              "zcl_type": "uint48",
              "value": 0
            },
            {
              "id": "0x0001",
              "name": "current_summ_received",
              "zcl_type": "uint48",
              "unsupported": true
            },
            {
              "id": "0x0100",
              "name": "current_tier1_summ_delivered",
              "zcl_type": "uint48",
              "unsupported": true
            },
            {
              "id": "0x0102",
              "name": "current_tier2_summ_delivered",
              "zcl_type": "uint48",
              "unsupported": true
            },
            {
              "id": "0x0104",
              "name": "current_tier3_summ_delivered",
              "zcl_type": "uint48",
              "unsupported": true
            },
            {
              "id": "0x0106",
              "name": "current_tier4_summ_delivered",
              "zcl_type": "uint48",
              "unsupported": true
            },
            {
              "id": "0x0108",
              "name": "current_tier5_summ_delivered",
              "zcl_type": "uint48",
              "unsupported": true
            },
            {
              "id": "0x010a",
              "name": "current_tier6_summ_delivered",
              "zcl_type": "uint48",
              "unsupported": true
            },
            {
              "id": "0x0304",
              "name": "demand_formatting",
              "zcl_type": "map8",
              "unsupported": true
            },
            {
              "id": "0x0302",
              "name": "divisor",
              "zcl_type": "uint24",
              "value": 1000
            },
            {
              "id": "0x0400",
              "name": "instantaneous_demand",
              "zcl_type": "int24",
              "unsupported": true
            },
            {
              "id": "0x0306",
              "name": "metering_device_type",
              "zcl_type": "map8",
              "value": 0
            },
            {
              "id": "0x0301",
              "name": "multiplier",
              "zcl_type": "uint24",
              "value": 1
            },
            {
              "id": "0x0200",
              "name": "status",
              "zcl_type": "map8",
              "unsupported": true
            },
            {
              "id": "0x0303",
              "name": "summation_formatting",
              "zcl_type": "map8",
              "value": 159
            },
            {
              "id": "0x0300",
              "name": "unit_of_measure",
              "zcl_type": "enum8",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0b04",
          "endpoint_attribute": "electrical_measurement",
          "attributes": [
            {
              "id": "0x0800",
              "name": "ac_alarms_mask",
              "zcl_type": "map16",
              "value": 0
            },
            {
              "id": "0x0603",
              "name": "ac_current_divisor",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0602",
              "name": "ac_current_multiplier",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0300",
              "name": "ac_frequency",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0401",
              "name": "ac_frequency_divisor",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0302",
              "name": "ac_frequency_max",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0400",
              "name": "ac_frequency_multiplier",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0605",
              "name": "ac_power_divisor",
              "zcl_type": "uint16",
              "value": 10
            },
            {
              "id": "0x0604",
              "name": "ac_power_multiplier",
              "zcl_type": "uint16",
              "value": 1
            },
            {
              "id": "0x0601",
              "name": "ac_voltage_divisor",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0600",
              "name": "ac_voltage_multiplier",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x050b",
              "name": "active_power",
              "zcl_type": "int16",
              "value": 0
            },
            {
              "id": "0x050d",
              "name": "active_power_max",
              "zcl_type": "int16",
              "unsupported": true
            },
            {
              "id": "0x090d",
              "name": "active_power_max_ph_b",
              "zcl_type": "int16",
              "unsupported": true
            },
            {
              "id": "0x0a0d",
              "name": "active_power_max_ph_c",
              "zcl_type": "int16",
              "unsupported": true
            },
            {
              "id": "0x090b",
              "name": "active_power_ph_b",
              "zcl_type": "int16",
              "unsupported": true
            },
            {
              "id": "0x0a0b",
              "name": "active_power_ph_c",
              "zcl_type": "int16",
              "unsupported": true
            },
            {
              "id": "0x050f",
              "name": "apparent_power",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0000",
              "name": "measurement_type",
              "zcl_type": "map32",
              "value": 1
            },
            {
              "id": "0x0403",
              "name": "power_divisor",
              "zcl_type": "uint32",
              "unsupported": true
            },
            {
              "id": "0x0510",
              "name": "power_factor",
              "zcl_type": "int8",
              "unsupported": true
            },
            {
              "id": "0x0910",
              "name": "power_factor_ph_b",
              "zcl_type": "int8",
              "unsupported": true
            },
            {
              "id": "0x0a10",
              "name": "power_factor_ph_c",
              "zcl_type": "int8",
              "unsupported": true
            },
            {
              "id": "0x0402",
              "name": "power_multiplier",
              "zcl_type": "uint32",
              "unsupported": true
            },
            {
              "id": "0x0508",
              "name": "rms_current",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x050a",
              "name": "rms_current_max",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x090a",
              "name": "rms_current_max_ph_b",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0a0a",
              "name": "rms_current_max_ph_c",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0908",
              "name": "rms_current_ph_b",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0a08",
              "name": "rms_current_ph_c",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0505",
              "name": "rms_voltage",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0507",
              "name": "rms_voltage_max",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0907",
              "name": "rms_voltage_max_ph_b",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0a07",
              "name": "rms_voltage_max_ph_c",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0905",
              "name": "rms_voltage_ph_b",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0a05",
              "name": "rms_voltage_ph_c",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x0304",
              "name": "total_active_power",
              "zcl_type": "int32",
              "unsupported": true
            }
          ]
        },
        {
          "cluster_id": "0xfcc0",
          "endpoint_attribute": "manufacturer_specific",
          "attributes": []
        }
      ],
      "out_clusters": [
        {
          "cluster_id": "0x000a",
          "endpoint_attribute": "time",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 1
            },
            {
              "id": "0x0004",
              "name": "dst_end",
              "zcl_type": "uint32",
              "unsupported": true
            },
            {
              "id": "0x0005",
              "name": "dst_shift",
              "zcl_type": "int32",
              "unsupported": true
            },
            {
              "id": "0x0003",
              "name": "dst_start",
              "zcl_type": "uint32",
              "unsupported": true
            },
            {
              "id": "0x0008",
              "name": "last_set_time",
              "zcl_type": "UTC",
              "unsupported": true
            },
            {
              "id": "0x0007",
              "name": "local_time",
              "zcl_type": "uint32",
              "unsupported": true
            },
            {
              "id": "0xfffe",
              "name": "reporting_status",
              "zcl_type": "enum8",
              "unsupported": true
            },
            {
              "id": "0x0006",
              "name": "standard_time",
              "zcl_type": "uint32",
              "unsupported": true
            },
            {
              "id": "0x0000",
              "name": "time",
              "zcl_type": "UTC",
              "value": 809090157
            },
            {
              "id": "0x0001",
              "name": "time_status",
              "zcl_type": "map8",
              "unsupported": true
            },
            {
              "id": "0x0002",
              "name": "time_zone",
              "zcl_type": "int32",
              "unsupported": true
            },
            {
              "id": "0x0009",
              "name": "valid_until_time",
              "zcl_type": "UTC",
              "unsupported": true
            }
          ]
        },
        {
          "cluster_id": "0x0019",
          "endpoint_attribute": "ota",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 3
            },
            {
              "id": "0x0002",
              "name": "current_file_version",
              "zcl_type": "uint32",
              "value": 3365
            },
            {
              "id": "0x0003",
              "name": "current_zigbee_stack_version",
              "zcl_type": "uint16",
              "value": 27
            },
            {
              "id": "0x0004",
              "name": "downloaded_file_version",
              "zcl_type": "uint32",
              "value": 0
            },
            {
              "id": "0x0005",
              "name": "downloaded_zigbee_stack_version",
              "zcl_type": "uint16",
              "value": 27
            },
            {
              "id": "0x0001",
              "name": "file_offset",
              "zcl_type": "uint32",
              "value": 0
            },
            {
              "id": "0x0008",
              "name": "image_type_id",
              "zcl_type": "uint16",
              "value": 142
            },
            {
              "id": "0x0006",
              "name": "image_upgrade_status",
              "zcl_type": "enum8",
              "value": 0
            },
            {
              "id": "0x0007",
              "name": "manufacturer_id",
              "zcl_type": "uint16",
              "value": 4447
            },
            {
              "id": "0x0000",
              "name": "upgrade_server_id",
              "zcl_type": "EUI64",
              "value": "00:00:00:00:00:00:00:00"
            }
          ]
        }
      ]
    },
    "2": {
      "profile_id": 260,
      "device_type": {
        "name": "COLOR_DIMMABLE_LIGHT",
        "id": 258
      },
      "in_clusters": [
        {
          "cluster_id": "0x0003",
          "endpoint_attribute": "identify",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 1
            },
            {
              "id": "0x0000",
              "name": "identify_time",
              "zcl_type": "uint16",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0004",
          "endpoint_attribute": "groups",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 2
            },
            {
              "id": "0x0000",
              "name": "name_support",
              "zcl_type": "map8",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0005",
          "endpoint_attribute": "scenes",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 2
            },
            {
              "id": "0x0000",
              "name": "count",
              "zcl_type": "uint8",
              "value": 0
            },
            {
              "id": "0x0002",
              "name": "current_group",
              "zcl_type": "uint16",
              "value": 0
            },
            {
              "id": "0x0001",
              "name": "current_scene",
              "zcl_type": "uint8",
              "value": 0
            },
            {
              "id": "0x0004",
              "name": "name_support",
              "zcl_type": "map8",
              "value": 0
            },
            {
              "id": "0x0003",
              "name": "scene_valid",
              "zcl_type": "bool",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0006",
          "endpoint_attribute": "on_off",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 2
            },
            {
              "id": "0x0000",
              "name": "on_off",
              "zcl_type": "bool",
              "value": 0
            },
            {
              "id": "0x4003",
              "name": "start_up_on_off",
              "zcl_type": "enum8",
              "unsupported": true
            }
          ]
        },
        {
          "cluster_id": "0x0012",
          "endpoint_attribute": "multistate_input",
          "attributes": [
            {
              "id": "0x0100",
              "name": "application_type",
              "zcl_type": "uint32",
              "unsupported": true
            },
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "unsupported": true
            },
            {
              "id": "0x001c",
              "name": "description",
              "zcl_type": "string",
              "unsupported": true
            },
            {
              "id": "0x004a",
              "name": "number_of_states",
              "zcl_type": "uint16",
              "value": 1
            },
            {
              "id": "0x0051",
              "name": "out_of_service",
              "zcl_type": "bool",
              "value": 0
            },
            {
              "id": "0x0055",
              "name": "present_value",
              "zcl_type": "uint16",
              "value": 0
            },
            {
              "id": "0x0067",
              "name": "reliability",
              "zcl_type": "enum8",
              "unsupported": true
            },
            {
              "id": "0xfffe",
              "name": "reporting_status",
              "zcl_type": "enum8",
              "unsupported": true
            },
            {
              "id": "0x000e",
              "name": "state_text",
              "zcl_type": "unk",
              "unsupported": true
            },
            {
              "id": "0x006f",
              "name": "status_flags",
              "zcl_type": "map8",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0xfcc0",
          "endpoint_attribute": "manufacturer_specific",
          "attributes": []
        }
      ],
      "out_clusters": []
    },
    "3": {
      "profile_id": 260,
      "device_type": {
        "name": "COLOR_DIMMABLE_LIGHT",
        "id": 258
      },
      "in_clusters": [
        {
          "cluster_id": "0x0003",
          "endpoint_attribute": "identify",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 1
            },
            {
              "id": "0x0000",
              "name": "identify_time",
              "zcl_type": "uint16",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0004",
          "endpoint_attribute": "groups",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 2
            },
            {
              "id": "0x0000",
              "name": "name_support",
              "zcl_type": "map8",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0005",
          "endpoint_attribute": "scenes",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 2
            },
            {
              "id": "0x0000",
              "name": "count",
              "zcl_type": "uint8",
              "value": 0
            },
            {
              "id": "0x0002",
              "name": "current_group",
              "zcl_type": "uint16",
              "value": 0
            },
            {
              "id": "0x0001",
              "name": "current_scene",
              "zcl_type": "uint8",
              "value": 0
            },
            {
              "id": "0x0004",
              "name": "name_support",
              "zcl_type": "map8",
              "value": 0
            },
            {
              "id": "0x0003",
              "name": "scene_valid",
              "zcl_type": "bool",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0012",
          "endpoint_attribute": "multistate_input",
          "attributes": [
            {
              "id": "0x004a",
              "name": "number_of_states",
              "zcl_type": "uint16",
              "value": 1
            },
            {
              "id": "0x0051",
              "name": "out_of_service",
              "zcl_type": "bool",
              "value": 0
            },
            {
              "id": "0x0055",
              "name": "present_value",
              "zcl_type": "uint16",
              "value": 0
            },
            {
              "id": "0x006f",
              "name": "status_flags",
              "zcl_type": "map8",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0xfcc0",
          "endpoint_attribute": "manufacturer_specific",
          "attributes": []
        }
      ],
      "out_clusters": []
    },
    "4": {
      "profile_id": 260,
      "device_type": {
        "name": "COLOR_DIMMABLE_LIGHT",
        "id": 258
      },
      "in_clusters": [
        {
          "cluster_id": "0x0003",
          "endpoint_attribute": "identify",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 1
            },
            {
              "id": "0x0000",
              "name": "identify_time",
              "zcl_type": "uint16",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0004",
          "endpoint_attribute": "groups",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 2
            },
            {
              "id": "0x0000",
              "name": "name_support",
              "zcl_type": "map8",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0005",
          "endpoint_attribute": "scenes",
          "attributes": [
            {
              "id": "0xfffd",
              "name": "cluster_revision",
              "zcl_type": "uint16",
              "value": 2
            },
            {
              "id": "0x0000",
              "name": "count",
              "zcl_type": "uint8",
              "value": 0
            },
            {
              "id": "0x0002",
              "name": "current_group",
              "zcl_type": "uint16",
              "value": 0
            },
            {
              "id": "0x0001",
              "name": "current_scene",
              "zcl_type": "uint8",
              "value": 0
            },
            {
              "id": "0x0004",
              "name": "name_support",
              "zcl_type": "map8",
              "value": 0
            },
            {
              "id": "0x0003",
              "name": "scene_valid",
              "zcl_type": "bool",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0x0012",
          "endpoint_attribute": "multistate_input",
          "attributes": [
            {
              "id": "0x004a",
              "name": "number_of_states",
              "zcl_type": "uint16",
              "value": 1
            },
            {
              "id": "0x0051",
              "name": "out_of_service",
              "zcl_type": "bool",
              "value": 0
            },
            {
              "id": "0x0055",
              "name": "present_value",
              "zcl_type": "uint16",
              "value": 0
            },
            {
              "id": "0x006f",
              "name": "status_flags",
              "zcl_type": "map8",
              "value": 0
            }
          ]
        },
        {
          "cluster_id": "0xfcc0",
          "endpoint_attribute": "manufacturer_specific",
          "attributes": []
        }
      ],
      "out_clusters": []
    },
    "21": {
      "profile_id": 260,
      "device_type": {
        "name": "ON_OFF_SWITCH",
        "id": 0
      },
      "in_clusters": [
        {
          "cluster_id": "0x000c",
          "endpoint_attribute": "analog_input",
          "attributes": [
            {
              "id": "0x0100",
              "name": "application_type",
              "zcl_type": "uint32",
              "unsupported": true
            },
            {
              "id": "0x001c",
              "name": "description",
              "zcl_type": "string",
              "unsupported": true
            },
            {
              "id": "0x0075",
              "name": "engineering_units",
              "zcl_type": "enum16",
              "unsupported": true
            },
            {
              "id": "0x0041",
              "name": "max_present_value",
              "zcl_type": "single",
              "unsupported": true
            },
            {
              "id": "0x0045",
              "name": "min_present_value",
              "zcl_type": "single",
              "unsupported": true
            },
            {
              "id": "0x0051",
              "name": "out_of_service",
              "zcl_type": "bool",
              "value": 0
            },
            {
              "id": "0x0055",
              "name": "present_value",
              "zcl_type": "single",
              "value": 0.0
            },
            {
              "id": "0x0067",
              "name": "reliability",
              "zcl_type": "enum8",
              "unsupported": true
            },
            {
              "id": "0x006a",
              "name": "resolution",
              "zcl_type": "single",
              "unsupported": true
            },
            {
              "id": "0x006f",
              "name": "status_flags",
              "zcl_type": "map8",
              "value": 0
            }
          ]
        }
      ],
      "out_clusters": []
    }
  },
  "zha_lib_entities": {
    "button": [
      {
        "info_object": {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "button",
          "class_name": "IdentifyButton",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "identify",
          "state_class": null,
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "cluster_handlers": [
            {
              "class_name": "IdentifyClusterHandler",
              "generic_id": "cluster_handler_0x0003",
              "endpoint_id": 4,
              "cluster": {
                "id": 3,
                "name": "Identify",
                "type": "server"
              },
              "id": "4:0x0003",
              "unique_id": "**REDACTED**",
              "status": "INITIALIZED",
              "value_attribute": null
            }
          ],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 4,
          "available": true,
          "group_id": null,
          "command": "identify",
          "args": [
            5
          ],
          "kwargs": {}
        },
        "state": {
          "class_name": "IdentifyButton",
          "available": true
        }
      }
    ],
    "light": [
      {
        "info_object": {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "light",
          "class_name": "Light",
          "translation_key": "light",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": null,
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "cluster_handlers": [
            {
              "class_name": "OnOffClusterHandler",
              "generic_id": "cluster_handler_0x0006",
              "endpoint_id": 1,
              "cluster": {
                "id": 6,
                "name": "On/Off",
                "type": "server"
              },
              "id": "1:0x0006",
              "unique_id": "**REDACTED**",
              "status": "INITIALIZED",
              "value_attribute": "on_off"
            }
          ],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "effect_list": [
            "off"
          ],
          "supported_features": 8,
          "min_mireds": 153,
          "max_mireds": 500
        },
        "state": {
          "class_name": "Light",
          "available": true,
          "on": false,
          "brightness": null,
          "xy_color": null,
          "color_temp": null,
          "effect_list": [
            "off"
          ],
          "effect": "off",
          "supported_features": 8,
          "color_mode": "onoff",
          "supported_color_modes": [
            "onoff"
          ],
          "off_with_transition": false,
          "off_brightness": null
        },
        "extra_state_attributes": [
          "off_brightness",
          "off_with_transition"
        ]
      },
      {
        "info_object": {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "light",
          "class_name": "Light",
          "translation_key": "light",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": null,
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "cluster_handlers": [
            {
              "class_name": "OnOffClusterHandler",
              "generic_id": "cluster_handler_0x0006",
              "endpoint_id": 2,
              "cluster": {
                "id": 6,
                "name": "On/Off",
                "type": "server"
              },
              "id": "2:0x0006",
              "unique_id": "**REDACTED**",
              "status": "INITIALIZED",
              "value_attribute": "on_off"
            }
          ],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 2,
          "available": true,
          "group_id": null,
          "effect_list": [
            "off"
          ],
          "supported_features": 8,
          "min_mireds": 153,
          "max_mireds": 500
        },
        "state": {
          "class_name": "Light",
          "available": true,
          "on": false,
          "brightness": null,
          "xy_color": null,
          "color_temp": null,
          "effect_list": [
            "off"
          ],
          "effect": "off",
          "supported_features": 8,
          "color_mode": "onoff",
          "supported_color_modes": [
            "onoff"
          ],
          "off_with_transition": false,
          "off_brightness": null
        },
        "extra_state_attributes": [
          "off_brightness",
          "off_with_transition"
        ]
      }
    ],
    "sensor": [
      {
        "info_object": {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "LQISensor",
          "translation_key": "lqi",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": "measurement",
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": false,
          "enabled": true,
          "primary": false,
          "cluster_handlers": [
            {
              "class_name": "BasicClusterHandler",
              "generic_id": "cluster_handler_0x0000",
              "endpoint_id": 1,
              "cluster": {
                "id": 0,
                "name": "Basic",
                "type": "server"
              },
              "id": "1:0x0000",
              "unique_id": "**REDACTED**",
              "status": "INITIALIZED",
              "value_attribute": null
            }
          ],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "suggested_display_precision": null,
          "unit": null
        },
        "state": {
          "class_name": "LQISensor",
          "available": true,
          "state": 100
        }
      },
      {
        "info_object": {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "RSSISensor",
          "translation_key": "rssi",
          "translation_placeholders": null,
          "device_class": "signal_strength",
          "state_class": "measurement",
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": false,
          "enabled": true,
          "primary": false,
          "cluster_handlers": [
            {
              "class_name": "BasicClusterHandler",
              "generic_id": "cluster_handler_0x0000",
              "endpoint_id": 1,
              "cluster": {
                "id": 0,
                "name": "Basic",
                "type": "server"
              },
              "id": "1:0x0000",
              "unique_id": "**REDACTED**",
              "status": "INITIALIZED",
              "value_attribute": null
            }
          ],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "suggested_display_precision": null,
          "unit": "dBm"
        },
        "state": {
          "class_name": "RSSISensor",
          "available": true,
          "state": -75
        }
      },
      {
        "info_object": {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "SmartEnergySummation",
          "translation_key": "summation_delivered",
          "translation_placeholders": null,
          "device_class": "energy",
          "state_class": "total_increasing",
          "entity_category": null,
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "cluster_handlers": [
            {
              "class_name": "MeteringClusterHandler",
              "generic_id": "cluster_handler_0x0702",
              "endpoint_id": 1,
              "cluster": {
                "id": 1794,
                "name": "Metering",
                "type": "server"
              },
              "id": "1:0x0702",
              "unique_id": "**REDACTED**",
              "status": "INITIALIZED",
              "value_attribute": "instantaneous_demand"
            }
          ],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "suggested_display_precision": 3,
          "unit": "kWh"
        },
        "state": {
          "class_name": "SmartEnergySummation",
          "available": true,
          "state": 0.0,
          "device_type": "Electric Metering",
          "zcl_unit_of_measurement": 0
        },
        "extra_state_attributes": [
          "device_type",
          "status",
          "zcl_unit_of_measurement"
        ]
      },
      {
        "info_object": {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "PolledElectricalMeasurement",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "power",
          "state_class": "measurement",
          "entity_category": null,
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "cluster_handlers": [
            {
              "class_name": "ElectricalMeasurementClusterHandler",
              "generic_id": "cluster_handler_0x0b04",
              "endpoint_id": 1,
              "cluster": {
                "id": 2820,
                "name": "Electrical Measurement",
                "type": "server"
              },
              "id": "1:0x0b04",
              "unique_id": "**REDACTED**",
              "status": "INITIALIZED",
              "value_attribute": "ac_voltage_multiplier"
            }
          ],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "suggested_display_precision": 1,
          "unit": "W"
        },
        "state": {
          "class_name": "PolledElectricalMeasurement",
          "available": true,
          "state": 0.0,
          "measurement_type": "ACTIVE_MEASUREMENT"
        },
        "extra_state_attributes": [
          "active_power_max",
          "measurement_type"
        ]
      }
    ],
    "update": [
      {
        "info_object": {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "update",
          "class_name": "FirmwareUpdateEntity",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "firmware",
          "state_class": null,
          "entity_category": "config",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "cluster_handlers": [
            {
              "class_name": "OtaClientClusterHandler",
              "generic_id": "cluster_handler_0x0019_client",
              "endpoint_id": 1,
              "cluster": {
                "id": 25,
                "name": "Ota",
                "type": "client"
              },
              "id": "1:0x0019_client",
              "unique_id": "**REDACTED**",
              "status": "INITIALIZED",
              "value_attribute": null
            }
          ],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "supported_features": 7
        },
        "state": {
          "class_name": "FirmwareUpdateEntity",
          "available": true,
          "installed_version": "0x00000d25",
          "in_progress": false,
          "update_percentage": null,
          "latest_version": null,
          "release_summary": null,
          "release_notes": null,
          "release_url": null
        }
      }
    ]
  },
  "neighbors": [
    {
      "device_type": "Coordinator",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x0000",
      "permit_joining": "Unknown",
      "depth": 0,
      "lqi": 103
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x0240",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 45
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x4458",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 80
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Parent",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x446C",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 131
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x4C73",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 131
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x5A38",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 90
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x658C",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 14
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x6668",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 72
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x8C76",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 76
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x90B1",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 86
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x921E",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 62
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x9360",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 61
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0x98AA",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 109
    },
    {
      "device_type": "Router",
      "rx_on_when_idle": "On",
      "relationship": "Sibling",
      "extended_pan_id": "**REDACTED**",
      "ieee": "**REDACTED**",
      "nwk": "0xD531",
      "permit_joining": "Unknown",
      "depth": 15,
      "lqi": 68
    }
  ],
  "routes": [
    {
      "dest_nwk": "0x0000",
      "route_status": "Active",
      "memory_constrained": false,
      "many_to_one": false,
      "route_record_required": false,
      "next_hop": "0x0000"
    }
  ]
}
</details>

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
