### PR TITLE
Fix Aqara Roller Shade E1 cover lift position not updated by `AnalogOutput` reports

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1997,10 +1997,10 @@ async def test_xiaomi_e1_roller_window_covering_read_redirection(
     )
 
 
-async def test_xiaomi_e1_roller_write_aware_update_attribute(
+async def test_xiaomi_e1_roller_position_updates(
     zigpy_device_from_v2_quirk,
 ):
-    """Test Aqara E1 roller AnalogOutput write-aware update_attribute method."""
+    """Test Aqara E1 roller lift position updates on read/report only."""
     device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.acn002")
 
     window_covering_cluster = device.endpoints[1].window_covering
@@ -2009,80 +2009,69 @@ async def test_xiaomi_e1_roller_write_aware_update_attribute(
     analog_cluster = device.endpoints[1].analog_output
     analog_listener = ClusterListener(analog_cluster)
     analog_attr = AnalogOutput.AttributeDefs.present_value
-    analog_attr_max = AnalogOutput.AttributeDefs.max_present_value
 
-    # patch write command for a success response
-    patch_analog_write = mock.patch.object(
+    # patch read command for a success response
+    patch_analog_read = mock.patch.object(
         analog_cluster,
-        "_write_attributes",
-        mock.AsyncMock(
-            return_value=(
-                [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],
-            )
-        ),
-    )
-
-    # patch write command for a fail response
-    patch_analog_write_fail = mock.patch.object(
-        analog_cluster,
-        "_write_attributes",
+        "_read_attributes",
         mock.AsyncMock(
             return_value=(
                 [
-                    foundation.WriteAttributesStatusRecord(
-                        foundation.Status.INVALID_VALUE, analog_attr.id
-                    ),
+                    foundation.ReadAttributeRecord(
+                        analog_attr.id,
+                        foundation.Status.SUCCESS,
+                        foundation.TypeValue(None, 40),
+                    )
                 ],
             )
         ),
     )
 
-    with (
-        patch_analog_write,
-    ):
-        # test writing valid and invalid values using name & id
-        await analog_cluster.write_attributes({analog_attr.id: 50})
-        await analog_cluster.write_attributes({analog_attr.name: 60})
-        assert analog_cluster._write_attributes.call_count == 2
+    with patch_analog_read:
+        analog_listener.attribute_updates.clear()
+        window_covering_listener.attribute_updates.clear()
 
-        # confirm the two successful writes updated the analog cluster
-        assert len(analog_listener.attribute_updates) == 2
-        assert analog_listener.attribute_updates[0] == (
-            analog_attr.id,
-            50,
-        )
-        assert analog_listener.attribute_updates[1] == (
-            analog_attr.id,
+        await analog_cluster.read_attributes([analog_attr.id])
+
+        # read events should update the WindowCovering position
+        assert len(window_covering_listener.attribute_updates) == 1
+        assert window_covering_listener.attribute_updates[0] == (
+            WindowCovering.AttributeDefs.current_position_lift_percentage.id,
             60,
         )
 
-    with (
-        patch_analog_write_fail,
-    ):
-        # test writing valid and invalid values using name & id
-        await analog_cluster.write_attributes(
-            {analog_attr_max.id: 100, analog_attr.id: 150}
-        )
-        await analog_cluster.write_attributes(
-            {analog_attr_max.name: 100, analog_attr.name: 160}
-        )
-        assert analog_cluster._write_attributes.call_count == 2
+    # report events should update the WindowCovering position
+    attr = foundation.Attribute(
+        attrid=analog_attr.id,
+        value=foundation.TypeValue(0x39, t.Single(25.0)),
+    )
+    hdr = foundation.ZCLHeader.general(
+        1,
+        foundation.GeneralCommand.Report_Attributes,
+        direction=foundation.Direction.Server_to_Client,
+    ).serialize()
+    cmd = (
+        foundation.GENERAL_COMMANDS[foundation.GeneralCommand.Report_Attributes]
+        .schema([attr])
+        .serialize()
+    )
 
-        # confirm the two failed attr writes did not update the analog cluster
-        assert len(analog_listener.attribute_updates) == 4
-
-        # confirm the two successful writes updated the analog cluster
-        assert analog_listener.attribute_updates[2] == (
-            analog_attr_max.id,
-            100,
+    window_covering_listener.attribute_updates.clear()
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=analog_cluster.cluster_id,
+            src_ep=analog_cluster.endpoint.endpoint_id,
+            dst_ep=analog_cluster.endpoint.endpoint_id,
+            data=t.SerializableBytes(hdr + cmd),
         )
-        assert analog_listener.attribute_updates[3] == (
-            analog_attr_max.id,
-            100,
-        )
+    )
 
-    # confirm the write invoked update_attributes did not update the covering cluster
-    assert len(window_covering_listener.attribute_updates) == 0
+    assert len(window_covering_listener.attribute_updates) == 1
+    assert window_covering_listener.attribute_updates[0] == (
+        WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+        75,
+    )
 
 
 @pytest.mark.parametrize("endpoint", [(1), (2)])

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -8,7 +8,7 @@ from typing import Any
 from zigpy import types as t
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
-from zigpy.zcl import AttributeReadEvent, Cluster, foundation
+from zigpy.zcl import AttributeReadEvent, AttributeReportedEvent, Cluster, foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import AnalogOutput, MultistateOutput, OnOff
 from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
@@ -110,10 +110,17 @@ class AnalogOutputRollerE1(CustomCluster, AnalogOutput):
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
-        self.on_event(AttributeReadEvent.event_type, self._handle_attribute_read)
+        self.on_event(
+            AttributeReadEvent.event_type, self._handle_attribute_read_or_reported
+        )
+        self.on_event(
+            AttributeReportedEvent.event_type, self._handle_attribute_read_or_reported
+        )
 
-    def _handle_attribute_read(self, event: AttributeReadEvent) -> None:
-        """Handle attribute read event."""
+    def _handle_attribute_read_or_reported(
+        self, event: AttributeReadEvent | AttributeReportedEvent
+    ) -> None:
+        """Handle attribute read/reported events."""
         if event.attribute_id == self.AttributeDefs.present_value.id:
             self.endpoint.window_covering.update_attribute(
                 WindowCovering.AttributeDefs.current_position_lift_percentage.id,


### PR DESCRIPTION

## Proposed change
Makes use of the new attribute reported events (AttributeReportedEvent) on the AnalogOutput to update the WindowCovering `current_position_lift_percentage`.

This addresses the regression introduced in #4658 which resulted in the cover lift position not being updated by the device.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
