### PR TITLE
Change Frient siren device types to `CONFIG`

### DIFF
--- a/zhaquirks/develco/smoke_alarm.py
+++ b/zhaquirks/develco/smoke_alarm.py
@@ -28,7 +28,7 @@ from . import DevelcoIasZone, DevelcoPowerConfiguration
         endpoint_id=35,
         cluster_id=IasWd.cluster_id,
         new_primary=False,
-        new_entity_category=EntityType.DIAGNOSTIC,
+        new_entity_category=EntityType.CONFIG,
     )
     .add_to_registry()
 )

--- a/zhaquirks/develco/water_leak.py
+++ b/zhaquirks/develco/water_leak.py
@@ -27,7 +27,7 @@ from . import DevelcoIasZone, DevelcoPowerConfiguration
         endpoint_id=35,
         cluster_id=IasWd.cluster_id,
         new_primary=False,
-        new_entity_category=EntityType.DIAGNOSTIC,
+        new_entity_category=EntityType.CONFIG,
     )
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
This changes the entity type/category for diagnostic siren entities to `CONFIG`, as `DIAGNOSTIC` is reserved for anything non-adjustable in HA.




## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
