### PR TITLE
Add `SIREN_BASIC` exposed feature

### DIFF
--- a/zhaquirks/quirk_ids.py
+++ b/zhaquirks/quirk_ids.py
@@ -20,3 +20,6 @@ DANFOSS_ALLY_THERMOSTAT = "danfoss.ally_thermostat"  # Thermostatic Radiator Val
 
 # Hint to poll SmartEnergy summation delivered and received attributes
 SE_POLL_SUMMATION = "se_poll_summation"
+
+# Hint to expose a basic siren entity
+SIREN_BASIC = "siren_basic"


### PR DESCRIPTION
## Proposed change
This adds an exposed feature to hint to ZHA that a siren only supports basic functionality, not different tones, volume, and so on.

## Additional information
For below PR and other Frient devices:
- https://github.com/zigpy/zha-device-handlers/pull/4839

Related ZHA PRs:
- https://github.com/zigpy/zha/pull/665
- https://github.com/zigpy/zha/pull/666

## Device diagnostics
N/A

## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
