### PR TITLE
Add signature variant for lumi.switch.l2aeu1 without extra endpoints

### DIFF
--- a/zhaquirks/xiaomi/aqara/switch_h1_double.py
+++ b/zhaquirks/xiaomi/aqara/switch_h1_double.py
@@ -238,3 +238,54 @@ class AqaraH1DoubleRockerSwitchNoNeutralAlt(XiaomiOpple2ButtonSwitchBase):
             },
         },
     }
+
+
+class AqaraH1DoubleRockerSwitchNoNeutralAlt2(XiaomiOpple2ButtonSwitchBase):
+    """Aqara H1 Double Rocker Switch (no neutral). Alarms on EP1, Opple on EP2."""
+
+    signature = {
+        MODELS_INFO: [(LUMI, "lumi.switch.l2aeu1")],
+        ENDPOINTS: {
+            # input_clusters=[0, 2, 3, 4, 5, 6, 9], output_clusters=[10, 25]
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DeviceTemperature.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    Alarms.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                ],
+            },
+            # input_clusters=[0, 3, 4, 5, 6, 18, 64704], output_clusters=[]
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    MultistateInput.cluster_id,
+                    OppleSwitchCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [
+                    GreenPowerProxy.cluster_id,
+                ],
+            },
+        },
+    }


### PR DESCRIPTION
## Proposed change

Add a new signature variant (`AqaraH1DoubleRockerSwitchNoNeutralCompact`) for the Aqara H1 Double Rocker Switch (no neutral) `lumi.switch.l2aeu1`.

Some units report MultistateInput (`0x0012`) and OppleSwitchCluster (`0xfcc0`) on both endpoints 1 and 2, but do **not** expose the additional endpoints 41, 42, and 51. Without a matching signature, the quirk is not applied and Opple cluster configuration (e.g. detached mode) is inaccessible.

## Additional information

Related: #4315

This is distinct from PR #4360 which adds a variant where EP1 has Alarms instead of MultistateInput/OppleSwitchCluster. This PR covers the case where both EP1 and EP2 have the Opple cluster but the extra endpoints are absent — likely due to a firmware update on the device.

## Device diagnostics

[zha-01KKMPDK0P0X01QZ7G3VVKYWZS-LUMI lumi.switch.l2aeu1-2e37219180dd498d0f4dd11404c1606c.json](https://github.com/user-attachments/files/26019214/zha-01KKMPDK0P0X01QZ7G3VVKYWZS-LUMI.lumi.switch.l2aeu1-2e37219180dd498d0f4dd11404c1606c.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached