### PR TITLE
Remove Frient EMI Norwegian HAN `divisor` workaround

### DIFF
--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -156,7 +156,7 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
     # TODO: mfr-specific report should not update the standard divisor attribute,
     #  but zigpy currently does not filter this. Fix in zigpy.
     assert len(metering_listener.attribute_updates) == 0
-    assert metering_cluster.get(Metering.AttributeDefs.divisor.id) is None
+    assert metering_cluster.get(Metering.AttributeDefs.divisor) is None
 
     # send real attribute report with current_summ_delivered, current_summ_received,
     # instantaneous_demand, and status

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -143,9 +143,9 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
     # divisor already fixed at 1000
     assert metering_cluster.get(Metering.AttributeDefs.divisor.id) == 1000
 
-    # send incorrect divisor attribute report (TODO: check comment)
-    # Frame: 0x18 (mfr-specific, server-to-client, disable-default-rsp),
-    #        TSN=1, cmd=0x0a (Report_Attributes), attr=0x0302 (divisor), value=512
+    # send incorrect divisor attribute report
+    # Frame: 0x1c (mfr-specific, server-to-client, disable-default-rsp),
+    #        TSN=3, cmd=0x0a (Report_Attributes), attr=0x0302 (divisor), value=512
     device.packet_received(
         t.ZigbeePacket(
             profile_id=260,

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -130,7 +130,7 @@ async def test_frient_emi(zigpy_device_from_v2_quirk):
 
 
 async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
-    """Test Frient EMI Norwegian HAN ignoring incorrect divisor attribute reports."""
+    """Test Frient EMI Norwegian HAN metering attribute reports."""
     device = zigpy_device_from_v2_quirk(
         "frient A/S",
         "EMIZB-132",
@@ -140,10 +140,7 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
     metering_cluster = device.endpoints[2].smartenergy_metering
     metering_listener = ClusterListener(metering_cluster)
 
-    # divisor already fixed at 1000
-    assert metering_cluster.get(Metering.AttributeDefs.divisor.id) == 1000
-
-    # send incorrect divisor attribute report
+    # send mfr-specific attribute report with divisor attribute ID — should be ignored
     # Frame: 0x1c (mfr-specific, server-to-client, disable-default-rsp),
     #        TSN=3, cmd=0x0a (Report_Attributes), attr=0x0302 (divisor), value=512
     device.packet_received(
@@ -156,11 +153,10 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
         )
     )
 
-    # attribute_updated event should not be emitted
+    # TODO: mfr-specific report should not update the standard divisor attribute,
+    #  but zigpy currently does not filter this. Fix in zigpy.
     assert len(metering_listener.attribute_updates) == 0
-
-    # divisor should still be fixed at 1000
-    assert metering_cluster.get(Metering.AttributeDefs.divisor.id) == 1000
+    assert metering_cluster.get(Metering.AttributeDefs.divisor.id) is None
 
     # send real attribute report with current_summ_delivered, current_summ_received,
     # instantaneous_demand, and status
@@ -181,8 +177,8 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
         )
     )
 
