### PR TITLE
Add Aqara Shutter Switch H2 EU (lumi.switch.aeu003) quirk

### DIFF
--- a/tests/test_aqara_switch_aeu003.py
+++ b/tests/test_aqara_switch_aeu003.py
@@ -269,3 +269,199 @@ async def test_non_position_commands_unchanged(zigpy_device_from_v2_quirk):
 
         base_request.assert_called_once()
         assert base_request.call_args.args[1] == stop_command_id
+
+
+@pytest.mark.asyncio
+async def test_mfg_cluster_bind_enables_multiclick_and_reads_position(
+    zigpy_device_from_v2_quirk,
+):
+    """Bind should enable multi-click on ep3/4 and read position on ep1."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara",
+        "lumi.switch.aeu003",
+        endpoint_ids=[1, 2, 3, 4, 21],
+        cluster_ids={
+            1: {
+                WindowCovering.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            2: {0xFCC0: ClusterType.Server},
+            3: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            4: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            21: {AnalogInput.cluster_id: ClusterType.Server},
+        },
+    )
+
+    ep1_cluster = device.endpoints[1].opple_cluster
+    ep3_cluster = device.endpoints[3].opple_cluster
+    ep4_cluster = device.endpoints[4].opple_cluster
+
+    with (
+        mock.patch(
+            "zigpy.zcl.Cluster.bind",
+            new=mock.AsyncMock(return_value=(foundation.Status.SUCCESS,)),
+        ),
+        mock.patch.object(
+            ep1_cluster,
+            "read_attributes",
+            new=mock.AsyncMock(return_value=({}, {})),
+        ) as ep1_read,
+        mock.patch.object(
+            ep3_cluster,
+            "write_attributes",
+            new=mock.AsyncMock(
+                return_value=(
+                    [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],
+                )
+            ),
+        ) as ep3_write,
+        mock.patch.object(
+            ep4_cluster,
+            "write_attributes",
+            new=mock.AsyncMock(
+                return_value=(
+                    [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],
+                )
+            ),
+        ) as ep4_write,
+    ):
+        assert await ep1_cluster.bind() == (foundation.Status.SUCCESS,)
+        assert await ep3_cluster.bind() == (foundation.Status.SUCCESS,)
+        assert await ep4_cluster.bind() == (foundation.Status.SUCCESS,)
+
+    ep1_read.assert_awaited_once_with([0x041F])
+    ep3_write.assert_awaited_once_with({0x0286: 2}, manufacturer=0x115F)
+    ep4_write.assert_awaited_once_with({0x0286: 2}, manufacturer=0x115F)
+
+
+@pytest.mark.asyncio
+async def test_mfg_cluster_read_write_default_manufacturer(zigpy_device_from_v2_quirk):
+    """Read/write helpers should default to Aqara manufacturer code."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara",
+        "lumi.switch.aeu003",
+        endpoint_ids=[1, 2, 3, 4, 21],
+        cluster_ids={
+            1: {
+                WindowCovering.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            2: {0xFCC0: ClusterType.Server},
+            3: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            4: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            21: {AnalogInput.cluster_id: ClusterType.Server},
+        },
+    )
+
+    cluster = device.endpoints[1].opple_cluster
+
+    with (
+        mock.patch(
+            "zigpy.zcl.Cluster.write_attributes",
+            new=mock.AsyncMock(
+                return_value=(
+                    [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],
+                )
+            ),
+        ) as super_write,
+        mock.patch(
+            "zigpy.zcl.Cluster.read_attributes",
+            new=mock.AsyncMock(return_value=({}, {})),
+        ) as super_read,
+    ):
+        await cluster.write_attributes({0x0286: 2})
+        await cluster.read_attributes([0x041F])
+
+    assert super_write.await_args.kwargs["manufacturer"] == 0x115F
+    assert super_read.await_args.kwargs["manufacturer"] == 0x115F
+
+
+@pytest.mark.asyncio
+async def test_mfg_cluster_logs_refresh_failures(zigpy_device_from_v2_quirk, caplog):
+    """Movement refresh failures should be logged, not raised."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara",
+        "lumi.switch.aeu003",
+        endpoint_ids=[1, 2, 3, 4, 21],
+        cluster_ids={
+            1: {
+                WindowCovering.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            2: {0xFCC0: ClusterType.Server},
+            3: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            4: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            21: {AnalogInput.cluster_id: ClusterType.Server},
+        },
+    )
+
+    cluster = device.endpoints[1].opple_cluster
+
+    def boom(coro, *args, **kwargs):
+        coro.close()
+        raise RuntimeError("boom")
+
+    with (
+        mock.patch.object(cluster, "read_attributes", new=mock.AsyncMock()),
+        mock.patch("asyncio.create_task", side_effect=boom),
+    ):
+        cluster._update_attribute(0x0420, 0)
+
+    assert "Failed to refresh position on movement update" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mfg_cluster_logs_position_update_failures(
+    zigpy_device_from_v2_quirk, caplog
+):
+    """Position update failures should be logged, not raised."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara",
+        "lumi.switch.aeu003",
+        endpoint_ids=[1, 2, 3, 4, 21],
+        cluster_ids={
+            1: {
+                WindowCovering.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            2: {0xFCC0: ClusterType.Server},
+            3: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            4: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            21: {AnalogInput.cluster_id: ClusterType.Server},
+        },
+    )
+
+    cluster = device.endpoints[1].opple_cluster
+
+    with mock.patch.object(
+        device.endpoints[1].window_covering,
+        "update_attribute",
+        side_effect=RuntimeError("boom"),
+    ):
+        cluster._update_attribute(0x041F, 50)
+
+    assert "Failed to update lift percentage from percent value" in caplog.text

