### PR TITLE
Fix `_TZE284_awepdiwi` soil moisture scale (3x too low)

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -259,11 +259,21 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE284_sgabhwa6", "TS0601")
     .applies_to("_TZE284_nhgdf6qr", "TS0601")  # Giex GX04
     .applies_to("_TZE284_ap9owrsa", "TS0601")  # Novadigital SG-ZB
-    .applies_to("_TZE284_awepdiwi", "TS0601")  # Solar powered
     .applies_to("_TZE284_33bwcga2", "TS0601")  # iHseno
     .tuya_temperature(dp_id=5, scale=10)
     .tuya_battery(dp_id=15)
     .tuya_soil_moisture(dp_id=3)
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+(
+    TuyaQuirkBuilder("_TZE284_awepdiwi", "TS0601")  # Solar powered soil sensor
+    .tuya_temperature(dp_id=5, scale=10)
+    .tuya_battery(dp_id=15)
+    .tuya_soil_moisture(dp_id=3, scale=300)
+    .tuya_electrical_conductivity(dp_id=1)
     .skip_configuration()
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change

The `_TZE284_awepdiwi` solar soil moisture sensor reports raw soil moisture values that are approximately **3x lower** than the actual percentage. The device was added in #4197 as a variant of the `_TZE284_aao3yzhs` group, which uses the default `scale=100` for `tuya_soil_moisture`. However, this device needs `scale=300` to produce correct readings.

**Evidence:** With 5 of these sensors deployed alongside `_TZE200_myd45weu` battery-powered soil sensors in the same locations, the solar sensors consistently read ~3x lower (e.g. 18% vs 54%, 39% vs 87% on the battery sensor next to it during heavy rain).

This PR:
- Separates `_TZE284_awepdiwi` from the `_TZE284_aao3yzhs` group into its own quirk definition
- Sets `scale=300` for `tuya_soil_moisture(dp_id=3)` to correct the 3x underreading
- Adds `tuya_electrical_conductivity(dp_id=1)` which this device also supports (confirmed via device data analysis)

Ref: https://github.com/zigpy/zha-device-handlers/issues/4143#issuecomment-2555455775 (@emogenet's analysis confirming `scale=3.0 * 100.0`)

## Additional information

- DP map confirmed from device attribute cache and Zigbee2MQTT converters:
  - dp 1: soil electrical conductivity (µS/cm)
  - dp 3: soil moisture (raw ÷ 3 = %)
  - dp 5: temperature (raw ÷ 10 = °C)
  - dp 14: battery state (enum)
  - dp 15: battery percentage (%)
- Tested with 5 `_TZE284_awepdiwi` devices on Home Assistant 2026.2.3

## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works

Made with [Cursor](https://cursor.com)