### PR TITLE
Add quirk for Tuya TS0726 multi-gang switch (Beseed/Moes)

### DIFF
--- a/zhaquirks/tuya/ts0726.py
+++ b/zhaquirks/tuya/ts0726.py
@@ -15,15 +15,7 @@ from typing import Final
 
 from zigpy.profiles import zha
 import zigpy.types as t
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    OnOff,
-    Ota,
-    Scenes,
-    Time,
-)
+from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
 from zigpy.zcl.foundation import ZCLAttributeDef
 
 from zhaquirks.const import (

--- a/zhaquirks/tuya/ts0726.py
+++ b/zhaquirks/tuya/ts0726.py
@@ -1,0 +1,214 @@
+"""Tuya TS0726 1/2/3-gang switch (Beseed/Moes).
+
+Fixes the issue where toggling one gang activates all gangs by:
+1. Replacing OnOff with a custom cluster that includes Tuya attribute 0x5000
+2. Writing 0x5000=0 (command mode) on initialization to enable per-gang control
+
+The TS0726 ships with attribute 0x5000 (operation_mode) set to 1 (event/scene mode),
+which causes all relays to toggle together on any On/Off command. Setting it to 0
+switches to command mode, enabling individual per-gang relay control.
+
+Based on the ts001x.py quirk pattern from zha-device-handlers.
+"""
+
+from typing import Final
+
+from zigpy.profiles import zha
+import zigpy.types as t
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.tuya import (
+    EnchantedDevice,
+    TuyaSwitch,
+    TuyaZBE000Cluster,
+    TuyaZBExternalSwitchTypeCluster,
+    TuyaZBOnOffAttributeCluster,
+)
+
+# Green Power endpoint constants
+GP_PROFILE_ID = 0xA1E0
+GP_DEVICE_TYPE = 0x0061
+GP_CLUSTER_ID = 0x0021
+
+
+class TuyaTS0726OnOffCluster(TuyaZBOnOffAttributeCluster):
+    """OnOff cluster for TS0726 with operation_mode attribute (0x5000).
+
+    Attribute 0x5000 controls the switch operation mode:
+      0 = command mode (individual relay control)
+      1 = event/scene mode (all relays toggle together)
+
+    The attribute uses enum8 type on endpoint 1 only.
+    """
+
+    class AttributeDefs(TuyaZBOnOffAttributeCluster.AttributeDefs):
+        """Attribute definitions."""
+
+        operation_mode: Final = ZCLAttributeDef(id=0x5000, type=t.enum8)
+
+    async def apply_custom_configuration(self, *args, **kwargs):
+        """Set operation_mode to 0 (command mode) for individual gang control."""
+        self.debug(
+            "Writing operation_mode=0 (command mode) on EP %s",
+            self.endpoint.endpoint_id,
+        )
+        try:
+            await self.write_attributes({"operation_mode": 0})
+        except Exception as e:  # noqa: BLE001
+            self.warning("Failed to write operation_mode: %s", e)
+        await super().apply_custom_configuration(*args, **kwargs)
+
+
+class TuyaTS0726_1Gang(EnchantedDevice, TuyaSwitch):
+    """Tuya TS0726 1-gang switch (Beseed/Moes) with 0xE000/0xE001 clusters."""
+
+    signature = {
+        MODELS_INFO: [("_TZ3002_jn2x20tg", "TS0726")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SCENE_SELECTOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    TuyaZBE000Cluster.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            242: {
+                PROFILE_ID: GP_PROFILE_ID,
+                DEVICE_TYPE: GP_DEVICE_TYPE,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GP_CLUSTER_ID],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaTS0726OnOffCluster,
+                    TuyaZBE000Cluster,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: GP_PROFILE_ID,
+                DEVICE_TYPE: GP_DEVICE_TYPE,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GP_CLUSTER_ID],
+            },
+        },
+    }
+
+
+class TuyaTS0726_2Gang(EnchantedDevice, TuyaSwitch):
+    """Tuya TS0726 2-gang switch (Beseed/Moes) with 0xE000/0xE001 clusters."""
+
+    signature = {
+        MODELS_INFO: [("_TZ3002_zjuvw9zf", "TS0726")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SCENE_SELECTOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    TuyaZBE000Cluster.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SCENE_SELECTOR,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: GP_PROFILE_ID,
+                DEVICE_TYPE: GP_DEVICE_TYPE,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GP_CLUSTER_ID],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaTS0726OnOffCluster,
+                    TuyaZBE000Cluster,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaTS0726OnOffCluster,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: GP_PROFILE_ID,
+                DEVICE_TYPE: GP_DEVICE_TYPE,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GP_CLUSTER_ID],
+            },
+        },
+    }


### PR DESCRIPTION
## Summary

- Adds quirk for Tuya TS0726 1/2-gang switches (Beseed/Moes) that fixes the issue where toggling one gang from ZHA activates all gangs simultaneously
- Physical buttons work correctly — only ZHA commands trigger all relays together
- Root cause: attribute `0x5000` (`operation_mode`) on the OnOff cluster defaults to `1` (event/scene mode). Writing `0` switches to command mode for individual relay control

## Details

The TS0726 reports as `SCENE_SELECTOR` and ships with `operation_mode=1`. In this mode, any On/Off ZCL command toggles all relays at once. The quirk:

1. Extends `TuyaZBOnOffAttributeCluster` with attribute `0x5000` (`enum8` type)
2. Writes `operation_mode=0` via `apply_custom_configuration` during device setup
3. Changes `device_type` to `ON_OFF_LIGHT` for proper entity creation
4. Includes endpoint 242 (Green Power) in the signature — required for quirk matching

### Tested manufacturer IDs
- `_TZ3002_zjuvw9zf` — 2-gang (Beseed)
- `_TZ3002_jn2x20tg` — 1-gang (Beseed)

Other TS0726 variants (`_TZ3002_vaq2bfcu` 3-gang, `_TZ3002_iedhxgyi`, etc.) likely need the same fix — additional `MODELS_INFO` entries and endpoints can be added once confirmed.

## Test plan

- [x] Verified quirk signature matches device (zigpy logs: `Found custom device replacement`)
- [x] Confirmed `operation_mode=0` write succeeds with `Status.SUCCESS` on EP1
- [x] Confirmed device reports back `operation_mode=0` via attribute report
- [x] Tested individual gang toggle from HA dashboard — each gang operates independently
- [x] Physical buttons continue to work correctly and sync state with ZHA

Tested on Home Assistant 2026.1.3 with ZHA + Inswift ZBM-MG24 coordinator.

Fixes #3154
Fixes #3913