### PR TITLE
Configure PM2.5 reporting interval for IKEA VINDSTYRKA

### DIFF
--- a/zhaquirks/ikea/vindstyrka.py
+++ b/zhaquirks/ikea/vindstyrka.py
@@ -37,7 +37,7 @@ class VOCIndex(CustomCluster):
         )
 
 
-class HPM25(CustomCluster, PM25):
+class PM25(CustomCluster, PM25):
     """PM2.5 cluster forced to override the IKEA default."""
 
     cluster_id = 0x042A
@@ -59,7 +59,7 @@ class HPM25(CustomCluster, PM25):
     )
     .sensor(
         attribute_name="measured_value",
-        cluster_id=HPM25.cluster_id,
+        cluster_id=PM25.cluster_id,
         device_class=SensorDeviceClass.PM25,
         state_class=SensorStateClass.MEASUREMENT,
         reporting_config=ReportingConfig(

--- a/zhaquirks/ikea/vindstyrka.py
+++ b/zhaquirks/ikea/vindstyrka.py
@@ -10,9 +10,11 @@ from zigpy.quirks.v2 import (
     SensorStateClass,
 )
 import zigpy.types as t
-from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 from zigpy.zcl.clusters.measurement import PM25  # Import the PM2.5 cluster
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
 from zhaquirks.ikea import IKEA
+
 
 class VOCIndex(CustomCluster):
     """IKEA VOC index cluster."""
@@ -33,9 +35,13 @@ class VOCIndex(CustomCluster):
         max_measured_value: Final = ZCLAttributeDef(
             id=0x0002, type=t.Single, access="r", is_manufacturer_specific=True
         )
+
+
 class HPM25(CustomCluster, PM25):
     """PM2.5 cluster forced to override the IKEA default."""
+
     cluster_id = 0x042A
+
 
 (
     QuirkBuilder(IKEA, "VINDSTYRKA")
@@ -57,9 +63,9 @@ class HPM25(CustomCluster, PM25):
         device_class=SensorDeviceClass.PM25,
         state_class=SensorStateClass.MEASUREMENT,
         reporting_config=ReportingConfig(
-            min_interval=5,      # 5 seconds
-            max_interval=45,     # 45 seconds max
-            reportable_change=1
+            min_interval=5,  # 5 seconds
+            max_interval=45,  # 45 seconds max
+            reportable_change=1,
         ),
         fallback_name="Particulate Matter 2.5",
     )

--- a/zhaquirks/ikea/vindstyrka.py
+++ b/zhaquirks/ikea/vindstyrka.py
@@ -36,8 +36,7 @@ class VOCIndex(CustomCluster):
             id=0x0002, type=t.Single, access="r", is_manufacturer_specific=True
         )
 
-
-#class PM25(CustomCluster, PM25):
+    # class PM25(CustomCluster, PM25):
     """PM2.5 cluster forced to override the IKEA default."""
 
     cluster_id = 0x042A
@@ -57,7 +56,7 @@ class VOCIndex(CustomCluster):
         translation_key="voc_index",
         fallback_name="VOC index",
     )
-    .replaces(PM25) #instead of new custom cluster PM25
+    .replaces(PM25)  # instead of new custom cluster PM25
     .sensor(
         attribute_name="measured_value",
         cluster_id=PM25.cluster_id,

--- a/zhaquirks/ikea/vindstyrka.py
+++ b/zhaquirks/ikea/vindstyrka.py
@@ -36,15 +36,10 @@ class VOCIndex(CustomCluster):
             id=0x0002, type=t.Single, access="r", is_manufacturer_specific=True
         )
 
