### PR TITLE
Add ELECRAM Ramses ESP32-C6 quirk

### DIFF
--- a/tests/test_elecram.py
+++ b/tests/test_elecram.py
@@ -1,7 +1,6 @@
 """Tests for the ELECRAM RAMSES ESP32-C6 quirk."""
 
 import zhaquirks
-import zhaquirks.elecram.ramses_esp
 from zhaquirks.elecram.ramses_esp import (
     RAMSES_RX_CLUSTER,
     RAMSES_TX_CLUSTER,

--- a/tests/test_elecram.py
+++ b/tests/test_elecram.py
@@ -1,0 +1,80 @@
+"""Tests for the ELECRAM RAMSES ESP32-C6 quirk."""
+
+import zhaquirks
+import zhaquirks.elecram.ramses_esp
+from zhaquirks.elecram.ramses_esp import (
+    RAMSES_RX_CLUSTER,
+    RAMSES_TX_CLUSTER,
+    RamsesESP,
+    RamsesRXCluster,
+    RamsesTXCluster,
+)
+
+zhaquirks.setup()
+
+
+def test_ramses_esp_signature(assert_signature_matches_quirk):
+    """Test that the RamsesESP signature matches the real device fingerprint."""
+
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=0, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=0, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "10": {
+                "profile_id": 260,
+                "device_type": "0x0000",
+                "in_clusters": [
+                    "0x0000",  # Basic
+                    "0x0003",  # Identify
+                    "0xfc01",  # RAMSES_TX_CLUSTER
+                ],
+                "out_clusters": [
+                    "0xfc00",  # RAMSES_RX_CLUSTER
+                ],
+            },
+        },
+        "manufacturer": "ELECRAM",
+        "model": "Ramses_esp32c6",
+        "class": "elecram.ramses_esp.RamsesESP",
+    }
+
+    assert_signature_matches_quirk(RamsesESP, signature)
+
+
+def test_ramses_esp_clusters(zigpy_device_from_quirk):
+    """Test that the quirk replaces the custom clusters correctly."""
+
+    device = zigpy_device_from_quirk(RamsesESP)
+
+    ep = device.endpoints[10]
+
+    # Replacement input cluster: RamsesTXCluster instead of bare 0xfc01
+    assert RAMSES_TX_CLUSTER in ep.in_clusters
+    assert isinstance(ep.in_clusters[RAMSES_TX_CLUSTER], RamsesTXCluster)
+
+    # Replacement output cluster: RamsesRXCluster instead of bare 0xfc00
+    assert RAMSES_RX_CLUSTER in ep.out_clusters
+    assert isinstance(ep.out_clusters[RAMSES_RX_CLUSTER], RamsesRXCluster)
+
+
+def test_ramses_rx_cluster_commands():
+    """Test that RamsesRXCluster defines the expected commands."""
+
+    # Client command 0x00: send_text
+    assert hasattr(RamsesRXCluster.ClientCommandDefs, "send_text")
+    assert RamsesRXCluster.ClientCommandDefs.send_text.id == 0x00
+
+    # Server command 0x01: ack_chunk
+    assert hasattr(RamsesRXCluster.ServerCommandDefs, "ack_chunk")
+    assert RamsesRXCluster.ServerCommandDefs.ack_chunk.id == 0x01
+
+
+def test_ramses_tx_cluster_commands():
+    """Test that RamsesTXCluster defines the expected commands."""
+
+    # Client command 0x00: set_text (ZHA -> ESP32)
+    assert hasattr(RamsesTXCluster.ClientCommandDefs, "set_text")
+    assert RamsesTXCluster.ClientCommandDefs.set_text.id == 0x00
+
+    # Server command 0x01: ack_chunk (ESP32 -> ZHA ACK)
+    assert hasattr(RamsesTXCluster.ServerCommandDefs, "ack_chunk")
+    assert RamsesTXCluster.ServerCommandDefs.ack_chunk.id == 0x01

--- a/zhaquirks/elecram/__init__.py
+++ b/zhaquirks/elecram/__init__.py
@@ -1,0 +1,1 @@
+"""Module for Aurora devices."""

--- a/zhaquirks/elecram/__init__.py
+++ b/zhaquirks/elecram/__init__.py
@@ -1,1 +1,1 @@
-"""Module for Aurora devices."""
+"""Quirks for Elecram (ELECRAM) devices, including RAMSES ESP-based hardware."""

