### PR TITLE
Add `read_only` to Tuya `DPToAttributeMapping`

### DIFF
--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -1,6 +1,18 @@
 """Test units for Tuya covers."""
 
+from unittest import mock
+
+from zigpy.quirks.v2 import CustomDeviceV2
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.closures import WindowCovering
+
+from tests.common import ClusterListener, wait_for_zigpy_tasks
+import zhaquirks
+from zhaquirks.tuya import TuyaCommand, TuyaData, TuyaDatapointData
+from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaWindowCovering
 from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601
+
+zhaquirks.setup()
 
 
 def test_ts601_moes_signature(assert_signature_matches_quirk):
@@ -20,3 +32,194 @@ def test_ts601_moes_signature(assert_signature_matches_quirk):
         "class": "zigpy.device.Device",
     }
     assert_signature_matches_quirk(TuyaMoesCover0601, signature)
+
+
+async def test_zemismart_zm16b_quirk(zigpy_device_from_v2_quirk):
+    """Test Zemismart ZM16B cover motor v2 quirk."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_3mzb0sdz", "TS0601")
+    assert isinstance(quirked, CustomDeviceV2)
+
+    ep = quirked.endpoints[1]
+
+    # Verify clusters are present
+    cover_cluster = ep.window_covering
+    assert cover_cluster is not None
+    assert isinstance(cover_cluster, TuyaWindowCovering)
+
+    tuya_cluster = ep.tuya_manufacturer
+    assert tuya_cluster is not None
+    assert isinstance(tuya_cluster, TuyaMCUCluster)
+
+
+async def test_zemismart_zm16b_position_report(zigpy_device_from_v2_quirk):
+    """Test that incoming position DP reports update the cover position."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_3mzb0sdz", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    cover_listener = ClusterListener(cover_cluster)
+
+    tuya_cluster = ep.tuya_manufacturer
+
+    # Simulate device reporting position 75 (75% open) via DP 8
+    # Should convert to ZCL 25% (0%=open, 100%=closed)
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[TuyaDatapointData(8, TuyaData(75))],
+        )
+    )
+
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 25
+    )
+
+    # Verify attribute update event was fired
+    assert len(cover_listener.attribute_updates) == 1
+    assert (
+        cover_listener.attribute_updates[0][0]
+        == WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+    assert cover_listener.attribute_updates[0][1] == 25
+
+    # Test DP 9 also updates position (position control echo)
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=2,
+            datapoints=[TuyaDatapointData(9, TuyaData(0))],
+        )
+    )
+
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 100
+    )
+
+
+async def test_zemismart_zm16b_open_command(zigpy_device_from_v2_quirk):
+    """Test that the open command sends the correct DP value."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_3mzb0sdz", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.up_open.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        # Verify the DP 1 command was sent with Open=0
+        call_data = req_mock.call_args[1]["data"]
+        # The payload contains DP 1 with value 0 (Open)
+        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[-1:] == b"\x00"  # Value = Open (0)
+
+
+async def test_zemismart_zm16b_close_command(zigpy_device_from_v2_quirk):
+    """Test that the close command sends the correct DP value."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_3mzb0sdz", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.down_close.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        # The payload contains DP 1 with value 2 (Close)
+        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[-1:] == b"\x02"  # Value = Close (2)
+
+
+async def test_zemismart_zm16b_stop_command(zigpy_device_from_v2_quirk):
+    """Test that the stop command sends the correct DP value."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_3mzb0sdz", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.stop.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        # The payload contains DP 1 with value 1 (Stop)
+        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[-1:] == b"\x01"  # Value = Stop (1)
+
+
+async def test_zemismart_zm16b_go_to_lift_percentage(zigpy_device_from_v2_quirk):
+    """Test that go_to_lift_percentage sends correct inverted position."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_3mzb0sdz", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        # Send ZCL go_to_lift_percentage with 25% (25% closed = 75% open)
+        await cover_cluster.command(
+            WindowCovering.ServerCommandDefs.go_to_lift_percentage.id, 25
+        )
+        await wait_for_zigpy_tasks()
+
+        # Should send inverted value (100 - 25 = 75) to device
+        # Multiple calls expected (DP 8 and DP 9 both mapped)
+        assert req_mock.call_count >= 1
+        # Check that at least one call has the correct position value
+        found_correct_position = False
+        for call in req_mock.call_args_list:
+            call_data = call[1]["data"]
+            # DP 9 (position control) with value 75
+            if b"\x09" in call_data and b"\x00\x00\x00\x4b" in call_data:
+                found_correct_position = True
+        assert found_correct_position, "Expected DP 9 with value 75 in sent data"
+
+
+async def test_zemismart_zm16b_battery_report(zigpy_device_from_v2_quirk):
+    """Test that battery DP reports update the battery percentage."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_3mzb0sdz", "TS0601")
+    ep = quirked.endpoints[1]
+
+    tuya_cluster = ep.tuya_manufacturer
+
+    # Simulate device reporting battery 85% via DP 13
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=3,
+            datapoints=[TuyaDatapointData(13, TuyaData(85))],
+        )
+    )
+
+    # Battery percentage should be scaled by 2 (default tuya_battery scale)
+    power_cluster = ep.power
+    assert power_cluster.get("battery_percentage_remaining") == 170

--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -2,14 +2,12 @@
 
 from unittest import mock
 
-from zigpy.quirks.v2 import CustomDeviceV2
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 
 from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
 from zhaquirks.tuya import TuyaCommand, TuyaData, TuyaDatapointData
-from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaWindowCovering
 from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601
 
 zhaquirks.setup()
@@ -32,24 +30,6 @@ def test_ts601_moes_signature(assert_signature_matches_quirk):
         "class": "zigpy.device.Device",
     }
     assert_signature_matches_quirk(TuyaMoesCover0601, signature)
-
-
-async def test_zemismart_zm16b_quirk(zigpy_device_from_v2_quirk):
-    """Test Zemismart ZM16B cover motor v2 quirk."""
-
-    quirked = zigpy_device_from_v2_quirk("_TZE284_3mzb0sdz", "TS0601")
-    assert isinstance(quirked, CustomDeviceV2)
-
-    ep = quirked.endpoints[1]
-
-    # Verify clusters are present
-    cover_cluster = ep.window_covering
-    assert cover_cluster is not None
-    assert isinstance(cover_cluster, TuyaWindowCovering)
-
-    tuya_cluster = ep.tuya_manufacturer
-    assert tuya_cluster is not None
-    assert isinstance(tuya_cluster, TuyaMCUCluster)
 
 
 async def test_zemismart_zm16b_position_report(zigpy_device_from_v2_quirk):

--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -190,17 +190,13 @@ async def test_zemismart_zm16b_go_to_lift_percentage(zigpy_device_from_v2_quirk)
         )
         await wait_for_zigpy_tasks()
 
-        # Should send inverted value (100 - 25 = 75) to device
-        # Multiple calls expected (DP 8 and DP 9 both mapped)
-        assert req_mock.call_count >= 1
-        # Check that at least one call has the correct position value
-        found_correct_position = False
-        for call in req_mock.call_args_list:
-            call_data = call[1]["data"]
-            # DP 9 (position control) with value 75
-            if b"\x09" in call_data and b"\x00\x00\x00\x4b" in call_data:
-                found_correct_position = True
-        assert found_correct_position, "Expected DP 9 with value 75 in sent data"
+        # Should send inverted value (100 - 25 = 75) only to DP 9
+        # DP 8 is read_only so it should not be written
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        # DP 9 (position control) with value 75
+        assert b"\x09" in call_data, "Expected DP 9 in sent data"
+        assert b"\x00\x00\x00\x4b" in call_data, "Expected value 75 in sent data"
 
 
 async def test_zemismart_zm16b_battery_report(zigpy_device_from_v2_quirk):

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1503,6 +1503,7 @@ class DPToAttributeMapping:
     attribute_name: str | tuple[str, ...]
     converter: Callable[[Any], Any] | None = None
     endpoint_id: int | None = None
+    read_only: bool = False
 
 
 @dataclasses.dataclass

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -8,6 +8,7 @@ import pathlib
 from types import FrameType
 from typing import Any, Self
 
+from zigpy.profiles import zha
 from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder, QuirksV2RegistryEntry
 from zigpy.quirks.v2.homeassistant import EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
@@ -15,6 +16,7 @@ from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
 from zigpy.zcl import foundation
+from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.measurement import (
     PM25,
     CarbonDioxideConcentration,
@@ -38,7 +40,12 @@ from zhaquirks.tuya import (
     TuyaLocalCluster,
     TuyaPowerConfigurationCluster,
 )
-from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster, TuyaOnOffNM
+from zhaquirks.tuya.mcu import (
+    DPToAttributeMapping,
+    TuyaMCUCluster,
+    TuyaOnOffNM,
+    TuyaWindowCovering,
+)
 
 MOL_VOL_AIR_NTP = 0.2445  # molar volume of air at NTP in cL/mol
 
@@ -408,6 +415,49 @@ class TuyaQuirkBuilder(QuirkBuilder):
             "on_off",
         )
         self.adds(onoff_cfg)
+        return self
+
+    def tuya_cover(
+        self,
+        control_dp: int,
+        position_state_dp: int,
+        position_control_dp: int,
+        invert: bool = True,
+        cover_cfg: TuyaLocalCluster = TuyaWindowCovering,
+    ) -> Self:
+        """Add a Tuya WindowCovering Configuration.
+
+        :param control_dp: DP ID for open/stop/close control (enum).
+        :param position_state_dp: DP ID for current position reports (0-100).
+        :param position_control_dp: DP ID for setting target position (0-100).
+        :param invert: Invert position values (most Tuya covers report
+            0=closed, 100=open which is opposite to ZCL convention).
+        :param cover_cfg: Custom WindowCovering cluster class to use.
+        """
+        converter = (lambda x: 100 - x) if invert else None
+        dp_converter = (lambda x: 100 - x) if invert else None
+
+        self.tuya_dp(
+            control_dp,
+            cover_cfg.ep_attribute,
+            TuyaWindowCovering.AttributeDefs.tuya_cover_command.name,
+        )
+        self.tuya_dp(
+            position_state_dp,
+            cover_cfg.ep_attribute,
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name,
+            converter=converter,
+            dp_converter=dp_converter,
+        )
+        self.tuya_dp(
+            position_control_dp,
+            cover_cfg.ep_attribute,
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name,
+            converter=converter,
+            dp_converter=dp_converter,
+        )
+        self.adds(cover_cfg)
+        self.replaces_endpoint(1, device_type=zha.DeviceType.WINDOW_COVERING_DEVICE)
         return self
 
     def tuya_humidity(

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -428,7 +428,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         """Add a Tuya WindowCovering Configuration.
 
         :param control_dp: DP ID for open/stop/close control (enum).
