### PR TITLE
Add Legrand connected contactor 412171/412191/199122

### DIFF
--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -7,8 +7,8 @@ import pytest
 import zigpy.types as t
 from zigpy.zcl import AttributeUnsupportedEvent
 from zigpy.zcl.clusters.general import PowerConfiguration
-from zigpy.zcl.foundation import ReadAttributeRecord, Status
 import zigpy.zcl.foundation as f
+from zigpy.zcl.foundation import ReadAttributeRecord, Status
 
 import zhaquirks
 from zhaquirks.legrand import LEGRAND

--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -1,6 +1,5 @@
 """Tests for Legrand."""
 
-import logging
 from unittest import mock
 
 import pytest
@@ -438,16 +437,10 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
     )
     await mode_cluster.write_attributes({0: LegrandMode.Switch}, manufacturer=0x1021)
     mode_cluster._write_attributes.assert_awaited_once()
-    try:
-        mode_cluster._write_attributes.assert_awaited_with(
-            [f.Attribute(attrid=0, value=f.TypeValue(value=t.data16([3, 0])))],
-            manufacturer=0x1021,
-        )
-    except AssertionError as e:
-        logging.warning(
-            "hum... Wrong assertion error due to unhashable nested list in data16 value.\n%s",
-            str(e),
-        )
+    call_args = mode_cluster._write_attributes.call_args
+    assert call_args[0][0][0].attrid == 0
+    assert list(call_args[0][0][0].value.value) == [3, 0]
+    assert call_args[1]["manufacturer"] == 0x1021
 
     mode_cluster._write_attributes = mock.AsyncMock(
         return_value=[
@@ -456,16 +449,10 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
     )
     await mode_cluster.write_attributes({0: LegrandMode.Auto}, manufacturer=0x1021)
     mode_cluster._write_attributes.assert_awaited_once()
-    try:
-        mode_cluster._write_attributes.assert_awaited_with(
-            [f.Attribute(attrid=0, value=f.TypeValue(value=t.data16([4, 0])))],
-            manufacturer=0x1021,
-        )
-    except AssertionError as e:
-        logging.warning(
-            "hum... Wrong assertion error due to unhashable nested list in data16 value.\n%s",
-            str(e),
-        )
+    call_args = mode_cluster._write_attributes.call_args
+    assert call_args[0][0][0].attrid == 0
+    assert list(call_args[0][0][0].value.value) == [4, 0]
+    assert call_args[1]["manufacturer"] == 0x1021
 
     mode_cluster._write_attributes = mock.AsyncMock(
         return_value=[
@@ -476,16 +463,10 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
         {"mode": LegrandMode.Switch}, manufacturer=0x1021
     )
     mode_cluster._write_attributes.assert_awaited_once()
-    try:
-        mode_cluster._write_attributes.assert_awaited_with(
-            [f.Attribute(attrid=0, value=f.TypeValue(value=t.data16([3, 0])))],
-            manufacturer=0x1021,
-        )
-    except AssertionError as e:
-        logging.warning(
-            "hum... Wrong assertion error due to unhashable nested list in data16 value.\n%s",
-            str(e),
-        )
+    call_args = mode_cluster._write_attributes.call_args
+    assert call_args[0][0][0].attrid == 0
+    assert list(call_args[0][0][0].value.value) == [3, 0]
+    assert call_args[1]["manufacturer"] == 0x1021
 
     mode_cluster._write_attributes = mock.AsyncMock(
         return_value=[
@@ -494,13 +475,7 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
     )
     await mode_cluster.write_attributes({"mode": LegrandMode.Auto}, manufacturer=0x1021)
     mode_cluster._write_attributes.assert_awaited_once()
-    try:
-        mode_cluster._write_attributes.assert_awaited_with(
-            [f.Attribute(attrid=0, value=f.TypeValue(value=t.data16([4, 0])))],
-            manufacturer=0x1021,
-        )
-    except AssertionError as e:
-        logging.warning(
-            "hum... Wrong assertion error due to unhashable nested list in data16 value.\n%s",
-            str(e),
-        )
+    call_args = mode_cluster._write_attributes.call_args
+    assert call_args[0][0][0].attrid == 0
+    assert list(call_args[0][0][0].value.value) == [4, 0]
+    assert call_args[1]["manufacturer"] == 0x1021

--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -1,5 +1,6 @@
 """Tests for Legrand."""
 
+import logging
 from unittest import mock
 
 import pytest
@@ -7,9 +8,18 @@ import zigpy.types as t
 from zigpy.zcl import AttributeUnsupportedEvent
 from zigpy.zcl.clusters.general import PowerConfiguration
 from zigpy.zcl.foundation import ReadAttributeRecord, Status
+import zigpy.zcl.foundation as f
 
 import zhaquirks
 from zhaquirks.legrand import LEGRAND
+from zhaquirks.legrand.contactor import (
+    AutoOverride,
+    AutoStatus,
+    LegrandContactorAutoOnOff,
+    LegrandContactorMode,
+    LegrandContactorSwitchOnOff,
+    LegrandMode,
+)
 
 zhaquirks.setup()
 
@@ -141,3 +151,356 @@ async def test_legrand_identify_command(zigpy_device_from_v2_quirk):
         assert request.call_args_list[1].kwargs["identify_time"] == IDENTIFY_TIME
         assert "effect_id" not in request.call_args_list[1].kwargs
         assert "effect_variant" not in request.call_args_list[1].kwargs
+
+
+async def test_legrand_contactor_switch(zigpy_device_from_v2_quirk):
+    """Test Legrand contactor switch."""
+
+    device = zigpy_device_from_v2_quirk(f" {LEGRAND}", " Contactor")
+
+    mode_cluster = device.endpoints[1].in_clusters[LegrandContactorMode.cluster_id]
+    auto_on_off_cluster = device.endpoints[1].in_clusters[
+        LegrandContactorAutoOnOff.cluster_id
+    ]
+    switch_on_off_cluster = device.endpoints[1].in_clusters[
+        LegrandContactorSwitchOnOff.cluster_id
+    ]
+
+    ##
+    ## Test Auto mode
+    ##
+    switch_on_off_cluster.contactor_is_switch_reported(False)
+    assert not switch_on_off_cluster._contactor_is_switch
+
+    switch_on_off_cluster.auto_on_off_reported(True)
+    switch_on_off_cluster.auto_on_off_reported(False)
+
+    # test sending turn_on command
+    mode_cluster._read_mode = mock.AsyncMock()
+    auto_on_off_cluster.turn_on = mock.AsyncMock()
+    auto_on_off_cluster.turn_off = mock.AsyncMock()
+    auto_on_off_cluster.toggle = mock.AsyncMock()
+    await switch_on_off_cluster.command(LegrandContactorSwitchOnOff.ON_CMD_ID)
+    mode_cluster._read_mode.assert_awaited_once()
+    auto_on_off_cluster.turn_on.assert_awaited_once()
+    auto_on_off_cluster.turn_off.assert_not_awaited()
+    auto_on_off_cluster.toggle.assert_not_awaited()
+
+    # test sending turn_off command
+    mode_cluster._read_mode = mock.AsyncMock()
+    auto_on_off_cluster.turn_on = mock.AsyncMock()
+    auto_on_off_cluster.turn_off = mock.AsyncMock()
+    auto_on_off_cluster.toggle = mock.AsyncMock()
+    await switch_on_off_cluster.command(LegrandContactorSwitchOnOff.OFF_CMD_ID)
+    mode_cluster._read_mode.assert_awaited_once()
+    auto_on_off_cluster.turn_on.assert_not_awaited()
+    auto_on_off_cluster.turn_off.assert_awaited_once()
+    auto_on_off_cluster.toggle.assert_not_awaited()
+
+    # test sending toggle command
+    mode_cluster._read_mode = mock.AsyncMock()
+    auto_on_off_cluster.turn_on = mock.AsyncMock()
+    auto_on_off_cluster.turn_off = mock.AsyncMock()
+    auto_on_off_cluster.toggle = mock.AsyncMock()
+    await switch_on_off_cluster.command(LegrandContactorSwitchOnOff.TOGGLE_CMD_ID)
+    mode_cluster._read_mode.assert_awaited_once()
+    auto_on_off_cluster.turn_on.assert_not_awaited()
+    auto_on_off_cluster.turn_off.assert_not_awaited()
+    auto_on_off_cluster.toggle.assert_awaited_once()
+
+    # cover _read_attributes
+    auto_on_off_cluster._read_states = mock.AsyncMock()
+    switch_on_off_cluster.request = mock.AsyncMock()
+    await switch_on_off_cluster._read_attributes(["on_off"])
+    auto_on_off_cluster._read_states.assert_awaited_once()
+    switch_on_off_cluster.request.assert_awaited_once()
+
+    auto_on_off_cluster._read_states = mock.AsyncMock()
+    switch_on_off_cluster.request = mock.AsyncMock()
+    await switch_on_off_cluster._read_attributes(
+        [LegrandContactorSwitchOnOff.ON_OFF_ID]
+    )
+    auto_on_off_cluster._read_states.assert_awaited_once()
+    switch_on_off_cluster.request.assert_awaited_once()
+    # cover _update_attribute
+    switch_on_off_cluster._update_attribute(LegrandContactorSwitchOnOff.ON_OFF_ID, 0)
+
+    ##
+    ## Test Switch mode
+    ##
+    switch_on_off_cluster.contactor_is_switch_reported(True)
+    assert switch_on_off_cluster._contactor_is_switch
+
+    switch_on_off_cluster.auto_on_off_reported(True)
+    switch_on_off_cluster.auto_on_off_reported(False)
+
+    # test sending turn_on command
+    mode_cluster._read_mode = mock.AsyncMock()
+    auto_on_off_cluster.turn_on = mock.AsyncMock()
+    auto_on_off_cluster.turn_off = mock.AsyncMock()
+    auto_on_off_cluster.toggle = mock.AsyncMock()
+    switch_on_off_cluster.request = mock.AsyncMock()
+    await switch_on_off_cluster.command(LegrandContactorSwitchOnOff.ON_CMD_ID)
+    mode_cluster._read_mode.assert_awaited_once()
+    auto_on_off_cluster.turn_on.assert_not_awaited()
+    auto_on_off_cluster.turn_off.assert_not_awaited()
+    auto_on_off_cluster.toggle.assert_not_awaited()
+    switch_on_off_cluster.request.assert_awaited_once()
+
+    # test sending turn_off command
+    mode_cluster._read_mode = mock.AsyncMock()
+    auto_on_off_cluster.turn_on = mock.AsyncMock()
+    auto_on_off_cluster.turn_off = mock.AsyncMock()
+    auto_on_off_cluster.toggle = mock.AsyncMock()
+    switch_on_off_cluster.request = mock.AsyncMock()
+    await switch_on_off_cluster.command(LegrandContactorSwitchOnOff.OFF_CMD_ID)
+    mode_cluster._read_mode.assert_awaited_once()
+    auto_on_off_cluster.turn_on.assert_not_awaited()
+    auto_on_off_cluster.turn_off.assert_not_awaited()
+    auto_on_off_cluster.toggle.assert_not_awaited()
+    switch_on_off_cluster.request.assert_awaited_once()
+
+    # test sending toggle command
+    mode_cluster._read_mode = mock.AsyncMock()
+    auto_on_off_cluster.turn_on = mock.AsyncMock()
+    auto_on_off_cluster.turn_off = mock.AsyncMock()
+    auto_on_off_cluster.toggle = mock.AsyncMock()
+    switch_on_off_cluster.request = mock.AsyncMock()
+    await switch_on_off_cluster.command(LegrandContactorSwitchOnOff.TOGGLE_CMD_ID)
+    mode_cluster._read_mode.assert_awaited_once()
+    auto_on_off_cluster.turn_on.assert_not_awaited()
+    auto_on_off_cluster.turn_off.assert_not_awaited()
+    auto_on_off_cluster.toggle.assert_not_awaited()
+    switch_on_off_cluster.request.assert_awaited_once()
+
+    # cover _read_attributes
+    auto_on_off_cluster._read_states = mock.AsyncMock()
+    switch_on_off_cluster.request = mock.AsyncMock()
+    await switch_on_off_cluster._read_attributes(["on_off"])
+    auto_on_off_cluster._read_states.assert_not_awaited()
+    switch_on_off_cluster.request.assert_awaited_once()
+
+    auto_on_off_cluster._read_states = mock.AsyncMock()
+    switch_on_off_cluster.request = mock.AsyncMock()
+    await switch_on_off_cluster._read_attributes(
+        [LegrandContactorSwitchOnOff.ON_OFF_ID]
+    )
+    auto_on_off_cluster._read_states.assert_not_awaited()
+    switch_on_off_cluster.request.assert_awaited_once()
+
+    await switch_on_off_cluster._read_attributes(
+        [LegrandContactorSwitchOnOff.ON_OFF_ID + 1]
+    )
+
+    # cover _update_attribute
+    switch_on_off_cluster._update_attribute(LegrandContactorSwitchOnOff.ON_OFF_ID, 0)
+
+    # test sending other command
+    try:
+        mode_cluster._read_mode = mock.AsyncMock()
+        auto_on_off_cluster.turn_on = mock.AsyncMock()
+        auto_on_off_cluster.turn_off = mock.AsyncMock()
+        auto_on_off_cluster.toggle = mock.AsyncMock()
+        await switch_on_off_cluster.command(
+            LegrandContactorSwitchOnOff.TOGGLE_CMD_ID + 1
+        )
+        mode_cluster._read_mode.assert_not_awaited()
+        auto_on_off_cluster.turn_on.assert_not_awaited()
+        auto_on_off_cluster.turn_off.assert_not_awaited()
+        auto_on_off_cluster.toggle.assert_not_awaited()
+    except Exception as e:
+        assert isinstance(e, KeyError)
+
+
+async def test_legrand_contactor_auto(zigpy_device_from_v2_quirk):
+    """Test Legrand contactor auto."""
+
+    device = zigpy_device_from_v2_quirk(f" {LEGRAND}", " Contactor")
+
+    auto_on_off_cluster = device.endpoints[1].in_clusters[
+        LegrandContactorAutoOnOff.cluster_id
+    ]
+
+    # cover _read_states
+    auto_on_off_cluster.read_attributes = mock.AsyncMock()
+    await auto_on_off_cluster._read_states()
+    auto_on_off_cluster.read_attributes.assert_awaited_with(
+        [LegrandContactorAutoOnOff.STATUS_ID, LegrandContactorAutoOnOff.ON_OFF_ID],
+        allow_cache=False,
+    )
+
+    # cover _read_status
+    auto_on_off_cluster.read_attributes = mock.AsyncMock()
+    await auto_on_off_cluster._read_status()
+    auto_on_off_cluster.read_attributes.assert_awaited_with(
+        [LegrandContactorAutoOnOff.STATUS_ID], allow_cache=False
+    )
+    auto_on_off_cluster.read_attributes = mock.AsyncMock(return_value=[None])
+    assert await auto_on_off_cluster._read_status() is None
+
+    # cover command
+    auto_on_off_cluster.request = mock.AsyncMock()
+    auto_on_off_cluster._read_states = mock.AsyncMock()
+    await auto_on_off_cluster.command(
+        LegrandContactorAutoOnOff.OVERRIDE_CMD_ID, t.data16([])
+    )
+    auto_on_off_cluster._read_states.assert_awaited_once()
+    auto_on_off_cluster.request.assert_awaited_once()
+
+    # cover turn_off
+    auto_on_off_cluster.command = mock.AsyncMock()
+    auto_on_off_cluster._read_status = mock.AsyncMock(return_value=AutoStatus.ForcedOn)
+    await auto_on_off_cluster.turn_off()
+    auto_on_off_cluster.command.assert_awaited_once()
+
+    auto_on_off_cluster.command = mock.AsyncMock()
+    auto_on_off_cluster._read_status = mock.AsyncMock(return_value=AutoStatus.ForcedOff)
+    await auto_on_off_cluster.turn_off()
+    auto_on_off_cluster.command.assert_not_awaited()
+
+    # cover turn_on
+    auto_on_off_cluster.command = mock.AsyncMock()
+    auto_on_off_cluster._read_status = mock.AsyncMock(return_value=AutoStatus.ForcedOff)
+    await auto_on_off_cluster.turn_on()
+    auto_on_off_cluster.command.assert_awaited_once()
+
+    auto_on_off_cluster.command = mock.AsyncMock()
+    auto_on_off_cluster._read_status = mock.AsyncMock(return_value=AutoStatus.ForcedOn)
+    await auto_on_off_cluster.turn_on()
+    auto_on_off_cluster.command.assert_not_awaited()
+
+    # cover toggle
+    assert auto_on_off_cluster.TOGGLE_MAP[AutoStatus.ForcedOn] == AutoOverride.ForceOff
+    assert auto_on_off_cluster.TOGGLE_MAP[AutoStatus.ForcedOff] == AutoOverride.ForceOn
+    assert auto_on_off_cluster.TOGGLE_MAP[AutoStatus.ManualOn] == AutoOverride.ForceOff
+    assert AutoStatus.Auto not in auto_on_off_cluster.TOGGLE_MAP
+
+    auto_on_off_cluster.command = mock.AsyncMock()
+    auto_on_off_cluster._read_status = mock.AsyncMock(return_value=AutoStatus.ForcedOff)
+    await auto_on_off_cluster.toggle()
+    auto_on_off_cluster._read_status.assert_awaited_once()
+    auto_on_off_cluster.command.assert_awaited_once()
+
+    auto_on_off_cluster.command = mock.AsyncMock()
+    auto_on_off_cluster._read_status = mock.AsyncMock(return_value=AutoStatus.ForcedOn)
+    await auto_on_off_cluster.toggle()
+    auto_on_off_cluster._read_status.assert_awaited_once()
+    auto_on_off_cluster.command.assert_awaited_once()
+
+    auto_on_off_cluster.command = mock.AsyncMock()
+    auto_on_off_cluster._read_status = mock.AsyncMock(return_value=AutoStatus.ManualOn)
+    await auto_on_off_cluster.toggle()
+    auto_on_off_cluster._read_status.assert_awaited_once()
+    auto_on_off_cluster.command.assert_awaited_once()
+
+    auto_on_off_cluster.command = mock.AsyncMock()
+    auto_on_off_cluster._read_status = mock.AsyncMock(return_value=AutoStatus.Auto)
+    await auto_on_off_cluster.toggle()
+    auto_on_off_cluster._read_status.assert_awaited_once()
+    auto_on_off_cluster.command.assert_not_awaited()
+
+    # cover _update_attribute
+    auto_on_off_cluster._update_attribute(LegrandContactorAutoOnOff.ON_OFF_ID, False)
+    auto_on_off_cluster._update_attribute(LegrandContactorAutoOnOff.ON_OFF_ID, True)
+
+
+async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
+    """Test Legrand contactor mode."""
+
+    device = zigpy_device_from_v2_quirk(f" {LEGRAND}", " Contactor")
+
+    mode_cluster = device.endpoints[1].in_clusters[LegrandContactorMode.cluster_id]
+    switch_on_off_cluster = device.endpoints[1].in_clusters[
+        LegrandContactorSwitchOnOff.cluster_id
+    ]
+
+    # cover _read_mode
+    mode_cluster.read_attributes = mock.AsyncMock(return_value=[None])
+    result = await mode_cluster._read_mode()
+    assert result is None
+    mode_cluster.read_attributes = mock.AsyncMock(
+        return_value=[{LegrandContactorMode.MODE_ID: "mode_id_value"}]
+    )
+    result = await mode_cluster._read_mode()
+    assert result == "mode_id_value"
+
+    # cover _update_attribute
+    mode_cluster._update_attribute(LegrandContactorMode.MODE_ID, [3, 0])
+    assert switch_on_off_cluster._contactor_is_switch
+    mode_cluster._update_attribute(LegrandContactorMode.MODE_ID, [4, 0])
+    assert not switch_on_off_cluster._contactor_is_switch
+
+    # cover write_attributes
+    mode_cluster._write_attributes = mock.AsyncMock(
+        return_value=[
+            [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
+        ]
+    )
+    await mode_cluster.write_attributes({0: LegrandMode.Switch}, manufacturer=0xFC40)
+    mode_cluster._write_attributes.assert_awaited_once()
+    try:
+        mode_cluster._write_attributes.assert_awaited_with(
+            [f.Attribute(attrid=0, value=f.TypeValue(value=t.data16([3, 0])))],
+            manufacturer=0xFC40,
+        )
+    except AssertionError as e:
+        logging.warning(
+            "hum... Wrong assertion error due to unhashable nested list in data16 value.\n%s",
+            str(e),
+        )
+
+    mode_cluster._write_attributes = mock.AsyncMock(
+        return_value=[
+            [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
+        ]
+    )
+    await mode_cluster.write_attributes({0: LegrandMode.Auto}, manufacturer=0xFC40)
+    mode_cluster._write_attributes.assert_awaited_once()
+    try:
+        mode_cluster._write_attributes.assert_awaited_with(
+            [f.Attribute(attrid=0, value=f.TypeValue(value=t.data16([4, 0])))],
+            manufacturer=0xFC40,
+        )
+    except AssertionError as e:
+        logging.warning(
+            "hum... Wrong assertion error due to unhashable nested list in data16 value.\n%s",
+            str(e),
+        )
+
+    mode_cluster._write_attributes = mock.AsyncMock(
+        return_value=[
+            [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
+        ]
+    )
+    await mode_cluster.write_attributes(
+        {"mode": LegrandMode.Switch}, manufacturer=0xFC40
+    )
+    mode_cluster._write_attributes.assert_awaited_once()
+    try:
+        mode_cluster._write_attributes.assert_awaited_with(
+            [f.Attribute(attrid=0, value=f.TypeValue(value=t.data16([3, 0])))],
+            manufacturer=0xFC40,
+        )
+    except AssertionError as e:
+        logging.warning(
+            "hum... Wrong assertion error due to unhashable nested list in data16 value.\n%s",
+            str(e),
+        )
+
+    mode_cluster._write_attributes = mock.AsyncMock(
+        return_value=[
+            [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
+        ]
+    )
+    await mode_cluster.write_attributes({"mode": LegrandMode.Auto}, manufacturer=0xFC40)
+    mode_cluster._write_attributes.assert_awaited_once()
+    try:
+        mode_cluster._write_attributes.assert_awaited_with(
+            [f.Attribute(attrid=0, value=f.TypeValue(value=t.data16([4, 0])))],
+            manufacturer=0xFC40,
+        )
+    except AssertionError as e:
+        logging.warning(
+            "hum... Wrong assertion error due to unhashable nested list in data16 value.\n%s",
+            str(e),
+        )

--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -5,7 +5,11 @@ from unittest import mock
 import pytest
 import zigpy.types as t
 from zigpy.zcl import AttributeUnsupportedEvent
-from zigpy.zcl.clusters.general import PowerConfiguration
+from zigpy.zcl.clusters.general import (
+    EffectIdentifier,
+    EffectVariant,
+    PowerConfiguration,
+)
 import zigpy.zcl.foundation as f
 from zigpy.zcl.foundation import ReadAttributeRecord, Status
 
@@ -14,10 +18,10 @@ from zhaquirks.legrand import LEGRAND
 from zhaquirks.legrand.contactor import (
     AutoOverride,
     AutoStatus,
+    DeviceMode,
     LegrandContactorAutoOnOff,
     LegrandContactorMode,
     LegrandContactorSwitchOnOff,
-    LegrandMode,
 )
 
 zhaquirks.setup()
@@ -412,70 +416,173 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
     switch_on_off_cluster = device.endpoints[1].in_clusters[
         LegrandContactorSwitchOnOff.cluster_id
     ]
+    auto_on_off_cluster = device.endpoints[1].in_clusters[
+        LegrandContactorAutoOnOff.cluster_id
+    ]
 
-    # cover _read_mode
-    mode_cluster.read_attributes = mock.AsyncMock(return_value=[None])
+    # cover _read_mode - no records returned
+    mode_cluster._read_attributes = mock.AsyncMock(return_value=[None])
     result = await mode_cluster._read_mode()
     assert result is None
-    mode_cluster.read_attributes = mock.AsyncMock(
-        return_value=[{LegrandContactorMode.MODE_ID: "mode_id_value"}]
+
+    # cover _read_mode - unsuccessful read
+    mode_cluster._read_attributes = mock.AsyncMock(
+        return_value=[
+            [ReadAttributeRecord(attrid=0, status=Status.UNSUPPORTED_ATTRIBUTE)]
+        ]
     )
     result = await mode_cluster._read_mode()
-    assert result == "mode_id_value"
+    assert result is None
+
+    # cover _read_mode - real data16 raw wire value.
+    #
+    # Regression test for: "TypeError: int() argument must be a string, a
+    # bytes-like object or a real number, not 'data16'". This used to be
+    # raised because the previous implementation called the generic
+    # read_attributes(), which casts the raw wire value with
+    # ``attr_def.type(record.value.value)``, i.e.
+    # ``DeviceMode(t.data16([3, 0]))`` - impossible since DeviceMode
+    # (t.enum16) is int-based and can't be constructed from a data16
+    # FixedList. _read_mode() must decode the raw bytes itself instead.
+    mode_cluster._read_attributes = mock.AsyncMock(
+        return_value=[
+            [
+                ReadAttributeRecord(
+                    attrid=0,
+                    status=Status.SUCCESS,
+                    value=f.TypeValue(type=f.DataTypeId.data16, value=t.data16([3, 0])),
+                )
+            ]
+        ]
+    )
+    result = await mode_cluster._read_mode()
+    assert result == DeviceMode.Switch
+    assert mode_cluster.get("mode") == DeviceMode.Switch
+
+    mode_cluster._read_attributes = mock.AsyncMock(
+        return_value=[
+            [
+                ReadAttributeRecord(
+                    attrid=0,
+                    status=Status.SUCCESS,
+                    value=f.TypeValue(type=f.DataTypeId.data16, value=t.data16([4, 0])),
+                )
+            ]
+        ]
+    )
+    result = await mode_cluster._read_mode()
+    assert result == DeviceMode.Auto
+    assert mode_cluster.get("mode") == DeviceMode.Auto
 
     # cover _update_attribute
-    mode_cluster._update_attribute(LegrandContactorMode.MODE_ID, [3, 0])
+    mode_cluster._update_attribute(LegrandContactorMode.MODE_ID, DeviceMode.Switch)
     assert switch_on_off_cluster._contactor_is_switch
-    mode_cluster._update_attribute(LegrandContactorMode.MODE_ID, [4, 0])
+    mode_cluster._update_attribute(LegrandContactorMode.MODE_ID, DeviceMode.Auto)
     assert not switch_on_off_cluster._contactor_is_switch
 
-    # cover write_attributes
+    # cover write_attributes (default CustomCluster.write_attributes) plus the
+    # auto-reset-to-Automatic behavior: switching mode to Auto must
+    # automatically call AutoOnOff.override(Automatic), equivalent to
+    # pressing "Reset Auto", so the device resumes obeying the external
+    # input without a manual button press. Switching to Switch must not
+    # trigger it.
+    auto_on_off_cluster.override = mock.AsyncMock(return_value=(f.Status.SUCCESS, None))
     mode_cluster._write_attributes = mock.AsyncMock(
         return_value=[
             [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
         ]
     )
-    await mode_cluster.write_attributes({0: LegrandMode.Switch}, manufacturer=0x1021)
+    await mode_cluster.write_attributes({0: DeviceMode.Switch}, manufacturer=0x1021)
     mode_cluster._write_attributes.assert_awaited_once()
     call_args = mode_cluster._write_attributes.call_args
     assert call_args[0][0][0].attrid == 0
-    assert list(call_args[0][0][0].value.value) == [3, 0]
+    assert call_args[0][0][0].value.type == f.DataTypeId.data16
+    assert call_args[0][0][0].value.value == DeviceMode.Switch
     assert call_args[1]["manufacturer"] == 0x1021
+    auto_on_off_cluster.override.assert_not_awaited()
 
+    auto_on_off_cluster.override = mock.AsyncMock(return_value=(f.Status.SUCCESS, None))
     mode_cluster._write_attributes = mock.AsyncMock(
         return_value=[
             [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
         ]
     )
-    await mode_cluster.write_attributes({0: LegrandMode.Auto}, manufacturer=0x1021)
+    await mode_cluster.write_attributes({0: DeviceMode.Auto}, manufacturer=0x1021)
     mode_cluster._write_attributes.assert_awaited_once()
     call_args = mode_cluster._write_attributes.call_args
     assert call_args[0][0][0].attrid == 0
-    assert list(call_args[0][0][0].value.value) == [4, 0]
+    assert call_args[0][0][0].value.type == f.DataTypeId.data16
+    assert call_args[0][0][0].value.value == DeviceMode.Auto
     assert call_args[1]["manufacturer"] == 0x1021
+    auto_on_off_cluster.override.assert_awaited_once_with(AutoOverride.Automatic)
 
+    auto_on_off_cluster.override = mock.AsyncMock(return_value=(f.Status.SUCCESS, None))
     mode_cluster._write_attributes = mock.AsyncMock(
         return_value=[
             [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
         ]
     )
     await mode_cluster.write_attributes(
-        {"mode": LegrandMode.Switch}, manufacturer=0x1021
+        {"mode": DeviceMode.Switch}, manufacturer=0x1021
     )
     mode_cluster._write_attributes.assert_awaited_once()
     call_args = mode_cluster._write_attributes.call_args
     assert call_args[0][0][0].attrid == 0
-    assert list(call_args[0][0][0].value.value) == [3, 0]
+    assert call_args[0][0][0].value.type == f.DataTypeId.data16
+    assert call_args[0][0][0].value.value == DeviceMode.Switch
     assert call_args[1]["manufacturer"] == 0x1021
+    auto_on_off_cluster.override.assert_not_awaited()
 
+    auto_on_off_cluster.override = mock.AsyncMock(return_value=(f.Status.SUCCESS, None))
     mode_cluster._write_attributes = mock.AsyncMock(
         return_value=[
             [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
         ]
     )
-    await mode_cluster.write_attributes({"mode": LegrandMode.Auto}, manufacturer=0x1021)
+    await mode_cluster.write_attributes({"mode": DeviceMode.Auto}, manufacturer=0x1021)
     mode_cluster._write_attributes.assert_awaited_once()
     call_args = mode_cluster._write_attributes.call_args
     assert call_args[0][0][0].attrid == 0
-    assert list(call_args[0][0][0].value.value) == [4, 0]
+    assert call_args[0][0][0].value.type == f.DataTypeId.data16
+    assert call_args[0][0][0].value.value == DeviceMode.Auto
     assert call_args[1]["manufacturer"] == 0x1021
+    auto_on_off_cluster.override.assert_awaited_once_with(AutoOverride.Automatic)
+
+    # cover write_attributes - mode write to Auto that fails must NOT
+    # auto-reset (only a successful write reflects the device's real state).
+    auto_on_off_cluster.override = mock.AsyncMock(return_value=(f.Status.SUCCESS, None))
+    mode_cluster._write_attributes = mock.AsyncMock(
+        return_value=[
+            [f.WriteAttributesStatusRecord(status=f.Status.FAILURE, attrid=0)]
+        ]
+    )
+    await mode_cluster.write_attributes({0: DeviceMode.Auto}, manufacturer=0x1021)
+    auto_on_off_cluster.override.assert_not_awaited()
+
+
+async def test_legrand_contactor_identify(zigpy_device_from_v2_quirk):
+    """Test Legrand contactor identify command redirect.
+
+    Regression test for: identify does nothing on the physical device, with
+    no error on the HA side. The Contactor doesn't honor the standard ZCL
+    'identify' command; like every other Legrand quirk (switch, dimmer,
+    shutter, micromodule, connected_outled - all via LegrandIdentify), it
+    needs the manufacturer-specific 'trigger_effect' command instead.
+    """
+    device = zigpy_device_from_v2_quirk(f" {LEGRAND}", " Contactor")
+
+    identify_cluster = device.endpoints[1].identify
+    identify_cluster.request = mock.AsyncMock(return_value=(Status.SUCCESS, None))
+
+    await identify_cluster.identify(5)
+
+    assert identify_cluster.request.await_count == 2
+
+    trigger_effect_call = identify_cluster.request.await_args_list[0]
+    assert trigger_effect_call.args[1] == 0x40  # trigger_effect command id
+    assert trigger_effect_call.kwargs["effect_id"] == EffectIdentifier.Blink
+    assert trigger_effect_call.kwargs["effect_variant"] == EffectVariant.Default
+
+    identify_call = identify_cluster.request.await_args_list[1]
+    assert identify_call.args[1] == 0x00  # identify command id
+    assert identify_call.args[3] == 5

--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -436,12 +436,12 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
             [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
         ]
     )
-    await mode_cluster.write_attributes({0: LegrandMode.Switch}, manufacturer=0xFC40)
+    await mode_cluster.write_attributes({0: LegrandMode.Switch}, manufacturer=0x1021)
     mode_cluster._write_attributes.assert_awaited_once()
     try:
         mode_cluster._write_attributes.assert_awaited_with(
             [f.Attribute(attrid=0, value=f.TypeValue(value=t.data16([3, 0])))],
-            manufacturer=0xFC40,
+            manufacturer=0x1021,
         )
     except AssertionError as e:
         logging.warning(
@@ -454,12 +454,12 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
             [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
         ]
     )
-    await mode_cluster.write_attributes({0: LegrandMode.Auto}, manufacturer=0xFC40)
+    await mode_cluster.write_attributes({0: LegrandMode.Auto}, manufacturer=0x1021)
     mode_cluster._write_attributes.assert_awaited_once()
     try:
         mode_cluster._write_attributes.assert_awaited_with(
             [f.Attribute(attrid=0, value=f.TypeValue(value=t.data16([4, 0])))],
-            manufacturer=0xFC40,
+            manufacturer=0x1021,
         )
     except AssertionError as e:
         logging.warning(
@@ -473,13 +473,13 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
         ]
     )
     await mode_cluster.write_attributes(
-        {"mode": LegrandMode.Switch}, manufacturer=0xFC40
+        {"mode": LegrandMode.Switch}, manufacturer=0x1021
     )
     mode_cluster._write_attributes.assert_awaited_once()
     try:
         mode_cluster._write_attributes.assert_awaited_with(
             [f.Attribute(attrid=0, value=f.TypeValue(value=t.data16([3, 0])))],
-            manufacturer=0xFC40,
+            manufacturer=0x1021,
         )
     except AssertionError as e:
         logging.warning(
@@ -492,12 +492,12 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
             [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
         ]
     )
-    await mode_cluster.write_attributes({"mode": LegrandMode.Auto}, manufacturer=0xFC40)
+    await mode_cluster.write_attributes({"mode": LegrandMode.Auto}, manufacturer=0x1021)
     mode_cluster._write_attributes.assert_awaited_once()
     try:
         mode_cluster._write_attributes.assert_awaited_with(
             [f.Attribute(attrid=0, value=f.TypeValue(value=t.data16([4, 0])))],
-            manufacturer=0xFC40,
+            manufacturer=0x1021,
         )
     except AssertionError as e:
         logging.warning(

--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -16,6 +16,7 @@ from zigpy.zcl.foundation import ReadAttributeRecord, Status
 import zhaquirks
 from zhaquirks.legrand import LEGRAND
 from zhaquirks.legrand.contactor import (
+    LEGRAND_MANUFACTURER_CODE,
     AutoOverride,
     AutoStatus,
     DeviceMode,
@@ -113,11 +114,13 @@ async def test_legrand_wire_pilot_cluster_write_attrs(zigpy_device_from_v2_quirk
     cable_cluster.set_pilot_wire_mode = mock.AsyncMock()
 
     # test writing read-only pilot_wire_mode attribute, should call set_pilot_wire_mode
-    await cable_cluster.write_attributes({0x00: 0x02}, manufacturer=0x1021)
+    await cable_cluster.write_attributes(
+        {0x00: 0x02}, manufacturer=LEGRAND_MANUFACTURER_CODE
+    )
 
     cable_cluster.set_pilot_wire_mode.assert_awaited_with(
         0x02,
-        manufacturer=0x1021,
+        manufacturer=LEGRAND_MANUFACTURER_CODE,
     )
     # With an empty attrs dict, _write_attributes is not called in the new zigpy API
     assert len(cable_cluster._write_attributes.mock_calls) == 0
@@ -492,13 +495,15 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
             [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
         ]
     )
-    await mode_cluster.write_attributes({0: DeviceMode.Switch}, manufacturer=0x1021)
+    await mode_cluster.write_attributes(
+        {0: DeviceMode.Switch}, manufacturer=LEGRAND_MANUFACTURER_CODE
+    )
     mode_cluster._write_attributes.assert_awaited_once()
     call_args = mode_cluster._write_attributes.call_args
     assert call_args[0][0][0].attrid == 0
     assert call_args[0][0][0].value.type == f.DataTypeId.data16
     assert call_args[0][0][0].value.value == DeviceMode.Switch
-    assert call_args[1]["manufacturer"] == 0x1021
+    assert call_args[1]["manufacturer"] == LEGRAND_MANUFACTURER_CODE
     auto_on_off_cluster.override.assert_not_awaited()
 
     auto_on_off_cluster.override = mock.AsyncMock(return_value=(f.Status.SUCCESS, None))
@@ -507,13 +512,15 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
             [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
         ]
     )
-    await mode_cluster.write_attributes({0: DeviceMode.Auto}, manufacturer=0x1021)
+    await mode_cluster.write_attributes(
+        {0: DeviceMode.Auto}, manufacturer=LEGRAND_MANUFACTURER_CODE
+    )
     mode_cluster._write_attributes.assert_awaited_once()
     call_args = mode_cluster._write_attributes.call_args
     assert call_args[0][0][0].attrid == 0
     assert call_args[0][0][0].value.type == f.DataTypeId.data16
     assert call_args[0][0][0].value.value == DeviceMode.Auto
-    assert call_args[1]["manufacturer"] == 0x1021
+    assert call_args[1]["manufacturer"] == LEGRAND_MANUFACTURER_CODE
     auto_on_off_cluster.override.assert_awaited_once_with(AutoOverride.Automatic)
 
     auto_on_off_cluster.override = mock.AsyncMock(return_value=(f.Status.SUCCESS, None))
@@ -523,14 +530,14 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
         ]
     )
     await mode_cluster.write_attributes(
-        {"mode": DeviceMode.Switch}, manufacturer=0x1021
+        {"mode": DeviceMode.Switch}, manufacturer=LEGRAND_MANUFACTURER_CODE
     )
     mode_cluster._write_attributes.assert_awaited_once()
     call_args = mode_cluster._write_attributes.call_args
     assert call_args[0][0][0].attrid == 0
     assert call_args[0][0][0].value.type == f.DataTypeId.data16
     assert call_args[0][0][0].value.value == DeviceMode.Switch
-    assert call_args[1]["manufacturer"] == 0x1021
+    assert call_args[1]["manufacturer"] == LEGRAND_MANUFACTURER_CODE
     auto_on_off_cluster.override.assert_not_awaited()
 
     auto_on_off_cluster.override = mock.AsyncMock(return_value=(f.Status.SUCCESS, None))
@@ -539,13 +546,15 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
             [f.WriteAttributesStatusRecord(status=f.Status.SUCCESS, attrid=0)]
         ]
     )
-    await mode_cluster.write_attributes({"mode": DeviceMode.Auto}, manufacturer=0x1021)
+    await mode_cluster.write_attributes(
+        {"mode": DeviceMode.Auto}, manufacturer=LEGRAND_MANUFACTURER_CODE
+    )
     mode_cluster._write_attributes.assert_awaited_once()
     call_args = mode_cluster._write_attributes.call_args
     assert call_args[0][0][0].attrid == 0
     assert call_args[0][0][0].value.type == f.DataTypeId.data16
     assert call_args[0][0][0].value.value == DeviceMode.Auto
-    assert call_args[1]["manufacturer"] == 0x1021
+    assert call_args[1]["manufacturer"] == LEGRAND_MANUFACTURER_CODE
     auto_on_off_cluster.override.assert_awaited_once_with(AutoOverride.Automatic)
 
     # cover write_attributes - mode write to Auto that fails must NOT
@@ -556,7 +565,9 @@ async def test_legrand_contactor_mode(zigpy_device_from_v2_quirk):
             [f.WriteAttributesStatusRecord(status=f.Status.FAILURE, attrid=0)]
         ]
     )
-    await mode_cluster.write_attributes({0: DeviceMode.Auto}, manufacturer=0x1021)
+    await mode_cluster.write_attributes(
+        {0: DeviceMode.Auto}, manufacturer=LEGRAND_MANUFACTURER_CODE
+    )
     auto_on_off_cluster.override.assert_not_awaited()
 
 

--- a/zhaquirks/legrand/contactor.py
+++ b/zhaquirks/legrand/contactor.py
@@ -262,12 +262,12 @@ class AutoStatus(t.enum8):
     NOTE: Oddly enough this status does not seem to reflect all the states.
 
     One may had expected the following states:
-    Zigby Forced Off
+    Zigbee Forced Off
     Manually Forced Off
     Auto Off
     Auto On
     Manually Forced On
-    Zigby Forced On
+    Zigbee Forced On
 
     or:
     Forced Off
@@ -297,14 +297,6 @@ class LegrandContactorAutoStatus(Enum):
     ForcedOn = 0x01
     Auto = 0x02
     ManualOn = 0x03
-
-
-class LegrandContactorSwitchStatus(Enum):
-    """Switch status values for UI display."""
-
-    Off = 0x00
-    On = 0x01
-
 
 class LegrandContactorAutoOnOff(CustomCluster):
     """Legrand Auto OnOff cluster.

--- a/zhaquirks/legrand/contactor.py
+++ b/zhaquirks/legrand/contactor.py
@@ -298,6 +298,7 @@ class LegrandContactorAutoStatus(Enum):
     Auto = 0x02
     ManualOn = 0x03
 
+
 class LegrandContactorAutoOnOff(CustomCluster):
     """Legrand Auto OnOff cluster.
 

--- a/zhaquirks/legrand/contactor.py
+++ b/zhaquirks/legrand/contactor.py
@@ -394,7 +394,7 @@ class LegrandContactorAutoOnOff(CustomCluster):
             schema={
                 "mode": AutoOverride,
             },
-            is_manufacturer_specific=True,
+            manufacturer_code=LEGRAND_MANUFACTURER_CODE,
         )
 
     async def turn_off(self, manufacturer=None, expect_reply=False, tsn=None):

--- a/zhaquirks/legrand/contactor.py
+++ b/zhaquirks/legrand/contactor.py
@@ -1,0 +1,813 @@
+"""Module for Legrand Contactor, Drivia with Netatmo 20AX - 230V~ - 50Hz.
+
+PN: 412171 - 412191 - 199122
+
+Documentation (en): https://assets.legrand.com/pim/NP-FT-GT/F03037EN-05%20(Connected%20contactor).pdf
+Documentation (fr): https://assets.legrand.com/pim/NP-FT-GT/F03037FR-05%20(Contacteur%20Connect%C3%A9).pdf
+
+Tested with PN: 199122
+FW version: 0x005a45ff
+
+signature:
+{
+  "node_descriptor": {
+    "logical_type": 1,
+    "complex_descriptor_available": 0,
+    "user_descriptor_available": 1,
+    "reserved": 0,
+    "aps_flags": 0,
+    "frequency_band": 8,
+    "mac_capability_flags": 142,
+    "manufacturer_code": 4129,
+    "maximum_buffer_size": 89,
+    "maximum_incoming_transfer_size": 63,
+    "server_mask": 11264,
+    "maximum_outgoing_transfer_size": 63,
+    "descriptor_capability_field": 0
+  },
+  "endpoints": {
+    "1": {
+      "profile_id": "0x0104",
+      "device_type": "0x010a",
+      "input_clusters": [
+        "0x0000",
+        "0x0003",
+        "0x0004",
+        "0x0005",
+        "0x0006",
+        "0x000f",
+        "0x0b04",
+        "0xfc01",
+        "0xfc41"
+      ],
+      "output_clusters": [
+        "0x0000",
+        "0x0005",
+        "0x0006",
+        "0x0019",
+        "0xfc01"
+      ]
+    },
+    "242": {
+      "profile_id": "0xa1e0",
+      "device_type": "0x0066",
+      "input_clusters": [
+        "0x0021"
+      ],
+      "output_clusters": [
+        "0x0021"
+      ]
+    }
+  },
+  "manufacturer": " Legrand",
+  "model": " Contactor",
+  "class": "contactor.LegrandContactor"
+}
+"""
+
+from enum import Enum
+import logging
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import (
+    CustomDeviceV2,
+    EntityPlatform,
+    EntityType,
+    QuirkBuilder,
+    ReportingConfig,
+)
+import zigpy.types as t
+from zigpy.zcl import ClusterType
+from zigpy.zcl.clusters.general import OnOff
+from zigpy.zcl.foundation import (
+    BaseAttributeDefs,
+    BaseCommandDefs,
+    Status,
+    ZCLAttributeDef,
+    ZCLCommandDef,
+)
+
+from zhaquirks import Bus
+from zhaquirks.legrand import (  # decimal = 64513
+    LEGRAND,
+    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+MANUFACTURER_SPECIFIC_CLUSTER_ID_2 = 0xFC41  # decimal = 64577
+LEGRAND_MANUFACTURER_CODE = 0x1021
+
+
+class DeviceMode(t.enum16):
+    """Device mode."""
+
+    MODE_SWITCH = 30
+    MODE_AUTO = 40
+
+
+class LegrandMode(Enum):
+    """Device readable mode."""
+
+    Switch = [3, 0]
+    Auto = [4, 0]
+
+
+class LegrandContactorMode(CustomCluster):
+    """Legrand Mode cluster.
+
+    ZHA Toolkit scan result:
+          cluster_id: "0xfc01"            # decimal = 64513
+          title: LegrandContactorMode
+          name: legrand_contactor_mode
+          attributes:
+            "0x0000":
+              attribute_id: "0x0000"
+              attribute_name: mode
+              value_type:
+                - "0x09"
+                - data16
+                - Discrete
+              access: READ|WRITE
+              access_acl: 3
+              manf_id: 4129
+              attribute_value:
+                - 4
+                - 0
+            "0x0001":
+              attribute_id: "0x0001"
+              attribute_name: led_dark
+              value_type:
+                - "0x10"
+                - Bool
+                - Discrete
+              access: READ|WRITE
+              access_acl: 3
+              manf_id: 4129
+              attribute_value: 0
+            "0x0002":
+              attribute_id: "0x0002"
+              attribute_name: led_on
+              value_type:
+                - "0x10"
+                - Bool
+                - Discrete
+              access: READ|WRITE
+              access_acl: 3
+              manf_id: 4129
+              attribute_value: 0
+          commands_received:
+            "0x03":                        # NOTE: no action identified. One mandatory parameter: arg[0]=2
+              command_id: "0x03"
+              command_name: "3"
+              command_arguments: not_in_zcl
+            "0x0e":                        # NOTE: no action identified. Accept any parameter.
+              command_id: "0x0e"
+              command_name: "14"
+              command_arguments: not_in_zcl
+            "0x11":                        # NOTE: no action identified. Accept any parameter.
+              command_id: "0x11"
+              command_name: "17"
+              command_arguments: not_in_zcl
+            "0x14":                        # NOTE: acts as a pairing reset. No parameter needed.
+              command_id: "0x14"
+              command_name: "20"
+              command_arguments: not_in_zcl
+          commands_generated:
+            "0x04":
+              command_id: "0x04"
+              command_name: "4"
+              command_args: not_in_zcl
+            "0x0c":
+              command_id: "0x0c"
+              command_name: "12"
+              command_args: not_in_zcl
+            "0x10":
+              command_id: "0x10"
+              command_name: "16"
+              command_args: not_in_zcl
+    """
+
+    cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID
+    name = "LegrandContactorMode"
+    ep_attribute = "legrand_contactor_mode"
+
+    CONTACTOR_IS_SWITCH_REPORTED = "contactor_is_switch_reported"
+    MODE_ID = 0x0000
+    MODES = [DeviceMode.MODE_SWITCH, DeviceMode.MODE_AUTO]
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        mode = ZCLAttributeDef(
+            id=0x0000,
+            type=t.data16,  # DeviceMode
+            manufacturer_code=LEGRAND_MANUFACTURER_CODE,
+        )
+        led_dark = ZCLAttributeDef(
+            id=0x0001,
+            type=t.Bool,  # LedDarkSwitch
+            manufacturer_code=LEGRAND_MANUFACTURER_CODE,
+        )
+        led_on = ZCLAttributeDef(
+            id=0x0002,
+            type=t.Bool,  # LedOnSwitch
+            manufacturer_code=LEGRAND_MANUFACTURER_CODE,
+        )
+
+    async def write_attributes(self, attributes, manufacturer=None):
+        """Write attributes."""
+
+        new_attributes = attributes.copy()
+        for k in new_attributes:
+            if k in [0, "mode"]:
+                v = new_attributes[k]
+                if isinstance(v, LegrandMode):
+                    if v == LegrandMode.Switch:
+                        new_v = [3, 0]
+                    elif v == LegrandMode.Auto:
+                        new_v = [4, 0]
+                    new_attributes[k] = new_v
+        return await super().write_attributes(new_attributes, manufacturer)
+
+    def _update_attribute(self, attrid, value):
+        """Attribute update."""
+
+        _LOGGER.debug(
+            "LegrandContactorMode._update_attribute: attrid=%s, value=%s",
+            str(attrid),
+            str(value),
+        )
+
+        super()._update_attribute(attrid, value)
+        if attrid == self.MODE_ID and value is not None:
+            mode = (int(value[0]) * 10) + int(value[1])
+            if mode in self.MODES:
+                self.endpoint.device.reporting_bus.listener_event(
+                    self.CONTACTOR_IS_SWITCH_REPORTED, mode == DeviceMode.MODE_SWITCH
+                )
+
+    async def _read_mode(self):
+        """Read mode."""
+        result = await self.read_attributes([self.MODE_ID], allow_cache=False)
+        if not result[0]:
+            return None
+
+        return result[0][self.MODE_ID]
+
+
+class AutoStatus(t.enum8):
+    """Auto mode status values.
+
+    NOTE: Oddly enough this status does not seem to reflect all the states.
+
+    One may had expected the following states:
+    Zigby Forced Off
+    Manually Forced Off
+    Auto Off
+    Auto On
+    Manually Forced On
+    Zigby Forced On
+
+    or:
+    Forced Off
+    Auto Off
+    Auto On
+    Forced On
+    """
+
+    ForcedOff = 0x00
+    ForcedOn = 0x01
+    Auto = 0x02
+    ManualOn = 0x03
+
+
+class AutoOverride(t.enum8):
+    """Auto override arguments values."""
+
+    ForceOff = 0x00
+    ForceOn = 0x01
+    Automatic = 0x02  # no override
+
+
+class LegrandContactorAutoStatus(Enum):
+    """Auto mode status values for UI display."""
+
+    ForcedOff = 0x00
+    ForcedOn = 0x01
+    Auto = 0x02
+    ManualOn = 0x03
+
+
+class LegrandContactorSwitchStatus(Enum):
+    """Switch status values for UI display."""
+
+    Off = 0x00
+    On = 0x01
+
+
+class LegrandContactorAutoOnOff(CustomCluster):
+    """Legrand Auto OnOff cluster.
+
+    ZHA Toolkit scan result:
+          cluster_id: "0xfc41"        # decimal = 64577
+          title: LegrandContactorAutoOnOff
+          name: legrand_contactor_auto_on_off
+          attributes:
+            "0x0000":
+              attribute_id: "0x0000"
+              attribute_name: status
+              value_type:
+                - "0x30"
+                - enum8
+                - Discrete
+              access: READ|REPORT
+              access_acl: 5
+              manf_id: 4129
+              attribute_value: 3
+            "0x0001":
+              attribute_id: "0x0001"
+              attribute_name: on_off
+              value_type:
+                - "0x10"
+                - Bool
+                - Discrete
+              access: READ|REPORT
+              access_acl: 5
+              manf_id: 4129
+              attribute_value: 1
+            "0xfffd":
+              attribute_id: "0xfffd"
+              attribute_name: "65533"
+              value_type:
+                - "0x21"
+                - uint16_t
+                - Analog
+              access: READ
+              access_acl: 1
+              manf_id: 4129
+              attribute_value: 1
+          commands_received:
+            "0x00":
+              command_id: "0x00"
+              command_name: override
+              command_arguments: <class 'zigpy.zcl.foundation.override'>
+          commands_generated:
+            "0x0a":
+              command_id: "0x0a"
+              command_name: "10"
+    """
+
+    cluster_id = MANUFACTURER_SPECIFIC_CLUSTER_ID_2
+    name = "LegrandContactorAutoOnOff"
+    ep_attribute = "legrand_contactor_auto_on_off"
+
+    AUTO_ON_OFF_REPORTED = "auto_on_off_reported"
+    STATUS_ID = 0
+    ON_OFF_ID = 1
+    OVERRIDE_CMD_ID = 0x00
+    TOGGLE_MAP = {
+        AutoStatus.ForcedOn: AutoOverride.ForceOff,
+        AutoStatus.ManualOn: AutoOverride.ForceOff,
+        AutoStatus.ForcedOff: AutoOverride.ForceOn,
+    }
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        status = ZCLAttributeDef(
+            id=0x0000,
+            type=AutoStatus,  # t.enum8
+            manufacturer_code=LEGRAND_MANUFACTURER_CODE,
+        )
+        on_off = ZCLAttributeDef(
+            id=0x0001,
+            type=t.Bool,  # on_off in AUTO mode
+            manufacturer_code=LEGRAND_MANUFACTURER_CODE,
+        )
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Server Command Definitions."""
+
+        override = ZCLCommandDef(
+            id=0x00,
+            schema={
+                "mode": AutoOverride,
+            },
+            is_manufacturer_specific=True,
+        )
+
+    async def turn_off(self, manufacturer=None, expect_reply=False, tsn=None):
+        """Force Off."""
+        _LOGGER.debug("LegrandContactorAutoOnOff.turn_off")
+
+        status = await self._read_status()
+
+        if status == AutoStatus.ForcedOff:
+            _LOGGER.debug("LegrandContactorAutoOnOff.toggle is in forcedOff state.")
+            return (None, Status.SUCCESS)
+
+        return await self.command(
+            self.OVERRIDE_CMD_ID,
+            AutoOverride.ForceOff,
+            manufacturer=manufacturer,
+            expect_reply=expect_reply,
+            tsn=tsn,
+        )
+
+    async def turn_on(self, manufacturer=None, expect_reply=False, tsn=None):
+        """Force On."""
+        _LOGGER.debug("LegrandContactorAutoOnOff.turn_on")
+
+        status = await self._read_status()
+
+        if status == AutoStatus.ForcedOn:
+            _LOGGER.debug("LegrandContactorAutoOnOff.toggle is in forcedOn state.")
+            return (None, Status.SUCCESS)
+
+        return await self.command(
+            self.OVERRIDE_CMD_ID,
+            AutoOverride.ForceOn,
+            manufacturer=manufacturer,
+            expect_reply=expect_reply,
+            tsn=tsn,
+        )
+
+    async def toggle(self, manufacturer=None, expect_reply=False, tsn=None):
+        """Toggle ForcedOff/ForcedOn."""
+        _LOGGER.debug("LegrandContactorAutoOnOff.toggle")
+
+        status = await self._read_status()
+
+        if status not in self.TOGGLE_MAP:
+            _LOGGER.debug("LegrandContactorAutoOnOff.toggle is not in forced state.")
+            return (None, Status.SUCCESS)
+
+        auto_override = self.TOGGLE_MAP[status]
+
+        return await self.command(
+            self.OVERRIDE_CMD_ID,
+            auto_override,
+            manufacturer=manufacturer,
+            expect_reply=expect_reply,
+            tsn=tsn,
+        )
+
+    async def _read_status(self):
+        """Read status."""
+        result = await self.read_attributes([self.STATUS_ID], allow_cache=False)
+        if not result[0]:
+            return None
+
+        return result[0][self.STATUS_ID]
+
+    async def _read_states(self):
+        """Read states."""
+        await self.read_attributes([self.STATUS_ID, self.ON_OFF_ID], allow_cache=False)
+
+    def _update_attribute(self, attrid, value):
+        """Attribute update."""
+
+        _LOGGER.debug(
+            "LegrandContactorAutoOnOff._update_attribute: attrid=%s, value=%s",
+            str(attrid),
+            str(value),
+        )
+
+        super()._update_attribute(attrid, value)
+
+        if attrid == self.ON_OFF_ID and value is not None:
+            self.endpoint.device.reporting_bus.listener_event(
+                self.AUTO_ON_OFF_REPORTED, value
+            )
+
+    async def command(
+        self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None
+    ):
+        """Command."""
+
+        _LOGGER.debug("LegrandContactorAutoOnOff.command: id=%s", str(command_id))
+
+        result = await super().command(
+            command_id,
+            *args,
+            manufacturer=manufacturer,
+            expect_reply=expect_reply,
+            tsn=tsn,
+        )
+
+        await self._read_states()
+
+        return result
+
+
+class LegrandContactorSwitchOnOff(CustomCluster, OnOff):
+    """Legrand Switch OnOff cluster.
+
+    When the device is in Switch mode, it operates normally the OnOff cluster.
+
+    However, when the device is in Auto mode, on, off and toggle OnOff cluster's
+    commands are not supported.
+
+    This class redirects them to the AutoOnOff cluster (id: 0xfc41).
+
+    Similarly, it redirects on_off attribute reads.
+
+    NOTE: The name and ep_attribute class attributes are NOT changed to benefit
+    of generic OnOff cluster's entities creation:
+    - switch
+    - startup behavior select
+    """
+
+    cluster_id = OnOff.cluster_id
+
+    ON_OFF_ID = 0x0000
+    OFF_CMD_ID = 0x00
+    ON_CMD_ID = 0x01
+    TOGGLE_CMD_ID = 0x02
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.reporting_bus.add_listener(self)
+        self._contactor_is_switch = None
+
+    def contactor_is_switch_reported(self, value):
+        """Contactor is switch reported."""
+
+        _LOGGER.debug(
+            "LegrandContactorSwitchOnOff.contactor_is_switch_reported: value=%s",
+            str(value),
+        )
+
+        self._contactor_is_switch = value
+
+    def auto_on_off_reported(self, value):
+        """Auto mode on_off status reported."""
+
+        _LOGGER.debug(
+            "LegrandContactorSwitchOnOff.on_off_reported: value=%s", str(value)
+        )
+
+        if self._contactor_is_switch:
+            _LOGGER.debug(
+                "LegrandContactorSwitchOnOff.on_off_reported: update switch ignored in switch mode."
+            )
+            return
+
+        super()._update_attribute(self.ON_OFF_ID, value)
+
+        _LOGGER.debug("LegrandContactorSwitchOnOff.on_off_reported done.")
+
+    async def _read_attributes(self, attr_ids, *args, **kwargs):
+        """Read attributes.
+
+        Redirects on_off attribute reads to the AutoOnOff cluster (id: 0xfc41) when the device is in Auto mode.
+        """
+        _LOGGER.debug("LegrandContactorSwitchOnOff._read_attributes")
+
+        attr_ids = [
+            self.ON_OFF_ID if attr_id == "on_off" else attr_id for attr_id in attr_ids
+        ]
+
+        if self.ON_OFF_ID not in attr_ids:
+            _LOGGER.debug(
+                "LegrandContactorSwitchOnOff.read_attributes not reading on_off attribute."
+            )
+
+            return await super()._read_attributes(attr_ids, *args, **kwargs)
+
+        await self._update_contactor_mode()
+
+        if not self._contactor_is_switch:
+            await self._update_auto_states()
+
+        return await super()._read_attributes(attr_ids, *args, **kwargs)
+
+    async def _update_contactor_mode(self):
+        """Update contactor mode for _contactor_is_switch."""
+
+        _LOGGER.debug("LegrandContactorSwitchOnOff._update_contactor_mode.")
+
+        mode_cluster = self.endpoint.device.endpoints[1].in_clusters[
+            LegrandContactorMode.cluster_id
+        ]
+
+        await mode_cluster._read_mode()
+
+    async def _update_auto_states(self):
+        """Update contactor auto mode status."""
+
+        _LOGGER.debug("LegrandContactorSwitchOnOff._update_auto_states.")
+
+        auto_cluster = self.endpoint.device.endpoints[1].in_clusters[
+            LegrandContactorAutoOnOff.cluster_id
+        ]
+
+        await auto_cluster._read_states()
+
+    async def command(
+        self, command_id, *args, manufacturer=None, expect_reply=True, tsn=None
+    ):
+        """Legrand switch OnOff command.
+
+        Redirects on, off and toggle commands to AutoOnOff cluster (id: 0xfc41) when the device is Auto mode.
+        The on and off commands FORCE the corresponding states.
+        The toggle command is only operationnal if the AutoOnOff cluster is in a FORCED state.
+        It toggles the ForcedOff (resp. ForcedOn) state to the FocedOn (resp. ForcedOff) state.
+        The device is also toggled to ForcedOff state if it is manually set to on.
+
+        When the device is in Switch mode, operates as a normal OnOff cluster.
+
+        FIXME: UI representation of the Automatic operation should exist.
+        => workaround with quirks-v2: 'Auto Status' diagnostic enum
+
+        FIXME: something should execute the LegrandContactorAutoOnOff.override(AutoOverride.Automatic)
+        to restore automatic operation after switch UI use.
+        => done with quirks-v2: 'Reset Auto' control button
+
+        FIXME: something should disable 'Reset Auto' and 'Auto Status' when Switch mode is active.
+        """
+        _LOGGER.debug("LegrandContactorSwitchOnOff.command")
+
+        if command_id not in [self.ON_CMD_ID, self.OFF_CMD_ID, self.TOGGLE_CMD_ID]:
+            _LOGGER.debug(
+                "LegrandContactorSwitchOnOff.command is neither on, off nor toggle."
+            )
+            return await super().command(
+                command_id,
+                *args,
+                manufacturer=manufacturer,
+                expect_reply=expect_reply,
+                tsn=tsn,
+            )
+
+        await self._update_contactor_mode()
+
+        if self._contactor_is_switch:
+            _LOGGER.debug("LegrandContactorSwitchOnOff.command in switch mode.")
+            return await super().command(
+                command_id,
+                *args,
+                manufacturer=manufacturer,
+                expect_reply=expect_reply,
+                tsn=tsn,
+            )
+
+        auto_cluster = self.endpoint.device.endpoints[1].in_clusters[
+            LegrandContactorAutoOnOff.cluster_id
+        ]
+
+        if command_id == self.ON_CMD_ID:
+            result = await auto_cluster.turn_on(
+                manufacturer=manufacturer, expect_reply=expect_reply, tsn=tsn
+            )
+
+        elif command_id == self.OFF_CMD_ID:
+            result = await auto_cluster.turn_off(
+                manufacturer=manufacturer, expect_reply=expect_reply, tsn=tsn
+            )
+
+        else:  # if command_id == self.TOGGLE_CMD_ID:
+            result = await auto_cluster.toggle(
+                manufacturer=manufacturer, expect_reply=expect_reply, tsn=tsn
+            )
+
+        return result
+
+    def _update_attribute(self, attrid, value):
+        """Legrand switch OnOff attribute update.
+
+        Ignores on_off attribute update when the device is Auto mode.
+        """
+
+        _LOGGER.debug(
+            "LegrandContactorSwitchOnOff._update_attribute: attrid=%s, value=%s",
+            str(attrid),
+            str(value),
+        )
+
+        # await self._update_contactor_mode()
+
+        if not self._contactor_is_switch:
+            _LOGGER.debug(
+                "LegrandContactorSwitchOnOff._update_attribute ignored in auto mode."
+            )
+            return
+
+        super()._update_attribute(attrid, value)
+
+
+class LegrandContactorV2(CustomDeviceV2):
+    """Legrand Contactor device.
+
+    The device offers two modes of operation:
+    - the, factory default, Auto mode where an external input can control the output.
+    - and a Switch mode where normal operations of a controlled switch are supported.
+
+    When the device is in Auto mode, its operation button selects three modes of operation:
+    - a ForcedOff mode where the switch output is opened,
+    - an Automatic mode where the switch output is controlled by the external input,
+    - and a ForcedOn mode where the switch output is closed.
+
+    When the device is in Switch mode, its operation button toggles the OnOff modes of operation:
+    - the Off mode where the switch output is opened,
+    - and the On mode where the switch output is closed.
+
+    Two leds reflect the states of the device.
+
+    The LED on the operation button reflects the device's state. It is:
+    - OFF when the device is (forced) OFF
+    - slow dark blinking with OFF/BLUE colors when the device is OFF, in Auto mode with external input not active,
+    - slow bright blinking with BLUE/GREEN colors when the device is ON, in Auto mode with external input active,
+    - and ON with e bright GREEN color when the device is (forced) ON.
+
+    The LED on the reset button reflects the association states of the device. It is:
+    - RED when the device is not paired,
+    - GREEN when it is in paired , while the network is still open (controller still searching devices)
+    - OFF when the device is paired.
+    - PURPLE when the device pairing failed (is it on timed out? not documented...)
+
+    The reset button controls the pairing.
+
+    1- A long press (approx. 10s) on the reset button resets the device's pairing and is reflected by a RED led.
+
+    2- When the device pairing is reset, another long press on the reset button followed by some (a few)
+    short presses (approx 1 every 1s) starts, and maintains, the pairing process.
+
+    3- Success of the pairing is reflected by a GREEN led.
+    If the pairing fails, retry at step 1.
+
+    4- the led turns OFF when the controller stops the pairing process.
+
+    It instantiates, in replacement, three custom clusters classes:
+    - The LegrandContactorMode cluster (id: 0xfc01) controls the operation mode of the device.
+    - The LegrandContactorAutoOnOff cluster (id: 0xfc41) controls the device in Auto mode.
+    - The LegrandContactorSwitchOnOff cluster (id: OnOff cluster id) controls the device in Switch mode and
+    acts as a proxy to LegrandContactorAutoOnOff in Auto mode.
+    """
+
+    def __init__(self, application, ieee, nwk, replaces, quirk_metadata):
+        """Init."""
+
+        self.reporting_bus = Bus()
+        super().__init__(application, ieee, nwk, replaces, quirk_metadata)
+
+
+REPORTING_WHEN_CHANGED = ReportingConfig(
+    min_interval=0, max_interval=0, reportable_change=1
+)
+
+(
+    QuirkBuilder(f" {LEGRAND}", " Contactor")
+    .device_class(LegrandContactorV2)
+    .replaces(LegrandContactorMode)
+    .replaces(LegrandContactorAutoOnOff)
+    .replaces(LegrandContactorSwitchOnOff)
+    .enum(
+        attribute_name="mode",
+        enum_class=LegrandMode,
+        cluster_id=LegrandContactorMode.cluster_id,
+        cluster_type=ClusterType.Server,
+        endpoint_id=1,
+        entity_platform=EntityPlatform.SELECT,
+        entity_type=EntityType.CONFIG,
+        initially_disabled=False,
+        attribute_initialized_from_cache=True,
+        reporting_config=REPORTING_WHEN_CHANGED,
+        translation_key="operating_mode",
+        fallback_name="Operating mode",
+    )
+    .command_button(
+        command_name="override",
+        cluster_id=LegrandContactorAutoOnOff.cluster_id,
+        command_args=(AutoOverride.Automatic,),
+        command_kwargs=None,
+        cluster_type=ClusterType.Server,
+        endpoint_id=1,
+        entity_type=EntityType.STANDARD,
+        initially_disabled=False,
+        translation_key="reset_auto",
+        fallback_name="Reset Auto",
+    )
+    .enum(
+        attribute_name="status",
+        enum_class=LegrandContactorAutoStatus,
+        cluster_id=LegrandContactorAutoOnOff.cluster_id,
+        cluster_type=ClusterType.Server,
+        endpoint_id=1,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        initially_disabled=False,
+        attribute_initialized_from_cache=True,
+        reporting_config=REPORTING_WHEN_CHANGED,
+        translation_key="auto_status",
+        fallback_name="Auto Status",
+    )
+    # .switch("led_dark", LegrandContactorMode.cluster_id,
+    #        ClusterType.Server, 1, False, None, 0, 1, EntityPlatform.SWITCH, False, True, 'led_dark')
+    # .switch("led_on", LegrandContactorMode.cluster_id,
+    #        ClusterType.Server, 1, False, None, 0, 1, EntityPlatform.SWITCH, False, True, 'led_on')
+    .add_to_registry()
+)

--- a/zhaquirks/legrand/contactor.py
+++ b/zhaquirks/legrand/contactor.py
@@ -741,11 +741,11 @@ class LegrandContactorV2(CustomDeviceV2):
     acts as a proxy to LegrandContactorAutoOnOff in Auto mode.
     """
 
-    def __init__(self, application, ieee, nwk, replaces, quirk_metadata):
+    def __init__(self, *args, **kwargs):
         """Init."""
 
         self.reporting_bus = Bus()
-        super().__init__(application, ieee, nwk, replaces, quirk_metadata)
+        super().__init__(*args, **kwargs)
 
 
 REPORTING_WHEN_CHANGED = ReportingConfig(

--- a/zhaquirks/legrand/contactor.py
+++ b/zhaquirks/legrand/contactor.py
@@ -102,8 +102,8 @@ LEGRAND_MANUFACTURER_CODE = 0x1021
 class DeviceMode(t.enum16):
     """Device mode."""
 
-    MODE_SWITCH = 30
-    MODE_AUTO = 40
+    MODE_SWITCH = 3
+    MODE_AUTO = 4
 
 
 class LegrandMode(Enum):
@@ -241,7 +241,7 @@ class LegrandContactorMode(CustomCluster):
 
         super()._update_attribute(attrid, value)
         if attrid == self.MODE_ID and value is not None:
-            mode = (int(value[0]) * 10) + int(value[1])
+            mode = value[0] | (value[1] << 8)
             if mode in self.MODES:
                 self.endpoint.device.reporting_bus.listener_event(
                     self.CONTACTOR_IS_SWITCH_REPORTED, mode == DeviceMode.MODE_SWITCH

--- a/zhaquirks/legrand/contactor.py
+++ b/zhaquirks/legrand/contactor.py
@@ -68,29 +68,26 @@ signature:
 from enum import Enum
 import logging
 
-from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import (
-    CustomDeviceV2,
-    EntityPlatform,
-    EntityType,
-    QuirkBuilder,
-    ReportingConfig,
-)
 import zigpy.types as t
 from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
+    DataTypeId,
     Status,
     ZCLAttributeDef,
     ZCLCommandDef,
 )
 
 from zhaquirks import Bus
+from zhaquirks.builder import EntityPlatform, EntityType, QuirkBuilder, ReportingConfig
+from zhaquirks.clusters import CustomCluster
+from zhaquirks.device import CustomZigpyDevice
 from zhaquirks.legrand import (  # decimal = 64513
     LEGRAND,
     MANUFACTURER_SPECIFIC_CLUSTER_ID,
+    LegrandIdentify,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -100,17 +97,16 @@ LEGRAND_MANUFACTURER_CODE = 0x1021
 
 
 class DeviceMode(t.enum16):
-    """Device mode."""
+    """Device mode.
 
-    MODE_SWITCH = 3
-    MODE_AUTO = 4
+    Wire encoding is a manufacturer-specific "data16" (2 raw bytes), matching
+    zhaquirks.legrand.cable_outlet.DeviceMode. The attribute's Python type
+    stays a plain int-based enum16 so the cached value (and the ZHA select
+    entity backed by it) can compare directly against these members.
+    """
 
-
-class LegrandMode(Enum):
-    """Device readable mode."""
-
-    Switch = [3, 0]
-    Auto = [4, 0]
+    Switch = 3
+    Auto = 4
 
 
 class LegrandContactorMode(CustomCluster):
@@ -194,14 +190,15 @@ class LegrandContactorMode(CustomCluster):
 
     CONTACTOR_IS_SWITCH_REPORTED = "contactor_is_switch_reported"
     MODE_ID = 0x0000
-    MODES = [DeviceMode.MODE_SWITCH, DeviceMode.MODE_AUTO]
+    MODES = [DeviceMode.Switch, DeviceMode.Auto]
 
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
 
         mode = ZCLAttributeDef(
             id=0x0000,
-            type=t.data16,  # DeviceMode
+            type=DeviceMode,
+            zcl_type=DataTypeId.data16,
             manufacturer_code=LEGRAND_MANUFACTURER_CODE,
         )
         led_dark = ZCLAttributeDef(
@@ -215,21 +212,6 @@ class LegrandContactorMode(CustomCluster):
             manufacturer_code=LEGRAND_MANUFACTURER_CODE,
         )
 
-    async def write_attributes(self, attributes, manufacturer=None):
-        """Write attributes."""
-
-        new_attributes = attributes.copy()
-        for k in new_attributes:
-            if k in [0, "mode"]:
-                v = new_attributes[k]
-                if isinstance(v, LegrandMode):
-                    if v == LegrandMode.Switch:
-                        new_v = [3, 0]
-                    elif v == LegrandMode.Auto:
-                        new_v = [4, 0]
-                    new_attributes[k] = new_v
-        return await super().write_attributes(new_attributes, manufacturer)
-
     def _update_attribute(self, attrid, value):
         """Attribute update."""
 
@@ -241,19 +223,83 @@ class LegrandContactorMode(CustomCluster):
 
         super()._update_attribute(attrid, value)
         if attrid == self.MODE_ID and value is not None:
-            mode = value[0] | (value[1] << 8)
+            mode = value
             if mode in self.MODES:
                 self.endpoint.device.reporting_bus.listener_event(
-                    self.CONTACTOR_IS_SWITCH_REPORTED, mode == DeviceMode.MODE_SWITCH
+                    self.CONTACTOR_IS_SWITCH_REPORTED, mode == DeviceMode.Switch
                 )
 
     async def _read_mode(self):
-        """Read mode."""
-        result = await self.read_attributes([self.MODE_ID], allow_cache=False)
-        if not result[0]:
+        """Read mode.
+
+        NOTE: Uses read_attributes_raw() instead of read_attributes(). The
+        latter casts the raw wire value with
+        ``attr_def.type(record.value.value)``, i.e. ``DeviceMode(raw)``.
+        Since the wire encoding is a raw ``data16`` (2 bytes, per the
+        ZCL Toolkit scan in this module's docstring) and ``DeviceMode`` is
+        int-based (``t.enum16``), this cast raises
+        ``TypeError: int() argument ... not 'data16'`` whenever this method
+        is called with a live read (e.g. from `_update_contactor_mode`,
+        itself invoked on every switch on/off/toggle). Decode the raw
+        little-endian bytes into ``DeviceMode`` manually here instead, and
+        update the cache ourselves so downstream consumers (``MODES``
+        comparisons, ``CONTACTOR_IS_SWITCH_REPORTED``) keep working
+        transparently.
+        """
+        result = await self.read_attributes_raw([self.MODE_ID])
+        records = result[0]
+        if not isinstance(records, list) or not records:
             return None
 
-        return result[0][self.MODE_ID]
+        record = records[0]
+        if record.status != Status.SUCCESS or record.value.value is None:
+            return None
+
+        raw = record.value.value
+        if isinstance(raw, (bytes, bytearray, list, tuple)):
+            mode = DeviceMode(raw[0] | (raw[1] << 8))
+        else:
+            mode = DeviceMode(raw)
+
+        self._update_attribute(self.MODE_ID, mode)
+        return mode
+
+    async def write_attributes(self, attributes, manufacturer=None, **kwargs):
+        """Write attributes.
+
+        NOTE: Restores AutoOnOff's Automatic override right after switching
+        mode to Auto (equivalent to pressing the 'Reset Auto' button).
+        Without this, the device stays in whatever Forced On/Off state it
+        was left in and requires a manual 'Reset Auto' press to resume
+        obeying the external input.
+        """
+        result = await super().write_attributes(
+            attributes, manufacturer=manufacturer, **kwargs
+        )
+
+        mode_value = attributes.get(self.MODE_ID, attributes.get("mode"))
+        if mode_value == DeviceMode.Auto and self._write_succeeded(
+            result, self.MODE_ID
+        ):
+            await self._reset_auto_override()
+
+        return result
+
+    @staticmethod
+    def _write_succeeded(result, attrid):
+        """Check whether a given attribute write succeeded."""
+        records = result[0] if result else []
+        return any(
+            record.attrid == attrid and record.status == Status.SUCCESS
+            for record in records
+        )
+
+    async def _reset_auto_override(self):
+        """Reset AutoOnOff override to Automatic."""
+        auto_cluster = self.endpoint.device.endpoints[1].in_clusters[
+            LegrandContactorAutoOnOff.cluster_id
+        ]
+        await auto_cluster.override(AutoOverride.Automatic)
 
 
 class AutoStatus(t.enum8):
@@ -692,7 +738,7 @@ class LegrandContactorSwitchOnOff(CustomCluster, OnOff):
         super()._update_attribute(attrid, value)
 
 
-class LegrandContactorV2(CustomDeviceV2):
+class LegrandContactorV2(CustomZigpyDevice):
     """Legrand Contactor device.
 
     The device offers two modes of operation:
@@ -758,9 +804,10 @@ REPORTING_WHEN_CHANGED = ReportingConfig(
     .replaces(LegrandContactorMode)
     .replaces(LegrandContactorAutoOnOff)
     .replaces(LegrandContactorSwitchOnOff)
+    .replaces(LegrandIdentify)
     .enum(
         attribute_name="mode",
-        enum_class=LegrandMode,
+        enum_class=DeviceMode,
         cluster_id=LegrandContactorMode.cluster_id,
         cluster_type=ClusterType.Server,
         endpoint_id=1,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Adds support for Legrand contactor PN: 412171 - 412191 - 199122

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

Linked to #3339
Resubmit of #3941 after src branch renaming and rebase.

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-4e7438fded8a244ee2b9a6fade3a1023- Legrand Contactor-1b4254d74ae8381ecd18231b939c9c3d.json](https://github.com/user-attachments/files/25153901/zha-4e7438fded8a244ee2b9a6fade3a1023-.Legrand.Contactor-1b4254d74ae8381ecd18231b939c9c3d.json)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
