### PR TITLE
Improve test coverage of `LocalDataCluster`

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -15,7 +15,7 @@ import zigpy.endpoint
 import zigpy.profiles
 import zigpy.quirks as zq
 from zigpy.quirks import CustomDevice, DeviceRegistry
-from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2 import QuirkBuilder, ReportingConfig
 import zigpy.types as t
 from zigpy.zcl import foundation
 import zigpy.zdo.types
@@ -1038,3 +1038,25 @@ async def test_local_data_cluster(device_mock) -> None:
     assert cluster.get(0xFF, 123) == 123
     # valid attribute with no cached value and no default value returns None
     assert cluster.get(2) is None
+
+    # bind/unbind/configure_reporting are no-ops that return success
+    assert await cluster.bind() == (foundation.Status.SUCCESS,)
+    assert await cluster.unbind() == (foundation.Status.SUCCESS,)
+
+    configure_rsp = await cluster.configure_reporting(
+        cluster.AttributeDefs.constant_attr, 0, 300, 1
+    )
+    assert (
+        configure_rsp[cluster.AttributeDefs.constant_attr] == foundation.Status.SUCCESS
+    )
+
+    configure_rsp = await cluster.configure_reporting_multiple(
+        {
+            cluster.AttributeDefs.constant_attr: ReportingConfig(
+                min_interval=0, max_interval=300, reportable_change=1
+            ),
+        }
+    )
+    assert (
+        configure_rsp[cluster.AttributeDefs.constant_attr] == foundation.Status.SUCCESS
+    )

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -91,7 +91,7 @@ class LocalDataCluster(CustomCluster):
             return result
         return self._DEFAULT_VALUES.get(attr_def.id, default)
 
-    async def bind(self):
+    async def bind(self, **kwargs):
         """Prevent bind."""
         self.debug("binding LocalDataCluster")
         return (foundation.Status.SUCCESS,)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This improves quirks test coverage for the `LocalDataCluster`.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Kind of related:
- https://github.com/zigpy/zha-device-handlers/pull/4771


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
N/A


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