-        :param position_state_dp: DP ID for current position reports (0-100).
+        :param position_state_dp: DP ID for current position reports (read-only).
         :param position_control_dp: DP ID for setting target position (0-100).
         :param invert: Invert position values (most Tuya covers report
             0=closed, 100=open which is opposite to ZCL convention).
@@ -447,7 +447,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
             cover_cfg.ep_attribute,
             WindowCovering.AttributeDefs.current_position_lift_percentage.name,
             converter=converter,
-            dp_converter=dp_converter,
+            read_only=True,
         )
         self.tuya_dp(
             position_control_dp,

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -565,6 +565,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         dp_converter: Callable[[Any], Any] | None = None,
         endpoint_id: int | None = None,
         dp_handler: str = "_dp_2_attr_update",
+        read_only: bool = False,
     ) -> Self:
         """Add Tuya DP Converter."""
 
@@ -577,6 +578,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
                     converter=converter,
                     dp_converter=dp_converter,
                     endpoint_id=endpoint_id,
+                    read_only=read_only,
                 )
             ],
             dp_handler,

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -423,15 +423,23 @@ class TuyaQuirkBuilder(QuirkBuilder):
         position_state_dp: int,
         position_control_dp: int,
         invert: bool = True,
+        covering_type: WindowCovering.WindowCoveringType = WindowCovering.WindowCoveringType.Rollershade,
         cover_cfg: TuyaLocalCluster = TuyaWindowCovering,
     ) -> Self:
         """Add a Tuya WindowCovering Configuration.
+
+        Both position_state_dp and position_control_dp are mapped to the same
+        ZCL attribute (current_position_lift_percentage). The position_state_dp
+        is marked read_only so that outgoing position commands only write to
+        position_control_dp.
 
         :param control_dp: DP ID for open/stop/close control (enum).
         :param position_state_dp: DP ID for current position reports (read-only).
         :param position_control_dp: DP ID for setting target position (0-100).
         :param invert: Invert position values (most Tuya covers report
             0=closed, 100=open which is opposite to ZCL convention).
+        :param covering_type: ZCL WindowCoveringType that determines the HA
+            device class (e.g. Rollershade→shade, Drapery→curtain).
         :param cover_cfg: Custom WindowCovering cluster class to use.
         """
         converter = (lambda x: 100 - x) if invert else None
