### PR TITLE
Move some `update_attribute` calls to `_CONSTANT_ATTRIBUTES`

### DIFF
--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -1408,13 +1408,14 @@ class ZONNSMARTUserInterface(TuyaUserInterfaceCluster):
 class ZONNSMARTWindowDetection(LocalDataCluster, BinaryInput):
     """Binary cluster for the window detection function of the heating thermostats."""
 
+    _CONSTANT_ATTRIBUTES = {
+        BinaryInput.AttributeDefs.description.id: "Open Window Detected",
+    }
+
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
         self.endpoint.device.window_detection_bus.add_listener(self)
-        self._update_attribute(
-            self.attributes_by_name["description"].id, "Open Window Detected"
-        )
 
     def set_value(self, value):
         """Set opened window value."""
@@ -1549,18 +1550,19 @@ class ZONNSMARTOnlineMode(ZONNSMARTHelperOnOff):
 class ZONNSMARTTemperatureOffset(LocalDataCluster, AnalogOutput):
     """AnalogOutput cluster for setting temperature offset."""
 
+    _CONSTANT_ATTRIBUTES = {
+        AnalogOutput.AttributeDefs.description.id: "Temperature Offset",
+        AnalogOutput.AttributeDefs.max_present_value.id: 5,
+        AnalogOutput.AttributeDefs.min_present_value.id: -5,
+        AnalogOutput.AttributeDefs.resolution.id: 0.1,
+        AnalogOutput.AttributeDefs.application_type.id: 0x0009,
+        AnalogOutput.AttributeDefs.engineering_units.id: 62,
+    }
+
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
         self.endpoint.device.temperature_calibration_bus.add_listener(self)
-        self._update_attribute(
-            self.attributes_by_name["description"].id, "Temperature Offset"
-        )
-        self._update_attribute(self.attributes_by_name["max_present_value"].id, 5)
-        self._update_attribute(self.attributes_by_name["min_present_value"].id, -5)
-        self._update_attribute(self.attributes_by_name["resolution"].id, 0.1)
-        self._update_attribute(self.attributes_by_name["application_type"].id, 0x0009)
-        self._update_attribute(self.attributes_by_name["engineering_units"].id, 62)
 
     def set_value(self, value):
         """Set new temperature offset value."""
@@ -1593,24 +1595,21 @@ class ZONNSMARTTemperatureOffset(LocalDataCluster, AnalogOutput):
 class ZONNSMARTWindowOpenedTemp(LocalDataCluster, AnalogOutput):
     """AnalogOutput cluster for temperature when opened window detected."""
 
+    _CONSTANT_ATTRIBUTES = {
+        AnalogOutput.AttributeDefs.description.id: "Opened Window Temperature",
+        AnalogOutput.AttributeDefs.max_present_value.id: ZONNSMART_MAX_TEMPERATURE_VAL
+        / 100,
+        AnalogOutput.AttributeDefs.min_present_value.id: ZONNSMART_MIN_TEMPERATURE_VAL
+        / 100,
+        AnalogOutput.AttributeDefs.resolution.id: 0.5,
+        AnalogOutput.AttributeDefs.application_type.id: 0 << 16,
+        AnalogOutput.AttributeDefs.engineering_units.id: 62,
+    }
+
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
         self.endpoint.device.window_temperature_bus.add_listener(self)
-        self._update_attribute(
-            self.attributes_by_name["description"].id, "Opened Window Temperature"
-        )
-        self._update_attribute(
-            self.attributes_by_name["max_present_value"].id,
-            ZONNSMART_MAX_TEMPERATURE_VAL / 100,
-        )
-        self._update_attribute(
-            self.attributes_by_name["min_present_value"].id,
-            ZONNSMART_MIN_TEMPERATURE_VAL / 100,
-        )
-        self._update_attribute(self.attributes_by_name["resolution"].id, 0.5)
-        self._update_attribute(self.attributes_by_name["application_type"].id, 0 << 16)
-        self._update_attribute(self.attributes_by_name["engineering_units"].id, 62)
 
     def set_value(self, value):
         """Set temperature value when opened window detected."""

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -41,11 +41,14 @@ ZONE_TYPE = 0x0001
 class EmulatedIasZone(LocalDataCluster, IasZone):
     """Emulated IAS zone cluster."""
 
+    _CONSTANT_ATTRIBUTES = {
+        ZONE_TYPE: MOISTURE_TYPE,
+    }
+
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
         self.endpoint.device.ias_bus.add_listener(self)
-        super()._update_attribute(ZONE_TYPE, MOISTURE_TYPE)
 
     async def bind(self):
         """Bind cluster."""


### PR DESCRIPTION
## Proposed change
This moves `update_attribute` calls out of `Cluster.__init__`, as recent zigpy versions have started clearing attribute cache during the quirk matching process. These calls don't really belong here anyway.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Split out from:
- https://github.com/zigpy/zha-device-handlers/pull/4771


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
N/A


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