-    # attribute_updated events should be emitted
-    assert len(metering_listener.attribute_updates) == 4
+    # attribute_updated events should be emitted (5 instead of 4 due to zigpy bug above)
+    assert len(metering_listener.attribute_updates) == 5
     assert (
         metering_cluster.get(Metering.AttributeDefs.current_summ_delivered.id)
         == 30_723_080

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -131,7 +131,11 @@ async def test_frient_emi(zigpy_device_from_v2_quirk):
 
 async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
     """Test Frient EMI Norwegian HAN ignoring incorrect divisor attribute reports."""
-    device = zigpy_device_from_v2_quirk("frient A/S", "EMIZB-132", endpoint_ids=[1, 2])
+    device = zigpy_device_from_v2_quirk(
+        "frient A/S",
+        "EMIZB-132",
+        cluster_ids={2: {Metering.cluster_id: ClusterType.Server}},
+    )
 
     metering_cluster = device.endpoints[2].smartenergy_metering
     metering_listener = ClusterListener(metering_cluster)

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -162,22 +162,31 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
     # divisor should still be fixed at 1000
     assert metering_cluster.get(Metering.AttributeDefs.divisor.id) == 1000
 
-    # send current_summ_delivered attribute report
-    # Frame: 0x18, TSN=1, cmd=0x0a, attr=0x0000, value=1234 (uint48)
+    # send real attribute report with current_summ_delivered, current_summ_received,
+    # instantaneous_demand, and status
+    # Frame: 0x18 (server-to-client, disable-default-rsp),
+    #        TSN=54, cmd=0x0a (Report_Attributes)
     device.packet_received(
         t.ZigbeePacket(
             profile_id=260,
             cluster_id=Metering.cluster_id,
             src_ep=2,
-            dst_ep=2,
+            dst_ep=1,
             data=t.SerializableBytes(
-                b"\x18\x01\x0a\x00\x00\x25\xd2\x04\x00\x00\x00\x00"
+                b"\x18\x36\x0a\x00\x00\x25\x08\xcc\xd4\x01\x00\x00"
+                b"\x01\x00\x25\x00\x00\x00\x00\x00\x00"
+                b"\x00\x04\x2a\xa1\x0f\x00"
+                b"\x00\x02\x18\x00"
             ),
         )
     )
 
-    # attribute_updated event should be emitted
-    assert len(metering_listener.attribute_updates) == 1
+    # attribute_updated events should be emitted
+    assert len(metering_listener.attribute_updates) == 4
     assert (
-        metering_cluster.get(Metering.AttributeDefs.current_summ_delivered.id) == 1234
+        metering_cluster.get(Metering.AttributeDefs.current_summ_delivered.id)
+        == 30_723_080
     )
+    assert metering_cluster.get(Metering.AttributeDefs.current_summ_received.id) == 0
+    assert metering_cluster.get(Metering.AttributeDefs.instantaneous_demand.id) == 4001
+    assert metering_cluster.get(Metering.AttributeDefs.status.id) == 0

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -151,7 +151,7 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
             profile_id=260,
             cluster_id=Metering.cluster_id,
             src_ep=2,
-            dst_ep=2,
+            dst_ep=1,
             data=t.SerializableBytes(b"\x1c\x15\x10\x03\x0a\x02\x03\x31\x00\x02"),
         )
     )

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -139,8 +139,8 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
     # divisor already fixed at 1000
     assert metering_cluster.get(Metering.AttributeDefs.divisor.id) == 1000
 
-    # send incorrect divisor attribute report
-    # Frame: 0x18 (non-mfr-specific, server-to-client, disable-default-rsp),
+    # send incorrect divisor attribute report (TODO: check comment)
+    # Frame: 0x18 (mfr-specific, server-to-client, disable-default-rsp),
     #        TSN=1, cmd=0x0a (Report_Attributes), attr=0x0302 (divisor), value=512
     device.packet_received(
         t.ZigbeePacket(
@@ -148,7 +148,7 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
             cluster_id=Metering.cluster_id,
             src_ep=2,
             dst_ep=2,
-            data=t.SerializableBytes(b"\x18\x01\x0a\x02\x03\x22\x00\x02\x00"),
+            data=t.SerializableBytes(b"\x1c\x15\x10\x03\x0a\x02\x03\x31\x00\x02"),
         )
     )
 

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -153,10 +153,23 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
         )
     )
 
-    # TODO: mfr-specific report should not update the standard divisor attribute,
-    #  but zigpy currently does not filter this. Fix in zigpy.
-    assert len(metering_listener.attribute_updates) == 0
+    # An attribute update with the divisor ID is emitted, but as the manufacturer bit
+    # is set, the value in the attribute cache for the divisor should NOT be updated.
+    assert len(metering_listener.attribute_updates) == 1
+    assert metering_listener.attribute_updates == [
+        (Metering.AttributeDefs.divisor.id, 512)
+    ]
     assert metering_cluster.get(Metering.AttributeDefs.divisor) is None
+
+    # It is only present in the legacy cache, as the definition for the manufacturer
+    # specific attribute does not yet exist in the quirk.
+    assert metering_cluster._attr_cache.get(Metering.AttributeDefs.divisor.id) == 512
+    assert (
+        metering_cluster._attr_cache._legacy_cache[
+            Metering.AttributeDefs.divisor.id
+        ].value
+        == 512
+    )
 
     # send real attribute report with current_summ_delivered, current_summ_received,
     # instantaneous_demand, and status
@@ -177,7 +190,7 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
         )
     )
 
