### PR TITLE
Skip `translation_placeholders` in name consistency test 

### DIFF
--- a/tests/test_quirks_v2.py
+++ b/tests/test_quirks_v2.py
@@ -37,6 +37,10 @@ def test_translation_key_and_fallback_name_match() -> None:
         for entity_metadata in quirk.entity_metadata:
             if (translation_key := entity_metadata.translation_key) is None:
                 continue
+            # skip entities using translation placeholders: they intentionally share
+            # the same translation key with different fallback names
+            if entity_metadata.translation_placeholders:
+                continue
             quirk_location = f"{quirk.quirk_file}:{quirk.quirk_file_line}"
             translation_key_map[translation_key].add(
                 (quirk_location, entity_metadata.fallback_name)


### PR DESCRIPTION
## Proposed change
We have a test checking if a `translation_key` is across quirks v2 entities. If it is, the `fallback_name` must also match. By default, the `fallback_name` is added to ZHA's `strings.json` in HA when ZHA (with zha-quirks) is bumped.

This is to make sure the `fallback_name` generally always matches what we display in HA, as it'll always use the translation based on the `translation_key`, completely ignoring the `fallback_name`. The `fallback_name` is only used when a custom quirk is installed.

This changes the `test_translation_key_and_fallback_name_match` test to ignore quirks v2 entities for this test if they provide `translation_placeholders`. This will likely be needed for upcoming Ubisys quirks that use translation keys with a placeholder for "Input mode 1" and "Input mode 2", with the number being a placeholder in the string.
So, the `translation_key` will be the same for both entities, but the `fallback_name` will not be the same. It'll have the differing number at the end.

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
