### PR TITLE
Add EpsilonRT DIY pilot wire module quirk

### DIFF
--- a/tests/test_epsilonrt.py
+++ b/tests/test_epsilonrt.py
@@ -1,20 +1,23 @@
 """Tests for EpsilonRT Pilot Wire quirk."""
+
 from zhaquirks.epsilonrt.pilot_wire import (
     EpsilonRTPilotWireCluster,
     EpsilonRTPilotWireMode,
 )
 
+
 def test_epsilonrt_pilot_wire_cluster():
     """Test EpsilonRTPilotWireCluster attributes and types."""
     cluster = EpsilonRTPilotWireCluster(None)
-    
+
     # Check if pilot_wire_mode attribute exists (ID 0x0000)
     attr_id = 0x0000
     assert attr_id in cluster.attributes
-    
+
     # Check attribute name and type
     assert cluster.attributes[attr_id].name == "pilot_wire_mode"
     assert cluster.attributes[attr_id].type is EpsilonRTPilotWireMode
+
 
 def test_epsilonrt_enum_values():
     """Test EpsilonRTPilotWireMode enum mapping."""

--- a/tests/test_epsilonrt.py
+++ b/tests/test_epsilonrt.py
@@ -1,33 +1,26 @@
-"""Test for EpsilonRT pilot wire heating module quirk."""
-
-import pytest
+"""Tests for EpsilonRT Pilot Wire quirk."""
 from zhaquirks.epsilonrt.pilot_wire import (
     EpsilonRTPilotWireCluster,
     EpsilonRTPilotWireMode,
-    EPSILONRT_MANUFACTURER_ID,
 )
-from zigpy.quirks.v2 import CustomDeviceV2
 
 def test_epsilonrt_pilot_wire_cluster():
-    """Test the custom cluster definition."""
+    """Test EpsilonRTPilotWireCluster attributes and types."""
     cluster = EpsilonRTPilotWireCluster(None)
     
-    # Verify cluster configuration
-    assert cluster.cluster_id == 0xFC00
-    assert cluster.name == "PilotWireCluster"
-    assert cluster.manufacturer_id_override == EPSILONRT_MANUFACTURER_ID
+    # Check if pilot_wire_mode attribute exists (ID 0x0000)
+    attr_id = 0x0000
+    assert attr_id in cluster.attributes
     
-    # Verify attribute definition
-    assert "pilot_wire_mode" in cluster.attributes
-    attr_def = cluster.attributes_by_name["pilot_wire_mode"]
-    assert attr_def.id == 0x0000
-    assert attr_def.type is EpsilonRTPilotWireMode
+    # Check attribute name and type
+    assert cluster.attributes[attr_id].name == "pilot_wire_mode"
+    assert cluster.attributes[attr_id].type is EpsilonRTPilotWireMode
 
-def test_epsilonrt_pilot_wire_mode_enum():
-    """Test the enum values and names (PascalCase)."""
-    assert EpsilonRTPilotWireMode.Off == 0x00
-    assert EpsilonRTPilotWireMode.Comfort == 0x01
-    assert EpsilonRTPilotWireMode.Eco == 0x02
-    assert EpsilonRTPilotWireMode.FrostProtection == 0x03
-    assert EpsilonRTPilotWireMode.ComfortMinus1 == 0x04
-    assert EpsilonRTPilotWireMode.ComfortMinus2 == 0x05
+def test_epsilonrt_enum_values():
+    """Test EpsilonRTPilotWireMode enum mapping."""
+    assert EpsilonRTPilotWireMode.Off == 0
+    assert EpsilonRTPilotWireMode.Comfort == 1
+    assert EpsilonRTPilotWireMode.Eco == 2
+    assert EpsilonRTPilotWireMode.FrostProtection == 3
+    assert EpsilonRTPilotWireMode.ComfortMinus1 == 4
+    assert EpsilonRTPilotWireMode.ComfortMinus2 == 5

