### PR TITLE
Fix `test_attributes_updated_not_replaced` test

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -818,6 +818,32 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
                                 f" extending it"
                             )
 
+            # Ensure quirk-only attributes on standard clusters are not silently
+            # defined as non-manufacturer-specific (False/None). This catches
+            # attributes that should have a manufacturer code but were defined
+            # with manufacturer_code=None.
+            for attr_id, by_mfr in cluster._attributes_by_id.items():
+                if attr_id not in base_cluster._attributes_by_id:
+                    continue
+                base_names_at_id = {
+                    attr_def.name
+                    for by_code in base_cluster._attributes_by_id.get(
+                        attr_id, {}
+                    ).values()
+                    for attr_def in by_code.values()
+                }
+                for is_mfr, by_code in by_mfr.items():
+                    for mfr_code, quirk_attr in by_code.items():
+                        if quirk_attr.name in base_names_at_id:
+                            continue
+                        if is_mfr is False and mfr_code is None:
+                            pytest.fail(
+                                f"Cluster {cluster} defines quirk-only attribute"
+                                f" {quirk_attr.name!r} (id=0x{attr_id:04X}) as"
+                                " non-manufacturer-specific with"
+                                " manufacturer_code=None"
+                            )
+
 
 @pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)
 def test_no_duplicate_clusters(quirk: CustomDevice) -> None:

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -752,15 +752,10 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
                 missing_attrs = base_cluster_attrs_name[cluster.ep_attribute] - set(
                     cluster.attributes_by_name.keys()
                 )
