### PR TITLE
Add quirk for Tuya TS0601 wireless alarm keypad

### DIFF
--- a/tests/test_tuya_keypad.py
+++ b/tests/test_tuya_keypad.py
@@ -1,5 +1,7 @@
 """Tests for Tuya TS0601 keypad quirk."""
 
+from unittest.mock import call
+
 import pytest
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import PowerConfiguration
@@ -7,6 +9,7 @@ from zigpy.zcl.clusters.security import IasAce, IasZone
 
 from tests.common import ClusterListener
 import zhaquirks
+from zhaquirks.const import ZHA_SEND_EVENT
 from zhaquirks.tuya.ts0601_keypad import (
     TuyaAlarmControlPanelCluster,
     TuyaIasZoneTamper,
@@ -130,11 +133,12 @@ class TestTuyaKeypadAlarmEvents:
         status = _send_tuya_command(ep, ZCL_TUYA_ARM_AWAY)
         assert status == foundation.Status.SUCCESS
 
-        # IAS ACE arm command should be fired
+        # IAS ACE arm command should be fired with empty user_code
+        # (DP 109 has not been received yet).
         assert len(ace_listener.cluster_commands) == 1
         assert ace_listener.cluster_commands[0][2] == [
             IasAce.ArmMode.Arm_All_Zones,
-            "1234",
+            "",
             0,
         ]
 
@@ -149,7 +153,7 @@ class TestTuyaKeypadAlarmEvents:
         assert len(ace_listener.cluster_commands) == 1
         assert ace_listener.cluster_commands[0][2] == [
             IasAce.ArmMode.Disarm,
-            "1234",
+            "",
             0,
         ]
 
@@ -164,7 +168,7 @@ class TestTuyaKeypadAlarmEvents:
         assert len(ace_listener.cluster_commands) == 1
         assert ace_listener.cluster_commands[0][2] == [
             IasAce.ArmMode.Arm_Day_Home_Only,
-            "1234",
+            "",
             0,
         ]
 
@@ -196,7 +200,11 @@ class TestTuyaKeypadAlarmEvents:
         )
 
     def test_tamper_sets_zone_status(self, keypad_device):
-        """Test that tamper/anti-remove sets and clears IAS Zone zone_status."""
+        """Test that tamper/anti-remove sets and clears IAS Zone zone_status.
+
+        ZHA's IAS Zone binary sensor masks the Tamper bit out of the alarm
+        state, so anti-remove is signalled via Alarm_1 only.
+        """
         ep = keypad_device.endpoints[1]
         zone_listener = ClusterListener(ep.ias_zone)
         zone_status_id = IasZone.AttributeDefs.zone_status.id
@@ -209,9 +217,7 @@ class TestTuyaKeypadAlarmEvents:
             u for u in zone_listener.attribute_updates if u[0] == zone_status_id
         ]
         assert len(tamper_updates) == 1
-        assert tamper_updates[0][1] == (
-            IasZone.ZoneStatus.Alarm_1 | IasZone.ZoneStatus.Tamper
-        )
+        assert tamper_updates[0][1] == IasZone.ZoneStatus.Alarm_1
 
         # Tamper cleared
         status = _send_tuya_command(ep, ZCL_TUYA_TAMPER_CLEAR)
@@ -222,6 +228,22 @@ class TestTuyaKeypadAlarmEvents:
         ]
         assert len(tamper_updates) == 2
         assert tamper_updates[1][1] == 0
+
+    def test_tamper_clear_does_not_fire_alarm_events(self, keypad_device):
+        """Test DP 24 release only updates zone_status, no alarm events.
+
+        Neither IAS ACE emergency nor zha_event ``emergency`` should fire
+        when the anti-remove switch transitions back to False.
+        """
+        ep = keypad_device.endpoints[1]
+        ace_listener = ClusterListener(ep.ias_ace)
+
+        status = _send_tuya_command(ep, ZCL_TUYA_TAMPER_CLEAR)
+        assert status == foundation.Status.SUCCESS
+
+        # No IAS ACE command, no zha_event. Otherwise we'd fire spurious
+        # panic/emergency every time the tamper switch reports "released".
+        assert ace_listener.cluster_commands == []
 
     def test_arm_uses_cached_user_code(self, keypad_device):
         """Test that arm events use the cached user code from DP 109."""
@@ -240,6 +262,44 @@ class TestTuyaKeypadAlarmEvents:
             "5678",
             0,
         ]
+
+
+class TestTuyaKeypadZhaEvents:
+    """Test that DP events emit the expected zha_event payloads."""
+
+    @pytest.mark.parametrize(
+        ("frame", "action"),
+        [
+            (ZCL_TUYA_ARM_AWAY, "arm_away"),
+            (ZCL_TUYA_DISARM, "disarm"),
+            (ZCL_TUYA_ARM_HOME, "arm_home"),
+            (ZCL_TUYA_PANIC, "panic"),
+            (ZCL_TUYA_EMERGENCY, "emergency"),
+        ],
+    )
+    def test_dp_emits_zha_event(self, keypad_device, mocker, frame, action):
+        """Each event-DP fires ZHA_SEND_EVENT with the matching action."""
+        ep = keypad_device.endpoints[1]
+        spy = mocker.spy(ep.tuya_manufacturer, "listener_event")
+
+        _send_tuya_command(ep, frame)
+
+        assert call(ZHA_SEND_EVENT, action, {}) in spy.call_args_list
+
+    def test_tamper_clear_does_not_emit_zha_event(self, keypad_device, mocker):
+        """Test DP 24 release does not emit a zha_event ``emergency``.
+
+        Otherwise panic automations would fire every time tamper recovers.
+        """
+        ep = keypad_device.endpoints[1]
+        spy = mocker.spy(ep.tuya_manufacturer, "listener_event")
+
+        _send_tuya_command(ep, ZCL_TUYA_TAMPER_CLEAR)
+
+        zha_events = [
+            c for c in spy.call_args_list if c.args and c.args[0] == ZHA_SEND_EVENT
+        ]
+        assert zha_events == []
 
 
 class TestTuyaKeypadModelsInfo:

--- a/tests/test_tuya_keypad.py
+++ b/tests/test_tuya_keypad.py
@@ -1,0 +1,253 @@
+"""Tests for Tuya TS0601 keypad quirk."""
+
+import pytest
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import PowerConfiguration
+from zigpy.zcl.clusters.security import IasAce, IasZone
+
+from tests.common import ClusterListener
+import zhaquirks
+from zhaquirks.tuya.ts0601_keypad import (
+    TuyaAlarmControlPanelCluster,
+    TuyaIasZoneTamper,
+    TuyaKeypadManufCluster,
+    TuyaPowerConfigurationCluster3AAA,
+    TuyaWirelessZigbeeKeypad,
+)
+
+zhaquirks.setup()
+
+# ZCL frames: frame_control(0x09) + TSN + cmd(0x01=get_data) + status + mcu_tsn + DP data
+# Enum DP format: dp_id + type(0x04=enum) + len(0x00 0x01) + value(0x00)
+# Integer DP format: dp_id + type(0x02=value) + len(0x00 0x04) + value(4 bytes BE)
+
+# DP 27 (armed away) - enum 0
+ZCL_TUYA_ARM_AWAY = b"\x09\x01\x01\x00\x01\x1b\x04\x00\x01\x00"
+# DP 26 (disarmed) - enum 0
+ZCL_TUYA_DISARM = b"\x09\x02\x01\x00\x02\x1a\x04\x00\x01\x00"
+# DP 28 (armed home) - enum 0
+ZCL_TUYA_ARM_HOME = b"\x09\x03\x01\x00\x03\x1c\x04\x00\x01\x00"
+# DP 29 (SOS/panic) - enum 0
+ZCL_TUYA_PANIC = b"\x09\x04\x01\x00\x04\x1d\x04\x00\x01\x00"
+# DP 24 (anti-remove/tamper triggered) - bool true
+ZCL_TUYA_EMERGENCY = b"\x09\x05\x01\x00\x05\x18\x01\x00\x01\x01"
+# DP 24 (anti-remove/tamper cleared) - bool false
+ZCL_TUYA_TAMPER_CLEAR = b"\x09\x08\x01\x00\x08\x18\x01\x00\x01\x00"
+# DP 3 (battery percentage = 100) - integer
+ZCL_TUYA_BATTERY_100 = b"\x09\x06\x01\x00\x06\x03\x02\x00\x04\x00\x00\x00\x64"
+# DP 3 (battery percentage = 50) - integer
+ZCL_TUYA_BATTERY_50 = b"\x09\x07\x01\x00\x07\x03\x02\x00\x04\x00\x00\x00\x32"
+
+
+@pytest.fixture
+def keypad_device(zigpy_device_from_quirk):
+    """Create a keypad device from the quirk."""
+    return zigpy_device_from_quirk(TuyaWirelessZigbeeKeypad)
+
+
+def _send_tuya_command(ep, frame):
+    """Deserialize and dispatch a Tuya ZCL frame to the MCU cluster."""
+    hdr, data = ep.tuya_manufacturer.deserialize(frame)
+    return ep.tuya_manufacturer.handle_get_data(data.data)
+
+
+class TestTuyaKeypadQuirk:
+    """Test the Tuya keypad quirk applies correctly."""
+
+    def test_quirk_signature(self, keypad_device):
+        """Test that the quirk applies and creates the expected clusters."""
+        ep = keypad_device.endpoints[1]
+
+        assert isinstance(ep.tuya_manufacturer, TuyaKeypadManufCluster)
+        assert isinstance(ep.ias_ace, TuyaAlarmControlPanelCluster)
+        assert isinstance(ep.power, TuyaPowerConfigurationCluster3AAA)
+        assert isinstance(ep.ias_zone, TuyaIasZoneTamper)
+        assert hasattr(keypad_device, "ias_bus")
+
+    def test_device_automation_triggers(self, keypad_device):
+        """Test that device automation triggers are defined."""
+        triggers = keypad_device.device_automation_triggers
+        assert ("disarm", "disarm") in triggers
+        assert ("arm_away", "arm_away") in triggers
+        assert ("arm_home", "arm_home") in triggers
+        assert ("panic", "panic") in triggers
+        assert ("emergency", "emergency") in triggers
+
+    def test_battery_constant_attributes(self, keypad_device):
+        """Test that battery constant attributes are set correctly."""
+        power_cluster = keypad_device.endpoints[1].power
+        battery_size_id = PowerConfiguration.attributes_by_name["battery_size"].id
+        battery_qty_id = PowerConfiguration.attributes_by_name["battery_quantity"].id
+        battery_voltage_id = PowerConfiguration.attributes_by_name[
+            "battery_rated_voltage"
+        ].id
+
+        assert power_cluster._CONSTANT_ATTRIBUTES[battery_size_id] == (
+            PowerConfiguration.BatterySize.AAA
+        )
+        assert power_cluster._CONSTANT_ATTRIBUTES[battery_qty_id] == 3
+        assert power_cluster._CONSTANT_ATTRIBUTES[battery_voltage_id] == 15
+
+
+class TestTuyaKeypadBattery:
+    """Test battery DP handling."""
+
+    def test_battery_100_percent(self, keypad_device):
+        """Test battery percentage reporting at 100%."""
+        ep = keypad_device.endpoints[1]
+        power_listener = ClusterListener(ep.power)
+
+        status = _send_tuya_command(ep, ZCL_TUYA_BATTERY_100)
+        assert status == foundation.Status.SUCCESS
+
+        # Battery 100 → battery_percentage_remaining = 200 (ZCL uses 0-200 range)
+        assert len(power_listener.attribute_updates) == 1
+        assert power_listener.attribute_updates[0][0] == (
+            PowerConfiguration.attributes_by_name["battery_percentage_remaining"].id
+        )
+        assert power_listener.attribute_updates[0][1] == 200
+
+    def test_battery_50_percent(self, keypad_device):
+        """Test battery percentage reporting at 50%."""
+        ep = keypad_device.endpoints[1]
+        power_listener = ClusterListener(ep.power)
+
+        status = _send_tuya_command(ep, ZCL_TUYA_BATTERY_50)
+        assert status == foundation.Status.SUCCESS
+
+        assert len(power_listener.attribute_updates) == 1
+        assert power_listener.attribute_updates[0][1] == 100  # 50 * 2 = 100
+
+
+class TestTuyaKeypadAlarmEvents:
+    """Test arm/disarm/panic event generation."""
+
+    def test_arm_away(self, keypad_device):
+        """Test arm away generates IAS ACE event and zha_event."""
+        ep = keypad_device.endpoints[1]
+        ace_listener = ClusterListener(ep.ias_ace)
+
+        status = _send_tuya_command(ep, ZCL_TUYA_ARM_AWAY)
+        assert status == foundation.Status.SUCCESS
+
+        # IAS ACE arm command should be fired
+        assert len(ace_listener.cluster_commands) == 1
+        assert ace_listener.cluster_commands[0][2] == [
+            IasAce.ArmMode.Arm_All_Zones,
+            "1234",
+            0,
+        ]
+
+    def test_disarm(self, keypad_device):
+        """Test disarm generates IAS ACE event."""
+        ep = keypad_device.endpoints[1]
+        ace_listener = ClusterListener(ep.ias_ace)
+
+        status = _send_tuya_command(ep, ZCL_TUYA_DISARM)
+        assert status == foundation.Status.SUCCESS
+
+        assert len(ace_listener.cluster_commands) == 1
+        assert ace_listener.cluster_commands[0][2] == [
+            IasAce.ArmMode.Disarm,
+            "1234",
+            0,
+        ]
+
+    def test_arm_home(self, keypad_device):
+        """Test arm home generates IAS ACE event."""
+        ep = keypad_device.endpoints[1]
+        ace_listener = ClusterListener(ep.ias_ace)
+
+        status = _send_tuya_command(ep, ZCL_TUYA_ARM_HOME)
+        assert status == foundation.Status.SUCCESS
+
+        assert len(ace_listener.cluster_commands) == 1
+        assert ace_listener.cluster_commands[0][2] == [
+            IasAce.ArmMode.Arm_Day_Home_Only,
+            "1234",
+            0,
+        ]
+
+    def test_panic(self, keypad_device):
+        """Test SOS/panic generates IAS ACE panic event."""
+        ep = keypad_device.endpoints[1]
+        ace_listener = ClusterListener(ep.ias_ace)
+
+        status = _send_tuya_command(ep, ZCL_TUYA_PANIC)
+        assert status == foundation.Status.SUCCESS
+
+        assert len(ace_listener.cluster_commands) == 1
+        # Panic command ID
+        assert ace_listener.cluster_commands[0][1] == (
+            IasAce.commands_by_name["panic"].id
+        )
+
+    def test_emergency(self, keypad_device):
+        """Test tamper/anti-remove generates IAS ACE emergency event."""
+        ep = keypad_device.endpoints[1]
+        ace_listener = ClusterListener(ep.ias_ace)
+
+        status = _send_tuya_command(ep, ZCL_TUYA_EMERGENCY)
+        assert status == foundation.Status.SUCCESS
+
+        assert len(ace_listener.cluster_commands) == 1
+        assert ace_listener.cluster_commands[0][1] == (
+            IasAce.commands_by_name["emergency"].id
+        )
+
+    def test_tamper_sets_zone_status(self, keypad_device):
+        """Test that tamper/anti-remove sets and clears IAS Zone zone_status."""
+        ep = keypad_device.endpoints[1]
+        zone_listener = ClusterListener(ep.ias_zone)
+        zone_status_id = IasZone.AttributeDefs.zone_status.id
+
+        # Tamper triggered
+        status = _send_tuya_command(ep, ZCL_TUYA_EMERGENCY)
+        assert status == foundation.Status.SUCCESS
+
+        tamper_updates = [
+            u for u in zone_listener.attribute_updates if u[0] == zone_status_id
+        ]
+        assert len(tamper_updates) == 1
+        assert tamper_updates[0][1] == (
+            IasZone.ZoneStatus.Alarm_1 | IasZone.ZoneStatus.Tamper
+        )
+
+        # Tamper cleared
+        status = _send_tuya_command(ep, ZCL_TUYA_TAMPER_CLEAR)
+        assert status == foundation.Status.SUCCESS
+
+        tamper_updates = [
+            u for u in zone_listener.attribute_updates if u[0] == zone_status_id
+        ]
+        assert len(tamper_updates) == 2
+        assert tamper_updates[1][1] == 0
+
+    def test_arm_uses_cached_user_code(self, keypad_device):
+        """Test that arm events use the cached user code from DP 109."""
+        ep = keypad_device.endpoints[1]
+        mcu_cluster = ep.tuya_manufacturer
+
+        # Set a custom user code in the attribute cache
+        user_code_attr_id = mcu_cluster.attributes_by_name["user_code"].id
+        mcu_cluster._attr_cache[user_code_attr_id] = "5678"
+
+        ace_listener = ClusterListener(ep.ias_ace)
+        _send_tuya_command(ep, ZCL_TUYA_ARM_AWAY)
+
+        assert ace_listener.cluster_commands[0][2] == [
+            IasAce.ArmMode.Arm_All_Zones,
+            "5678",
+            0,
+        ]
+
+
+class TestTuyaKeypadModelsInfo:
+    """Test that all supported models are listed."""
+
+    def test_models_info(self):
+        """Test that both known manufacturer IDs are supported."""
+        models = TuyaWirelessZigbeeKeypad.signature["models_info"]
+        manufacturers = [m[0] for m in models]
+        assert "_TZE200_n9clpsht" in manufacturers
+        assert "_TZE200_nyvavzbj" in manufacturers

