### PR TITLE
Add support for RDM005 (Philips Hue Button 2025)

### DIFF
--- a/tests/test_philips.py
+++ b/tests/test_philips.py
@@ -35,7 +35,14 @@ from zhaquirks.const import (
     TURN_ON,
 )
 import zhaquirks.philips
-from zhaquirks.philips import Button, ButtonPressQueue, PhilipsRemoteCluster, PressType
+from zhaquirks.philips import (
+    PHILIPS,
+    SIGNIFY,
+    Button,
+    ButtonPressQueue,
+    PhilipsRemoteCluster,
+    PressType,
+)
 from zhaquirks.philips.rdm002 import PhilipsRDM002
 from zhaquirks.philips.rom001 import PhilipsROM001
 from zhaquirks.philips.rwl022 import PhilipsRWL022
@@ -894,3 +901,39 @@ async def test_RDM002_levelcontrol_on_dial_rotary_event(zigpy_device_from_quirk)
     # These call counts is the same, regardless of whether PhilipsRdm002LevelControl is used or not.
     assert listener.zha_send_event.call_count == 0
     assert listener.cluster_command.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "manufacturer, model",
+    (
+        (PHILIPS, "ROM001"),
+        (SIGNIFY, "ROM001"),
+        (SIGNIFY, "RDM003"),
+        (SIGNIFY, "RDM005"),
+    ),
+)
+def test_rom001_signature(assert_signature_matches_quirk, manufacturer, model):
+    """Test ROM001 signature matching."""
+    signature = {
+        "ieee": "00:17:88:01:0f:bc:68:0b",
+        "manufacturer": manufacturer,
+        "model": model,
+        "endpoints": {
+            "1": {
+                "profile_id": 260,
+                "device_type": "0x0830",
+                "in_clusters": ["0x0000", "0x0001", "0x0003", "0x1000", "0xfc00"],
+                "out_clusters": [
+                    "0x0000",
+                    "0x0003",
+                    "0x0004",
+                    "0x0005",
+                    "0x0006",
+                    "0x0008",
+                    "0x0019",
+                    "0x1000",
+                ],
+            }
+        },
+    }
+    assert_signature_matches_quirk(PhilipsROM001, signature)

--- a/zhaquirks/philips/rom001.py
+++ b/zhaquirks/philips/rom001.py
@@ -65,7 +65,12 @@ class PhilipsROM001(CustomDevice):
         #  device_version=1
         #  input_clusters=[0, 1, 3, 64512, 4096]
         #  output_clusters=[25, 0, 3, 4, 6, 8, 5, 4096]>
