### PR TITLE
Add Tuya ceiling fan controller _TZE284_z5jz7wpo

### DIFF
--- a/zhaquirks/tuya/ts0601_fan.py
+++ b/zhaquirks/tuya/ts0601_fan.py
@@ -1,8 +1,9 @@
 from zigpy.quirks.v2 import EntityType
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
-from zhaquirks.tuya.builder import TuyaQuirkBuilder
 import zigpy.types as t
+
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
 class PowerOnState(t.enum8):
@@ -20,6 +21,7 @@ class FanSpeed(t.enum8):
     Level_3 = 0x02
     Level_4 = 0x03
     Level_5 = 0x04
+
 
 (
     TuyaQuirkBuilder("_TZE284_z5jz7wpo", "TS0601")

--- a/zhaquirks/tuya/ts0601_fan.py
+++ b/zhaquirks/tuya/ts0601_fan.py
@@ -1,4 +1,5 @@
 """Tuya fan control."""
+
 from zigpy.quirks.v2 import EntityType
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass

--- a/zhaquirks/tuya/ts0601_fan.py
+++ b/zhaquirks/tuya/ts0601_fan.py
@@ -1,3 +1,4 @@
+"""Tuya fan control."""
 from zigpy.quirks.v2 import EntityType
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
@@ -65,14 +66,14 @@ class FanSpeed(t.enum8):
         max_value=43200,
         step=1,
         translation_key="timer_duration",
-        fallback_name="timer",
+        fallback_name="Timer duration",
     )
     .tuya_enum(  # The app offers three states: on, off and remember last state. The latter does not work, so I don't offer it.
         dp_id=11,
         attribute_name="power_on_state",
         enum_class=PowerOnState,
         translation_key="power_on_state",
-        fallback_name="Power On State",
+        fallback_name="Power on state",
     )
     # According to the Tuya-App (when paired to a Tuya-gateway) and the guide to find DPs (https://www.zigbee2mqtt.io/advanced/support-new-devices/03_find_tuya_data_points.html),
     # the device offers two more DPs (both are also not available in Zigbee2Mqtt)

--- a/zhaquirks/tuya/ts0601_fan.py
+++ b/zhaquirks/tuya/ts0601_fan.py
@@ -1,6 +1,7 @@
 from zigpy.quirks.v2 import EntityType
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
 import zigpy.types as t
 
 
@@ -12,16 +13,13 @@ class PowerOnState(t.enum8):
 
 
 class FanSpeed(t.enum8):
-    """Enum for the fan's speed"""
+    """Enum for the fan's speed."""
 
     Level_1 = 0x00
     Level_2 = 0x01
     Level_3 = 0x02
     Level_4 = 0x03
     Level_5 = 0x04
-
-
-from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 (
     TuyaQuirkBuilder("_TZE284_z5jz7wpo", "TS0601")
@@ -37,7 +35,7 @@ from zhaquirks.tuya.builder import TuyaQuirkBuilder
         attribute_name="speed",
         enum_class=FanSpeed,
         translation_key="speed",
-        fallback_name="fan speed",
+        fallback_name="Speed",
         entity_type=EntityType.STANDARD,
     )
     # I tried using a "tuya_number" instead of a tuya_enum. The following displayed the value correctly (even though one off from the device's display), but does not let me set the value via ZHA.

