### PR TITLE
Add Third Reality color light settings

### DIFF
--- a/zhaquirks/thirdreality/color_light.py
+++ b/zhaquirks/thirdreality/color_light.py
@@ -1,0 +1,39 @@
+"""Third Reality light devices."""
+
+from typing import Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+
+class ThirdRealityLightCluster(CustomCluster):
+    """Third Reality's light private cluster."""
+
+    cluster_id = 0xFF04
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Define the attributes of a private cluster."""
+
+        allow_bind: Final = ZCLAttributeDef(
+            id=0x0020,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
+
+
+(
+    QuirkBuilder("Third Reality, Inc", "3RCB02070Z")
+    .applies_to("Third Reality, Inc", "3RCB01057Z")
+    .applies_to("Third Reality, Inc", "3RCB1095Z")
+    .replaces(ThirdRealityLightCluster, endpoint_id=1)
+    .write_attr_button(
+        attribute_name=ThirdRealityLightCluster.AttributeDefs.allow_bind.name,
+        attribute_value=0x01,
+        cluster_id=ThirdRealityLightCluster.cluster_id,
+        translation_key="allow_remote_binding",
+        fallback_name="Allow remote bind",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/thirdreality/color_light.py
+++ b/zhaquirks/thirdreality/color_light.py
@@ -33,7 +33,7 @@ class ThirdRealityLightCluster(CustomCluster):
         attribute_value=0x01,
         cluster_id=ThirdRealityLightCluster.cluster_id,
         translation_key="allow_remote_binding",
-        fallback_name="Allow remote bind",
+        fallback_name="Allow remote binding",
     )
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR added three device setting and one private cluster
1.allow_remote_bind: open or close bind

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
