### PR TITLE
Update Inovelli VZM32-SN attributes

### DIFF
--- a/zhaquirks/inovelli/__init__.py
+++ b/zhaquirks/inovelli/__init__.py
@@ -1000,6 +1000,16 @@ class InovelliVZM32SNCluster(InovelliCluster):
             type=t.uint8_t,
             is_manufacturer_specific=True,
         )
+        quick_start_time = ZCLAttributeDef(
+            id=0x0017,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
+        quick_start_level = ZCLAttributeDef(
+            id=0x0018,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
         increased_non_neutral_output = ZCLAttributeDef(
             id=0x0019,
             type=t.Bool,

--- a/zhaquirks/inovelli/__init__.py
+++ b/zhaquirks/inovelli/__init__.py
@@ -1275,11 +1275,6 @@ class InovelliVZM32SNCluster(InovelliCluster):
             type=t.Bool,
             is_manufacturer_specific=True,
         )
-        relay_click_in_on_off_mode = ZCLAttributeDef(
-            id=0x0105,
-            type=t.Bool,
-            is_manufacturer_specific=True,
-        )
         disable_clear_notifications_double_tap = ZCLAttributeDef(
             id=0x0106,
             type=t.Bool,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Add missing attributes that are available for the Inovelli VZM32-SN. These are identical to the VZM31-SN attributes. The fact that these are missing was brought up in a [community discussion](https://community.inovelli.com/t/zigbee-motion-switch-project-linus-bug-enhancement-thread/20438/288).


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
