### PR TITLE
Remove `total_active_power` from Aqara `_DEFAULT_VALUES`

### DIFF
--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -696,7 +696,6 @@ class ElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
     _DEFAULT_VALUES = {
         ElectricalMeasurement.AttributeDefs.active_power.id: 0,
         ElectricalMeasurement.AttributeDefs.rms_voltage.id: 0,
-        ElectricalMeasurement.AttributeDefs.total_active_power.id: 0,
     }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Remove `total_active_power` from Aqara `_DEFAULT_VALUES`. This attribute should be unsupported for these plugs, not supported with `0` as a default value.

Unfortunately, we currently have no override for unsupported attributes.
The `update_attribute` with `value=None` in `__init__` doesn't work anymore due to recent zigpy changes.
This is something that should be looked at soon.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
This was mistakenly included in:
- https://github.com/zigpy/zha-device-handlers/pull/4771

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
N/A


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
