### PR TITLE
Fix Aqara `PowerConfiguration` clusters

### DIFF
--- a/zhaquirks/xiaomi/aqara/illumination.py
+++ b/zhaquirks/xiaomi/aqara/illumination.py
@@ -6,7 +6,6 @@ from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement
 from zigpy.zdo.types import NodeDescriptor
 
-from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -21,6 +20,7 @@ from zhaquirks.xiaomi import (
     BasicCluster,
     XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 
 
@@ -60,7 +60,7 @@ class Illumination(XiaomiCustomDevice):
                     BasicCluster,
                     Identify.cluster_id,
                     IlluminanceMeasurement.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                 ],
                 OUTPUT_CLUSTERS: [Identify.cluster_id],
             }
@@ -94,7 +94,7 @@ class IlluminationT1(XiaomiCustomDevice):
                     BasicCluster,
                     Identify.cluster_id,
                     IlluminanceMeasurement.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                 ],
                 OUTPUT_CLUSTERS: [Identify.cluster_id],

--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -8,11 +8,12 @@ from zigpy.zcl.clusters.general import (
     LevelControl,
     MultistateInput,
     OnOff,
+    PowerConfiguration,
 )
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zdo.types import NodeDescriptor
 
-from zhaquirks import CustomCluster, PowerConfigurationCluster
+from zhaquirks import CustomCluster
 from zhaquirks.const import (
     ALT_DOUBLE_PRESS,
     ALT_LONG_PRESS,
@@ -55,6 +56,7 @@ from zhaquirks.xiaomi import (
     BasicCluster,
     XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 
 PRESS_TYPES = {0: "hold", 1: "single", 2: "double", 3: "triple", 255: "release"}
@@ -169,7 +171,7 @@ class RemoteB286OPCN01(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -206,7 +208,7 @@ class RemoteB286OPCN01(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -282,7 +284,7 @@ class RemoteB286OPCN01V2(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -305,7 +307,7 @@ class RemoteB286OPCN01V2(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -368,7 +370,7 @@ class RemoteB286OPCN01Alt(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -396,7 +398,7 @@ class RemoteB286OPCN01Alt(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -439,7 +441,7 @@ class RemoteB486OPCN01(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -476,7 +478,7 @@ class RemoteB486OPCN01(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -572,7 +574,7 @@ class RemoteB686OPCN01(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -609,7 +611,7 @@ class RemoteB686OPCN01(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -745,7 +747,7 @@ class RemoteB286OPCN01V3(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -778,7 +780,7 @@ class RemoteB286OPCN01V3(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -811,7 +813,7 @@ class RemoteB286OPCN01V4(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -876,7 +878,7 @@ class RemoteB286OPCN01V4(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -939,7 +941,7 @@ class RemoteB486OPCN01V2(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -962,7 +964,7 @@ class RemoteB486OPCN01V2(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -1013,7 +1015,7 @@ class RemoteB486OPCN01V3(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -1041,7 +1043,7 @@ class RemoteB486OPCN01V3(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -1094,7 +1096,7 @@ class RemoteB486OPCN01V4(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -1155,7 +1157,7 @@ class RemoteB486OPCN01V4(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -1218,7 +1220,7 @@ class RemoteB686OPCN01V2(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -1241,7 +1243,7 @@ class RemoteB686OPCN01V2(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -1304,7 +1306,7 @@ class RemoteB686OPCN01V3(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -1369,7 +1371,7 @@ class RemoteB686OPCN01V3(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -1432,7 +1434,7 @@ class RemoteB686OPCN01V4(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -1481,7 +1483,7 @@ class RemoteB686OPCN01V4(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],
@@ -1544,7 +1546,7 @@ class RemoteB686OPCN01V5(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -1572,7 +1574,7 @@ class RemoteB686OPCN01V5(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     OppleCluster,
                     MultistateInputCluster,
                 ],

--- a/zhaquirks/xiaomi/aqara/remote_e1.py
+++ b/zhaquirks/xiaomi/aqara/remote_e1.py
@@ -30,7 +30,12 @@ from zhaquirks.const import (
     SHORT_PRESS,
     TRIPLE_PRESS,
 )
-from zhaquirks.xiaomi import LUMI, BasicCluster, XiaomiCustomDevice
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
+)
 from zhaquirks.xiaomi.aqara.opple_remote import (
     COMMAND_1_DOUBLE,
     COMMAND_1_HOLD,
@@ -46,10 +51,7 @@ from zhaquirks.xiaomi.aqara.opple_remote import (
     COMMAND_3_TRIPLE,
     MultistateInputCluster,
 )
-from zhaquirks.xiaomi.aqara.remote_h1 import (
-    AqaraRemoteManuSpecificCluster,
-    PowerConfigurationClusterH1Remote,
-)
+from zhaquirks.xiaomi.aqara.remote_h1 import AqaraRemoteManuSpecificCluster
 
 BOTH_BUTTONS = "both_buttons"
 
@@ -90,7 +92,7 @@ class RemoteE1SingleRocker1(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationClusterH1Remote,
+                    XiaomiPowerConfiguration,
                     MultistateInputCluster,
                     AqaraRemoteManuSpecificCluster,
                 ],
@@ -169,7 +171,7 @@ class RemoteE1DoubleRocker1(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     Identify.cluster_id,
-                    PowerConfigurationClusterH1Remote,
+                    XiaomiPowerConfiguration,
                     MultistateInputCluster,
                     AqaraRemoteManuSpecificCluster,
                 ],

--- a/zhaquirks/xiaomi/aqara/remote_h1.py
+++ b/zhaquirks/xiaomi/aqara/remote_h1.py
@@ -6,7 +6,6 @@ from zigpy.quirks.v2 import ClusterType, QuirkBuilder
 from zigpy.zcl.clusters.general import Identify, OnOff
 from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
 
-from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
     ALT_DOUBLE_PRESS,
     ALT_SHORT_PRESS,
@@ -23,7 +22,7 @@ from zhaquirks.const import (
     SHORT_PRESS,
     TRIPLE_PRESS,
 )
-from zhaquirks.xiaomi import LUMI, XiaomiAqaraE1Cluster
+from zhaquirks.xiaomi import LUMI, XiaomiAqaraE1Cluster, XiaomiPowerConfiguration
 from zhaquirks.xiaomi.aqara.opple_remote import (
     COMMAND_1_DOUBLE,
     COMMAND_1_HOLD,
@@ -82,15 +81,6 @@ class AqaraRemoteManuSpecificCluster(XiaomiAqaraE1Cluster):
         )
 
 
-class PowerConfigurationClusterH1Remote(PowerConfigurationCluster):
-    """Reports battery level."""
-
-    # Aqara H1 wireless remote uses one CR2450 battery.
-    # Values are copied from zigbee-herdsman-converters.
-    MIN_VOLTS = 2.5
-    MAX_VOLTS = 3.0
-
-
 (
     QuirkBuilder(LUMI, "lumi.remote.b18ac1")
     # temporarily commented out due to potentially breaking existing blueprints
@@ -99,7 +89,7 @@ class PowerConfigurationClusterH1Remote(PowerConfigurationCluster):
     # )
     .replaces(AqaraRemoteManuSpecificCluster)
     .replaces(MultistateInputCluster)
-    .replaces(PowerConfigurationClusterH1Remote)
+    .replaces(XiaomiPowerConfiguration)
     .enum(
         AqaraRemoteManuSpecificCluster.AttributeDefs.click_mode.name,
         AqaraSwitchClickMode,
@@ -156,7 +146,7 @@ class PowerConfigurationClusterH1Remote(PowerConfigurationCluster):
     .adds(OnOff, cluster_type=ClusterType.Client)
     .adds(OnOff, endpoint_id=2, cluster_type=ClusterType.Client)
     .adds(OnOff, endpoint_id=3, cluster_type=ClusterType.Client)
-    .replaces(PowerConfigurationClusterH1Remote)
+    .replaces(XiaomiPowerConfiguration)
     .enum(
         AqaraRemoteManuSpecificCluster.AttributeDefs.click_mode.name,
         AqaraSwitchClickMode,

--- a/zhaquirks/xiaomi/aqara/tvoc.py
+++ b/zhaquirks/xiaomi/aqara/tvoc.py
@@ -5,13 +5,19 @@ from typing import Final
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
-from zigpy.zcl.clusters.general import AnalogInput, Basic, Identify, Ota
+from zigpy.zcl.clusters.general import (
+    AnalogInput,
+    Basic,
+    Identify,
+    Ota,
+    PowerConfiguration,
+)
 from zigpy.zcl.clusters.measurement import RelativeHumidity, TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
 from zigpy.zdo.types import NodeDescriptor
 
-from zhaquirks import LocalDataCluster, PowerConfigurationCluster
+from zhaquirks import LocalDataCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -28,6 +34,7 @@ from zhaquirks.xiaomi import (
     TemperatureMeasurementCluster,
     XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
 )
 
 MEASURED_VALUE = 0x0000
@@ -112,7 +119,7 @@ class TVOCMonitor(XiaomiCustomDevice):
                     Identify.cluster_id,
                     TemperatureMeasurement.cluster_id,
                     RelativeHumidity.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                     AnalogInput.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
@@ -132,7 +139,7 @@ class TVOCMonitor(XiaomiCustomDevice):
                     BasicCluster,
                     Identify.cluster_id,
                     TemperatureMeasurementCluster,
-                    PowerConfigurationCluster,
+                    XiaomiPowerConfiguration,
                     RelativeHumidityCluster,
                     AnalogInputCluster,
                     EmulatedTVOCMeasurement,
@@ -161,7 +168,7 @@ class TVOCMonitor2(XiaomiCustomDevice):
                     Basic.cluster_id,
                     Identify.cluster_id,
                     IasZone.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfiguration.cluster_id,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
             }


### PR DESCRIPTION
## Proposed change

This changes Aqara quirks, that use the general quirks custom `PowerConfigurationCluster` which remaps voltage to percentage, to use the `XiaomiPowerConfiguration` cluster instead, so custom Xiaomi attribute reports with battery voltage are mapped to the battery percentage attribute.

### Small caveat

Do note that the `XiaomiPowerConfiguration` is a `LocalDataCluster`, unlike the general quirks `PowerConfigurationCluster`, so `battery_voltage` can no longer be read directly.

Note that `LocalDataCluster` does not block ZCL attribute reports, so if some Aqara devices use standard ZCL attribute reports for reporting battery voltage, they'd still make it through. However, `LocalDataCluster` will now block binding the `PowerConfiguration` cluster for these devices.

### Why it's likely fine

From what I can see, these devices should all send Xiaomi attribute reports with battery voltage.
Unfortunately, the changes as is prevent reading the `battery_voltage` attribute during pairing, which seems to be supported by most Aqara devices and should make the battery percentage entity available immediately, without having to wait for an Xiaomi attribute report.

### Sensor unknown after pairing until first Xiaomi report comes in

But due the order in [zha/zigbee/cluster_handlers/general.py#L737-L746](https://github.com/zigpy/zha/blob/7754950897220bfb8b2d46e3ee1b2ff458486373/zha/zigbee/cluster_handlers/general.py#L737-L746), it's likely that `battery_voltage` is read first (making battery percentage showing up), but when then reading `battery_percentage_remaining` afterwards, it's marked as unsupported again, removing the value from the zigpy cache and thus setting the entity to "unknown" until a (Xiaomi) attribute report comes in.

This is a behavioral change due to https://github.com/zigpy/zigpy/pull/1719, which is more correct, but changes the behavior where the battery sensor previously always used the last available value, even if it was marked as an "unsupported attribute" then.

As soon as the first Xiaomi report comes in, the value is mapped to the `LocalDataCluster`'s `battery_percentage_remaining` attribute and the attribute is marked as supported, showing the sensor value in HA.

### Future

We may want to consider adding `_PREVENT_READS`, `_PREVENT_BIND`, `_PREVENT_REPORTING`, `_PREVENT_WRITES`/`_LOCAL_WRITES` to `LocalDataCluster`.
We may also want to consider using `_VALID_ATTRIBUTES` if we keep this a `LocalDataCluster`.

Also see this comment about attribute reporting and binding no longer being set up for the `PowerConfiguration` cluster, as well as the initial `battery_voltage` read missing during pairing because of the `LocalDataCluster`: https://github.com/zigpy/zha-device-handlers/pull/4735#issuecomment-3894465249

This is something to improve in the future.

## Additional information

Should address:
- https://github.com/home-assistant/core/issues/162430

Apparently, at least the `lumi.remote.b286opcn01`, `lumi.remote.b486opcn01`, `lumi.sen_ill.mgl01`, and `lumi.airmonitor.acn01` do not use standard ZCL attribute reports anyway.


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
