### PR TITLE
Fix Ubisys H1 `season` datatype

### DIFF
--- a/zhaquirks/ubisys/trv_h1.py
+++ b/zhaquirks/ubisys/trv_h1.py
@@ -15,6 +15,13 @@ from zigpy.zcl.clusters.hvac import Thermostat
 from zigpy.zcl.foundation import ZCLAttributeAccess, ZCLAttributeDef
 
 
+class Season(t.enum8):
+    """Season mode for heating demand backup presets."""
+
+    Winter = 0x00
+    Summer = 0x01
+
+
 class ThermostatCluster(CustomCluster, Thermostat):
     """ubisys H1 thermostat cluster."""
 
@@ -111,7 +118,7 @@ class ThermostatCluster(CustomCluster, Thermostat):
 
         season = ZCLAttributeDef(
             id=0x001C,
-            type=t.Bool,
+            type=Season,
             access=ZCLAttributeAccess.Read | ZCLAttributeAccess.Write,
             manufacturer_code=0x10F2,
         )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This fixes the datatype for the Ubisys H1 `season` attribute. There's a switch entity that controls this (disabled by default, as no one should actually need this).


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Follow-up to:
- https://github.com/zigpy/zha-device-handlers/pull/4595


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->



## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
