### PR TITLE
Bump zigpy to 0.91.3 and adjust quirks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "David F. Mulcahey", email = "david.mulcahey@icloud.com" }]
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.12"
-dependencies = ["zigpy>=0.91.0"]
+dependencies = ["zigpy>=0.91.3"]
 
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]

--- a/uv.lock
+++ b/uv.lock
@@ -1321,7 +1321,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "zigpy", specifier = ">=0.91.0" }]
+requires-dist = [{ name = "zigpy", specifier = ">=0.91.3" }]
 
 [package.metadata.requires-dev]
 ci = [
@@ -1347,7 +1347,7 @@ dev = [
 
 [[package]]
 name = "zigpy"
-version = "0.91.0"
+version = "0.91.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1361,7 +1361,7 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "voluptuous" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/32/87d5723e840bea973522ec2dbdd4e35e1f9b3622f16c4ef91ca7487dc550/zigpy-0.91.0.tar.gz", hash = "sha256:3f43cb2d2b1dfdc2a1de185be3365bd0d9c0712999f2301a49eb4a8beca5cbab", size = 322520, upload-time = "2026-01-27T23:14:58.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/af/47b5dcb583f1f97dc8db9881c2939e36bcfffc31e0ada7e27e0edf48674a/zigpy-0.91.3.tar.gz", hash = "sha256:1e9ab28e762493aa5b5c8f5d7ffc4264d01697ebd85fe0ab5fdef8dddf72e6f4", size = 325403, upload-time = "2026-01-29T18:20:02.662Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/63/9d7f3a476490385a0c330f8f362014f8afa6f46515df588659b712d3de04/zigpy-0.91.0-py3-none-any.whl", hash = "sha256:dadfe7cf68edd4efaff2021b551ef040b4393abf219eff11e4f815174c529a74", size = 246454, upload-time = "2026-01-27T23:14:57.404Z" },
+    { url = "https://files.pythonhosted.org/packages/85/03/caf84ca151c647d645189da76fdd761c2c4dd7cc637da2213bf8e03470b6/zigpy-0.91.3-py3-none-any.whl", hash = "sha256:228c90dfbc4e5b001d687606b02c6c2508c0b3f074ce8ea07d13030701e96313", size = 247625, upload-time = "2026-01-29T18:20:00.788Z" },
 ]

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -7,6 +7,7 @@ from zigpy.quirks.v2 import QuirkBuilder, ReportingConfig
 from zigpy.quirks.v2.homeassistant import EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
+from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.hvac import (
     ControlSequenceOfOperation,
@@ -189,8 +190,11 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         )
 
     async def write_attributes(
-        self, attributes: dict[str | int, Any], manufacturer: int | None = None
-    ) -> list:
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """system_mode special handling.
 
         - turn off by setting operating_mode to Pause
@@ -303,11 +307,12 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
 
     async def read_attributes(
         self,
-        attributes: list[int | str],
+        attributes: list[int | str | foundation.ZCLAttributeDef],
         allow_cache: bool = False,
         only_cache: bool = False,
-        manufacturer: int | t.uint16_t | None = None,
-    ):
+        manufacturer: int | UndefinedType | None = UNDEFINED,
+        **kwargs,
+    ) -> Any:
         """system_mode special handling.
 
         - read and convert operating_mode to system_mode.

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -7,7 +7,6 @@ from zigpy.quirks.v2 import QuirkBuilder, ReportingConfig
 from zigpy.quirks.v2.homeassistant import EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