-    # attribute_updated events should be emitted (5 instead of 4 due to zigpy bug above)
+    # attribute_updated events should be emitted (5 due to previous mfr-specific report)
     assert len(metering_listener.attribute_updates) == 5
     assert (
         metering_cluster.get(Metering.AttributeDefs.current_summ_delivered.id)

--- a/zhaquirks/develco/emi_han.py
+++ b/zhaquirks/develco/emi_han.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 from zigpy.quirks.v2 import QuirkBuilder
 
+# This quirk had a workaround for blocking attribute reports with the ZCL divisor
+# attribute ID and manufacturer-specific bit set. The underlying issue of incorrectly
+# parsing manufacturer-specific attribute reports for ZCL attributes was resolved
+# with zigpy 0.91.0.
+# There's still a test for this device which tests that the divisor is not incorrectly
+# updated. The quirk will also be expanded to use support manufacturer-specific
+# attributes for this device, so it's kept, even though there's no functionality now.
+
 (
     QuirkBuilder("frient A/S", "EMIZB-132")
     .add_to_registry()

--- a/zhaquirks/develco/emi_han.py
+++ b/zhaquirks/develco/emi_han.py
@@ -4,41 +4,11 @@ from __future__ import annotations
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
-import zigpy.types as t
-from zigpy.zcl import foundation
 from zigpy.zcl.clusters.smartenergy import Metering
 
 
 class FrientMetering(CustomCluster, Metering):
     """Frient EMI Norwegian HAN Metering cluster definition."""
-
-    # fix device issue
-    _CONSTANT_ATTRIBUTES = {Metering.AttributeDefs.divisor.id: 1000}
-
-    def handle_cluster_general_request(
-        self,
-        hdr: foundation.ZCLHeader,
-        args: list,
-        *,
-        dst_addressing: t.Addressing.Group
-        | t.Addressing.IEEE
-        | t.Addressing.NWK
-        | None = None,
-    ) -> None:
-        """Filter out incorrect divisor attribute reports from device."""
-        if hdr.command_id == foundation.GeneralCommand.Report_Attributes:
-            # Filter out divisor attribute reports
-            args.attribute_reports = [
-                attr
-                for attr in args.attribute_reports
-                if attr.attrid != Metering.AttributeDefs.divisor.id
-            ]
-
-            # Don't process if no attributes remain
-            if not args.attribute_reports:
-                return
-
-        super().handle_cluster_general_request(hdr, args, dst_addressing=dst_addressing)
 
 
 (

--- a/zhaquirks/develco/emi_han.py
+++ b/zhaquirks/develco/emi_han.py
@@ -2,17 +2,9 @@
 
 from __future__ import annotations
 
-from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.zcl.clusters.smartenergy import Metering
-
-
-class FrientMetering(CustomCluster, Metering):
-    """Frient EMI Norwegian HAN Metering cluster definition."""
-
 
 (
     QuirkBuilder("frient A/S", "EMIZB-132")
-    .replaces(FrientMetering, endpoint_id=2)
     .add_to_registry()
-)
+)  # fmt: skip


### PR DESCRIPTION
## Proposed change

This removes the workaround for the Frient EMI Norwegian HAN, which previously blocked attribute reports for the `divisor` attribute, similar to Z2M [here](https://github.com/Koenkk/zigbee-herdsman-converters/blob/e410903af3516701e48d4a851cda7488f70f928d/src/devices/develco.ts#L35-L46). With HA Core 2026.2.0 and later, this should no longer be needed.

The Frient EMI HAN test was also changed to use a message from a real device (with the mfr-specific bit set).


## Additional information

This essentially reverts the following PR:
- https://github.com/zigpy/zha-device-handlers/pull/4396

There's more context in the comments of that PR. @uvNikita was able to grab such an attribute report for the manufacturer specific attribute that conflicts with the ZCL `divisor` attribute and we confirmed the `is_manufacturer_specific` bit is correctly set, meaning that zigpy no longer parses those attribute reports for the ZCL attribute. (Thanks!!)

- In a future PR, we can implement support for the Frient specific attributes.
- The "quirk" (temporarily without function) was kept, as we still have a test for this device and plan to add more functionality to it soon. 
- We should only merge this for HA Core 2026.3.x.


## Device diagnostics
See this comment: https://github.com/zigpy/zha-device-handlers/pull/4396#issuecomment-3401998359

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
