### PR TITLE
Remove unnecessary Tuya `NoManufacturerCluster` functionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "David F. Mulcahey", email = "david.mulcahey@icloud.com" }]
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.12"
-dependencies = ["zigpy>=0.91.4"]
+dependencies = ["zigpy>=0.91.5"]
 
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]

--- a/uv.lock
+++ b/uv.lock
@@ -1321,7 +1321,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "zigpy", specifier = ">=0.91.4" }]
+requires-dist = [{ name = "zigpy", specifier = ">=0.91.5" }]
 
 [package.metadata.requires-dev]
 ci = [
@@ -1347,7 +1347,7 @@ dev = [
 
 [[package]]
 name = "zigpy"
-version = "0.91.4"
+version = "0.91.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1361,7 +1361,7 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "voluptuous" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/b8/f3cff284d51ae4f412831338bcf7a45bc7d97db99761a00c41a247513612/zigpy-0.91.4.tar.gz", hash = "sha256:d9bddd4e972ba7ff7eac2f4242277f92053468b4313e486542800e4dfa408462", size = 325780, upload-time = "2026-01-29T22:51:15.549Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/35/668257a7cf432d75509db22fa0d76abbeda465fac684aa34c66faa9b73f6/zigpy-0.91.5.tar.gz", hash = "sha256:cf3854c70552ab717d323611c42cb5a8e618f6f328ad961637703c75d6ced2ea", size = 326697, upload-time = "2026-01-30T01:04:33.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ca/8fdebf27a277ac90f0210c3b1a623a6b4845bc75581ab2186a09cbb5d54d/zigpy-0.91.4-py3-none-any.whl", hash = "sha256:35daac77d235a9bc7547f2708c40767bdd6d7740a61b5840741b89fcfc555711", size = 247657, upload-time = "2026-01-29T22:51:14.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/41/f85a5cc479d58cc1209d6ba49e8234599c3039570e31e1cda91ba770404a/zigpy-0.91.5-py3-none-any.whl", hash = "sha256:7558272a9e6aa6631780ab90866b14948e9af272f89aa5b199845fb2fd1e10da", size = 247841, upload-time = "2026-01-30T01:04:31.561Z" },
 ]

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -337,7 +337,7 @@ class MCUVersionRsp(t.Struct):
 
 
 class NoManufacturerCluster(CustomCluster):
-    """Originally used to force no manufacturer id in command. Now useless.
+    """Originally used to force no manufacturer id in command. Now without function.
 
     Instead, specify manufacturer_code=None in the command definitions instead.
     TODO: Remove this class once all clusters are properly migrated.

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -337,30 +337,11 @@ class MCUVersionRsp(t.Struct):
 
 
 class NoManufacturerCluster(CustomCluster):
-    """Forces no manufacturer id in command.
+    """Originally used to force no manufacturer id in command. Now useless.
 
+    Instead, specify manufacturer_code=None in the command definitions instead.
     TODO: Remove this class once all clusters are properly migrated.
     """
-
-    async def command(
-        self,
-        command_id: foundation.GeneralCommand | int | t.uint8_t,
-        *args,
-        manufacturer: int | t.uint16_t | None = None,
-        expect_reply: bool = True,
-        tsn: int | t.uint8_t | None = None,
-        **kwargs: Any,
-    ):
-        """Override the default Cluster command."""
-        self.debug("Setting no manufacturer id in command: %s", command_id)
-        return await super().command(
-            command_id,
-            *args,
-            manufacturer=None,
-            expect_reply=expect_reply,
-            tsn=tsn,
-            **kwargs,
-        )
 
 
 class TuyaManufCluster(CustomCluster):


### PR DESCRIPTION
## Proposed change
This removes the non-working Tuya `NoManufacturerCluster` functionality. It has to be replaced by specifying `manufacturer_code=None` in the various command definitions. All Tuya command definitions should already use `manufacturer_code=None` anyway.

Zigpy is also bumped to [0.91.5](https://github.com/zigpy/zigpy/releases/tag/0.91.5).

## Additional information
Follow-up to various PRs regarding zigpy 0.91.x.

In the future, we still need to remove the `manufacturer=None` default in various quirks.
For now, `None` is treated as `UNDEFINED`, so automatically determined manufacturer code, in zigpy.

## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