-        MODELS_INFO: [(PHILIPS, "ROM001"), (SIGNIFY, "ROM001"), (SIGNIFY, "RDM003")],
+        MODELS_INFO: [
+            (PHILIPS, "ROM001"),
+            (SIGNIFY, "ROM001"),
+            (SIGNIFY, "RDM003"),
+            (SIGNIFY, "RDM005"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,


### PR DESCRIPTION
Issues: #4294, #4306, #4754

## Proposed change
This change adds support for the new Philips Hue Button (2025 model): RDM005 .

The button appears to have an identical signature to ROM001, RMD003, so the only significant change is the addition of the new model id to the MODEL_INFO list.

## Additional information
I decided to add a test similar to what i found in other quirks (e.g. some aqara or ikea or xiaomi ones) to verify the signature of the device is recognized correctly. I am not sure it provides much value.
I have not tested this with a custom quirk as i am not too familiar with custom quirks in ZHA and I'd like to avoid breaking the entire set of my home buttons (ROM001s) by overriding the main quirk.

However I "forked" the ROM001 quirk, replaced the model info and scoped it to the new button and it is working just fine.
See https://github.com/zigpy/zha-device-handlers/issues/4306#issuecomment-3969665516 for context.


## Device diagnostics
The device diagnostic has been downloaded from a ZHA with the custom quirk mentioned above:

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant OS",
    "version": "2026.2.3",
    "dev": false,
    "hassio": true,
    "virtualenv": false,
    "python_version": "3.13.11",
    "docker": true,
    "arch": "x86_64",
    "timezone": "Europe/Dublin",
    "os_name": "Linux",
    "os_version": "6.12.67-haos",
    "container_arch": "amd64",
    "supervisor": "2026.02.3",
    "host_os": "Home Assistant OS 17.1",
    "docker_version": "29.1.3",
    "chassis": "vm",
    "run_as_root": true
  },
  "custom_components": {
    "hacs": {
      "documentation": "https://hacs.xyz/docs/use/",
      "version": "2.0.5",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    },
    "adaptive_lighting": {
      "documentation": "https://github.com/basnijholt/adaptive-lighting#readme",
      "version": "1.26.0",
      "requirements": [
        "ulid-transform"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==0.0.90",
      "serialx==0.6.2"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.00011880999999647202
    },
    "be2d7d9358fb3b5d7086ca3f7660f426": {
      "wait_import_platforms": -0.06647181600000351,
      "wait_base_component": -0.0008261380000007534,
      "config_entry_setup": 15.210209724999999
    }
  },
  "data": {
    "version": 1,
    "ieee": "**REDACTED**",
    "nwk": "0x6D64",
    "manufacturer": "Signify Netherlands B.V.",
    "model": "RDM005",
    "friendly_manufacturer": "Signify Netherlands B.V.",
    "friendly_model": "RDM005",
    "name": "Signify Netherlands B.V. RDM005",
    "quirk_applied": true,
    "quirk_class": "rdm005.PhilipsRDM005",
    "exposes_features": [],
    "manufacturer_code": 4107,
    "power_source": "Battery or Unknown",
    "lqi": null,
    "rssi": null,
    "last_seen": "2026-02-27T22:48:02.425524+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4107,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 128,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 128,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "NON_COLOR_SCENE_CONTROLLER",
          "id": 2096
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "Signify Netherlands B.V."
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "RDM005"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "zcl_type": "uint8",
                "value": 200
              },
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "unsupported": true
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "unsupported": true
              },
              {
                "id": "0x0020",
                "name": "battery_voltage",
                "zcl_type": "uint8",
                "value": 28
              }
            ]
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x1000",
            "endpoint_attribute": "lightlink",
            "attributes": []
          },
          {
            "cluster_id": "0xfc00",
            "endpoint_attribute": "philips_remote_cluster",
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": []
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x0005",
            "endpoint_attribute": "scenes",
            "attributes": []
          },
          {
            "cluster_id": "0x0006",
            "endpoint_attribute": "on_off",
            "attributes": [
              {
                "id": "0x0000",
                "name": "on_off",
                "zcl_type": "bool",
                "value": 0
              }
            ]
          },
          {
            "cluster_id": "0x0008",
            "endpoint_attribute": "level",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 33575681
              }
            ]
          },
          {
            "cluster_id": "0x1000",
            "endpoint_attribute": "lightlink",
            "attributes": []
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "Signify Netherlands B.V.",
      "model": "RDM005",
      "node_desc": {
        "logical_type": 2,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 128,
        "manufacturer_code": 4107,
        "maximum_buffer_size": 82,
        "maximum_incoming_transfer_size": 128,
        "server_mask": 11264,
        "maximum_outgoing_transfer_size": 128,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0830",
          "input_clusters": [
            "0x0000",
            "0x0001",
            "0x0003",
            "0xfc00",
            "0x1000"
          ],
          "output_clusters": [
            "0x0019",
            "0x0000",
            "0x0003",
            "0x0004",
            "0x0006",
            "0x0008",
            "0x0005",
            "0x1000"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "button": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "button",
            "class_name": "IdentifyButton",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "identify",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "IdentifyClusterHandler",
                "generic_id": "cluster_handler_0x0003",
                "endpoint_id": 1,
                "cluster": {
                  "id": 3,
                  "name": "Identify",
                  "type": "server"
                },
                "id": "1:0x0003",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "command": "identify",
            "args": [
              5
            ],
            "kwargs": {}
          },
          "state": {
            "class_name": "IdentifyButton",
            "available": true
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "PhilipsBasicCluster",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "PhilipsBasicCluster",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Battery",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "battery",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "PowerConfigurationClusterHandler",
                "generic_id": "cluster_handler_0x0001",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1,
                  "name": "Power Configuration",
                  "type": "server"
                },
                "id": "1:0x0001",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "battery_voltage"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": 0,
            "unit": "%"
          },
          "state": {
            "class_name": "Battery",
            "available": true,
            "state": 100.0,
            "battery_voltage": 2.8
          },
          "extra_state_attributes": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ]
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OtaClientClusterHandler",
                "generic_id": "cluster_handler_0x0019_client",
                "endpoint_id": 1,
                "cluster": {
                  "id": 25,
                  "name": "Ota",
                  "type": "client"
                },
                "id": "1:0x0019_client",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x02005301",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
