### PR TITLE
Change unit of Third Reality 60G radar TVOC sensor

### DIFF
--- a/zhaquirks/thirdreality/60g_radar.py
+++ b/zhaquirks/thirdreality/60g_radar.py
@@ -9,10 +9,7 @@ from zigpy.quirks.v2 import (
     SensorDeviceClass,
     SensorStateClass,
 )
-from zigpy.quirks.v2.homeassistant import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_BILLION,
-)
+from zigpy.quirks.v2.homeassistant import CONCENTRATION_PARTS_PER_BILLION
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
@@ -57,12 +54,9 @@ class ThirdRealityRadarCluster(CustomCluster):
     .sensor(
         attribute_name=ThirdRealityRadarCluster.AttributeDefs.volatile_organic_compounds.name,
         cluster_id=ThirdRealityRadarCluster.cluster_id,
-        device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
+        device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
         state_class=SensorStateClass.MEASUREMENT,
-        unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-        # Convert ppb to µg/m³: µg/m³ = ppb × (molecular_weight / 24.45)
-        # Using average TVOC molecular weight of 100 g/mol
-        attribute_converter=lambda value: round(float(value) * (100.0 / 24.45)),
+        unit=CONCENTRATION_PARTS_PER_BILLION,
         translation_key="total_volatile_organic_compounds",
         fallback_name="Total volatile organic compounds",
     )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Change unit of Third Reality 60G radar TVOC sensor from `µg/m³` to `ppb`.
We do keep the "Total" in the name though. This will be shown to HA users.



## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
For reference, see the discussion here:
- https://github.com/zigpy/zha-device-handlers/pull/4830#discussion_r2955923843

This also matches the "Air threshold" entity then, which is already in `ppb`.

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
N/A

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