--- a/tests/test_tuya_keypad.py
+++ b/tests/test_tuya_keypad.py
@@ -1,6 +1,6 @@
 """Tests for Tuya TS0601 keypad quirk."""
 
-from unittest.mock import call
+from unittest import mock
 
 import pytest
 from zigpy.zcl import foundation
@@ -9,7 +9,6 @@ from zigpy.zcl.clusters.security import IasAce, IasZone
 
 from tests.common import ClusterListener
 import zhaquirks
-from zhaquirks.const import ZHA_SEND_EVENT
 from zhaquirks.tuya.ts0601_keypad import (
     TuyaAlarmControlPanelCluster,
     TuyaIasZoneTamper,
@@ -277,29 +276,28 @@ class TestTuyaKeypadZhaEvents:
             (ZCL_TUYA_EMERGENCY, "emergency"),
         ],
     )
-    def test_dp_emits_zha_event(self, keypad_device, mocker, frame, action):
+    def test_dp_emits_zha_event(self, keypad_device, frame, action):
         """Each event-DP fires ZHA_SEND_EVENT with the matching action."""
         ep = keypad_device.endpoints[1]
-        spy = mocker.spy(ep.tuya_manufacturer, "listener_event")
+        listener = mock.MagicMock()
+        ep.tuya_manufacturer.add_listener(listener)
 
         _send_tuya_command(ep, frame)
 
-        assert call(ZHA_SEND_EVENT, action, {}) in spy.call_args_list
+        assert listener.zha_send_event.call_args_list == [mock.call(action, {})]
 
-    def test_tamper_clear_does_not_emit_zha_event(self, keypad_device, mocker):
+    def test_tamper_clear_does_not_emit_zha_event(self, keypad_device):
         """Test DP 24 release does not emit a zha_event ``emergency``.
 
         Otherwise panic automations would fire every time tamper recovers.
         """
         ep = keypad_device.endpoints[1]
-        spy = mocker.spy(ep.tuya_manufacturer, "listener_event")
+        listener = mock.MagicMock()
+        ep.tuya_manufacturer.add_listener(listener)
 
         _send_tuya_command(ep, ZCL_TUYA_TAMPER_CLEAR)
 
-        zha_events = [
-            c for c in spy.call_args_list if c.args and c.args[0] == ZHA_SEND_EVENT
-        ]
-        assert zha_events == []
+        listener.zha_send_event.assert_not_called()
 
 
 class TestTuyaKeypadModelsInfo:

--- a/zhaquirks/tuya/ts0601_keypad.py
+++ b/zhaquirks/tuya/ts0601_keypad.py
@@ -48,6 +48,7 @@ from zigpy.zcl.clusters.general import (
     Time,
 )
 from zigpy.zcl.clusters.security import IasAce, IasZone