-    # class PM25(CustomCluster, PM25):
-    """PM2.5 cluster forced to override the IKEA default."""
-
-    cluster_id = 0x042A
-
-
 (
     QuirkBuilder(IKEA, "VINDSTYRKA")
     .replaces(VOCIndex)
+    .replaces(PM25)
     .sensor(
         VOCIndex.AttributeDefs.measured_value.name,
         VOCIndex.cluster_id,
@@ -56,7 +51,6 @@ class VOCIndex(CustomCluster):
         translation_key="voc_index",
         fallback_name="VOC index",
     )
-    .replaces(PM25)  # instead of new custom cluster PM25
     .sensor(
         attribute_name="measured_value",
         cluster_id=PM25.cluster_id,

--- a/zhaquirks/ikea/vindstyrka.py
+++ b/zhaquirks/ikea/vindstyrka.py
@@ -37,7 +37,7 @@ class VOCIndex(CustomCluster):
         )
 
 
-class PM25(CustomCluster, PM25):
+class HPM25(CustomCluster, PM25):
     """PM2.5 cluster forced to override the IKEA default."""
 
     cluster_id = 0x042A
@@ -59,7 +59,7 @@ class PM25(CustomCluster, PM25):
     )
     .sensor(
         attribute_name="measured_value",
-        cluster_id=PM25.cluster_id,
+        cluster_id=HPM25.cluster_id,
         device_class=SensorDeviceClass.PM25,
         state_class=SensorStateClass.MEASUREMENT,
         reporting_config=ReportingConfig(

--- a/zhaquirks/ikea/vindstyrka.py
+++ b/zhaquirks/ikea/vindstyrka.py
@@ -36,6 +36,7 @@ class VOCIndex(CustomCluster):
             id=0x0002, type=t.Single, access="r", is_manufacturer_specific=True
         )
 
+
 (
     QuirkBuilder(IKEA, "VINDSTYRKA")
     .replaces(VOCIndex)

--- a/zhaquirks/ikea/vindstyrka.py
+++ b/zhaquirks/ikea/vindstyrka.py
@@ -11,9 +11,8 @@ from zigpy.quirks.v2 import (
 )
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
-
+from zigpy.zcl.clusters.measurement import PM25  # Import the PM2.5 cluster
 from zhaquirks.ikea import IKEA
-
 
 class VOCIndex(CustomCluster):
     """IKEA VOC index cluster."""
@@ -34,7 +33,9 @@ class VOCIndex(CustomCluster):
         max_measured_value: Final = ZCLAttributeDef(
             id=0x0002, type=t.Single, access="r", is_manufacturer_specific=True
         )
-
+class HPM25(CustomCluster, PM25):
+    """PM2.5 cluster forced to override the IKEA default."""
+    cluster_id = 0x042A
 
 (
     QuirkBuilder(IKEA, "VINDSTYRKA")
@@ -49,6 +50,18 @@ class VOCIndex(CustomCluster):
         ),
         translation_key="voc_index",
         fallback_name="VOC index",
+    )
+    .sensor(
+        attribute_name="measured_value",
+        cluster_id=HPM25.cluster_id,
+        device_class=SensorDeviceClass.PM25,
+        state_class=SensorStateClass.MEASUREMENT,
+        reporting_config=ReportingConfig(
+            min_interval=5,      # 5 seconds
+            max_interval=45,     # 45 seconds max
+            reportable_change=1
+        ),
+        fallback_name="Particulate Matter 2.5",
     )
     .add_to_registry()
 )

--- a/zhaquirks/ikea/vindstyrka.py
+++ b/zhaquirks/ikea/vindstyrka.py
@@ -37,7 +37,7 @@ class VOCIndex(CustomCluster):
         )
 
 
-class PM25(CustomCluster, PM25):
+#class PM25(CustomCluster, PM25):
     """PM2.5 cluster forced to override the IKEA default."""
 
     cluster_id = 0x042A
@@ -57,6 +57,7 @@ class PM25(CustomCluster, PM25):
         translation_key="voc_index",
         fallback_name="VOC index",
     )
+    .replaces(PM25) #instead of new custom cluster PM25
     .sensor(
         attribute_name="measured_value",
         cluster_id=PM25.cluster_id,

--- a/zhaquirks/ikea/vindstyrka.py
+++ b/zhaquirks/ikea/vindstyrka.py
@@ -63,8 +63,8 @@ class HPM25(CustomCluster, PM25):
         device_class=SensorDeviceClass.PM25,
         state_class=SensorStateClass.MEASUREMENT,
         reporting_config=ReportingConfig(
-            min_interval=5,  # 5 seconds
-            max_interval=45,  # 45 seconds max
+            min_interval=20,  # 20 seconds
+            max_interval=120,  # 120 seconds max
             reportable_change=1,
         ),
         fallback_name="Particulate Matter 2.5",


### PR DESCRIPTION
This quirk allows to change the polling frequency of the PM25 values. The default ist up to 900 seconds.

## Proposed change
<!--
  Explain your proposed change below.
--> The default for polling the PM25 sensor in zha is minimum 30 seconds and maximum 900 seconds. This cannot be changed in the interface, with this change it is possible to set the values in a custom quirk without coding everything. The new values are min: 5 seconds and max: 45 seconds


## Additional information
<!--
Reportable change is 0.1 by default, but the device only has a resolution of 1 for PM25
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.
[zha-01JBP5G37KTXPAFK8N2RFG9EZB-IKEA of Sweden VINDSTYRKA-7f16e5b631dcf47b5be65a32550ee3f7.json](https://github.com/user-attachments/files/24985990/zha-01JBP5G37KTXPAFK8N2RFG9EZB-IKEA.of.Sweden.VINDSTYRKA-7f16e5b631dcf47b5be65a32550ee3f7.json)


  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-01JBP5G37KTXPAFK8N2RFG9EZB-IKEA of Sweden VINDSTYRKA-7f16e5b631dcf47b5be65a32550ee3f7.json](https://github.com/user-attachments/files/24985990/zha-01JBP5G37KTXPAFK8N2RFG9EZB-IKEA.of.Sweden.VINDSTYRKA-7f16e5b631dcf47b5be65a32550ee3f7.json)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ x] Device diagnostics data has been attached