--- a/zhaquirks/tuya/ts0601_fan.py
+++ b/zhaquirks/tuya/ts0601_fan.py
@@ -1,0 +1,78 @@
+from zigpy.quirks.v2 import EntityType
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+from zigpy.quirks.v2.homeassistant import UnitOfTime, EntityPlatform
+import zigpy.types as t
+
+class PowerOnState(t.enum8):
+    """Tuya power on state enum."""
+    Off = 0x00
+    On = 0x01
+    
+class FanSpeed(t.enum8):
+    """Enum for the fan's speed"""
+    Level_1 = 0x00
+    Level_2 = 0x01
+    Level_3 = 0x02
+    Level_4 = 0x03
+    Level_5 = 0x04
+    
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+(
+    TuyaQuirkBuilder("_TZE284_z5jz7wpo", "TS0601")
+    .tuya_switch(#Fan switch
+        dp_id=1,
+        attribute_name="on_off",
+        entity_type=EntityType.STANDARD,
+        translation_key="switch",
+        fallback_name="switch",
+    )
+    .tuya_enum(#Fan speed. Unfortunately, when the device is turned by changing this value, the "on_off"-value does not change accordingly. In the Tuya-app, it is not possible to change the fan's speed when the device is turned off. Thus this issue does not matter to them.
+        dp_id=3,
+        attribute_name="speed",
+        enum_class=FanSpeed,
+        translation_key="speed",
+        fallback_name="fan speed",
+        entity_type=EntityType.STANDARD,
+    )
+#   I tried using a "tuya_number" instead of a tuya_enum. The following displayed the value correctly (even though one off from the device's display), but does not let me set the value via ZHA.
+#    .tuya_number(
+#        dp_id=3,
+#        attribute_name="speed",
+#        type=t.uint16_t,
+#        entity_type=EntityType.STANDARD,
+#        device_class=NumberDeviceClass.SPEED,
+#        unit=None,
+#        min_value=0,
+#        max_value=4,
+#        step=1,
+#        translation_key="speed",
+#        fallback_name="fan speed",
+#    )
+    .tuya_number(#Fan countdown -> after a certain number of seconds, the device will change toggle the on-off-state. If it is toggled by some other source in the meantime, the countdown is deactivated.
+        dp_id=2,
+        attribute_name="timer_duration",
+        type=t.uint16_t,
+        entity_type=EntityType.STANDARD,
+        device_class=NumberDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        min_value=0,
+        max_value=43200,
+        step=1,
+        translation_key="timer_duration",
+        fallback_name="timer",
+    )
+    .tuya_enum(#The app offers three states: on, off and remember last state. The latter does not work, so I don't offer it.
+        dp_id=11,
+        attribute_name="power_on_state",
+        enum_class=PowerOnState,
+        translation_key="power_on_state",
+        fallback_name="Power On State",
+    )
+#According to the Tuya-App (when paired to a Tuya-gateway) and the guide to find DPs (https://www.zigbee2mqtt.io/advanced/support-new-devices/03_find_tuya_data_points.html),
+#the device offers two more DPs (both are also not available in Zigbee2Mqtt)
+#10 ("Mode"): This has only one possible value: "white". There is no reason to include it.
+#12 ("Indicator status setting"): It has three values in the App: "Indicator off", "Indicate on/off status (The status of the indicator signals that the fan is on or off)", "Indicate switch position (When the fan is off, it can indicate the position of the switch at night)". This setting seems to not be working at all. This setting does not work. It does not change anything on the device.
+    .skip_configuration()
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0601_fan.py
+++ b/zhaquirks/tuya/ts0601_fan.py
@@ -3,31 +3,36 @@ from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 from zigpy.quirks.v2.homeassistant import UnitOfTime, EntityPlatform
 import zigpy.types as t
 
+
 class PowerOnState(t.enum8):
     """Tuya power on state enum."""
+
     Off = 0x00
     On = 0x01
-    
+
+
 class FanSpeed(t.enum8):
     """Enum for the fan's speed"""
+
     Level_1 = 0x00
     Level_2 = 0x01
     Level_3 = 0x02
     Level_4 = 0x03
     Level_5 = 0x04
-    
+
+
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 (
     TuyaQuirkBuilder("_TZE284_z5jz7wpo", "TS0601")
-    .tuya_switch(#Fan switch
+    .tuya_switch(  # Fan switch
         dp_id=1,
         attribute_name="on_off",
         entity_type=EntityType.STANDARD,
         translation_key="switch",
         fallback_name="switch",
     )
-    .tuya_enum(#Fan speed. Unfortunately, when the device is turned by changing this value, the "on_off"-value does not change accordingly. In the Tuya-app, it is not possible to change the fan's speed when the device is turned off. Thus this issue does not matter to them.
+    .tuya_enum(  # Fan speed. Unfortunately, when the device is turned by changing this value, the "on_off"-value does not change accordingly. In the Tuya-app, it is not possible to change the fan's speed when the device is turned off. Thus this issue does not matter to them.
         dp_id=3,
         attribute_name="speed",
         enum_class=FanSpeed,
@@ -35,21 +40,21 @@ from zhaquirks.tuya.builder import TuyaQuirkBuilder
         fallback_name="fan speed",
         entity_type=EntityType.STANDARD,
     )
-#   I tried using a "tuya_number" instead of a tuya_enum. The following displayed the value correctly (even though one off from the device's display), but does not let me set the value via ZHA.
-#    .tuya_number(
-#        dp_id=3,
-#        attribute_name="speed",
-#        type=t.uint16_t,
-#        entity_type=EntityType.STANDARD,
-#        device_class=NumberDeviceClass.SPEED,
-#        unit=None,
-#        min_value=0,
-#        max_value=4,
-#        step=1,
-#        translation_key="speed",
-#        fallback_name="fan speed",
-#    )
-    .tuya_number(#Fan countdown -> after a certain number of seconds, the device will change toggle the on-off-state. If it is toggled by some other source in the meantime, the countdown is deactivated.
+    # I tried using a "tuya_number" instead of a tuya_enum. The following displayed the value correctly (even though one off from the device's display), but does not let me set the value via ZHA.
+    # .tuya_number(
+    #    dp_id=3,
+    #    attribute_name="speed",
+    #    type=t.uint16_t,
+    #    entity_type=EntityType.STANDARD,
+    #    device_class=NumberDeviceClass.SPEED,
+    #    unit=None,
+    #    min_value=0,
+    #    max_value=4,
+    #    step=1,
+    #    translation_key="speed",
+    #    fallback_name="fan speed",
+    # )
+    .tuya_number(  # Fan countdown -> after a certain number of seconds, the device will change toggle the on-off-state. If it is toggled by some other source in the meantime, the countdown is deactivated.
         dp_id=2,
         attribute_name="timer_duration",
         type=t.uint16_t,
@@ -62,17 +67,17 @@ from zhaquirks.tuya.builder import TuyaQuirkBuilder
         translation_key="timer_duration",
         fallback_name="timer",
     )
-    .tuya_enum(#The app offers three states: on, off and remember last state. The latter does not work, so I don't offer it.
+    .tuya_enum(  # The app offers three states: on, off and remember last state. The latter does not work, so I don't offer it.
         dp_id=11,
         attribute_name="power_on_state",
         enum_class=PowerOnState,
         translation_key="power_on_state",
         fallback_name="Power On State",
     )
-#According to the Tuya-App (when paired to a Tuya-gateway) and the guide to find DPs (https://www.zigbee2mqtt.io/advanced/support-new-devices/03_find_tuya_data_points.html),
-#the device offers two more DPs (both are also not available in Zigbee2Mqtt)
-#10 ("Mode"): This has only one possible value: "white". There is no reason to include it.
-#12 ("Indicator status setting"): It has three values in the App: "Indicator off", "Indicate on/off status (The status of the indicator signals that the fan is on or off)", "Indicate switch position (When the fan is off, it can indicate the position of the switch at night)". This setting seems to not be working at all. This setting does not work. It does not change anything on the device.
+    # According to the Tuya-App (when paired to a Tuya-gateway) and the guide to find DPs (https://www.zigbee2mqtt.io/advanced/support-new-devices/03_find_tuya_data_points.html),
+    # the device offers two more DPs (both are also not available in Zigbee2Mqtt)
+    # 10 ("Mode"): This has only one possible value: "white". There is no reason to include it.
+    # 12 ("Indicator status setting"): It has three values in the App: "Indicator off", "Indicate on/off status (The status of the indicator signals that the fan is on or off)", "Indicate switch position (When the fan is off, it can indicate the position of the switch at night)". This setting seems to not be working at all. This setting does not work. It does not change anything on the device.
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0601_fan.py
+++ b/zhaquirks/tuya/ts0601_fan.py
@@ -1,6 +1,6 @@
 from zigpy.quirks.v2 import EntityType
+from zigpy.quirks.v2.homeassistant import UnitOfTime
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
-from zigpy.quirks.v2.homeassistant import UnitOfTime, EntityPlatform
 import zigpy.types as t
 
 


### PR DESCRIPTION
## Proposed change
Add support for this device:
https://www.zigbee2mqtt.io/devices/TS0601_fan_switch.html

## Additional information
The device has been supported by Zig2Mqtt for some time now, but not by ZHA. I joind it to a tuya-gateway for completeness according to this manual: https://www.zigbee2mqtt.io/advanced/support-new-devices/03_find_tuya_data_points.html
The device is working fine in my HA now.

## Device diagnostics
[zha-368b6756705a757ba91d12d0b22cd937-_TZE284_z5jz7wpo TS0601-7d76fa6f216c3ebfb4a7da23a4b00de1.json](https://github.com/user-attachments/files/24840446/zha-368b6756705a757ba91d12d0b22cd937-_TZE284_z5jz7wpo.TS0601-7d76fa6f216c3ebfb4a7da23a4b00de1.json)


## Checklist
- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [X] Device diagnostics data has been attached