### PR TITLE
Add Moes ZTRV-S01 support

### DIFF
--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -982,7 +982,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     .tuya_number(
         dp_id=9,
         attribute_name="max_temperature",
-        type=t.int16s,
+        type=t.int32s,
         min_value=20,
         max_value=35,
         step=1,
@@ -994,7 +994,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     .tuya_number(
         dp_id=10,
         attribute_name="min_temperature",
-        type=t.int16s,
+        type=t.int32s,
         min_value=5,
         max_value=15,
         step=1,
@@ -1018,7 +1018,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     .tuya_number(
         dp_id=21,
         attribute_name="holiday_temperature",
-        type=t.int16s,
+        type=t.int32s,
         min_value=5,
         max_value=35,
         step=0.5,
@@ -1041,7 +1041,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         max_value=10,
         step=0.5,
         unit=UnitOfTemperature.CELSIUS,
-        multiplier=0.5,
+        multiplier=0.1,
         translation_key="local_temperature_calibration",
         fallback_name="Local temperature calibration",
     )
@@ -1064,7 +1064,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     .tuya_number(
         dp_id=105,
         attribute_name="eco_temperature",
-        type=t.int16s,
+        type=t.int32s,
         min_value=5,
         max_value=35,
         step=0.5,

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -1092,7 +1092,13 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         attribute_name=TuyaThermostatV2.AttributeDefs.local_temperature.name,
         converter=lambda x: x * 10,
     )
-    .adds(TuyaThermostatV2)
+    .adds(
+        TuyaThermostatV2,
+        constant_attributes={
+            Thermostat.AttributeDefs.abs_max_heat_setpoint_limit: 3500,
+        },
+    )
+    .tuya_enchantment()
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -982,7 +982,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     .tuya_number(
         dp_id=9,
         attribute_name="max_temperature",
-        type=t.int32s,
+        type=t.uint16_t,
         min_value=20,
         max_value=35,
         step=1,
@@ -994,7 +994,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     .tuya_number(
         dp_id=10,
         attribute_name="min_temperature",
-        type=t.int32s,
+        type=t.uint16_t,
         min_value=5,
         max_value=15,
         step=1,
@@ -1026,7 +1026,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     .tuya_number(
         dp_id=21,
         attribute_name="holiday_temperature",
-        type=t.int32s,
+        type=t.uint16_t,
         min_value=5,
         max_value=35,
         step=0.5,
@@ -1072,7 +1072,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
     .tuya_number(
         dp_id=105,
         attribute_name="eco_temperature",
-        type=t.int32s,
+        type=t.uint16_t,
         min_value=5,
         max_value=35,
         step=0.5,

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -1015,6 +1015,14 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         device_class=BinarySensorDeviceClass.WINDOW,
         fallback_name="Window open",
     )
+    # Button to mark window as closed (manually reset the window open state as it reports open since the device was turned on)
+    .write_attr_button(
+        attribute_name="window_open",
+        cluster_id=TUYA_CLUSTER_ID,
+        attribute_value=0,
+        translation_key="mark_window_as_closed",
+        fallback_name="Mark window as closed",
+    )
     .tuya_number(
         dp_id=21,
         attribute_name="holiday_temperature",

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -989,7 +989,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         unit=UnitOfTemperature.CELSIUS,
         multiplier=0.1,
         translation_key="max_temperature",
-        fallback_name="Maximum temperature",
+        fallback_name="Max temperature",
     )
     .tuya_number(
         dp_id=10,
@@ -1001,7 +1001,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         unit=UnitOfTemperature.CELSIUS,
         multiplier=0.1,
         translation_key="min_temperature",
-        fallback_name="Minimum temperature",
+        fallback_name="Min temperature",
     )
     .tuya_switch(
         dp_id=14,

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -71,6 +71,13 @@ class ScreenOrientation(t.enum8):
     Left = 0x03
 
 
+class MoesScreenOrientation(t.enum8):
+    """Moes screen orientation (0-1 only)."""
+
+    Normal = 0x00
+    Inverted = 0x01
+
+
 class TuyaDisplayBrightness(t.enum8):
     """Tuya display brightness mode."""
 
@@ -932,6 +939,158 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         attribute_name="scale_protection",
         translation_key="scale_protection",
         fallback_name="Scale protection",
+    )
+    .adds(TuyaThermostatV2)
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+(
+    TuyaQuirkBuilder("_TZE200_ivdc0kwl", "TS0601")
+    .replaces_endpoint(1, device_type=zha.DeviceType.THERMOSTAT)
+    .tuya_dp(
+        dp_id=2,
+        ep_attribute=TuyaThermostatV2.ep_attribute,
+        attribute_name=TuyaThermostatV2.AttributeDefs.system_mode.name,
+        converter=lambda x: {
+            0: Thermostat.SystemMode.Auto,
+            1: Thermostat.SystemMode.Heat,
+            2: Thermostat.SystemMode.Off,
+            3: Thermostat.SystemMode.Heat,  # on -> Heat
+            4: Thermostat.SystemMode.Auto,  # holiday -> Auto
+        }.get(x, Thermostat.SystemMode.Heat),
+        dp_converter=lambda x: {
+            Thermostat.SystemMode.Auto: 0,
+            Thermostat.SystemMode.Heat: 1,
+            Thermostat.SystemMode.Off: 2,
+        }.get(x, 1),
+    )
+    .tuya_dp(
+        dp_id=3,
+        ep_attribute=TuyaThermostatV2.ep_attribute,
+        attribute_name=TuyaThermostatV2.AttributeDefs.running_state.name,
+        converter=lambda x: RunningState.Heat_State_On if x == 0 else RunningState.Idle,
+    )
+    .tuya_battery(dp_id=6)
+    .tuya_switch(
+        dp_id=7,
+        attribute_name="child_lock",
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    .tuya_number(
+        dp_id=9,
+        attribute_name="max_temperature",
+        type=t.int16s,
+        min_value=20,
+        max_value=35,
+        step=1,
+        unit=UnitOfTemperature.CELSIUS,
+        multiplier=0.1,
+        translation_key="max_temperature",
+        fallback_name="Maximum temperature",
+    )
+    .tuya_number(
+        dp_id=10,
+        attribute_name="min_temperature",
+        type=t.int16s,
+        min_value=5,
+        max_value=15,
+        step=1,
+        unit=UnitOfTemperature.CELSIUS,
+        multiplier=0.1,
+        translation_key="min_temperature",
+        fallback_name="Minimum temperature",
+    )
+    .tuya_switch(
+        dp_id=14,
+        attribute_name="window_detection",
+        translation_key="window_detection",
+        fallback_name="Open window detection",
+    )
+    .tuya_binary_sensor(
+        dp_id=15,
+        attribute_name="window_open",
+        device_class=BinarySensorDeviceClass.WINDOW,
+        fallback_name="Window open",
+    )
+    .tuya_number(
+        dp_id=21,
+        attribute_name="holiday_temperature",
+        type=t.int16s,
+        min_value=5,
+        max_value=35,
+        step=0.5,
+        unit=UnitOfTemperature.CELSIUS,
+        multiplier=0.1,
+        translation_key="holiday_temperature",
+        fallback_name="Holiday temperature",
+    )
+    .tuya_switch(
+        dp_id=36,
+        attribute_name="frost_protection",
+        translation_key="frost_protection",
+        fallback_name="Frost protection",
+    )
+    .tuya_number(
+        dp_id=47,
+        attribute_name=TuyaThermostatV2.AttributeDefs.local_temperature_calibration.name,
+        type=t.int32s,
+        min_value=-10,
+        max_value=10,
+        step=0.5,
+        unit=UnitOfTemperature.CELSIUS,
+        multiplier=0.5,
+        translation_key="local_temperature_calibration",
+        fallback_name="Local temperature calibration",
+    )
+    .tuya_sensor(
+        dp_id=102,
+        attribute_name="valve_position",
+        type=t.uint32_t,
+        unit=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="valve_position",
+        fallback_name="Valve position",
+    )
+    .tuya_enum(
+        dp_id=103,
+        attribute_name="screen_orientation",
+        enum_class=MoesScreenOrientation,
+        translation_key="screen_orientation",
+        fallback_name="Screen orientation",
+    )
+    .tuya_number(
+        dp_id=105,
+        attribute_name="eco_temperature",
+        type=t.int16s,
+        min_value=5,
+        max_value=35,
+        step=0.5,
+        unit=UnitOfTemperature.CELSIUS,
+        multiplier=0.1,
+        translation_key="eco_temperature",
+        fallback_name="Eco temperature",
+    )
+    .tuya_switch(
+        dp_id=106,
+        attribute_name="eco_mode",
+        translation_key="eco_mode",
+        fallback_name="Eco mode",
+    )
+    .tuya_dp(
+        dp_id=108,
+        ep_attribute=TuyaThermostatV2.ep_attribute,
+        attribute_name=TuyaThermostatV2.AttributeDefs.occupied_heating_setpoint.name,
+        converter=lambda x: x * 10,
+        dp_converter=lambda x: x // 10,
+    )
+    .tuya_dp(
+        dp_id=109,
+        ep_attribute=TuyaThermostatV2.ep_attribute,
+        attribute_name=TuyaThermostatV2.AttributeDefs.local_temperature.name,
+        converter=lambda x: x * 10,
     )
     .adds(TuyaThermostatV2)
     .skip_configuration()

--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -1100,12 +1100,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         attribute_name=TuyaThermostatV2.AttributeDefs.local_temperature.name,
         converter=lambda x: x * 10,
     )
-    .adds(
-        TuyaThermostatV2,
-        constant_attributes={
-            Thermostat.AttributeDefs.abs_max_heat_setpoint_limit: 3500,
-        },
-    )
+    .adds(TuyaThermostatV2)
     .tuya_enchantment()
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
Fix #4696

## Proposed change
<!--
  Explain your proposed change below.
-->
Add support for moes Thermostat Radiator valve ZTRV-S01

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
This is a fresh quirk only tested today, it seems to work but clearly needs review

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-01KBAJS39XQ7DWM9PK85R8PT23-_TZE200_ivdc0kwl TS0601-8cfd1ddf5fd438daf6e9e278a6115596 (1).json](https://github.com/user-attachments/files/24969583/zha-01KBAJS39XQ7DWM9PK85R8PT23-_TZE200_ivdc0kwl.TS0601-8cfd1ddf5fd438daf6e9e278a6115596.1.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly **-> tested in a separate file as a custom quirk**
- [ ] `pre-commit` checks pass / the code has been formatted using Black **-> formatted with ruff as seen in contributing guidelines**
- [ ] Tests have been added to verify that the new code works -> sorry, don't have time at the moment to dig into tests (having correctly set python env and dive in the test framework)
- [x] Device diagnostics data has been attached
