### PR TITLE
Fix IKEA STARKVIND manufacturer code

### DIFF
--- a/zhaquirks/ikea/starkvind.py
+++ b/zhaquirks/ikea/starkvind.py
@@ -43,27 +43,27 @@ class IkeaAirpurifier(CustomCluster):
         """Cluster attributes."""
 
         filter_run_time = ZCLAttributeDef(
-            id=0x0000, type=t.uint32_t, manufacturer_code=0x1002
+            id=0x0000, type=t.uint32_t, manufacturer_code=0x117C
         )
         replace_filter = ZCLAttributeDef(
-            id=0x0001, type=t.uint8_t, manufacturer_code=0x1002
+            id=0x0001, type=t.uint8_t, manufacturer_code=0x117C
         )
         filter_life_time = ZCLAttributeDef(
-            id=0x0002, type=t.uint32_t, manufacturer_code=0x1002
+            id=0x0002, type=t.uint32_t, manufacturer_code=0x117C
         )
-        disable_led = ZCLAttributeDef(id=0x0003, type=t.Bool, manufacturer_code=0x1002)
+        disable_led = ZCLAttributeDef(id=0x0003, type=t.Bool, manufacturer_code=0x117C)
         air_quality_25pm = ZCLAttributeDef(
-            id=0x0004, type=t.uint16_t, manufacturer_code=0x1002
+            id=0x0004, type=t.uint16_t, manufacturer_code=0x117C
         )
-        child_lock = ZCLAttributeDef(id=0x0005, type=t.Bool, manufacturer_code=0x1002)
+        child_lock = ZCLAttributeDef(id=0x0005, type=t.Bool, manufacturer_code=0x117C)
         fan_mode = ZCLAttributeDef(
-            id=0x0006, type=t.uint8_t, manufacturer_code=0x1002
+            id=0x0006, type=t.uint8_t, manufacturer_code=0x117C
         )  # fan mode (Off, Auto, fanspeed 10 - 50)  read/write
         fan_speed = ZCLAttributeDef(
-            id=0x0007, type=t.uint8_t, manufacturer_code=0x1002
+            id=0x0007, type=t.uint8_t, manufacturer_code=0x117C
         )  # current fan speed (only fan speed 10-50)
         device_run_time = ZCLAttributeDef(
-            id=0x0008, type=t.uint32_t, manufacturer_code=0x1002
+            id=0x0008, type=t.uint32_t, manufacturer_code=0x117C
         )
 
     def __init__(self, *args, **kwargs):

--- a/zhaquirks/ikea/vallhorn.py
+++ b/zhaquirks/ikea/vallhorn.py
@@ -21,13 +21,13 @@ class IkeaVallhornManufSpecificConfig(CustomCluster):
         on_only_when_dark: Final = ZCLAttributeDef(
             id=0x0000,
             type=t.Bool,
-            manufacturer_code=4476,
+            manufacturer_code=0x117C,
         )
 
         on_time: Final = ZCLAttributeDef(
             id=0x0002,
             type=t.uint16_t,
-            manufacturer_code=4476,
+            manufacturer_code=0x117C,
         )
 
 


### PR DESCRIPTION
## Proposed change
This fixes the IKEA STARKVIND manufacturer code in all of the manufacturer specific attribute definitions to use the correct one (`0x117C`/`4476`), and not the Tuya one (`0x1002`/`4098`).

## Additional information
Follow-up to:
- https://github.com/zigpy/zha-device-handlers/pull/4658


## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