+from zigpy.zcl.foundation import ZCLAttributeDef
 
 from zhaquirks import Bus, PowerConfigurationCluster
 from zhaquirks.const import (
@@ -72,62 +73,61 @@ ARM_HOME = "arm_home"
 PANIC = "panic"
 EMERGENCY = "emergency"
 
+# Tuya DP IDs (see module docstring)
+BATTERY_PERCENTAGE_DP_ID = 3
+ANTI_REMOVE_ALARM_DP_ID = 24
+DISARMED_DP_ID = 26
+ARMED_DP_ID = 27
+ARMED_HOME_DP_ID = 28
+SOS_DP_ID = 29
+ARM_DELAY_TIME_DP_ID = 103
+KEYPAD_BEEPS_DP_ID = 104
+QUICK_SOS_DP_ID = 105
+QUICK_DISARM_DP_ID = 106
+QUICK_ARM_DP_ID = 107
+ADMIN_CODE_DP_ID = 108
+USER_CODE_DP_ID = 109
+ARM_DELAY_BEEPS_DP_ID = 111
+
 
 class TuyaKeypadManufCluster(TuyaMCUCluster):
     """Tuya keypad manufacturer cluster."""
 
-    BATTERY_PERCENTAGE_DP_ID = 3
-    ANTI_REMOVE_ALARM_DP_ID = 24
-    DISARMED_DP_ID = 26
-    ARMED_DP_ID = 27
-    ARMED_HOME_DP_ID = 28
-    SOS_DP_ID = 29
-    ARM_DELAY_TIME_DP_ID = 103
-    KEYPAD_BEEPS_DP_ID = 104
-    QUICK_SOS_DP_ID = 105
-    QUICK_DISARM_DP_ID = 106
-    QUICK_ARM_DP_ID = 107
-    ADMIN_CODE_DP_ID = 108
-    USER_CODE_DP_ID = 109
-    ARM_DELAY_BEEPS_DP_ID = 111
+    class AttributeDefs(TuyaMCUCluster.AttributeDefs):
+        """Tuya keypad attribute definitions."""
 
-    attributes = TuyaMCUCluster.attributes.copy()
-    attributes.update(
-        {
-            TuyaMCUCluster.cluster_id + ARM_DELAY_TIME_DP_ID: (
-                "arm_delay_time",
-                t.uint8_t,
-            ),
-            TuyaMCUCluster.cluster_id + ARM_DELAY_BEEPS_DP_ID: (
-                "arm_delay_beeps",
-                t.uint8_t,
-            ),
-            TuyaMCUCluster.cluster_id + KEYPAD_BEEPS_DP_ID: (
-                "keypad_beeps",
-                t.uint8_t,
-            ),
-            TuyaMCUCluster.cluster_id + QUICK_DISARM_DP_ID: (
-                "quick_disarm",
-                t.uint8_t,
-            ),
-            TuyaMCUCluster.cluster_id + QUICK_ARM_DP_ID: (
-                "quick_arm",
-                t.uint8_t,
-            ),
-            TuyaMCUCluster.cluster_id + QUICK_SOS_DP_ID: (
-                "quick_sos",
-                t.uint8_t,
-            ),
-            TuyaMCUCluster.cluster_id + ADMIN_CODE_DP_ID: (
-                "admin_code",
-                t.CharacterString,
-            ),
-            TuyaMCUCluster.cluster_id + USER_CODE_DP_ID: (
-                "user_code",
-                t.CharacterString,
-            ),
-        }
-    )
+        arm_delay_time = ZCLAttributeDef(
+            id=TuyaMCUCluster.cluster_id + ARM_DELAY_TIME_DP_ID,
+            type=t.uint8_t,
+        )
+        arm_delay_beeps = ZCLAttributeDef(
+            id=TuyaMCUCluster.cluster_id + ARM_DELAY_BEEPS_DP_ID,
+            type=t.uint8_t,
+        )
+        keypad_beeps = ZCLAttributeDef(
+            id=TuyaMCUCluster.cluster_id + KEYPAD_BEEPS_DP_ID,
+            type=t.uint8_t,
+        )
+        quick_disarm = ZCLAttributeDef(
+            id=TuyaMCUCluster.cluster_id + QUICK_DISARM_DP_ID,
+            type=t.uint8_t,
+        )
+        quick_arm = ZCLAttributeDef(
+            id=TuyaMCUCluster.cluster_id + QUICK_ARM_DP_ID,
+            type=t.uint8_t,
+        )
+        quick_sos = ZCLAttributeDef(
+            id=TuyaMCUCluster.cluster_id + QUICK_SOS_DP_ID,
+            type=t.uint8_t,
+        )
+        admin_code = ZCLAttributeDef(
+            id=TuyaMCUCluster.cluster_id + ADMIN_CODE_DP_ID,
+            type=t.CharacterString,
+        )
+        user_code = ZCLAttributeDef(
+            id=TuyaMCUCluster.cluster_id + USER_CODE_DP_ID,
+            type=t.CharacterString,
+        )
 
     dp_to_attribute: dict[int, DPToAttributeMapping] = {
         BATTERY_PERCENTAGE_DP_ID: DPToAttributeMapping(
@@ -187,10 +187,21 @@ class TuyaKeypadManufCluster(TuyaMCUCluster):
 
     def _dp_2_event(self, datapoint: TuyaDatapointData) -> None:
         """Convert arm/disarm/SOS datapoints to ZHA events and IAS ACE commands."""
+        # Update tamper zone_status on IAS Zone cluster: always reflect current
+        # state (set on trigger, clear on release). Note: ZHA masks the Tamper
+        # bit out of the IAS Zone binary sensor state, so we use Alarm_1 here.
+        if datapoint.dp == ANTI_REMOVE_ALARM_DP_ID:
+            zone_status = IasZone.ZoneStatus.Alarm_1 if datapoint.data.payload else 0
+            self.endpoint.ias_zone._update_attribute(
+                IasZone.AttributeDefs.zone_status.id, zone_status
+            )
+            # Anti-remove fires on both trigger and release; only emit
+            # alarm/zha events when the tamper switch transitions to True.
+            if not datapoint.data.payload:
+                return
+
         zone_id = 0
-        user_code = self._attr_cache.get(
-            self.attributes_by_name["user_code"].id, "1234"
-        )
+        user_code = self._attr_cache.get(self.attributes_by_name["user_code"].id, "")
 
         # Fire IAS ACE event via internal bus
         ias_ace = self.DP_TO_IAS_ACE.get(datapoint.dp)
@@ -202,17 +213,6 @@ class TuyaKeypadManufCluster(TuyaMCUCluster):
                 )
             else:
                 self.endpoint.device.ias_bus.listener_event(event_name)
-
-        # Update tamper zone_status on IAS Zone cluster
-        if datapoint.dp == self.ANTI_REMOVE_ALARM_DP_ID:
-            zone_status = (
-                IasZone.ZoneStatus.Alarm_1 | IasZone.ZoneStatus.Tamper
-                if datapoint.data.payload
-                else 0
-            )
-            self.endpoint.ias_zone._update_attribute(
-                IasZone.AttributeDefs.zone_status.id, zone_status
-            )
 
         # Fire zha_event for HA automations
         action = self.DP_TO_ACTION.get(datapoint.dp)
@@ -274,10 +274,16 @@ class TuyaAlarmControlPanelCluster(TuyaLocalCluster, IasAce):
 
 
 class TuyaIasZoneTamper(TuyaLocalCluster, IasZone):
-    """IAS Zone cluster for tamper/anti-remove detection."""
+    """IAS Zone cluster for tamper/anti-remove detection.
+
+    Uses ``Standard_CIE`` zone_type so HA presents the entity as a generic
+    IAS Zone — not a contact/opening sensor. ZHA's IAS Zone binary sensor
+    masks the Tamper bit out of the alarm state (only Alarm_1 / Alarm_2
+    drive entity state), so anti-remove is signalled via Alarm_1.
+    """
 
     _CONSTANT_ATTRIBUTES = {
-        IasZone.attributes_by_name["zone_type"].id: IasZone.ZoneType.Contact_Switch,
+        IasZone.attributes_by_name["zone_type"].id: IasZone.ZoneType.Standard_CIE,
     }
 
 

--- a/zhaquirks/tuya/ts0601_keypad.py
+++ b/zhaquirks/tuya/ts0601_keypad.py
@@ -1,0 +1,354 @@
+"""Tuya TS0601 wireless Zigbee keypad (MS-K1AZ / Immax NEO 07505L).
+
+Alarm keypad that communicates via Tuya MCU DPs on cluster 0xEF00.
+Translates Tuya arm/disarm/SOS datapoints into ZHA events and IAS ACE
+cluster commands for alarm control panel integration (e.g. Alarmo).
+
+Manual: https://manuals.plus/immax/07505l-neo-smart-keypad-manual
+
+Tuya DPs:
+  DP 3:   battery_percentage (int, 0-100, read only)
+  DP 24:  anti-remove/tamper alarm (bool, read only → emergency + IAS Zone)
+  DP 26:  disarmed (enum, read only → disarm event)
+  DP 27:  armed away (enum, read only → arm_away event)
+  DP 28:  armed home (enum, read only → arm_home event)
+  DP 29:  SOS trigger (enum, read only → panic event)
+  DP 103: arm delay time (int, 0-180, read only via Zigbee)
+  DP 104: keypad beeps (bool, read only via Zigbee)
+  DP 105: quick SOS (bool, read only via Zigbee)
+  DP 106: quick disarm (bool, read only via Zigbee)
+  DP 107: quick arm (bool, read only via Zigbee)
+  DP 108: admin code (string, read only)
+  DP 109: user code (string, read only)
+  DP 111: arm delay beeps (bool, read only via Zigbee)
+  DP 112: unknown, always 0, sent with every arm/disarm event
+
+Known limitations:
+  - PIN codes (DP 108/109) are read-only via Zigbee; change via keypad
+    settings mode only (admin code + # → 38/39 + new code + #).
+  - Keypad settings (DP 103-107, 111) are reported at join/wake but not
+    when changed on the keypad. They are stored as MCU cluster attributes
+    (visible in ZHA cluster management) but not exposed as HA entities.
+    TuyaQuirkBuilder (v2) cannot expose these because it overwrites custom
+    data_point_handlers and has no mechanism for firing ZHA events from DPs.
+  - The keypad does not send "arming/pending" events during arm delay;
+    arm delay must be handled by HA/Alarmo, not the keypad.
+  - DP 112 is sent with every arm/disarm event with value 0; purpose unknown.
+"""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Ota,
+    PowerConfiguration,
+    Scenes,
+    Time,
+)
+from zigpy.zcl.clusters.security import IasAce, IasZone
+
+from zhaquirks import Bus, PowerConfigurationCluster
+from zhaquirks.const import (
+    CLUSTER_COMMAND,
+    COMMAND,
+    DEVICE_TYPE,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SKIP_CONFIGURATION,
+    ZHA_SEND_EVENT,
+)
+from zhaquirks.tuya import TuyaDatapointData, TuyaLocalCluster
+from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster
+
+DISARM = "disarm"
+ARM_AWAY = "arm_away"
+ARM_HOME = "arm_home"
+PANIC = "panic"
+EMERGENCY = "emergency"
+
+
+class TuyaKeypadManufCluster(TuyaMCUCluster):
+    """Tuya keypad manufacturer cluster."""
+
+    BATTERY_PERCENTAGE_DP_ID = 3
+    ANTI_REMOVE_ALARM_DP_ID = 24
+    DISARMED_DP_ID = 26
+    ARMED_DP_ID = 27
+    ARMED_HOME_DP_ID = 28
+    SOS_DP_ID = 29
+    ARM_DELAY_TIME_DP_ID = 103
+    KEYPAD_BEEPS_DP_ID = 104
+    QUICK_SOS_DP_ID = 105
+    QUICK_DISARM_DP_ID = 106
+    QUICK_ARM_DP_ID = 107
+    ADMIN_CODE_DP_ID = 108
+    USER_CODE_DP_ID = 109
+    ARM_DELAY_BEEPS_DP_ID = 111
+
+    attributes = TuyaMCUCluster.attributes.copy()
+    attributes.update(
+        {
+            TuyaMCUCluster.cluster_id + ARM_DELAY_TIME_DP_ID: (
+                "arm_delay_time",
+                t.uint8_t,
+            ),
+            TuyaMCUCluster.cluster_id + ARM_DELAY_BEEPS_DP_ID: (
+                "arm_delay_beeps",
+                t.uint8_t,
+            ),
+            TuyaMCUCluster.cluster_id + KEYPAD_BEEPS_DP_ID: (
+                "keypad_beeps",
+                t.uint8_t,
+            ),
+            TuyaMCUCluster.cluster_id + QUICK_DISARM_DP_ID: (
+                "quick_disarm",
+                t.uint8_t,
+            ),
+            TuyaMCUCluster.cluster_id + QUICK_ARM_DP_ID: (
+                "quick_arm",
+                t.uint8_t,
+            ),
+            TuyaMCUCluster.cluster_id + QUICK_SOS_DP_ID: (
+                "quick_sos",
+                t.uint8_t,
+            ),
+            TuyaMCUCluster.cluster_id + ADMIN_CODE_DP_ID: (
+                "admin_code",
+                t.CharacterString,
+            ),
+            TuyaMCUCluster.cluster_id + USER_CODE_DP_ID: (
+                "user_code",
+                t.CharacterString,
+            ),
+        }
+    )
+
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
+        BATTERY_PERCENTAGE_DP_ID: DPToAttributeMapping(
+            PowerConfigurationCluster.ep_attribute,
+            "battery_percentage_remaining",
+            converter=lambda x: x * 2,
+        ),
+        ARM_DELAY_TIME_DP_ID: DPToAttributeMapping(
+            TuyaMCUCluster.ep_attribute,
+            "arm_delay_time",
+        ),
+        ARM_DELAY_BEEPS_DP_ID: DPToAttributeMapping(
+            TuyaMCUCluster.ep_attribute,
+            "arm_delay_beeps",
+        ),
+        KEYPAD_BEEPS_DP_ID: DPToAttributeMapping(
+            TuyaMCUCluster.ep_attribute,
+            "keypad_beeps",
+        ),
+        QUICK_DISARM_DP_ID: DPToAttributeMapping(
+            TuyaMCUCluster.ep_attribute,
+            "quick_disarm",
+        ),
+        QUICK_ARM_DP_ID: DPToAttributeMapping(
+            TuyaMCUCluster.ep_attribute,
+            "quick_arm",
+        ),
+        QUICK_SOS_DP_ID: DPToAttributeMapping(
+            TuyaMCUCluster.ep_attribute,
+            "quick_sos",
+        ),
+        ADMIN_CODE_DP_ID: DPToAttributeMapping(
+            TuyaMCUCluster.ep_attribute,
+            "admin_code",
+        ),
+        USER_CODE_DP_ID: DPToAttributeMapping(
+            TuyaMCUCluster.ep_attribute,
+            "user_code",
+        ),
+    }
+
+    DP_TO_ACTION = {
+        DISARMED_DP_ID: DISARM,
+        ARMED_DP_ID: ARM_AWAY,
+        ARMED_HOME_DP_ID: ARM_HOME,
+        SOS_DP_ID: PANIC,
+        ANTI_REMOVE_ALARM_DP_ID: EMERGENCY,
+    }
+
+    DP_TO_IAS_ACE = {
+        DISARMED_DP_ID: ("arm_event", IasAce.ArmMode.Disarm),
+        ARMED_DP_ID: ("arm_event", IasAce.ArmMode.Arm_All_Zones),
+        ARMED_HOME_DP_ID: ("arm_event", IasAce.ArmMode.Arm_Day_Home_Only),
+        SOS_DP_ID: ("panic_event", None),
+        ANTI_REMOVE_ALARM_DP_ID: ("emergency_event", None),
+    }
+
+    def _dp_2_event(self, datapoint: TuyaDatapointData) -> None:
+        """Convert arm/disarm/SOS datapoints to ZHA events and IAS ACE commands."""
+        zone_id = 0
+        user_code = self._attr_cache.get(
+            self.attributes_by_name["user_code"].id, "1234"
+        )
+
+        # Fire IAS ACE event via internal bus
+        ias_ace = self.DP_TO_IAS_ACE.get(datapoint.dp)
+        if ias_ace:
+            event_name, arm_mode = ias_ace
+            if arm_mode is not None:
+                self.endpoint.device.ias_bus.listener_event(
+                    event_name, arm_mode, user_code, zone_id
+                )
+            else:
+                self.endpoint.device.ias_bus.listener_event(event_name)
+
+        # Update tamper zone_status on IAS Zone cluster
+        if datapoint.dp == self.ANTI_REMOVE_ALARM_DP_ID:
+            zone_status = (
+                IasZone.ZoneStatus.Alarm_1 | IasZone.ZoneStatus.Tamper
+                if datapoint.data.payload
+                else 0
+            )
+            self.endpoint.ias_zone._update_attribute(
+                IasZone.AttributeDefs.zone_status.id, zone_status
+            )
+
+        # Fire zha_event for HA automations
+        action = self.DP_TO_ACTION.get(datapoint.dp)
+        if action:
+            self.listener_event(ZHA_SEND_EVENT, action, {})
+
+    data_point_handlers = {
+        BATTERY_PERCENTAGE_DP_ID: "_dp_2_attr_update",
+        ARM_DELAY_TIME_DP_ID: "_dp_2_attr_update",
+        ARM_DELAY_BEEPS_DP_ID: "_dp_2_attr_update",
+        KEYPAD_BEEPS_DP_ID: "_dp_2_attr_update",
+        QUICK_DISARM_DP_ID: "_dp_2_attr_update",
+        QUICK_ARM_DP_ID: "_dp_2_attr_update",
+        QUICK_SOS_DP_ID: "_dp_2_attr_update",
+        ADMIN_CODE_DP_ID: "_dp_2_attr_update",
+        USER_CODE_DP_ID: "_dp_2_attr_update",
+        DISARMED_DP_ID: "_dp_2_event",
+        ARMED_DP_ID: "_dp_2_event",
+        ARMED_HOME_DP_ID: "_dp_2_event",
+        SOS_DP_ID: "_dp_2_event",
+        ANTI_REMOVE_ALARM_DP_ID: "_dp_2_event",
+    }
+
+
+class TuyaAlarmControlPanelCluster(TuyaLocalCluster, IasAce):
+    """IAS ACE cluster that receives arm/disarm/panic events from the Tuya MCU."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.ias_bus.add_listener(self)
+
+    def arm_event(self, arm_mode: IasAce.ArmMode, arm_disarm_code: str, zone_id: int):
+        """Handle arm event from Tuya MCU cluster."""
+        self.listener_event(
+            CLUSTER_COMMAND,
+            self.endpoint.endpoint_id,
+            self.commands_by_name["arm"].id,
+            [arm_mode, arm_disarm_code, zone_id],
+        )
+
+    def emergency_event(self):
+        """Handle emergency/tamper event from Tuya MCU cluster."""
+        self.listener_event(
+            CLUSTER_COMMAND,
+            self.endpoint.endpoint_id,
+            self.commands_by_name["emergency"].id,
+            [],
+        )
+
+    def panic_event(self):
+        """Handle SOS/panic event from Tuya MCU cluster."""
+        self.listener_event(
+            CLUSTER_COMMAND,
+            self.endpoint.endpoint_id,
+            self.commands_by_name["panic"].id,
+            [],
+        )
+
+
+class TuyaIasZoneTamper(TuyaLocalCluster, IasZone):
+    """IAS Zone cluster for tamper/anti-remove detection."""
+
+    _CONSTANT_ATTRIBUTES = {
+        IasZone.attributes_by_name["zone_type"].id: IasZone.ZoneType.Contact_Switch,
+    }
+
+
+class TuyaPowerConfigurationCluster3AAA(TuyaLocalCluster, PowerConfigurationCluster):
+    """PowerConfiguration cluster for devices with 3 AAA batteries."""
+
+    _CONSTANT_ATTRIBUTES = {
+        PowerConfiguration.attributes_by_name[
+            "battery_size"
+        ].id: PowerConfiguration.BatterySize.AAA,
+        PowerConfiguration.attributes_by_name["battery_quantity"].id: 3,
+        PowerConfiguration.attributes_by_name["battery_rated_voltage"].id: 15,
+    }
+
+
+class TuyaWirelessZigbeeKeypad(CustomDevice):
+    """Tuya TS0601 wireless Zigbee keypad."""
+
+    device_automation_triggers = {
+        (DISARM, DISARM): {ENDPOINT_ID: 1, COMMAND: DISARM},
+        (ARM_AWAY, ARM_AWAY): {ENDPOINT_ID: 1, COMMAND: ARM_AWAY},
+        (ARM_HOME, ARM_HOME): {ENDPOINT_ID: 1, COMMAND: ARM_HOME},
+        (PANIC, PANIC): {ENDPOINT_ID: 1, COMMAND: PANIC},
+        (EMERGENCY, EMERGENCY): {ENDPOINT_ID: 1, COMMAND: EMERGENCY},
+    }
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.ias_bus = Bus()
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        MODELS_INFO: [
+            ("_TZE200_n9clpsht", "TS0601"),
+            ("_TZE200_nyvavzbj", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaMCUCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        SKIP_CONFIGURATION: True,
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ANCILLARY_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    TuyaKeypadManufCluster,
+                    TuyaAlarmControlPanelCluster,
+                    TuyaPowerConfigurationCluster3AAA,
+                    TuyaIasZoneTamper,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                ],
+            }
+        },
+    }


### PR DESCRIPTION
## Summary

Add support for the Tuya TS0601-based wireless Zigbee alarm keypad (MS-K1AZ / Immax NEO 07505L / 07046L). The keypad communicates via Tuya MCU DPs on cluster 0xEF00.

**Supported manufacturer IDs:** `_TZE200_n9clpsht`, `_TZE200_nyvavzbj`

**Features:**
- Arm away, arm home, disarm, SOS/panic via IAS ACE cluster commands
- ZHA events (`zha_event`) for HA automation triggers (e.g. Alarmo)
- Device automation triggers for all 5 actions (arm_away, arm_home, disarm, panic, emergency)
- Battery reporting (3x AAA)
- Tamper/anti-remove detection via IAS Zone binary sensor
- Keypad configuration attributes stored as MCU cluster attributes (arm delay, beeps, quick modes, codes)

**Known limitations (documented in module docstring):**
- PIN codes (DP 108/109) are read-only via Zigbee; must be changed via keypad settings mode
- Settings DPs (103-107, 111) are reported at join/wake but not when changed on the keypad. They are stored as MCU cluster attributes (visible in ZHA cluster management) but not exposed as HA entities — TuyaQuirkBuilder (v2) cannot be used because it overwrites custom `data_point_handlers` and has no mechanism for firing ZHA events from DPs
- The keypad does not send "arming/pending" events during arm delay
- DP 112 is sent with every arm/disarm event with value 0; purpose unknown, ignored

**Device manual:** https://manuals.plus/immax/07505l-neo-smart-keypad-manual

**Based on** the work in #1908 by @MrAdam. Key improvements over that PR:
- `ZHA_SEND_EVENT` for HA automation triggers (the original PR couldn't fire `device_automation_triggers` from Tuya clusters)
- Tamper/anti-remove binary sensor via IAS Zone
- Device automation triggers for all 5 actions
- Comprehensive test coverage (13 tests)

Closes #997, closes #1852.

## Device diagnostics

<details>
<summary>ZHA device diagnostics JSON (HA 2026.3.4, ZHA 1.0.2)</summary>

[diagnostics data.json](https://github.com/user-attachments/files/26327316/diagnostics.data.json)

</details>

## Test plan

- [x] Quirk signature matches device
- [x] Battery reporting (DP 3 → PowerConfiguration)
- [x] Arm away event (DP 27 → zha_event + IAS ACE)
- [x] Arm home event (DP 28 → zha_event + IAS ACE)
- [x] Disarm event (DP 26 → zha_event + IAS ACE)
- [x] Panic/SOS event (DP 29 → zha_event + IAS ACE)
- [x] Emergency/tamper event (DP 24 → zha_event + IAS ACE + IAS Zone)
- [x] Tamper binary sensor set/clear via IAS Zone zone_status
- [x] User code caching from DP 109
- [x] Device automation triggers defined
- [x] Both manufacturer IDs supported
- [x] Tested on real hardware with Alarmo integration
- [x] ruff, mypy, codespell, pre-commit all passing
- [x] 13 unit tests passing