-from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.hvac import (
     ControlSequenceOfOperation,
@@ -192,7 +191,6 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
     async def write_attributes(
         self,
         attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
-        manufacturer: int | UndefinedType | None = UNDEFINED,
         **kwargs,
     ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """system_mode special handling.
@@ -242,7 +240,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
                 system_mode_value
             ]
             result += await super().write_attributes(
-                {operating_mode_attr.id: new_operating_mode_value}, manufacturer
+                {operating_mode_attr.id: new_operating_mode_value}, **kwargs
             )
             self._update_attribute(SYSTEM_MODE_ATTR.id, system_mode_value)
         elif operating_mode_value is not None:
@@ -256,7 +254,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
                     Thermostat.AttributeDefs.ctrl_sequence_of_oper
                 )
                 successful_r, failed_r = await super().read_attributes(
-                    [ctrl_sequence_of_oper_attr.name], True, False, manufacturer
+                    [ctrl_sequence_of_oper_attr.name], True, False, **kwargs
                 )
                 if ctrl_sequence_of_oper_attr.name in successful_r:
                     ctrl_sequence_of_oper_value = successful_r.pop(
@@ -282,7 +280,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
                 )
                 if ctrl_sequence_of_oper_value is not None:
                     successful_r, failed_r = await super().read_attributes(
-                        [operating_mode_attr.name], True, False, manufacturer
+                        [operating_mode_attr.name], True, False, **kwargs
                     )
                     if operating_mode_attr.name in successful_r:
                         operating_mode_attr_value = successful_r.pop(
@@ -302,7 +300,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
 
         """Write the remaining attributes to thermostat cluster."""
         if remaining_attributes:
-            result += await super().write_attributes(remaining_attributes, manufacturer)
+            result += await super().write_attributes(remaining_attributes, **kwargs)
         return result
 
     async def read_attributes(
@@ -310,7 +308,6 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         attributes: list[int | str | foundation.ZCLAttributeDef],
         allow_cache: bool = False,
         only_cache: bool = False,
-        manufacturer: int | UndefinedType | None = UNDEFINED,
         **kwargs,
     ) -> Any:
         """system_mode special handling.
@@ -338,7 +335,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
                 [operating_mode_attr.name, ctrl_sequence_of_oper_attr.name],
                 allow_cache,
                 only_cache,
-                manufacturer,
+                **kwargs,
             )
             if operating_mode_attr.name in successful_r:
                 operating_mode_value = successful_r.pop(operating_mode_attr.name)
@@ -364,7 +361,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         """Read remaining attributes from thermostat cluster."""
         if remaining_attributes:
             remaining_result = await super().read_attributes(
-                remaining_attributes, allow_cache, only_cache, manufacturer
+                remaining_attributes, allow_cache, only_cache, **kwargs
             )
 
             successful_r.update(remaining_result[0])

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -306,8 +306,6 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
     async def read_attributes(
         self,
         attributes: list[int | str | foundation.ZCLAttributeDef],
-        allow_cache: bool = False,
-        only_cache: bool = False,
         **kwargs,
     ) -> Any:
         """system_mode special handling.
@@ -333,8 +331,6 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
 
             successful_r, failed_r = await super().read_attributes(
                 [operating_mode_attr.name, ctrl_sequence_of_oper_attr.name],
-                allow_cache,
-                only_cache,
                 **kwargs,
             )
             if operating_mode_attr.name in successful_r:
@@ -361,7 +357,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         """Read remaining attributes from thermostat cluster."""
         if remaining_attributes:
             remaining_result = await super().read_attributes(
-                remaining_attributes, allow_cache, only_cache, **kwargs
+                remaining_attributes, **kwargs
             )
 
             successful_r.update(remaining_result[0])

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -7,6 +7,7 @@ import datetime
 from typing import Any, Final
 
 import zigpy.types as t
+from zigpy.typing import UndefinedType
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import LevelControl, OnOff
 from zigpy.zcl.foundation import ZCLAttributeDef
@@ -60,7 +61,7 @@ class TuyaClusterData(t.Struct):
     cluster_attr: str
     attr_value: int  # Maybe also others types?
     expect_reply: bool
-    manufacturer: int | None
+    manufacturer: int | UndefinedType | None
 
 
 class MoesBacklight(t.enum8):

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -78,8 +78,6 @@ class ThermostatCluster(CustomCluster, Thermostat):
     async def read_attributes(
         self,
         attributes: list[int | str | foundation.ZCLAttributeDef],
-        allow_cache: bool = False,
-        only_cache: bool = False,
         **kwargs,
     ):
         """Pass reading attributes to Xiaomi cluster if applicable."""
@@ -96,10 +94,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
                 remaining_attributes.remove("system_mode")
 
             successful_r, failed_r = await self.endpoint.opple_cluster.read_attributes(
-                [SYSTEM_MODE],
-                allow_cache,
-                only_cache,
-                **kwargs,
+                [SYSTEM_MODE], **kwargs
             )
             # convert Xiaomi system_mode to ZCL attribute
             if SYSTEM_MODE in successful_r:
@@ -110,7 +105,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
         # read remaining attributes from thermostat cluster
         if remaining_attributes:
             remaining_result = await super().read_attributes(
-                remaining_attributes, allow_cache, only_cache, **kwargs
+                remaining_attributes, **kwargs
             )
             successful_r.update(remaining_result[0])
             failed_r.update(remaining_result[1])

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -10,6 +10,8 @@ from typing import Any, Final
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
+from zigpy.typing import UNDEFINED, UndefinedType
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, Time
 from zigpy.zcl.clusters.hvac import Thermostat
 from zigpy.zcl.foundation import ZCLAttributeDef
@@ -76,10 +78,13 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
     async def read_attributes(
         self,
-        attributes: list[int | str],
+        attributes: list[int | str | foundation.ZCLAttributeDef],
         allow_cache: bool = False,
         only_cache: bool = False,
-        manufacturer: int | t.uint16_t | None = None,
+        manufacturer: int
+        | t.uint16_t
+        | UndefinedType
+        | None = UNDEFINED,  # Not needed to make tests pass
     ):
         """Pass reading attributes to Xiaomi cluster if applicable."""
         successful_r, failed_r = {}, {}
@@ -95,7 +100,10 @@ class ThermostatCluster(CustomCluster, Thermostat):
                 remaining_attributes.remove("system_mode")
 
             successful_r, failed_r = await self.endpoint.opple_cluster.read_attributes(
-                [SYSTEM_MODE], allow_cache, only_cache, manufacturer
+                [SYSTEM_MODE],
+                allow_cache,
+                only_cache,
+                UNDEFINED,  # This makes test pass
             )
             # convert Xiaomi system_mode to ZCL attribute
             if SYSTEM_MODE in successful_r:

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -10,7 +10,6 @@ from typing import Any, Final
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
-from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, Time
 from zigpy.zcl.clusters.hvac import Thermostat
@@ -81,10 +80,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
         attributes: list[int | str | foundation.ZCLAttributeDef],
         allow_cache: bool = False,
         only_cache: bool = False,
-        manufacturer: int
-        | t.uint16_t
-        | UndefinedType
-        | None = UNDEFINED,  # Not needed to make tests pass
+        **kwargs,
     ):
         """Pass reading attributes to Xiaomi cluster if applicable."""
         successful_r, failed_r = {}, {}
@@ -103,7 +99,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
                 [SYSTEM_MODE],
                 allow_cache,
                 only_cache,
-                UNDEFINED,  # This makes test pass
+                **kwargs,
             )
             # convert Xiaomi system_mode to ZCL attribute
             if SYSTEM_MODE in successful_r:
@@ -114,14 +110,14 @@ class ThermostatCluster(CustomCluster, Thermostat):
         # read remaining attributes from thermostat cluster
         if remaining_attributes:
             remaining_result = await super().read_attributes(
-                remaining_attributes, allow_cache, only_cache, manufacturer
+                remaining_attributes, allow_cache, only_cache, **kwargs
             )
             successful_r.update(remaining_result[0])
             failed_r.update(remaining_result[1])
         return successful_r, failed_r
 
     async def write_attributes(
-        self, attributes: dict[str | int, Any], manufacturer: int | None = None
+        self, attributes: dict[str | int, Any], **kwargs
     ) -> list:
         """Pass writing attributes to Xiaomi cluster if applicable."""
         result = []
@@ -140,14 +136,14 @@ class ThermostatCluster(CustomCluster, Thermostat):
         if system_mode_value is not None:
             self.debug("Passing 'system_mode' write to Xiaomi cluster")
             result += await self.endpoint.opple_cluster.write_attributes(
-                {SYSTEM_MODE: min(int(system_mode_value), 1)}
+                {SYSTEM_MODE: min(int(system_mode_value), 1)}, **kwargs
             )
             # Update the thermostat cluster's cache
             self._update_attribute(ZCL_SYSTEM_MODE, system_mode_value)
 
         # write remaining attributes to thermostat cluster
         if remaining_attributes:
-            result += await super().write_attributes(remaining_attributes, manufacturer)
+            result += await super().write_attributes(remaining_attributes, **kwargs)
         return result
 
 


### PR DESCRIPTION
## Proposed change
This bumps zigpy to [0.91.3](https://github.com/zigpy/zigpy/releases/tag/0.91.3) and adjusts a couple of quirks for the recent change of `read_attributes` and `write_attributes` using `UNDEFINED` as the default for the manufacturer code (meaning: "automatically determine" whether to use or not). Previously, that was `None`.
Instead, `None` now means "override by not sending one".

So far, only quirks that were failing tests were updated. Others should be updated as well, though we should explicitly pass `manufacturer=UNDEFINED` from ZHA when reading and writing attributes to account for older (custom) quirks.

`TuyaClusterData` was also updated to expect `manufacturer=UNDEFINED`. As far as I can see, it's only used internally.

## Additional information
Required for:
- https://github.com/zigpy/zha/pull/637


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
