### PR TITLE
Add Tuya ZTH13 temperature sensor `_TZE204_kwi6bbk4` variant

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -312,6 +312,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE284_upagmta9", "TS0601")
     .applies_to("_TZE204_1wnh8bqp", "TS0601")
     .applies_to("_TZE284_1wnh8bqp", "TS0601")
+    .applies_to("_TZE204_kwi6bbk4", "TS0601")
     .tuya_temperature(dp_id=1, scale=10)
     .tuya_humidity(dp_id=2)
     .tuya_dp(


### PR DESCRIPTION
## Proposed change

Add support for the tuya ZTH13 temperature and humidity sensor

## Additional information

Uses the same mapping as the existing sensors. Appears to be identical to ZTH11 except that ZTH13 also has an LCD display.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
