### PR TITLE
Add support for Aqara Cube T1 Pro (lumi.remote.cagl02)

### DIFF
--- a/zhaquirks/xiaomi/aqara/cube_t1_pro.py
+++ b/zhaquirks/xiaomi/aqara/cube_t1_pro.py
@@ -1,9 +1,9 @@
 """Xiaomi Aqara Cube T1 Pro quirk."""
-
 import logging
 
-from zigpy.profiles import zha
 import zigpy.types as t
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import Identify, OnOff # Добавили импорт стандартных кластеров
 
 from zhaquirks import CustomCluster
 from zhaquirks.const import (
@@ -20,11 +20,11 @@ from zhaquirks.xiaomi import (
     BasicCluster,
     XiaomiCustomDevice,
     XiaomiPowerConfiguration,
+    XIAOMI_SENSORS_REPLACEMENT,
 )
 from zhaquirks.xiaomi.aqara.cube_aqgl01 import (
     ACTIVATED_FACE,
     FLIP,
-    XIAOMI_SENSORS_REPLACEMENT,
     AnalogInputCluster,
     CubeAQGL01,
     MultistateInputCluster,
@@ -86,6 +86,8 @@ class CustomCubeT1Pro(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     XiaomiPowerConfiguration,
+                    Identify,  # Возвращаем Identify на место
+                    OnOff,     # И OnOff тоже, для порядка
                     OppleCluster,
                     MultistateInputCluster,
                 ],

--- a/zhaquirks/xiaomi/aqara/cube_t1_pro.py
+++ b/zhaquirks/xiaomi/aqara/cube_t1_pro.py
@@ -1,8 +1,9 @@
 """Xiaomi Aqara Cube T1 Pro quirk."""
+
 import logging
 
-import zigpy.types as t
 from zigpy.profiles import zha
+import zigpy.types as t
 
 from zhaquirks import CustomCluster
 from zhaquirks.const import (

--- a/zhaquirks/xiaomi/aqara/cube_t1_pro.py
+++ b/zhaquirks/xiaomi/aqara/cube_t1_pro.py
@@ -1,13 +1,9 @@
 """Xiaomi Aqara Cube T1 Pro quirk."""
-
 import logging
 
-from zigpy.profiles import zha
 import zigpy.types as t
-from zigpy.zcl.clusters.general import (  # Добавили импорт стандартных кластеров
-    Identify,
-    OnOff,
-)
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import Identify, OnOff
 
 from zhaquirks import CustomCluster
 from zhaquirks.const import (
@@ -21,7 +17,6 @@ from zhaquirks.const import (
 )
 from zhaquirks.xiaomi import (
     LUMI,
-    XIAOMI_SENSORS_REPLACEMENT,
     BasicCluster,
     XiaomiCustomDevice,
     XiaomiPowerConfiguration,
@@ -29,6 +24,7 @@ from zhaquirks.xiaomi import (
 from zhaquirks.xiaomi.aqara.cube_aqgl01 import (
     ACTIVATED_FACE,
     FLIP,
+    XIAOMI_SENSORS_REPLACEMENT,  # Вернул её сюда
     AnalogInputCluster,
     CubeAQGL01,
     MultistateInputCluster,
@@ -90,8 +86,8 @@ class CustomCubeT1Pro(XiaomiCustomDevice):
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     XiaomiPowerConfiguration,
-                    Identify,  # Возвращаем Identify на место
-                    OnOff,  # И OnOff тоже, для порядка
+                    Identify,
+                    OnOff,
                     OppleCluster,
                     MultistateInputCluster,
                 ],

--- a/zhaquirks/xiaomi/aqara/cube_t1_pro.py
+++ b/zhaquirks/xiaomi/aqara/cube_t1_pro.py
@@ -1,8 +1,9 @@
 """Xiaomi Aqara Cube T1 Pro quirk."""
+
 import logging
 
-import zigpy.types as t
 from zigpy.profiles import zha
+import zigpy.types as t
 from zigpy.zcl.clusters.general import Identify, OnOff
 
 from zhaquirks import CustomCluster

--- a/zhaquirks/xiaomi/aqara/cube_t1_pro.py
+++ b/zhaquirks/xiaomi/aqara/cube_t1_pro.py
@@ -1,9 +1,13 @@
 """Xiaomi Aqara Cube T1 Pro quirk."""
+
 import logging
 
-import zigpy.types as t
 from zigpy.profiles import zha
-from zigpy.zcl.clusters.general import Identify, OnOff # Добавили импорт стандартных кластеров
+import zigpy.types as t
+from zigpy.zcl.clusters.general import (  # Добавили импорт стандартных кластеров
+    Identify,
+    OnOff,
+)
 
 from zhaquirks import CustomCluster
 from zhaquirks.const import (
@@ -17,10 +21,10 @@ from zhaquirks.const import (
 )
 from zhaquirks.xiaomi import (
     LUMI,
+    XIAOMI_SENSORS_REPLACEMENT,
     BasicCluster,
     XiaomiCustomDevice,
     XiaomiPowerConfiguration,
-    XIAOMI_SENSORS_REPLACEMENT,
 )
 from zhaquirks.xiaomi.aqara.cube_aqgl01 import (
     ACTIVATED_FACE,
@@ -87,7 +91,7 @@ class CustomCubeT1Pro(XiaomiCustomDevice):
                     BasicCluster,
                     XiaomiPowerConfiguration,
                     Identify,  # Возвращаем Identify на место
-                    OnOff,     # И OnOff тоже, для порядка
+                    OnOff,  # И OnOff тоже, для порядка
                     OppleCluster,
                     MultistateInputCluster,
                 ],

--- a/zhaquirks/xiaomi/aqara/cube_t1_pro.py
+++ b/zhaquirks/xiaomi/aqara/cube_t1_pro.py
@@ -1,9 +1,10 @@
 """Xiaomi Aqara Cube T1 Pro quirk."""
+
 import logging
 
-import zigpy.types as t
 from zigpy.profiles import zha
-from zigpy.zcl.clusters.general import Identify, OnOff, Ota # Добавили Ota
+import zigpy.types as t
+from zigpy.zcl.clusters.general import Identify, OnOff, Ota  # Добавили Ota
 
 from zhaquirks import CustomCluster
 from zhaquirks.const import (
@@ -91,17 +92,17 @@ class CustomCubeT1Pro(XiaomiCustomDevice):
                     OppleCluster,
                     MultistateInputCluster,
                 ],
-                OUTPUT_CLUSTERS: [BasicCluster, Identify, Ota], # Добавили зеркально
+                OUTPUT_CLUSTERS: [BasicCluster, Identify, Ota],  # Добавили зеркально
             },
             2: {
                 DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,
                 INPUT_CLUSTERS: [MultistateInputCluster, OppleCluster],
-                OUTPUT_CLUSTERS: [MultistateInputCluster], # Добавили зеркально
+                OUTPUT_CLUSTERS: [MultistateInputCluster],  # Добавили зеркально
             },
             3: {
                 DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,
                 INPUT_CLUSTERS: [AnalogInputCluster, OppleCluster],
-                OUTPUT_CLUSTERS: [AnalogInputCluster], # Добавили зеркально
+                OUTPUT_CLUSTERS: [AnalogInputCluster],  # Добавили зеркально
             },
         },
     }

--- a/zhaquirks/xiaomi/aqara/cube_t1_pro.py
+++ b/zhaquirks/xiaomi/aqara/cube_t1_pro.py
@@ -1,0 +1,103 @@
+"""Xiaomi Aqara Cube T1 Pro quirk."""
+import logging
+
+import zigpy.types as t
+from zigpy.profiles import zha
+
+from zhaquirks import CustomCluster
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    ZHA_SEND_EVENT,
+)
+from zhaquirks.xiaomi import (
+    LUMI,
+    BasicCluster,
+    XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
+)
+from zhaquirks.xiaomi.aqara.cube_aqgl01 import (
+    ACTIVATED_FACE,
+    FLIP,
+    XIAOMI_SENSORS_REPLACEMENT,
+    AnalogInputCluster,
+    CubeAQGL01,
+    MultistateInputCluster,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OppleCluster(CustomCluster):
+    """Opple cluster for Aqara Cube T1 Pro face status."""
+
+    cluster_id = 0xFCC0
+    name = "opple_cluster"
+    ep_attribute = "opple_cluster"
+
+    attributes = {
+        0x0147: ("flip_event", t.uint8_t, True),
+        0x0149: ("face_status", t.uint8_t, True),
+    }
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid in (0x0147, 0x0149):
+            face = value + 1
+            self.listener_event(ZHA_SEND_EVENT, FLIP, {ACTIVATED_FACE: face})
+
+
+class CustomCubeT1Pro(XiaomiCustomDevice):
+    """Aqara Cube T1 Pro custom device."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.remote.cagl02")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: 259,
+                INPUT_CLUSTERS: [0x0000, 0x0001, 0x0003, 0x0006, 0x0012],
+                OUTPUT_CLUSTERS: [0x0000, 0x0003, 0x0019],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: 259,
+                INPUT_CLUSTERS: [0x0012],
+                OUTPUT_CLUSTERS: [0x0012],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: 259,
+                INPUT_CLUSTERS: [0x000C],
+                OUTPUT_CLUSTERS: [0x000C],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    XiaomiPowerConfiguration,
+                    OppleCluster,
+                    MultistateInputCluster,
+                ],
+            },
+            2: {
+                DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,
+                INPUT_CLUSTERS: [MultistateInputCluster, OppleCluster],
+            },
+            3: {
+                DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,
+                INPUT_CLUSTERS: [AnalogInputCluster, OppleCluster],
+            },
+        },
+    }
+
+    device_automation_triggers = CubeAQGL01.device_automation_triggers

--- a/zhaquirks/xiaomi/aqara/cube_t1_pro.py
+++ b/zhaquirks/xiaomi/aqara/cube_t1_pro.py
@@ -1,10 +1,9 @@
 """Xiaomi Aqara Cube T1 Pro quirk."""
-
 import logging
 
-from zigpy.profiles import zha
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Identify, OnOff
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import Identify, OnOff, Ota # Добавили Ota
 
 from zhaquirks import CustomCluster
 from zhaquirks.const import (
@@ -25,7 +24,7 @@ from zhaquirks.xiaomi import (
 from zhaquirks.xiaomi.aqara.cube_aqgl01 import (
     ACTIVATED_FACE,
     FLIP,
-    XIAOMI_SENSORS_REPLACEMENT,  # Вернул её сюда
+    XIAOMI_SENSORS_REPLACEMENT,
     AnalogInputCluster,
     CubeAQGL01,
     MultistateInputCluster,
@@ -92,14 +91,17 @@ class CustomCubeT1Pro(XiaomiCustomDevice):
                     OppleCluster,
                     MultistateInputCluster,
                 ],
+                OUTPUT_CLUSTERS: [BasicCluster, Identify, Ota], # Добавили зеркально
             },
             2: {
                 DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,
                 INPUT_CLUSTERS: [MultistateInputCluster, OppleCluster],
+                OUTPUT_CLUSTERS: [MultistateInputCluster], # Добавили зеркально
             },
             3: {
                 DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,
                 INPUT_CLUSTERS: [AnalogInputCluster, OppleCluster],
+                OUTPUT_CLUSTERS: [AnalogInputCluster], # Добавили зеркально
             },
         },
     }


### PR DESCRIPTION
## What does this PR do?
Adds support for the Aqara Cube T1 Pro (`lumi.remote.cagl02`). This quirk correctly parses the `OppleCluster` (0xFCC0) attributes to emit `zha_send_event` for flip events and active face status, utilizing the existing `CubeAQGL01` automation triggers and `MultistateInputCluster`. This allows the cube to function properly in its default "Scene Mode".

## Device signature
```json
{
  "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.EndDevice: 2>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress: 128>, manufacturer_code=4151, maximum_buffer_size=127, maximum_incoming_transfer_size=100, server_mask=11264, maximum_outgoing_transfer_size=100, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=True, *is_full_function_device=False, *is_mains_powered=False, *is_receiver_on_when_idle=False, *is_router=False, *is_security_capable=False)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": "0x0103",
      "in_clusters": [
        "0x0000",
        "0x0001",
        "0x0003",
        "0x0006",
        "0x0012"
      ],
      "out_clusters": [
        "0x0000",
        "0x0003",
        "0x0019"
      ]
    },
    "2": {
      "profile_id": 260,
      "device_type": "0x0103",
      "in_clusters": [
        "0x0012"
      ],
      "out_clusters": [
        "0x0012"
      ]
    },
    "3": {
      "profile_id": 260,
      "device_type": "0x0103",
      "in_clusters": [
        "0x000c"
      ],
      "out_clusters": [
        "0x000c"
      ]
    }
  },
  "manufacturer": "LUMI",
  "model": "lumi.remote.cagl02",
  "class": "zigpy.device.Device"
}