### PR TITLE
Downgrade log message after loading custom quirks to INFO from WARNING

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -510,7 +510,7 @@ def setup(custom_quirks_path: str | None = None) -> None:
             loaded = True
 
     if loaded:
-        _LOGGER.warning(
+        _LOGGER.info(
             "Loaded custom quirks. Please contribute them to"
             " https://github.com/zigpy/zha-device-handlers"
         )


### PR DESCRIPTION
## Proposed change

This one-line change downgrades the logging call when custom quirks are loaded down to `info` from `warning`

- Warnings appear in the condensed system logs, which novice users like myself use at the first sign of trouble. Noisy log entries unrelated to potential problems shouldn't appear here.
- The [`INFO` level](https://docs.python.org/3/library/logging.html#logging.INFO) is a better fit for this message. `logging.WARNING` is `An indication that something unexpected happened, or that a problem might occur in the near future`. The existence of a custom quirk isn't any more of a sign of future problems than the existence of user-written automations or YAML already are.

## Additional information

There's arguably some value in prompting users to contribute custom quirks to the project, but the system error/warning log doesn't seem like the appropriate place.

Most users are *consuming* these custom quirks, not writing them, and probably aren't likely to have enough experience to know how to "contribute them" to the repository. 

## Device diagnostics

N/A, not a quirk

## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
