### PR TITLE
Ignore suspicious cluster moves for IKEA Somrig button

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -899,6 +899,7 @@ def test_no_duplicate_clusters(quirk: CustomDevice) -> None:
             zhaquirks.ikea.starkvind.IkeaSTARKVIND_v2,
             # removes Group input cluster (IKEA remote):
             zhaquirks.ikea.twobtnremote.IkeaRodretRemote2BtnNew,
+            zhaquirks.ikea.somrigsmartbtn.IkeaSomrigSmartButton,
             # remove WindowCovering input cluster (IKEA remote):
             zhaquirks.ikea.twobtnremote.IkeaTradfriRemote2BtnZLL,
             #


### PR DESCRIPTION
## Proposed change
Unbreaks CI failing due to:
- https://github.com/zigpy/zha-device-handlers/pull/3840


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
