### PR TITLE
Fix `Tuya3PhaseElectricalMeasurement` missing `.id`

### DIFF
--- a/zhaquirks/tuya/ts0601_power.py
+++ b/zhaquirks/tuya/ts0601_power.py
@@ -52,7 +52,7 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     _CONSTANT_ATTRIBUTES = {
         ElectricalMeasurement.AttributeDefs.ac_current_multiplier.id: 1,
         ElectricalMeasurement.AttributeDefs.ac_current_divisor.id: 1000,
-        ElectricalMeasurement.AttributeDefs.ac_voltage_multiplier: 1,
+        ElectricalMeasurement.AttributeDefs.ac_voltage_multiplier.id: 1,
         ElectricalMeasurement.AttributeDefs.ac_voltage_divisor.id: 10,
     }
 


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This fixes the `Tuya3PhaseElectricalMeasurement` `ac_voltage_multiplier` missing `.id` in `_CONSTANT_ATTRIBUTES`.



## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
This likely didn't cause any real issues, as the multiplier is `1` by default. Still, something that should be fixed.
Caught by Copilot in this PR:
- https://github.com/zigpy/zha-device-handlers/pull/4685#discussion_r2985174531


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
N/A


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
