### PR TITLE
Limit Sonoff TRVZB entities for installed firmware

### DIFF
--- a/zhaquirks/sonoff/trvzb.py
+++ b/zhaquirks/sonoff/trvzb.py
@@ -107,18 +107,9 @@ class CustomSonoffCluster(CustomCluster):
         )
 
 
-(
+base_trvzb_quirk = (
     QuirkBuilder("SONOFF", "TRVZB")
     .replaces(CustomSonoffCluster)
-    .switch(
-        CustomSonoffCluster.AttributeDefs.smart_temperature_control.name,
-        # ControlModeType,
-        CustomSonoffCluster.cluster_id,
-        on_value=2,
-        off_value=0,
-        translation_key="adaptive_mode",
-        fallback_name="Adaptive mode",
-    )
     .switch(
         CustomSonoffCluster.AttributeDefs.child_lock.name,
         CustomSonoffCluster.cluster_id,
@@ -130,46 +121,6 @@ class CustomSonoffCluster(CustomCluster):
         CustomSonoffCluster.cluster_id,
         translation_key="open_window",
         fallback_name="Open window",
-    )
-    .number(
-        CustomSonoffCluster.AttributeDefs.timer_mode_target_temperature.name,
-        CustomSonoffCluster.cluster_id,
-        min_value=4.0,
-        max_value=35.0,
-        step=0.5,
-        device_class=NumberDeviceClass.TEMPERATURE,
-        unit=UnitOfTemperature.CELSIUS,
-        multiplier=0.01,
-        translation_key="timer_mode_target_temperature",
-        fallback_name="Timer mode target temperature",
-    )
-    .number(
-        CustomSonoffCluster.AttributeDefs.temporary_mode_duration.name,
-        CustomSonoffCluster.cluster_id,
-        min_value=0,
-        max_value=1440,
-        step=1,
-        device_class=NumberDeviceClass.DURATION,
-        unit=UnitOfTime.MINUTES,
-        multiplier=1 / 60,
-        translation_key="temporary_mode_duration",
-        fallback_name="Temporary mode duration",
-    )
-    .write_attr_button(
-        attribute_name=CustomSonoffCluster.AttributeDefs.temporary_mode.name,
-        cluster_id=CustomSonoffCluster.cluster_id,
-        attribute_value=0x00,
-        unique_id_suffix="boost_mode",
-        translation_key="boost_mode",
-        fallback_name="Boost mode",
-    )
-    .write_attr_button(
-        attribute_name=CustomSonoffCluster.AttributeDefs.temporary_mode.name,
-        cluster_id=CustomSonoffCluster.cluster_id,
-        attribute_value=0x01,
-        unique_id_suffix="timer_mode",
-        translation_key="timer_mode",
-        fallback_name="Timer mode",
     )
     .number(
         CustomSonoffCluster.AttributeDefs.frost_protection_temperature.name,
@@ -232,6 +183,66 @@ class CustomSonoffCluster(CustomCluster):
         multiplier=0.01,
         translation_key="external_temperature_sensor_value",
         fallback_name="External temperature sensor value",
+    )
+)
+
+(
+    base_trvzb_quirk.clone()
+    .firmware_version_filter(max_version=0x00001404, allow_missing=False)
+    .add_to_registry()
+)
+
+(
+    base_trvzb_quirk.clone()
+    .firmware_version_filter(min_version=0x00001404, allow_missing=True)
+    .switch(
+        CustomSonoffCluster.AttributeDefs.smart_temperature_control.name,
+        # ControlModeType,
+        CustomSonoffCluster.cluster_id,
+        on_value=2,
+        off_value=0,
+        translation_key="adaptive_mode",
+        fallback_name="Adaptive mode",
+    )
+    .number(
+        CustomSonoffCluster.AttributeDefs.timer_mode_target_temperature.name,
+        CustomSonoffCluster.cluster_id,
+        min_value=4.0,
+        max_value=35.0,
+        step=0.5,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        unit=UnitOfTemperature.CELSIUS,
+        multiplier=0.01,
+        translation_key="timer_mode_target_temperature",
+        fallback_name="Timer mode target temperature",
+    )
+    .number(
+        CustomSonoffCluster.AttributeDefs.temporary_mode_duration.name,
+        CustomSonoffCluster.cluster_id,
+        min_value=0,
+        max_value=1440,
+        step=1,
+        device_class=NumberDeviceClass.DURATION,
+        unit=UnitOfTime.MINUTES,
+        multiplier=1 / 60,
+        translation_key="temporary_mode_duration",
+        fallback_name="Temporary mode duration",
+    )
+    .write_attr_button(
+        attribute_name=CustomSonoffCluster.AttributeDefs.temporary_mode.name,
+        cluster_id=CustomSonoffCluster.cluster_id,
+        attribute_value=0x00,
+        unique_id_suffix="boost_mode",
+        translation_key="boost_mode",
+        fallback_name="Boost mode",
+    )
+    .write_attr_button(
+        attribute_name=CustomSonoffCluster.AttributeDefs.temporary_mode.name,
+        cluster_id=CustomSonoffCluster.cluster_id,
+        attribute_value=0x01,
+        unique_id_suffix="timer_mode",
+        translation_key="timer_mode",
+        fallback_name="Timer mode",
     )
     .add_to_registry()
 )

--- a/zhaquirks/sonoff/trvzb.py
+++ b/zhaquirks/sonoff/trvzb.py
@@ -186,26 +186,15 @@ base_trvzb_quirk = (
     )
 )
 
