### PR TITLE
Add Third Reality 24g radar settings

### DIFF
--- a/zhaquirks/thirdreality/24G_radar.py
+++ b/zhaquirks/thirdreality/24G_radar.py
@@ -1,0 +1,57 @@
+"""Third Reality 24G radar sensor devices."""
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder, ReportingConfig, SensorDeviceClass, SensorStateClass
+from zigpy.quirks.v2.homeassistant import CONCENTRATION_PARTS_PER_BILLION
+import zigpy.types as t
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+from zigpy.zcl.clusters.measurement import FormaldehydeConcentration
+
+from zhaquirks.tuya.builder import TuyaFormaldehydeConcentration
+from zhaquirks.develco.air_quality import DevelcoVOCMeasurement
+
+
+class ThirdRealityRadarCluster(CustomCluster):
+    """Third Reality's 24G radar private cluster."""
+
+    cluster_id = 0xff01
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Define the attributes of a private cluster."""
+
+        # reset the accumulated power of the plug
+        senior_calibation: Final = ZCLAttributeDef(
+            id=0x0003,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
+        
+        # reset the accumulated power of the plug
+        senior_sensitive: Final = ZCLAttributeDef(
+            id=0x0060,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
+
+(
+    QuirkBuilder("Third Reality, Inc", "3RPS01083Z")
+    .replaces(ThirdRealityRadarCluster)
+    .switch(
+        cluster_id=ThirdRealityRadarCluster.cluster_id,
+        attribute_name=ThirdRealityRadarCluster.AttributeDefs.senior_calibation.name,
+        translation_key="senior_calibation",
+        fallback_name="Senior calibation",
+    )
+    .number(
+        attribute_name=ThirdRealityRadarCluster.AttributeDefs.senior_sensitive.name,
+        min_value=1,
+        max_value=5,
+        step=1,
+        cluster_id=ThirdRealityRadarCluster.cluster_id,
+        translation_key="senior_sensitive",
+        fallback_name="Senior sensitive",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/thirdreality/24G_radar.py
+++ b/zhaquirks/thirdreality/24G_radar.py
@@ -8,7 +8,7 @@ import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 
-class ThirdRealityRadarCluster(CustomCluster):
+class ThirdReality24GRadarCluster(CustomCluster):
     """Third Reality's 24G radar private cluster."""
 
     cluster_id = 0xFF01
