### PR TITLE
Mark Frient siren sensors with `SIREN_BASIC`

### DIFF
--- a/zhaquirks/develco/smoke_alarm.py
+++ b/zhaquirks/develco/smoke_alarm.py
@@ -5,6 +5,8 @@ from zigpy.quirks.v2.homeassistant import EntityType
 from zigpy.zcl.clusters.general import BinaryInput
 from zigpy.zcl.clusters.security import IasWd, IasZone
 
+from zhaquirks.quirk_ids import SIREN_BASIC
+
 from . import DevelcoIasZone, DevelcoPowerConfiguration
 
 (
@@ -12,6 +14,8 @@ from . import DevelcoIasZone, DevelcoPowerConfiguration
     .applies_to("Develco Products A/S", "SMSZB-120")
     .replaces(DevelcoIasZone, endpoint_id=35)
     .replaces(DevelcoPowerConfiguration, endpoint_id=35)
+    # The device only has basic siren features, so hint that to ZHA
+    .exposes_feature(SIREN_BASIC)
     # Hide the default binary input sensor
     .prevent_default_entity_creation(
         endpoint_id=35,

--- a/zhaquirks/develco/smoke_alarm.py
+++ b/zhaquirks/develco/smoke_alarm.py
@@ -5,9 +5,8 @@ from zigpy.quirks.v2.homeassistant import EntityType
 from zigpy.zcl.clusters.general import BinaryInput
 from zigpy.zcl.clusters.security import IasWd, IasZone
 
+from zhaquirks.develco import DevelcoIasZone, DevelcoPowerConfiguration
 from zhaquirks.quirk_ids import SIREN_BASIC
-
-from . import DevelcoIasZone, DevelcoPowerConfiguration
 
 (
     QuirkBuilder("frient A/S", "SMSZB-120")

--- a/zhaquirks/develco/smoke_alarm_us.py
+++ b/zhaquirks/develco/smoke_alarm_us.py
@@ -29,6 +29,7 @@ class DevelcoIasZoneCO(DevelcoIasZone):
     .replaces(DevelcoIasZone, endpoint_id=35)
     .replaces(DevelcoIasZoneCO, endpoint_id=46)
     .replaces(DevelcoPowerConfiguration, endpoint_id=35)
+    # The device only has basic siren features, so hint that to ZHA
     .exposes_feature(SIREN_BASIC)
     # Hide the BinaryInput sensors on both endpoints (duplicated by IAS Zone)
     .prevent_default_entity_creation(

--- a/zhaquirks/develco/water_leak.py
+++ b/zhaquirks/develco/water_leak.py
@@ -5,12 +5,16 @@ from zigpy.quirks.v2.homeassistant import EntityType
 from zigpy.zcl.clusters.general import BinaryInput
 from zigpy.zcl.clusters.security import IasWd, IasZone
 
+from zhaquirks.quirk_ids import SIREN_BASIC
+
 from . import DevelcoIasZone, DevelcoPowerConfiguration
 
 (
     QuirkBuilder("frient A/S", "FLSZB-110")
     .replaces(DevelcoIasZone, endpoint_id=35)
     .replaces(DevelcoPowerConfiguration, endpoint_id=35)
+    # The device only has basic siren features, so hint that to ZHA
+    .exposes_feature(SIREN_BASIC)
     # Hide the default binary input sensor
     .prevent_default_entity_creation(
         endpoint_id=35,

--- a/zhaquirks/develco/water_leak.py
+++ b/zhaquirks/develco/water_leak.py
@@ -5,9 +5,8 @@ from zigpy.quirks.v2.homeassistant import EntityType
 from zigpy.zcl.clusters.general import BinaryInput
 from zigpy.zcl.clusters.security import IasWd, IasZone
 
+from zhaquirks.develco import DevelcoIasZone, DevelcoPowerConfiguration
 from zhaquirks.quirk_ids import SIREN_BASIC
-
-from . import DevelcoIasZone, DevelcoPowerConfiguration
 
 (
     QuirkBuilder("frient A/S", "FLSZB-110")


### PR DESCRIPTION
## Proposed change
Mark Frient sensors with siren only supporting basic functionality

## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
