### PR TITLE
Add Tuya Moes BHT-002 floor heating thermostat quirk

### DIFF
--- a/zhaquirks/tuya/tuya_thermostat.py
+++ b/zhaquirks/tuya/tuya_thermostat.py
@@ -126,6 +126,16 @@ class TuyaThermostat(Thermostat, TuyaAttributesCluster):
         )
 
 
+class TuyaThermostatExtendedLimits(TuyaThermostat):
+    """Tuya local thermostat cluster with extended temperature limits up to 45C."""
+
+    _CONSTANT_ATTRIBUTES = {
+        Thermostat.AttributeDefs.abs_min_heat_setpoint_limit.id: 500,
+        Thermostat.AttributeDefs.abs_max_heat_setpoint_limit.id: 4500,
+        Thermostat.AttributeDefs.ctrl_sequence_of_oper.id: Thermostat.ControlSequenceOfOperation.Heating_Only,
+    }
+
+
 class NoManufTimeNoVersionRespTuyaMCUCluster(TuyaMCUCluster):
     """Tuya Manufacturer Cluster with set_time mod."""
 
@@ -140,7 +150,7 @@ class NoManufTimeNoVersionRespTuyaMCUCluster(TuyaMCUCluster):
 
     def handle_mcu_version_response(
         self,
-        payload: TuyaMCUCluster.MCUVersion,  # type:ignore[valid-type]
+        payload: TuyaMCUCluster.MCUVersion,  # type: ignore[valid-type]
     ) -> foundation.Status:
         """Handle MCU version response."""
         return foundation.Status.SUCCESS
@@ -604,5 +614,118 @@ base_avatto_quirk = (
     )
     .adds(TuyaThermostat)
     .skip_configuration()
+    .add_to_registry()
+)
+
+
+moes_base_quirk = (
+    TuyaQuirkBuilder()
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
+        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.system_mode.name,
+        converter=lambda x: {
+            True: Thermostat.SystemMode.Heat,
+            False: Thermostat.SystemMode.Off,
+        }[x],
+        dp_converter=lambda x: {
+            Thermostat.SystemMode.Heat: True,
+            Thermostat.SystemMode.Off: False,
+        }[x],
+    )
+    .tuya_switch(
+        dp_id=2,
+        attribute_name="manual_mode",
+        translation_key="manual_mode",
+        on_value=0,
+        off_value=1,
+        fallback_name="Manual mode",
+    )
+    .tuya_switch(
+        dp_id=3,
+        attribute_name="schedule_mode",
+        on_value=0,
+        off_value=1,
+        translation_key="schedule_mode",
+        fallback_name="Schedule mode",
+    )
+    .tuya_dp(
+        dp_id=36,
+        ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
+        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.running_state.name,
+        converter=lambda x: RunningState.Heat_State_On if not x else RunningState.Idle,
+    )
+    .tuya_switch(
+        dp_id=40,
+        attribute_name="child_lock",
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    .tuya_enum(
+        dp_id=43,
+        attribute_name="temperature_sensor_select",
+        enum_class=SensorMode,
+        translation_key="sensor_mode",
+        fallback_name="Sensor mode",
+    )
+    .tuya_number(
+        dp_id=28,
+        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.local_temperature_calibration.name,
+        type=t.int32s,
+        min_value=-30,
+        max_value=30,
+        unit=UnitOfTemperature.CELSIUS,
+        step=0.1,
+        translation_key="local_temperature_calibration",
+        fallback_name="Local temperature calibration",
+    )
+    .adds(TuyaThermostatExtendedLimits)
+    .skip_configuration()
+)
+
+(
+    moes_base_quirk.clone()
+    .applies_to("_TZE204_aoclfnxz", "TS0601")
+    .applies_to("_TZE204_xalsoe3m", "TS0601")
+    .applies_to("_TZE204_u9bfwha0", "TS0601")
+    .applies_to("_TZE200_ztvwu4nk", "TS0601")
+    .tuya_dp(
+        dp_id=16,
+        ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
+        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.occupied_heating_setpoint.name,
+        converter=lambda x: x * 100,
+        dp_converter=lambda x: x // 100,
+    )
+    .tuya_dp(
+        dp_id=24,
+        ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
+        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.local_temperature.name,
+        converter=lambda x: x * 10,
+    )
+    .tuya_dp(
+        dp_id=18,
+        ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
+        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.max_heat_setpoint_limit.name,
+        converter=lambda x: x * 10,
+        dp_converter=lambda x: x // 10,
+    )
+    .tuya_number(
+        dp_id=20,
+        attribute_name="deadzone_temperature",
+        type=t.uint16_t,
+        unit=UnitOfTemperature.CELSIUS,
+        min_value=0,
+        max_value=5,
+        step=1,
+        translation_key="deadzone_temperature",
+        fallback_name="Deadzone temperature",
+    )
+    .tuya_dp(
+        dp_id=26,
+        ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
+        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.min_heat_setpoint_limit.name,
+        converter=lambda x: x * 10,
+        dp_converter=lambda x: x // 10,
+    )
     .add_to_registry()
 )

--- a/zhaquirks/tuya/tuya_thermostat.py
+++ b/zhaquirks/tuya/tuya_thermostat.py
@@ -618,6 +618,10 @@ base_avatto_quirk = (
 )
 
 
