### PR TITLE
Fix `EventableCluster` not listening to `AttributeUpdatedEvent`

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -154,7 +154,7 @@ async def test_ts0021_remote(
         "attribute_updated",
         {
             "attribute_id": expected_attr_name,
-            "attribute_name": "Unknown",
+            "attribute_name": "Unknown",  # no ZCLAttributeDef for Tuya DP-mapped attr
             "value": expected_attr_value,
         },
     )

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -120,64 +120,44 @@ async def test_singleswitch_state_report(zigpy_device_from_quirk, quirk):
 
 
 @pytest.mark.parametrize(
-    "quirk,raw_event,expected_attr_name,expected_attr_value",
+    "raw_event,expected_attr_name,expected_attr_value",
     (
-        (
-            zhaquirks.tuya.ts0021.TS0021,
-            ZCL_TUYA_BUTTON_1_SINGLE_PRESS,
-            "btn_1_pressed",
-            0x00,
-        ),
-        (
-            zhaquirks.tuya.ts0021.TS0021,
-            ZCL_TUYA_BUTTON_1_DOUBLE_PRESS,
-            "btn_1_pressed",
-            0x01,
-        ),
-        (
-            zhaquirks.tuya.ts0021.TS0021,
-            ZCL_TUYA_BUTTON_1_LONG_PRESS,
-            "btn_1_pressed",
-            0x02,
-        ),
-        (
-            zhaquirks.tuya.ts0021.TS0021,
-            ZCL_TUYA_BUTTON_2_SINGLE_PRESS,
-            "btn_2_pressed",
-            0x00,
-        ),
-        (
-            zhaquirks.tuya.ts0021.TS0021,
-            ZCL_TUYA_BUTTON_2_DOUBLE_PRESS,
-            "btn_2_pressed",
-            0x01,
-        ),
-        (
-            zhaquirks.tuya.ts0021.TS0021,
-            ZCL_TUYA_BUTTON_2_LONG_PRESS,
-            "btn_2_pressed",
-            0x02,
-        ),
+        (ZCL_TUYA_BUTTON_1_SINGLE_PRESS, "btn_1_pressed", 0x00),
+        (ZCL_TUYA_BUTTON_1_DOUBLE_PRESS, "btn_1_pressed", 0x01),
+        (ZCL_TUYA_BUTTON_1_LONG_PRESS, "btn_1_pressed", 0x02),
+        (ZCL_TUYA_BUTTON_2_SINGLE_PRESS, "btn_2_pressed", 0x00),
+        (ZCL_TUYA_BUTTON_2_DOUBLE_PRESS, "btn_2_pressed", 0x01),
+        (ZCL_TUYA_BUTTON_2_LONG_PRESS, "btn_2_pressed", 0x02),
     ),
 )
-async def test_ts0021_switch(
-    zigpy_device_from_quirk, quirk, raw_event, expected_attr_name, expected_attr_value
+async def test_ts0021_remote(
+    zigpy_device_from_quirk, raw_event, expected_attr_name, expected_attr_value
 ):
-    """Test tuya TS0021 2-gang switch."""
+    """Test tuya TS0021 2-button remote attributes and ZHA events."""
 
-    device = zigpy_device_from_quirk(quirk)
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts0021.TS0021)
 
     tuya_cluster = device.endpoints[1].tuya_manufacturer
     switch_listener = ClusterListener(tuya_cluster)
+    zha_listener = mock.MagicMock()
+    tuya_cluster.add_listener(zha_listener)
 
     hdr, args = tuya_cluster.deserialize(raw_event)
     tuya_cluster.handle_message(hdr, args)
 
     assert len(switch_listener.cluster_commands) == 1
     assert len(switch_listener.attribute_updates) == 1
-
     assert switch_listener.attribute_updates[0][0] == expected_attr_name
     assert switch_listener.attribute_updates[0][1] == expected_attr_value
+
+    zha_listener.zha_send_event.assert_called_once_with(
+        "attribute_updated",
+        {
+            "attribute_id": expected_attr_name,
+            "attribute_name": "Unknown",
+            "value": expected_attr_value,
+        },
+    )
 
 
 @pytest.mark.parametrize("quirk", (zhaquirks.tuya.ts0601_switch.TuyaDoubleSwitchTO,))

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -168,7 +168,9 @@ class EventableCluster(CustomCluster):
                 args,
             )
 
-    def _handle_attribute_report(self, event: AttributeReportedEvent) -> None:
+    def _handle_attribute_report(
+        self, event: AttributeReportedEvent | AttributeUpdatedEvent
+    ) -> None:
         """Handle attribute report event."""
         self.listener_event(
             ZHA_SEND_EVENT,

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -171,7 +171,7 @@ class EventableCluster(CustomCluster):
     def _handle_attribute_report(
         self, event: AttributeReportedEvent | AttributeUpdatedEvent
     ) -> None:
-        """Handle attribute report event."""
+        """Handle attribute report or update event."""
         self.listener_event(
             ZHA_SEND_EVENT,
             COMMAND_ATTRIBUTE_UPDATED,

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -147,6 +147,7 @@ class EventableCluster(CustomCluster):
         """Init."""
         super().__init__(*args, **kwargs)
         self.on_event(AttributeReportedEvent.event_type, self._handle_attribute_report)
+        self.on_event(AttributeUpdatedEvent.event_type, self._handle_attribute_report)
 
     def handle_cluster_request(
         self,

--- a/zhaquirks/tuya/ts0021.py
+++ b/zhaquirks/tuya/ts0021.py
@@ -1,4 +1,4 @@
-"""Device handler the TS0021."""
+"""Device handler for the TS0021."""
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -54,7 +54,7 @@ class TuyaCustomCluster(TuyaNewManufCluster, EventableCluster):
 
 
 class TS0021(CustomDevice):
-    """Tuya TS0021 2-button switch device."""
+    """Tuya TS0021 2-button remote device."""
 
     signature = {
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=1026,


### PR DESCRIPTION
## Proposed change
This fixes an issue where the `EventableCluster` does not listen to `AttributeUpdatedEvent` events.

For example, if a Tuya datapoint is remapped to a "ZCL" attribute, which is updated using `update_attribute`, it'll never fire `AttributeReportedEvent`, only `AttributeUpdatedEvent`. So, the `zha_event` for the attribute update is never fired.

The test for the Tuya TS021 remote is also improved to make sure the `EventableCluster` also listens to `AttributeUpdatedEvent`. 

## Additional information
Should address:
- https://github.com/home-assistant/core/issues/163118

See related quirk:
https://github.com/zigpy/zha-device-handlers/blob/40b41de4c0abae1f5265b1d05cbf47861f253afc/zhaquirks/tuya/ts0021.py#L36-L53

It would probably make sense to add decent test coverage for `EventableCluster` in another PR.
Maybe even utilizing the Tuya datapoint remapping, or just have `update_attribute` be called there.

## Device diagnostics
Possibly in linked HA issue or already in ZHA diagnostics.


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
