### PR TITLE
Add Yandex YNDX-00531 and YNDX-00532 wired switches

### DIFF
--- a/zhaquirks/yandex/__init__.py
+++ b/zhaquirks/yandex/__init__.py
@@ -1,5 +1,36 @@
 """Common code for Yandex devices."""
 
+import zigpy.types as t
+
 ### CONSTANTS ###
 
+
 YANDEX = "Yandex"
+YANDEX_MANUFACTURER_CODE_1 = 0x140A
+
+
+### TYPES ###
+
+
+class YandexType_SwitchMode(t.enum8):
+    """Wired switches: gang mode."""
+
+    Control_Relay = 0x00
+    Up_Decoupled = 0x01
+    Decoupled = 0x02
+    Down_Decoupled = 0x03
+
+
+class YandexType_PowerType(t.enum8):
+    """Wired devices: power level."""
+
+    High = 0x00
+    Medium = 0x01
+    Low = 0x02
+
+
+class YandexType_LedIndicator(t.basic.enum8):
+    """Enable/disable LED indicator."""
+
+    Enabled = 0
+    Disabled = 1

--- a/zhaquirks/yandex/__init__.py
+++ b/zhaquirks/yandex/__init__.py
@@ -1,0 +1,5 @@
+"""Common code for Yandex devices."""
+
+### CONSTANTS ###
+
+YANDEX = "Yandex"

