### PR TITLE
Fix Legrand Cable Outlet manufacturer code

### DIFF
--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -43,11 +43,11 @@ async def test_legrand_wire_pilot_cluster_write_attrs(zigpy_device_from_v2_quirk
     cable_cluster.set_pilot_wire_mode = mock.AsyncMock()
 
     # test writing read-only pilot_wire_mode attribute, should call set_pilot_wire_mode
-    await cable_cluster.write_attributes({0x00: 0x02}, manufacturer=0xFC40)
+    await cable_cluster.write_attributes({0x00: 0x02}, manufacturer=0x1021)
 
     cable_cluster.set_pilot_wire_mode.assert_awaited_with(
         0x02,
-        manufacturer=0xFC40,
+        manufacturer=0x1021,
     )
     # With an empty attrs dict, _write_attributes is not called in the new zigpy API
     assert len(cable_cluster._write_attributes.mock_calls) == 0

--- a/zhaquirks/legrand/cable_outlet.py
+++ b/zhaquirks/legrand/cable_outlet.py
@@ -77,7 +77,7 @@ class LegrandCableOutletCluster(CustomCluster):
         pilot_wire_mode = ZCLAttributeDef(
             id=0x00,
             type=PilotWireMode,
-            manufacturer_code=0xFC40,
+            manufacturer_code=0x1021,
         )
 
     class ServerCommandDefs(BaseCommandDefs):
@@ -86,7 +86,7 @@ class LegrandCableOutletCluster(CustomCluster):
         set_pilot_wire_mode = ZCLCommandDef(
             id=0x00,
             schema={"mode": PilotWireMode},
-            manufacturer_code=0xFC40,
+            manufacturer_code=0x1021,
         )
 
     async def write_attributes(


### PR DESCRIPTION
## Proposed change
This fixes the Legrand Cable Outlet manufacturer code. `0xFC40` is the `cluster_id`, not the `manufacturer_code`.

## Additional information
Follow-up to:
- https://github.com/zigpy/zha-device-handlers/pull/4658


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