@@ -456,7 +464,12 @@ class TuyaQuirkBuilder(QuirkBuilder):
             converter=converter,
             dp_converter=dp_converter,
         )
-        self.adds(cover_cfg)
+        self.adds(
+            cover_cfg,
+            constant_attributes={
+                WindowCovering.AttributeDefs.window_covering_type: covering_type,
+            },
+        )
         self.replaces_endpoint(1, device_type=zha.DeviceType.WINDOW_COVERING_DEVICE)
         return self
 

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -9,6 +9,7 @@ from typing import Any, Final
 import zigpy.types as t
 from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.zcl import foundation
+from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import LevelControl, OnOff
 from zigpy.zcl.foundation import ZCLAttributeDef
 
@@ -410,6 +411,119 @@ class TuyaOnOff(OnOff, TuyaLocalCluster):
 
 class TuyaOnOffNM(NoManufacturerCluster, TuyaOnOff):
     """Tuya OnOff cluster with NoManufacturerID."""
+
+
+class TuyaCoverControl(t.enum8):
+    """Tuya cover control command values."""
+
+    Open = 0x00
+    Stop = 0x01
+    Close = 0x02
+
+
+class TuyaWindowCovering(WindowCovering, TuyaLocalCluster):
+    """Tuya MCU WindowCovering cluster."""
+
+    class AttributeDefs(WindowCovering.AttributeDefs):
+        """Attribute definitions."""
+
+        tuya_cover_command: Final = ZCLAttributeDef(
+            id=0xEF01, type=TuyaCoverControl, is_manufacturer_specific=True
+        )
+
+    async def command(
+        self,
+        command_id: foundation.GeneralCommand | int | t.uint8_t,
+        *args,
+        manufacturer: int | t.uint16_t | None = None,
+        expect_reply: bool = True,
+        tsn: int | t.uint8_t | None = None,
+        **kwargs: Any,
+    ):
+        """Override the default Cluster command."""
+
+        self.debug(
+            "Sending Tuya Cluster Command... Cluster Command is %x, Arguments are %s",
+            command_id,
+            args,
+        )
+
+        # up_open
+        if command_id == WindowCovering.ServerCommandDefs.up_open.id:
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_name=self.ep_attribute,
+                cluster_attr=self.AttributeDefs.tuya_cover_command.name,
+                attr_value=TuyaCoverControl.Open,
+                expect_reply=expect_reply,
+                manufacturer=manufacturer,
+            )
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cluster_data,
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        # down_close
+        if command_id == WindowCovering.ServerCommandDefs.down_close.id:
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_name=self.ep_attribute,
+                cluster_attr=self.AttributeDefs.tuya_cover_command.name,
+                attr_value=TuyaCoverControl.Close,
+                expect_reply=expect_reply,
+                manufacturer=manufacturer,
+            )
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cluster_data,
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        # stop
+        if command_id == WindowCovering.ServerCommandDefs.stop.id:
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_name=self.ep_attribute,
+                cluster_attr=self.AttributeDefs.tuya_cover_command.name,
+                attr_value=TuyaCoverControl.Stop,
+                expect_reply=expect_reply,
+                manufacturer=manufacturer,
+            )
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cluster_data,
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        # go_to_lift_percentage
+        if command_id == WindowCovering.ServerCommandDefs.go_to_lift_percentage.id:
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_name=self.ep_attribute,
+                cluster_attr=WindowCovering.AttributeDefs.current_position_lift_percentage.name,
+                attr_value=args[0],
+                expect_reply=expect_reply,
+                manufacturer=manufacturer,
+            )
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cluster_data,
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        self.warning("Unsupported command_id: %s", command_id)
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
 
 
 class TuyaOnOffManufCluster(TuyaMCUCluster):

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -48,9 +48,12 @@ class DPToAttributeMapping(DpToAttributeMappingBase):
         converter: Callable[[Any], Any] | None = None,
         dp_converter: Callable[[Any], Any] | None = None,
         endpoint_id: int | None = None,
