### PR TITLE
Add MCU-based quirk for TZE200_rmymn92d and TZE200_r0jdjrvi covers

### DIFF
--- a/tests/test_tuya_cover_mcu.py
+++ b/tests/test_tuya_cover_mcu.py
@@ -1,0 +1,137 @@
+"""Tests for Tuya MCU cover quirks."""
+
+from unittest import mock
+
+import pytest
+from zigpy.zcl import foundation
+
+from tests.common import ClusterListener
+import zhaquirks
+from zhaquirks.tuya.mcu import TuyaClusterData
+from zhaquirks.tuya.ts0601_cover_mcu import TuyaCoverCommand, TuyaMCUCover0601
+
+zhaquirks.setup()
+
+
+def test_signature_rmymn92d(assert_signature_matches_quirk):
+    """Test TZE200_rmymn92d signature matches quirk."""
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 0x0104,
+                "device_type": "0x0051",
+                "in_clusters": ["0x0000", "0x0004", "0x0005", "0xef00"],
+                "out_clusters": ["0x000a", "0x0019"],
+            },
+            "242": {
+                "profile_id": 0xA1E0,
+                "device_type": "0x0061",
+                "in_clusters": [],
+                "out_clusters": ["0x0021"],
+            },
+        },
+        "manufacturer": "_TZE200_rmymn92d",
+        "model": "TS0601",
+        "class": "zigpy.device.Device",
+    }
+    assert_signature_matches_quirk(TuyaMCUCover0601, signature)
+
+
+def test_signature_r0jdjrvi(assert_signature_matches_quirk):
+    """Test TZE200_r0jdjrvi signature matches quirk."""
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 0x0104,
+                "device_type": "0x0051",
+                "in_clusters": ["0x0000", "0x0004", "0x0005", "0xef00"],
+                "out_clusters": ["0x000a", "0x0019"],
+            },
+            "242": {
+                "profile_id": 0xA1E0,
+                "device_type": "0x0061",
+                "in_clusters": [],
+                "out_clusters": ["0x0021"],
+            },
+        },
+        "manufacturer": "_TZE200_r0jdjrvi",
+        "model": "TS0601",
+        "class": "zigpy.device.Device",
+    }
+    assert_signature_matches_quirk(TuyaMCUCover0601, signature)
+
+
+@pytest.mark.parametrize(
+    "command_id, expected_tuya_command",
+    [
+        (0x0000, TuyaCoverCommand.OPEN),
+        (0x0001, TuyaCoverCommand.CLOSE),
+        (0x0002, TuyaCoverCommand.STOP),
+    ],
+)
+async def test_cover_open_close_stop(
+    zigpy_device_from_quirk, command_id, expected_tuya_command
+):
+    """Test open, close, and stop commands."""
+    device = zigpy_device_from_quirk(TuyaMCUCover0601)
+    cover_cluster = device.endpoints[1].window_covering
+    tuya_cluster = device.endpoints[1].tuya_manufacturer
+
+    with mock.patch.object(tuya_cluster, "tuya_mcu_command") as mcu_cmd:
+        rsp = await cover_cluster.command(command_id)
+
+        assert rsp.status == foundation.Status.SUCCESS
+        mcu_cmd.assert_called_once()
+
+        cluster_data = mcu_cmd.call_args[0][0]
+        assert isinstance(cluster_data, TuyaClusterData)
+        assert cluster_data.cluster_attr == "curtain_switch"
+        assert cluster_data.attr_value == expected_tuya_command
+        assert cluster_data.manufacturer is None
+
+
+async def test_cover_go_to_lift_percentage(zigpy_device_from_quirk):
+    """Test go_to_lift_percentage command."""
+    device = zigpy_device_from_quirk(TuyaMCUCover0601)
+    cover_cluster = device.endpoints[1].window_covering
+    tuya_cluster = device.endpoints[1].tuya_manufacturer
+
+    with mock.patch.object(tuya_cluster, "tuya_mcu_command") as mcu_cmd:
+        rsp = await cover_cluster.command(0x0005, 50)
+
+        assert rsp.status == foundation.Status.SUCCESS
+        mcu_cmd.assert_called_once()
+
+        cluster_data = mcu_cmd.call_args[0][0]
+        assert isinstance(cluster_data, TuyaClusterData)
+        assert cluster_data.cluster_attr == "current_position_lift_percentage"
+        assert cluster_data.attr_value == 50
+        assert cluster_data.manufacturer is None
+
+
+async def test_cover_unsupported_command(zigpy_device_from_quirk):
+    """Test unsupported command returns error status."""
+    device = zigpy_device_from_quirk(TuyaMCUCover0601)
+    cover_cluster = device.endpoints[1].window_covering
+
+    rsp = await cover_cluster.command(0x0006)
+    assert rsp.status == foundation.Status.UNSUP_CLUSTER_COMMAND
+
+
+async def test_cover_dp_updates(zigpy_device_from_quirk):
+    """Test that DP updates propagate to the WindowCovering cluster."""
+    device = zigpy_device_from_quirk(TuyaMCUCover0601)
+    cover_cluster = device.endpoints[1].window_covering
+    listener = ClusterListener(cover_cluster)
+
+    # Simulate DP2 position update (current_position_lift_percentage)
+    cover_cluster.update_attribute("current_position_lift_percentage", 75)
+    assert len(listener.attribute_updates) == 1
+    assert listener.attribute_updates[0][1] == 75
+
+    # Simulate DP1 curtain_switch update
+    cover_cluster.update_attribute("curtain_switch", 0)
+    assert len(listener.attribute_updates) == 2
+    assert listener.attribute_updates[1][1] == 0