--- a/tests/test_aqara_switch_aeu003.py
+++ b/tests/test_aqara_switch_aeu003.py
@@ -3,11 +3,12 @@
 from unittest import mock
 
 import pytest
-from zigpy.zcl import ClusterType
+from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import AnalogInput, MultistateInput
 
 from tests.common import ClusterListener
+from zhaquirks.xiaomi.aqara.switch_aeu003 import InvertedWindowCoveringCluster
 
 
 class _EventListener:
@@ -126,3 +127,145 @@ async def test_multistate_input_emits_event(zigpy_device_from_v2_quirk):
 
     assert multistate_cluster._attr_cache.get(0) == "3_single"
     assert listener.events
+
+
+@pytest.mark.parametrize(
+    ("device_reports", "expected_in_ha"),
+    [
+        (0, 100),
+        (100, 0),
+        (20, 80),
+        (80, 20),
+        (50, 50),
+    ],
+)
+async def test_window_covering_position_inversion(
+    zigpy_device_from_v2_quirk, device_reports, expected_in_ha
+):
+    """WindowCovering position reports should be inverted for ZHA."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara",
+        "lumi.switch.aeu003",
+        endpoint_ids=[1, 2, 3, 4, 21],
+        cluster_ids={
+            1: {
+                WindowCovering.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            2: {0xFCC0: ClusterType.Server},
+            3: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            4: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            21: {AnalogInput.cluster_id: ClusterType.Server},
+        },
+    )
+
+    cluster = device.endpoints[1].window_covering
+    assert isinstance(cluster, InvertedWindowCoveringCluster)
+    listener = ClusterListener(cluster)
+
+    cluster._update_attribute(
+        WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+        device_reports,
+    )
+
+    assert listener.attribute_updates == [
+        (
+            WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+            expected_in_ha,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("zha_sends", "device_should_receive"),
+    [
+        (0, 100),
+        (100, 0),
+        (20, 80),
+        (80, 20),
+        (50, 50),
+    ],
+)
+async def test_go_to_lift_percentage_command_inverted(
+    zigpy_device_from_v2_quirk, zha_sends, device_should_receive
+):
+    """Outgoing go_to_lift_percentage commands should be inverted."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara",
+        "lumi.switch.aeu003",
+        endpoint_ids=[1, 2, 3, 4, 21],
+        cluster_ids={
+            1: {
+                WindowCovering.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            2: {0xFCC0: ClusterType.Server},
+            3: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            4: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            21: {AnalogInput.cluster_id: ClusterType.Server},
+        },
+    )
+
+    cluster = device.endpoints[1].window_covering
+    assert isinstance(cluster, InvertedWindowCoveringCluster)
+    command_id = WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
+
+    with mock.patch.object(
+        WindowCovering, "request", new_callable=mock.AsyncMock
+    ) as base_request:
+        base_request.return_value = foundation.Status.SUCCESS, "done"
+
+        await cluster.request(False, command_id, {}, zha_sends)
+
+        base_request.assert_called_once()
+        assert base_request.call_args.args[3] == device_should_receive
+
+
+async def test_non_position_commands_unchanged(zigpy_device_from_v2_quirk):
+    """Commands other than go_to_lift_percentage should pass through."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara",
+        "lumi.switch.aeu003",
+        endpoint_ids=[1, 2, 3, 4, 21],
+        cluster_ids={
+            1: {
+                WindowCovering.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            2: {0xFCC0: ClusterType.Server},
+            3: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            4: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            21: {AnalogInput.cluster_id: ClusterType.Server},
+        },
+    )
+
+    cluster = device.endpoints[1].window_covering
+    stop_command_id = WindowCovering.ServerCommandDefs.stop.id
+
+    with mock.patch.object(
+        WindowCovering, "request", new_callable=mock.AsyncMock
+    ) as base_request:
+        base_request.return_value = foundation.Status.SUCCESS, "done"
+
+        await cluster.request(False, stop_command_id, {})
+
+        base_request.assert_called_once()
+        assert base_request.call_args.args[1] == stop_command_id

--- a/tests/test_aqara_switch_aeu003.py
+++ b/tests/test_aqara_switch_aeu003.py
@@ -1,0 +1,128 @@
+"""Tests for Aqara Shutter Switch H2 EU (lumi.switch.aeu003) quirk."""
+
+from unittest import mock
+
+import pytest
+from zigpy.zcl import ClusterType
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import AnalogInput, MultistateInput
+
+from tests.common import ClusterListener
+
+
+class _EventListener:
+    def __init__(self):
+        self.events = []
+
+    def zha_send_event(self, action, args):
+        self.events.append((action, args))
+
+
+@pytest.mark.asyncio
+async def test_position_percent_updates_cover(zigpy_device_from_v2_quirk):
+    """Position percent should update cover lift percentage (inverted)."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara",
+        "lumi.switch.aeu003",
+        endpoint_ids=[1, 2, 3, 4, 21],
+        cluster_ids={
+            1: {
+                WindowCovering.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            2: {0xFCC0: ClusterType.Server},
+            3: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            4: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            21: {AnalogInput.cluster_id: ClusterType.Server},
+        },
+    )
+
+    manu_cluster = device.endpoints[1].opple_cluster
+    cover_cluster = device.endpoints[1].window_covering
+    cover_listener = ClusterListener(cover_cluster)
+
+    manu_cluster._update_attribute(0x041F, 0)
+
+    assert (WindowCovering.AttributeDefs.current_position_lift_percentage.id, 100) in (
+        cover_listener.attribute_updates
+    )
+
+
+@pytest.mark.asyncio
+async def test_position_stuck_after_stop_nudged(zigpy_device_from_v2_quirk):
+    """If movement stops at an end, position is nudged to keep controls enabled."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara",
+        "lumi.switch.aeu003",
+        endpoint_ids=[1, 2, 3, 4, 21],
+        cluster_ids={
+            1: {
+                WindowCovering.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            2: {0xFCC0: ClusterType.Server},
+            3: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            4: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            21: {AnalogInput.cluster_id: ClusterType.Server},
+        },
+    )
+
+    manu_cluster = device.endpoints[1].opple_cluster
+    cover_cluster = device.endpoints[1].window_covering
+    cover_listener = ClusterListener(cover_cluster)
+
+    manu_cluster.read_attributes = mock.AsyncMock(return_value=([], []))
+
+    manu_cluster._update_attribute(0x0420, 0)
+    manu_cluster._update_attribute(0x041F, 0)
+
+    assert (WindowCovering.AttributeDefs.current_position_lift_percentage.id, 50) in (
+        cover_listener.attribute_updates
+    )
+
+
+@pytest.mark.asyncio
+async def test_multistate_input_emits_event(zigpy_device_from_v2_quirk):
+    """Multistate input updates should emit zha_send_event and update attr 0."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara",
+        "lumi.switch.aeu003",
+        endpoint_ids=[1, 2, 3, 4, 21],
+        cluster_ids={
+            1: {
+                WindowCovering.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            2: {0xFCC0: ClusterType.Server},
+            3: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            4: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                0xFCC0: ClusterType.Server,
+            },
+            21: {AnalogInput.cluster_id: ClusterType.Server},
+        },
+    )
+
+    multistate_cluster = device.endpoints[3].multistate_input
+    listener = _EventListener()
+    multistate_cluster.add_listener(listener)
+
+    multistate_cluster._update_attribute(0x0055, 1)
+
+    assert multistate_cluster._attr_cache.get(0) == "3_single"
+    assert listener.events

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -105,8 +105,6 @@ class AqaraManuSpecificCluster(CustomCluster):
     _MULTI_CLICK_ATTR: Final = 0x0286
     _Aqara_MFG_CODE: Final = 0x115F
     _RAW_POSITION_MASK: Final = 0xFF
