### PR TITLE
Adjust Sonoff ZBMINIR2 and Mini ZB RBS attribute types

### DIFF
--- a/zhaquirks/sonoff/mini_zbrbs.py
+++ b/zhaquirks/sonoff/mini_zbrbs.py
@@ -3,7 +3,29 @@
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import EntityPlatform, EntityType, QuirkBuilder
 import zigpy.types as t
-from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
+
+
+class SonoffCoverCalibrationStatus(t.enum8):
+    """Cover calibration status."""
+
+    not_calibrated = 0x00
+    calibrated = 0x01
+
+
+class SonoffMotorState(t.enum8):
+    """Motor state (can be different from cover state)."""
+
+    stopped = 0x00
+    opening = 0x01
+    closing = 0x02
+
+
+class SonoffExternalSwitchTriggerType(t.enum8):
+    """External switch trigger type."""
+
+    edge_trigger = 0x00
+    pulse_trigger = 0x01
 
 
 class SonoffCluster(CustomCluster):
@@ -16,17 +38,20 @@ class SonoffCluster(CustomCluster):
 
         external_trigger_mode = ZCLAttributeDef(
             id=0x0016,
-            type=t.uint8_t,
+            type=SonoffExternalSwitchTriggerType,
+            zcl_type=DataTypeId.uint8,
             manufacturer_code=None,
         )
         cover_calibrated = ZCLAttributeDef(
             id=0x5012,
-            type=t.uint8_t,
+            type=SonoffCoverCalibrationStatus,
+            zcl_type=DataTypeId.uint8,
             manufacturer_code=None,
         )
         motor_state = ZCLAttributeDef(
             id=0x5013,
-            type=t.uint8_t,
+            type=SonoffMotorState,
+            zcl_type=DataTypeId.uint8,
             manufacturer_code=None,
             access="r",
         )
@@ -51,28 +76,6 @@ class SonoffCluster(CustomCluster):
             type=t.uint16_t,
             manufacturer_code=None,
         )
-
-
-class SonoffCoverCalibrationStatus(t.enum8):
-    """Cover calibration status."""
-
-    not_calibrated = 0x00
-    calibrated = 0x01
-
-
-class SonoffMotorState(t.enum8):
-    """Motor state (can be different from cover state)."""
-
-    stopped = 0x00
-    opening = 0x01
-    closing = 0x02
-
-
-class SonoffExternalSwitchTriggerType(t.enum8):
-    """External switch trigger type."""
-
-    edge_trigger = 0x00
-    pulse_trigger = 0x01
 
 
 (

--- a/zhaquirks/sonoff/zbminir2.py
+++ b/zhaquirks/sonoff/zbminir2.py
@@ -4,7 +4,16 @@ from zigpy import types
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
-from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
+
+
+class SonoffExternalSwitchTriggerType(types.enum8):
+    """External switch trigger type."""
+
+    Edge_trigger = 0x00
+    Pulse_trigger = 0x01
+    Normally_off_follow_trigger = 0x02
+    Normally_on_follow_trigger = 0x82
 
 
 class SonoffCluster(CustomCluster):
@@ -17,7 +26,8 @@ class SonoffCluster(CustomCluster):
 
         external_trigger_mode = ZCLAttributeDef(
             id=0x0016,
-            type=t.uint8_t,
+            type=SonoffExternalSwitchTriggerType,
+            zcl_type=DataTypeId.uint8,
             manufacturer_code=None,
         )
         detach_relay = ZCLAttributeDef(
@@ -35,15 +45,6 @@ class SonoffCluster(CustomCluster):
             type=t.Bool,
             manufacturer_code=None,
         )
-
-
-class SonoffExternalSwitchTriggerType(types.enum8):
-    """extern switch trigger type."""
-
-    Edge_trigger = 0x00
-    Pulse_trigger = 0x01
-    Normally_off_follow_trigger = 0x02
-    Normally_on_follow_trigger = 0x82
 
 
 (


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This ports some tweaks made in https://github.com/zigpy/zha-device-handlers/pull/4742 to the other similar Sonoff devices, including changing the `type` to an enum for internal zigpy handling, and adding `zcl_type` for writing the attribute.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
Maybe in original PRs for these.


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