-
-                # A few are expected to fail and are handled by ZHA
-                if cluster not in (
-                    zhaquirks.centralite.cl_3310S.SmartthingsRelativeHumidityCluster,
-                ):
-                    pytest.fail(
-                        f"Cluster {cluster} with endpoint name {cluster.ep_attribute!r}"
-                        f" does not contain all named attributes: {missing_attrs}"
-                    )
+                pytest.fail(
+                    f"Cluster {cluster} with endpoint name {cluster.ep_attribute!r}"
+                    f" does not contain all named attributes: {missing_attrs}"
+                )
 
             # Check if attributes match based on cluster ID
             if not (

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -805,10 +805,21 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
             base_attr_names = {a.name for a in base_cluster.attributes.values()}
             quirk_attr_names = {a.name for a in cluster.attributes.values()}
 
-            if not base_attr_names <= quirk_attr_names:
+            # Allow base class attribute names to be superseded by manufacturer-specific
+            # attributes at the same ID. These use manufacturer_code to differentiate
+            # and do not actually conflict at the protocol level.
+            superseded_by_mfr = {
+                base_attr.name
+                for attr_id, base_attr in base_cluster.attributes.items()
+                if attr_id in cluster.attributes
+                and cluster.attributes[attr_id].name != base_attr.name
+                and isinstance(cluster.attributes[attr_id].manufacturer_code, int)
+            }
+
+            if not (base_attr_names - superseded_by_mfr) <= quirk_attr_names:
                 pytest.fail(
                     f"Cluster {cluster} deletes parent class's attributes instead of"
-                    f" extending them: {base_attr_names - quirk_attr_names}"
+                    f" extending them: {(base_attr_names - superseded_by_mfr) - quirk_attr_names}"
                 )
 
 

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -54,6 +54,7 @@ from zhaquirks.const import (
 )
 import zhaquirks.konke
 import zhaquirks.philips
+import zhaquirks.sinope.switch
 from zhaquirks.xiaomi import XIAOMI_NODE_DESC
 import zhaquirks.xiaomi.aqara.vibration_aq1
 
@@ -792,28 +793,30 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
             base_cluster = list(base_clusters)[0]
 
             # Ensure every base class attribute is preserved in the quirk cluster.
-            # For each attr_id, all attribute names from the base must still exist
-            # somewhere under that ID in the quirk's _attributes_by_id. This correctly
-            # handles manufacturer-specific attributes sharing an ID with a ZCL one
-            # (they occupy distinct keys and don't displace each other), while still
-            # catching genuine deletions or ZCL-overrides-ZCL with a different name.
+            # Using _attributes_by_id correctly handles manufacturer-specific attributes
+            # sharing an ID with a ZCL attribute — they occupy distinct keys and don't
+            # displace each other, unlike the flat .attributes dict.
             for attr_id, by_mfr in base_cluster._attributes_by_id.items():
-                base_names_at_id = {
-                    attr_def.name
-                    for by_code in by_mfr.values()
-                    for attr_def in by_code.values()
-                }
-                quirk_names_at_id = {
-                    attr_def.name
-                    for by_code in cluster._attributes_by_id.get(attr_id, {}).values()
-                    for attr_def in by_code.values()
-                }
-                missing = base_names_at_id - quirk_names_at_id
-                if missing:
-                    pytest.fail(
-                        f"Cluster {cluster} deletes parent class's attributes instead of"
-                        f" extending them: {missing} (id=0x{attr_id:04X})"
-                    )
+                for is_mfr, by_code in by_mfr.items():
+                    for mfr_code, base_attr in by_code.items():
+                        quirk_attr = (
+                            cluster._attributes_by_id.get(attr_id, {})
+                            .get(is_mfr, {})
+                            .get(mfr_code)
+                        )
+                        if quirk_attr is None or quirk_attr.name != base_attr.name:
+                            if cluster in (
+                                zhaquirks.sinope.switch.SinopeTechnologiesBasicCluster,
+                                zhaquirks.sinope.switch.SinopeTechnologiesMeteringCluster,
+                            ):
+                                continue
+                            pytest.fail(
+                                f"Cluster {cluster} deletes parent class's attribute"
+                                f" {base_attr.name!r} (id=0x{attr_id:04X},"
+                                f" is_manufacturer_specific={is_mfr},"
+                                f" manufacturer_code={mfr_code!r}) instead of"
+                                f" extending it"
+                            )
 
 
 @pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -791,36 +791,29 @@ def test_attributes_updated_not_replaced(quirk: CustomDevice) -> None:
 
             base_cluster = list(base_clusters)[0]
 
-            # Ensure the attribute IDs are extended
-            base_attr_ids = set(base_cluster.attributes)
-            quirk_attr_ids = set(cluster.attributes)
-
-            if not base_attr_ids <= quirk_attr_ids:
-                pytest.fail(
-                    f"Cluster {cluster} deletes parent class's attributes instead of"
-                    f" extending them: {base_attr_ids - quirk_attr_ids}"
-                )
-
-            # Ensure the attribute names are extended
-            base_attr_names = {a.name for a in base_cluster.attributes.values()}
-            quirk_attr_names = {a.name for a in cluster.attributes.values()}
-
-            # Allow base class attribute names to be superseded by manufacturer-specific
-            # attributes at the same ID. These use manufacturer_code to differentiate
-            # and do not actually conflict at the protocol level.
-            superseded_by_mfr = {
-                base_attr.name
-                for attr_id, base_attr in base_cluster.attributes.items()
-                if attr_id in cluster.attributes
-                and cluster.attributes[attr_id].name != base_attr.name
-                and isinstance(cluster.attributes[attr_id].manufacturer_code, int)
-            }
-
-            if not (base_attr_names - superseded_by_mfr) <= quirk_attr_names:
-                pytest.fail(
-                    f"Cluster {cluster} deletes parent class's attributes instead of"
-                    f" extending them: {(base_attr_names - superseded_by_mfr) - quirk_attr_names}"
-                )
+            # Ensure every base class attribute is preserved in the quirk cluster.
+            # For each attr_id, all attribute names from the base must still exist
+            # somewhere under that ID in the quirk's _attributes_by_id. This correctly
+            # handles manufacturer-specific attributes sharing an ID with a ZCL one
+            # (they occupy distinct keys and don't displace each other), while still
+            # catching genuine deletions or ZCL-overrides-ZCL with a different name.
+            for attr_id, by_mfr in base_cluster._attributes_by_id.items():
+                base_names_at_id = {
+                    attr_def.name
+                    for by_code in by_mfr.values()
+                    for attr_def in by_code.values()
+                }
+                quirk_names_at_id = {
+                    attr_def.name
+                    for by_code in cluster._attributes_by_id.get(attr_id, {}).values()
+                    for attr_def in by_code.values()
+                }
+                missing = base_names_at_id - quirk_names_at_id
+                if missing:
+                    pytest.fail(
+                        f"Cluster {cluster} deletes parent class's attributes instead of"
+                        f" extending them: {missing} (id=0x{attr_id:04X})"
+                    )
 
 
 @pytest.mark.parametrize("quirk", ALL_QUIRK_CLASSES)


### PR DESCRIPTION
DRAFT. Testing.

## Proposed change
- Update `test_attributes_updated_not_replaced` to validate inherited attributes using `cluster._attributes_by_id` instead of flat `.attributes`, so valid manufacturer-specific definitions sharing a ZCL ID are handled correctly.
  - Fixes false positive for: https://github.com/zigpy/zha-device-handlers/pull/4793
- Add a targeted guard that fails quirk-only attributes defined with `manufacturer_code=None` only when the ID collides with a base ZCL attribute, while allowing non-colliding IDs.
- Keep explicit ignore entries for known Sinope cluster issues.


## Additional information


## Device diagnostics
None.


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