-    _RAW_POSITION_OPEN: Final = 0x3F
-    _RAW_POSITION_CLOSED: Final = 0x27
 
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions for Aqara shutter switch."""
@@ -159,6 +157,12 @@ class AqaraManuSpecificCluster(CustomCluster):
             access="r",
             is_manufacturer_specific=True,
         )
+        position_percent: Final = ZCLAttributeDef(
+            id=0x041F,
+            type=t.uint8_t,
+            access="r",
+            is_manufacturer_specific=True,
+        )
 
     def _update_attribute(self, attrid, value):
         """Log manufacturer-specific updates to help map attributes."""
@@ -168,31 +172,26 @@ class AqaraManuSpecificCluster(CustomCluster):
             attrid,
             value,
         )
-        if attrid == self.AttributeDefs.position_raw.id:
-            raw = int(value) & self._RAW_POSITION_MASK
-            span = self._RAW_POSITION_CLOSED - self._RAW_POSITION_OPEN
-            if span:
-                pct = (raw - self._RAW_POSITION_OPEN) / span * 100.0
-                pct = 100 - pct  # 0x0D=open, 0x12=closed
-                pct = max(0, min(100, int(round(pct))))
-                try:
-                    self.endpoint.window_covering.update_attribute(
-                        WindowCovering.AttributeDefs.current_position_lift_percentage.id,
-                        pct,
-                    )
-                    self.endpoint.window_covering.update_attribute(
-                        WindowCovering.AttributeDefs.current_position_lift.id,
-                        pct,
-                    )
-                except Exception:  # noqa: BLE001 - best effort update
-                    LOGGER.debug("Failed to update lift percentage from raw value")
+        if attrid == self.AttributeDefs.position_percent.id:
+            try:
+                pct = max(0, min(100, int(value)))
+                self.endpoint.window_covering.update_attribute(
+                    WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+                    pct,
+                )
+                self.endpoint.window_covering.update_attribute(
+                    WindowCovering.AttributeDefs.current_position_lift.id,
+                    pct,
+                )
+            except Exception:  # noqa: BLE001 - best effort update
+                LOGGER.debug("Failed to update lift percentage from percent value")
         if attrid in (0x0420, 0x0421):
             try:
                 asyncio.create_task(
-                    self.read_attributes([self.AttributeDefs.position_raw.id])
+                    self.read_attributes([self.AttributeDefs.position_percent.id])
                 )
             except Exception:
-                LOGGER.debug("Failed to refresh raw position on movement update")
+                LOGGER.debug("Failed to refresh position on movement update")
         super()._update_attribute(attrid, value)
 
     async def bind(self):
@@ -208,7 +207,7 @@ class AqaraManuSpecificCluster(CustomCluster):
                 {self._MULTI_CLICK_ATTR: 2}, manufacturer=self._Aqara_MFG_CODE
             )
         if self.endpoint.endpoint_id == 1:
-            await self.read_attributes([self.AttributeDefs.position_raw.id])
+            await self.read_attributes([self.AttributeDefs.position_percent.id])
         return result
 
     async def write_attributes(self, attributes, manufacturer=None):

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -96,6 +96,40 @@ class AqaraPowerOnMode(t.enum8):
     Inverted = 0x03
 
 
+class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
+    """WindowCovering cluster that corrects the Aqara H2 position convention.
+
+    The Aqara H2 shutter switch uses Home Assistant convention throughout
+    (0 = closed, 100 = open), while ZHA expects Zigbee spec convention
+    (0 = open, 100 = closed) and applies a 100-x inversion on both reads
+    and writes. Without correction this produces a double inversion in
+    both directions. This cluster pre-inverts values in both directions
+    so the two inversions cancel out:
+
+    - Incoming attribute reports (_update_attribute): device→cluster value
+      is inverted before ZHA reads it.
+    - Outgoing go_to_lift_percentage commands (request): ZHA-inverted value
+      is re-inverted before it is sent to the device.
+    """
+
+    CURRENT_POSITION_LIFT_PERCENTAGE: Final = (
+        WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+    GO_TO_LIFT_PERCENTAGE_CMD: Final = (
+        WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
+    )
+
+    def _update_attribute(self, attrid, value):
+        """Pre-invert reported lift percentage."""
+        if attrid == self.CURRENT_POSITION_LIFT_PERCENTAGE and value is not None:
+            value = 100 - value
+        super()._update_attribute(attrid, value)
+
+    async def request(self, general, command_id, schema, *args, **kwargs):
+        """Pre-invert go-to-lift-percentage commands."""
+        if not general and command_id == self.GO_TO_LIFT_PERCENTAGE_CMD and args:
+            args = (100 - args[0],) + args[1:]
+        return await super().request(general, command_id, schema, *args, **kwargs)
 
 
 class AqaraManuSpecificCluster(CustomCluster):
@@ -175,7 +209,7 @@ class AqaraManuSpecificCluster(CustomCluster):
         )
         if attrid == self.AttributeDefs.position_percent.id:
             try:
-                pct = max(0, min(100, 100 - int(value)))
+                pct = max(0, min(100, int(value)))
                 if self._movement_stopped and pct in (0, 100):
                     pct = 50
                 self.endpoint.window_covering.update_attribute(
@@ -230,6 +264,7 @@ class AqaraManuSpecificCluster(CustomCluster):
 (
     QuirkBuilder("Aqara", "lumi.switch.aeu003")
     .friendly_name(model="Shutter Switch H2", manufacturer="Aqara")
+    .replaces(InvertedWindowCoveringCluster, endpoint_id=1)
     .replaces(MultistateInputCluster, endpoint_id=3)
     .replaces(MultistateInputCluster, endpoint_id=4)
     .replaces(AqaraManuSpecificCluster, endpoint_id=1)

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -105,8 +105,8 @@ class AqaraManuSpecificCluster(CustomCluster):
     _MULTI_CLICK_ATTR: Final = 0x0286
     _Aqara_MFG_CODE: Final = 0x115F
     _RAW_POSITION_MASK: Final = 0xFF
-    _RAW_POSITION_OPEN: Final = 0x0D
-    _RAW_POSITION_CLOSED: Final = 0x12
+    _RAW_POSITION_OPEN: Final = 0x3F
+    _RAW_POSITION_CLOSED: Final = 0x27
 
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions for Aqara shutter switch."""
@@ -178,6 +178,10 @@ class AqaraManuSpecificCluster(CustomCluster):
                 try:
                     self.endpoint.window_covering.update_attribute(
                         WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+                        pct,
+                    )
+                    self.endpoint.window_covering.update_attribute(
+                        WindowCovering.AttributeDefs.current_position_lift.id,
                         pct,
                     )
                 except Exception:  # noqa: BLE001 - best effort update

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -187,6 +187,19 @@ class AqaraManuSpecificCluster(CustomCluster):
                 LOGGER.debug("Failed to update lift percentage from percent value")
         if attrid in (0x0420, 0x0421):
             try:
+                # If position is stuck at an end, nudge to mid so UI enables both actions
+                current = self.endpoint.window_covering.get(
+                    WindowCovering.AttributeDefs.current_position_lift_percentage.id
+                )
+                if current in (0, 100):
+                    self.endpoint.window_covering.update_attribute(
+                        WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+                        50,
+                    )
+                    self.endpoint.window_covering.update_attribute(
+                        WindowCovering.AttributeDefs.current_position_lift.id,
+                        50,
+                    )
                 asyncio.create_task(
                     self.read_attributes([self.AttributeDefs.position_percent.id])
                 )

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -3,6 +3,7 @@
 from typing import Final
 
 import logging
+import asyncio
 
 from zigpy import types as t
 from zigpy.quirks import CustomCluster
@@ -183,7 +184,9 @@ class AqaraManuSpecificCluster(CustomCluster):
                     LOGGER.debug("Failed to update lift percentage from raw value")
         if attrid in (0x0420, 0x0421):
             try:
-                self.read_attributes([self.AttributeDefs.position_raw.id])
+                asyncio.create_task(
+                    self.read_attributes([self.AttributeDefs.position_raw.id])
+                )
             except Exception:
                 LOGGER.debug("Failed to refresh raw position on movement update")
         super()._update_attribute(attrid, value)

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -96,6 +96,8 @@ class AqaraPowerOnMode(t.enum8):
     Inverted = 0x03
 
 
+
+
 class AqaraManuSpecificCluster(CustomCluster):
     """Manufacturer-specific cluster for Aqara shutter switch features."""
 
@@ -122,7 +124,7 @@ class AqaraManuSpecificCluster(CustomCluster):
         )
         operation_mode: Final = ZCLAttributeDef(
             id=0x0200,
-            type=AqaraOperationMode,
+            type=t.uint8_t,
             access="rw",
             is_manufacturer_specific=True,
         )
