### PR TITLE
Let Hue sensor cluster inherit from `OccupancySensing`

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -773,7 +773,6 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
                 # A few are expected to fail and are handled by ZHA
                 if cluster not in (
                     zhaquirks.konke.KonkeOnOffCluster,
-                    zhaquirks.philips.PhilipsOccupancySensing,
                     zhaquirks.xiaomi.aqara.vibration_aq1.VibrationAQ1.MultistateInputCluster,
                 ):
                     pytest.fail(
@@ -805,7 +804,10 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
             base_attr_names = {a.name for a in base_cluster.attributes.values()}
             quirk_attr_names = {a.name for a in cluster.attributes.values()}
 
-            if not base_attr_names <= quirk_attr_names:
+            if not base_attr_names <= quirk_attr_names and cluster not in (
+                # XXX: Test to be updated for mf-attributes with same ID as ZCL ones
+                zhaquirks.philips.PhilipsOccupancySensing,
+            ):
                 pytest.fail(
                     f"Cluster {cluster} deletes parent class's attributes instead of"
                     f" extending them: {base_attr_names - quirk_attr_names}"

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -43,20 +43,17 @@ SIGNIFY = "Signify Netherlands B.V."
 _LOGGER = logging.getLogger(__name__)
 
 
-class PhilipsOccupancySensing(CustomCluster):
+class PhilipsOccupancySensing(CustomCluster, OccupancySensing):
     """Philips occupancy cluster."""
-
-    cluster_id = OccupancySensing.cluster_id
-    ep_attribute = "philips_occupancy"
 
     class AttributeDefs(OccupancySensing.AttributeDefs):
         """Attribute definitions."""
 
         sensitivity: Final = ZCLAttributeDef(
-            id=0x0030, type=t.uint8_t, is_manufacturer_specific=True
+            id=0x0030, type=t.uint8_t, manufacturer_code=0x100B
         )
         sensitivity_max: Final = ZCLAttributeDef(
-            id=0x0031, type=t.uint8_t, is_manufacturer_specific=True
+            id=0x0031, type=t.uint8_t, manufacturer_code=0x100B
         )
 
 


### PR DESCRIPTION
## Proposed change
This removes the `ep_attribute` override for the Hue sensor occupancy cluster. The cluster now also inherits from `OccupancySensing`.


## Additional information
Recently, ZHA introduced support for the `pir_o_to_u_delay` attribute/entity with https://github.com/zigpy/zha/pull/669. This should be supported by the Hue sensors as well. However, the number entities aren't created as they require the `occupancy` `ep_attribute` (cluster handler name), yet the Hue sensors use `philips_occupancy`: [zha/application/platforms/binary_sensor/__init__.py#L199-L209](https://github.com/zigpy/zha/blob/9d03d639ee93f61135c2c02445cae23f8abd6723/zha/application/platforms/binary_sensor/__init__.py#L199-L209).

This was done as the custom Hue attributes conflicted with the ZCL attribute IDs for `physical_contact_u_to_o_delay` + `physical_contact_o_to_u_delay` attributes. As zigpy now properly supports ZCL attributes and manufacturer-specific ones using the same attribute ID, we no longer need this workaround.



## Device diagnostics
Should be in ZHA.

## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
