### PR TITLE
Remove `ep_attribute="humidity"` for SmartThings humidity sensor

### DIFF
--- a/zhaquirks/centralite/cl_3310S.py
+++ b/zhaquirks/centralite/cl_3310S.py
@@ -27,7 +27,6 @@ class SmartthingsRelativeHumidityCluster(CustomCluster):
 
     cluster_id = SMRT_THINGS_REL_HUM_CLSTR
     name = "Smartthings Relative Humidity Measurement"
-    ep_attribute = "humidity"
 
     class AttributeDefs(BaseAttributeDefs):
         """Cluster attributes."""


### PR DESCRIPTION
## Proposed change
This removes setting the `ep_attribute = "humidity"` for the SmartThings humidity sensor, aka the Centralite 3310-G.


## Additional information
Alternative approach to:
- https://github.com/zigpy/zha/pull/645

Should address:
- https://github.com/home-assistant/core/issues/162340


## Device diagnostics
- See https://github.com/zigpy/zha/pull/645

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