@@ -16,15 +16,15 @@ class ThirdRealityRadarCluster(CustomCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Define the attributes of a private cluster."""
 
-        # reset the accumulated power of the plug
-        senior_calibation: Final = ZCLAttributeDef(
+        # calibrate of the plug
+        sensor_calibration: Final = ZCLAttributeDef(
             id=0x0003,
             type=t.uint8_t,
             is_manufacturer_specific=True,
         )
 
-        # reset the accumulated power of the plug
-        senior_sensitive: Final = ZCLAttributeDef(
+        # set the sensitive of the plug
+        sensor_sensitive: Final = ZCLAttributeDef(
             id=0x0060,
             type=t.uint8_t,
             is_manufacturer_specific=True,
@@ -33,19 +33,19 @@ class ThirdRealityRadarCluster(CustomCluster):
 
 (
     QuirkBuilder("Third Reality, Inc", "3RPS01083Z")
-    .replaces(ThirdRealityRadarCluster)
+    .replaces(ThirdReality24GRadarCluster)
     .switch(
-        cluster_id=ThirdRealityRadarCluster.cluster_id,
-        attribute_name=ThirdRealityRadarCluster.AttributeDefs.senior_calibation.name,
-        translation_key="sensor_calibation",
-        fallback_name="Sensor calibation",
+        cluster_id=ThirdReality24GRadarCluster.cluster_id,
+        attribute_name=ThirdReality24GRadarCluster.AttributeDefs.sensor_calibration.name,
+        translation_key="sensor_calibration",
+        fallback_name="Sensor calibration",
     )
     .number(
-        attribute_name=ThirdRealityRadarCluster.AttributeDefs.senior_sensitive.name,
+        attribute_name=ThirdReality24GRadarCluster.AttributeDefs.sensor_sensitive.name,
         min_value=1,
         max_value=5,
         step=1,
-        cluster_id=ThirdRealityRadarCluster.cluster_id,
+        cluster_id=ThirdReality24GRadarCluster.cluster_id,
         translation_key="sensor_sensitive",
         fallback_name="Sensor sensitive",
     )

--- a/zhaquirks/thirdreality/24G_radar.py
+++ b/zhaquirks/thirdreality/24G_radar.py
@@ -36,8 +36,8 @@ class ThirdRealityRadarCluster(CustomCluster):
     .switch(
         cluster_id=ThirdRealityRadarCluster.cluster_id,
         attribute_name=ThirdRealityRadarCluster.AttributeDefs.senior_calibation.name,
-        translation_key="senior_calibation",
-        fallback_name="Senior calibation",
+        translation_key="sensor_calibation",
+        fallback_name="Sensor calibation",
     )
     .number(
         attribute_name=ThirdRealityRadarCluster.AttributeDefs.senior_sensitive.name,
@@ -45,8 +45,8 @@ class ThirdRealityRadarCluster(CustomCluster):
         max_value=5,
         step=1,
         cluster_id=ThirdRealityRadarCluster.cluster_id,
-        translation_key="senior_sensitive",
-        fallback_name="Senior sensitive",
+        translation_key="sensor_sensitive",
+        fallback_name="Sensor sensitive",
     )
     .add_to_registry()
 )

--- a/zhaquirks/thirdreality/24G_radar.py
+++ b/zhaquirks/thirdreality/24G_radar.py
@@ -16,14 +16,12 @@ class ThirdReality24GRadarCluster(CustomCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Define the attributes of a private cluster."""
 
-
         sensor_calibration: Final = ZCLAttributeDef(
             id=0x0003,
             type=t.uint8_t,
             is_manufacturer_specific=True,
         )
-        
-        
+
         sensor_sensitivity: Final = ZCLAttributeDef(
             id=0x0060,
             type=t.uint8_t,

--- a/zhaquirks/thirdreality/24G_radar.py
+++ b/zhaquirks/thirdreality/24G_radar.py
@@ -11,7 +11,7 @@ from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 class ThirdRealityRadarCluster(CustomCluster):
     """Third Reality's 24G radar private cluster."""
 
-    cluster_id = 0xff01
+    cluster_id = 0xFF01
 
     class AttributeDefs(BaseAttributeDefs):
         """Define the attributes of a private cluster."""
@@ -22,13 +22,14 @@ class ThirdRealityRadarCluster(CustomCluster):
             type=t.uint8_t,
             is_manufacturer_specific=True,
         )
-        
+
         # reset the accumulated power of the plug
         senior_sensitive: Final = ZCLAttributeDef(
             id=0x0060,
             type=t.uint8_t,
             is_manufacturer_specific=True,
         )
+
 
 (
     QuirkBuilder("Third Reality, Inc", "3RPS01083Z")

--- a/zhaquirks/thirdreality/24G_radar.py
+++ b/zhaquirks/thirdreality/24G_radar.py
@@ -32,9 +32,10 @@ class ThirdReality24GRadarCluster(CustomCluster):
 (
     QuirkBuilder("Third Reality, Inc", "3RPS01083Z")
     .replaces(ThirdReality24GRadarCluster)
-    .switch(
-        cluster_id=ThirdReality24GRadarCluster.cluster_id,
+    .write_attr_button(
         attribute_name=ThirdReality24GRadarCluster.AttributeDefs.sensor_calibration.name,
+        attribute_value=0x01,  # 1 sensor calibration
+        cluster_id=ThirdReality24GRadarCluster.cluster_id,
         translation_key="sensor_calibration",
         fallback_name="Sensor calibration",
     )

--- a/zhaquirks/thirdreality/24G_radar.py
+++ b/zhaquirks/thirdreality/24G_radar.py
@@ -36,8 +36,8 @@ class ThirdReality24GRadarCluster(CustomCluster):
         attribute_name=ThirdReality24GRadarCluster.AttributeDefs.sensor_calibration.name,
         attribute_value=0x01,  # 1 sensor calibration
         cluster_id=ThirdReality24GRadarCluster.cluster_id,
-        translation_key="sensor_calibration",
-        fallback_name="Sensor calibration",
+        translation_key="calibrate_sensor",
+        fallback_name="Calibrate sensor",
     )
     .number(
         attribute_name=ThirdReality24GRadarCluster.AttributeDefs.sensor_sensitivity.name,

--- a/zhaquirks/thirdreality/24G_radar.py
+++ b/zhaquirks/thirdreality/24G_radar.py
@@ -3,14 +3,9 @@
 from typing import Final
 
 from zigpy.quirks import CustomCluster
-from zigpy.quirks.v2 import QuirkBuilder, ReportingConfig, SensorDeviceClass, SensorStateClass
-from zigpy.quirks.v2.homeassistant import CONCENTRATION_PARTS_PER_BILLION
+from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
-from zigpy.zcl.clusters.measurement import FormaldehydeConcentration
-
-from zhaquirks.tuya.builder import TuyaFormaldehydeConcentration
-from zhaquirks.develco.air_quality import DevelcoVOCMeasurement
 
 
 class ThirdRealityRadarCluster(CustomCluster):

--- a/zhaquirks/thirdreality/24G_radar.py
+++ b/zhaquirks/thirdreality/24G_radar.py
@@ -16,15 +16,15 @@ class ThirdReality24GRadarCluster(CustomCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Define the attributes of a private cluster."""
 
-        # calibrate of the plug
+
         sensor_calibration: Final = ZCLAttributeDef(
             id=0x0003,
             type=t.uint8_t,
             is_manufacturer_specific=True,
         )
-
-        # set the sensitive of the plug
-        sensor_sensitive: Final = ZCLAttributeDef(
+        
+        
+        sensor_sensitivity: Final = ZCLAttributeDef(
             id=0x0060,
             type=t.uint8_t,
             is_manufacturer_specific=True,
@@ -41,13 +41,13 @@ class ThirdReality24GRadarCluster(CustomCluster):
         fallback_name="Sensor calibration",
     )
     .number(
-        attribute_name=ThirdReality24GRadarCluster.AttributeDefs.sensor_sensitive.name,
+        attribute_name=ThirdReality24GRadarCluster.AttributeDefs.sensor_sensitivity.name,
         min_value=1,
         max_value=5,
         step=1,
         cluster_id=ThirdReality24GRadarCluster.cluster_id,
-        translation_key="sensor_sensitive",
-        fallback_name="Sensor sensitive",
+        translation_key="sensor_sensitivity",
+        fallback_name="Sensor sensitivity",
     )
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR added adaptation code for 24g radar and added 2 additional private clusters
sensor_calibation：Calibration mode (learning calibration)
sensor_sensitive：Radar sensitivity (trigger distance gear)

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
