### PR TITLE
Add support for Develco/frient Smart Plugs (SPLZB-131/132/134/137/141/142/144/147), Smart Cables (SMRZB-143/153) and Smart DIN Relays (SMRZB-332/342)

### DIFF
--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -2,13 +2,13 @@
 
 from unittest import mock
 
-import zigpy.types as t
 import zigpy.quirks
+from zigpy.quirks.v2 import EntityPlatform
+import zigpy.types as t
 from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import DeviceTemperature, OnOff
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
-from zigpy.quirks.v2 import EntityPlatform
 
 from tests.common import ClusterListener
 import zhaquirks
@@ -321,12 +321,15 @@ async def test_frient_power_plug_write_attributes_mixed(
         OnOff.AttributeDefs.on_off.id: 0,
     }
 
-    with mock.patch.object(
-        VendorOnOff, "_send_safe_mode", new=mock.AsyncMock()
-    ) as send_safe_mode, mock.patch(
-        "zigpy.quirks.CustomCluster.write_attributes",
-        new=mock.AsyncMock(return_value=[status]),
-    ) as write_mock:
+    with (
+        mock.patch.object(
+            VendorOnOff, "_send_safe_mode", new=mock.AsyncMock()
+        ) as send_safe_mode,
+        mock.patch(
+            "zigpy.quirks.CustomCluster.write_attributes",
+            new=mock.AsyncMock(return_value=[status]),
+        ) as write_mock,
+    ):
         result = await on_off.write_attributes(attrs, priority=2)
 
     send_safe_mode.assert_called_once_with(0x01, 4)

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -3,11 +3,16 @@
 from unittest import mock
 
 import zigpy.types as t
+import zigpy.quirks
 from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.general import DeviceTemperature, OnOff
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
+from zigpy.quirks.v2 import EntityPlatform
 
 from tests.common import ClusterListener
 import zhaquirks
+from zhaquirks.develco.power_plug import VendorOnOff
 
 zhaquirks.setup()
 
@@ -177,3 +182,120 @@ async def test_mfg_cluster_events(zigpy_device_from_v2_quirk):
     assert (
         metering_cluster.get(Metering.AttributeDefs.current_summ_delivered.id) == 1234
     )
