### PR TITLE
Add Tuya Novato temperature sensor clock `_TZE284_4dosadbh` variant

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -116,6 +116,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE200_w6n8jeuu", "TS0601")
     .applies_to("_TZE200_vvmbj46n", "TS0601")
     .applies_to("_TZE284_vvmbj46n", "TS0601")
+    .applies_to("_TZE284_4dosadbh", "TS0601")
     .tuya_temperature(dp_id=1, scale=10)
     .tuya_humidity(dp_id=2)
     .tuya_battery(dp_id=4)


### PR DESCRIPTION
## Proposed change

Add Novato temperature and humidity sensor with clock to the device list in tuya_sensor.py::THZ01


## Additional information

Novato temperature and humidity sensor with clock is just another variant of THZ01, and once added to the device list, works out-of-the-box.

Product Link: https://novato.com.tr/urun/tuya-zigbee-lcd-ekranli-sicaklik-ve-nem-sensoru/
The page is in Turkish, and unfortunately I don't think it has English translation. If you have any questions about it, I can translate.

This PR is also a potential fix for #4577 


## Device diagnostics
 
N/A


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] ~~Tests have been added to verify that the new code works~~
- [ ] ~~Device diagnostics data has been attached~~