--- a/tests/test_epsilonrt.py
+++ b/tests/test_epsilonrt.py
@@ -1,0 +1,33 @@
+"""Test for EpsilonRT pilot wire heating module quirk."""
+
+import pytest
+from zhaquirks.epsilonrt.pilot_wire import (
+    EpsilonRTPilotWireCluster,
+    EpsilonRTPilotWireMode,
+    EPSILONRT_MANUFACTURER_ID,
+)
+from zigpy.quirks.v2 import CustomDeviceV2
+
+def test_epsilonrt_pilot_wire_cluster():
+    """Test the custom cluster definition."""
+    cluster = EpsilonRTPilotWireCluster(None)
+    
+    # Verify cluster configuration
+    assert cluster.cluster_id == 0xFC00
+    assert cluster.name == "PilotWireCluster"
+    assert cluster.manufacturer_id_override == EPSILONRT_MANUFACTURER_ID
+    
+    # Verify attribute definition
+    assert "pilot_wire_mode" in cluster.attributes
+    attr_def = cluster.attributes_by_name["pilot_wire_mode"]
+    assert attr_def.id == 0x0000
+    assert attr_def.type is EpsilonRTPilotWireMode
+
+def test_epsilonrt_pilot_wire_mode_enum():
+    """Test the enum values and names (PascalCase)."""
+    assert EpsilonRTPilotWireMode.Off == 0x00
+    assert EpsilonRTPilotWireMode.Comfort == 0x01
+    assert EpsilonRTPilotWireMode.Eco == 0x02
+    assert EpsilonRTPilotWireMode.FrostProtection == 0x03
+    assert EpsilonRTPilotWireMode.ComfortMinus1 == 0x04
+    assert EpsilonRTPilotWireMode.ComfortMinus2 == 0x05

--- a/zhaquirks/epsilonrt/__init__.py
+++ b/zhaquirks/epsilonrt/__init__.py
@@ -1,0 +1,1 @@
+"""EpsilonRT module for custom device handlers."""

--- a/zhaquirks/epsilonrt/pilot_wire.py
+++ b/zhaquirks/epsilonrt/pilot_wire.py
@@ -1,7 +1,6 @@
-"""
-EpsilonRT pilot wire heating module quirk.
+"""EpsilonRT pilot wire heating module quirk.
 
-This is a DIY project. The manufacturer ID (0x1234) is used for 
+This is a DIY project. The manufacturer ID (0x1234) is used for
 development and non-commercial purposes.
 
 Firmware and documentation:
@@ -19,14 +18,17 @@ EPSILONRT_MANUFACTURER_ID = 0x1234
 EPSILONRT_PILOT_WIRE_CLUSTER_ID = 0xFC00  # 64512
 EPSILONRT_PILOT_WIRE_MODEL = "ERT-MPZ-03"
 
+
 class EpsilonRTPilotWireMode(t.enum8):
     """Pilot wire mode enum (PascalCase for current ZHA compatibility)."""
+
     Off = 0x00
     Comfort = 0x01
     Eco = 0x02
     FrostProtection = 0x03
     ComfortMinus1 = 0x04
     ComfortMinus2 = 0x05
+
 
 class EpsilonRTPilotWireCluster(CustomCluster):
     """EpsilonRT manufacturer specific cluster to control Pilot Wire mode."""
