### PR TITLE
Add Tuya CO2/temp/humidity sensors (Nous E10)

### DIFF
--- a/zhaquirks/tuya/ts0601_co2.py
+++ b/zhaquirks/tuya/ts0601_co2.py
@@ -1,0 +1,84 @@
+"""Nous E10 CO2, Temperature, and Humidity Detector.
+
+The quirk applies to the Zorro Alert ZR360CDB as well, which appears to be
+identical to the Nous E10.
+
+The quirk was developed based on the Zigbee2MQTT device definition:
+    https://github.com/Koenkk/zigbee-herdsman-converters/blob/7eb0b699e500bb945a45bd3533fe0b5a47c721e6/src/devices/tuya.ts#L17480
+"""
+
+from zigpy.quirks.v2 import EntityPlatform, EntityType
+import zigpy.types as t
+
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+
+class AirQuality(t.enum8):
+    """Tuya air quality enum."""
+
+    excellent = 0x00
+    moderate = 0x01
+    poor = 0x02
+
+
+class AlarmRingtone(t.enum8):
+    """Tuya alarm ringtone enum."""
+
+    volume_low = 0x00
+    volume_high = 0x01
+    OFF = 0x02
+
+
+class BatteryState(t.enum8):
+    """Tuya battery state enum."""
+
+    low = 0x00
+    medium = 0x01
+    high = 0x02
+
+
+(
+    TuyaQuirkBuilder("_TZE200_pl31aqf5", "TS0601")
+    .applies_to("_TZE200_xpvamyfz", "TS0601")
+    .applies_to("_TZE284_xpvamyfz", "TS0601")
+    .tuya_enum(
+        dp_id=1,
+        attribute_name="air_quality",
+        enum_class=AirQuality,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="air_quality",
+        fallback_name="Air quality",
+    )
+    .tuya_co2(dp_id=2)
+    .tuya_enum(
+        dp_id=5,
+        attribute_name="alarm_ringtone",
+        enum_class=AlarmRingtone,
+        translation_key="alarm_ringtone",
+        fallback_name="Alarm ringtone",
+    )
+    .tuya_enum(
+        dp_id=14,
+        attribute_name="battery_state",
+        enum_class=BatteryState,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="battery_state",
+        fallback_name="Battery state",
+    )
+    .tuya_number(
+        dp_id=17,
+        attribute_name="backlight_mode",
+        type=t.uint16_t,
+        min_value=1,
+        max_value=3,
+        step=1,
+        translation_key="backlight_mode",
+        fallback_name="Backlight mode",
+    )
+    .tuya_temperature(dp_id=18)
+    .tuya_humidity(dp_id=19)
+    .skip_configuration()
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0601_co2.py
+++ b/zhaquirks/tuya/ts0601_co2.py
@@ -26,7 +26,7 @@ class AlarmRingtone(t.enum8):
 
     volume_low = 0x00
     volume_high = 0x01
-    OFF = 0x02
+    off = 0x02
 
 
 class BatteryState(t.enum8):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This adds a quirk for the Nous E10 CO2/temp/humidity sensor.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
The quirk was developed based in the Zigbee2MQTT device definition in
[zigbee-herdsman-converters/src/devices/tuya.ts](https://github.com/Koenkk/zigbee-herdsman-converters/blob/7eb0b699e500bb945a45bd3533fe0b5a47c721e6/src/devices/tuya.ts#L17480)
From the Zigbee2MQTT commits, it appears that this not only applies to the Nous E10, but also the Zorro Alert ZR360CDB device.

This PR supersedes a previous PR (https://github.com/zigpy/zha-device-handlers/pull/4597), adding all data points from Zigbee2MQTT such as information on the battery status.

This has been tested locally on my HA system with a Nous E10 CO2/temp/humidity sensor for a few days now.

Fixes: https://github.com/home-assistant/core/issues/151069


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
