### PR TITLE
Remove broken `instantaneous_demand` entity for Sonoff plugs

### DIFF
--- a/zhaquirks/sonoff/s60zbtpf.py
+++ b/zhaquirks/sonoff/s60zbtpf.py
@@ -15,6 +15,7 @@ import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.smartenergy import Metering
 
 
 class SonoffS60OnOff(CustomCluster, OnOff):
@@ -69,5 +70,11 @@ class SonoffS60ElectricalMeasurement(CustomCluster, ElectricalMeasurement):
     .applies_to("SONOFF", "S60ZBTPG")
     .replaces(SonoffS60OnOff)
     .replaces(SonoffS60ElectricalMeasurement)
+    # firmware v2.0.2 reports instantaneous_demand as supported, always with value 0
+    .prevent_default_entity_creation(
+        endpoint_id=1,
+        cluster_id=Metering.cluster_id,
+        unique_id_suffix="1-1794",  # no actual suffix for this
+    )
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
This prevents the SE `instantaneous_demand` entity from being created for Sonoff plugs `S60ZBTPF` and `S60ZBTPG`.

## Additional information
With firmware version 2.0.2 (https://github.com/zigpy/zigpy-ota/issues/25), the `instantaneous_demand` attribute is now supported but it always return `0` when reading. The EM `active_power` entity works properly, so we can just remove this one.


## Device diagnostics
TODO

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