+# Firmware older than 1.4.0 (0x00001400): base entities only.
 (
-    base_trvzb_quirk.clone()
-    # Firmware 1.4.4 (0x00001404) introduced additional entities.
-    .firmware_version_filter(max_version=0x00001404, allow_missing=False)
+    base_trvzb_quirk.clone(omit_man_model_data=False)
+    .firmware_version_filter(max_version=0x00001400, allow_missing=False)
     .add_to_registry()
 )
 
-(
-    base_trvzb_quirk.clone()
-    # Apply additional entities to firmware 1.4.4 (0x00001404) and newer.
-    .firmware_version_filter(min_version=0x00001404, allow_missing=True)
-    .switch(
-        CustomSonoffCluster.AttributeDefs.smart_temperature_control.name,
-        # ControlModeType,
-        CustomSonoffCluster.cluster_id,
-        on_value=2,
-        off_value=0,
-        translation_key="adaptive_mode",
-        fallback_name="Adaptive mode",
-    )
+trvzb_v1400_quirk = (
+    base_trvzb_quirk.clone(omit_man_model_data=False)
     .number(
         CustomSonoffCluster.AttributeDefs.timer_mode_target_temperature.name,
         CustomSonoffCluster.cluster_id,
@@ -245,6 +234,30 @@ base_trvzb_quirk = (
         unique_id_suffix="timer_mode",
         translation_key="timer_mode",
         fallback_name="Timer mode",
+    )
+)
+
+# Firmware 1.4.0 (0x00001400) through 1.4.3: add temporary mode entities.
+(
+    trvzb_v1400_quirk.clone(omit_man_model_data=False)
+    .firmware_version_filter(
+        min_version=0x00001400, max_version=0x00001404, allow_missing=False
+    )
+    .add_to_registry()
+)
+
+# Firmware 1.4.4 (0x00001404) and newer: add adaptive mode as well.
+(
+    trvzb_v1400_quirk.clone(omit_man_model_data=False)
+    .firmware_version_filter(min_version=0x00001404, allow_missing=True)
+    .switch(
+        CustomSonoffCluster.AttributeDefs.smart_temperature_control.name,
+        # ControlModeType,
+        CustomSonoffCluster.cluster_id,
+        on_value=2,
+        off_value=0,
+        translation_key="adaptive_mode",
+        fallback_name="Adaptive mode",
     )
     .add_to_registry()
 )

--- a/zhaquirks/sonoff/trvzb.py
+++ b/zhaquirks/sonoff/trvzb.py
@@ -188,12 +188,14 @@ base_trvzb_quirk = (
 
 (
     base_trvzb_quirk.clone()
+    # Firmware 1.4.4 (0x00001404) introduced additional entities.
     .firmware_version_filter(max_version=0x00001404, allow_missing=False)
     .add_to_registry()
 )
 
 (
     base_trvzb_quirk.clone()
+    # Apply additional entities to firmware 1.4.4 (0x00001404) and newer.
     .firmware_version_filter(min_version=0x00001404, allow_missing=True)
     .switch(
         CustomSonoffCluster.AttributeDefs.smart_temperature_control.name,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This limits Sonoff TRVZB entities based on the installed firmware version.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Related PRs:
- https://github.com/zigpy/zha-device-handlers/pull/4740


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
TODO


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