@@ -134,12 +136,6 @@ class AqaraManuSpecificCluster(CustomCluster):
         )
         flip_led_indicator: Final = ZCLAttributeDef(
             id=0x00F0,
-            type=t.Bool,
-            access="rw",
-            is_manufacturer_specific=True,
-        )
-        lock_relay: Final = ZCLAttributeDef(
-            id=0x0285,
             type=t.Bool,
             access="rw",
             is_manufacturer_specific=True,
@@ -233,6 +229,7 @@ class AqaraManuSpecificCluster(CustomCluster):
 
 (
     QuirkBuilder("Aqara", "lumi.switch.aeu003")
+    .friendly_name(model="Shutter Switch H2", manufacturer="Aqara")
     .replaces(MultistateInputCluster, endpoint_id=3)
     .replaces(MultistateInputCluster, endpoint_id=4)
     .replaces(AqaraManuSpecificCluster, endpoint_id=1)
@@ -244,52 +241,11 @@ class AqaraManuSpecificCluster(CustomCluster):
         cluster_id=WindowCovering.cluster_id,
         function=lambda entity: getattr(entity, "translation_key", None) == "inverted",
     )
-    .enum(
-        AqaraManuSpecificCluster.AttributeDefs.operation_mode.name,
-        AqaraOperationMode,
-        AqaraManuSpecificCluster.cluster_id,
-        endpoint_id=1,
-        translation_key="operation_mode_left",
-        fallback_name="Operation mode left",
-        unique_id_suffix="left",
-        entity_type=EntityType.DIAGNOSTIC,
-        initially_disabled=True,
-    )
-    .enum(
-        AqaraManuSpecificCluster.AttributeDefs.operation_mode.name,
-        AqaraOperationMode,
-        AqaraManuSpecificCluster.cluster_id,
-        endpoint_id=2,
-        translation_key="operation_mode_right",
-        fallback_name="Operation mode right",
-        unique_id_suffix="right",
-        entity_type=EntityType.DIAGNOSTIC,
-        initially_disabled=True,
-    )
-    .switch(
-        AqaraManuSpecificCluster.AttributeDefs.lock_relay.name,
-        AqaraManuSpecificCluster.cluster_id,
-        endpoint_id=1,
-        translation_key="lock_relay_left",
-        fallback_name="Lock relay left",
-        unique_id_suffix="left",
-        entity_type=EntityType.DIAGNOSTIC,
-        initially_disabled=True,
-    )
-    .switch(
-        AqaraManuSpecificCluster.AttributeDefs.lock_relay.name,
-        AqaraManuSpecificCluster.cluster_id,
-        endpoint_id=2,
-        translation_key="lock_relay_right",
-        fallback_name="Lock relay right",
-        unique_id_suffix="right",
-        entity_type=EntityType.DIAGNOSTIC,
-        initially_disabled=True,
-    )
     .command_button(
         command_name="up_open",
         cluster_id=WindowCovering.cluster_id,
         endpoint_id=1,
+        entity_type=EntityType.STANDARD,
         translation_key="force_open_cover",
         fallback_name="Force open cover",
     )
@@ -297,6 +253,7 @@ class AqaraManuSpecificCluster(CustomCluster):
         command_name="down_close",
         cluster_id=WindowCovering.cluster_id,
         endpoint_id=1,
+        entity_type=EntityType.STANDARD,
         translation_key="force_close_cover",
         fallback_name="Force close cover",
     )
@@ -304,8 +261,9 @@ class AqaraManuSpecificCluster(CustomCluster):
         command_name="stop",
         cluster_id=WindowCovering.cluster_id,
         endpoint_id=1,
+        entity_type=EntityType.STANDARD,
         translation_key="stop_cover",
