### PR TITLE
Override power source for ZBMINIL2 to Mains

### DIFF
--- a/tests/test_sonoff.py
+++ b/tests/test_sonoff.py
@@ -1,0 +1,27 @@
+"""Test Sonoff devices."""
+
+from zigpy.zcl.clusters.general import Basic
+
+import zhaquirks
+from zhaquirks.sonoff.zbminil2 import BasicConfigCluster
+
+zhaquirks.setup()
+
+
+async def test_basic_cluster_zbminil2(zigpy_device_from_v2_quirk):
+    """Make sure the basic cluster returns Mains power."""
+
+    device = zigpy_device_from_v2_quirk(model="ZBMINIL2", manufacturer="SONOFF")
+
+    basic_cluster: BasicConfigCluster = device.endpoints[1].in_clusters[
+        Basic.cluster_id
+    ]
+    assert isinstance(basic_cluster, BasicConfigCluster)
+
+    attrs, fail = await basic_cluster.read_attributes(
+        [Basic.AttributeDefs.power_source]
+    )
+    assert (
+        attrs[Basic.AttributeDefs.power_source] == Basic.PowerSource.Mains_single_phase
+    )
+    assert len(fail) == 0

--- a/zhaquirks/sonoff/zbminil2.py
+++ b/zhaquirks/sonoff/zbminil2.py
@@ -1,0 +1,21 @@
+"""Sonoff ZBMINIL2 - No-Neutral Zigbee Switch."""
+
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.general import Basic
+
+from zhaquirks import LocalDataCluster
+
+
+class BasicConfigCluster(LocalDataCluster, Basic):
+    """Attributes override for basic config."""
+
+    _CONSTANT_ATTRIBUTES = {
+        Basic.AttributeDefs.power_source.id: Basic.PowerSource.Mains_single_phase,
+    }
+
+
+(
+    QuirkBuilder("SONOFF", "ZBMINIL2")
+    .replace_cluster_occurrences(BasicConfigCluster, replace_client_instances=False)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The ZBMINIL2 reports its power source as unknown even though it can only be powered by the line power it's switching. This change adds a quirk to hardcode the power source attribute to `Mains_single_phase`.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
It was closed due to inactivity, but this should fix the following:  
Fixes #2949.

I've noticed that adding this quirk to my Home Assistant instance doesn't change the power source on my already paired ZBMINIL2 devices, which is reflected in the diagnostic file below. I don't know if this is something I need to do in this PR or something related to the ZHA integration itself.

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-01KDP8C1QNBSVBGJG4CVS76CAR-SONOFF ZBMINIL2-7c89f812de59a2b7092f2f69912b254e.json](https://github.com/user-attachments/files/24996598/zha-01KDP8C1QNBSVBGJG4CVS76CAR-SONOFF.ZBMINIL2-7c89f812de59a2b7092f2f69912b254e.json)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
