### PR TITLE
Update read/write_attributes method signatures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "David F. Mulcahey", email = "david.mulcahey@icloud.com" }]
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.12"
-dependencies = ["zigpy>=0.91.3"]
+dependencies = ["zigpy>=0.91.4"]
 
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]

--- a/uv.lock
+++ b/uv.lock
@@ -1321,7 +1321,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "zigpy", specifier = ">=0.91.3" }]
+requires-dist = [{ name = "zigpy", specifier = ">=0.91.4" }]
 
 [package.metadata.requires-dev]
 ci = [
@@ -1347,7 +1347,7 @@ dev = [
 
 [[package]]
 name = "zigpy"
-version = "0.91.3"
+version = "0.91.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1361,7 +1361,7 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "voluptuous" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/af/47b5dcb583f1f97dc8db9881c2939e36bcfffc31e0ada7e27e0edf48674a/zigpy-0.91.3.tar.gz", hash = "sha256:1e9ab28e762493aa5b5c8f5d7ffc4264d01697ebd85fe0ab5fdef8dddf72e6f4", size = 325403, upload-time = "2026-01-29T18:20:02.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/b8/f3cff284d51ae4f412831338bcf7a45bc7d97db99761a00c41a247513612/zigpy-0.91.4.tar.gz", hash = "sha256:d9bddd4e972ba7ff7eac2f4242277f92053468b4313e486542800e4dfa408462", size = 325780, upload-time = "2026-01-29T22:51:15.549Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/03/caf84ca151c647d645189da76fdd761c2c4dd7cc637da2213bf8e03470b6/zigpy-0.91.3-py3-none-any.whl", hash = "sha256:228c90dfbc4e5b001d687606b02c6c2508c0b3f074ce8ea07d13030701e96313", size = 247625, upload-time = "2026-01-29T18:20:00.788Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ca/8fdebf27a277ac90f0210c3b1a623a6b4845bc75581ab2186a09cbb5d54d/zigpy-0.91.4-py3-none-any.whl", hash = "sha256:35daac77d235a9bc7547f2708c40767bdd6d7740a61b5840741b89fcfc555711", size = 247657, upload-time = "2026-01-29T22:51:14.278Z" },
 ]

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -16,6 +16,7 @@ import zigpy.device
 import zigpy.endpoint
 from zigpy.quirks import DEVICE_REGISTRY, CustomCluster, CustomDevice
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.util import ListenableMixin
 from zigpy.zcl import AttributeReportedEvent, AttributeUpdatedEvent, foundation
 from zigpy.zcl.clusters.general import PowerConfiguration
@@ -120,7 +121,7 @@ class LocalDataCluster(CustomCluster):
             records.append(record)
         return records
 
-    async def write_attributes(self, attributes, manufacturer=None, **kwargs):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED, **kwargs):
         """Prevent remote writes."""
         msg = "writing attributes for LocalDataCluster"
         self.debug(f"{msg}: attributes={attributes} manufacturer={manufacturer}")

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -16,7 +16,7 @@ import zigpy.device
 import zigpy.endpoint
 from zigpy.quirks import DEVICE_REGISTRY, CustomCluster, CustomDevice
 import zigpy.types as t
-from zigpy.typing import UNDEFINED
+from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.util import ListenableMixin
 from zigpy.zcl import AttributeReportedEvent, AttributeUpdatedEvent, foundation
 from zigpy.zcl.clusters.general import PowerConfiguration
