### PR TITLE
Add scene mode support for the Aqara cube

### DIFF
--- a/tests/test_xiaomi_cube.py
+++ b/tests/test_xiaomi_cube.py
@@ -1,0 +1,169 @@
+"""Tests for Xiaomi Aqara Cube AQGL01."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from zigpy.types import AddrMode, AddrModeAddress, SerializableBytes, ZigbeePacket
+
+import zhaquirks
+from zhaquirks.xiaomi.aqara.cube_aqgl01 import CubeAQGL01
+
+zhaquirks.setup()
+
+
+@pytest.fixture
+def cube_device(zigpy_device_from_quirk):
+    """Create a cube device for testing."""
+    return zigpy_device_from_quirk(CubeAQGL01)
+
+
+@pytest.mark.parametrize(
+    "endpoint_id, cluster_id, payload, expected_command, expected_args",
+    [
+        # Some events I grabbed from the logs:
+        # Gesture mode:
+        (2, 18, b"\x18\x36\x0a\x55\x00\x21\x00\x00", "shake", {"value": 0}),
+        (
+            2,
+            18,
+            b"\x18\x49\x0a\x55\x00\x21\x6b\x00",
+            "flip",
+            {
+                "value": 107,
+                "flip_degrees": 90,
+                "deactivated_face": 6,
+                "activated_face": 4,
+            },
+        ),
+        (
+            2,
+            18,
+            b"\x18\x49\x0a\x55\x00\x21\x6c\x00",
+            "flip",
+            {
+                "value": 108,
+                "flip_degrees": 90,
+                "deactivated_face": 6,
+                "activated_face": 5,
+            },
+        ),
+        (
+            2,
+            18,
+            b"\x18\x49\x0a\x55\x00\x21\x65\x00",
+            "flip",
+            {
+                "value": 101,
+                "flip_degrees": 90,
+                "deactivated_face": 5,
+                "activated_face": 6,
+            },
+        ),
+        (
+            2,
+            18,
+            b"\x18\x49\x0a\x55\x00\x21\x41\x00",
+            "flip",
+            {
+                "value": 65,
+                "flip_degrees": 90,
+                "deactivated_face": 1,
+                "activated_face": 2,
+            },
+        ),
+        (
+            2,
+            18,
+            b"\x18\x49\x0a\x55\x00\x21\x80\x00",
+            "flip",
+            {
+                "value": 128,
+                "flip_degrees": 180,
+                "deactivated_face": 6,
+                "activated_face": 1,
+            },
+        ),
+        (
+            2,
+            18,
+            b"\x18\x4b\x0a\x55\x00\x21\x03\x01",
+            "slide",
+            {"value": 259, "activated_face": 4},
+        ),
+        (
+            3,
+            12,
+            b"\x18\x50\x0a\x0b\x01\x21\xf4\x01\x55\x00\x39\xff\xff\x8c\x42",
+            "rotate_right",
+            {"relative_degrees": 70.49999237060547},
+        ),
+        (
+            3,
+            12,
+            b"\x18\x61\x0a\x49\x01\x20\x05\x0b\x01\x21\xf4\x01\x55\x00\x39\xa5\x70\x75\xc2",
+            "rotate_left",
+            {"relative_degrees": -61.36000442504883},
+        ),
+        # Gesture mode (not able to reproduce with my cube):
+        (2, 18, b"\x18\x36\x0a\x55\x00\x21\x03\x00", "drop", {"value": 3}),
+        (
+            2,
+            18,
+            b"\x18\x36\x0a\x55\x00\x21\x04\x02",
+            "knock",
+            {"value": 516, "activated_face": 5},
+        ),
+        # Scene mode:
+        (
+            2,
+            18,
+            b"\x18\x69\x0a\x55\x00\x21\x02\x04",
+            "scene",
+            {"value": 1026, "activated_face": 3},
+        ),
+        # Secret Xiaomi cluster messages; not-yet-implemented
+        # This is the status update event, which you get if you leave the cube idle, or if you press the button once:
+        # (1, 64704,  b'\x1C\x5F\x11\x59\x0A\xF7\x00\x41\x3E\x01\x21\xFC\x0B\x03\x28\x19\x04\x21\xA8\x13\x05\x21\x09\x00\x06\x24\x1C\x00\x00\x00\x00\x08\x21\x1C\x01\x0A\x21\xEA\x14\x0C\x20\x01\x66\x20\x03\x67\x20\x01\x68\x21\xA8\x00\x97\x21\x00\x00\x98\x21\x00\x00\x99\x21\x00\x00\x9A\x21\x04\x00\x9B\x20\x01', None, None),
+        # This is a mode change event, which you get if you push the button 6 times:
+        # (1, 64704, b'\x18\x58\x0A\x48\x01\x20\x01', "mode_change", {"mode": 1}),
+    ],
+)
+async def test_cube_zha_events(
+    cube_device, endpoint_id, cluster_id, payload, expected_command, expected_args
+):
+    """Test that raw Zigbee messages generate expected events."""
+
+    # GIVEN: Dynamically find the right cluster and attach a listener
+    cluster = cube_device.endpoints[endpoint_id].in_clusters[cluster_id]
+    listener = MagicMock()
+    cluster.add_listener(listener)
+
+    # Formulate the incoming packet
+    packet = ZigbeePacket(
+        profile_id=0x0104,  # Home Automation Profile
+        cluster_id=cluster_id,
+        src_ep=endpoint_id,
+        dst_ep=1,
+        data=SerializableBytes(payload),
+        dst=AddrModeAddress(
+            addr_mode=AddrMode.NWK,
+            address=cube_device.nwk,
+        ),
+    )
+
+    # WHEN: The device receives the packet
+    cube_device.packet_received(packet)
+
+    # THEN: Exactly one ZHA event should be fired
+    assert listener.zha_send_event.call_count == 1, (
+        f"Expected 1 event, got {listener.zha_send_event.call_count}"
+    )
+
+    # Extract what was actually sent to Home Assistant
+    fired_command, fired_args = listener.zha_send_event.call_args[0]
+
+    # Assert it matches our table
+    assert fired_command == expected_command
+    assert fired_args == expected_args
+
+    cluster.remove_listener(listener)

--- a/tests/test_xiaomi_cube.py
+++ b/tests/test_xiaomi_cube.py
@@ -17,116 +17,36 @@ def cube_device(zigpy_device_from_quirk):
     return zigpy_device_from_quirk(CubeAQGL01)
 
 
+# fmt: off
+test_cases = [
+    # Some events I grabbed from the logs:
+    # Gesture mode:
+    (2, 18, b"\x18\x36\x0a\x55\x00\x21\x00\x00", "shake", {"value": 0}),
+    (2, 18, b"\x18\x49\x0a\x55\x00\x21\x6b\x00", "flip", {"value": 107, "flip_degrees": 90, "deactivated_face": 6, "activated_face": 4}),
+    (2, 18, b"\x18\x49\x0a\x55\x00\x21\x6c\x00", "flip", {"value": 108, "flip_degrees": 90, "deactivated_face": 6, "activated_face": 5}),
+    (2, 18, b"\x18\x49\x0a\x55\x00\x21\x65\x00", "flip", {"value": 101, "flip_degrees": 90, "deactivated_face": 5, "activated_face": 6}),
+    (2, 18, b"\x18\x49\x0a\x55\x00\x21\x41\x00", "flip", {"value": 65, "flip_degrees": 90, "deactivated_face": 1, "activated_face": 2}),
+    (2, 18, b"\x18\x49\x0a\x55\x00\x21\x80\x00", "flip", {"value": 128, "flip_degrees": 180, "deactivated_face": 6, "activated_face": 1}),
+    (2, 18, b"\x18\x4b\x0a\x55\x00\x21\x03\x01", "slide", {"value": 259, "activated_face": 4}),
+    (3, 12, b"\x18\x50\x0a\x0b\x01\x21\xf4\x01\x55\x00\x39\xff\xff\x8c\x42", "rotate_right", {"relative_degrees": 70.49999237060547}),
+    (3, 12, b"\x18\x61\x0a\x49\x01\x20\x05\x0b\x01\x21\xf4\x01\x55\x00\x39\xa5\x70\x75\xc2", "rotate_left", {"relative_degrees": -61.36000442504883}),
+    # Gesture mode (not able to reproduce with my cube):
+    (2, 18, b"\x18\x36\x0a\x55\x00\x21\x03\x00", "drop", {"value": 3}),
+    (2, 18, b"\x18\x36\x0a\x55\x00\x21\x04\x02", "knock", {"value": 516, "activated_face": 5}),
+    # Scene mode:
+    (2, 18, b"\x18\x69\x0a\x55\x00\x21\x02\x04", "scene", {"value": 1026, "activated_face": 3}),
+    # Secret Xiaomi cluster messages; not-yet-implemented
+    # This is the status update event, which you get if you leave the cube idle, or if you press the button once:
+    # (1, 64704,  b'\x1C\x5F\x11\x59\x0A\xF7\x00\x41\x3E\x01\x21\xFC\x0B\x03\x28\x19\x04\x21\xA8\x13\x05\x21\x09\x00\x06\x24\x1C\x00\x00\x00\x00\x08\x21\x1C\x01\x0A\x21\xEA\x14\x0C\x20\x01\x66\x20\x03\x67\x20\x01\x68\x21\xA8\x00\x97\x21\x00\x00\x98\x21\x00\x00\x99\x21\x00\x00\x9A\x21\x04\x00\x9B\x20\x01', None, None),
+    # This is a mode change event, which you get if you push the button 6 times:
+    # (1, 64704, b'\x18\x58\x0A\x48\x01\x20\x01', "mode_change", {"mode": 1}),
+]
+# fmt: on
+
+
 @pytest.mark.parametrize(
     "endpoint_id, cluster_id, payload, expected_command, expected_args",
-    [
-        # Some events I grabbed from the logs:
-        # Gesture mode:
-        (2, 18, b"\x18\x36\x0a\x55\x00\x21\x00\x00", "shake", {"value": 0}),
-        (
-            2,
-            18,
-            b"\x18\x49\x0a\x55\x00\x21\x6b\x00",
-            "flip",
-            {
-                "value": 107,
-                "flip_degrees": 90,
-                "deactivated_face": 6,
-                "activated_face": 4,
-            },
-        ),
-        (
-            2,
-            18,
-            b"\x18\x49\x0a\x55\x00\x21\x6c\x00",
-            "flip",
-            {
-                "value": 108,
-                "flip_degrees": 90,
-                "deactivated_face": 6,
-                "activated_face": 5,
-            },
-        ),
-        (
-            2,
-            18,
-            b"\x18\x49\x0a\x55\x00\x21\x65\x00",
-            "flip",
-            {
-                "value": 101,
-                "flip_degrees": 90,
-                "deactivated_face": 5,
-                "activated_face": 6,
-            },
-        ),
-        (
-            2,
-            18,
-            b"\x18\x49\x0a\x55\x00\x21\x41\x00",
-            "flip",
-            {
-                "value": 65,
-                "flip_degrees": 90,
-                "deactivated_face": 1,
-                "activated_face": 2,
-            },
-        ),
-        (
-            2,
-            18,
-            b"\x18\x49\x0a\x55\x00\x21\x80\x00",
-            "flip",
-            {
-                "value": 128,
-                "flip_degrees": 180,
-                "deactivated_face": 6,
-                "activated_face": 1,
-            },
-        ),
-        (
-            2,
-            18,
-            b"\x18\x4b\x0a\x55\x00\x21\x03\x01",
-            "slide",
-            {"value": 259, "activated_face": 4},
-        ),
-        (
-            3,
-            12,
-            b"\x18\x50\x0a\x0b\x01\x21\xf4\x01\x55\x00\x39\xff\xff\x8c\x42",
-            "rotate_right",
-            {"relative_degrees": 70.49999237060547},
-        ),
-        (
-            3,
-            12,
-            b"\x18\x61\x0a\x49\x01\x20\x05\x0b\x01\x21\xf4\x01\x55\x00\x39\xa5\x70\x75\xc2",
-            "rotate_left",
-            {"relative_degrees": -61.36000442504883},
-        ),
-        # Gesture mode (not able to reproduce with my cube):
-        (2, 18, b"\x18\x36\x0a\x55\x00\x21\x03\x00", "drop", {"value": 3}),
-        (
-            2,
-            18,
-            b"\x18\x36\x0a\x55\x00\x21\x04\x02",
-            "knock",
-            {"value": 516, "activated_face": 5},
-        ),
-        # Scene mode:
-        (
-            2,
-            18,
-            b"\x18\x69\x0a\x55\x00\x21\x02\x04",
-            "scene",
-            {"value": 1026, "activated_face": 3},
-        ),
-        # Secret Xiaomi cluster messages; not-yet-implemented
-        # This is the status update event, which you get if you leave the cube idle, or if you press the button once:
-        # (1, 64704,  b'\x1C\x5F\x11\x59\x0A\xF7\x00\x41\x3E\x01\x21\xFC\x0B\x03\x28\x19\x04\x21\xA8\x13\x05\x21\x09\x00\x06\x24\x1C\x00\x00\x00\x00\x08\x21\x1C\x01\x0A\x21\xEA\x14\x0C\x20\x01\x66\x20\x03\x67\x20\x01\x68\x21\xA8\x00\x97\x21\x00\x00\x98\x21\x00\x00\x99\x21\x00\x00\x9A\x21\x04\x00\x9B\x20\x01', None, None),
-        # This is a mode change event, which you get if you push the button 6 times:
-        # (1, 64704, b'\x18\x58\x0A\x48\x01\x20\x01', "mode_change", {"mode": 1}),
-    ],
+    test_cases,
 )
 async def test_cube_zha_events(
     cube_device, endpoint_id, cluster_id, payload, expected_command, expected_args

--- a/zhaquirks/xiaomi/aqara/cube_aqgl01.py
+++ b/zhaquirks/xiaomi/aqara/cube_aqgl01.py
@@ -37,12 +37,45 @@ from zhaquirks.xiaomi import (
     XiaomiPowerConfiguration,
 )
 
+STATUS_TYPE_ATTR = 0x0055  # decimal = 85
+XIAOMI_ANALOG = 0x5F03  # decimal = 24323 ? analog input
+XIAOMI_ANALOG_REPLACEMENT = 0x6F03
+XIAOMI_MEASUREMENTS = 0x5F02  # decimal = 24322 ? multistate measurements
+XIAOMI_MEASUREMENTS_REPLACEMENT = 0x6F02
+XIAOMI_SENSORS = 0x5F01  # decimal = 24321 ? sensors
+XIAOMI_SENSORS_REPLACEMENT = 0x6F01
+
+# Keywords
+DESCRIPTION = "description"
 ACTIVATED_FACE = "activated_face"
 DEACTIVATED_FACE = "deactivated_face"
-DESCRIPTION = "description"
+FLIP_DEGREES = "flip_degrees"
+
+# Discrete events:
+SHAKE = "shake"
 DROP = "drop"
-DROP_VALUE = 3
+FLIP_90 = "flip_90"
+FLIP_180 = "flip_180"
+SLIDE = "slide"
+KNOCK = "knock"
+SCENE = "scene"
+UNKNOWN = "unknown"
+FLIP = "flip"
+
+# Analog events:
+LEFT = "left"
+RELATIVE_DEGREES = "relative_degrees"
+RIGHT = "right"
+ROTATE_LEFT = "rotate_left"
+ROTATE_RIGHT = "rotate_right"
+ROTATED = "device_rotated"
+
+# Automation triggers:
 DROPPED = "device_dropped"
+FLIPPED = "device_flipped"
+KNOCKED = "device_knocked"
+SLID = "device_slid"
+SCENE_CHANGED = "device_scene_change"
 
 FACE_ANY = "face_any"
 FACE_1 = "face_1"
@@ -52,105 +85,18 @@ FACE_4 = "face_4"
 FACE_5 = "face_5"
 FACE_6 = "face_6"
 
-FLIP = "flip"
-FLIP_BEGIN = 50
-FLIP_DEGREES = "flip_degrees"
-FLIP_END = 180
-FLIPPED = "device_flipped"
-KNOCK = "knock"
-
-KNOCK_1_VALUE = 512  # aqara skyside
-KNOCK_2_VALUE = 513  # aqara facing me 90 right
-KNOCK_3_VALUE = 514  # aqara facing me upside down
-KNOCK_4_VALUE = 515  # aqara tableside
-KNOCK_5_VALUE = 516  # aqara facing me 90 left
-KNOCK_6_VALUE = 517  # aqara facing me upright
-
-KNOCKED = "device_knocked"
-LEFT = "left"
-RELATIVE_DEGREES = "relative_degrees"
-RIGHT = "right"
-ROTATE_LEFT = "rotate_left"
-ROTATE_RIGHT = "rotate_right"
-ROTATED = "device_rotated"
-SHAKE = "shake"
-SHAKE_VALUE = 0
-SLID = "device_slid"
-SLIDE = "slide"
-
-SLIDE_1_VALUE = 256  # aqara skyside
-SLIDE_2_VALUE = 257  # aqara facing me 90 right
-SLIDE_3_VALUE = 258  # aqara facing me upside down
-SLIDE_4_VALUE = 259  # aqara tableside
-SLIDE_5_VALUE = 260  # aqara facing me 90 left
-SLIDE_6_VALUE = 261  # aqara facing me upright
-
-SLIDE_VALUE = 261
-STATUS_TYPE_ATTR = 0x0055  # decimal = 85
-XIAOMI_ANALOG = 0x5F03  # decimal = 24323 ? analog input
-XIAOMI_ANALOG_REPLACEMENT = 0x6F03
-XIAOMI_MEASUREMENTS = 0x5F02  # decimal = 24322 ? multistate measurements
-XIAOMI_MEASUREMENTS_REPLACEMENT = 0x6F02
-XIAOMI_SENSORS = 0x5F01  # decimal = 24321 ? sensors
-XIAOMI_SENSORS_REPLACEMENT = 0x6F01
 
 MOVEMENT_TYPE = {
-    SHAKE_VALUE: SHAKE,
-    DROP_VALUE: DROP,
-    SLIDE_1_VALUE: SLIDE,
-    SLIDE_2_VALUE: SLIDE,
-    SLIDE_3_VALUE: SLIDE,
-    SLIDE_4_VALUE: SLIDE,
-    SLIDE_5_VALUE: SLIDE,
-    SLIDE_6_VALUE: SLIDE,
-    KNOCK_1_VALUE: KNOCK,
-    KNOCK_2_VALUE: KNOCK,
-    KNOCK_3_VALUE: KNOCK,
-    KNOCK_4_VALUE: KNOCK,
-    KNOCK_5_VALUE: KNOCK,
-    KNOCK_6_VALUE: KNOCK,
+    0: SHAKE,  # Doesn't include an activated face
+    3: DROP,  # Have to special-case this as it doesn't follow the rules.
+    # Never seen bit 16
+    # Bit 32 appears in FLIP_90 events, not sure why - possibly clockwise / anti-clockwise?
+    64: FLIP_90,
+    128: FLIP_180,
+    256: SLIDE,
+    512: KNOCK,  # Seems VERY unreliable
+    1024: SCENE,  # A bit like FLIP, but fired in scene mode.
 }
-
-MOVEMENT_TYPE_DESCRIPTION = {
-    SHAKE_VALUE: SHAKE,
-    DROP_VALUE: DROP,
-    SLIDE_1_VALUE: "aqara logo on top",
-    SLIDE_2_VALUE: "aqara logo facing user rotated 90 degrees right",
-    SLIDE_3_VALUE: "aqara logo facing user upside down",
-    SLIDE_4_VALUE: "aqara logo on bottom",
-    SLIDE_5_VALUE: "aqara logo facing user rotated 90 degrees left",
-    SLIDE_6_VALUE: "aqara logo facing user upright",
-    KNOCK_1_VALUE: "aqara logo on top",
-    KNOCK_2_VALUE: "aqara logo facing user rotated 90 degrees right",
-    KNOCK_3_VALUE: "aqara logo facing user upside down",
-    KNOCK_4_VALUE: "aqara logo on bottom",
-    KNOCK_5_VALUE: "aqara logo facing user rotated 90 degrees left",
-    KNOCK_6_VALUE: "aqara logo facing user upright",
-}
-
-SIDES = {
-    SLIDE_1_VALUE: 1,
-    SLIDE_2_VALUE: 2,
-    SLIDE_3_VALUE: 3,
-    SLIDE_4_VALUE: 4,
-    SLIDE_5_VALUE: 5,
-    SLIDE_6_VALUE: 6,
-    KNOCK_1_VALUE: 1,
-    KNOCK_2_VALUE: 2,
-    KNOCK_3_VALUE: 3,
-    KNOCK_4_VALUE: 4,
-    KNOCK_5_VALUE: 5,
-    KNOCK_6_VALUE: 6,
-}
-
-
-def extend_dict(dictionary, value, ranges):
-    """Extend a dict."""
-    for item in ranges:
-        dictionary[item] = value
-
-
-extend_dict(MOVEMENT_TYPE, FLIP, range(FLIP_BEGIN, FLIP_END))
 
 
 class MultistateInputCluster(CustomCluster, MultistateInput):
@@ -163,25 +109,46 @@ class MultistateInputCluster(CustomCluster, MultistateInput):
 
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
-        if attrid == STATUS_TYPE_ATTR:
-            self._current_state[STATUS_TYPE_ATTR] = action = MOVEMENT_TYPE.get(value)
+        if attrid == STATUS_TYPE_ATTR:  # 0x55
+            # Bitwise split: The lowest bits represent the face, the higher bits represent the type of movement
+            # +1 because we want to count faces from 1 to 6, not from 0 to 5
+            activated_face = (value & 0x7) + 1
+            deactivated_face = ((value >> 3) & 0x7) + 1  # Only applies to FLIP_90
+
+            # Zero-out the lowest 8 bits to get the movement type
+            movement = value & 0xFFC0
+
+            if movement == 0:
+                # SHAKE and DROP don't seem to have activated_face attributes.
+                action = MOVEMENT_TYPE.get(value)
+            else:
+                action = MOVEMENT_TYPE.get(movement)
+            self._current_state[STATUS_TYPE_ATTR] = action
+
             event_args = {VALUE: value}
             if action is not None:
-                if action in (SLIDE, KNOCK):
-                    event_args[DESCRIPTION] = MOVEMENT_TYPE_DESCRIPTION[value]
-                    event_args[ACTIVATED_FACE] = SIDES[value]
+                if action in (SHAKE, DROP):
+                    # No args for these events.
+                    pass
+                else:
+                    # All other actions have an ACTIVATED_FACE:
+                    event_args[ACTIVATED_FACE] = activated_face
 
-                if action == FLIP:
-                    if value > 108:
+                    # Only flips have a DEACTIVATED_FACE and FLIP_DEGREES:
+                    if action in [FLIP_180]:
                         event_args[FLIP_DEGREES] = 180
-                    else:
+                        # Opposite sides add up to 7
+                        event_args[DEACTIVATED_FACE] = 7 - activated_face
+                        action = FLIP
+                    if action in [FLIP_90]:
                         event_args[FLIP_DEGREES] = 90
-                        event_args[DEACTIVATED_FACE] = (value // 8) % 8 + 1
-                    event_args[ACTIVATED_FACE] = int((value % 8) + 1)
+                        event_args[DEACTIVATED_FACE] = deactivated_face
+                        action = FLIP
 
                 self.listener_event(ZHA_SEND_EVENT, action, event_args)
 
             # show something in the sensor in HA
+            # Though I think post: https://github.com/home-assistant/core/pull/36696 this is no-longer meaningful
             super()._update_attribute(0, action)
 
 
@@ -190,22 +157,24 @@ class AnalogInputCluster(CustomCluster, AnalogInput):
 
     def __init__(self, *args, **kwargs):
         """Init."""
-        self._current_state = {}
         super().__init__(*args, **kwargs)
 
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
+
         if attrid == STATUS_TYPE_ATTR:
             if value > 0:
-                self._current_state[STATUS_TYPE_ATTR] = ROTATE_RIGHT
+                action = ROTATE_RIGHT
             else:
-                self._current_state[STATUS_TYPE_ATTR] = ROTATE_LEFT
+                action = ROTATE_LEFT
+
             # show something in the sensor in HA
-            super()._update_attribute(0, value)
-            if self._current_state[STATUS_TYPE_ATTR] is not None:
+            super()._update_attribute(0, action)
+
+            if action is not None:
                 self.listener_event(
                     ZHA_SEND_EVENT,
-                    self._current_state[STATUS_TYPE_ATTR],
+                    action,
                     {RELATIVE_DEGREES: value},
                 )
 
@@ -299,6 +268,7 @@ class CubeAQGL01(XiaomiCustomDevice):
             },
             2: {
                 DEVICE_TYPE: XIAOMI_MEASUREMENTS_REPLACEMENT,
+                # There's also a secret Xaiaomi 0xfcc0 cluster in this endpoint, not yet implemented.
                 INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
                 OUTPUT_CLUSTERS: [
                     Groups.cluster_id,
@@ -346,6 +316,13 @@ class CubeAQGL01(XiaomiCustomDevice):
         (FLIPPED, FACE_4): {COMMAND: FLIP, ARGS: {ACTIVATED_FACE: 4}},
         (FLIPPED, FACE_5): {COMMAND: FLIP, ARGS: {ACTIVATED_FACE: 5}},
         (FLIPPED, FACE_6): {COMMAND: FLIP, ARGS: {ACTIVATED_FACE: 6}},
+        (SCENE_CHANGED, FACE_ANY): {COMMAND: SCENE},
+        (SCENE_CHANGED, FACE_1): {COMMAND: SCENE, ARGS: {ACTIVATED_FACE: 1}},
+        (SCENE_CHANGED, FACE_2): {COMMAND: SCENE, ARGS: {ACTIVATED_FACE: 2}},
+        (SCENE_CHANGED, FACE_3): {COMMAND: SCENE, ARGS: {ACTIVATED_FACE: 3}},
+        (SCENE_CHANGED, FACE_4): {COMMAND: SCENE, ARGS: {ACTIVATED_FACE: 4}},
+        (SCENE_CHANGED, FACE_5): {COMMAND: SCENE, ARGS: {ACTIVATED_FACE: 5}},
+        (SCENE_CHANGED, FACE_6): {COMMAND: SCENE, ARGS: {ACTIVATED_FACE: 6}},
     }
 
 


### PR DESCRIPTION
## Proposed change


This PR introduces "scene mode" support for the Xiaomi Cube device, allowing it to correctly emit ZHA events for physical actions. Additionally, I have refactored and tidied up the existing logic within the base quirk to improve readability and maintainability.

## Additional information

The cube device has 2 modes: Gesture, and Scene. In Gesture mode, only certain gestures (e.g. flipping) become events. In scene mode it simply records which face is up. However for the purpose of the quirks, it can simply forward on any message it receives.

I removed the "description" field in the event as it implied the event know which orientation the cube was in, which it doesn't!


- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works