@@ -38,12 +40,14 @@ class EpsilonRTPilotWireCluster(CustomCluster):
 
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions for the Pilot Wire cluster."""
+
         pilot_wire_mode = ZCLAttributeDef(
             id=0x0000,
             type=EpsilonRTPilotWireMode,
             zcl_type=DataTypeId.uint8,
             is_manufacturer_specific=True,
         )
+
 
 # Quirk Registration
 (

--- a/zhaquirks/epsilonrt/pilot_wire.py
+++ b/zhaquirks/epsilonrt/pilot_wire.py
@@ -1,0 +1,61 @@
+"""
+EpsilonRT pilot wire heating module quirk.
+
+This is a DIY project. The manufacturer ID (0x1234) is used for 
+development and non-commercial purposes.
+
+Firmware and documentation:
+https://github.com/epsilonrt/ZigbeePilotWireControl
+"""
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import EntityType, QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
+
+EPSILONRT = "EpsilonRT"
+# Manufacturer ID 0x1234 is used by EpsilonRT DIY modules.
+EPSILONRT_MANUFACTURER_ID = 0x1234
+EPSILONRT_PILOT_WIRE_CLUSTER_ID = 0xFC00  # 64512
+EPSILONRT_PILOT_WIRE_MODEL = "ERT-MPZ-03"
+
+class EpsilonRTPilotWireMode(t.enum8):
+    """Pilot wire mode enum (PascalCase for current ZHA compatibility)."""
+    Off = 0x00
+    Comfort = 0x01
+    Eco = 0x02
+    FrostProtection = 0x03
+    ComfortMinus1 = 0x04
+    ComfortMinus2 = 0x05
+
+class EpsilonRTPilotWireCluster(CustomCluster):
+    """EpsilonRT manufacturer specific cluster to control Pilot Wire mode."""
+
+    name: str = "PilotWireCluster"
+    cluster_id: t.uint16_t = EPSILONRT_PILOT_WIRE_CLUSTER_ID
+    manufacturer_id_override: t.uint16_t = EPSILONRT_MANUFACTURER_ID
+    ep_attribute: str = "pilot_wire_cluster"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions for the Pilot Wire cluster."""
+        pilot_wire_mode = ZCLAttributeDef(
+            id=0x0000,
+            type=EpsilonRTPilotWireMode,
+            zcl_type=DataTypeId.uint8,
+            is_manufacturer_specific=True,
+        )
+
+# Quirk Registration
+(
+    QuirkBuilder(EPSILONRT, EPSILONRT_PILOT_WIRE_MODEL)
+    .replaces(EpsilonRTPilotWireCluster)
+    .enum(
+        attribute_name=EpsilonRTPilotWireCluster.AttributeDefs.pilot_wire_mode.name,
+        enum_class=EpsilonRTPilotWireMode,
+        cluster_id=EpsilonRTPilotWireCluster.cluster_id,
+        entity_type=EntityType.STANDARD,
+        translation_key="pilot_wire_mode",
+        fallback_name="Pilot wire mode",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
This PR adds a new quirk for the **EpsilonRT DIY Pilot Wire** heating module (Model: `ERT-MPZ-03`). 

The quirk implements a manufacturer-specific cluster (`0xFC00`) to manage the 6 standard pilot wire modes. It follows the existing implementation patterns for French pilot wire modules (like **Nodon**) by using **PascalCase** for the Enum states to ensure immediate compatibility with current ZHA and Home Assistant versions.

## Additional information
* **DIY Project:** This is a non-commercial DIY module using Manufacturer ID `0x1234`.
* **Firmware & Hardware:** Technical details and firmware source can be found at: https://github.com/epsilonrt/ZigbeePilotWireControl
* **Standardization:** I am using the official `pilot_wire_mode` translation key for seamless integration.
* **Consistency:** While I'm aware of the discussion regarding "slugs" in future versions, this PR maintains consistency with other pilot wire quirks already merged in the repository.

<img width="500" height="342" alt="ha_lovelace_full" src="https://github.com/user-attachments/assets/6423fc4e-db23-46db-9b5e-3e23da919d7a" />

## Device diagnostics
[zha-01K8ZVXHG121GK60Z1SXFF0QAY-EpsilonRT ERT-MPZ-03-1b98d0483970a0c72e98f9e9a6ef208b.json](https://github.com/user-attachments/files/25985814/zha-01K8ZVXHG121GK60Z1SXFF0QAY-EpsilonRT.ERT-MPZ-03-1b98d0483970a0c72e98f9e9a6ef208b.json)


## Checklist
- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
