### PR TITLE
Add Tuya TS0601 cover _TZE284_2gi1hy8s

### DIFF
--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -1,6 +1,9 @@
 """Test units for Tuya covers."""
 
-from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601
+from zhaquirks.tuya.ts0601_cover import (
+    TuyaMoesCover0601,
+    TuyaZemismartSmartCover0601_TZE284,
+)
 
 
 def test_ts601_moes_signature(assert_signature_matches_quirk):
@@ -20,3 +23,22 @@ def test_ts601_moes_signature(assert_signature_matches_quirk):
         "class": "zigpy.device.Device",
     }
     assert_signature_matches_quirk(TuyaMoesCover0601, signature)
+
+
+def test_ts0601_TZE284_signature(assert_signature_matches_quirk):
+    """Test TS0601_TZE284 cover signature is matched to its quirk."""
+    signature = {
+        "node_descriptor": "<NodeDescriptor byte1=2 byte2=0 mac_capability_flags=128 manufacturer_code=4417 maximum_buffer_size=66 maximum_incoming_transfer_size=66 server_mask=10752 maximum_outgoing_transfer_size=66 descriptor_capability_field=0>",
+        "endpoints": {
+            "1": {
+                "profile_id": 0x0104,
+                "device_type": "0x0051",
+                "in_clusters": ["0x0000", "0x0004", "0x0005", "0xed00", "0xef00"],
+                "out_clusters": ["0x000a", "0x0019"],
+            }
+        },
+        "manufacturer": "_TZE284_2gi1hy8s",
+        "model": "TS0601",
+        "class": "zigpy.device.Device",
+    }
+    assert_signature_matches_quirk(TuyaZemismartSmartCover0601_TZE284, signature)

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -12,6 +12,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import (
+    TUYA_CLUSTER_ED00_ID,
     TuyaManufacturerWindowCover,
     TuyaManufCluster,
     TuyaWindowCover,
@@ -344,6 +345,51 @@ class TuyaZemismartSmartCover0601_2_inv_position(TuyaWindowCover):
                     TuyaWindowCoverControl,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }
+
+
+class TuyaZemismartSmartCover0601_TZE284(TuyaWindowCover):
+    """Tuya Zemismart blind cover motor."""
+
+    signature = {
+        # "node_descriptor": "<NodeDescriptor byte1=2 byte2=0 mac_capability_flags=128 manufacturer_code=4417
+        #                       maximum_buffer_size=66 maximum_incoming_transfer_size=66 server_mask=10752
+        #                       maximum_outgoing_transfer_size=66 descriptor_capability_field=0>",
+        # input_clusters=[0x0000, 0x0004, 0x0005, 0xed00, 0xef00]
+        # output_clusters=[0x000a,0x0019]
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=81 input_clusters=[0, 4, 5, 60672, 61184] output_clusters=[10, 25]>
+        MODELS_INFO: [
+            ("_TZE284_2gi1hy8s", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TUYA_CLUSTER_ED00_ID,
+                    TuyaManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufacturerWindowCover,
+                    TuyaWindowCoverControl,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
         },
     }


### PR DESCRIPTION
## Proposed change
Adding support for another tuya smart cover variant 0601 TZE284_2gi1hy8s.

## Additional information
The device doesn't work without this quirk. Only basic TS0601 data is present (RSSI and LQI) and no controls are available. This quirk adds support for moving the cover up, down and stopping it.

Resolves https://github.com/zigpy/zha-device-handlers/issues/4149 and https://github.com/zigpy/zha-device-handlers/issues/4173.

## Device diagnostics
[zha-01KFQKDWR91907PZJRPZYPVHTZ-_TZE284_2gi1hy8s TS0601-3393db88981df66af67585ebb74a0d3f.json](https://github.com/user-attachments/files/24837256/zha-01KFQKDWR91907PZJRPZYPVHTZ-_TZE284_2gi1hy8s.TS0601-3393db88981df66af67585ebb74a0d3f.json)



## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
