### PR TITLE
Add TS0601 _TZE284_5m4nchbm RCBO quirk

### DIFF
--- a/tests/test_tuya_rcbo.py
+++ b/tests/test_tuya_rcbo.py
@@ -489,7 +489,9 @@ async def test_write_attr_rcbo2(zigpy_device_from_v2_quirk):
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
         ]
 
-        (status,) = await tuya_cluster.write_attributes({"under_voltage_threshold": 200})
+        (status,) = await tuya_cluster.write_attributes(
+            {"under_voltage_threshold": 200}
+        )
         await wait_for_zigpy_tasks()
         m1.assert_called_with(
             cluster=61184,

--- a/tests/test_tuya_rcbo.py
+++ b/tests/test_tuya_rcbo.py
@@ -369,3 +369,139 @@ async def test_power_factor(zigpy_device_from_quirk):
     )
     tuya_cluster.handle_message(hdr, args)  # active_power
     assert tuya_listener.attribute_updates == [(0x050B, 1611), (0x0510, 99)]
+
+
+@pytest.mark.parametrize(
+    "frame, attributes",
+    (
+        (
+            b"\x09\x01\x01\x02\x03\x01\x01\x00\x01\x01",
+            {"state": True},
+        ),
+        (
+            b"\x09\x02\x01\x02\x03\x26\x04\x00\x01\x02",
+            {
+                "power_outage_memory": zhaquirks.tuya.ts0601_rcbo.RCBO2PowerOutageMemory.restore,
+            },
+        ),
+        (
+            b"\x09\x03\x01\x02\x030\x00\x00\x0c\xaa\x01\x00\x14\xbb\x00\x00\x5a\xcc\x01\x00\x03",
+            {
+                "alarm1_reserved_0": 0xAA,
+                "leakage_breaker": True,
+                "leakage_threshold": 20,
+                "alarm1_reserved_4": 0xBB,
+                "high_temperature_breaker": False,
+                "high_temperature_threshold": 90,
+                "alarm1_reserved_8": 0xCC,
+                "high_power_breaker": True,
+                "high_power_threshold": 3,
+            },
+        ),
+        (
+            b"\x09\x04\x01\x02\x031\x00\x00\x0c\x11\x00\x00\x32\x22\x01\x00\xfa\x33\x00\x00\xb4",
+            {
+                "alarm2_reserved_0": 0x11,
+                "over_current_breaker": False,
+                "over_current_threshold": 50,
+                "alarm2_reserved_4": 0x22,
+                "over_voltage_breaker": True,
+                "over_voltage_threshold": 250,
+                "alarm2_reserved_8": 0x33,
+                "under_voltage_breaker": False,
+                "under_voltage_threshold": 180,
+            },
+        ),
+        (
+            b"\x09\x05\x01\x02\x035\x02\x00\x04\x00\x00\x00\x07",
+            {"leakage": 7},
+        ),
+    ),
+)
+async def test_report_values_rcbo2(zigpy_device_from_v2_quirk, frame, attributes):
+    """Test receiving attributes from `_TZE284_5m4nchbm` RCBO."""
+
+    rcbo_dev = zigpy_device_from_v2_quirk("_TZE284_5m4nchbm", "TS0601")
+    tuya_cluster = rcbo_dev.endpoints[1].tuya_manufacturer
+    tuya_listener = ClusterListener(tuya_cluster)
+
+    hdr, args = tuya_cluster.deserialize(frame)
+    tuya_cluster.handle_message(hdr, args)
+
+    expected = [
+        (tuya_cluster.attributes_by_name[name].id, value)
+        for name, value in attributes.items()
+    ]
+    assert tuya_listener.attribute_updates == expected
+
+
+async def test_write_attr_rcbo2(zigpy_device_from_v2_quirk):
+    """Test write cluster attributes for `_TZE284_5m4nchbm` RCBO."""
+
+    rcbo_dev = zigpy_device_from_v2_quirk("_TZE284_5m4nchbm", "TS0601")
+    tuya_cluster = rcbo_dev.endpoints[1].tuya_manufacturer
+
+    tuya_cluster.handle_message(
+        *tuya_cluster.deserialize(
+            b"\x09\x01\x01\x02\x030\x00\x00\x0c\xaa\x01\x00\x14\xbb\x00\x00\x5a\xcc\x01\x00\x03"
+        )
+    )
+    tuya_cluster.handle_message(
+        *tuya_cluster.deserialize(
+            b"\x09\x02\x01\x02\x031\x00\x00\x0c\x11\x00\x00\x32\x22\x01\x00\xfa\x33\x00\x00\xb4"
+        )
+    )
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as m1:
+        (status,) = await tuya_cluster.write_attributes({"power_outage_memory": 2})
+        await wait_for_zigpy_tasks()
+        m1.assert_called_with(
+            cluster=61184,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x26\x04\x00\x01\x02",
+            command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
+            priority=None,
+        )
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
+
+        (status,) = await tuya_cluster.write_attributes({"leakage_threshold": 40})
+        await wait_for_zigpy_tasks()
+        m1.assert_called_with(
+            cluster=61184,
+            sequence=2,
+            data=b"\x01\x02\x00\x00\x020\x00\x00\x0c\xaa\x01\x00\x28\xbb\x00\x00\x5a\xcc\x01\x00\x03",
+            command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
+            priority=None,
+        )
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
+
+        (status,) = await tuya_cluster.write_attributes({"under_voltage_threshold": 200})
+        await wait_for_zigpy_tasks()
+        m1.assert_called_with(
+            cluster=61184,
+            sequence=3,
+            data=b"\x01\x03\x00\x00\x031\x00\x00\x0c\x11\x00\x00\x32\x22\x01\x00\xfa\x33\x00\x00\xc8",
+            command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
+            priority=None,
+        )
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]

--- a/zhaquirks/tuya/ts0601_rcbo.py
+++ b/zhaquirks/tuya/ts0601_rcbo.py
@@ -39,7 +39,12 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import TUYA_MCU_COMMAND, AttributeWithMask, PowerOnState
+from zhaquirks.tuya import (
+    TUYA_CLUSTER_ID,
+    TUYA_MCU_COMMAND,
+    AttributeWithMask,
+    PowerOnState,
+)
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zhaquirks.tuya.mcu import (
     DPToAttributeMapping,
@@ -686,124 +691,163 @@ def _rcbo2_alarm2_dp_converter(
     )
 
 
-class TuyaRCBO2ManufCluster(TuyaMCUCluster):
-    """Manufacturer cluster for `_TZE284_5m4nchbm`."""
-
-    class AttributeDefs(TuyaMCUCluster.AttributeDefs):
-        """Attribute definitions."""
-
-        state: Final = ZCLAttributeDef(
-            id=0xEF01, type=t.Bool, is_manufacturer_specific=True
-        )
-        energy: Final = ZCLAttributeDef(
-            id=0xEF02, type=t.uint32_t, is_manufacturer_specific=True
-        )
-        current: Final = ZCLAttributeDef(
-            id=0xEF03, type=t.uint32_t, is_manufacturer_specific=True
-        )
-        power: Final = ZCLAttributeDef(
-            id=0xEF04, type=t.uint32_t, is_manufacturer_specific=True
-        )
-        voltage: Final = ZCLAttributeDef(
-            id=0xEF05, type=t.uint32_t, is_manufacturer_specific=True
-        )
-        fault: Final = ZCLAttributeDef(
-            id=0xEF06, type=RCBO2FaultCode, is_manufacturer_specific=True
-        )
-        power_outage_memory: Final = ZCLAttributeDef(
-            id=0xEF07, type=RCBO2PowerOutageMemory, is_manufacturer_specific=True
-        )
-        child_lock: Final = ZCLAttributeDef(
-            id=0xEF08, type=t.Bool, is_manufacturer_specific=True
-        )
-        leakage_test: Final = ZCLAttributeDef(
-            id=0xEF09, type=t.Bool, is_manufacturer_specific=True
-        )
-        temperature: Final = ZCLAttributeDef(
-            id=0xEF0A, type=t.int16s, is_manufacturer_specific=True
-        )
-        leakage: Final = ZCLAttributeDef(
-            id=0xEF0B, type=t.uint32_t, is_manufacturer_specific=True
-        )
-        alarm1_reserved_0: Final = ZCLAttributeDef(
-            id=0xEF10, type=t.uint8_t, is_manufacturer_specific=True
-        )
-        leakage_breaker: Final = ZCLAttributeDef(
-            id=0xEF11, type=t.Bool, is_manufacturer_specific=True
-        )
-        leakage_threshold: Final = ZCLAttributeDef(
-            id=0xEF12, type=t.uint16_t, is_manufacturer_specific=True
-        )
-        alarm1_reserved_4: Final = ZCLAttributeDef(
-            id=0xEF13, type=t.uint8_t, is_manufacturer_specific=True
-        )
-        high_temperature_breaker: Final = ZCLAttributeDef(
-            id=0xEF14, type=t.Bool, is_manufacturer_specific=True
-        )
-        high_temperature_threshold: Final = ZCLAttributeDef(
-            id=0xEF15, type=t.uint16_t, is_manufacturer_specific=True
-        )
-        alarm1_reserved_8: Final = ZCLAttributeDef(
-            id=0xEF16, type=t.uint8_t, is_manufacturer_specific=True
-        )
-        high_power_breaker: Final = ZCLAttributeDef(
-            id=0xEF17, type=t.Bool, is_manufacturer_specific=True
-        )
-        high_power_threshold: Final = ZCLAttributeDef(
-            id=0xEF18, type=t.uint16_t, is_manufacturer_specific=True
-        )
-        alarm2_reserved_0: Final = ZCLAttributeDef(
-            id=0xEF19, type=t.uint8_t, is_manufacturer_specific=True
-        )
-        over_current_breaker: Final = ZCLAttributeDef(
-            id=0xEF1A, type=t.Bool, is_manufacturer_specific=True
-        )
-        over_current_threshold: Final = ZCLAttributeDef(
-            id=0xEF1B, type=t.uint16_t, is_manufacturer_specific=True
-        )
-        alarm2_reserved_4: Final = ZCLAttributeDef(
-            id=0xEF1C, type=t.uint8_t, is_manufacturer_specific=True
-        )
-        over_voltage_breaker: Final = ZCLAttributeDef(
-            id=0xEF1D, type=t.Bool, is_manufacturer_specific=True
-        )
-        over_voltage_threshold: Final = ZCLAttributeDef(
-            id=0xEF1E, type=t.uint16_t, is_manufacturer_specific=True
-        )
-        alarm2_reserved_8: Final = ZCLAttributeDef(
-            id=0xEF1F, type=t.uint8_t, is_manufacturer_specific=True
-        )
-        under_voltage_breaker: Final = ZCLAttributeDef(
-            id=0xEF20, type=t.Bool, is_manufacturer_specific=True
-        )
-        under_voltage_threshold: Final = ZCLAttributeDef(
-            id=0xEF21, type=t.uint16_t, is_manufacturer_specific=True
-        )
-
-    dp_to_attribute: dict[int, list[DPToAttributeMapping]] = {
-        1: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "state")],
-        17: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "energy")],
-        18: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "current")],
-        19: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "power")],
-        20: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "voltage")],
-        26: [
-            DPToAttributeMapping(
-                TuyaMCUCluster.ep_attribute,
-                "fault",
-                converter=lambda value: RCBO2FaultCode(value),
-            )
-        ],
-        38: [
-            DPToAttributeMapping(
-                TuyaMCUCluster.ep_attribute,
-                "power_outage_memory",
-                converter=lambda value: RCBO2PowerOutageMemory(value),
-            )
-        ],
-        41: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "child_lock")],
-        45: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "leakage_test")],
-        47: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "temperature")],
-        48: [
+(
+    TuyaQuirkBuilder("_TZE284_5m4nchbm", "TS0601")
+    .tuya_switch(
+        dp_id=1,
+        attribute_name="state",
+        entity_type=EntityType.STANDARD,
+        translation_key="state",
+        fallback_name="Switch",
+    )
+    .tuya_sensor(
+        dp_id=17,
+        attribute_name="energy",
+        type=t.uint32_t,
+        divisor=100,
+        entity_type=EntityType.STANDARD,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="energy",
+        fallback_name="Energy",
+    )
+    .tuya_sensor(
+        dp_id=18,
+        attribute_name="current",
+        type=t.uint32_t,
+        divisor=100,
+        entity_type=EntityType.STANDARD,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricCurrent.AMPERE,
+        translation_key="current",
+        fallback_name="Current",
+    )
+    .tuya_sensor(
+        dp_id=19,
+        attribute_name="power",
+        type=t.uint32_t,
+        divisor=10,
+        entity_type=EntityType.STANDARD,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfPower.WATT,
+        translation_key="power",
+        fallback_name="Power",
+    )
+    .tuya_sensor(
+        dp_id=20,
+        attribute_name="voltage",
+        type=t.uint32_t,
+        divisor=10,
+        entity_type=EntityType.STANDARD,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricPotential.VOLT,
+        translation_key="voltage",
+        fallback_name="Voltage",
+    )
+    .tuya_enum(
+        dp_id=26,
+        attribute_name="fault",
+        enum_class=RCBO2FaultCode,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.STANDARD,
+        translation_key="fault",
+        fallback_name="Fault",
+    )
+    .tuya_enum(
+        dp_id=38,
+        attribute_name="power_outage_memory",
+        enum_class=RCBO2PowerOutageMemory,
+        translation_key="power_outage_memory",
+        fallback_name="Power outage memory",
+    )
+    .tuya_switch(
+        dp_id=41,
+        attribute_name="child_lock",
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    .tuya_switch(
+        dp_id=45,
+        attribute_name="leakage_test",
+        entity_type=EntityType.STANDARD,
+        translation_key="leakage_test",
+        fallback_name="Leakage test",
+    )
+    .tuya_sensor(
+        dp_id=47,
+        attribute_name="temperature",
+        type=t.int16s,
+        entity_type=EntityType.STANDARD,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfTemperature.CELSIUS,
+        translation_key="temperature",
+        fallback_name="Temperature",
+    )
+    .tuya_attribute(
+        dp_id=0x60,
+        attribute_name="alarm1_reserved_0",
+        type=t.uint8_t,
+        access=foundation.ZCLAttributeAccess.Read
+        | foundation.ZCLAttributeAccess.Report,
+    )
+    .tuya_attribute(
+        dp_id=0x61,
+        attribute_name="leakage_breaker",
+        type=t.Bool,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_attribute(
+        dp_id=0x62,
+        attribute_name="leakage_threshold",
+        type=t.uint16_t,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_attribute(
+        dp_id=0x63,
+        attribute_name="alarm1_reserved_4",
+        type=t.uint8_t,
+        access=foundation.ZCLAttributeAccess.Read
+        | foundation.ZCLAttributeAccess.Report,
+    )
+    .tuya_attribute(
+        dp_id=0x64,
+        attribute_name="high_temperature_breaker",
+        type=t.Bool,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_attribute(
+        dp_id=0x65,
+        attribute_name="high_temperature_threshold",
+        type=t.uint16_t,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_attribute(
+        dp_id=0x66,
+        attribute_name="alarm1_reserved_8",
+        type=t.uint8_t,
+        access=foundation.ZCLAttributeAccess.Read
+        | foundation.ZCLAttributeAccess.Report,
+    )
+    .tuya_attribute(
+        dp_id=0x67,
+        attribute_name="high_power_breaker",
+        type=t.Bool,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_attribute(
+        dp_id=0x68,
+        attribute_name="high_power_threshold",
+        type=t.uint16_t,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_dp_multi(
+        dp_id=48,
+        attribute_mapping=[
             DPToAttributeMapping(
                 TuyaMCUCluster.ep_attribute,
                 "alarm1_reserved_0",
@@ -850,7 +894,68 @@ class TuyaRCBO2ManufCluster(TuyaMCUCluster):
                 converter=lambda value: (value[10] << 8) | value[11],
             ),
         ],
-        49: [
+        dp_converter=_rcbo2_alarm1_dp_converter,
+    )
+    .tuya_attribute(
+        dp_id=0x69,
+        attribute_name="alarm2_reserved_0",
+        type=t.uint8_t,
+        access=foundation.ZCLAttributeAccess.Read
+        | foundation.ZCLAttributeAccess.Report,
+    )
+    .tuya_attribute(
+        dp_id=0x6A,
+        attribute_name="over_current_breaker",
+        type=t.Bool,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_attribute(
+        dp_id=0x6B,
+        attribute_name="over_current_threshold",
+        type=t.uint16_t,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_attribute(
+        dp_id=0x6C,
+        attribute_name="alarm2_reserved_4",
+        type=t.uint8_t,
+        access=foundation.ZCLAttributeAccess.Read
+        | foundation.ZCLAttributeAccess.Report,
+    )
+    .tuya_attribute(
+        dp_id=0x6D,
+        attribute_name="over_voltage_breaker",
+        type=t.Bool,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_attribute(
+        dp_id=0x6E,
+        attribute_name="over_voltage_threshold",
+        type=t.uint16_t,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_attribute(
+        dp_id=0x6F,
+        attribute_name="alarm2_reserved_8",
+        type=t.uint8_t,
+        access=foundation.ZCLAttributeAccess.Read
+        | foundation.ZCLAttributeAccess.Report,
+    )
+    .tuya_attribute(
+        dp_id=0x70,
+        attribute_name="under_voltage_breaker",
+        type=t.Bool,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_attribute(
+        dp_id=0x71,
+        attribute_name="under_voltage_threshold",
+        type=t.uint16_t,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_dp_multi(
+        dp_id=49,
+        attribute_mapping=[
             DPToAttributeMapping(
                 TuyaMCUCluster.ep_attribute,
                 "alarm2_reserved_0",
@@ -897,121 +1002,12 @@ class TuyaRCBO2ManufCluster(TuyaMCUCluster):
                 converter=lambda value: (value[10] << 8) | value[11],
             ),
         ],
-        53: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "leakage")],
-    }
-
-    data_point_handlers = {dp_id: "_dp_2_attr_update" for dp_id in dp_to_attribute}
-
-    attributes_to_dp_converters = {
-        38: lambda value: RCBO2PowerOutageMemory(value),
-        48: _rcbo2_alarm1_dp_converter,
-        49: _rcbo2_alarm2_dp_converter,
-    }
-
-
-(
-    TuyaQuirkBuilder("_TZE284_5m4nchbm", "TS0601")
-    .replaces(TuyaRCBO2ManufCluster)
-    .switch(
-        attribute_name="state",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
-        entity_type=EntityType.STANDARD,
-        translation_key="state",
-        fallback_name="Switch",
-        primary=True,
+        dp_converter=_rcbo2_alarm2_dp_converter,
     )
-    .sensor(
-        attribute_name="energy",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
-        divisor=100,
-        suggested_display_precision=2,
-        entity_type=EntityType.STANDARD,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        unit=UnitOfEnergy.KILO_WATT_HOUR,
-        translation_key="energy",
-        fallback_name="Energy",
-    )
-    .sensor(
-        attribute_name="current",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
-        divisor=100,
-        suggested_display_precision=2,
-        entity_type=EntityType.STANDARD,
-        device_class=SensorDeviceClass.CURRENT,
-        state_class=SensorStateClass.MEASUREMENT,
-        unit=UnitOfElectricCurrent.AMPERE,
-        translation_key="current",
-        fallback_name="Current",
-    )
-    .sensor(
-        attribute_name="power",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
-        divisor=10,
-        suggested_display_precision=1,
-        entity_type=EntityType.STANDARD,
-        device_class=SensorDeviceClass.POWER,
-        state_class=SensorStateClass.MEASUREMENT,
-        unit=UnitOfPower.WATT,
-        translation_key="power",
-        fallback_name="Power",
-    )
-    .sensor(
-        attribute_name="voltage",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
-        divisor=10,
-        suggested_display_precision=1,
-        entity_type=EntityType.STANDARD,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        unit=UnitOfElectricPotential.VOLT,
-        translation_key="voltage",
-        fallback_name="Voltage",
-    )
-    .enum(
-        attribute_name="fault",
-        enum_class=RCBO2FaultCode,
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
-        entity_platform=EntityPlatform.SENSOR,
-        entity_type=EntityType.STANDARD,
-        translation_key="fault",
-        fallback_name="Fault",
-    )
-    .enum(
-        attribute_name="power_outage_memory",
-        enum_class=RCBO2PowerOutageMemory,
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
-        translation_key="power_outage_memory",
-        fallback_name="Power outage memory",
-    )
-    .switch(
-        attribute_name="child_lock",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
-        translation_key="child_lock",
-        fallback_name="Child lock",
-    )
-    .switch(
-        attribute_name="leakage_test",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
-        entity_type=EntityType.STANDARD,
-        translation_key="leakage_test",
-        fallback_name="Leakage test",
-    )
-    .sensor(
-        attribute_name="temperature",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
-        suggested_display_precision=0,
-        entity_type=EntityType.STANDARD,
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        unit=UnitOfTemperature.CELSIUS,
-        translation_key="temperature",
-        fallback_name="Temperature",
-    )
-    .sensor(
+    .tuya_sensor(
+        dp_id=53,
         attribute_name="leakage",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
-        suggested_display_precision=0,
+        type=t.uint32_t,
         entity_type=EntityType.STANDARD,
         state_class=SensorStateClass.MEASUREMENT,
         unit=UnitOfElectricCurrent.MILLIAMPERE,
@@ -1020,13 +1016,13 @@ class TuyaRCBO2ManufCluster(TuyaMCUCluster):
     )
     .switch(
         attribute_name="leakage_breaker",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        cluster_id=TUYA_CLUSTER_ID,
         translation_key="leakage_breaker",
         fallback_name="Leakage breaker",
     )
     .number(
         attribute_name="leakage_threshold",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        cluster_id=TUYA_CLUSTER_ID,
         min_value=10,
         max_value=99,
         step=1,
@@ -1036,13 +1032,13 @@ class TuyaRCBO2ManufCluster(TuyaMCUCluster):
     )
     .switch(
         attribute_name="high_temperature_breaker",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        cluster_id=TUYA_CLUSTER_ID,
         translation_key="high_temperature_breaker",
         fallback_name="High temperature breaker",
     )
     .number(
         attribute_name="high_temperature_threshold",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        cluster_id=TUYA_CLUSTER_ID,
         min_value=40,
         max_value=150,
         step=1,
@@ -1052,13 +1048,13 @@ class TuyaRCBO2ManufCluster(TuyaMCUCluster):
     )
     .switch(
         attribute_name="high_power_breaker",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        cluster_id=TUYA_CLUSTER_ID,
         translation_key="high_power_breaker",
         fallback_name="High power breaker",
     )
     .number(
         attribute_name="high_power_threshold",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        cluster_id=TUYA_CLUSTER_ID,
         min_value=1,
         max_value=26,
         step=1,
@@ -1068,13 +1064,13 @@ class TuyaRCBO2ManufCluster(TuyaMCUCluster):
     )
     .switch(
         attribute_name="over_current_breaker",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        cluster_id=TUYA_CLUSTER_ID,
         translation_key="over_current_breaker",
         fallback_name="Over current breaker",
     )
     .number(
         attribute_name="over_current_threshold",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        cluster_id=TUYA_CLUSTER_ID,
         min_value=1,
         max_value=63,
         step=1,
@@ -1084,13 +1080,13 @@ class TuyaRCBO2ManufCluster(TuyaMCUCluster):
     )
     .switch(
         attribute_name="over_voltage_breaker",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        cluster_id=TUYA_CLUSTER_ID,
         translation_key="over_voltage_breaker",
         fallback_name="Over voltage breaker",
     )
     .number(
         attribute_name="over_voltage_threshold",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        cluster_id=TUYA_CLUSTER_ID,
         min_value=110,
         max_value=300,
         step=1,
@@ -1100,13 +1096,13 @@ class TuyaRCBO2ManufCluster(TuyaMCUCluster):
     )
     .switch(
         attribute_name="under_voltage_breaker",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        cluster_id=TUYA_CLUSTER_ID,
         translation_key="under_voltage_breaker",
         fallback_name="Under voltage breaker",
     )
     .number(
         attribute_name="under_voltage_threshold",
-        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        cluster_id=TUYA_CLUSTER_ID,
         min_value=85,
         max_value=220,
         step=1,

--- a/zhaquirks/tuya/ts0601_rcbo.py
+++ b/zhaquirks/tuya/ts0601_rcbo.py
@@ -692,21 +692,39 @@ class TuyaRCBO2ManufCluster(TuyaMCUCluster):
     class AttributeDefs(TuyaMCUCluster.AttributeDefs):
         """Attribute definitions."""
 
-        state: Final = ZCLAttributeDef(id=0xEF01, type=t.Bool, is_manufacturer_specific=True)
-        energy: Final = ZCLAttributeDef(id=0xEF02, type=t.uint32_t, is_manufacturer_specific=True)
-        current: Final = ZCLAttributeDef(id=0xEF03, type=t.uint32_t, is_manufacturer_specific=True)
-        power: Final = ZCLAttributeDef(id=0xEF04, type=t.uint32_t, is_manufacturer_specific=True)
-        voltage: Final = ZCLAttributeDef(id=0xEF05, type=t.uint32_t, is_manufacturer_specific=True)
+        state: Final = ZCLAttributeDef(
+            id=0xEF01, type=t.Bool, is_manufacturer_specific=True
+        )
+        energy: Final = ZCLAttributeDef(
+            id=0xEF02, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        current: Final = ZCLAttributeDef(
+            id=0xEF03, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        power: Final = ZCLAttributeDef(
+            id=0xEF04, type=t.uint32_t, is_manufacturer_specific=True
+        )
+        voltage: Final = ZCLAttributeDef(
+            id=0xEF05, type=t.uint32_t, is_manufacturer_specific=True
+        )
         fault: Final = ZCLAttributeDef(
             id=0xEF06, type=RCBO2FaultCode, is_manufacturer_specific=True
         )
         power_outage_memory: Final = ZCLAttributeDef(
             id=0xEF07, type=RCBO2PowerOutageMemory, is_manufacturer_specific=True
         )
-        child_lock: Final = ZCLAttributeDef(id=0xEF08, type=t.Bool, is_manufacturer_specific=True)
-        leakage_test: Final = ZCLAttributeDef(id=0xEF09, type=t.Bool, is_manufacturer_specific=True)
-        temperature: Final = ZCLAttributeDef(id=0xEF0A, type=t.int16s, is_manufacturer_specific=True)
-        leakage: Final = ZCLAttributeDef(id=0xEF0B, type=t.uint32_t, is_manufacturer_specific=True)
+        child_lock: Final = ZCLAttributeDef(
+            id=0xEF08, type=t.Bool, is_manufacturer_specific=True
+        )
+        leakage_test: Final = ZCLAttributeDef(
+            id=0xEF09, type=t.Bool, is_manufacturer_specific=True
+        )
+        temperature: Final = ZCLAttributeDef(
+            id=0xEF0A, type=t.int16s, is_manufacturer_specific=True
+        )
+        leakage: Final = ZCLAttributeDef(
+            id=0xEF0B, type=t.uint32_t, is_manufacturer_specific=True
+        )
         alarm1_reserved_0: Final = ZCLAttributeDef(
             id=0xEF10, type=t.uint8_t, is_manufacturer_specific=True
         )

--- a/zhaquirks/tuya/ts0601_rcbo.py
+++ b/zhaquirks/tuya/ts0601_rcbo.py
@@ -4,6 +4,19 @@ from typing import Any, Final, Optional, Union
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.quirks.v2 import (
+    EntityPlatform,
+    EntityType,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from zigpy.quirks.v2.homeassistant import (
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+)
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import (
@@ -27,6 +40,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import TUYA_MCU_COMMAND, AttributeWithMask, PowerOnState
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zhaquirks.tuya.mcu import (
     DPToAttributeMapping,
     TuyaAttributesCluster,
@@ -556,3 +570,533 @@ class TuyaCircuitBreaker(CustomDevice):
             }
         }
     }
+
+
+class RCBO2FaultCode(t.enum16):
+    """Fault code enum for `_TZE284_5m4nchbm`."""
+
+    clear = 0x0000
+    short_circuit_alarm = 0x0001
+    surge_alarm = 0x0002
+    overload_alarm = 0x0004
+    overvoltage_alarm = 0x0008
+    undervoltage_alarm = 0x0010
+    temp_dif_fault = 0x0020
+    self_test_alarm = 0x0040
+    fire_alarm = 0x0080
+    leakagecurr_alarm = 0x0100
+    high_power_alarm = 0x0200
+    overcurrent_alarm = 0x0400
+    outage_alarm = 0x0800
+    magnetism_alarm = 0x1000
+    credit_alarm = 0x2000
+
+
+class RCBO2PowerOutageMemory(t.enum8):
+    """Power restore behavior for `_TZE284_5m4nchbm`."""
+
+    off = 0x00
+    on = 0x01
+    restore = 0x02
+
+
+class RCBO2Alarm1Payload(t.Struct):
+    """Raw payload for datapoint 48."""
+
+    reserved_0: t.uint8_t
+    leakage_breaker: t.Bool
+    leakage_threshold: t.uint16_t_be
+    reserved_4: t.uint8_t
+    high_temperature_breaker: t.Bool
+    high_temperature_threshold: t.uint16_t_be
+    reserved_8: t.uint8_t
+    high_power_breaker: t.Bool
+    high_power_threshold: t.uint16_t_be
+
+
+class RCBO2Alarm2Payload(t.Struct):
+    """Raw payload for datapoint 49."""
+
+    reserved_0: t.uint8_t
+    over_current_breaker: t.Bool
+    over_current_threshold: t.uint16_t_be
+    reserved_4: t.uint8_t
+    over_voltage_breaker: t.Bool
+    over_voltage_threshold: t.uint16_t_be
+    reserved_8: t.uint8_t
+    under_voltage_breaker: t.Bool
+    under_voltage_threshold: t.uint16_t_be
+
+
+def _int_or_default(value: object, default: int = 0) -> int:
+    """Return an int while tolerating unset cached attributes."""
+
+    return default if value is None else int(value)
+
+
+def _rcbo2_alarm1_dp_converter(
+    alarm1_reserved_0: object,
+    leakage_breaker: object,
+    leakage_threshold: object,
+    alarm1_reserved_4: object,
+    high_temperature_breaker: object,
+    high_temperature_threshold: object,
+    alarm1_reserved_8: object,
+    high_power_breaker: object,
+    high_power_threshold: object,
+) -> RCBO2Alarm1Payload:
+    """Preserve the full raw DP48 payload when only one field changes."""
+
+    return RCBO2Alarm1Payload(
+        _int_or_default(alarm1_reserved_0),
+        leakage_breaker is True,
+        _int_or_default(leakage_threshold),
+        _int_or_default(alarm1_reserved_4),
+        high_temperature_breaker is True,
+        _int_or_default(high_temperature_threshold),
+        _int_or_default(alarm1_reserved_8),
+        high_power_breaker is True,
+        _int_or_default(high_power_threshold),
+    )
+
+
+def _rcbo2_alarm2_dp_converter(
+    alarm2_reserved_0: object,
+    over_current_breaker: object,
+    over_current_threshold: object,
+    alarm2_reserved_4: object,
+    over_voltage_breaker: object,
+    over_voltage_threshold: object,
+    alarm2_reserved_8: object,
+    under_voltage_breaker: object,
+    under_voltage_threshold: object,
+) -> RCBO2Alarm2Payload:
+    """Preserve the full raw DP49 payload when only one field changes."""
+
+    return RCBO2Alarm2Payload(
+        _int_or_default(alarm2_reserved_0),
+        over_current_breaker is True,
+        _int_or_default(over_current_threshold),
+        _int_or_default(alarm2_reserved_4),
+        over_voltage_breaker is True,
+        _int_or_default(over_voltage_threshold),
+        _int_or_default(alarm2_reserved_8),
+        under_voltage_breaker is True,
+        _int_or_default(under_voltage_threshold),
+    )
+
+
+class TuyaRCBO2ManufCluster(TuyaMCUCluster):
+    """Manufacturer cluster for `_TZE284_5m4nchbm`."""
+
+    class AttributeDefs(TuyaMCUCluster.AttributeDefs):
+        """Attribute definitions."""
+
+        state: Final = ZCLAttributeDef(id=0xEF01, type=t.Bool, is_manufacturer_specific=True)
+        energy: Final = ZCLAttributeDef(id=0xEF02, type=t.uint32_t, is_manufacturer_specific=True)
+        current: Final = ZCLAttributeDef(id=0xEF03, type=t.uint32_t, is_manufacturer_specific=True)
+        power: Final = ZCLAttributeDef(id=0xEF04, type=t.uint32_t, is_manufacturer_specific=True)
+        voltage: Final = ZCLAttributeDef(id=0xEF05, type=t.uint32_t, is_manufacturer_specific=True)
+        fault: Final = ZCLAttributeDef(
+            id=0xEF06, type=RCBO2FaultCode, is_manufacturer_specific=True
+        )
+        power_outage_memory: Final = ZCLAttributeDef(
+            id=0xEF07, type=RCBO2PowerOutageMemory, is_manufacturer_specific=True
+        )
+        child_lock: Final = ZCLAttributeDef(id=0xEF08, type=t.Bool, is_manufacturer_specific=True)
+        leakage_test: Final = ZCLAttributeDef(id=0xEF09, type=t.Bool, is_manufacturer_specific=True)
+        temperature: Final = ZCLAttributeDef(id=0xEF0A, type=t.int16s, is_manufacturer_specific=True)
+        leakage: Final = ZCLAttributeDef(id=0xEF0B, type=t.uint32_t, is_manufacturer_specific=True)
+        alarm1_reserved_0: Final = ZCLAttributeDef(
+            id=0xEF10, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        leakage_breaker: Final = ZCLAttributeDef(
+            id=0xEF11, type=t.Bool, is_manufacturer_specific=True
+        )
+        leakage_threshold: Final = ZCLAttributeDef(
+            id=0xEF12, type=t.uint16_t, is_manufacturer_specific=True
+        )
+        alarm1_reserved_4: Final = ZCLAttributeDef(
+            id=0xEF13, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        high_temperature_breaker: Final = ZCLAttributeDef(
+            id=0xEF14, type=t.Bool, is_manufacturer_specific=True
+        )
+        high_temperature_threshold: Final = ZCLAttributeDef(
+            id=0xEF15, type=t.uint16_t, is_manufacturer_specific=True
+        )
+        alarm1_reserved_8: Final = ZCLAttributeDef(
+            id=0xEF16, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        high_power_breaker: Final = ZCLAttributeDef(
+            id=0xEF17, type=t.Bool, is_manufacturer_specific=True
+        )
+        high_power_threshold: Final = ZCLAttributeDef(
+            id=0xEF18, type=t.uint16_t, is_manufacturer_specific=True
+        )
+        alarm2_reserved_0: Final = ZCLAttributeDef(
+            id=0xEF19, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        over_current_breaker: Final = ZCLAttributeDef(
+            id=0xEF1A, type=t.Bool, is_manufacturer_specific=True
+        )
+        over_current_threshold: Final = ZCLAttributeDef(
+            id=0xEF1B, type=t.uint16_t, is_manufacturer_specific=True
+        )
+        alarm2_reserved_4: Final = ZCLAttributeDef(
+            id=0xEF1C, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        over_voltage_breaker: Final = ZCLAttributeDef(
+            id=0xEF1D, type=t.Bool, is_manufacturer_specific=True
+        )
+        over_voltage_threshold: Final = ZCLAttributeDef(
+            id=0xEF1E, type=t.uint16_t, is_manufacturer_specific=True
+        )
+        alarm2_reserved_8: Final = ZCLAttributeDef(
+            id=0xEF1F, type=t.uint8_t, is_manufacturer_specific=True
+        )
+        under_voltage_breaker: Final = ZCLAttributeDef(
+            id=0xEF20, type=t.Bool, is_manufacturer_specific=True
+        )
+        under_voltage_threshold: Final = ZCLAttributeDef(
+            id=0xEF21, type=t.uint16_t, is_manufacturer_specific=True
+        )
+
+    dp_to_attribute: dict[int, list[DPToAttributeMapping]] = {
+        1: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "state")],
+        17: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "energy")],
+        18: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "current")],
+        19: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "power")],
+        20: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "voltage")],
+        26: [
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "fault",
+                converter=lambda value: RCBO2FaultCode(value),
+            )
+        ],
+        38: [
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "power_outage_memory",
+                converter=lambda value: RCBO2PowerOutageMemory(value),
+            )
+        ],
+        41: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "child_lock")],
+        45: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "leakage_test")],
+        47: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "temperature")],
+        48: [
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "alarm1_reserved_0",
+                converter=lambda value: value[0],
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "leakage_breaker",
+                converter=lambda value: bool(value[1]),
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "leakage_threshold",
+                converter=lambda value: (value[2] << 8) | value[3],
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "alarm1_reserved_4",
+                converter=lambda value: value[4],
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "high_temperature_breaker",
+                converter=lambda value: bool(value[5]),
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "high_temperature_threshold",
+                converter=lambda value: (value[6] << 8) | value[7],
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "alarm1_reserved_8",
+                converter=lambda value: value[8],
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "high_power_breaker",
+                converter=lambda value: bool(value[9]),
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "high_power_threshold",
+                converter=lambda value: (value[10] << 8) | value[11],
+            ),
+        ],
+        49: [
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "alarm2_reserved_0",
+                converter=lambda value: value[0],
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "over_current_breaker",
+                converter=lambda value: bool(value[1]),
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "over_current_threshold",
+                converter=lambda value: (value[2] << 8) | value[3],
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "alarm2_reserved_4",
+                converter=lambda value: value[4],
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "over_voltage_breaker",
+                converter=lambda value: bool(value[5]),
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "over_voltage_threshold",
+                converter=lambda value: (value[6] << 8) | value[7],
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "alarm2_reserved_8",
+                converter=lambda value: value[8],
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "under_voltage_breaker",
+                converter=lambda value: bool(value[9]),
+            ),
+            DPToAttributeMapping(
+                TuyaMCUCluster.ep_attribute,
+                "under_voltage_threshold",
+                converter=lambda value: (value[10] << 8) | value[11],
+            ),
+        ],
+        53: [DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "leakage")],
+    }
+
+    data_point_handlers = {dp_id: "_dp_2_attr_update" for dp_id in dp_to_attribute}
+
+    attributes_to_dp_converters = {
+        38: lambda value: RCBO2PowerOutageMemory(value),
+        48: _rcbo2_alarm1_dp_converter,
+        49: _rcbo2_alarm2_dp_converter,
+    }
+
+
+(
+    TuyaQuirkBuilder("_TZE284_5m4nchbm", "TS0601")
+    .replaces(TuyaRCBO2ManufCluster)
+    .switch(
+        attribute_name="state",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        entity_type=EntityType.STANDARD,
+        translation_key="state",
+        fallback_name="Switch",
+        primary=True,
+    )
+    .sensor(
+        attribute_name="energy",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        divisor=100,
+        suggested_display_precision=2,
+        entity_type=EntityType.STANDARD,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="energy",
+        fallback_name="Energy",
+    )
+    .sensor(
+        attribute_name="current",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        divisor=100,
+        suggested_display_precision=2,
+        entity_type=EntityType.STANDARD,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricCurrent.AMPERE,
+        translation_key="current",
+        fallback_name="Current",
+    )
+    .sensor(
+        attribute_name="power",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        divisor=10,
+        suggested_display_precision=1,
+        entity_type=EntityType.STANDARD,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfPower.WATT,
+        translation_key="power",
+        fallback_name="Power",
+    )
+    .sensor(
+        attribute_name="voltage",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        divisor=10,
+        suggested_display_precision=1,
+        entity_type=EntityType.STANDARD,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricPotential.VOLT,
+        translation_key="voltage",
+        fallback_name="Voltage",
+    )
+    .enum(
+        attribute_name="fault",
+        enum_class=RCBO2FaultCode,
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.STANDARD,
+        translation_key="fault",
+        fallback_name="Fault",
+    )
+    .enum(
+        attribute_name="power_outage_memory",
+        enum_class=RCBO2PowerOutageMemory,
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        translation_key="power_outage_memory",
+        fallback_name="Power outage memory",
+    )
+    .switch(
+        attribute_name="child_lock",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    .switch(
+        attribute_name="leakage_test",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        entity_type=EntityType.STANDARD,
+        translation_key="leakage_test",
+        fallback_name="Leakage test",
+    )
+    .sensor(
+        attribute_name="temperature",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        suggested_display_precision=0,
+        entity_type=EntityType.STANDARD,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfTemperature.CELSIUS,
+        translation_key="temperature",
+        fallback_name="Temperature",
+    )
+    .sensor(
+        attribute_name="leakage",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        suggested_display_precision=0,
+        entity_type=EntityType.STANDARD,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricCurrent.MILLIAMPERE,
+        translation_key="leakage",
+        fallback_name="Leakage current",
+    )
+    .switch(
+        attribute_name="leakage_breaker",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        translation_key="leakage_breaker",
+        fallback_name="Leakage breaker",
+    )
+    .number(
+        attribute_name="leakage_threshold",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        min_value=10,
+        max_value=99,
+        step=1,
+        unit=UnitOfElectricCurrent.MILLIAMPERE,
+        translation_key="leakage_threshold",
+        fallback_name="Leakage threshold",
+    )
+    .switch(
+        attribute_name="high_temperature_breaker",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        translation_key="high_temperature_breaker",
+        fallback_name="High temperature breaker",
+    )
+    .number(
+        attribute_name="high_temperature_threshold",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        min_value=40,
+        max_value=150,
+        step=1,
+        unit=UnitOfTemperature.CELSIUS,
+        translation_key="high_temperature_threshold",
+        fallback_name="High temperature threshold",
+    )
+    .switch(
+        attribute_name="high_power_breaker",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        translation_key="high_power_breaker",
+        fallback_name="High power breaker",
+    )
+    .number(
+        attribute_name="high_power_threshold",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        min_value=1,
+        max_value=26,
+        step=1,
+        unit=UnitOfPower.KILO_WATT,
+        translation_key="high_power_threshold",
+        fallback_name="High power threshold",
+    )
+    .switch(
+        attribute_name="over_current_breaker",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        translation_key="over_current_breaker",
+        fallback_name="Over current breaker",
+    )
+    .number(
+        attribute_name="over_current_threshold",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        min_value=1,
+        max_value=63,
+        step=1,
+        unit=UnitOfElectricCurrent.AMPERE,
+        translation_key="over_current_threshold",
+        fallback_name="Over current threshold",
+    )
+    .switch(
+        attribute_name="over_voltage_breaker",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        translation_key="over_voltage_breaker",
+        fallback_name="Over voltage breaker",
+    )
+    .number(
+        attribute_name="over_voltage_threshold",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        min_value=110,
+        max_value=300,
+        step=1,
+        unit=UnitOfElectricPotential.VOLT,
+        translation_key="over_voltage_threshold",
+        fallback_name="Over voltage threshold",
+    )
+    .switch(
+        attribute_name="under_voltage_breaker",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        translation_key="under_voltage_breaker",
+        fallback_name="Under voltage breaker",
+    )
+    .number(
+        attribute_name="under_voltage_threshold",
+        cluster_id=TuyaRCBO2ManufCluster.cluster_id,
+        min_value=85,
+        max_value=220,
+        step=1,
+        unit=UnitOfElectricPotential.VOLT,
+        translation_key="under_voltage_threshold",
+        fallback_name="Under voltage threshold",
+    )
+    .tuya_enchantment(data_query_spell=True)
+    .skip_configuration()
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0601_rcbo.py
+++ b/zhaquirks/tuya/ts0601_rcbo.py
@@ -631,7 +631,7 @@ class RCBO2Alarm2Payload(t.Struct):
 def _int_or_default(value: object, default: int = 0) -> int:
     """Return an int while tolerating unset cached attributes."""
 
-    return default if value is None else int(value)
+    return int(value) if isinstance(value, int) else default
 
 
 def _rcbo2_alarm1_dp_converter(


### PR DESCRIPTION
## Proposed change

Add support for the Tuya RCBO variant `_TZE284_5m4nchbm` / `TS0601`.

This PR adds a new v2 quirk entry in `zhaquirks/tuya/ts0601_rcbo.py` that maps the datapoints from a working Zigbee2MQTT converter, including the composite raw datapoints `48` and `49` used for the alarm/breaker threshold payloads. The implementation preserves the reserved bytes in those payloads when writing updated thresholds back to the device.

The PR also adds tests to verify:
- datapoint report parsing for the new variant
- serialized write payloads for normal enum writes and composite raw writes
- no regressions in quirks v2 registration

## Additional information

This is additive only and should not be a breaking change.

The device diagnostics used for this work show the unsupported device before this quirk is applied:
- manufacturer: `_TZE284_5m4nchbm`
- model: `TS0601`
- power source: `Mains`
- device type: `Router`
- `quirk_applied: false`

Validation run locally:
- `uv run pytest tests/test_tuya_rcbo.py -q`
- `uv run pytest tests/test_quirks_v2.py -q`
- `uv run pre-commit run --all-files`

## Device diagnostics

[zha-01KKZ1NW5GS19MYYHNAPKR43FC-_TZE284_5m4nchbm TS0601-bb977f4b1014ef6e4cf4f7a3f15e139a.json](https://github.com/user-attachments/files/26101362/zha-01KKZ1NW5GS19MYYHNAPKR43FC-_TZE284_5m4nchbm.TS0601-bb977f4b1014ef6e4cf4f7a3f15e139a.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
