### PR TITLE
Add Tuya TS0601 pilot wire heating control quirk

### DIFF
--- a/zhaquirks/tuya/ts0601_pilot_wire.py
+++ b/zhaquirks/tuya/ts0601_pilot_wire.py
@@ -40,7 +40,7 @@ class OperatingMode(t.enum8):
         attribute_name="pilot_wire_mode",
         enum_class=PilotWireMode,
         translation_key="pilot_wire_mode",
-        fallback_name="Pilot Wire Mode",
+        fallback_name="Pilot wire mode",
         entity_type=EntityType.STANDARD,
         entity_platform=EntityPlatform.SELECT,
     )

--- a/zhaquirks/tuya/ts0601_pilot_wire.py
+++ b/zhaquirks/tuya/ts0601_pilot_wire.py
@@ -35,24 +35,6 @@ class OperatingMode(t.enum8):
         entity_platform=EntityPlatform.SELECT,
     )
     .tuya_temperature(dp_id=16, scale=10)
-"""
-    .tuya_sensor(
-        dp_id=8,
-        attribute_name="unknown_dp8",
-        type=t.uint8_t,
-        entity_type=EntityType.DIAGNOSTIC,
-        translation_key="unknown_dp8",
-        fallback_name="Unknown DP8 (41-42)",
-    )
-    .tuya_sensor(
-        dp_id=126,
-        attribute_name="unknown_dp126",
-        type=t.uint8_t,
-        entity_type=EntityType.DIAGNOSTIC,
-        translation_key="unknown_dp126",
-        fallback_name="Unknown DP126",
-    )
-"""
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0601_pilot_wire.py
+++ b/zhaquirks/tuya/ts0601_pilot_wire.py
@@ -31,7 +31,7 @@ class OperatingMode(t.enum8):
         attribute_name="operating_mode",
         enum_class=OperatingMode,
         translation_key="operating_mode",
-        fallback_name="Operating Mode",
+        fallback_name="Operating mode",
         entity_type=EntityType.STANDARD,
         entity_platform=EntityPlatform.SELECT,
     )

--- a/zhaquirks/tuya/ts0601_pilot_wire.py
+++ b/zhaquirks/tuya/ts0601_pilot_wire.py
@@ -1,0 +1,58 @@
+"""Tuya TS0601 pilot wire heating control quirk for ZHA - Complete."""
+from zigpy.quirks.v2 import EntityPlatform, EntityType
+import zigpy.types as t
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+class PilotWireMode(t.enum8):
+    """Pilot wire mode enum."""
+    Comfort = 0x00
+    Comfort_Minus_1 = 0x01
+    Comfort_Minus_2 = 0x02
+    Eco = 0x03
+    Anti_Frost = 0x04
+    Off = 0x05
+class OperatingMode(t.enum8):
+    """Operating mode enum."""
+    Auto = 0x00
+    Manual = 0x01
+(
+    TuyaQuirkBuilder("_TZE204_3q3maeoo", "TS0601")
+    .tuya_enum(
+        dp_id=2,
+        attribute_name="operating_mode",
+        enum_class=OperatingMode,
+        translation_key="operating_mode",
+        fallback_name="Operating Mode",
+        entity_type=EntityType.STANDARD,
+        entity_platform=EntityPlatform.SELECT,
+    )
+    .tuya_enum(
+        dp_id=127,
+        attribute_name="pilot_wire_mode",
+        enum_class=PilotWireMode,
+        translation_key="pilot_wire_mode",
+        fallback_name="Pilot Wire Mode",
+        entity_type=EntityType.STANDARD,
+        entity_platform=EntityPlatform.SELECT,
+    )
+    .tuya_temperature(dp_id=16, scale=10)
+"""
+    .tuya_sensor(
+        dp_id=8,
+        attribute_name="unknown_dp8",
+        type=t.uint8_t,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="unknown_dp8",
+        fallback_name="Unknown DP8 (41-42)",
+    )
+    .tuya_sensor(
+        dp_id=126,
+        attribute_name="unknown_dp126",
+        type=t.uint8_t,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="unknown_dp126",
+        fallback_name="Unknown DP126",
+    )
+"""
+    .skip_configuration()
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0601_pilot_wire.py
+++ b/zhaquirks/tuya/ts0601_pilot_wire.py
@@ -1,19 +1,29 @@
 """Tuya TS0601 pilot wire heating control quirk for ZHA - Complete."""
+
 from zigpy.quirks.v2 import EntityPlatform, EntityType
 import zigpy.types as t
+
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+
 class PilotWireMode(t.enum8):
     """Pilot wire mode enum."""
+
     Comfort = 0x00
     Comfort_Minus_1 = 0x01
     Comfort_Minus_2 = 0x02
     Eco = 0x03
     Anti_Frost = 0x04
     Off = 0x05
+
+
 class OperatingMode(t.enum8):
     """Operating mode enum."""
+
     Auto = 0x00
     Manual = 0x01
+
+
 (
     TuyaQuirkBuilder("_TZE204_3q3maeoo", "TS0601")
     .tuya_enum(


### PR DESCRIPTION
## Proposed change
<!--
Add Tuya TS0601 pilot wire heating control quirk 

Material Xanlite Pilot wire electrical heater control
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
