### PR TITLE
Fix Aqara roller shade driver E1 quirk

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -10,7 +10,13 @@ import pytest
 import zigpy.device
 from zigpy.profiles import zha
 import zigpy.types as t
-from zigpy.zcl import AttributeReportedEvent, AttributeUpdatedEvent, Cluster, foundation
+from zigpy.zcl import (
+    AttributeReportedEvent,
+    AttributeUpdatedEvent,
+    Cluster,
+    ClusterType,
+    foundation,
+)
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import (
     AnalogInput,
@@ -1668,7 +1674,11 @@ async def test_xiaomi_e1_roller_commands_1(
     zigpy_device_from_v2_quirk, command, value, read_current_position
 ):
     """Test Aqara E1 roller commands for basic movement functions using MultistateOutput Cluster."""
-    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.acn002")
+    device = zigpy_device_from_v2_quirk(
+        LUMI,
+        "lumi.curtain.acn002",
+        cluster_ids={1: {MultistateOutput.cluster_id: ClusterType.Server}},
+    )
 
     window_covering_cluster = device.endpoints[1].window_covering
     window_covering_listener = ClusterListener(window_covering_cluster)

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1726,7 +1726,7 @@ async def test_xiaomi_e1_roller_commands_1(
     with (
         patch_window_covering_read,
         patch_analog_read,
-        patch_multistate_write,
+        patch_multistate_write as mock_writes,
     ):
         # test command
         await window_covering_cluster.command(command)
@@ -1757,6 +1757,16 @@ async def test_xiaomi_e1_roller_commands_1(
         else:
             # confirm the command did not read the current position
             assert len(analog_cluster._read_attributes.mock_calls) == 0
+
+        assert len(mock_writes.mock_calls) == 1
+        assert mock_writes.mock_calls[0].args[0] == [
+            foundation.Attribute(
+                attrid=MultistateOutput.AttributeDefs.present_value.id,
+                value=foundation.TypeValue(
+                    type=foundation.DataTypeId.uint16, value=value
+                ),
+            )
+        ]
 
 
 @pytest.mark.parametrize(

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Final
+from typing import Any
 
 from zigpy import types as t
 from zigpy.quirks.v2 import QuirkBuilder
@@ -256,25 +256,6 @@ class WindowCoveringRollerE1(CustomCluster, WindowCovering):
         return success, failure
 
 
-class MultistateOutputRollerE1(CustomCluster, MultistateOutput):
-    """MultistateOutput cluster used for writing commands (up_open, down_close, stop).
-
-    This requires a change to the present_value attribute type because the device responds
-    with an error when using the standard t.Single type.
-    """
-
-    class AttributeDefs(MultistateOutput.AttributeDefs):
-        """Aqara attribute definition overrides."""
-
-        present_value: Final = ZCLAttributeDef(
-            id=0x0055,
-            type=t.Single,
-            zcl_type=DataTypeId.uint16,
-            access="r*w",
-            mandatory=True,
-        )
-
-
 (
     QuirkBuilder(LUMI, "lumi.curtain.acn002")
     # temporarily commented out due to potentially breaking existing blueprints
@@ -288,7 +269,6 @@ class MultistateOutputRollerE1(CustomCluster, MultistateOutput):
     .prevent_default_entity_creation(endpoint_id=1, cluster_id=OnOff.cluster_id)
     .replaces(AnalogOutputRollerE1, endpoint_id=1)
     .replaces(BasicCluster, endpoint_id=1)
-    .replaces(MultistateOutputRollerE1, endpoint_id=1)
     .replaces(XiaomiPowerConfigurationPercent, endpoint_id=1)
     .replaces(WindowCoveringRollerE1, endpoint_id=1)
     .replaces(XiaomiAqaraRollerE1, endpoint_id=1)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The recent zigpy attribute reading/writing sync (https://github.com/zigpy/zha-device-handlers/pull/4658) changed the data type for the `MultistateOutputRollerE1` multistate output cluster's present value from `uint16_t` to `Single`. This wasn't correct.

This PR fixes https://github.com/zigpy/zha-device-handlers/issues/4662. You can see this behavior in the debug log in the above issue:

```python
# The attribute is erroneously converted to `TypeValue(type=Single, value=1.0)`
2026-02-03 15:22:30.440 DEBUG (MainThread) [zigpy.zcl] [0xFACE:1:0x0013] Sending request: Write_Attributes(attributes=[Attribute(attrid=0x0055, value=TypeValue(type=Single, value=1.0))])

# Which the device does not support
2026-02-03 15:22:31.097 DEBUG (MainThread) [zigpy.zcl] [0xFACE:1:0x0013] Decoded ZCL frame: MultistateOutputRollerE1:Write_Attributes_rsp(status_records=[WriteAttributesStatusRecord(status=<Status.UNSUPPORTED_ATTRIBUTE: 134>, attrid=0x3F80)])
```

Zigpy incorrectly defined this attribute as `t.Single` many months ago and we have since fixed the definition so this entire cluster override should be deleted.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
