### PR TITLE
Add Third Reality curtain gen2 Last remaining battery percentage entity

### DIFF
--- a/zhaquirks/thirdreality/curtain_gen2.py
+++ b/zhaquirks/thirdreality/curtain_gen2.py
@@ -6,7 +6,7 @@ from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
-
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 
 class THIRD_REALITY_Blind_Gen2_CLUSTER(CustomCluster):
     """Third Reality's Blind Gen2 private cluster."""
@@ -73,7 +73,7 @@ class THIRD_REALITY_Blind_Gen2_CLUSTER(CustomCluster):
         cluster_id=THIRD_REALITY_Blind_Gen2_CLUSTER.cluster_id,
         endpoint_id=1,
         min_value=0,
-        max_value=3800,
+        max_value=4000,
         step=1,
         translation_key="limit_position",
         fallback_name="Limit position",
@@ -87,6 +87,15 @@ class THIRD_REALITY_Blind_Gen2_CLUSTER(CustomCluster):
         step=1,
         translation_key="total_cycle_times",
         fallback_name="Total cycle times",
+    )
+    .sensor(
+        attribute_name=THIRD_REALITY_Blind_Gen2_CLUSTER.AttributeDefs.last_remaining_battery_percentage.name,
+        cluster_id=THIRD_REALITY_Blind_Gen2_CLUSTER.cluster_id,
+        endpoint_id=1,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="last_remaining_battery_percentage",
+        fallback_name="Last remaining battery percentage",
     )
     .add_to_registry()
 )

--- a/zhaquirks/thirdreality/curtain_gen2.py
+++ b/zhaquirks/thirdreality/curtain_gen2.py
@@ -4,9 +4,10 @@ from typing import Final
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
-from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
+
 
 class THIRD_REALITY_Blind_Gen2_CLUSTER(CustomCluster):
     """Third Reality's Blind Gen2 private cluster."""


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR added added 1 additional private clusters entity

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
