### PR TITLE
Add Tuya soil sensor `_TZE284_tgrzpqf4` variant

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -269,6 +269,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE284_ap9owrsa", "TS0601")  # Novadigital SG-ZB
     .applies_to("_TZE284_awepdiwi", "TS0601")  # Solar powered
     .applies_to("_TZE284_33bwcga2", "TS0601")  # iHseno
+    .applies_to("_TZE284_tgrzpqf4", "TS0601")
     .tuya_temperature(dp_id=5, scale=10)
     .tuya_battery(dp_id=15)
     .tuya_soil_moisture(dp_id=3)


### PR DESCRIPTION
## Proposed change

Add support for the `_TZE284_tgrzpqf4` Tuya TS0601 soil moisture sensor variant.

This device is physically identical to other sensors in this family (same packet as a working `_TZE284_aao3yzhs` unit) but reports a different manufacturer string. The existing quirk for `_TZE284_aao3yzhs` applies correctly — tested and confirmed working with soil moisture, temperature, and battery entities all reporting.

## Additional information

- Two physically identical sensors from the same batch — one identified as `_TZE284_aao3yzhs` (matched existing quirk), the other as `_TZE284_tgrzpqf4` (did not match).
- After adding this fingerprint as a local custom quirk, the previously unsupported sensor paired correctly with all expected entities.

## Device diagnostics

**Zigbee device signature (before quirk):**
```json
{
  "node_descriptor": {
    "logical_type": 2,
    "complex_descriptor_available": 0,
    "user_descriptor_available": 0,
    "reserved": 0,
    "aps_flags": 0,
    "frequency_band": 8,
    "mac_capability_flags": 128,
    "manufacturer_code": 4417,
    "maximum_buffer_size": 66,
    "maximum_incoming_transfer_size": 66,
    "server_mask": 10752,
    "maximum_outgoing_transfer_size": 66,
    "descriptor_capability_field": 0
  },
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0051",
      "input_clusters": [
        "0x0000",
        "0x0004",
        "0x0005",
        "0xed00",
        "0xef00"
      ],
      "output_clusters": [
        "0x000a",
        "0x0019"
      ]
    }
  },
  "manufacturer": "_TZE284_tgrzpqf4",
  "model": "TS0601",
  "class": "zigpy.device.Device"
}
```

**After applying the quirk, the device exposes:**
- Soil moisture sensor
- Temperature sensor
- Battery sensor

Using the same datapoint mapping as the sibling variants (dp 3 = soil moisture, dp 5 = temperature, dp 15 = battery).

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached