### PR TITLE
Add `LocalDataCluster._DEFAULT_VALUES` and migrate quirks

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -992,6 +992,7 @@ async def test_local_data_cluster(device_mock) -> None:
 
         cluster_id = 0x1234
         _CONSTANT_ATTRIBUTES = {1: 10}
+        _DEFAULT_VALUES = {3: 42}
         _VALID_ATTRIBUTES = [2]
 
         class AttributeDefs(foundation.BaseAttributeDefs):
@@ -999,6 +1000,7 @@ async def test_local_data_cluster(device_mock) -> None:
 
             constant_attr = foundation.ZCLAttributeDef(id=1, type=t.uint8_t)
             valid_attr = foundation.ZCLAttributeDef(id=2, type=t.uint8_t)
+            default_attr = foundation.ZCLAttributeDef(id=3, type=t.uint8_t)
 
     (
         QuirkBuilder(device_mock.manufacturer, device_mock.model, registry=registry)
@@ -1006,16 +1008,33 @@ async def test_local_data_cluster(device_mock) -> None:
         .add_to_registry()
     )
     device = registry.get_device(device_mock)
-    assert isinstance(device.endpoints[1].in_clusters[0x1234], TestLocalCluster)
+    cluster = device.endpoints[1].in_clusters[0x1234]
+    assert isinstance(cluster, TestLocalCluster)
 
     # reading constant attribute works
-    assert await device.endpoints[1].in_clusters[0x1234].read_attributes([1]) == (
-        {1: 10},
-        {},
-    )
+    assert await cluster.read_attributes([1]) == ({1: 10}, {})
 
     # reading valid attribute returns None with success status
-    assert await device.endpoints[1].in_clusters[0x1234].read_attributes([2]) == (
-        {2: None},
-        {},
-    )
+    assert await cluster.read_attributes([2]) == ({2: None}, {})
+
+    # reading default value attribute returns the default
+    assert await cluster.read_attributes([3]) == ({3: 42}, {})
+
+    # get() returns default value when no cached value exists
+    assert cluster.get(3) == 42
+    assert cluster.get("default_attr") == 42
+
+    # get() returns cached value over default value
+    cluster._update_attribute(3, 99)
+    assert await cluster.read_attributes([3]) == ({3: 99}, {})
+    assert cluster.get(3) == 99
+    assert cluster.get("default_attr") == 99
+
+    # get() returns constant attribute
+    assert cluster.get(1) == 10
+    assert cluster.get("constant_attr") == 10
+
+    # get() returns provided default for unknown attributes
+    assert cluster.get(0xFF, 123) == 123
+    # valid attribute with no cached value and no default value returns None
+    assert cluster.get(2) is None

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -70,12 +70,28 @@ class LocalDataCluster(CustomCluster):
     """Cluster meant to prevent remote calls.
 
     Set _CONSTANT_ATTRIBUTES to provide constant values for attribute ids.
+    Set _DEFAULT_VALUES to provide default values for attribute ids. These are
+    returned when no value is cached yet, but are overridden by any cached value.
     Set _VALID_ATTRIBUTES to provide a list of valid attribute ids that will never be shown as unsupported.
     These are attributes that should be populated later.
     """
 
     _CONSTANT_ATTRIBUTES: dict[int, typing.Any] = {}
+    _DEFAULT_VALUES: dict[int, typing.Any] = {}
     _VALID_ATTRIBUTES: set[int] = set()
+
+    def get(self, key: int | str, default: typing.Any | None = None) -> typing.Any:
+        """Get cached attribute, falling back to _DEFAULT_VALUES then default."""
+        result = super().get(key)
+        if result is not None:
+            return result
+        try:
+            attr_def = self.find_attribute(key)
+        except KeyError:
+            return default
+        if attr_def.id in self._DEFAULT_VALUES:
+            return self._DEFAULT_VALUES[attr_def.id]
+        return default
 
     async def bind(self):
         """Prevent bind."""
@@ -106,7 +122,9 @@ class LocalDataCluster(CustomCluster):
             if record.attrid in self._CONSTANT_ATTRIBUTES:
                 record.value.value = self._CONSTANT_ATTRIBUTES[record.attrid]
             else:
-                record.value.value = self._attr_cache.get(record.attrid)
+                record.value.value = self._attr_cache.get(
+                    record.attrid, self._DEFAULT_VALUES.get(record.attrid)
+                )
             if (
                 record.value.value is not None
                 or record.attrid in self._VALID_ATTRIBUTES

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -82,16 +82,14 @@ class LocalDataCluster(CustomCluster):
 
     def get(self, key: int | str, default: typing.Any | None = None) -> typing.Any:
         """Get cached attribute, falling back to _DEFAULT_VALUES then default."""
-        result = super().get(key)
-        if result is not None:
-            return result
         try:
             attr_def = self.find_attribute(key)
         except KeyError:
             return default
-        if attr_def.id in self._DEFAULT_VALUES:
-            return self._DEFAULT_VALUES[attr_def.id]
-        return default
+        result = super().get(key)
+        if result is not None:
+            return result
+        return self._DEFAULT_VALUES.get(attr_def.id, default)
 
     async def bind(self):
         """Prevent bind."""

--- a/zhaquirks/sonoff/zbm5.py
+++ b/zhaquirks/sonoff/zbm5.py
@@ -108,13 +108,11 @@ class SonoffInputConfigCluster(LocalDataCluster):
         AttributeDefs.relay_3_detached.id: SonoffDetachedRelayMask.Relay3,
     }
 
-    def __init__(self, *args, **kwargs):
-        """Init with all relays attached by default."""
-        super().__init__(*args, **kwargs)
-        # TODO: Use _DEFAULT_VALUES when ready, this doesn't work in all circumstances
-        for attr_id in self._RELAY_BITS:
-            if attr_id not in self._attr_cache:
-                self._update_attribute(attr_id, t.Bool.false)
+    _DEFAULT_VALUES = {
+        AttributeDefs.relay_1_detached.id: t.Bool.false,
+        AttributeDefs.relay_2_detached.id: t.Bool.false,
+        AttributeDefs.relay_3_detached.id: t.Bool.false,
+    }
 
     def update_relay_states(self, mask: int) -> None:
         """Update individual relay states from a bitmap mask."""

--- a/zhaquirks/ubisys/__init__.py
+++ b/zhaquirks/ubisys/__init__.py
@@ -148,7 +148,7 @@ class UbisysInputConfigCluster(LocalDataCluster):
                 mode = override_mode
             else:
                 attr_def = self.find_attribute(attr_name)
-                mode = InputMode(self._attr_cache.get(attr_def.id, InputMode.Toggle))
+                mode = InputMode(self.get(attr_def.id, InputMode.Toggle))
             actions.extend(build_onoff_actions(input_index, source_ep, mode))
         return actions
 

--- a/zhaquirks/ubisys/__init__.py
+++ b/zhaquirks/ubisys/__init__.py
@@ -106,7 +106,7 @@ class UbisysInputConfigCluster(LocalDataCluster):
 
     Subclass and override class constants to customize for different devices:
     - BIND_CLUSTERS: Cluster IDs to bind/unbind for detached mode
-    - _ATTRIBUTE_DEFAULTS: {attr_id: default_value} for init cache population
+    - _DEFAULT_VALUES: {attr_id: default_value} for attribute defaults
     - _INPUT_MODE_CONFIG: (attr_name, input_index, source_ep) per input
     - _DETACHED_CONFIG: (attr_name, input_ep, output_ep) per input
     """
@@ -123,7 +123,7 @@ class UbisysInputConfigCluster(LocalDataCluster):
         input_mode: Final = ZCLAttributeDef(id=0x0000, type=InputMode)
         detached: Final = ZCLAttributeDef(id=0x0001, type=t.Bool)
 
-    _ATTRIBUTE_DEFAULTS: dict[int, Any] = {
+    _DEFAULT_VALUES: dict[int, Any] = {
         AttributeDefs.input_mode.id: InputMode.Toggle,
         AttributeDefs.detached.id: t.Bool.false,
     }
@@ -133,13 +133,6 @@ class UbisysInputConfigCluster(LocalDataCluster):
 
     # (attr_name, input_ep, output_ep) per input — empty tuple to disable
     _DETACHED_CONFIG: tuple[tuple[str, int, int], ...] = (("detached", 2, 1),)
-
-    def __init__(self, *args, **kwargs):
-        """Init with defaults from _ATTRIBUTE_DEFAULTS."""
-        super().__init__(*args, **kwargs)
-        for attr_id, default in self._ATTRIBUTE_DEFAULTS.items():
-            if attr_id not in self._attr_cache:
-                self._update_attribute(attr_id, default)
 
     def _build_all_actions(
         self, override_attr_name: str, override_mode: InputMode

--- a/zhaquirks/ubisys/control_c4.py
+++ b/zhaquirks/ubisys/control_c4.py
@@ -39,7 +39,7 @@ class UbisysC4InputConfigCluster(UbisysInputConfigCluster):
         input_mode_3: Final = ZCLAttributeDef(id=0x0002, type=InputMode)
         input_mode_4: Final = ZCLAttributeDef(id=0x0003, type=InputMode)
 
-    _ATTRIBUTE_DEFAULTS: dict[int, Any] = {
+    _DEFAULT_VALUES: dict[int, Any] = {
         AttributeDefs.input_mode_1.id: InputMode.Toggle,
         AttributeDefs.input_mode_2.id: InputMode.Toggle,
         AttributeDefs.input_mode_3.id: InputMode.Toggle,

--- a/zhaquirks/ubisys/cover_j1.py
+++ b/zhaquirks/ubisys/cover_j1.py
@@ -190,12 +190,9 @@ class UbisysJ1CalibrationCluster(LocalDataCluster):
         exit_calibration_mode: Final = ZCLAttributeDef(id=0x0003, type=t.Bool)
         calibration_state: Final = ZCLAttributeDef(id=0x0004, type=CalibrationState)
 
-    def __init__(self, *args, **kwargs):
-        """Init with calibration state set to Idle."""
-        super().__init__(*args, **kwargs)
-        self._update_attribute(
-            self.AttributeDefs.calibration_state, CalibrationState.Idle
-        )
+    _DEFAULT_VALUES = {
+        AttributeDefs.calibration_state.id: CalibrationState.Idle,
+    }
 
     def _set_state(self, state: CalibrationState) -> None:
         """Update the calibration state attribute."""

--- a/zhaquirks/ubisys/dimmer_d1.py
+++ b/zhaquirks/ubisys/dimmer_d1.py
@@ -159,7 +159,7 @@ class UbisysD1InputConfigCluster(UbisysInputConfigCluster):
         input_mode_2: Final = ZCLAttributeDef(id=0x0002, type=DimmerInputMode)
         detached_2: Final = ZCLAttributeDef(id=0x0003, type=t.Bool)
 
-    _ATTRIBUTE_DEFAULTS: dict[int, Any] = {
+    _DEFAULT_VALUES: dict[int, Any] = {
         AttributeDefs.input_mode_1.id: DimmerInputMode.Toggle,
         AttributeDefs.detached_1.id: t.Bool.false,
         AttributeDefs.input_mode_2.id: DimmerInputMode.Toggle,

--- a/zhaquirks/ubisys/dimmer_d1.py
+++ b/zhaquirks/ubisys/dimmer_d1.py
@@ -187,9 +187,7 @@ class UbisysD1InputConfigCluster(UbisysInputConfigCluster):
             else:
                 attr_def = self.find_attribute(attr_name)
                 modes.append(
-                    DimmerInputMode(
-                        self._attr_cache.get(attr_def.id, DimmerInputMode.Toggle)
-                    )
+                    DimmerInputMode(self.get(attr_def.id, DimmerInputMode.Toggle))
                 )
         return modes
 
@@ -236,7 +234,7 @@ class UbisysD1InputConfigCluster(UbisysInputConfigCluster):
                     )
                     other_attr = self.find_attribute(other_attr_name)
                     other_mode = DimmerInputMode(
-                        self._attr_cache.get(other_attr.id, DimmerInputMode.Toggle)
+                        self.get(other_attr.id, DimmerInputMode.Toggle)
                     )
 
                     if (
@@ -251,7 +249,7 @@ class UbisysD1InputConfigCluster(UbisysInputConfigCluster):
                         # re-bind any detached inputs before writing actions
                         for det_attr_name, _, _ in self._DETACHED_CONFIG:
                             det_attr = self.find_attribute(det_attr_name)
-                            if self._attr_cache.get(det_attr.id, t.Bool.false):
+                            if self.get(det_attr.id, t.Bool.false):
                                 await self._set_detached(det_attr_name, False)
                     elif (
                         new_mode != DimmerInputMode.Dimmer_double

--- a/zhaquirks/ubisys/switch_s1r.py
+++ b/zhaquirks/ubisys/switch_s1r.py
@@ -51,7 +51,7 @@ class UbisysS1RInputConfigCluster(UbisysInputConfigCluster):
         input_mode_2: Final = ZCLAttributeDef(id=0x0002, type=InputMode)
         detached_2: Final = ZCLAttributeDef(id=0x0003, type=t.Bool)
 
-    _ATTRIBUTE_DEFAULTS: dict[int, Any] = {
+    _DEFAULT_VALUES: dict[int, Any] = {
         AttributeDefs.input_mode_1.id: InputMode.Toggle,
         AttributeDefs.detached_1.id: t.Bool.false,
         AttributeDefs.input_mode_2.id: InputMode.Toggle,

--- a/zhaquirks/ubisys/switch_s2.py
+++ b/zhaquirks/ubisys/switch_s2.py
@@ -50,7 +50,7 @@ class UbisysS2InputConfigCluster(UbisysInputConfigCluster):
         input_mode_2: Final = ZCLAttributeDef(id=0x0002, type=InputMode)
         detached_2: Final = ZCLAttributeDef(id=0x0003, type=t.Bool)
 
-    _ATTRIBUTE_DEFAULTS: dict[int, Any] = {
+    _DEFAULT_VALUES: dict[int, Any] = {
         AttributeDefs.input_mode_1.id: InputMode.Toggle,
         AttributeDefs.detached_1.id: t.Bool.false,
         AttributeDefs.input_mode_2.id: InputMode.Toggle,

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -693,17 +693,14 @@ class ElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
         ElectricalMeasurement.AttributeDefs.ac_power_divisor.id: 10,
     }
 
+    _DEFAULT_VALUES = {
+        ElectricalMeasurement.AttributeDefs.active_power.id: 0,
+        ElectricalMeasurement.AttributeDefs.rms_voltage.id: 0,
+    }
+
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
-        # put a default value so the sensors are created
-        if self.POWER_ID not in self._attr_cache:
-            self._update_attribute(self.POWER_ID, 0)
-        if self.VOLTAGE_ID not in self._attr_cache:
-            self._update_attribute(self.VOLTAGE_ID, 0)
-        if self.CONSUMPTION_ID not in self._attr_cache:
-            self._update_attribute(self.CONSUMPTION_ID, 0)
-
         # Previously, this cluster was wrongly setting the total_active_power attribute,
         # which was not added to HA.
         # Since it is now added to HA and the incorrect value could be set, we need to
@@ -725,12 +722,9 @@ class MeteringCluster(LocalDataCluster, Metering):
         Metering.AttributeDefs.metering_device_type.id: 0,  # electric
     }
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        # put a default value so the sensor is created
-        if self.CURRENT_SUMM_DELIVERED_ID not in self._attr_cache:
-            self._update_attribute(self.CURRENT_SUMM_DELIVERED_ID, 0)
+    _DEFAULT_VALUES = {
+        Metering.AttributeDefs.current_summ_delivered.id: 0,
+    }
 
 
 class IlluminanceMeasurementCluster(CustomCluster, IlluminanceMeasurement):
@@ -747,12 +741,9 @@ class LocalIlluminanceMeasurementCluster(
 ):
     """Illuminance measurement cluster based on LocalDataCluster."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        if self.AttributeDefs.measured_value.id not in self._attr_cache:
-            # put a default value so the sensor is created
-            self._update_attribute(self.AttributeDefs.measured_value.id, 0)
+    _DEFAULT_VALUES = {
+        IlluminanceMeasurement.AttributeDefs.measured_value.id: 0,
+    }
 
 
 class OnOffCluster(OnOff, CustomCluster):

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -696,6 +696,7 @@ class ElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
     _DEFAULT_VALUES = {
         ElectricalMeasurement.AttributeDefs.active_power.id: 0,
         ElectricalMeasurement.AttributeDefs.rms_voltage.id: 0,
+        ElectricalMeasurement.AttributeDefs.total_active_power.id: 0,
     }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Proposed change
This adds a `_DEFAULT_VALUES` dict to `LocalDataCluster`, similar to `_CONSTANT_ATTRIBUTES`.
This allows quirks using `LocalDataCluster` to set default values that can be overridden, unlike `_CONSTANT_ATTRIBUTES`.


## Additional information
There are multiple issues with the current pattern of checking `attrid not in self._attr_cache` and then using `update_attribute`:
- Zigpy clears the attribute cache after the quirk is applied, so the `update_attribute` call essentially did nothing. Appdb loading:  https://github.com/zigpy/zigpy/blob/70d15a5dde9adc28c230261d4ac32b7309075415/zigpy/appdb.py#L701-L724
- Zigpy does not populate the attribute cache for custom clusters before the quirk is loaded. Same link as above.
- Zigpy apparently does not save attribute values to the DB that happen in `Cluster.__init__` using `update_attribute`.
  - Zigpy also does not save attribute values on shutdown for any quirked devices: https://github.com/zigpy/zigpy/blob/70d15a5dde9adc28c230261d4ac32b7309075415/zigpy/appdb.py#L433-L441

There's an issue though: The Aqara feeder implementation also uses default values, but it's not a `LocalDataCluster`. That should be converted and/or **we should consider moving this into zigpy's `CustomCluster`, where the `_CONSTANT_ATTRIBUTES` also (partly) live already.**

In the future, we can also look at making `_CONSTANT_ATTRIBUTES`, `_VALID_ATTRIBUTES`, and `_DEFAULT_VALUES` (only) compatible with `ZCLAttributeDef` and/or name, instead of just IDs.
I'd do that in a separate PR though and keep the implementations consistent for now.

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
