### PR TITLE
Use `HS1SA-E-PLUS` as friendly name for Heiman smoke sensor

### DIFF
--- a/zhaquirks/heiman/hs1sa_efa.py
+++ b/zhaquirks/heiman/hs1sa_efa.py
@@ -119,6 +119,7 @@ class CustomHeimanCluster(CustomCluster):
     QuirkBuilder()
     .applies_to("HEIMAN", "HS1SA-EF-3.0")
     .applies_to("HEIMAN", "HS1SA-E-PLUS")
+    .friendly_name(manufacturer="HEIMAN", model="HS1SA-E-PLUS")  # Used by newer fw
     .replaces(CustomHeimanCluster)
     .exposes_feature(SIREN_BASIC)
     .change_entity_metadata(


### PR DESCRIPTION
## Proposed change

This uses `HS1SA-E-PLUS` as the friendly name for the Heiman smoke sensor. See below for *why*.


## Additional information

Only early (beta) revisions of this smoke sensor used the model name `HS1SA-EF-3.0`. Newer revisions already use `HS1SA-E-PLUS`. The v2.2 firmware (https://github.com/zigpy/zigpy-ota/pull/53) changes the model name to `HS1SA-E-PLUS`. However, zigpy currently does not re-interview a device after an OTA upgrade, so users would need to remove and re-add the device to see the new name.

To work around this somewhat, this PR changes the displayed (friendly) name in Home Assistant to the "PLUS" variant for both models/firmware versions, so the user will see the (intended) `HS1SA-E-PLUS` name, regardless of what firmware version they're running (or which one they used to pair the device).

In the future, zigpy will also re-interview devices after an OTA upgrade.


## Device diagnostics

Before upgrade:
[zha-01KAH6BZ8GBKBJXCPX8V4BB4KP-HEIMAN HS1SA-EF-3.0-379c9bbed8bd1abe144b10c6212aa552_heiman_sensor_before_upgrade.json](https://github.com/user-attachments/files/26393230/zha-01KAH6BZ8GBKBJXCPX8V4BB4KP-HEIMAN.HS1SA-EF-3.0-379c9bbed8bd1abe144b10c6212aa552_heiman_sensor_before_upgrade.json)

After upgrade:
[zha-01KAH6BZ8GBKBJXCPX8V4BB4KP-HEIMAN HS1SA-E-PLUS-379c9bbed8bd1abe144b10c6212aa552_heiman_sensor_after_upgrade.json](https://github.com/user-attachments/files/26393229/zha-01KAH6BZ8GBKBJXCPX8V4BB4KP-HEIMAN.HS1SA-E-PLUS-379c9bbed8bd1abe144b10c6212aa552_heiman_sensor_after_upgrade.json)




## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
