### PR TITLE
Add Tuya water leak sensor `_TZE284_1di7ujzp`

### DIFF
--- a/tests/test_tuya_water_leak.py
+++ b/tests/test_tuya_water_leak.py
@@ -1,0 +1,95 @@
+"""Test for Tuya water leak sensor."""
+
+import pytest
+
+from tests.common import ClusterListener
+import zhaquirks
+
+zhaquirks.setup()
+
+ZCL_TUYA_WATER_PRESENCE = bytes.fromhex("09 e0 02 01 e9 01 04 00 01 01")
+ZCL_TUYA_WATER_ABSENCE = bytes.fromhex("09 e0 02 01 e9 01 04 00 01 00")
+ZCL_TUYA_WATER_LEAK_TRUE = bytes.fromhex("09 e1 02 01 ea 66 04 00 01 01")
+ZCL_TUYA_WATER_LEAK_FALSE = bytes.fromhex("09 e1 02 01 ea 66 04 00 01 00")
+ZCL_TUYA_BATTERY_37 = bytes.fromhex("09 da 02 01 e5 04 02 00 04 00 00 00 25")
+ZCL_TUYA_BATTERY_100 = bytes.fromhex("09 da 02 01 e5 04 02 00 04 00 00 00 64")
+ZCL_TUYA_ALARM_MODE_0 = bytes.fromhex("09 f0 02 01 f9 65 04 00 01 00")
+ZCL_TUYA_ALARM_MODE_1 = bytes.fromhex("09 f0 02 01 f9 65 04 00 01 01")
+ZCL_TUYA_RINGTONE_0 = bytes.fromhex("09 db 02 01 e6 67 04 00 01 00")
+ZCL_TUYA_RINGTONE_2 = bytes.fromhex("09 db 02 01 e6 67 04 00 01 02")
+
+
+@pytest.mark.parametrize(
+    "frame, expected_value",
+    [
+        (ZCL_TUYA_WATER_PRESENCE, True),
+        (ZCL_TUYA_WATER_ABSENCE, False),
+        (ZCL_TUYA_WATER_LEAK_TRUE, True),
+        (ZCL_TUYA_WATER_LEAK_FALSE, False),
+    ],
+)
+async def test_water_sensors_state_report(
+    zigpy_device_from_v2_quirk, frame, expected_value
+):
+    """Test water presence and leak sensors."""
+
+    dev = zigpy_device_from_v2_quirk("_TZE284_1di7ujzp", "TS0601")
+    tuya_cluster = dev.endpoints[1].tuya_manufacturer
+
+    tuya_listener = ClusterListener(tuya_cluster)
+    hdr, args = tuya_cluster.deserialize(frame)
+    tuya_cluster.handle_message(hdr, args)
+
+    assert len(tuya_listener.attribute_updates) == 1
+    assert tuya_listener.attribute_updates[0][1] == expected_value
+
+
+@pytest.mark.parametrize(
+    "frame, expected_value",
+    [
+        (ZCL_TUYA_ALARM_MODE_0, 0),
+        (ZCL_TUYA_ALARM_MODE_1, 1),
+        (ZCL_TUYA_RINGTONE_0, 0),
+        (ZCL_TUYA_RINGTONE_2, 2),
+    ],
+)
+async def test_sensor_and_enum_state_report(
+    zigpy_device_from_v2_quirk, frame, expected_value
+):
+    """Test battery sensor and enum attributes."""
+
+    dev = zigpy_device_from_v2_quirk("_TZE284_1di7ujzp", "TS0601")
+    tuya_cluster = dev.endpoints[1].tuya_manufacturer
+
+    tuya_listener = ClusterListener(tuya_cluster)
+    hdr, args = tuya_cluster.deserialize(frame)
+    tuya_cluster.handle_message(hdr, args)
+
+    assert len(tuya_listener.attribute_updates) == 1
+    assert tuya_listener.attribute_updates[0][1] == expected_value
+
+
+@pytest.mark.parametrize(
+    "frame, expected_value",
+    [
+        (ZCL_TUYA_BATTERY_37, 37),
+        (ZCL_TUYA_BATTERY_100, 100),
+    ],
+)
+async def test_battery_via_tuya_cluster(
+    zigpy_device_from_v2_quirk, frame, expected_value
+):
+    """Test battery level via Tuya cluster."""
+
+    dev = zigpy_device_from_v2_quirk("_TZE284_1di7ujzp", "TS0601")
+
+    tuya_cluster = dev.endpoints[1].tuya_manufacturer
+    power_cluster = dev.endpoints[1].power
+
+    listener = ClusterListener(power_cluster)
+    hdr, args = tuya_cluster.deserialize(frame)
+    tuya_cluster.handle_message(hdr, args)
+
+    assert len(listener.attribute_updates) == 1
+    # Due to half-percent precision
+    assert listener.attribute_updates[0][1] == expected_value * 2

