### PR TITLE
Fix Inovelli custom attribute data types

### DIFF
--- a/zhaquirks/inovelli/__init__.py
+++ b/zhaquirks/inovelli/__init__.py
@@ -317,7 +317,7 @@ class InovelliVZM30SNCluster(InovelliCluster):
         )
         periodic_power_and_energy_reports = ZCLAttributeDef(
             id=0x0013,
-            type=t.uint8_t,
+            type=t.uint16_t,
             is_manufacturer_specific=True,
         )
         active_energy_reports = ZCLAttributeDef(
@@ -647,7 +647,7 @@ class InovelliVZM31SNCluster(InovelliCluster):
         )
         periodic_power_and_energy_reports = ZCLAttributeDef(
             id=0x0013,
-            type=t.uint8_t,
+            type=t.uint16_t,
             is_manufacturer_specific=True,
         )
         active_energy_reports = ZCLAttributeDef(
@@ -987,7 +987,7 @@ class InovelliVZM32SNCluster(InovelliCluster):
         )
         periodic_power_and_energy_reports = ZCLAttributeDef(
             id=0x0013,
-            type=t.uint8_t,
+            type=t.uint16_t,
             is_manufacturer_specific=True,
         )
         active_energy_reports = ZCLAttributeDef(

--- a/zhaquirks/inovelli/__init__.py
+++ b/zhaquirks/inovelli/__init__.py
@@ -146,7 +146,7 @@ class InovelliCluster(CustomCluster):
         )
         power_type = ZCLAttributeDef(
             id=0x0015,
-            type=t.uint8_t,
+            type=t.Bool,
             is_manufacturer_specific=True,
         )
         internal_temp_monitor = ZCLAttributeDef(

--- a/zhaquirks/inovelli/__init__.py
+++ b/zhaquirks/inovelli/__init__.py
@@ -151,7 +151,7 @@ class InovelliCluster(CustomCluster):
         )
         internal_temp_monitor = ZCLAttributeDef(
             id=0x0020,
-            type=t.uint8_t,
+            type=t.int8s,
             is_manufacturer_specific=True,
         )
         overheated = ZCLAttributeDef(


### PR DESCRIPTION
## Proposed change
This fixes the ZCL data types for some custom Inovelli attributes.


## Additional information

See:
- https://github.com/home-assistant/core/issues/163027

`read_attributers` tries to convert the ZCL types, but if this doesn't work, we fail [here](https://github.com/zigpy/zigpy/blob/70d15a5dde9adc28c230261d4ac32b7309075415/zigpy/zcl/__init__.py#L1088) now.
We should also investigate whether we want to reintroduce [previous guards zigpy had](https://github.com/zigpy/zigpy/blob/f7550584b04d0df2aa8af3514ec0931fb6fee6d5/zigpy/zcl/__init__.py#L633-L644) there, or not.

In this case, `periodic_power_and_energy_reports` having a value of `3600` was the issue.

ZHA cluster handler init issue:

<details><summary>Logs (CLICK TO OPEN)</summary>
<p>

```python
2026-02-16 00:30:09.910 DEBUG (MainThread) [zha.zigbee.cluster_handlers] [0x0CE2:1:0xfc31]: 'async_initialize' stage failed: 3600 is not an unsigned 8 bit integer
Traceback (most recent call last):
  File "/Users/julian/PythonProjects/HomeAssistantcore/.venv/lib/python3.14/site-packages/zha/async_.py", line 64, in sem_task
    return await task
           ^^^^^^^^^^
  File "/Users/julian/PythonProjects/HomeAssistantcore/.venv/lib/python3.14/site-packages/zha/zigbee/cluster_handlers/__init__.py", line 521, in async_initialize
    await self._get_attributes(
        True, cached, from_cache=True, only_cache=from_cache
    )
  File "/Users/julian/PythonProjects/HomeAssistantcore/.venv/lib/python3.14/site-packages/zha/zigbee/cluster_handlers/__init__.py", line 614, in _get_attributes
    read, _ = await RETRYABLE_REQUEST_DECORATOR(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File "/Users/julian/PythonProjects/HomeAssistantcore/.venv/lib/python3.14/site-packages/zigpy/util.py", line 150, in retry
    return await func()
           ^^^^^^^^^^^^
  File "/Users/julian/PythonProjects/HomeAssistantcore/.venv/lib/python3.14/site-packages/zigpy/zcl/__init__.py", line 1088, in read_attributes
    value = attr_def.type(record.value.value)
  File "/Users/julian/PythonProjects/HomeAssistantcore/.venv/lib/python3.14/site-packages/zigpy/types/basic.py", line 134, in __new__
    raise ValueError(
    ...<2 lines>...
    )
ValueError: 3600 is not an unsigned 8 bit integer
```

</p>
</details> 

## Device diagnostics

See HA issue.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
