### PR TITLE
Fix Aqara FP1E using incorrect manufacturer code

### DIFF
--- a/zhaquirks/xiaomi/aqara/motion_agl1.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl1.py
@@ -70,7 +70,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             id=0x015B,
             type=types.uint32_t,
             access="rw",
-            is_manufacturer_specific=True,
+            manufacturer_code=None,
         )
 
         # Detected motion
@@ -79,7 +79,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             type=AqaraMotion,
             zcl_type=DataTypeId.uint8,
             access="rp",
-            is_manufacturer_specific=True,
+            manufacturer_code=None,
         )
 
         # Distance to the detected motion in millimeters
@@ -87,7 +87,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             id=0x015F,
             type=types.uint32_t,
             access="rp",
-            is_manufacturer_specific=True,
+            manufacturer_code=None,
         )
 
         # The configurable detection sensitivity
@@ -96,7 +96,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             type=AqaraMotionSensitivity,
             zcl_type=DataTypeId.uint8,
             access="rw",
-            is_manufacturer_specific=True,
+            manufacturer_code=None,
         )
 
         # Detected occupancy
@@ -105,7 +105,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             type=AqaraOccupancy,
             zcl_type=DataTypeId.uint8,
             access="rp",
-            is_manufacturer_specific=True,
+            manufacturer_code=None,
         )
 
         # Trigger AI spatial learning (write 1)
@@ -113,7 +113,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             id=0x0157,
             type=types.uint8_t,
             access="w",
-            is_manufacturer_specific=True,
+            manufacturer_code=None,
         )
 
         # Trigger device restart (write 0)
@@ -121,7 +121,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             id=0x00E8,
             type=types.Bool,
             access="w",
-            is_manufacturer_specific=True,
+            manufacturer_code=None,
         )
 
     def _update_attribute(self, attrid: int, value: Any) -> None:


### PR DESCRIPTION
## Proposed change
This changes the attribute definition's manufacturer codes to `None` for the Aqara FP1E mm-wave sensor.
Otherwise, we aren't parsing the attribute reports from the device, since they don't have the manufacturer bit set.
For writes, it looks like the manufacturer code doesn't matter at all(??)


## Additional information
Should address https://github.com/home-assistant/core/issues/162484


## Device diagnostics
[zha-01KAH6BZ8GBKBJXCPX8V4BB4KP-Aqara Presence Sensor FP1E-73e318d90a5606426bd23584f7e84776.json](https://github.com/user-attachments/files/25267670/zha-01KAH6BZ8GBKBJXCPX8V4BB4KP-Aqara.Presence.Sensor.FP1E-73e318d90a5606426bd23584f7e84776.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