+        read_only: bool = False,
     ):
         """Init method for compatibility with previous quirks using positional arguments."""
-        super().__init__(ep_attribute, attribute_name, converter, endpoint_id)
+        super().__init__(
+            ep_attribute, attribute_name, converter, endpoint_id, read_only
+        )
         self.dp_converter = dp_converter
 
 
@@ -295,6 +298,8 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
         result: dict[int, DPToAttributeMapping] = {}
         for dp, dp_mapping in self._dp_to_attributes.items():
             for mapped_attr in dp_mapping:
+                if mapped_attr.read_only:
+                    continue
                 if (
                     attribute_name == mapped_attr.attribute_name
                     or (

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -1,6 +1,7 @@
 """Tuya based cover and blinds."""
 
 from zigpy.profiles import zha
+import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
 
 from zhaquirks.const import (
@@ -17,6 +18,7 @@ from zhaquirks.tuya import (
     TuyaWindowCover,
     TuyaWindowCoverControl,
 )
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
 class TuyaZemismartSmartCover0601(TuyaWindowCover):
@@ -623,3 +625,26 @@ class TuyaCloneCover0601(TuyaWindowCover):
             }
         }
     }
+
+
+class MotorDirection(t.enum8):
+    """Motor direction values."""
+
+    Forward = 0x00
+    Back = 0x01
+
+
+(
+    TuyaQuirkBuilder("_TZE284_3mzb0sdz", "TS0601")
+    .tuya_cover(control_dp=1, position_state_dp=8, position_control_dp=9)
+    .tuya_battery(dp_id=13)
+    .tuya_enum(
+        dp_id=11,
+        attribute_name="motor_direction",
+        enum_class=MotorDirection,
+        translation_key="motor_direction",
+        fallback_name="Motor direction",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -13,6 +13,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import (
+    TUYA_CLUSTER_ID,
     TuyaManufacturerWindowCover,
     TuyaManufCluster,
     TuyaWindowCover,
@@ -634,6 +635,16 @@ class MotorDirection(t.enum8):
     Back = 0x01
 
 
+class BorderSetting(t.enum8):
+    """Border/limit setting values."""
+
+    Up = 0x00
+    Down = 0x01
+    Up_delete = 0x02
+    Down_delete = 0x03
+    Remove_top_bottom = 0x04
+
+
 (
     TuyaQuirkBuilder("_TZE284_3mzb0sdz", "TS0601")
     .tuya_cover(control_dp=1, position_state_dp=8, position_control_dp=9)
@@ -644,6 +655,51 @@ class MotorDirection(t.enum8):
         enum_class=MotorDirection,
         translation_key="motor_direction",
         fallback_name="Motor direction",
+    )
+    .tuya_dp_attribute(
+        dp_id=16,
+        attribute_name="border",
+        type=BorderSetting,
+    )
+    .write_attr_button(
+        attribute_name="border",
+        attribute_value=BorderSetting.Up,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="border_up",
+        translation_key="set_upper_limit",
+        fallback_name="Set upper limit",
+    )
+    .write_attr_button(
+        attribute_name="border",
+        attribute_value=BorderSetting.Down,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="border_down",
+        translation_key="set_lower_limit",
+        fallback_name="Set lower limit",
+    )
+    .write_attr_button(
+        attribute_name="border",
+        attribute_value=BorderSetting.Up_delete,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="border_up_delete",
+        translation_key="delete_upper_limit",
+        fallback_name="Delete upper limit",
+    )
+    .write_attr_button(
+        attribute_name="border",
+        attribute_value=BorderSetting.Down_delete,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="border_down_delete",
+        translation_key="delete_lower_limit",
+        fallback_name="Delete lower limit",
+    )
+    .write_attr_button(
+        attribute_name="border",
+        attribute_value=BorderSetting.Remove_top_bottom,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="border_remove_all",
+        translation_key="delete_all_limits",
+        fallback_name="Delete all limits",
     )
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
DRAFT. Needs to be rebased.

## Proposed change
This implements the `read_only` field in `DPToAttributeMapping`, as mentioned in the linked PR below.
It's also used in the `_TZE284_3mzb0sdz` Tuya v2 cover quirk to not write to the read-only lift percentage DP.

## Additional information
Original PR adding basic cover support to `TuyaQuirkBuilder`:
- https://github.com/zigpy/zha-device-handlers/pull/4779

Related device issue:
- https://github.com/zigpy/zha-device-handlers/issues/4776

## Device diagnostics
See linked issue above.


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