--- a/tests/test_tuya_water_leak.py
+++ b/tests/test_tuya_water_leak.py
@@ -20,16 +20,16 @@ ZCL_TUYA_RINGTONE_2 = bytes.fromhex("09 db 02 01 e6 67 04 00 01 02")
 
 
 @pytest.mark.parametrize(
-    "frame, expected_value",
+    "frame, expected_attr_id, expected_value",
     [
-        (ZCL_TUYA_WATER_PRESENCE, True),
-        (ZCL_TUYA_WATER_ABSENCE, False),
-        (ZCL_TUYA_WATER_LEAK_TRUE, True),
-        (ZCL_TUYA_WATER_LEAK_FALSE, False),
+        (ZCL_TUYA_WATER_PRESENCE, 0xEF01, True),
+        (ZCL_TUYA_WATER_ABSENCE, 0xEF01, False),
+        (ZCL_TUYA_WATER_LEAK_TRUE, 0xEF66, True),
+        (ZCL_TUYA_WATER_LEAK_FALSE, 0xEF66, False),
     ],
 )
 async def test_water_sensors_state_report(
-    zigpy_device_from_v2_quirk, frame, expected_value
+    zigpy_device_from_v2_quirk, frame, expected_attr_id, expected_value
 ):
     """Test water presence and leak sensors."""
 