+
+
+async def test_frient_power_plug_defaults(zigpy_device_from_v2_quirk):
+    """Test power plug initializes mode values."""
+    device = zigpy_device_from_v2_quirk(
+        "frient A/S",
+        "SPLZB-131",
+        endpoint_ids=[1, 2],
+        cluster_ids={2: {OnOff.cluster_id: ClusterType.Server}},
+    )
+
+    on_off = device.endpoints[2].on_off
+    assert isinstance(on_off, VendorOnOff)
+    assert on_off.get(VendorOnOff.AttributeDefs.mode_on_value.id) == 0
+    assert on_off.get(VendorOnOff.AttributeDefs.mode_off_value.id) == 0
+
+
+async def test_frient_power_plug_safe_mode_writes(zigpy_device_from_v2_quirk):
+    """Test mode writes invoke manufacturer safe-mode commands."""
+    device = zigpy_device_from_v2_quirk(
+        "frient A/S",
+        "SPLZB-131",
+        endpoint_ids=[1, 2],
+        cluster_ids={
+            2: {
+                OnOff.cluster_id: ClusterType.Server,
+                DeviceTemperature.cluster_id: ClusterType.Server,
+                ElectricalMeasurement.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    on_off = device.endpoints[2].on_off
+
+    with mock.patch.object(
+        VendorOnOff, "_send_safe_mode", new=mock.AsyncMock()
+    ) as send_safe_mode:
+        await on_off.write_attributes(
+            {VendorOnOff.AttributeDefs.mode_on_value.id: 5}
+        )
+        send_safe_mode.assert_called_once_with(0x01, 5)
+        assert on_off.get(VendorOnOff.AttributeDefs.mode_on_value.id) == 5
+
+        send_safe_mode.reset_mock()
+
+        await on_off.write_attributes(
+            {VendorOnOff.AttributeDefs.mode_off_value.name: 7}
+        )
+        send_safe_mode.assert_called_once_with(0x00, 7)
+        assert on_off.get(VendorOnOff.AttributeDefs.mode_off_value.id) == 7
+
+
+def _get_power_plug_entry():
+    entries = zigpy.quirks.DEVICE_REGISTRY.registry_v2.get(
+        ("frient A/S", "SPLZB-131"),
+        [],
+    )
+    assert entries, "Power plug quirk not registered in v2 registry"
+    return entries[0]
+
+
+def test_frient_power_plug_entity_metadata() -> None:
+    """Test power plug entity metadata is registered as expected."""
+    entry = _get_power_plug_entry()
+
+    mode_on = next(
+        meta for meta in entry.entity_metadata if meta.translation_key == "mode_on"
+    )
+    assert mode_on.entity_platform is EntityPlatform.NUMBER
+    assert mode_on.cluster_id == OnOff.cluster_id
+    assert mode_on.endpoint_id == 2
+    assert mode_on.unique_id_suffix == "mode_on"
+
+    mode_off = next(
+        meta for meta in entry.entity_metadata if meta.translation_key == "mode_off"
+    )
+    assert mode_off.entity_platform is EntityPlatform.NUMBER
+    assert mode_off.cluster_id == OnOff.cluster_id
+    assert mode_off.endpoint_id == 2
+    assert mode_off.unique_id_suffix == "mode_off"
+
+    dev_temp = next(
+        meta
+        for meta in entry.entity_metadata
+        if meta.translation_key == "device_temperature"
+    )
+    assert dev_temp.entity_platform is EntityPlatform.SENSOR
+    assert dev_temp.cluster_id == DeviceTemperature.cluster_id
+    assert dev_temp.endpoint_id == 2
+    if hasattr(dev_temp, "divisor"):
+        assert dev_temp.divisor == 1
+
+    return_to_state = next(
+        meta
+        for meta in entry.entity_metadata
+        if meta.translation_key == "return_to_state"
+    )
+    assert return_to_state.entity_platform is EntityPlatform.BINARY_SENSOR
+    assert return_to_state.cluster_id == OnOff.cluster_id
+    assert return_to_state.endpoint_id == 2
+
+
+def test_frient_power_plug_prevents_default_entities() -> None:
+    """Test power plug prevents default entities for temp and power clusters."""
+    entry = _get_power_plug_entry()
+
+    prevented = list(entry.disabled_default_entities)
+    assert prevented, "No disabled default entity metadata found"
+
+    def _matches(item, cluster_id):
+        return (
+            getattr(item, "cluster_id", None) == cluster_id
+            and getattr(item, "endpoint_id", None) == 2
+        )
+
+    assert any(_matches(item, DeviceTemperature.cluster_id) for item in prevented)
+    assert any(_matches(item, ElectricalMeasurement.cluster_id) for item in prevented)

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -343,6 +343,51 @@ async def test_frient_power_plug_write_attributes_mixed(
     }
 
 
+async def test_frient_power_plug_write_attributes_multiple_vendor(
+    zigpy_device_from_v2_quirk,
+):
+    """Test multiple vendor mode writes are processed together."""
+    device = zigpy_device_from_v2_quirk(
+        "frient A/S",
+        "SPLZB-131",
+        endpoint_ids=[1, 2],
+        cluster_ids={2: {OnOff.cluster_id: ClusterType.Server}},
+    )
+
+    on_off = device.endpoints[2].on_off
+    attrs = {
+        VendorOnOff.AttributeDefs.mode_on_value.id: 12,
+        VendorOnOff.AttributeDefs.mode_off_value: 34,
+    }
+
+    with (
+        mock.patch.object(
+            VendorOnOff, "_send_safe_mode", new=mock.AsyncMock()
+        ) as send_safe_mode,
+        mock.patch(
+            "zigpy.quirks.CustomCluster.write_attributes",
+            new=mock.AsyncMock(),
+        ) as write_mock,
+    ):
+        result = await on_off.write_attributes(attrs)
+
+    send_safe_mode.assert_has_calls(
+        [
+            mock.call(0x01, 12),
+            mock.call(0x00, 34),
+        ],
+        any_order=False,
+    )
+    write_mock.assert_not_called()
+    assert on_off.get(VendorOnOff.AttributeDefs.mode_on_value.id) == 12
+    assert on_off.get(VendorOnOff.AttributeDefs.mode_off_value.id) == 34
+    assert attrs == {
+        VendorOnOff.AttributeDefs.mode_on_value.id: 12,
+        VendorOnOff.AttributeDefs.mode_off_value: 34,
+    }
+    assert result == [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+
+
 def _get_power_plug_entry():
     entries = zigpy.quirks.DEVICE_REGISTRY.registry_v2.get(
         ("frient A/S", "SPLZB-131"),

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -12,7 +12,7 @@ from zigpy.quirks.v2 import EntityPlatform
 
 from tests.common import ClusterListener
 import zhaquirks
-from zhaquirks.develco.power_plug import VendorOnOff
+from zhaquirks.develco.power_plug import MANUFACTURER_CODE, VendorOnOff
 
 zhaquirks.setup()
 
@@ -216,22 +216,128 @@ async def test_frient_power_plug_safe_mode_writes(zigpy_device_from_v2_quirk):
 
     on_off = device.endpoints[2].on_off
 
+    attrs_on = {VendorOnOff.AttributeDefs.mode_on_value.id: 5}
+    attrs_off = {VendorOnOff.AttributeDefs.mode_off_value.name: 7}
+    attrs_on_name = {VendorOnOff.AttributeDefs.mode_on_value.name: 9}
+    attrs_off_id = {VendorOnOff.AttributeDefs.mode_off_value.id: 11}
+
     with mock.patch.object(
         VendorOnOff, "_send_safe_mode", new=mock.AsyncMock()
     ) as send_safe_mode:
-        await on_off.write_attributes(
-            {VendorOnOff.AttributeDefs.mode_on_value.id: 5}
-        )
+        await on_off.write_attributes(attrs_on)
         send_safe_mode.assert_called_once_with(0x01, 5)
         assert on_off.get(VendorOnOff.AttributeDefs.mode_on_value.id) == 5
+        assert attrs_on == {VendorOnOff.AttributeDefs.mode_on_value.id: 5}
 
         send_safe_mode.reset_mock()
 
-        await on_off.write_attributes(
-            {VendorOnOff.AttributeDefs.mode_off_value.name: 7}
-        )
+        await on_off.write_attributes(attrs_off)
         send_safe_mode.assert_called_once_with(0x00, 7)
         assert on_off.get(VendorOnOff.AttributeDefs.mode_off_value.id) == 7
+        assert attrs_off == {VendorOnOff.AttributeDefs.mode_off_value.name: 7}
+
+        send_safe_mode.reset_mock()
+
+        await on_off.write_attributes(attrs_on_name)
+        send_safe_mode.assert_called_once_with(0x01, 9)
+        assert on_off.get(VendorOnOff.AttributeDefs.mode_on_value.id) == 9
+        assert attrs_on_name == {VendorOnOff.AttributeDefs.mode_on_value.name: 9}
+
+        send_safe_mode.reset_mock()
+
+        await on_off.write_attributes(attrs_off_id)
+        send_safe_mode.assert_called_once_with(0x00, 11)
+        assert on_off.get(VendorOnOff.AttributeDefs.mode_off_value.id) == 11
+        assert attrs_off_id == {VendorOnOff.AttributeDefs.mode_off_value.id: 11}
+
+
+async def test_frient_power_plug_send_safe_mode_request(zigpy_device_from_v2_quirk):
+    """Test safe mode command uses manufacturer code and no reply."""
+    device = zigpy_device_from_v2_quirk(
+        "frient A/S",
+        "SPLZB-131",
+        endpoint_ids=[1, 2],
+        cluster_ids={2: {OnOff.cluster_id: ClusterType.Server}},
+    )
+
+    on_off = device.endpoints[2].on_off
+
+    with mock.patch.object(on_off, "request", new=mock.AsyncMock()) as request_mock:
+        await on_off._send_safe_mode(0x01, 4)
+
+    request_mock.assert_called_once()
+    call_args = request_mock.call_args
+    assert call_args.args[0] is False
+    assert call_args.args[1] == 0x01
+    assert call_args.kwargs["manufacturer"] == MANUFACTURER_CODE
+    assert call_args.kwargs["expect_reply"] is False
+    assert call_args.kwargs["mode"] == 4
+
+
+async def test_frient_power_plug_write_attributes_passthrough(
+    zigpy_device_from_v2_quirk,
+):
+    """Test non-vendor writes pass kwargs through to base implementation."""
+    device = zigpy_device_from_v2_quirk(
+        "frient A/S",
+        "SPLZB-131",
+        endpoint_ids=[1, 2],
+        cluster_ids={2: {OnOff.cluster_id: ClusterType.Server}},
+    )
+
+    on_off = device.endpoints[2].on_off
+    status = [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+
+    with mock.patch(
+        "zigpy.quirks.CustomCluster.write_attributes",
+        new=mock.AsyncMock(return_value=[status]),
+    ) as write_mock:
+        result = await on_off.write_attributes(
+            {OnOff.AttributeDefs.on_off.id: 1},
+            timeout=3,
+        )
+
+    write_mock.assert_called_once()
+    assert write_mock.call_args.args[0] == {OnOff.AttributeDefs.on_off.id: 1}
+    assert write_mock.call_args.kwargs["timeout"] == 3
+    assert result == [status]
+
+
+async def test_frient_power_plug_write_attributes_mixed(
+    zigpy_device_from_v2_quirk,
+):
+    """Test vendor and standard writes can be combined without mutation."""
+    device = zigpy_device_from_v2_quirk(
+        "frient A/S",
+        "SPLZB-131",
+        endpoint_ids=[1, 2],
+        cluster_ids={2: {OnOff.cluster_id: ClusterType.Server}},
+    )
+
+    on_off = device.endpoints[2].on_off
+    status = [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+    attrs = {
+        VendorOnOff.AttributeDefs.mode_on_value.id: 4,
+        OnOff.AttributeDefs.on_off.id: 0,
+    }
+
+    with mock.patch.object(
+        VendorOnOff, "_send_safe_mode", new=mock.AsyncMock()
+    ) as send_safe_mode, mock.patch(
+        "zigpy.quirks.CustomCluster.write_attributes",
+        new=mock.AsyncMock(return_value=[status]),
+    ) as write_mock:
+        result = await on_off.write_attributes(attrs, priority=2)
+
+    send_safe_mode.assert_called_once_with(0x01, 4)
+    write_mock.assert_called_once()
+    assert write_mock.call_args.args[0] == {OnOff.AttributeDefs.on_off.id: 0}
+    assert write_mock.call_args.kwargs["priority"] == 2
+    assert result == [status]
+    assert attrs == {
+        VendorOnOff.AttributeDefs.mode_on_value.id: 4,
+        OnOff.AttributeDefs.on_off.id: 0,
+    }
 
 
 def _get_power_plug_entry():

--- a/tests/test_develco.py
+++ b/tests/test_develco.py
@@ -385,7 +385,9 @@ async def test_frient_power_plug_write_attributes_multiple_vendor(
         VendorOnOff.AttributeDefs.mode_on_value.id: 12,
         VendorOnOff.AttributeDefs.mode_off_value: 34,
     }
-    assert result == [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+    assert result == [
+        [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+    ]
 
 
 def _get_power_plug_entry():

--- a/zhaquirks/develco/power_plug.py
+++ b/zhaquirks/develco/power_plug.py
@@ -6,16 +6,15 @@ from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import (
     EntityType,
     QuirkBuilder,
+    ReportingConfig,
     SensorDeviceClass,
     SensorStateClass,
-    ReportingConfig,
 )
 from zigpy.quirks.v2.homeassistant import UnitOfTemperature
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import DeviceTemperature, OnOff
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
-from zigpy.zcl.clusters.smartenergy import Metering
 from zigpy.zcl.foundation import ZCLAttributeDef
 
 MANUFACTURER_CODE = 0x1015
@@ -91,6 +90,7 @@ class VendorOnOff(CustomCluster, OnOff):
 
         return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
+
 (
     QuirkBuilder("frient A/S", "SPLZB-141")
     .applies_to("Develco Products A/S", "SPLZB-131")
@@ -120,7 +120,7 @@ class VendorOnOff(CustomCluster, OnOff):
     .prevent_default_entity_creation(
         endpoint_id=2,
         cluster_id=DeviceTemperature.cluster_id,
-        function=lambda entity: entity.__class__.__name__ == "DeviceTemperature"
+        function=lambda entity: entity.__class__.__name__ == "DeviceTemperature",
     )
     .prevent_default_entity_creation(
         endpoint_id=2,

--- a/zhaquirks/develco/power_plug.py
+++ b/zhaquirks/develco/power_plug.py
@@ -1,21 +1,141 @@
 """Develco smart plugs."""
 
+from typing import Final
+
+from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import (
     EntityType,
     QuirkBuilder,
     SensorDeviceClass,
     SensorStateClass,
+    ReportingConfig,
 )
 from zigpy.quirks.v2.homeassistant import UnitOfTemperature
-from zigpy.zcl.clusters.general import DeviceTemperature
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import DeviceTemperature, OnOff
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.smartenergy import Metering
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+MANUFACTURER_CODE = 0x1015
+
+
+class VendorOnOff(CustomCluster, OnOff):
+    """OnOff with manufacturer-specific commands."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Set defaults so HA shows 0 until a value is written.
+        self._update_attribute(self.AttributeDefs.mode_on_value.id, 0)
+        self._update_attribute(self.AttributeDefs.mode_off_value.id, 0)
+
+    class AttributeDefs(OnOff.AttributeDefs):
+        """Attributes used to drive the vendor commands."""
+
+        mode_value: Final = ZCLAttributeDef(
+            id=0x8100, type=t.uint8_t, access="r", manufacturer_code=MANUFACTURER_CODE
+        )
+        mode_on_value: Final = ZCLAttributeDef(id=0x8102, type=t.uint8_t, access="w")
+        mode_off_value: Final = ZCLAttributeDef(id=0x8103, type=t.uint8_t, access="w")
+        return_to_state: Final = ZCLAttributeDef(
+            id=0x8101, type=t.Bool, access="r", manufacturer_code=MANUFACTURER_CODE
+        )
+
+    async def _send_safe_mode(self, command_id: int, mode_value: int) -> None:
+        """Send manufacturer-specific safe-mode command without overriding On/Off."""
+        cmd_def = foundation.ZCLCommandDef(
+            id=command_id,
+            name="safe_mode",
+            schema={"mode": t.uint8_t},
+            is_manufacturer_specific=True,
+        ).with_compiled_schema()
+        await self.request(
+            False,
+            command_id,
+            cmd_def.schema,
+            mode=mode_value,
+            manufacturer=MANUFACTURER_CODE,
+            expect_reply=False,
+        )
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, int],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
+        """Translate mode writes into manufacturer-specific commands."""
+        mode_value = None
+
+        if self.AttributeDefs.mode_on_value.id in attributes:
+            mode_value = attributes.pop(self.AttributeDefs.mode_on_value.id)
+            await self._send_safe_mode(0x01, mode_value)
+            self._update_attribute(self.AttributeDefs.mode_on_value.id, mode_value)
+        elif self.AttributeDefs.mode_off_value.id in attributes:
+            mode_value = attributes.pop(self.AttributeDefs.mode_off_value.id)
+            await self._send_safe_mode(0x00, mode_value)
+            self._update_attribute(self.AttributeDefs.mode_off_value.id, mode_value)
+        elif self.AttributeDefs.mode_on_value.name in attributes:
+            mode_value = attributes.pop(self.AttributeDefs.mode_on_value.name)
+            await self._send_safe_mode(0x01, mode_value)
+            self._update_attribute(self.AttributeDefs.mode_on_value.id, mode_value)
+        elif self.AttributeDefs.mode_off_value.name in attributes:
+            mode_value = attributes.pop(self.AttributeDefs.mode_off_value.name)
+            await self._send_safe_mode(0x00, mode_value)
+            self._update_attribute(self.AttributeDefs.mode_off_value.id, mode_value)
+
+        if attributes:
+            return await super().write_attributes(attributes, **kwargs)
+
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
 (
     QuirkBuilder("frient A/S", "SPLZB-141")
     .applies_to("Develco Products A/S", "SPLZB-131")
+    .applies_to("Develco Products A/S", "SPLZB-132")
+    .applies_to("frient A/S", "SPLZB-131")
+    .applies_to("frient A/S", "SPLZB-132")
+    .applies_to("frient A/S", "SPLZB-134")
+    .applies_to("frient A/S", "SPLZB-137")
+    .applies_to("frient A/S", "SPLZB-142")
+    .applies_to("frient A/S", "SPLZB-144")
+    .applies_to("frient A/S", "SPLZB-147")
+    .applies_to("frient A/S", "SMRZB-143")
+    .applies_to("frient A/S", "SMRZB-153")
+    .applies_to("frient A/S", "SMRZB-332")
+    .applies_to("frient A/S", "SMRZB-342")
+    .replaces(VendorOnOff, endpoint_id=2)
     .prevent_default_entity_creation(
         endpoint_id=2,
         cluster_id=DeviceTemperature.cluster_id,
-        function=lambda entity: entity.__class__.__name__ == "DeviceTemperature",
+        function=lambda entity: entity.__class__.__name__ == "DeviceTemperature"
+    )
+    .prevent_default_entity_creation(
+        endpoint_id=2,
+        cluster_id=ElectricalMeasurement.cluster_id,
+        function=lambda entity: entity.device_class == "power",
+    )
+    .number(
+        attribute_name=VendorOnOff.AttributeDefs.mode_on_value.name,
+        cluster_id=OnOff.cluster_id,
+        endpoint_id=2,
+        min_value=0,
+        max_value=255,
+        step=1,
+        translation_key="mode_on",
+        fallback_name="On after (min)",
+        unique_id_suffix="mode_on",
+    )
+    .number(
+        attribute_name=VendorOnOff.AttributeDefs.mode_off_value.name,
+        cluster_id=OnOff.cluster_id,
+        endpoint_id=2,
+        min_value=0,
+        max_value=255,
+        step=1,
+        translation_key="mode_off",
+        fallback_name="Off after (min)",
+        unique_id_suffix="mode_off",
     )
     .sensor(
         endpoint_id=2,
@@ -29,6 +149,20 @@ from zigpy.zcl.clusters.general import DeviceTemperature
         fallback_name="Device temperature",
         entity_type=EntityType.DIAGNOSTIC,
         unique_id_suffix="2",  # Replace the ZHA entity
+    )
+    .binary_sensor(
+        attribute_name=VendorOnOff.AttributeDefs.return_to_state.name,
+        cluster_id=OnOff.cluster_id,
+        endpoint_id=2,
+        reporting_config=ReportingConfig(
+            min_interval=1,
+            max_interval=300,
+            reportable_change=1,
+        ),
+        translation_key="return_to_state",
+        fallback_name="Return to state",
+        entity_type=EntityType.DIAGNOSTIC,
+        unique_id_suffix="return_to_state",
     )
     .add_to_registry()
 )

--- a/zhaquirks/develco/power_plug.py
+++ b/zhaquirks/develco/power_plug.py
@@ -39,7 +39,7 @@ class VendorOnOff(CustomCluster, OnOff):
         mode_on_value: Final = ZCLAttributeDef(id=0x8102, type=t.uint8_t, access="w")
         mode_off_value: Final = ZCLAttributeDef(id=0x8103, type=t.uint8_t, access="w")
         return_to_state: Final = ZCLAttributeDef(
-            id=0x8101, type=t.Bool, access="r", manufacturer_code=MANUFACTURER_CODE
+            id=0x8101, type=t.Bool, access="rp", manufacturer_code=MANUFACTURER_CODE
         )
 
     async def _send_safe_mode(self, command_id: int, mode_value: int) -> None:
@@ -66,29 +66,37 @@ class VendorOnOff(CustomCluster, OnOff):
     ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Translate mode writes into manufacturer-specific commands."""
         attributes_copy = dict(attributes)
-        mode_value = None
 
-        if self.AttributeDefs.mode_on_value.id in attributes_copy:
-            mode_value = attributes_copy.pop(self.AttributeDefs.mode_on_value.id)
-            await self._send_safe_mode(0x01, mode_value)
-            self._update_attribute(self.AttributeDefs.mode_on_value.id, mode_value)
-        elif self.AttributeDefs.mode_off_value.id in attributes_copy:
-            mode_value = attributes_copy.pop(self.AttributeDefs.mode_off_value.id)
-            await self._send_safe_mode(0x00, mode_value)
-            self._update_attribute(self.AttributeDefs.mode_off_value.id, mode_value)
-        elif self.AttributeDefs.mode_on_value.name in attributes_copy:
-            mode_value = attributes_copy.pop(self.AttributeDefs.mode_on_value.name)
-            await self._send_safe_mode(0x01, mode_value)
-            self._update_attribute(self.AttributeDefs.mode_on_value.id, mode_value)
-        elif self.AttributeDefs.mode_off_value.name in attributes_copy:
-            mode_value = attributes_copy.pop(self.AttributeDefs.mode_off_value.name)
-            await self._send_safe_mode(0x00, mode_value)
-            self._update_attribute(self.AttributeDefs.mode_off_value.id, mode_value)
+        def _pop_attr_value(
+            attr_def: foundation.ZCLAttributeDef,
+        ) -> tuple[bool, int | None]:
+            value = None
+            found = False
+            for key in (attr_def.id, attr_def.name, attr_def):
+                if key in attributes_copy:
+                    value = attributes_copy.pop(key)
+                    found = True
+            return found, value
+
+        has_mode_on, mode_on_value = _pop_attr_value(self.AttributeDefs.mode_on_value)
+        has_mode_off, mode_off_value = _pop_attr_value(self.AttributeDefs.mode_off_value)
+        handled_vendor_attr = has_mode_on or has_mode_off
+
+        if has_mode_on:
+            await self._send_safe_mode(0x01, mode_on_value)
+            self._update_attribute(self.AttributeDefs.mode_on_value.id, mode_on_value)
+
+        if has_mode_off:
+            await self._send_safe_mode(0x00, mode_off_value)
+            self._update_attribute(self.AttributeDefs.mode_off_value.id, mode_off_value)
 
         if attributes_copy:
             return await super().write_attributes(attributes_copy, **kwargs)
 
-        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+        if handled_vendor_attr:
+            return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+
+        return await super().write_attributes(attributes_copy, **kwargs)
 
 
 (

--- a/zhaquirks/develco/power_plug.py
+++ b/zhaquirks/develco/power_plug.py
@@ -79,7 +79,9 @@ class VendorOnOff(CustomCluster, OnOff):
             return found, value
 
         has_mode_on, mode_on_value = _pop_attr_value(self.AttributeDefs.mode_on_value)
-        has_mode_off, mode_off_value = _pop_attr_value(self.AttributeDefs.mode_off_value)
+        has_mode_off, mode_off_value = _pop_attr_value(
+            self.AttributeDefs.mode_off_value
+        )
         handled_vendor_attr = has_mode_on or has_mode_off
 
         if has_mode_on:

--- a/zhaquirks/develco/power_plug.py
+++ b/zhaquirks/develco/power_plug.py
@@ -25,6 +25,7 @@ class VendorOnOff(CustomCluster, OnOff):
     """OnOff with manufacturer-specific commands."""
 
     def __init__(self, *args, **kwargs) -> None:
+        """Seed attributes so entities start with a defined value."""
         super().__init__(*args, **kwargs)
         # Set defaults so HA shows 0 until a value is written.
         self._update_attribute(self.AttributeDefs.mode_on_value.id, 0)
@@ -65,44 +66,55 @@ class VendorOnOff(CustomCluster, OnOff):
         **kwargs,
     ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Translate mode writes into manufacturer-specific commands."""
+        attributes_copy = dict(attributes)
         mode_value = None
 
-        if self.AttributeDefs.mode_on_value.id in attributes:
-            mode_value = attributes.pop(self.AttributeDefs.mode_on_value.id)
+        if self.AttributeDefs.mode_on_value.id in attributes_copy:
+            mode_value = attributes_copy.pop(self.AttributeDefs.mode_on_value.id)
             await self._send_safe_mode(0x01, mode_value)
             self._update_attribute(self.AttributeDefs.mode_on_value.id, mode_value)
-        elif self.AttributeDefs.mode_off_value.id in attributes:
-            mode_value = attributes.pop(self.AttributeDefs.mode_off_value.id)
+        elif self.AttributeDefs.mode_off_value.id in attributes_copy:
+            mode_value = attributes_copy.pop(self.AttributeDefs.mode_off_value.id)
             await self._send_safe_mode(0x00, mode_value)
             self._update_attribute(self.AttributeDefs.mode_off_value.id, mode_value)
-        elif self.AttributeDefs.mode_on_value.name in attributes:
-            mode_value = attributes.pop(self.AttributeDefs.mode_on_value.name)
+        elif self.AttributeDefs.mode_on_value.name in attributes_copy:
+            mode_value = attributes_copy.pop(self.AttributeDefs.mode_on_value.name)
             await self._send_safe_mode(0x01, mode_value)
             self._update_attribute(self.AttributeDefs.mode_on_value.id, mode_value)
-        elif self.AttributeDefs.mode_off_value.name in attributes:
-            mode_value = attributes.pop(self.AttributeDefs.mode_off_value.name)
+        elif self.AttributeDefs.mode_off_value.name in attributes_copy:
+            mode_value = attributes_copy.pop(self.AttributeDefs.mode_off_value.name)
             await self._send_safe_mode(0x00, mode_value)
             self._update_attribute(self.AttributeDefs.mode_off_value.id, mode_value)
 
-        if attributes:
-            return await super().write_attributes(attributes, **kwargs)
+        if attributes_copy:
+            return await super().write_attributes(attributes_copy, **kwargs)
 
         return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
 (
     QuirkBuilder("frient A/S", "SPLZB-141")
     .applies_to("Develco Products A/S", "SPLZB-131")
-    .applies_to("Develco Products A/S", "SPLZB-132")
     .applies_to("frient A/S", "SPLZB-131")
+    .applies_to("Develco Products A/S", "SPLZB-132")
     .applies_to("frient A/S", "SPLZB-132")
+    .applies_to("Develco Products A/S", "SPLZB-134")
     .applies_to("frient A/S", "SPLZB-134")
+    .applies_to("Develco Products A/S", "SPLZB-137")
     .applies_to("frient A/S", "SPLZB-137")
+    .applies_to("Develco Products A/S", "SPLZB-141")
+    .applies_to("Develco Products A/S", "SPLZB-142")
     .applies_to("frient A/S", "SPLZB-142")
+    .applies_to("Develco Products A/S", "SPLZB-144")
     .applies_to("frient A/S", "SPLZB-144")
+    .applies_to("Develco Products A/S", "SPLZB-147")
     .applies_to("frient A/S", "SPLZB-147")
+    .applies_to("Develco Products A/S", "SMRZB-143")
     .applies_to("frient A/S", "SMRZB-143")
+    .applies_to("Develco Products A/S", "SMRZB-153")
     .applies_to("frient A/S", "SMRZB-153")
+    .applies_to("Develco Products A/S", "SMRZB-332")
     .applies_to("frient A/S", "SMRZB-332")
+    .applies_to("Develco Products A/S", "SMRZB-342")
     .applies_to("frient A/S", "SMRZB-342")
     .replaces(VendorOnOff, endpoint_id=2)
     .prevent_default_entity_creation(


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The quirk has been made to extend functionality of the following frient/Develco Smart Plugs, Smart Cables and Smart DIN Relays:
 - frient Smart Plug Mini with model no. SPLZB-131
 - frient Smart Plug Mini with model no. SPLZB-132
 - frient Smart Plug Mini UK with model no. SPLZB-134
 - frient Smart Plug Mini with model no. SPLZB-137
 - frient Smart Plug Mini 2 with model no. SPLZB-141
 - frient Smart Plug Mini 2 with model no. SPLZB-142
 - frient Smart Plug Mini 2 UK with model no. SPLZB-144
 - frient Smart Plug Mini 2 with model no. SPLZB-147
 - frient Smart Cable with model no. SMRZB-143
 - frient Smart Cable 2 with model no. SMRZB-153
 - frient Smart DIN Relay with model no. SMRZB-332
 - frient Smart DIN Relay 2 with model no. SMRZB-342
 - Develco Smart Plug Mini with model no. SPLZB-131
 - Develco Smart Plug Mini with model no. SPLZB-132
 - Develco Smart Plug Mini UK with model no. SPLZB-134
 - Develco Smart Plug Mini with model no. SPLZB-137
 - Develco Smart Plug Mini 2 with model no. SPLZB-141
 - Develco Smart Plug Mini 2 with model no. SPLZB-142
 - Develco Smart Plug Mini 2 UK with model no. SPLZB-144
 - Develco Smart Plug Mini 2 with model no. SPLZB-147
 - Develco Smart Cable with model no. SMRZB-143
 - Develco Smart Cable 2 with model no. SMRZB-153
 - Develco Smart DIN Relay with model no. SMRZB-332
 - Develco Smart DIN Relay 2 with model no. SMRZB-342
 
The quirk contains following changes:
 - Add delayed turn on/off functionality
 - Add return to state entity to track the last sent command to turn on/off with delay

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
<img width="1574" height="1732" alt="image" src="https://github.com/user-attachments/assets/3107514e-0bae-48b8-bbd0-60b97e0776a4" />


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-01KJYXWD9VV3FMNDJEFN115MC4-frient A_S SMRZB-153-59b661ecb0fc7ef52e3630f969e79742.json](https://github.com/user-attachments/files/26302146/zha-01KJYXWD9VV3FMNDJEFN115MC4-frient.A_S.SMRZB-153-59b661ecb0fc7ef52e3630f969e79742.json)
[zha-01KJYXWD9VV3FMNDJEFN115MC4-frient A_S SMRZB-342-c9ca9838109ed505f89b8687390fccfc.json](https://github.com/user-attachments/files/26302150/zha-01KJYXWD9VV3FMNDJEFN115MC4-frient.A_S.SMRZB-342-c9ca9838109ed505f89b8687390fccfc.json)
[zha-01KJYXWD9VV3FMNDJEFN115MC4-frient A_S SPLZB-132-54d2a1249af9626f191030cccc09a47d.json](https://github.com/user-attachments/files/26302151/zha-01KJYXWD9VV3FMNDJEFN115MC4-frient.A_S.SPLZB-132-54d2a1249af9626f191030cccc09a47d.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