@@ -121,7 +121,12 @@ class LocalDataCluster(CustomCluster):
             records.append(record)
         return records
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED, **kwargs):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,  # XXX: default in quirks
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Prevent remote writes."""
         msg = "writing attributes for LocalDataCluster"
         self.debug(f"{msg}: attributes={attributes} manufacturer={manufacturer}")

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -137,7 +137,7 @@ class LocalDataCluster(CustomCluster):
                 self.error("%d is not a valid attribute id", attrid)
                 continue
             self._update_attribute(attrid, value)
-        return ([foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],)
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
 
 class EventableCluster(CustomCluster):

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -254,7 +254,10 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
                     Thermostat.AttributeDefs.ctrl_sequence_of_oper
                 )
                 successful_r, failed_r = await super().read_attributes(
-                    [ctrl_sequence_of_oper_attr.name], True, False, **kwargs
+                    [ctrl_sequence_of_oper_attr.name],
+                    allow_cache=True,
+                    only_cache=False,
+                    **kwargs,
                 )
                 if ctrl_sequence_of_oper_attr.name in successful_r:
                     ctrl_sequence_of_oper_value = successful_r.pop(
@@ -280,7 +283,10 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
                 )
                 if ctrl_sequence_of_oper_value is not None:
                     successful_r, failed_r = await super().read_attributes(
-                        [operating_mode_attr.name], True, False, **kwargs
+                        [operating_mode_attr.name],
+                        allow_cache=True,
+                        only_cache=False,
+                        **kwargs,
                     )
                     if operating_mode_attr.name in successful_r:
                         operating_mode_attr_value = successful_r.pop(

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -368,7 +368,7 @@ class DanfossThermostatCluster(CustomizedStandardCluster, Thermostat):
             attributes[system_mode.name] = system_mode.type.Heat
 
         # Attributes cannot be empty, because write_res cannot be empty, but it can contain unrequested items
-        write_res = await super().write_attributes(attributes, **kwargs)
+        write_res = await super().write_attributes(attributes, manufacturer, **kwargs)
 
         if fast_setpoint_change is not None:
             # On Danfoss a fast setpoint change is done through a command

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -36,6 +36,7 @@ from typing import Any
 from zigpy import types
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters.general import (
     Basic,
     Identify,
@@ -337,7 +338,7 @@ class DanfossThermostatCluster(CustomizedStandardCluster, Thermostat):
             id=0x4051, type=types.Bool, access="rw", is_manufacturer_specific=True
         )  # non-configurable reporting
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
         """There are 2 types of setpoint changes: Fast and Slow.
 
         Fast is used for immediate changes; this is done using a command (setpoint_command).

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -36,6 +36,7 @@ from typing import Any
 from zigpy import types
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -341,6 +342,7 @@ class DanfossThermostatCluster(CustomizedStandardCluster, Thermostat):
     async def write_attributes(
         self,
         attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,  # XXX: default in quirks
         **kwargs,
     ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """There are 2 types of setpoint changes: Fast and Slow.
@@ -373,7 +375,7 @@ class DanfossThermostatCluster(CustomizedStandardCluster, Thermostat):
             await self.setpoint_command(
                 DanfossSetpointCommandEnum.User_interaction,
                 fast_setpoint_change,
-                **kwargs,
+                manufacturer=manufacturer,
             )
 
         return write_res

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -36,7 +36,7 @@ from typing import Any
 from zigpy import types
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
-from zigpy.typing import UNDEFINED
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
     Identify,
@@ -338,7 +338,11 @@ class DanfossThermostatCluster(CustomizedStandardCluster, Thermostat):
             id=0x4051, type=types.Bool, access="rw", is_manufacturer_specific=True
         )  # non-configurable reporting
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """There are 2 types of setpoint changes: Fast and Slow.
 
         Fast is used for immediate changes; this is done using a command (setpoint_command).
@@ -362,16 +366,14 @@ class DanfossThermostatCluster(CustomizedStandardCluster, Thermostat):
             attributes[system_mode.name] = system_mode.type.Heat
 
         # Attributes cannot be empty, because write_res cannot be empty, but it can contain unrequested items
-        write_res = await super().write_attributes(
-            attributes, manufacturer=manufacturer
-        )
+        write_res = await super().write_attributes(attributes, **kwargs)
 
         if fast_setpoint_change is not None:
             # On Danfoss a fast setpoint change is done through a command
             await self.setpoint_command(
                 DanfossSetpointCommandEnum.User_interaction,
                 fast_setpoint_change,
-                manufacturer=manufacturer,
+                **kwargs,
             )
 
         return write_res

--- a/zhaquirks/danfoss/thermostat.py
+++ b/zhaquirks/danfoss/thermostat.py
@@ -368,7 +368,11 @@ class DanfossThermostatCluster(CustomizedStandardCluster, Thermostat):
             attributes[system_mode.name] = system_mode.type.Heat
 
         # Attributes cannot be empty, because write_res cannot be empty, but it can contain unrequested items
-        write_res = await super().write_attributes(attributes, manufacturer, **kwargs)
+        write_res = await super().write_attributes(
+            attributes,
+            manufacturer=manufacturer,
+            **kwargs,
+        )
 
         if fast_setpoint_change is not None:
             # On Danfoss a fast setpoint change is done through a command

--- a/zhaquirks/elko/smart_super_thermostat.py
+++ b/zhaquirks/elko/smart_super_thermostat.py
@@ -1,10 +1,10 @@
 """Module to handle quirks of the Elko Smart Super thermostat."""
 
-from typing import Final
+from typing import Any, Final
 
 import zigpy.profiles.zha as zha_p
 import zigpy.types as t
-from zigpy.typing import UNDEFINED
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, Ota, Scenes
 from zigpy.zcl.clusters.hvac import Thermostat
 from zigpy.zcl.foundation import ZCLAttributeDef
@@ -90,7 +90,11 @@ class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
         super().__init__(*args, **kwargs)
         self.active_sensor = None
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Override writes to thermostat attributes."""
         if "system_mode" in attributes:
             val = attributes.get("system_mode")
@@ -105,7 +109,7 @@ class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
             attributes["device_on"] = device_on
             attributes["night_lowering"] = night_lowering
 
-        return await super().write_attributes(attributes, manufacturer=manufacturer)
+        return await super().write_attributes(attributes, **kwargs)
 
     def _update_attribute(self, attrid, value):
         if attrid == HEATING_ACTIVE:

--- a/zhaquirks/elko/smart_super_thermostat.py
+++ b/zhaquirks/elko/smart_super_thermostat.py
@@ -4,6 +4,7 @@ from typing import Final
 
 import zigpy.profiles.zha as zha_p
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, Ota, Scenes
 from zigpy.zcl.clusters.hvac import Thermostat
 from zigpy.zcl.foundation import ZCLAttributeDef
@@ -89,7 +90,7 @@ class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
         super().__init__(*args, **kwargs)
         self.active_sensor = None
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
         """Override writes to thermostat attributes."""
         if "system_mode" in attributes:
             val = attributes.get("system_mode")

--- a/zhaquirks/eurotronic/__init__.py
+++ b/zhaquirks/eurotronic/__init__.py
@@ -5,6 +5,7 @@ from typing import Final
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.hvac import Thermostat
 from zigpy.zcl.foundation import ZCLAttributeDef
@@ -139,7 +140,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
         return success, error
 
-    async def write_attributes(self, attributes, manufacturer=None, **kwargs):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED, **kwargs):
         """Override wrong writes to thermostat attributes."""
         if "system_mode" in attributes:
             host_flags = self._attr_cache.get(HOST_FLAGS_ATTR, 1)

--- a/zhaquirks/eurotronic/__init__.py
+++ b/zhaquirks/eurotronic/__init__.py
@@ -1,11 +1,10 @@
 """Eurotronic devices."""
 
 import logging
-from typing import Final
+from typing import Any, Final
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
-from zigpy.typing import UNDEFINED
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.hvac import Thermostat
 from zigpy.zcl.foundation import ZCLAttributeDef
@@ -140,7 +139,11 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
         return success, error
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED, **kwargs):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Override wrong writes to thermostat attributes."""
         if "system_mode" in attributes:
             host_flags = self._attr_cache.get(HOST_FLAGS_ATTR, 1)
@@ -148,11 +151,13 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
             if attributes.get("system_mode") == 0x0:
                 return await super().write_attributes(
-                    {"host_flags": host_flags | SET_OFF_MODE_FLAG}, MANUFACTURER
+                    {"host_flags": host_flags | SET_OFF_MODE_FLAG},
+                    manufacturer=MANUFACTURER,
                 )
             if attributes.get("system_mode") == 0x4:
                 return await super().write_attributes(
-                    {"host_flags": host_flags | CLR_OFF_MODE_FLAG}, MANUFACTURER
+                    {"host_flags": host_flags | CLR_OFF_MODE_FLAG},
+                    manufacturer=MANUFACTURER,
                 )
 
-        return await super().write_attributes(attributes, manufacturer, **kwargs)
+        return await super().write_attributes(attributes, **kwargs)

--- a/zhaquirks/ikea/starkvind.py
+++ b/zhaquirks/ikea/starkvind.py
@@ -7,7 +7,7 @@ from typing import Any
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
-from zigpy.typing import UNDEFINED
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
@@ -84,17 +84,17 @@ class IkeaAirpurifier(CustomCluster):
         super()._update_attribute(attrid, value)
 
     async def write_attributes(
-        self, attributes: dict[str | int, Any], manufacturer=UNDEFINED
-    ) -> list:
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Override wrong writes to thermostat attributes."""
         if "fan_mode" in attributes:
             fan_mode = attributes.get("fan_mode")
             if fan_mode and fan_mode > 1 and fan_mode < 11:
                 fan_mode = fan_mode * 5
-                return await super().write_attributes(
-                    {"fan_mode": fan_mode}, manufacturer
-                )
-        return await super().write_attributes(attributes, manufacturer)
+                return await super().write_attributes({"fan_mode": fan_mode}, **kwargs)
+        return await super().write_attributes(attributes, **kwargs)
 
 
 class PM25Cluster(CustomCluster, PM25):
@@ -118,27 +118,19 @@ class PM25Cluster(CustomCluster, PM25):
             super()._update_attribute(attrid, value)
 
     async def read_attributes(
-        self, attributes, allow_cache=False, only_cache=False, manufacturer=UNDEFINED
-    ):
+        self,
+        attributes: list[int | str | foundation.ZCLAttributeDef],
+        **kwargs,
+    ) -> Any:
         """Read attributes ZCL foundation command."""
         if "measured_value" in attributes:
             return (
                 await self.endpoint.device.endpoints[1]
                 .in_clusters[64637]
-                .read_attributes(
-                    ["air_quality_25pm"],
-                    allow_cache=allow_cache,
-                    only_cache=only_cache,
-                    manufacturer=manufacturer,
-                )
+                .read_attributes(["air_quality_25pm"], **kwargs)
             )
         else:
-            return await super().read_attributes(
-                attributes,
-                allow_cache=allow_cache,
-                only_cache=only_cache,
-                manufacturer=manufacturer,
-            )
+            return await super().read_attributes(attributes, **kwargs)
 
 
 class IkeaSTARKVIND(CustomDevice):

--- a/zhaquirks/ikea/starkvind.py
+++ b/zhaquirks/ikea/starkvind.py
@@ -7,6 +7,7 @@ from typing import Any
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
@@ -83,7 +84,7 @@ class IkeaAirpurifier(CustomCluster):
         super()._update_attribute(attrid, value)
 
     async def write_attributes(
-        self, attributes: dict[str | int, Any], manufacturer: int | None = None
+        self, attributes: dict[str | int, Any], manufacturer=UNDEFINED
     ) -> list:
         """Override wrong writes to thermostat attributes."""
         if "fan_mode" in attributes:
@@ -117,7 +118,7 @@ class PM25Cluster(CustomCluster, PM25):
             super()._update_attribute(attrid, value)
 
     async def read_attributes(
-        self, attributes, allow_cache=False, only_cache=False, manufacturer=None
+        self, attributes, allow_cache=False, only_cache=False, manufacturer=UNDEFINED
     ):
         """Read attributes ZCL foundation command."""
         if "measured_value" in attributes:

--- a/zhaquirks/legrand/cable_outlet.py
+++ b/zhaquirks/legrand/cable_outlet.py
@@ -5,6 +5,7 @@ from typing import Any
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import EntityType, QuirkBuilder
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
@@ -90,7 +91,7 @@ class LegrandCableOutletCluster(CustomCluster):
     async def write_attributes(
         self,
         attributes: dict[str | int, Any],
-        manufacturer: int | None = None,
+        manufacturer=UNDEFINED,
         **kwargs,
     ) -> list:
         """Write attributes to the cluster."""

--- a/zhaquirks/legrand/cable_outlet.py
+++ b/zhaquirks/legrand/cable_outlet.py
@@ -5,7 +5,8 @@ from typing import Any
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import EntityType, QuirkBuilder
 import zigpy.types as t
-from zigpy.typing import UNDEFINED
+from zigpy.typing import UNDEFINED, UndefinedType
+from zigpy.zcl import foundation
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
@@ -90,10 +91,10 @@ class LegrandCableOutletCluster(CustomCluster):
 
     async def write_attributes(
         self,
-        attributes: dict[str | int, Any],
-        manufacturer=UNDEFINED,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,  # XXX: default in quirks
         **kwargs,
-    ) -> list:
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Write attributes to the cluster."""
 
         attrs = {}
@@ -102,7 +103,7 @@ class LegrandCableOutletCluster(CustomCluster):
             if attr_def == LegrandCableOutletCluster.AttributeDefs.pilot_wire_mode:
                 await self.set_pilot_wire_mode(value, manufacturer=manufacturer)
                 await super().read_attributes([attr], manufacturer=manufacturer)
-        return await super().write_attributes(attrs, manufacturer)
+        return await super().write_attributes(attrs, manufacturer, **kwargs)
 
 
 (

--- a/zhaquirks/legrand/cable_outlet.py
+++ b/zhaquirks/legrand/cable_outlet.py
@@ -103,7 +103,9 @@ class LegrandCableOutletCluster(CustomCluster):
             if attr_def == LegrandCableOutletCluster.AttributeDefs.pilot_wire_mode:
                 await self.set_pilot_wire_mode(value, manufacturer=manufacturer)
                 await super().read_attributes([attr], manufacturer=manufacturer)
-        return await super().write_attributes(attrs, manufacturer=manufacturer, **kwargs)
+        return await super().write_attributes(
+            attrs, manufacturer=manufacturer, **kwargs
+        )
 
 
 (

--- a/zhaquirks/legrand/cable_outlet.py
+++ b/zhaquirks/legrand/cable_outlet.py
@@ -103,7 +103,7 @@ class LegrandCableOutletCluster(CustomCluster):
             if attr_def == LegrandCableOutletCluster.AttributeDefs.pilot_wire_mode:
                 await self.set_pilot_wire_mode(value, manufacturer=manufacturer)
                 await super().read_attributes([attr], manufacturer=manufacturer)
-        return await super().write_attributes(attrs, manufacturer, **kwargs)
+        return await super().write_attributes(attrs, manufacturer=manufacturer, **kwargs)
 
 
 (

--- a/zhaquirks/plaid/soil.py
+++ b/zhaquirks/plaid/soil.py
@@ -1,6 +1,9 @@
 """PLAID SYSTEMS PS-SPRZMS-SLP3 soil moisture sensor."""
 
+from typing import Any
+
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl import foundation
 
 from zhaquirks import PowerConfigurationCluster
 from zhaquirks.plaid import PLAID_SYSTEMS
@@ -25,10 +28,14 @@ class PowerConfigurationClusterMains(PowerConfigurationCluster):
             return self.MAINS_VOLTAGE_ATTR
         return attr
 
-    async def read_attributes(self, attributes, *args, **kwargs):
+    async def read_attributes(
+        self,
+        attributes: list[int | str | foundation.ZCLAttributeDef],
+        **kwargs,
+    ) -> Any:
         """Replace battery voltage with mains voltage."""
         return await super().read_attributes(
-            [self._remap(attr) for attr in attributes], *args, **kwargs
+            [self._remap(attr) for attr in attributes], **kwargs
         )
 
     async def configure_reporting(self, attribute, *args, **kwargs):

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -11,7 +11,7 @@ from typing import Any, Final
 
 from zigpy.quirks import BaseCustomDevice, CustomCluster, CustomDevice
 import zigpy.types as t
-from zigpy.typing import AddressingMode
+from zigpy.typing import UNDEFINED, AddressingMode
 from zigpy.zcl import BaseAttributeDefs, foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import Basic, LevelControl, OnOff, PowerConfiguration
@@ -546,7 +546,7 @@ class TuyaManufClusterAttributes(TuyaManufCluster):
             attributes, allow_cache=True, only_cache=True, manufacturer=manufacturer
         )
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
         """Defer attributes writing to the set_data tuya command."""
 
         records = self._write_attr_records(attributes)
@@ -750,7 +750,7 @@ class TuyaThermostatCluster(LocalDataCluster, Thermostat):
         """Map standardized attribute value to dict of manufacturer values."""
         return {}
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
         """Implement writeable attributes."""
 
         records = self._write_attr_records(attributes)
@@ -862,7 +862,7 @@ class TuyaUserInterfaceCluster(LocalDataCluster, UserInterface):
         """Map standardized attribute value to dict of manufacturer values."""
         return {}
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
         """Defer the keypad_lockout attribute to child_lock."""
 
         records = self._write_attr_records(attributes)

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -538,12 +538,14 @@ class TuyaManufClusterAttributes(TuyaManufCluster):
         self._update_attribute(tuya_cmd, zvalue)
 
     async def read_attributes(
-        self, attributes, allow_cache=False, only_cache=False, manufacturer=None
-    ):
+        self,
+        attributes: list[int | str | foundation.ZCLAttributeDef],
+        **kwargs,
+    ) -> Any:
         """Ignore remote reads as the "get_data" command doesn't seem to do anything."""
 
         return await super().read_attributes(
-            attributes, allow_cache=True, only_cache=True, manufacturer=manufacturer
+            attributes, allow_cache=True, only_cache=True, **kwargs
         )
 
     async def write_attributes(self, attributes, manufacturer=UNDEFINED):
@@ -750,7 +752,11 @@ class TuyaThermostatCluster(LocalDataCluster, Thermostat):
         """Map standardized attribute value to dict of manufacturer values."""
         return {}
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Implement writeable attributes."""
 
         records = self._write_attr_records(attributes)
@@ -788,7 +794,7 @@ class TuyaThermostatCluster(LocalDataCluster, Thermostat):
             ]
 
         await self.endpoint.tuya_manufacturer.write_attributes(
-            manufacturer_attrs, manufacturer=manufacturer
+            manufacturer_attrs, **kwargs
         )
 
         return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
@@ -862,7 +868,11 @@ class TuyaUserInterfaceCluster(LocalDataCluster, UserInterface):
         """Map standardized attribute value to dict of manufacturer values."""
         return {}
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Defer the keypad_lockout attribute to child_lock."""
 
         records = self._write_attr_records(attributes)
@@ -901,7 +911,7 @@ class TuyaUserInterfaceCluster(LocalDataCluster, UserInterface):
             ]
 
         await self.endpoint.tuya_manufacturer.write_attributes(
-            manufacturer_attrs, manufacturer=manufacturer
+            manufacturer_attrs, **kwargs
         )
 
         return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -11,7 +11,7 @@ from typing import Any, Final
 
 from zigpy.quirks import BaseCustomDevice, CustomCluster, CustomDevice
 import zigpy.types as t
-from zigpy.typing import UNDEFINED, AddressingMode
+from zigpy.typing import UNDEFINED, AddressingMode, UndefinedType
 from zigpy.zcl import BaseAttributeDefs, foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import Basic, LevelControl, OnOff, PowerConfiguration
@@ -548,7 +548,12 @@ class TuyaManufClusterAttributes(TuyaManufCluster):
             attributes, allow_cache=True, only_cache=True, **kwargs
         )
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,  # XXX: default in quirks
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Defer attributes writing to the set_data tuya command."""
 
         records = self._write_attr_records(attributes)

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -83,13 +83,15 @@ class TuyaAttributesCluster(TuyaLocalCluster):
     """Manufacturer specific cluster for Tuya converting attributes <-> commands."""
 
     async def read_attributes(
-        self, attributes, allow_cache=False, only_cache=False, manufacturer=None
-    ):
+        self,
+        attributes: list[int | str | foundation.ZCLAttributeDef],
+        **kwargs,
+    ) -> Any:
         """Ignore remote reads as the "get_data" command doesn't seem to do anything."""
 
         self.debug("read_attributes --> attrs: %s", attributes)
         return await super().read_attributes(
-            attributes, allow_cache=True, only_cache=True, manufacturer=manufacturer
+            attributes, allow_cache=True, only_cache=True, **kwargs
         )
 
     async def write_attributes(self, attributes, manufacturer=UNDEFINED):

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -94,10 +94,15 @@ class TuyaAttributesCluster(TuyaLocalCluster):
             attributes, allow_cache=True, only_cache=True, **kwargs
         )
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,  # XXX: default in quirks
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Defer attributes writing to the set_data tuya command."""
 
-        await super().write_attributes(attributes, manufacturer)
+        await super().write_attributes(attributes, manufacturer=manufacturer, **kwargs)
 
         records = self._write_attr_records(attributes)
 

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -90,6 +90,9 @@ class TuyaAttributesCluster(TuyaLocalCluster):
         """Ignore remote reads as the "get_data" command doesn't seem to do anything."""
 
         self.debug("read_attributes --> attrs: %s", attributes)
