### PR TITLE
Add Inovelli attributes for VZM31-SN fw 3.05 + 3.07

### DIFF
--- a/zhaquirks/inovelli/__init__.py
+++ b/zhaquirks/inovelli/__init__.py
@@ -680,6 +680,11 @@ class InovelliVZM31SNCluster(InovelliCluster):
             type=t.uint8_t,
             is_manufacturer_specific=True,
         )
+        dimming_algorithm = ZCLAttributeDef(
+            id=0x001B,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
         button_delay = ZCLAttributeDef(
             id=0x0032,
             type=t.uint8_t,
@@ -880,6 +885,11 @@ class InovelliVZM31SNCluster(InovelliCluster):
             type=t.Bool,
             is_manufacturer_specific=True,
         )
+        aux_detection_level = ZCLAttributeDef(
+            id=0x007C,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
         binding_off_to_on_sync_level = ZCLAttributeDef(
             id=0x007D,
             type=t.Bool,
@@ -907,6 +917,11 @@ class InovelliVZM31SNCluster(InovelliCluster):
         )
         led_color_for_bound_control = ZCLAttributeDef(
             id=0x0086,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
+        dumb_detection_level = ZCLAttributeDef(
+            id=0x00A5,
             type=t.uint8_t,
             is_manufacturer_specific=True,
         )


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Inovelli vzm31-sn has a couple new attributes that are being added in fw 3.05 and 3.07.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
