### PR TITLE
Use `translation_placeholders` for Sonoff ZBM5

### DIFF
--- a/zhaquirks/sonoff/zbm5.py
+++ b/zhaquirks/sonoff/zbm5.py
@@ -165,8 +165,9 @@ zbm_1c_quirk = (
     .switch(
         SonoffInputConfigCluster.AttributeDefs.relay_1_detached.name,
         SonoffInputConfigCluster.cluster_id,
-        translation_key="detach_relay_1",
+        translation_key="detach_relay_id",
         fallback_name="Detach relay 1",
+        translation_placeholders={"id": "1"},
     )
     .device_automation_triggers(
         {(SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1}}
@@ -187,8 +188,9 @@ zbm_2c_quirk = (
     .switch(
         SonoffInputConfigCluster.AttributeDefs.relay_2_detached.name,
         SonoffInputConfigCluster.cluster_id,
-        translation_key="detach_relay_2",
+        translation_key="detach_relay_id",
         fallback_name="Detach relay 2",
+        translation_placeholders={"id": "2"},
     )
     .device_automation_triggers(
         {(SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 2}}
@@ -209,8 +211,9 @@ zbm_3c_quirk = (
     .switch(
         SonoffInputConfigCluster.AttributeDefs.relay_3_detached.name,
         SonoffInputConfigCluster.cluster_id,
-        translation_key="detach_relay_3",
+        translation_key="detach_relay_id",
         fallback_name="Detach relay 3",
+        translation_placeholders={"id": "3"},
     )
     .device_automation_triggers(
         {(SHORT_PRESS, BUTTON_3): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 3}}


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This uses `translation_placeholders` for the Sonoff ZBM5 devices. This is similar to existing Ubisys quirks, but it will need a manual change in `strings.json` in HA (done by me in the bump – otherwise fully handled by an automatic script).

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Small follow-up to:
- https://github.com/zigpy/zha-device-handlers/pull/4198


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
Maybe provided in above PR.


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