+        # Pop from kwargs to avoid duplicate keyword argument errors
+        kwargs.pop("allow_cache", None)
+        kwargs.pop("only_cache", None)
         return await super().read_attributes(
             attributes, allow_cache=True, only_cache=True, **kwargs
         )

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -7,7 +7,7 @@ import datetime
 from typing import Any, Final
 
 import zigpy.types as t
-from zigpy.typing import UndefinedType
+from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import LevelControl, OnOff
 from zigpy.zcl.foundation import ZCLAttributeDef
@@ -92,7 +92,7 @@ class TuyaAttributesCluster(TuyaLocalCluster):
             attributes, allow_cache=True, only_cache=True, manufacturer=manufacturer
         )
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
         """Defer attributes writing to the set_data tuya command."""
 
         await super().write_attributes(attributes, manufacturer)

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -6,6 +6,7 @@ from typing import Final, Optional, Union
 
 from zigpy.profiles import zha
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     AnalogOutput,
@@ -958,7 +959,7 @@ class MoesWindowDetection(LocalDataCluster, OnOff):
         )
         self._update_attribute(self.attributes_by_name["on_off"].id, value[2])
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
         """Defer attributes writing to the set_data tuya command."""
 
         records = self._write_attr_records(attributes)
@@ -1428,7 +1429,7 @@ class ZONNSMARTHelperOnOff(LocalDataCluster, OnOff):
         """Return dict with attribute and value for thermostat."""
         return None
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
         """Defer attributes writing to the set_data tuya command."""
         records = self._write_attr_records(attributes)
         if not records:
