### PR TITLE
Use LocalDataCluster for TS130F covering cluster

### DIFF
--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -5,6 +5,7 @@ from typing import Final
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -18,6 +19,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.foundation import ZCLAttributeDef
 
+from zhaquirks import LocalDataCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -48,8 +50,14 @@ class MotorMode(t.enum8):
     WEAK_MOTOR = 0x01
 
 
-class TuyaCoveringCluster(CustomCluster, WindowCovering):
-    """TuyaSmartCurtainWindowCoveringCluster: Allow to setup Window covering tuya devices."""
+class TuyaCoveringCluster(LocalDataCluster, WindowCovering):
+    """TuyaSmartCurtainWindowCoveringCluster: Allow to setup Window covering tuya devices.
+
+    Uses LocalDataCluster to prevent reading attributes from the device, as some
+    Tuya TS130F variants return stale/incorrect values when attributes are read
+    directly. Instead, we rely on attribute reports from the device and cache them
+    locally. See https://github.com/zigpy/zha-device-handlers/issues/2676
+    """
 
     class AttributeDefs(WindowCovering.AttributeDefs):
         """Attribute definitions."""
@@ -65,6 +73,20 @@ class TuyaCoveringCluster(CustomCluster, WindowCovering):
             # Invert the percentage value (cf https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3757)
             value = 100 - value
         super()._update_attribute(attrid, value)
+
+    async def read_attributes_raw(self, attributes, manufacturer=None, **kwargs):
+        """Un-invert percent lift value when reading attributes from cache."""
+        records = await super().read_attributes_raw(
+            attributes, manufacturer=manufacturer, **kwargs
+        )
+        for record in records[0]:
+            if (
+                record.attrid == ATTR_CURRENT_POSITION_LIFT_PERCENTAGE
+                and record.status == foundation.Status.SUCCESS
+                and record.value.value is not None
+            ):
+                record.value.value = 100 - record.value.value
+        return records
 
     async def command(
         self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
While the position reported while moving is fine, the device always reports 100 when reading the cover position attribute. To fix this we need to use the LocalDataCluster.

Fixes #2676


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
