### PR TITLE
Add Sunricher SR-ZG9032A-PIR configuration entities

### DIFF
--- a/zhaquirks/sunricher/sr_zg9032a_pir.py
+++ b/zhaquirks/sunricher/sr_zg9032a_pir.py
@@ -1,0 +1,88 @@
+"""Sunricher SR-ZG9032A-PIR motion sensor + light sensor + dimmer."""
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import EntityType
+import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+SUNRICHER_MANUFACTURER_CODE = 0x1224
+
+
+class SunricherPIRBasicCluster(CustomCluster, Basic):
+    """Sunricher Basic cluster with manufacturer-specific attributes."""
+
+    class AttributeDefs(Basic.AttributeDefs):
+        """Attribute definitions."""
+
+        motion_sensor_lux_threshold: Final = ZCLAttributeDef(
+            id=0x8903,
+            type=t.uint16_t,
+            manufacturer_code=SUNRICHER_MANUFACTURER_CODE,
+        )
+        motion_sensor_sensitivity: Final = ZCLAttributeDef(
+            id=0x8905,
+            type=t.uint8_t,
+            manufacturer_code=SUNRICHER_MANUFACTURER_CODE,
+        )
+        pwm_output_percentage: Final = ZCLAttributeDef(
+            id=0x8909,
+            type=t.uint8_t,
+            manufacturer_code=SUNRICHER_MANUFACTURER_CODE,
+        )
+        linearity_error_ratio_lux: Final = ZCLAttributeDef(
+            id=0x890D,
+            type=t.uint16_t,
+            manufacturer_code=SUNRICHER_MANUFACTURER_CODE,
+        )
+
+
+(
+    QuirkBuilder("Sunricher", "HK-DIM-PIR")
+    .friendly_name(
+        manufacturer="Sunricher",
+        model="SR-ZG9032A-PIR",
+    )
+    .replaces(SunricherPIRBasicCluster)
+    .number(
+        SunricherPIRBasicCluster.AttributeDefs.motion_sensor_lux_threshold.name,
+        SunricherPIRBasicCluster.cluster_id,
+        min_value=0,
+        max_value=65535,
+        entity_type=EntityType.CONFIG,
+        translation_key="motion_sensor_lux_threshold",
+        fallback_name="Daylight sensor lux threshold",
+    )
+    .number(
+        SunricherPIRBasicCluster.AttributeDefs.motion_sensor_sensitivity.name,
+        SunricherPIRBasicCluster.cluster_id,
+        min_value=0,
+        max_value=15,
+        entity_type=EntityType.CONFIG,
+        translation_key="motion_sensor_sensitivity",
+        fallback_name="Motion sensor sensitivity",
+    )
+    .number(
+        SunricherPIRBasicCluster.AttributeDefs.pwm_output_percentage.name,
+        SunricherPIRBasicCluster.cluster_id,
+        min_value=0,
+        max_value=254,
+        unit="%",
+        entity_type=EntityType.CONFIG,
+        translation_key="pwm_output_percentage",
+        fallback_name="PWM output percentage",
+    )
+    .number(
+        SunricherPIRBasicCluster.AttributeDefs.linearity_error_ratio_lux.name,
+        SunricherPIRBasicCluster.cluster_id,
+        min_value=100,
+        max_value=10000,
+        entity_type=EntityType.CONFIG,
+        translation_key="linearity_error_ratio_lux",
+        fallback_name="Linearity error ratio coefficient",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/sunricher/sr_zg9032a_pir.py
+++ b/zhaquirks/sunricher/sr_zg9032a_pir.py
@@ -28,12 +28,12 @@ class SunricherPIRBasicCluster(CustomCluster, Basic):
             type=t.uint8_t,
             manufacturer_code=SUNRICHER_MANUFACTURER_CODE,
         )
-        pwm_output_percentage: Final = ZCLAttributeDef(
+        pwm_output_level: Final = ZCLAttributeDef(
             id=0x8909,
             type=t.uint8_t,
             manufacturer_code=SUNRICHER_MANUFACTURER_CODE,
         )
-        linearity_error_ratio_lux: Final = ZCLAttributeDef(
+        linearity_error_ratio: Final = ZCLAttributeDef(
             id=0x890D,
             type=t.uint16_t,
             manufacturer_code=SUNRICHER_MANUFACTURER_CODE,
@@ -66,22 +66,21 @@ class SunricherPIRBasicCluster(CustomCluster, Basic):
         fallback_name="Motion sensor sensitivity",
     )
     .number(
-        SunricherPIRBasicCluster.AttributeDefs.pwm_output_percentage.name,
+        SunricherPIRBasicCluster.AttributeDefs.pwm_output_level.name,
         SunricherPIRBasicCluster.cluster_id,
         min_value=0,
         max_value=254,
-        unit="%",
         entity_type=EntityType.CONFIG,
-        translation_key="pwm_output_percentage",
-        fallback_name="PWM output percentage",
+        translation_key="pwm_output_level",
+        fallback_name="PWM output level",
     )
     .number(
-        SunricherPIRBasicCluster.AttributeDefs.linearity_error_ratio_lux.name,
+        SunricherPIRBasicCluster.AttributeDefs.linearity_error_ratio.name,
         SunricherPIRBasicCluster.cluster_id,
         min_value=100,
         max_value=10000,
         entity_type=EntityType.CONFIG,
-        translation_key="linearity_error_ratio_lux",
+        translation_key="linearity_error_ratio",
         fallback_name="Linearity error ratio coefficient",
     )
     .add_to_registry()


### PR DESCRIPTION
## Proposed change

Add quirk for Sunricher SR-ZG9032A-PIR (`HK-DIM-PIR`).

  Exposes 4 manufacturer-specific config attributes on `genBasic` that require manufacturer code `0x1224`:

  - Daylight sensor lux threshold (`0x8903`)
  - Motion sensor sensitivity (`0x8905`)
  - PWM output percentage (`0x8909`)
  - Linearity error ratio coefficient (`0x890D`)

## Additional information

Z2M converter reference: Koenkk/zigbee-herdsman-converters#11723

## Device diagnostics

[sr_zg9032a_pir_diagnostics.json](https://github.com/user-attachments/files/26342041/sr_zg9032a_pir_diagnostics.json)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

  - [x] The changes are tested and work correctly
  - [x] `pre-commit` checks pass / the code has been formatted using Black
  - [ ] Tests have been added to verify that the new code works
  - [x] Device diagnostics data has been attached