@@ -1562,7 +1563,7 @@ class ZONNSMARTTemperatureOffset(LocalDataCluster, AnalogOutput):
         """Get current temperature offset value."""
         return self._attr_cache.get(self.attributes_by_name["present_value"].id)
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
         """Modify value before passing it to the set_data tuya command."""
         for attrid, value in attributes.items():
             if isinstance(attrid, str):
@@ -1608,7 +1609,7 @@ class ZONNSMARTWindowOpenedTemp(LocalDataCluster, AnalogOutput):
         """Get temperature value when opened window detected."""
         return self._attr_cache.get(self.attributes_by_name["present_value"].id)
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
         """Modify value before passing it to the set_data tuya command."""
         for attrid, value in attributes.items():
             if isinstance(attrid, str):

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1587,7 +1587,7 @@ class ZONNSMARTTemperatureOffset(LocalDataCluster, AnalogOutput):
             await self.endpoint.tuya_manufacturer.write_attributes(
                 {ZONNSMART_TEMPERATURE_CALIBRATION_ATTR: value * 10}, **kwargs
             )
-        return ([foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],)
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
 
 class ZONNSMARTWindowOpenedTemp(LocalDataCluster, AnalogOutput):
@@ -1638,7 +1638,7 @@ class ZONNSMARTWindowOpenedTemp(LocalDataCluster, AnalogOutput):
             await ZonnsmartManuClusterSelf.endpoint.tuya_manufacturer.write_attributes(
                 {ZONNSMART_OPENED_WINDOW_TEMP: value * 10}, **kwargs
             )