--- a/zhaquirks/elecram/ramses_esp.py
+++ b/zhaquirks/elecram/ramses_esp.py
@@ -1,0 +1,101 @@
+"""Device handler for RAMSES ESP32-C6 Zigbee."""
+
+from zigpy import types
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import Basic, Identify
+
+from zhaquirks.const import (
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+RAMSES_RX_CLUSTER = 0xFC00
+RAMSES_TX_CLUSTER = 0xFC01
+
+
+class RamsesRXCluster(CustomCluster):
+    """RAMSES RX cluster (RAMSES_RX_CLUSTER) — ESP32 -> ZHA (device-originated messages)."""
+
+    cluster_id = RAMSES_RX_CLUSTER
+
+    class ClientCommandDefs(foundation.BaseCommandDefs):
+        """Commands that ESP32 (client) sends to coordinator (server)."""
+
+        send_text: foundation.ZCLCommandDef = foundation.ZCLCommandDef(
+            id=0x00,
+            schema={"text": types.CharacterString},
+        )
+
+    class ServerCommandDefs(foundation.BaseCommandDefs):
+        """Server commands (ACKs) sent in response to `send_text` messages."""
+
+        ack_chunk: foundation.ZCLCommandDef = foundation.ZCLCommandDef(
+            id=0x01,
+            schema={"text": types.CharacterString},
+        )
+
+
+class RamsesTXCluster(CustomCluster):
+    """RAMSES TX cluster (RAMSES_TX_CLUSTER) — ZHA -> ESP32 (coordinator-originated messages)."""
+
+    cluster_id = RAMSES_TX_CLUSTER
+
+    class ClientCommandDefs(foundation.BaseCommandDefs):
+        """Client commands (from ZHA to ESP32) — the RAMSES-II message payload."""
+
+        set_text: foundation.ZCLCommandDef = foundation.ZCLCommandDef(
+            id=0x00,
+            schema={"text": types.CharacterString},
+        )
+
+    class ServerCommandDefs(foundation.BaseCommandDefs):
+        """Server commands (ACKs) sent by the ESP32 in response to `set_text`."""
+
+        ack_chunk: foundation.ZCLCommandDef = foundation.ZCLCommandDef(
+            id=0x01,
+            schema={"text": types.CharacterString},
+        )
+
+
+class RamsesESP(CustomDevice):
+    """Ramses ESP32-C6 Zigbee."""
+
+    signature = {
+        MODELS_INFO: [
+            ("ELECRAM", "Ramses_esp32c6"),
+        ],
+        ENDPOINTS: {
+            10: {
+                PROFILE_ID: zha.PROFILE_ID,  # Home Automation
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,  # 0x0000
+                    Identify.cluster_id,  # 0x0003
+                    RAMSES_TX_CLUSTER,  # Ramses TX Cluster (server - receives commands from ZHA)
+                ],
+                OUTPUT_CLUSTERS: [
+                    RAMSES_RX_CLUSTER,  # Ramses RX Cluster (client - sends commands to ZHA)
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            10: {
+                PROFILE_ID: zha.PROFILE_ID,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    RamsesTXCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    RamsesRXCluster,
+                ],
+            }
+        },
+    }

--- a/zhaquirks/elecram/ramses_esp.py
+++ b/zhaquirks/elecram/ramses_esp.py
@@ -7,6 +7,7 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Identify
 
 from zhaquirks.const import (
+    DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
@@ -72,6 +73,7 @@ class RamsesESP(CustomDevice):
         ENDPOINTS: {
             10: {
                 PROFILE_ID: zha.PROFILE_ID,  # Home Automation
+                DEVICE_TYPE: 0x0000,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,  # 0x0000
                     Identify.cluster_id,  # 0x0003
@@ -88,6 +90,7 @@ class RamsesESP(CustomDevice):
         ENDPOINTS: {
             10: {
                 PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: 0x0000,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,


### PR DESCRIPTION
## Proposed change
For the project [ramses_cc](https://github.com/ramses-rf/ramses_cc) I am working on Zigbee communication for my [Ramses ESP](https://github.com/IMMRMKW/ramses_esp) board. Until now, only serial and MQTT communication was possible.


## Additional information
The device supports two custom clusters, in similar fashion as the MQTT communication. One cluster is for sending received messages to Ramses RF, the other for receiving messages from Ramses RF.


## Device diagnostics
[diagnostics.txt](https://github.com/user-attachments/files/25468743/diagnostics.txt)


## Checklist
[x] The changes are tested and work correctly
[x] pre-commit checks pass / the code has been formatted using Black
[x] Tests have been added to verify that the new code works
[x] Device diagnostics data has been attached