-        fallback_name="Stop cover",
+        fallback_name="Force stop cover",
     )
     .switch(
         AqaraManuSpecificCluster.AttributeDefs.multi_click.name,
@@ -314,7 +272,7 @@ class AqaraManuSpecificCluster(CustomCluster):
         on_value=2,
         endpoint_id=3,
         translation_key="multi_click_button_3",
-        fallback_name="Multi click button 3",
+        fallback_name="Multi-click button 3",
         unique_id_suffix="button_3",
     )
     .switch(
@@ -324,20 +282,15 @@ class AqaraManuSpecificCluster(CustomCluster):
         on_value=2,
         endpoint_id=4,
         translation_key="multi_click_button_4",
-        fallback_name="Multi click button 4",
+        fallback_name="Multi-click button 4",
         unique_id_suffix="button_4",
-    )
-    .switch(
-        AqaraManuSpecificCluster.AttributeDefs.reverse_direction.name,
-        AqaraManuSpecificCluster.cluster_id,
-        endpoint_id=1,
-        translation_key="inverted",
-        fallback_name="Inverted",
     )
     .sensor(
         AqaraManuSpecificCluster.AttributeDefs.position_raw.name,
         AqaraManuSpecificCluster.cluster_id,
         endpoint_id=1,
+        entity_type=EntityType.DIAGNOSTIC,
+        initially_disabled=True,
         translation_key="position_raw",
         fallback_name="Position raw",
     )

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -1,0 +1,343 @@
+"""Quirk for Aqara Shutter Switch H2 EU (lumi.switch.aeu003)."""
+
+from typing import Final
+
+import logging
+
+from zigpy import types as t
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import EntityType
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import MultistateInput
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+LOGGER: Final = logging.getLogger(__name__)
+
+ATTR_ID: Final = "attr_id"
+BUTTON: Final = "button"
+BUTTON_3: Final = "button_3"
+BUTTON_4: Final = "button_4"
+COMMAND: Final = "command"
+COMMAND_DOUBLE: Final = "double"
+COMMAND_HOLD: Final = "hold"
+COMMAND_RELEASE: Final = "release"
+COMMAND_SINGLE: Final = "single"
+PRESS_TYPE: Final = "press_type"
+VALUE: Final = "value"
+ZHA_SEND_EVENT: Final = "zha_send_event"
+
+COMMAND_3_SINGLE: Final = "3_single"
+COMMAND_3_DOUBLE: Final = "3_double"
+COMMAND_3_HOLD: Final = "3_hold"
+COMMAND_3_RELEASE: Final = "3_release"
+COMMAND_4_SINGLE: Final = "4_single"
+COMMAND_4_DOUBLE: Final = "4_double"
+COMMAND_4_HOLD: Final = "4_hold"
+COMMAND_4_RELEASE: Final = "4_release"
+
+PRESS_TYPES: Final = {
+    0: "hold",
+    1: "single",
+    2: "double",
+    3: "triple",
+    255: "release",
+}
+STATUS_TYPE_ATTR: Final = 0x0055
+
+
+class MultistateInputCluster(CustomCluster, MultistateInput):
+    """Multistate input cluster for button events."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self._current_state = None
+        super().__init__(*args, **kwargs)
+
+    async def configure_reporting(
+        self,
+        attribute,
+        min_interval,
+        max_interval,
+        reportable_change,
+        manufacturer=None,
+    ):
+        """Configure reporting (unused)."""
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == STATUS_TYPE_ATTR:
+            self._current_state = PRESS_TYPES.get(value)
+            event_args = {
+                BUTTON: self.endpoint.endpoint_id,
+                PRESS_TYPE: self._current_state,
+                ATTR_ID: attrid,
+                VALUE: value,
+            }
+            action = f"{self.endpoint.endpoint_id}_{self._current_state}"
+            self.listener_event(ZHA_SEND_EVENT, action, event_args)
+            # show something in the sensor in HA
+            super()._update_attribute(0, action)
+
+
+class AqaraOperationMode(t.enum8):
+    """Aqara operation mode attribute values."""
+
+    Decoupled = 0x00
+    Relay = 0x01
+
+
+class AqaraPowerOnMode(t.enum8):
+    """Aqara power on mode attribute values."""
+
+    On = 0x00
+    Previous = 0x01
+    Off = 0x02
+    Inverted = 0x03
+
+
+class AqaraManuSpecificCluster(CustomCluster):
+    """Manufacturer-specific cluster for Aqara shutter switch features."""
+
+    cluster_id: Final = 0xFCC0
+    ep_attribute: Final = "opple_cluster"
+    _MULTI_CLICK_ATTR: Final = 0x0286
+    _Aqara_MFG_CODE: Final = 0x115F
+    _RAW_POSITION_MASK: Final = 0xFF
+    _RAW_POSITION_OPEN: Final = 0x0D
+    _RAW_POSITION_CLOSED: Final = 0x12
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions for Aqara shutter switch."""
+
+        power_on_mode: Final = ZCLAttributeDef(
+            id=0x0517,
+            type=AqaraPowerOnMode,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+        operation_mode: Final = ZCLAttributeDef(
+            id=0x0200,
+            type=AqaraOperationMode,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+        led_indicator: Final = ZCLAttributeDef(
+            id=0x0203,
+            type=t.Bool,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+        flip_led_indicator: Final = ZCLAttributeDef(
+            id=0x00F0,
+            type=t.Bool,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+        lock_relay: Final = ZCLAttributeDef(
+            id=0x0285,
+            type=t.Bool,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+        multi_click: Final = ZCLAttributeDef(
+            id=0x0286,
+            type=t.uint8_t,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+        reverse_direction: Final = ZCLAttributeDef(
+            id=0x0402,
+            type=t.Bool,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+        position_raw: Final = ZCLAttributeDef(
+            id=0x00F5,
+            type=t.uint32_t,
+            access="r",
+            is_manufacturer_specific=True,
+        )
+
+    def _update_attribute(self, attrid, value):
+        """Log manufacturer-specific updates to help map attributes."""
+        LOGGER.debug(
+            "Aqara aeu003 mfg attr update: ep=%s attr=0x%04X value=%s",
+            self.endpoint.endpoint_id,
+            attrid,
+            value,
+        )
+        if attrid == self.AttributeDefs.position_raw.id:
+            raw = int(value) & self._RAW_POSITION_MASK
+            span = self._RAW_POSITION_CLOSED - self._RAW_POSITION_OPEN
+            if span:
+                pct = (raw - self._RAW_POSITION_OPEN) / span * 100.0
+                pct = 100 - pct  # 0x0D=open, 0x12=closed
+                pct = max(0, min(100, int(round(pct))))
+                try:
+                    self.endpoint.window_covering.update_attribute(
+                        WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+                        pct,
+                    )
+                except Exception:  # noqa: BLE001 - best effort update
+                    LOGGER.debug("Failed to update lift percentage from raw value")
+        if attrid in (0x0420, 0x0421):
+            try:
+                self.read_attributes([self.AttributeDefs.position_raw.id])
+            except Exception:
+                LOGGER.debug("Failed to refresh raw position on movement update")
+        super()._update_attribute(attrid, value)
+
+    async def bind(self):
+        """Bind cluster and enable multi-click reporting.
+
+        This device only emits double/hold/release once multi-click is enabled
+        (write attribute 0x0286 = 2 with Aqara manufacturer code 0x115F) on
+        endpoints 3 and 4.
+        """
+        result = await super().bind()
+        if self.endpoint.endpoint_id in (3, 4):
+            await self.write_attributes(
+                {self._MULTI_CLICK_ATTR: 2}, manufacturer=self._Aqara_MFG_CODE
+            )
+        if self.endpoint.endpoint_id == 1:
+            await self.read_attributes([self.AttributeDefs.position_raw.id])
+        return result
+
+    async def write_attributes(self, attributes, manufacturer=None):
+        """Ensure Aqara manufacturer code is used for mfg-specific writes."""
+        return await super().write_attributes(
+            attributes, manufacturer=manufacturer or self._Aqara_MFG_CODE
+        )
+
+    async def read_attributes(self, attributes, manufacturer=None, **kwargs):
+        """Ensure Aqara manufacturer code is used for mfg-specific reads."""
+        return await super().read_attributes(
+            attributes, manufacturer=manufacturer or self._Aqara_MFG_CODE, **kwargs
+        )
+
+
+(
+    QuirkBuilder("Aqara", "lumi.switch.aeu003")
+    .replaces(MultistateInputCluster, endpoint_id=3)
+    .replaces(MultistateInputCluster, endpoint_id=4)
+    .replaces(AqaraManuSpecificCluster, endpoint_id=1)
+    .replaces(AqaraManuSpecificCluster, endpoint_id=2)
+    .replaces(AqaraManuSpecificCluster, endpoint_id=3)
+    .replaces(AqaraManuSpecificCluster, endpoint_id=4)
+    .prevent_default_entity_creation(
+        endpoint_id=1,
+        cluster_id=WindowCovering.cluster_id,
+        function=lambda entity: getattr(entity, "translation_key", None) == "inverted",
+    )
+    .enum(
+        AqaraManuSpecificCluster.AttributeDefs.operation_mode.name,
+        AqaraOperationMode,
+        AqaraManuSpecificCluster.cluster_id,
+        endpoint_id=1,
+        translation_key="operation_mode_left",
+        fallback_name="Operation mode left",
+        unique_id_suffix="left",
+        entity_type=EntityType.DIAGNOSTIC,
+        initially_disabled=True,
+    )
+    .enum(
+        AqaraManuSpecificCluster.AttributeDefs.operation_mode.name,
+        AqaraOperationMode,
+        AqaraManuSpecificCluster.cluster_id,
+        endpoint_id=2,
+        translation_key="operation_mode_right",
+        fallback_name="Operation mode right",
+        unique_id_suffix="right",
+        entity_type=EntityType.DIAGNOSTIC,
+        initially_disabled=True,
+    )
+    .switch(
+        AqaraManuSpecificCluster.AttributeDefs.lock_relay.name,
+        AqaraManuSpecificCluster.cluster_id,
+        endpoint_id=1,
+        translation_key="lock_relay_left",
+        fallback_name="Lock relay left",
+        unique_id_suffix="left",
+        entity_type=EntityType.DIAGNOSTIC,
+        initially_disabled=True,
+    )
+    .switch(
+        AqaraManuSpecificCluster.AttributeDefs.lock_relay.name,
+        AqaraManuSpecificCluster.cluster_id,
+        endpoint_id=2,
+        translation_key="lock_relay_right",
+        fallback_name="Lock relay right",
+        unique_id_suffix="right",
+        entity_type=EntityType.DIAGNOSTIC,
+        initially_disabled=True,
+    )
+    .command_button(
+        command_name="up_open",
+        cluster_id=WindowCovering.cluster_id,
+        endpoint_id=1,
+        translation_key="force_open_cover",
+        fallback_name="Force open cover",
+    )
+    .command_button(
+        command_name="down_close",
+        cluster_id=WindowCovering.cluster_id,
+        endpoint_id=1,
+        translation_key="force_close_cover",
+        fallback_name="Force close cover",
+    )
+    .command_button(
+        command_name="stop",
+        cluster_id=WindowCovering.cluster_id,
+        endpoint_id=1,
+        translation_key="stop_cover",
+        fallback_name="Stop cover",
+    )
+    .switch(
+        AqaraManuSpecificCluster.AttributeDefs.multi_click.name,
+        AqaraManuSpecificCluster.cluster_id,
+        off_value=1,
+        on_value=2,
+        endpoint_id=3,
+        translation_key="multi_click_button_3",
+        fallback_name="Multi click button 3",
+        unique_id_suffix="button_3",
+    )
+    .switch(
+        AqaraManuSpecificCluster.AttributeDefs.multi_click.name,
+        AqaraManuSpecificCluster.cluster_id,
+        off_value=1,
+        on_value=2,
+        endpoint_id=4,
+        translation_key="multi_click_button_4",
+        fallback_name="Multi click button 4",
+        unique_id_suffix="button_4",
+    )
+    .switch(
+        AqaraManuSpecificCluster.AttributeDefs.reverse_direction.name,
+        AqaraManuSpecificCluster.cluster_id,
+        endpoint_id=1,
+        translation_key="inverted",
+        fallback_name="Inverted",
+    )
+    .sensor(
+        AqaraManuSpecificCluster.AttributeDefs.position_raw.name,
+        AqaraManuSpecificCluster.cluster_id,
+        endpoint_id=1,
+        translation_key="position_raw",
+        fallback_name="Position raw",
+    )
+    .device_automation_triggers(
+        {
+            (COMMAND_HOLD, BUTTON_3): {COMMAND: COMMAND_3_HOLD},
+            (COMMAND_SINGLE, BUTTON_3): {COMMAND: COMMAND_3_SINGLE},
+            (COMMAND_DOUBLE, BUTTON_3): {COMMAND: COMMAND_3_DOUBLE},
+            (COMMAND_RELEASE, BUTTON_3): {COMMAND: COMMAND_3_RELEASE},
+            (COMMAND_HOLD, BUTTON_4): {COMMAND: COMMAND_4_HOLD},
+            (COMMAND_SINGLE, BUTTON_4): {COMMAND: COMMAND_4_SINGLE},
+            (COMMAND_DOUBLE, BUTTON_4): {COMMAND: COMMAND_4_DOUBLE},
+            (COMMAND_RELEASE, BUTTON_4): {COMMAND: COMMAND_4_RELEASE},
+        },
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -1,9 +1,8 @@
 """Quirk for Aqara Shutter Switch H2 EU (lumi.switch.aeu003)."""
 
-from typing import Final
-
-import logging
 import asyncio
+import logging
+from typing import Final
 
 from zigpy import types as t
 from zigpy.quirks import CustomCluster
@@ -100,6 +99,12 @@ class AqaraPowerOnMode(t.enum8):
 class AqaraManuSpecificCluster(CustomCluster):
     """Manufacturer-specific cluster for Aqara shutter switch features."""
 
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self._movement_stopped: bool = False
+        self._position_refresh_task: asyncio.Task | None = None
+        super().__init__(*args, **kwargs)
+
     cluster_id: Final = 0xFCC0
     ep_attribute: Final = "opple_cluster"
     _MULTI_CLICK_ATTR: Final = 0x0286
@@ -190,7 +195,7 @@ class AqaraManuSpecificCluster(CustomCluster):
         if attrid in (0x0420, 0x0421):
             try:
                 self._movement_stopped = value == 0
-                asyncio.create_task(
+                self._position_refresh_task = asyncio.create_task(
                     self.read_attributes([self.AttributeDefs.position_percent.id])
                 )
             except Exception:

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -175,6 +175,8 @@ class AqaraManuSpecificCluster(CustomCluster):
         if attrid == self.AttributeDefs.position_percent.id:
             try:
                 pct = max(0, min(100, 100 - int(value)))
+                if self._movement_stopped and pct in (0, 100):
+                    pct = 50
                 self.endpoint.window_covering.update_attribute(
                     WindowCovering.AttributeDefs.current_position_lift_percentage.id,
                     pct,
@@ -187,19 +189,7 @@ class AqaraManuSpecificCluster(CustomCluster):
                 LOGGER.debug("Failed to update lift percentage from percent value")
         if attrid in (0x0420, 0x0421):
             try:
-                # If position is stuck at an end, nudge to mid so UI enables both actions
-                current = self.endpoint.window_covering.get(
-                    WindowCovering.AttributeDefs.current_position_lift_percentage.id
-                )
-                if current in (0, 100):
-                    self.endpoint.window_covering.update_attribute(
-                        WindowCovering.AttributeDefs.current_position_lift_percentage.id,
-                        50,
-                    )
-                    self.endpoint.window_covering.update_attribute(
-                        WindowCovering.AttributeDefs.current_position_lift.id,
-                        50,
-                    )
+                self._movement_stopped = value == 0
                 asyncio.create_task(
                     self.read_attributes([self.AttributeDefs.position_percent.id])
                 )

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -200,7 +200,7 @@ class AqaraManuSpecificCluster(CustomCluster):
         )
 
     def _update_attribute(self, attrid, value):
-        """Log manufacturer-specific updates to help map attributes."""
+        """Map Aqara position and movement attributes to cover state."""
         LOGGER.debug(
             "Aqara aeu003 mfg attr update: ep=%s attr=0x%04X value=%s",
             self.endpoint.endpoint_id,

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -174,7 +174,7 @@ class AqaraManuSpecificCluster(CustomCluster):
         )
         if attrid == self.AttributeDefs.position_percent.id:
             try:
-                pct = max(0, min(100, int(value)))
+                pct = max(0, min(100, 100 - int(value)))
                 self.endpoint.window_covering.update_attribute(
                     WindowCovering.AttributeDefs.current_position_lift_percentage.id,
                     pct,


### PR DESCRIPTION
## Proposed change

Add support for Aqara Shutter Switch H2 EU (`lumi.switch.aeu003`).

This quirk now covers both:
- proper cover position handling for the shutter entity
- multi-click support for buttons 3/4

Specifically it:
- enables Aqara multi-click on endpoints 3/4 via manufacturer attribute `0x0286`
- emits `3_*` / `4_*` button events for single, double, hold, and release
- corrects the device’s inverted position convention for cover position reports
- corrects `go_to_lift_percentage` / set-position handling
- keeps cover controls usable near end positions after stop events
- exposes command buttons for open / close / stop
- exposes per-button multi-click switches

## Additional information

This started from my original multi-click-focused draft in #4769.

The position handling was corrected by adapting the approach from @panagiks in #5060, while preserving the already working multi-click behavior from this branch. Attribution is preserved in commit history.

I have now also verified in Home Assistant that:
- the quirk is applied correctly
- cover position is reported correctly (`0 = closed`, `100 = open`)
- setting cover position from Home Assistant works correctly
- multi-click events for buttons 3/4 still work reliably

Fixes #4410.

## Device diagnostics

<details>
  <summary>Click to expand device diagnostics</summary>
  
```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Container",
    "version": "2026.1.3",
    "dev": false,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.13.11",
    "docker": true,
    "arch": "x86_64",
    "timezone": "Europe/Vienna",
    "os_name": "Linux",
    "os_version": "6.19.0",
    "container_arch": "amd64",
    "run_as_root": true
  },
  "custom_components": {
    "ntfy": {
      "documentation": "https://github.com/hbrennhaeuser/homeassistant_integration_ntfy",
      "version": "0.2.3",
      "requirements": [
        "requests"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==0.0.84",
      "serialx==0.6.2"
    ]
  }
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
