### PR TITLE
Add Senoro.Win v2 door sensor (_TZE284_6teua268)

### DIFF
--- a/zhaquirks/tuya/tuya_door.py
+++ b/zhaquirks/tuya/tuya_door.py
@@ -3,7 +3,12 @@
 import zigpy.types as t
 from zigpy.zcl import foundation
 
-from zhaquirks.builder import BinarySensorDeviceClass, EntityPlatform, EntityType
+from zhaquirks.builder import (
+    BinarySensorDeviceClass,
+    EntityPlatform,
+    EntityType,
+    UnitOfTime,
+)
 from zhaquirks.tuya import TUYA_CLUSTER_ID, BatterySize
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
@@ -54,6 +59,187 @@ class OpeningStateEnum(t.enum8):
         unique_id_suffix="alarm_reset",
         translation_key="reset_alarm",
         fallback_name="Reset alarm",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)
+
+(
+    TuyaQuirkBuilder("_TZE284_6teua268", "TS0601")
+    .tuya_battery(
+        dp_id=2,
+        battery_type=BatterySize.CR2032,
+        battery_qty=3,
+    )
+    .tuya_enum(
+        dp_id=101,
+        attribute_name="opening_state",
+        enum_class=OpeningStateEnum,
+        entity_type=EntityType.STANDARD,
+        entity_platform=EntityPlatform.SENSOR,
+        translation_key="opening",
+        fallback_name="Opening",
+    )
+    .tuya_dp_attribute(
+        dp_id=16,
+        attribute_name="alarm",
+        type=t.Bool,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .binary_sensor(
+        attribute_name="alarm",
+        cluster_id=TUYA_CLUSTER_ID,
+        entity_type=EntityType.STANDARD,
+        device_class=BinarySensorDeviceClass.TAMPER,
+        unique_id_suffix="alarm_sensor",
+        fallback_name="Tamper",
+    )
+    .write_attr_button(
+        attribute_name="alarm",
+        attribute_value=0,
+        cluster_id=TUYA_CLUSTER_ID,
+        entity_type=EntityType.STANDARD,
+        unique_id_suffix="alarm_reset",
+        translation_key="reset_alarm",
+        fallback_name="Reset alarm",
+    )
+    .tuya_dp_attribute(
+        dp_id=107,
+        attribute_name="setup_mode",
+        type=t.Bool,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .binary_sensor(
+        attribute_name="setup_mode",
+        cluster_id=TUYA_CLUSTER_ID,
+        entity_type=EntityType.STANDARD,
+        device_class=BinarySensorDeviceClass.TAMPER,
+        unique_id_suffix="setup_mode_sensor",
+        fallback_name="Setup Mode",
+    )
+    .write_attr_button(
+        attribute_name="setup_mode",
+        attribute_value=0,
+        cluster_id=TUYA_CLUSTER_ID,
+        entity_type=EntityType.STANDARD,
+        unique_id_suffix="setup_mode_reset",
+        translation_key="reset_setup_mode",
+        fallback_name="Exit Setup Mode",
+    )
+    .tuya_dp_attribute(
+        dp_id=103,
+        attribute_name="alarm_siren",
+        type=t.Bool,
+        access=foundation.ZCLAttributeAccess.Read
+        | foundation.ZCLAttributeAccess.Write
+        | foundation.ZCLAttributeAccess.Report,
+    )
+    .switch(
+        attribute_name="alarm_siren",
+        cluster_id=TUYA_CLUSTER_ID,
+        entity_type=EntityType.STANDARD,
+        unique_id_suffix="alarm_siren_switch",
+        translation_key="alarm_siren",
+        fallback_name="Alarm siren",
+    )
+    .tuya_number(
+        dp_id=109,
+        attribute_name="alarm_siren_duration",
+        type=t.uint16_t,
+        min_value=5,
+        max_value=180,
+        unit=UnitOfTime.SECONDS,
+        step=1,
+        fallback_name="Alarm siren duration",
+        translation_key="alarm_siren_duration",
+    )
+    .tuya_dp_attribute(
+        dp_id=102,
+        attribute_name="vibration",
+        type=t.uint16_t,
+        access=foundation.ZCLAttributeAccess.Read
+        | foundation.ZCLAttributeAccess.Report,
+    )
+    .sensor(
+        attribute_name="vibration",
+        cluster_id=TUYA_CLUSTER_ID,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="vibration",
+        fallback_name="Vibration",
+    )
+    .tuya_number(
+        dp_id=106,
+        attribute_name="vibration_limit",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=100,
+        step=1,
+        fallback_name="Vibration limit",
+        translation_key="vibration_limit",
+    )
+    .tuya_number(
+        dp_id=110,
+        attribute_name="vibration_siren_duration",
+        type=t.uint16_t,
+        min_value=5,
+        max_value=180,
+        unit=UnitOfTime.SECONDS,
+        step=1,
+        fallback_name="Vibrating siren duration",
+        translation_key="vibration_siren_duration",
+    )
+    .tuya_dp_attribute(
+        dp_id=108,
+        attribute_name="vibration_siren",
+        type=t.Bool,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .switch(
+        attribute_name="vibration_siren",
+        cluster_id=TUYA_CLUSTER_ID,
+        entity_type=EntityType.STANDARD,
+        translation_key="vibration_siren",
+        fallback_name="Vibration siren",
+    )
+    .tuya_dp_attribute(
+        dp_id=104,
+        attribute_name="close_signal",
+        type=t.Bool,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .switch(
+        attribute_name="close_signal",
+        cluster_id=TUYA_CLUSTER_ID,
+        entity_type=EntityType.STANDARD,
+        translation_key="close_signal",
+        fallback_name="Close signal",
+    )
+    .tuya_number(
+        dp_id=105,
+        attribute_name="transmission_power",
+        type=t.uint8_t,
+        min_value=11,
+        max_value=19,
+        step=1,
+        fallback_name="Transmission power",
+        translation_key="transmission_power",
+    )
+    .tuya_dp_attribute(
+        dp_id=111,
+        attribute_name="magnetic_status",
+        type=t.Bool,
+        converter=lambda value: not value,
+        dp_converter=lambda value: not value,
+        access=foundation.ZCLAttributeAccess.Read
+        | foundation.ZCLAttributeAccess.Report,
+    )
+    .binary_sensor(
+        attribute_name="magnetic_status",
+        cluster_id=TUYA_CLUSTER_ID,
+        entity_type=EntityType.STANDARD,
+        device_class=BinarySensorDeviceClass.DOOR,
+        translation_key="magnetic_status",
+        fallback_name="Magnetic status",
     )
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
- Added sensor definition for DP 102 (vibration intensity)
- Configured as DIAGNOSTIC entity type
- Add Support for Senoro.WIN v2 Door Sensor. This PR adds support for the new Senoro.WIN v2 device, a Tuya door sensor variant _TZE284_6teua268 with enhanced features.

Device Settings
The Senoro.WIN v2 device requires entering setup mode to accept configuration changes. To enter setup mode, press the button on the device. Once in setup mode, the device will accept settings changes. The "setup_mode" push button in the interface can be used to exit setup mode, after which the device will resume normal operation.