+# Moes BHT-002 family. DP map cross-referenced with Z2M:
+# https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/lib/legacy.ts (`dataPoints.moes*`)
+# Setpoints/limits are sent as raw whole degrees on the wire; calibration
+# uses DP 27 (not 28 — DP 28 is `connecteTempCalibration`, an unrelated device).
 moes_base_quirk = (
     TuyaQuirkBuilder()
     .tuya_dp(
@@ -650,6 +654,49 @@ moes_base_quirk = (
         fallback_name="Schedule mode",
     )
     .tuya_dp(
+        dp_id=16,
+        ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
+        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.occupied_heating_setpoint.name,
+        converter=lambda x: x * 100,
+        dp_converter=lambda x: x // 100,
+    )
+    .tuya_dp(
+        dp_id=18,
+        ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
+        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.max_heat_setpoint_limit.name,
+        converter=lambda x: x * 100,
+        dp_converter=lambda x: x // 100,
+    )
+    .tuya_number(
+        dp_id=20,
+        attribute_name="deadzone_temperature",
+        type=t.uint16_t,
+        unit=UnitOfTemperature.CELSIUS,
+        min_value=0,
+        max_value=5,
+        step=1,
+        translation_key="deadzone_temperature",
+        fallback_name="Deadzone temperature",
+    )
+    .tuya_dp(
+        dp_id=26,
+        ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
+        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.min_heat_setpoint_limit.name,
+        converter=lambda x: x * 100,
+        dp_converter=lambda x: x // 100,
+    )
+    .tuya_number(
+        dp_id=27,
+        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.local_temperature_calibration.name,
+        type=t.int32s,
+        min_value=-30,
+        max_value=30,
+        unit=UnitOfTemperature.CELSIUS,
+        step=1,
+        translation_key="local_temperature_calibration",
+        fallback_name="Local temperature calibration",
+    )
+    .tuya_dp(
         dp_id=36,
         ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
         attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.running_state.name,
@@ -668,64 +715,34 @@ moes_base_quirk = (
         translation_key="sensor_mode",
         fallback_name="Sensor mode",
     )
-    .tuya_number(
-        dp_id=28,
-        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.local_temperature_calibration.name,
-        type=t.int32s,
-        min_value=-30,
-        max_value=30,
-        unit=UnitOfTemperature.CELSIUS,
-        step=0.1,
-        translation_key="local_temperature_calibration",
-        fallback_name="Local temperature calibration",
-    )
     .adds(TuyaThermostatExtendedLimits)
     .skip_configuration()
 )
 
+# DP 24 (local_temperature) reports tenths of a degree on these models.
 (
     moes_base_quirk.clone()
     .applies_to("_TZE204_aoclfnxz", "TS0601")
-    .applies_to("_TZE204_xalsoe3m", "TS0601")
     .applies_to("_TZE204_u9bfwha0", "TS0601")
-    .applies_to("_TZE200_ztvwu4nk", "TS0601")
-    .tuya_dp(
-        dp_id=16,
-        ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
-        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.occupied_heating_setpoint.name,
-        converter=lambda x: x * 100,
-        dp_converter=lambda x: x // 100,
-    )
     .tuya_dp(
         dp_id=24,
         ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
         attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.local_temperature.name,
         converter=lambda x: x * 10,
     )
+    .add_to_registry()
+)
+
+# DP 24 (local_temperature) reports whole degrees on this model — see
+# https://github.com/Koenkk/zigbee2mqtt/issues/11980
+(
+    moes_base_quirk.clone()
+    .applies_to("_TZE200_ztvwu4nk", "TS0601")
     .tuya_dp(
-        dp_id=18,
+        dp_id=24,
         ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
-        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.max_heat_setpoint_limit.name,
-        converter=lambda x: x * 10,
-        dp_converter=lambda x: x // 10,
-    )
-    .tuya_number(
-        dp_id=20,
-        attribute_name="deadzone_temperature",
-        type=t.uint16_t,
-        unit=UnitOfTemperature.CELSIUS,
-        min_value=0,
-        max_value=5,
-        step=1,
-        translation_key="deadzone_temperature",
-        fallback_name="Deadzone temperature",
-    )
-    .tuya_dp(
-        dp_id=26,
-        ep_attribute=TuyaThermostatExtendedLimits.ep_attribute,
-        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.min_heat_setpoint_limit.name,
-        converter=lambda x: x * 10,
-        dp_converter=lambda x: x // 10,
+        attribute_name=TuyaThermostatExtendedLimits.AttributeDefs.local_temperature.name,
+        converter=lambda x: x * 100,
     )
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
Add V2 QuirkBuilder support for Moes BHT-series thermostats, including model IDs _TZE204_aoclfnxz, _TZE204_xalsoe3m, _TZE204_u9bfwha0, and _TZE200_ztvwu4nk.

This implementation includes TuyaThermostatExtendedLimits to correctly handle setpoint limits up to 45 °C, which prevents "out of range" errors in Home Assistant when the device is adjusted manually.


## Additional information

Follows logic originally proposed by @prairiesnpr in draft PR #3870 (which I had been using but it hasn't moved in a year)

These newer _TZE204 devices require the V2 architecture to correctly expose all climate entities and attributes.

Tested with _TZE204_aoclfnxz on Home Assistant Container 2026.3.4

## Device diagnostics

[zha-01K7PPW960F3FNGVX7VKE3XCQ2-_TZE204_aoclfnxz TS0601-2c3f947eec7c2daff8e49ac9cfe65da4.json](https://github.com/user-attachments/files/26256313/zha-01K7PPW960F3FNGVX7VKE3XCQ2-_TZE204_aoclfnxz.TS0601-2c3f947eec7c2daff8e49ac9cfe65da4.json)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