--- a/zhaquirks/tuya/ts0601_cover_mcu.py
+++ b/zhaquirks/tuya/ts0601_cover_mcu.py
@@ -1,0 +1,198 @@
+"""Tuya MCU based cover and blinds."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from zigpy.profiles import zha
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Groups, Ota, Scenes, Time
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.tuya import TUYA_MCU_COMMAND, TuyaLocalCluster, TuyaWindowCover
+from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaClusterData, TuyaMCUCluster
+
+
+class TuyaCoverCommand(t.enum8):
+    """Tuya cover commands."""
+
+    OPEN = 0x00
+    STOP = 0x01
+    CLOSE = 0x02
+
+
+class ZclCoverCommand(t.enum8):
+    """ZCL cover commands."""
+
+    OPEN = 0x00
+    CLOSE = 0x01
+    STOP = 0x02
+
+
+TUYA_TO_ZCL_COVER_COMMAND = {
+    ZclCoverCommand.OPEN: TuyaCoverCommand.OPEN,
+    ZclCoverCommand.CLOSE: TuyaCoverCommand.CLOSE,
+    ZclCoverCommand.STOP: TuyaCoverCommand.STOP,
+}
+
+
+class TuyaMCUWindowCovering(WindowCovering, TuyaLocalCluster):
+    """Tuya MCU WindowCovering cluster."""
+
+    attributes = WindowCovering.attributes.copy()
+    attributes.update(
+        {
+            # 0: open, 1: stop, 2: close
+            0xF000: ("curtain_switch", t.enum8, True),
+            # 0: calibration started, 1: calibration finished
+            0xF001: ("accurate_calibration", t.enum8, True),
+            # 0: default, 1: reverse
+            0xF002: ("motor_steering", t.enum8, True),
+            # 30 to 9000 (units of 0.1 seconds)
+            0xF003: ("travel", t.uint16_t, True),
+        }
+    )
+
+    async def command(
+        self,
+        command_id: foundation.GeneralCommand | int | t.uint8_t,
+        *args,
+        manufacturer: int | t.uint16_t | None = None,
+        expect_reply: bool = True,
+        tsn: int | t.uint8_t | None = None,
+        **kwargs: Any,
+    ):
+        """Override the default Cluster command."""
+
+        self.debug(
+            "Sending Tuya Cluster Command. Cluster Command is %x, Arguments are %s",
+            command_id,
+            args,
+        )
+
+        # up_open, down_close, stop
+        if command_id in (0x0000, 0x0001, 0x0002):
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_name=self.ep_attribute,
+                cluster_attr="curtain_switch",
+                attr_value=TUYA_TO_ZCL_COVER_COMMAND[command_id],
+                expect_reply=expect_reply,
+                manufacturer=None,
+            )
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cluster_data,
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        # go_to_lift_percentage
+        if command_id == 0x0005:
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_name=self.ep_attribute,
+                cluster_attr="current_position_lift_percentage",
+                attr_value=args[0],
+                expect_reply=expect_reply,
+                manufacturer=None,
+            )
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cluster_data,
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        self.warning("Unsupported command_id: %s", command_id)
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
+
+
+class TuyaMCUWindowCoverManufCluster(TuyaMCUCluster):
+    """Tuya MCU cluster with WindowCover data points."""
+
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
+        1: DPToAttributeMapping(
+            TuyaMCUWindowCovering.ep_attribute,
+            "curtain_switch",
+        ),
+        2: DPToAttributeMapping(
+            TuyaMCUWindowCovering.ep_attribute,
+            "current_position_lift_percentage",
+        ),
+        3: DPToAttributeMapping(
+            TuyaMCUWindowCovering.ep_attribute,
+            "current_position_lift_percentage",
+        ),
+    }
+
+    data_point_handlers = {
+        1: "_dp_2_attr_update",
+        2: "_dp_2_attr_update",
+        3: "_dp_2_attr_update",
+    }
+
+
+class TuyaMCUCover0601(TuyaWindowCover):
+    """Tuya MCU blind controller with GreenPowerProxy."""
+
+    signature = {
+        MODELS_INFO: [
+            ("_TZE200_rmymn92d", "TS0601"),
+            ("_TZE200_r0jdjrvi", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaMCUWindowCoverManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaMCUWindowCoverManufCluster,
+                    TuyaMCUWindowCovering,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }


### PR DESCRIPTION
## Proposed change
Adds support for two Tuya TS0601 blind controller models that use the MCU data point protocol:
- `_TZE200_rmymn92d`
- `_TZE200_r0jdjrvi`

These devices differ from the existing covers in `ts0601_cover.py` in two ways:
1. They use the newer MCU-based approach (`TuyaMCUCluster` with `dp_to_attribute` mappings) instead of the older `TuyaManufCluster` + `TuyaWindowCoverControl` pattern
2. They have a GreenPowerProxy on endpoint 242

### Data point mappings
| DP | Attribute | Description |
|----|-----------|-------------|
| 1 | `curtain_switch` | Open (0) / Stop (1) / Close (2) |
| 2 | `current_position_lift_percentage` | Position control (slider) |
| 3 | `current_position_lift_percentage` | Position reporting |

### Additional attributes
| ID | Name | Description |
|----|------|-------------|
| 0xF000 | `curtain_switch` | Open/Stop/Close command |
| 0xF001 | `accurate_calibration` | Calibration started/finished |
| 0xF002 | `motor_steering` | Default/Reverse direction |
| 0xF003 | `travel` | Travel time (0.1s units, 30-9000) |

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached

Related: #3269