@@ -41,22 +41,23 @@ async def test_water_sensors_state_report(
     tuya_cluster.handle_message(hdr, args)
 
     assert len(tuya_listener.attribute_updates) == 1
+    assert tuya_listener.attribute_updates[0][0] == expected_attr_id
     assert tuya_listener.attribute_updates[0][1] == expected_value
 
 
 @pytest.mark.parametrize(
-    "frame, expected_value",
+    "frame, expected_attr_id, expected_value",
     [
-        (ZCL_TUYA_ALARM_MODE_0, 0),
-        (ZCL_TUYA_ALARM_MODE_1, 1),
-        (ZCL_TUYA_RINGTONE_0, 0),
-        (ZCL_TUYA_RINGTONE_2, 2),
+        (ZCL_TUYA_ALARM_MODE_0, 0xEF65, 0),
+        (ZCL_TUYA_ALARM_MODE_1, 0xEF65, 1),
+        (ZCL_TUYA_RINGTONE_0, 0xEF67, 0),
+        (ZCL_TUYA_RINGTONE_2, 0xEF67, 2),
     ],
 )
 async def test_sensor_and_enum_state_report(
-    zigpy_device_from_v2_quirk, frame, expected_value
+    zigpy_device_from_v2_quirk, frame, expected_attr_id, expected_value
 ):
-    """Test battery sensor and enum attributes."""
+    """Test alarm mode and ringtone enum attributes."""
 
     dev = zigpy_device_from_v2_quirk("_TZE284_1di7ujzp", "TS0601")
     tuya_cluster = dev.endpoints[1].tuya_manufacturer
@@ -66,6 +67,7 @@ async def test_sensor_and_enum_state_report(
     tuya_cluster.handle_message(hdr, args)
 
     assert len(tuya_listener.attribute_updates) == 1
+    assert tuya_listener.attribute_updates[0][0] == expected_attr_id
     assert tuya_listener.attribute_updates[0][1] == expected_value
 
 

--- a/zhaquirks/tuya/ts0601_water_leak.py
+++ b/zhaquirks/tuya/ts0601_water_leak.py
@@ -1,0 +1,62 @@
+"""Tuya water leak sensor."""
+
+from zigpy.profiles import zha
+from zigpy.quirks.v2 import EntityType
+from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
+from zigpy.types import enum8
+
+from zhaquirks.const import BatterySize
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+
+class AlarmMode(enum8):
+    """Alarm mode of the sensor, which can be configured by user."""
+
+    WATER_PRESENCE = 0x00
+    WATER_ABSENCE = 0x01
+
+
+class Ringtone(enum8):
+    """Alarm tone of the sensor, which can be configured by user."""
+
+    MUTED = 0x00
+    TONE_1 = 0x01
+    TONE_2 = 0x02
+    TONE_3 = 0x03
+
+
+# <SimpleDescriptor endpoint=1 profile=260 device_type=81
+# device_version=1
+# input_clusters=[4, 5, 61184, 0, 60672]
+# output_clusters=[25, 10]>
+TuyaQuirkBuilder(
+    "_TZE284_1di7ujzp", "TS0601"
+).tuya_binary_sensor(  # Water presence (DP 1)
+    dp_id=1,
+    attribute_name="water_presence",
+    device_class=BinarySensorDeviceClass.MOISTURE,
+    fallback_name="Water presence",
+).tuya_binary_sensor(  # Water leak (DP 102)
+    dp_id=102,
+    attribute_name="water_leak",
+    device_class=BinarySensorDeviceClass.PROBLEM,
+    fallback_name="Water leak",
+).tuya_battery(  # Battery (DP 4)
+    dp_id=4, battery_type=BatterySize.AAA, battery_qty=2
+).tuya_enum(  # Alarm mode (DP 101)
+    dp_id=101,
+    attribute_name="alarm_mode",
+    enum_class=AlarmMode,
+    translation_key="alarm_mode",
+    fallback_name="Alarm mode",
+    entity_type=EntityType.CONFIG,
+).tuya_enum(  # Ringtone (DP 103)
+    dp_id=103,
+    attribute_name="ringtone",
+    enum_class=Ringtone,
+    translation_key="ringtone",
+    fallback_name="Ringtone",
+    entity_type=EntityType.CONFIG,
+).replaces_endpoint(
+    1, device_type=zha.DeviceType.IAS_ZONE
+).skip_configuration().add_to_registry()

--- a/zhaquirks/tuya/ts0601_water_leak.py
+++ b/zhaquirks/tuya/ts0601_water_leak.py
@@ -29,34 +29,40 @@ class Ringtone(enum8):
 # device_version=1
 # input_clusters=[4, 5, 61184, 0, 60672]
 # output_clusters=[25, 10]>
-TuyaQuirkBuilder(
-    "_TZE284_1di7ujzp", "TS0601"
-).tuya_binary_sensor(  # Water presence (DP 1)
-    dp_id=1,
-    attribute_name="water_presence",
-    device_class=BinarySensorDeviceClass.MOISTURE,
-    fallback_name="Water presence",
-).tuya_binary_sensor(  # Water leak (DP 102)
-    dp_id=102,
-    attribute_name="water_leak",
-    device_class=BinarySensorDeviceClass.PROBLEM,
-    fallback_name="Water leak",
-).tuya_battery(  # Battery (DP 4)
-    dp_id=4, battery_type=BatterySize.AAA, battery_qty=2
-).tuya_enum(  # Alarm mode (DP 101)
-    dp_id=101,
-    attribute_name="alarm_mode",
-    enum_class=AlarmMode,
-    translation_key="alarm_mode",
-    fallback_name="Alarm mode",
-    entity_type=EntityType.CONFIG,
-).tuya_enum(  # Ringtone (DP 103)
-    dp_id=103,
-    attribute_name="ringtone",
-    enum_class=Ringtone,
-    translation_key="ringtone",
-    fallback_name="Ringtone",
-    entity_type=EntityType.CONFIG,
-).replaces_endpoint(
-    1, device_type=zha.DeviceType.IAS_ZONE
-).skip_configuration().add_to_registry()
+(
+    TuyaQuirkBuilder("_TZE284_1di7ujzp", "TS0601")
+    .tuya_binary_sensor(  # Water presence (DP 1)
+        dp_id=1,
+        attribute_name="water_presence",
+        device_class=BinarySensorDeviceClass.MOISTURE,
+        fallback_name="Water presence",
+    )
+    .tuya_binary_sensor(  # Water leak (DP 102)
+        dp_id=102,
+        attribute_name="water_leak",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        fallback_name="Water leak",
+    )
+    .tuya_battery(  # Battery (DP 4)
+        dp_id=4, battery_type=BatterySize.AAA, battery_qty=2
+    )
+    .tuya_enum(  # Alarm mode (DP 101)
+        dp_id=101,
+        attribute_name="alarm_mode",
+        enum_class=AlarmMode,
+        translation_key="alarm_mode",
+        fallback_name="Alarm mode",
+        entity_type=EntityType.CONFIG,
+    )
+    .tuya_enum(  # Ringtone (DP 103)
+        dp_id=103,
+        attribute_name="ringtone",
+        enum_class=Ringtone,
+        translation_key="ringtone",
+        fallback_name="Ringtone",
+        entity_type=EntityType.CONFIG,
+    )
+    .replaces_endpoint(1, device_type=zha.DeviceType.IAS_ZONE)
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
Add support for the Tuya water leak sensor `_TZE284_1di7ujzp` / `TS0601` (Nous E13).


## Additional information
Added previously unsupported device and new quirk. I am new to quirks, so not sure if I met all criteria, please let me know if I did something wrong.

Should close https://github.com/zigpy/zha-device-handlers/issues/4823

Also added tests to verify the different datapoint values. Ran locally:
- `uv run pytest tests/test_tuya_water_leak.py -q`
- `uv run pre-commit run --all-files`


## Device diagnostics

[zha-01JR32Z6V61S31ESE3H7JM9ZN5-_TZE284_1di7ujzp TS0601-c0f3253a6c179e9f9f4ac08ebb611adb.json](https://github.com/user-attachments/files/26167461/zha-01JR32Z6V61S31ESE3H7JM9ZN5-_TZE284_1di7ujzp.TS0601-c0f3253a6c179e9f9f4ac08ebb611adb.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
