### PR TITLE
Add initial BEGA quirk

### DIFF
--- a/zhaquirks/bega/__init__.py
+++ b/zhaquirks/bega/__init__.py
@@ -1,0 +1,1 @@
+"""Quirks for BEGA devices."""

--- a/zhaquirks/bega/light.py
+++ b/zhaquirks/bega/light.py
@@ -10,6 +10,8 @@ import zigpy.types as t
 from zigpy.zcl.clusters.general import LevelControl, OnOff
 from zigpy.zcl.foundation import ZCLAttributeDef
 
+from zhaquirks.quirk_ids import BEGA_LIGHT_SWITCHABLE_WHITE
+
 
 class LevelControlBega(CustomCluster, LevelControl):
     """Bega LevelControl cluster with custom attributes."""
@@ -35,9 +37,14 @@ class LevelControlBega(CustomCluster, LevelControl):
 
 (
     QuirkBuilder()
+    # Color temperature is not available on all of these lights, but the attributes are
     .applies_to("BEGA Gantenbrink-Leuchten KG", "Smart Dimmable Light")
     .applies_to("BEGA Gantenbrink-Leuchten KG", "Smart Dimmable Light Boost")
+    # To add custom attributes
     .replaces(LevelControlBega)
+    # Expose a feature to match the ZHA entity against
+    .exposes_feature(BEGA_LIGHT_SWITCHABLE_WHITE)
+    # To prevent non-functional binary sensor from being created
     .prevent_default_entity_creation(
         endpoint_id=1,
         cluster_id=OnOff.cluster_id,

--- a/zhaquirks/bega/light.py
+++ b/zhaquirks/bega/light.py
@@ -1,0 +1,47 @@
+"""BEGA luminaires."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl.clusters.general import LevelControl, OnOff
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+
+class LevelControlBega(CustomCluster, LevelControl):
+    """Bega LevelControl cluster with custom attributes."""
+
+    class AttributeDefs(LevelControl.AttributeDefs):
+        """Attribute definitions for Bega LevelControl cluster."""
+
+        # False: warm-white, True: cool-white
+        switchable_white: Final = ZCLAttributeDef(
+            id=0x4001, type=t.Bool, manufacturer_code=0x1105
+        )
+
+        # Color temperature for "False" in Kelvin, 0xFFFF when not supported
+        switchable_color_temperature_1: Final = ZCLAttributeDef(
+            id=0x4002, type=t.uint16_t_t, manufacturer_code=0x1105
+        )
+
+        # Color temperature for "True" in Kelvin, 0xFFFF when not supported
+        switchable_color_temperature_2: Final = ZCLAttributeDef(
+            id=0x4003, type=t.uint16_t_t, manufacturer_code=0x1105
+        )
+
+
+(
+    QuirkBuilder()
+    .applies_to("BEGA Gantenbrink-Leuchten KG", "Smart Dimmable Light")
+    .applies_to("BEGA Gantenbrink-Leuchten KG", "Smart Dimmable Light Boost")
+    .replaces(LevelControlBega)
+    .prevent_default_entity_creation(
+        endpoint_id=1,
+        cluster_id=OnOff.cluster_id,
+        function=lambda entity: entity.device_class == "opening",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/bega/light.py
+++ b/zhaquirks/bega/light.py
@@ -24,12 +24,12 @@ class LevelControlBega(CustomCluster, LevelControl):
 
         # Color temperature for "False" in Kelvin, 0xFFFF when not supported
         switchable_color_temperature_1: Final = ZCLAttributeDef(
-            id=0x4002, type=t.uint16_t_t, manufacturer_code=0x1105
+            id=0x4002, type=t.uint16_t, manufacturer_code=0x1105
         )
 
         # Color temperature for "True" in Kelvin, 0xFFFF when not supported
         switchable_color_temperature_2: Final = ZCLAttributeDef(
-            id=0x4003, type=t.uint16_t_t, manufacturer_code=0x1105
+            id=0x4003, type=t.uint16_t, manufacturer_code=0x1105
         )
 
 

--- a/zhaquirks/quirk_ids.py
+++ b/zhaquirks/quirk_ids.py
@@ -16,6 +16,10 @@ XIAOMI_AQARA_VIBRATION_AQ1 = (
 DANFOSS_ALLY_THERMOSTAT = "danfoss.ally_thermostat"  # Thermostatic Radiator Valves based on Danfoss Ally with custom clusters
 
 
+# BEGA
+BEGA_LIGHT_SWITCHABLE_WHITE = "bega.light_switchable_white"  # Adjustable color temp
+
+
 # Exposed features
 
 # Hint to poll SmartEnergy summation delivered and received attributes


### PR DESCRIPTION
## Proposed change
This adds an initial quirk for BEGA lights. The quirk does not add any entities, as we need to conditionally add them depending on `switchable_color_temperature_1` and `switchable_color_temperature_2`. This will need to be done directly in ZHA.

The non-functional "opening" binary sensor entity is removed by the quirk.



## Additional information

The model names for most light appears to be "Smart Dimmable Light". This does not tell us if the device supports switching color temperature.

It's unclear if the "Smart Dimmable Light Boost" is exactly the model name for the other variant.

### ZHA PR

ZHA PR adding the entity (also see for more information):
- https://github.com/zigpy/zha/pull/721

## Device diagnostics
Added to ZHA with the linked PR.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