--- a/zhaquirks/yandex/yandex_wired_switches.py
+++ b/zhaquirks/yandex/yandex_wired_switches.py
@@ -1,0 +1,343 @@
+"""Support for YNDX-00531 and YNDX-00532 one-gang and two-gang wired switches."""
+
+from typing import Final
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import Basic, Identify, OnOff, Ota
+from zigpy.zcl.foundation import (
+    BaseAttributeDefs,
+    BaseCommandDefs,
+    Direction,
+    ZCLAttributeDef,
+    ZCLCommandDef,
+)
+
+from zhaquirks.const import (
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_TOGGLE,
+    DEVICE_TYPE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    LONG_PRESS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+)
+from zhaquirks.yandex import (
+    YANDEX,
+    YANDEX_MANUFACTURER_CODE_1,
+    YandexType_LedIndicator,
+    YandexType_PowerType,
+    YandexType_SwitchMode,
+)
+
+
+class YandexSwitchClusterWired(CustomCluster):
+    """Yandex switch cluster for YNDX-00531, YNDX-00532 wired switches."""
+
+    cluster_id = 0xFC03
+    manufacturer_id_override = YANDEX_MANUFACTURER_CODE_1
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        switch_mode: Final = ZCLAttributeDef(
+            id=0x0001,
+            type=YandexType_SwitchMode,
+            access="rw",
+        )
+        power_type: Final = ZCLAttributeDef(
+            id=0x0003,
+            type=YandexType_PowerType,
+            access="rw",
+        )
+        led_indicator: Final = ZCLAttributeDef(
+            id=0x0005,
+            type=YandexType_LedIndicator,
+            access="rw",
+        )
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Server command definitions."""
+
+        switch_mode: Final = ZCLCommandDef(
+            id=0x01,
+            schema={"value": YandexType_SwitchMode},
+            direction=Direction.Client_to_Server,
+            is_manufacturer_specific=True,
+        )
+        power_type: Final = ZCLCommandDef(
+            id=0x03,
+            schema={"value": YandexType_PowerType},
+            direction=Direction.Client_to_Server,
+            is_manufacturer_specific=True,
+        )
+
+
+class YandexOneGangWiredSwitch(CustomDevice):
+    """YNDX-00531 one-gang wired switch."""
+
+    signature = {
+        MODELS_INFO: [(YANDEX, "YNDX-00531")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=256
+            # device_version=0
+            # input_clusters=[0, 3, 6, 64515]
+            # output_clusters=[25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YandexSwitchClusterWired.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YandexSwitchClusterWired,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            # Down
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            },
+            # Up
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            },
+        }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, "Button (Down)"): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 2,
+        },
+        (DOUBLE_PRESS, "Button (Down)"): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 2,
+        },
+        (LONG_PRESS, "Button (Down)"): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 2,
+        },
+        (SHORT_PRESS, "Button (Up)"): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 3,
+        },
+        (DOUBLE_PRESS, "Button (Up)"): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 3,
+        },
+        (LONG_PRESS, "Button (Up)"): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 3,
+        },
+    }
+
+
+class YandexTwoGangWiredSwitch(CustomDevice):
+    """YNDX-00532 two-gang wired switch."""
+
+    signature = {
+        MODELS_INFO: [(YANDEX, "YNDX-00532")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=256
+            # device_version=0
+            # input_clusters=[0, 3, 6, 64515]
+            # output_clusters=[25]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YandexSwitchClusterWired.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=256
+            # device_version=0
+            # input_clusters=[0, 3, 6, 64515]
+            # output_clusters=[]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YandexSwitchClusterWired.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YandexSwitchClusterWired,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    YandexSwitchClusterWired,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+            # Button 1 Down
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            },
+            # Button 2 Down
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            },
+            # Button 1 Up
+            5: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            },
+            # Button 2 Up
+            6: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            },
+        }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, "Button 1 (Down)"): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 3,
+        },
+        (DOUBLE_PRESS, "Button 1 (Down)"): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 3,
+        },
+        (LONG_PRESS, "Button 1 (Down)"): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 3,
+        },
+        (SHORT_PRESS, "Button 2 (Down)"): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 4,
+        },
+        (DOUBLE_PRESS, "Button 2 (Down)"): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 4,
+        },
+        (LONG_PRESS, "Button 2 (Down)"): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 4,
+        },
+        (SHORT_PRESS, "Button 1 (Up)"): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 5,
+        },
+        (DOUBLE_PRESS, "Button 1 (Up)"): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 5,
+        },
+        (LONG_PRESS, "Button 1 (Up)"): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 5,
+        },
+        (SHORT_PRESS, "Button 2 (Up)"): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 6,
+        },
+        (DOUBLE_PRESS, "Button 2 (Up)"): {
+            COMMAND: COMMAND_ON,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 6,
+        },
+        (LONG_PRESS, "Button 2 (Up)"): {
+            COMMAND: COMMAND_OFF,
+            CLUSTER_ID: OnOff.cluster_id,
+            ENDPOINT_ID: 6,
+        },
+    }

--- a/zhaquirks/yandex/yandex_wired_switches.py
+++ b/zhaquirks/yandex/yandex_wired_switches.py
@@ -163,20 +163,20 @@ class YandexSwitchClusterWired(CustomCluster):
         enum_class=YandexType_PowerType,
         cluster_id=YandexSwitchClusterWired.cluster_id,
         translation_key="power_type",
-        fallback_name="Power Type",
+        fallback_name="Power type",
     )
     .enum(
         attribute_name=YandexSwitchClusterWired.AttributeDefs.switch_mode.name,
         enum_class=YandexType_SwitchMode,
         cluster_id=YandexSwitchClusterWired.cluster_id,
         translation_key="switch_mode",
-        fallback_name="Switch Mode",
+        fallback_name="Switch mode",
     )
     .switch(
         attribute_name=YandexSwitchClusterWired.AttributeDefs.led_indicator.name,
         cluster_id=YandexSwitchClusterWired.cluster_id,
         translation_key="led_indicator",
-        fallback_name="LED Indicator",
+        fallback_name="LED indicator",
         off_value=YandexType_LedIndicator.Disabled,
         on_value=YandexType_LedIndicator.Enabled,
     )
@@ -292,7 +292,7 @@ class YandexSwitchClusterWired(CustomCluster):
         enum_class=YandexType_PowerType,
         cluster_id=YandexSwitchClusterWired.cluster_id,
         translation_key="power_type",
-        fallback_name="Power Type",
+        fallback_name="Power type",
     )
     .enum(
         attribute_name=YandexSwitchClusterWired.AttributeDefs.switch_mode.name,
@@ -300,7 +300,7 @@ class YandexSwitchClusterWired(CustomCluster):
         cluster_id=YandexSwitchClusterWired.cluster_id,
         endpoint_id=1,
         translation_key="switch_mode",
-        fallback_name="Switch Mode",
+        fallback_name="Switch mode",
     )
     .enum(
         attribute_name=YandexSwitchClusterWired.AttributeDefs.switch_mode.name,
@@ -308,13 +308,13 @@ class YandexSwitchClusterWired(CustomCluster):
         cluster_id=YandexSwitchClusterWired.cluster_id,
         endpoint_id=2,
         translation_key="switch_mode",
-        fallback_name="Switch Mode",
+        fallback_name="Switch mode",
     )
     .switch(
         attribute_name=YandexSwitchClusterWired.AttributeDefs.led_indicator.name,
         cluster_id=YandexSwitchClusterWired.cluster_id,
         translation_key="led_indicator",
-        fallback_name="LED Indicator",
+        fallback_name="LED indicator",
         off_value=YandexType_LedIndicator.Disabled,
         on_value=YandexType_LedIndicator.Enabled,
     )

--- a/zhaquirks/yandex/yandex_wired_switches.py
+++ b/zhaquirks/yandex/yandex_wired_switches.py
@@ -1,10 +1,12 @@
 """Support for YNDX-00531 and YNDX-00532 one-gang and two-gang wired switches."""
 
-from typing import Final
+from typing import Any, Final
 
 from zigpy.profiles import zha
-from zigpy.quirks import CustomCluster, CustomDevice
-from zigpy.zcl.clusters.general import Basic, Identify, OnOff, Ota
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl import ClusterType
+from zigpy.zcl.clusters.general import Basic, Identify, OnOff
 from zigpy.zcl.foundation import (
     BaseAttributeDefs,
     BaseCommandDefs,
@@ -19,15 +21,9 @@ from zhaquirks.const import (
     COMMAND_OFF,
     COMMAND_ON,
     COMMAND_TOGGLE,
-    DEVICE_TYPE,
     DOUBLE_PRESS,
     ENDPOINT_ID,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
     LONG_PRESS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
     SHORT_PRESS,
 )
 from zhaquirks.yandex import (
@@ -80,264 +76,247 @@ class YandexSwitchClusterWired(CustomCluster):
             is_manufacturer_specific=True,
         )
 
+    async def write_attributes(
+        self, attributes: dict[str | int, Any], manufacturer: int | None = None
+    ) -> list:
+        """Write attributes using commands because manufacturer-specific attribute writing is unsupported by Yandex devices."""
 
-class YandexOneGangWiredSwitch(CustomDevice):
-    """YNDX-00531 one-gang wired switch."""
+        result = []
+        remaining_attributes = attributes.copy()
 
-    signature = {
-        MODELS_INFO: [(YANDEX, "YNDX-00531")],
-        ENDPOINTS: {
-            # <SimpleDescriptor endpoint=1 profile=260 device_type=256
-            # device_version=0
-            # input_clusters=[0, 3, 6, 64515]
-            # output_clusters=[25]>
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    YandexSwitchClusterWired.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            }
-        },
-    }
+        if "switch_mode" in attributes:
+            remaining_attributes.pop("switch_mode")
+            result += await self.command(0x01, attributes.get("switch_mode"))
+        if 0x0001 in attributes:
+            remaining_attributes.pop(0x0001)
+            result += await self.command(0x01, attributes.get(0x0001))
+        if "power_type" in attributes:
+            remaining_attributes.pop("power_type")
+            result += await self.command(0x03, attributes.get("power_type"))
+        if 0x0003 in attributes:
+            remaining_attributes.pop(0x0003)
+            result += await self.command(0x03, attributes.get(0x0003))
 
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    YandexSwitchClusterWired,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
+        if remaining_attributes:
+            result += await super().write_attributes(remaining_attributes, manufacturer)
+
+        return result
+
+
+(
+    QuirkBuilder(YANDEX, "YNDX-00531")
+    .replaces(YandexSwitchClusterWired, endpoint_id=1)
+    .adds_endpoint(
+        endpoint_id=2,
+        profile_id=zha.PROFILE_ID,
+        device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+    )
+    .adds(Basic, endpoint_id=2, cluster_type=ClusterType.Server)
+    .adds(Identify, endpoint_id=2, cluster_type=ClusterType.Server)
+    .adds(Identify, endpoint_id=2, cluster_type=ClusterType.Client)
+    .adds(OnOff, endpoint_id=2, cluster_type=ClusterType.Client)
+    .adds_endpoint(
+        endpoint_id=3,
+        profile_id=zha.PROFILE_ID,
+        device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+    )
+    .adds(Basic, endpoint_id=3, cluster_type=ClusterType.Server)
+    .adds(Identify, endpoint_id=3, cluster_type=ClusterType.Server)
+    .adds(Identify, endpoint_id=3, cluster_type=ClusterType.Client)
+    .adds(OnOff, endpoint_id=3, cluster_type=ClusterType.Client)
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, "Button (Down)"): {
+                COMMAND: COMMAND_TOGGLE,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 2,
             },
-            # Down
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            (DOUBLE_PRESS, "Button (Down)"): {
+                COMMAND: COMMAND_ON,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 2,
             },
-            # Up
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            (LONG_PRESS, "Button (Down)"): {
+                COMMAND: COMMAND_OFF,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 2,
+            },
+            (SHORT_PRESS, "Button (Up)"): {
+                COMMAND: COMMAND_TOGGLE,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 3,
+            },
+            (DOUBLE_PRESS, "Button (Up)"): {
+                COMMAND: COMMAND_ON,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 3,
+            },
+            (LONG_PRESS, "Button (Up)"): {
+                COMMAND: COMMAND_OFF,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 3,
             },
         }
-    }
+    )
+    .enum(
+        attribute_name=YandexSwitchClusterWired.AttributeDefs.power_type.name,
+        enum_class=YandexType_PowerType,
+        cluster_id=YandexSwitchClusterWired.cluster_id,
+        translation_key="power_type",
+        fallback_name="Power Type",
+    )
+    .enum(
+        attribute_name=YandexSwitchClusterWired.AttributeDefs.switch_mode.name,
+        enum_class=YandexType_SwitchMode,
+        cluster_id=YandexSwitchClusterWired.cluster_id,
+        translation_key="switch_mode",
+        fallback_name="Switch Mode",
+    )
+    .switch(
+        attribute_name=YandexSwitchClusterWired.AttributeDefs.led_indicator.name,
+        cluster_id=YandexSwitchClusterWired.cluster_id,
+        translation_key="led_indicator",
+        fallback_name="LED Indicator",
+        off_value=YandexType_LedIndicator.Disabled,
+        on_value=YandexType_LedIndicator.Enabled,
+    )
+    .add_to_registry()
+)
 
-    device_automation_triggers = {
-        (SHORT_PRESS, "Button (Down)"): {
-            COMMAND: COMMAND_TOGGLE,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 2,
-        },
-        (DOUBLE_PRESS, "Button (Down)"): {
-            COMMAND: COMMAND_ON,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 2,
-        },
-        (LONG_PRESS, "Button (Down)"): {
-            COMMAND: COMMAND_OFF,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 2,
-        },
-        (SHORT_PRESS, "Button (Up)"): {
-            COMMAND: COMMAND_TOGGLE,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 3,
-        },
-        (DOUBLE_PRESS, "Button (Up)"): {
-            COMMAND: COMMAND_ON,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 3,
-        },
-        (LONG_PRESS, "Button (Up)"): {
-            COMMAND: COMMAND_OFF,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 3,
-        },
-    }
-
-
-class YandexTwoGangWiredSwitch(CustomDevice):
-    """YNDX-00532 two-gang wired switch."""
-
-    signature = {
-        MODELS_INFO: [(YANDEX, "YNDX-00532")],
-        ENDPOINTS: {
-            # <SimpleDescriptor endpoint=1 profile=260 device_type=256
-            # device_version=0
-            # input_clusters=[0, 3, 6, 64515]
-            # output_clusters=[25]>
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    YandexSwitchClusterWired.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
+(
+    QuirkBuilder(YANDEX, "YNDX-00532")
+    .replaces(YandexSwitchClusterWired, endpoint_id=1)
+    .replaces(YandexSwitchClusterWired, endpoint_id=2)
+    .adds_endpoint(
+        endpoint_id=3,
+        profile_id=zha.PROFILE_ID,
+        device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+    )
+    .adds(Basic, endpoint_id=3, cluster_type=ClusterType.Server)
+    .adds(Identify, endpoint_id=3, cluster_type=ClusterType.Server)
+    .adds(Identify, endpoint_id=3, cluster_type=ClusterType.Client)
+    .adds(OnOff, endpoint_id=3, cluster_type=ClusterType.Client)
+    .adds_endpoint(
+        endpoint_id=4,
+        profile_id=zha.PROFILE_ID,
+        device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+    )
+    .adds(Basic, endpoint_id=4, cluster_type=ClusterType.Server)
+    .adds(Identify, endpoint_id=4, cluster_type=ClusterType.Server)
+    .adds(Identify, endpoint_id=4, cluster_type=ClusterType.Client)
+    .adds(OnOff, endpoint_id=4, cluster_type=ClusterType.Client)
+    .adds_endpoint(
+        endpoint_id=5,
+        profile_id=zha.PROFILE_ID,
+        device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+    )
+    .adds(Basic, endpoint_id=5, cluster_type=ClusterType.Server)
+    .adds(Identify, endpoint_id=5, cluster_type=ClusterType.Server)
+    .adds(Identify, endpoint_id=5, cluster_type=ClusterType.Client)
+    .adds(OnOff, endpoint_id=5, cluster_type=ClusterType.Client)
+    .adds_endpoint(
+        endpoint_id=6,
+        profile_id=zha.PROFILE_ID,
+        device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+    )
+    .adds(Basic, endpoint_id=6, cluster_type=ClusterType.Server)
+    .adds(Identify, endpoint_id=6, cluster_type=ClusterType.Server)
+    .adds(Identify, endpoint_id=6, cluster_type=ClusterType.Client)
+    .adds(OnOff, endpoint_id=6, cluster_type=ClusterType.Client)
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, "Button 1 (Down)"): {
+                COMMAND: COMMAND_TOGGLE,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 3,
             },
-            # <SimpleDescriptor endpoint=2 profile=260 device_type=256
-            # device_version=0
-            # input_clusters=[0, 3, 6, 64515]
-            # output_clusters=[]>
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    YandexSwitchClusterWired.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [],
+            (DOUBLE_PRESS, "Button 1 (Down)"): {
+                COMMAND: COMMAND_ON,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 3,
             },
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    YandexSwitchClusterWired,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            (LONG_PRESS, "Button 1 (Down)"): {
+                COMMAND: COMMAND_OFF,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 3,
             },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    YandexSwitchClusterWired,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            (SHORT_PRESS, "Button 2 (Down)"): {
+                COMMAND: COMMAND_TOGGLE,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 4,
             },
-            # Button 1 Down
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            (DOUBLE_PRESS, "Button 2 (Down)"): {
+                COMMAND: COMMAND_ON,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 4,
             },
-            # Button 2 Down
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            (LONG_PRESS, "Button 2 (Down)"): {
+                COMMAND: COMMAND_OFF,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 4,
             },
-            # Button 1 Up
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            (SHORT_PRESS, "Button 1 (Up)"): {
+                COMMAND: COMMAND_TOGGLE,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 5,
             },
-            # Button 2 Up
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
+            (DOUBLE_PRESS, "Button 1 (Up)"): {
+                COMMAND: COMMAND_ON,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 5,
+            },
+            (LONG_PRESS, "Button 1 (Up)"): {
+                COMMAND: COMMAND_OFF,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 5,
+            },
+            (SHORT_PRESS, "Button 2 (Up)"): {
+                COMMAND: COMMAND_TOGGLE,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 6,
+            },
+            (DOUBLE_PRESS, "Button 2 (Up)"): {
+                COMMAND: COMMAND_ON,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 6,
+            },
+            (LONG_PRESS, "Button 2 (Up)"): {
+                COMMAND: COMMAND_OFF,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 6,
             },
         }
-    }
-
-    device_automation_triggers = {
-        (SHORT_PRESS, "Button 1 (Down)"): {
-            COMMAND: COMMAND_TOGGLE,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 3,
-        },
-        (DOUBLE_PRESS, "Button 1 (Down)"): {
-            COMMAND: COMMAND_ON,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 3,
-        },
-        (LONG_PRESS, "Button 1 (Down)"): {
-            COMMAND: COMMAND_OFF,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 3,
-        },
-        (SHORT_PRESS, "Button 2 (Down)"): {
-            COMMAND: COMMAND_TOGGLE,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 4,
-        },
-        (DOUBLE_PRESS, "Button 2 (Down)"): {
-            COMMAND: COMMAND_ON,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 4,
-        },
-        (LONG_PRESS, "Button 2 (Down)"): {
-            COMMAND: COMMAND_OFF,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 4,
-        },
-        (SHORT_PRESS, "Button 1 (Up)"): {
-            COMMAND: COMMAND_TOGGLE,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 5,
-        },
-        (DOUBLE_PRESS, "Button 1 (Up)"): {
-            COMMAND: COMMAND_ON,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 5,
-        },
-        (LONG_PRESS, "Button 1 (Up)"): {
-            COMMAND: COMMAND_OFF,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 5,
-        },
-        (SHORT_PRESS, "Button 2 (Up)"): {
-            COMMAND: COMMAND_TOGGLE,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 6,
-        },
-        (DOUBLE_PRESS, "Button 2 (Up)"): {
-            COMMAND: COMMAND_ON,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 6,
-        },
-        (LONG_PRESS, "Button 2 (Up)"): {
-            COMMAND: COMMAND_OFF,
-            CLUSTER_ID: OnOff.cluster_id,
-            ENDPOINT_ID: 6,
-        },
-    }
+    )
+    .enum(
+        attribute_name=YandexSwitchClusterWired.AttributeDefs.power_type.name,
+        enum_class=YandexType_PowerType,
+        cluster_id=YandexSwitchClusterWired.cluster_id,
+        translation_key="power_type",
+        fallback_name="Power Type",
+    )
+    .enum(
+        attribute_name=YandexSwitchClusterWired.AttributeDefs.switch_mode.name,
+        enum_class=YandexType_SwitchMode,
+        cluster_id=YandexSwitchClusterWired.cluster_id,
+        endpoint_id=1,
+        translation_key="switch_mode",
+        fallback_name="Switch Mode",
+    )
+    .enum(
+        attribute_name=YandexSwitchClusterWired.AttributeDefs.switch_mode.name,
+        enum_class=YandexType_SwitchMode,
+        cluster_id=YandexSwitchClusterWired.cluster_id,
+        endpoint_id=2,
+        translation_key="switch_mode",
+        fallback_name="Switch Mode",
+    )
+    .switch(
+        attribute_name=YandexSwitchClusterWired.AttributeDefs.led_indicator.name,
+        cluster_id=YandexSwitchClusterWired.cluster_id,
+        translation_key="led_indicator",
+        fallback_name="LED Indicator",
+        off_value=YandexType_LedIndicator.Disabled,
+        on_value=YandexType_LedIndicator.Enabled,
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Add support for manufacturer-specific features of the following Yandex devices:

- YNDX-00531 1-Gang Wired Switch
- YNDX-00532 2-Gang Wired Switch

## Additional information

This is a PR to replace #3999. I've tried to convert the v1 quirks I originally wrote to v2 quirks, as well as compartmentalize the code for different device types into different files as @puddly suggested, while trying to use existing quirks as an example.

I have more branches with more devices supported in [Nullcaller/zha-device-handlers](/Nullcaller/zha-device-handlers) ready to go. I decided to start with this particular one because the wired switches are, I would say, most in need of a quirk out of all Yandex devices. All other devices are more or less usable without any quirks, these ones aren't.

I've used code from Koenkk/zigbee-herdsman-converters#8345 as reference for cluster attributes and commands.

Known issues:

- On the device page in Home Assistant, 'Power type' and 'Switch mode' enum selector boxes display 'unknown' instead of one of the correct options ('High', 'Medium', 'Low'), despite the attribute being read correctly if reading it manually with 'Manage Zigbee device' -> 'Clusters: YandexSwitchClusterWired' -> 'Attributes: power_type'/'Attributes: switch_mode' menu. 
- On the device page in Home Assistant, changing 'Power type' and 'Switch mode' enum selector boxes makes an error message appear on the bottom of the page. The error message reads "Failed to perform the action select/select_option. 'uint8_t' object is not iterable", and the selected value is not changed from the incorrect 'unknown' value. The actual attribute, however, does change, which can be verified through the aforementioned 'Manage Zigbee device' menu. The relevant error in the home assistant log reads:
```
Logger: homeassistant.components.websocket_api.http.connection
Source: components/websocket_api/commands.py:279
integration: Home Assistant WebSocket API ([documentation](https://www.home-assistant.io/integrations/websocket_api), [issues](https://github.com/home-assistant/core/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+websocket_api%22))
First occurred: 18:02:29 (14 occurrences)
Last logged: 19:32:31

    [546901910496] Unexpected exception
    [546878184224] Unexpected exception
    [546901954528] Unexpected exception
    [546506522304] Unexpected exception
    [546473083104] Unexpected exception

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 279, in handle_call_service
    response = await hass.services.async_call(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2817, in async_call
    response_data = await coro
                    ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2860, in _execute_service
    return await target(service_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 835, in entity_service_call
    single_response = await _handle_entity_call(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
        hass, entity, func, data, call.context
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 907, in _handle_entity_call
    result = await task
             ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/select/__init__.py", line 188, in async_handle_select_option
    await self.async_select_option(option)
  File "/usr/src/homeassistant/homeassistant/components/zha/helpers.py", line 1383, in handler
    return await func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/zha/select.py", line 66, in async_select_option
    await self.entity_data.entity.async_select_option(option=option)
  File "/usr/local/lib/python3.14/site-packages/zha/application/platforms/select.py", line 282, in async_select_option
    await self._cluster_handler.write_attributes_safe(
        {self._attribute_name: self._enum[option.replace(" ", "_")]}
    )
  File "/usr/local/lib/python3.14/site-packages/zha/zigbee/cluster_handlers/__init__.py", line 654, in write_attributes_safe
    for record in res[0]:
                  ~~~^^^
TypeError: 'uint8_t' object is not iterable
```
- On the device page in Home Assistant, the 'LED indicator' switch state is displayed incorrectly as 'Off' when the 'led_indicator' attribute is set to 'YandexType_LedIndicator.Enabled'.
- On the device page in Home Assistant, changing 'LED indicator' switch state makes an error message appear on the bottom of the page. The error message reads "Failed to perform the action switch/turn_on. Failed to write attribute led_indicator=<YandexType_LedIndicator.Enabled: 0>: <Status.INVALID_DATA_TYPE: 141>", and the switch state is not changed. The actual attribute does not change, as verified through the aforementioned 'Manage Zigbee device' menu. The relevant error in the home assistant log reads:
```
Logger: homeassistant.components.websocket_api.http.connection
Source: components/websocket_api/commands.py:332
integration: Home Assistant WebSocket API ([documentation](https://www.home-assistant.io/integrations/websocket_api), [issues](https://github.com/home-assistant/core/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+websocket_api%22))
First occurred: 18:00:54 (13 occurrences)
Last logged: 19:39:58

    <...>
    [546473083104] Error during service call to switch.turn_on: Failed to write attribute led_indicator=<YandexType_LedIndicator.Enabled: 0>: <Status.INVALID_DATA_TYPE: 141>
```

I've been trying to fix all of the above issues, but nothing I try makes a difference. As far as I can tell, I am doing everything exactly as other quirks do it, but for some reason that doesn't quite work. If you have any ideas as to how these issues could be fixed, please post them. Any help is appreciated.

Also, if this is in any way relevant, the way I've been testing the quirk is by adding

```
zha:
  enable_quirks: true
  custom_quirks_path: /config/zha_quirks/
```

to `configuration.yaml`, condensing the entire `yandex` directory from this PR into one file called `yndx.py` and placing it into the `zha_quirks` directory, which is in turn in the same directory as `configuration.yaml`.

If you know of a better way, please tell me.

## Device diagnostics

[YNDX-00531.json](https://github.com/user-attachments/files/26160146/YNDX-00531.json)
[YNDX-00532.json](https://github.com/user-attachments/files/26160148/YNDX-00532.json)

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
