### PR TITLE
Adjust Frient vibration sensor device class

### DIFF
--- a/zhaquirks/develco/vibration.py
+++ b/zhaquirks/develco/vibration.py
@@ -67,7 +67,7 @@ class FrientAccelerationMeasurement(CustomCluster):
         attribute_name=IasZone.AttributeDefs.zone_status.name,
         cluster_id=IasZone.cluster_id,
         endpoint_id=45,
-        device_class=BinarySensorDeviceClass.MOTION,
+        device_class=BinarySensorDeviceClass.MOVING,
         attribute_converter=lambda value: bool(value & IasZone.ZoneStatus.Alarm_1),
         unique_id_suffix="movement",
         entity_type=EntityType.STANDARD,


### PR DESCRIPTION
## Proposed change
This adjusts the device class of the second entity provided by the Frient vibration sensor from `MOTION` to `MOVING`.
The other entity is (and stays) a binary sensor with the vibration device class. This is just another entity provided by this sensor, indicating a different movement.


## Additional information

Follow-up to:
- https://github.com/zigpy/zha-device-handlers/pull/4432

## Device diagnostics

Will be added to ZHA, if not done already.

## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