-        return ([foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],)
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
 
 class SiterwellGS361_Type1(TuyaThermostat):

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -2,11 +2,10 @@
 
 import datetime
 import logging
-from typing import Final, Optional, Union
+from typing import Any, Final, Optional, Union
 
 from zigpy.profiles import zha
 import zigpy.types as t
-from zigpy.typing import UNDEFINED
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     AnalogOutput,
@@ -959,7 +958,11 @@ class MoesWindowDetection(LocalDataCluster, OnOff):
         )
         self._update_attribute(self.attributes_by_name["on_off"].id, value[2])
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Defer attributes writing to the set_data tuya command."""
 
         records = self._write_attr_records(attributes)
@@ -1005,7 +1008,7 @@ class MoesWindowDetection(LocalDataCluster, OnOff):
 
         if has_change:
             return await self.endpoint.tuya_manufacturer.write_attributes(
-                {MOES_WINDOW_DETECT_ATTR: data}, manufacturer=manufacturer
+                {MOES_WINDOW_DETECT_ATTR: data}, **kwargs
             )
 
         return [
@@ -1429,7 +1432,11 @@ class ZONNSMARTHelperOnOff(LocalDataCluster, OnOff):
         """Return dict with attribute and value for thermostat."""
         return None
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Defer attributes writing to the set_data tuya command."""
         records = self._write_attr_records(attributes)
         if not records:
@@ -1447,7 +1454,7 @@ class ZONNSMARTHelperOnOff(LocalDataCluster, OnOff):
             if attr_val is not None:
                 # global self in case when different endpoint has to exist
                 return await ZonnsmartManuClusterSelf.endpoint.tuya_manufacturer.write_attributes(
-                    attr_val, manufacturer=manufacturer
+                    attr_val, **kwargs
                 )
 
         return [
@@ -1563,7 +1570,11 @@ class ZONNSMARTTemperatureOffset(LocalDataCluster, AnalogOutput):
         """Get current temperature offset value."""
         return self._attr_cache.get(self.attributes_by_name["present_value"].id)
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Modify value before passing it to the set_data tuya command."""
         for attrid, value in attributes.items():
             if isinstance(attrid, str):
@@ -1609,7 +1620,11 @@ class ZONNSMARTWindowOpenedTemp(LocalDataCluster, AnalogOutput):
         """Get temperature value when opened window detected."""
         return self._attr_cache.get(self.attributes_by_name["present_value"].id)
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Modify value before passing it to the set_data tuya command."""
         for attrid, value in attributes.items():
             if isinstance(attrid, str):

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1585,7 +1585,7 @@ class ZONNSMARTTemperatureOffset(LocalDataCluster, AnalogOutput):
             self._update_attribute(attrid, value)
 
             await self.endpoint.tuya_manufacturer.write_attributes(
-                {ZONNSMART_TEMPERATURE_CALIBRATION_ATTR: value * 10}, manufacturer=None
+                {ZONNSMART_TEMPERATURE_CALIBRATION_ATTR: value * 10}, **kwargs
             )
         return ([foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],)
 
@@ -1636,7 +1636,7 @@ class ZONNSMARTWindowOpenedTemp(LocalDataCluster, AnalogOutput):
 
             # different Endpoint for compatibility issue
             await ZonnsmartManuClusterSelf.endpoint.tuya_manufacturer.write_attributes(
-                {ZONNSMART_OPENED_WINDOW_TEMP: value * 10}, manufacturer=None
+                {ZONNSMART_OPENED_WINDOW_TEMP: value * 10}, **kwargs
             )
         return ([foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],)
 

--- a/zhaquirks/tuya/ts1201.py
+++ b/zhaquirks/tuya/ts1201.py
@@ -11,6 +11,7 @@ from typing import Any, Final, Optional, Union
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.zcl import BaseAttributeDefs, BaseCommandDefs, foundation
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -83,7 +84,7 @@ class ZosungIRControl(CustomCluster):
         )
 
     async def read_attributes(
-        self, attributes, allow_cache=False, only_cache=False, manufacturer=None
+        self, attributes, allow_cache=False, only_cache=False, manufacturer=UNDEFINED
     ):
         """Read attributes ZCL foundation command."""
         if (

--- a/zhaquirks/tuya/ts1201.py
+++ b/zhaquirks/tuya/ts1201.py
@@ -11,7 +11,6 @@ from typing import Any, Final, Optional, Union
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
-from zigpy.typing import UNDEFINED
 from zigpy.zcl import BaseAttributeDefs, BaseCommandDefs, foundation
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -84,8 +83,10 @@ class ZosungIRControl(CustomCluster):
         )
 
     async def read_attributes(
-        self, attributes, allow_cache=False, only_cache=False, manufacturer=UNDEFINED
-    ):
+        self,
+        attributes: list[int | str | foundation.ZCLAttributeDef],
+        **kwargs,
+    ) -> Any:
         """Read attributes ZCL foundation command."""
         if (
             self.AttributeDefs.last_learned_ir_code.id in attributes

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -7,7 +7,7 @@ from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTemperature, UnitOfT
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorStateClass
 import zigpy.types as t
-from zigpy.typing import UNDEFINED
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.hvac import RunningState, Thermostat
 
 from zhaquirks.tuya import TUYA_CLUSTER_ID
@@ -147,12 +147,11 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
 
     async def write_attributes(
         self,
-        attributes: dict[str | int, Any],
-        manufacturer=UNDEFINED,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
         **kwargs,
-    ) -> list:
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Catch attribute writes for system_mode and set schedule to off."""
-        results = await super().write_attributes(attributes, manufacturer)
+        results = await super().write_attributes(attributes, **kwargs)
         if (
             Thermostat.AttributeDefs.system_mode.id in attributes
             or Thermostat.AttributeDefs.system_mode.name in attributes

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -7,6 +7,7 @@ from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTemperature, UnitOfT
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorStateClass
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters.hvac import RunningState, Thermostat
 
 from zhaquirks.tuya import TUYA_CLUSTER_ID
@@ -147,7 +148,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     async def write_attributes(
         self,
         attributes: dict[str | int, Any],
-        manufacturer: int | None = None,
+        manufacturer=UNDEFINED,
         **kwargs,
     ) -> list:
         """Catch attribute writes for system_mode and set schedule to off."""

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -57,7 +57,7 @@ class EmulatedIasZone(LocalDataCluster, IasZone):
         **kwargs,
     ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Ignore write_attributes."""
-        return (0,)
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
     def update_state(self, value):
         """Update IAS state."""

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, Union
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -51,7 +52,7 @@ class EmulatedIasZone(LocalDataCluster, IasZone):
         """Bind cluster."""
         return await self.endpoint.device.app_cluster.bind()
 
-    async def write_attributes(self, attributes, manufacturer=None):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
         """Ignore write_attributes."""
         return (0,)
 

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -6,7 +6,6 @@ from typing import Any, Optional, Union
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
-from zigpy.typing import UNDEFINED
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -52,7 +51,11 @@ class EmulatedIasZone(LocalDataCluster, IasZone):
         """Bind cluster."""
         return await self.endpoint.device.app_cluster.bind()
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Ignore write_attributes."""
         return (0,)
 

--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 from zigpy.quirks import CustomDevice
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     AnalogInput,
@@ -249,7 +250,7 @@ class XBeePWM(LocalDataCluster, AnalogOutput):
 
     _ep_id_2_pwm = {0xDA: "M0", 0xDB: "M1"}
 
-    async def write_attributes(self, attributes, manufacturer=None, **kwargs):
+    async def write_attributes(self, attributes, manufacturer=UNDEFINED, **kwargs):
         """Intercept present_value attribute write."""
         attr_id = None
         if ATTR_PRESENT_VALUE in attributes:

--- a/zhaquirks/xbee/__init__.py
+++ b/zhaquirks/xbee/__init__.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 from zigpy.quirks import CustomDevice
 import zigpy.types as t
-from zigpy.typing import UNDEFINED
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
     AnalogInput,
@@ -250,7 +249,11 @@ class XBeePWM(LocalDataCluster, AnalogOutput):
 
     _ep_id_2_pwm = {0xDA: "M0", 0xDB: "M1"}
 
-    async def write_attributes(self, attributes, manufacturer=UNDEFINED, **kwargs):
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Intercept present_value attribute write."""
         attr_id = None
         if ATTR_PRESENT_VALUE in attributes:
@@ -265,7 +268,7 @@ class XBeePWM(LocalDataCluster, AnalogOutput):
             at_command = ENDPOINT_TO_AT.get(self._endpoint.endpoint_id)
             await self._endpoint.device.remote_at(at_command, PIN_ANALOG_OUTPUT)
 
-        return await super().write_attributes(attributes, manufacturer, **kwargs)
+        return await super().write_attributes(attributes, **kwargs)
 
     async def read_attributes_raw(self, attributes, manufacturer=None, **kwargs):
         """Intercept present_value attribute read."""

--- a/zhaquirks/xiaomi/aqara/feeder_acn001.py
+++ b/zhaquirks/xiaomi/aqara/feeder_acn001.py
@@ -270,6 +270,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         LOGGER.debug("OppleCluster.write_attributes: %s", attrs)
         # Skip attr cache because of the encoding from Xiaomi and
         # the attributes are reported back by the device
+        kwargs.pop("update_cache", None)  # To not break when this is passed already
         return await super().write_attributes(attrs, update_cache=False, **kwargs)
 
 

--- a/zhaquirks/xiaomi/aqara/feeder_acn001.py
+++ b/zhaquirks/xiaomi/aqara/feeder_acn001.py
@@ -270,10 +270,9 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         LOGGER.debug("OppleCluster.write_attributes: %s", attrs)
         return await super().write_attributes(attrs, **kwargs)
 
+    # XXX: This is not called anymore
     async def write_attributes_raw(
-        self,
-        attrs: list[foundation.Attribute],
-        manufacturer=None,
+        self, attrs: list[foundation.Attribute], manufacturer: int | None = None
     ) -> list:
         """Write attributes to device without internal 'attributes' validation."""
         # intentionally skip attr cache because of the encoding from Xiaomi and

--- a/zhaquirks/xiaomi/aqara/feeder_acn001.py
+++ b/zhaquirks/xiaomi/aqara/feeder_acn001.py
@@ -250,8 +250,10 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         return FEEDER_ATTR_NAME, val
 
     async def write_attributes(
-        self, attributes: dict[str | int, Any], manufacturer=UNDEFINED
-    ) -> list:
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Write attributes to device with internal 'attributes' validation."""
         attrs = {}
         for attr, value in attributes.items():
@@ -267,7 +269,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             else:
                 attrs[attr] = value
         LOGGER.debug("OppleCluster.write_attributes: %s", attrs)
-        return await super().write_attributes(attrs, manufacturer)
+        return await super().write_attributes(attrs, **kwargs)
 
     async def write_attributes_raw(
         self, attrs: list[foundation.Attribute], manufacturer=UNDEFINED

--- a/zhaquirks/xiaomi/aqara/feeder_acn001.py
+++ b/zhaquirks/xiaomi/aqara/feeder_acn001.py
@@ -7,7 +7,6 @@ from typing import Any, Final
 
 from zigpy import types
 from zigpy.profiles import zgp, zha
-from zigpy.typing import UNDEFINED
 from zigpy.zcl import AttributeReportedEvent, AttributeUpdatedEvent, foundation
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -272,7 +271,9 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         return await super().write_attributes(attrs, **kwargs)
 
     async def write_attributes_raw(
-        self, attrs: list[foundation.Attribute], manufacturer=UNDEFINED
+        self,
+        attrs: list[foundation.Attribute],
+        manufacturer=None,
     ) -> list:
         """Write attributes to device without internal 'attributes' validation."""
         # intentionally skip attr cache because of the encoding from Xiaomi and

--- a/zhaquirks/xiaomi/aqara/feeder_acn001.py
+++ b/zhaquirks/xiaomi/aqara/feeder_acn001.py
@@ -7,6 +7,7 @@ from typing import Any, Final
 
 from zigpy import types
 from zigpy.profiles import zgp, zha
+from zigpy.typing import UNDEFINED
 from zigpy.zcl import AttributeReportedEvent, AttributeUpdatedEvent, foundation
 from zigpy.zcl.clusters.general import (
     Basic,
@@ -249,7 +250,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         return FEEDER_ATTR_NAME, val
 
     async def write_attributes(
-        self, attributes: dict[str | int, Any], manufacturer: int | None = None
+        self, attributes: dict[str | int, Any], manufacturer=UNDEFINED
     ) -> list:
         """Write attributes to device with internal 'attributes' validation."""
         attrs = {}
@@ -269,7 +270,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         return await super().write_attributes(attrs, manufacturer)
 
     async def write_attributes_raw(
-        self, attrs: list[foundation.Attribute], manufacturer: int | None = None
+        self, attrs: list[foundation.Attribute], manufacturer=UNDEFINED
     ) -> list:
         """Write attributes to device without internal 'attributes' validation."""
         # intentionally skip attr cache because of the encoding from Xiaomi and

--- a/zhaquirks/xiaomi/aqara/feeder_acn001.py
+++ b/zhaquirks/xiaomi/aqara/feeder_acn001.py
@@ -268,16 +268,9 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             else:
                 attrs[attr] = value
         LOGGER.debug("OppleCluster.write_attributes: %s", attrs)
-        return await super().write_attributes(attrs, **kwargs)
-
-    # XXX: This is not called anymore
-    async def write_attributes_raw(
-        self, attrs: list[foundation.Attribute], manufacturer: int | None = None
-    ) -> list:
-        """Write attributes to device without internal 'attributes' validation."""
-        # intentionally skip attr cache because of the encoding from Xiaomi and
+        # Skip attr cache because of the encoding from Xiaomi and
         # the attributes are reported back by the device
-        return await self._write_attributes(attrs, manufacturer=manufacturer)
+        return await super().write_attributes(attrs, update_cache=False, **kwargs)
 
 
 class AqaraFeederAcn001(XiaomiCustomDevice):

--- a/zhaquirks/xiaomi/aqara/motion_ac02.py
+++ b/zhaquirks/xiaomi/aqara/motion_ac02.py
@@ -8,6 +8,7 @@ from typing import Any
 from zigpy import types
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 
 from zhaquirks import Bus, LocalDataCluster
@@ -49,7 +50,7 @@ class OppleCluster(XiaomiMotionManufacturerCluster):
     }
 
     async def write_attributes(
-        self, attributes: dict[str | int, Any], manufacturer: int | None = None
+        self, attributes: dict[str | int, Any], manufacturer=UNDEFINED
     ) -> list:
         """Write attributes to device with internal 'attributes' validation."""
         result = await super().write_attributes(attributes, manufacturer)

--- a/zhaquirks/xiaomi/aqara/motion_ac02.py
+++ b/zhaquirks/xiaomi/aqara/motion_ac02.py
@@ -8,7 +8,7 @@ from typing import Any
 from zigpy import types
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
-from zigpy.typing import UNDEFINED
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 
 from zhaquirks import Bus, LocalDataCluster
@@ -50,10 +50,12 @@ class OppleCluster(XiaomiMotionManufacturerCluster):
     }
 
     async def write_attributes(
-        self, attributes: dict[str | int, Any], manufacturer=UNDEFINED
-    ) -> list:
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Write attributes to device with internal 'attributes' validation."""
-        result = await super().write_attributes(attributes, manufacturer)
+        result = await super().write_attributes(attributes, **kwargs)
         interval = attributes.get(
             "detection_interval", attributes.get(DETECTION_INTERVAL)
         )

--- a/zhaquirks/xiaomi/aqara/motion_agl04.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl04.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from zigpy import types
 from zigpy.profiles import zha
-from zigpy.typing import UNDEFINED
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.measurement import OccupancySensing
 
@@ -42,10 +42,12 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     }
 
     async def write_attributes(
-        self, attributes: dict[str | int, Any], manufacturer=UNDEFINED
-    ) -> list:
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Write attributes to device with internal 'attributes' validation."""
-        result = await super().write_attributes(attributes, manufacturer)
+        result = await super().write_attributes(attributes, **kwargs)
         interval = attributes.get(
             "detection_interval", attributes.get(DETECTION_INTERVAL)
         )

--- a/zhaquirks/xiaomi/aqara/motion_agl04.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl04.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from zigpy import types
 from zigpy.profiles import zha
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.measurement import OccupancySensing
 
@@ -41,7 +42,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     }
 
     async def write_attributes(
-        self, attributes: dict[str | int, Any], manufacturer: int | None = None
+        self, attributes: dict[str | int, Any], manufacturer=UNDEFINED
     ) -> list:
         """Write attributes to device with internal 'attributes' validation."""
         result = await super().write_attributes(attributes, manufacturer)

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -211,8 +211,10 @@ class WindowCoveringRollerE1(CustomCluster, WindowCovering):
         ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
 
     async def read_attributes(
-        self, attributes: list[int | str | ZCLAttributeDef], *args, **kwargs
-    ):
+        self,
+        attributes: list[int | str | foundation.ZCLAttributeDef],
+        **kwargs,
+    ) -> Any:
         """Redirect attribute reads to another cluster."""
         success = {}
         failure = {}
@@ -231,7 +233,7 @@ class WindowCoveringRollerE1(CustomCluster, WindowCovering):
             # Skip this attribute and read it from the other cluster
             other_cluster = getattr(self.endpoint, target_cluster.ep_attribute)
             other_success, other_failure = await other_cluster.read_attributes(
-                [target_attr], *args, **kwargs
+                [target_attr], **kwargs
             )
 
             # Remove it from the remaining attributes
@@ -246,7 +248,7 @@ class WindowCoveringRollerE1(CustomCluster, WindowCovering):
 
         # Read the remaining ones directly
         other_success, other_failure = await super().read_attributes(
-            attributes, *args, **kwargs
+            attributes, **kwargs
         )
         success.update(other_success)
         failure.update(other_failure)

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -79,7 +79,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
         self,
         attributes: list[int | str | foundation.ZCLAttributeDef],
         **kwargs,
-    ):
+    ) -> Any:
         """Pass reading attributes to Xiaomi cluster if applicable."""
         successful_r, failed_r = {}, {}
         remaining_attributes = attributes.copy()
@@ -112,8 +112,10 @@ class ThermostatCluster(CustomCluster, Thermostat):
         return successful_r, failed_r
 
     async def write_attributes(
-        self, attributes: dict[str | int, Any], **kwargs
-    ) -> list:
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Pass writing attributes to Xiaomi cluster if applicable."""
         result = []
         remaining_attributes = attributes.copy()


### PR DESCRIPTION
## Proposed change
This updates the `read_attributes` and `write_attributes` method signatures to pass through `**kwargs`.
Only a few keep the `manufacturer=UNDEFINED` default.

The minimum zigpy version is bumped to 0.91.4.

The Aqara feeder now calls `write_attributes` with `update_cache=False`, as the previously overridden `write_attributes_raw` method no longer exists in zigpy.

## Additional information
Follow-up to:
- https://github.com/zigpy/zha-device-handlers/pull/4695 (+ see reviews)
- for recent zigpy 0.91.x changes

## Checklist
- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
