### PR TITLE
Update AI instructions for new `manufacturer_code`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -371,7 +371,7 @@ class CustomOnOffCluster(CustomCluster, OnOff):
 
     class AttributeDefs(OnOff.AttributeDefs):
         custom_attr: Final = ZCLAttributeDef(
-            id=0x8000, type=t.Bool, is_manufacturer_specific=True
+            id=0x8000, type=t.Bool, manufacturer_code=0x117C
         )
 ```
 
@@ -390,11 +390,11 @@ class VOCIndex(CustomCluster):
 
     class AttributeDefs(BaseAttributeDefs):  # Note: BaseAttributeDefs, not a ZCL cluster
         measured_value: Final = ZCLAttributeDef(
-            id=0x0000, type=t.Single, access="rp", is_manufacturer_specific=True
+            id=0x0000, type=t.Single, access="rp", manufacturer_code=0x117C
         )
 ```
 
-**`is_manufacturer_specific`**: When `True`, the device's manufacturer code (from its NodeDescriptor) is sent with read/write requests for this attribute. Required for vendor-specific attributes that aren't part of the ZCL standard. Without it, the device may not recognize or respond to the attribute request.
+**`manufacturer_code`**: Specifies the manufacturer code to send with read/write requests for this attribute. Required for vendor-specific attributes that aren't part of the ZCL standard. Without it, the device may not recognize or respond to the attribute request. Use the hex code for the manufacturer (e.g., `0x117C` for IKEA, `0x115F` for Xiaomi). Set `manufacturer_code=None` to explicitly suppress sending a manufacturer code, even on manufacturer-specific clusters. This replaces the older `is_manufacturer_specific=True` approach which obtained the code from the device's NodeDescriptor.
 
 **`access`**: Controls attribute read/write/report capabilities. Not needed to explicitly specify - defaults to `"rwp"`. Values:
 - `"r"` - Read-only
@@ -413,7 +413,7 @@ class BoschOperatingMode(t.enum8):
 
 # Use in attribute definition:
 operating_mode = ZCLAttributeDef(
-    id=0x4007, type=BoschOperatingMode, is_manufacturer_specific=True
+    id=0x4007, type=BoschOperatingMode, manufacturer_code=0x1209
 )
 ```
 


### PR DESCRIPTION
## Proposed change
Update AI instructions for new zigpy `manufacturer_code` usage in `AttributeDefs`, replacing the old `is_manufacturer_specific` way.

## Additional information



## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
