### PR TITLE
Add Tuya motion CK-BL702-MWS-01(7016) variants

### DIFF
--- a/tests/test_tuya_motion.py
+++ b/tests/test_tuya_motion.py
@@ -64,6 +64,8 @@ zhaquirks.setup()
         ("_TZE204_uxllnywp", "TS0601", ZCL_TUYA_MOTION_V5),
         ("_TZE200_gjldowol", "TS0601", ZCL_TUYA_MOTION),
         ("_TZE200_2aaelwxk", "TS0225", ZCL_TUYA_MOTION),
+        ("_TZE200_crq3r3la", "CK-BL702-MWS-01(7016)", ZCL_TUYA_MOTION),
+        ("HOBEIAN", "CK-BL702-MWS-01(7016)", ZCL_TUYA_MOTION),
         ("_TZE200_2aaelwxk", "TS0601", ZCL_TUYA_MOTION),
         ("_TZE200_kb5noeto", "TS0601", ZCL_TUYA_MOTION),
         ("_TZE204_ex3rcdha", "TS0601", ZCL_TUYA_MOTION_V8),

--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -1324,6 +1324,8 @@ base_tuya_motion = (
 # Tuya ZG-205Z/A, 5.8Ghz/24Ghz Human presence sensor.
 (
     TuyaQuirkBuilder("_TZE200_2aaelwxk", "TS0225")
+    .applies_to("_TZE200_crq3r3la", "CK-BL702-MWS-01(7016)")
+    .applies_to("HOBEIAN", "CK-BL702-MWS-01(7016)")
     .tuya_dp(
         dp_id=1,
         ep_attribute=TuyaOccupancySensing.ep_attribute,


### PR DESCRIPTION
## Summary
Adds missing `applies_to` mappings for `CK-BL702-MWS-01(7016)` so `_TZE200_crq3r3la` and `HOBEIAN` variants use the existing Tuya ZG-205Z/A quirk (`_TZE200_2aaelwxk`, `TS0225`) and expose configuration entities.

## Changes
- `zhaquirks/tuya/tuya_motion.py`
  - add `.applies_to(\"_TZE200_crq3r3la\", \"CK-BL702-MWS-01(7016)\")`
  - add `.applies_to(\"HOBEIAN\", \"CK-BL702-MWS-01(7016)\")`
- `tests/test_tuya_motion.py`
  - add occupancy test cases for both manufacturer/model pairs

Fixes #4596
References https://github.com/home-assistant/core/issues/148809