### PR TITLE
Add more Hue models for multicolor command

### DIFF
--- a/zhaquirks/philips/hue_light.py
+++ b/zhaquirks/philips/hue_light.py
@@ -33,7 +33,6 @@ from zhaquirks.philips import PHILIPS, SIGNIFY, PhilipsHueLightCluster
     .applies_to(SIGNIFY, "LCX001")
     .applies_to(SIGNIFY, "LCX002")
     .applies_to(SIGNIFY, "LCX003")
-    .applies_to(SIGNIFY, "LCX004")
     .applies_to(SIGNIFY, "LCX005")
     .applies_to(SIGNIFY, "LCX006")
     .friendly_name(
@@ -60,9 +59,9 @@ from zhaquirks.philips import PHILIPS, SIGNIFY, PhilipsHueLightCluster
 
 (
     QuirkBuilder()
-    .applies_to(SIGNIFY, "LCX024") # 91ft
-    .applies_to(SIGNIFY, "LCX025") # 45ft
-    .applies_to(SIGNIFY, "LCX026") # Likely model for 22ft
+    .applies_to(SIGNIFY, "LCX024")  # 91ft
+    .applies_to(SIGNIFY, "LCX025")  # 45ft
+    .applies_to(SIGNIFY, "LCX026")  # Likely model for 22ft
     .friendly_name(
         model="Hue Festavia globe outdoor string lights",
         manufacturer="Philips",

--- a/zhaquirks/philips/hue_light.py
+++ b/zhaquirks/philips/hue_light.py
@@ -33,6 +33,7 @@ from zhaquirks.philips import PHILIPS, SIGNIFY, PhilipsHueLightCluster
     .applies_to(SIGNIFY, "LCX001")
     .applies_to(SIGNIFY, "LCX002")
     .applies_to(SIGNIFY, "LCX003")
+    .applies_to(SIGNIFY, "LCX004")
     .applies_to(SIGNIFY, "LCX005")
     .applies_to(SIGNIFY, "LCX006")
     .friendly_name(
@@ -51,6 +52,19 @@ from zhaquirks.philips import PHILIPS, SIGNIFY, PhilipsHueLightCluster
     .applies_to(SIGNIFY, "LCX017")
     .friendly_name(
         model="Hue Festavia gradient light string",
+        manufacturer="Philips",
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder()
+    .applies_to(SIGNIFY, "LCX024") # 91ft
+    .applies_to(SIGNIFY, "LCX025") # 45ft
+    .applies_to(SIGNIFY, "LCX026") # Likely model for 22ft
+    .friendly_name(
+        model="Hue Festavia globe outdoor string lights",
         manufacturer="Philips",
     )
     .replaces(PhilipsHueLightCluster, endpoint_id=11)


### PR DESCRIPTION
## Proposed change
`LCX024` and `LCX025` are from my own devices.  
`LCX026` is a guess/extrapolation from the previous 2 models. If someone has the 22ft version of the Festavia globe, it can be confirmed/corrected.


## Device diagnostics
[zha-01KDP8C1QNBSVBGJG4CVS76CAR-Philips Hue Festavia Globe light string-6e82505059ef065c5bbf231bdd7908c3.json](https://github.com/user-attachments/files/26460865/zha-01KDP8C1QNBSVBGJG4CVS76CAR-Philips.Hue.Festavia.Globe.light.string-6e82505059ef065c5bbf231bdd7908c3.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
