### PR TITLE
Add Tuya Brennenstuhl TRV `_TZE200_lrznf59v` variant

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1702,6 +1702,7 @@ class SiterwellGS361_Type2(TuyaThermostat):
             ("_TZE200_8daqwrsj", "TS0601"),
             ("_TZE200_czk78ptr", "TS0601"),
             ("_TZE200_2cs6g9i7", "TS0601"),  # Brennenstuhl Zigbee Connect 01
+            ("_TZE200_lrznf59v", "TS0601"),
             ("_TZE200_04yfvweb", "TS0601"),  # Appartme APRM-04-001
         ],
         ENDPOINTS: {


### PR DESCRIPTION
new batch of thermostats we got have a new model name *(`_TZE200_lrznf59v`)*, but function as the old ones. this quirk enables controls in Home Assistant through ZHA

## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
–


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-5f1c507fd5f33fd19d75b80d13ab3d82-_TZE200_lrznf59v TS0601-ab42afb92e2e7744ab4144f4c0236c4c.json](https://github.com/user-attachments/files/25368781/zha-5f1c507fd5f33fd19d75b80d13ab3d82-_TZE200_lrznf59v.TS0601-ab42afb92e2e7744ab4144f4c0236c4c.json)



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] ~~Tests have been added to verify that the new code works~~
- [X] Device diagnostics data has been attached
