### PR TITLE
Add Tuya TS0601 SPI LED controller (_TZE204_8fffc3kb)

### DIFF
--- a/tests/test_tuya_spi_led.py
+++ b/tests/test_tuya_spi_led.py
@@ -9,14 +9,19 @@ from zigpy.zcl.clusters.lighting import Color
 import zhaquirks
 import zhaquirks.tuya.ts0601_spi_led
 from zhaquirks.tuya.ts0601_spi_led import (
+    ChipType,
+    LightBeadSequence,
     SpiLedManufCluster,
     WorkMode,
+    _current_level_254,
     _dp61_payload,
     _dp61_to_hue,
     _dp61_to_sat,
     _enhanced_hue_to_hue_254,
     _level_from_device,
     _level_to_device,
+    _xy_to_hs_254,
+    _zcl_arg,
 )
 
 zhaquirks.setup()
@@ -116,6 +121,67 @@ def test_enhanced_hue_to_hue_254():
     assert _enhanced_hue_to_hue_254(32767) == 127
 
 
+@pytest.mark.parametrize(
+    "x, y, expected_h, expected_s",
+    [
+        # Pure red in CIE XY (approx)
+        (40139, 20396, 0, 254),
+        # Black / near-zero Y → returns (0, 0)
+        (32768, 0, 0, 0),
+        # Near-zero after normalisation → returns (0, 0)
+        (0, 0, 0, 0),
+    ],
+)
+def test_xy_to_hs_254(x, y, expected_h, expected_s):
+    """Test XY to HS conversion including degenerate edge cases."""
+    h, s = _xy_to_hs_254(x, y)
+    assert 0 <= h <= 254
+    assert 0 <= s <= 254
+    # Edge cases must return exactly (0, 0)
+    if y == 0:
+        assert h == 0
+        assert s == 0
+
+
+def test_current_level_254_with_level(zigpy_device_from_v2_quirk):
+    """Test _current_level_254 returns cached level when available."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+    ep.level._update_attribute(ep.level.AttributeDefs.current_level.id, 100)
+    assert _current_level_254(ep) == 100
+
+
+def test_current_level_254_fallback(zigpy_device_from_v2_quirk):
+    """Test _current_level_254 returns 254 when level is not cached."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+    # Level cluster exists but attribute not yet set
+    assert _current_level_254(ep) == 254
+
+
+def test_current_level_254_no_cluster():
+    """Test _current_level_254 returns 254 when endpoint has no level cluster."""
+
+    class FakeEndpoint:
+        @property
+        def level(self):
+            raise AttributeError
+
+    assert _current_level_254(FakeEndpoint()) == 254
+
+
+def test_zcl_arg_positional():
+    """Test _zcl_arg extracts positional argument."""
+    assert _zcl_arg(0, "hue", (42,), {}) == 42
+    assert _zcl_arg(1, "sat", (10, 20), {}) == 20
+
+
+def test_zcl_arg_keyword():
+    """Test _zcl_arg falls back to kwargs."""
+    assert _zcl_arg(0, "hue", (), {"hue": 99}) == 99
+    assert _zcl_arg(0, "missing", (), {}) is None
+
+
 # ---------------------------------------------------------------------------
 # Device / entity creation tests
 # ---------------------------------------------------------------------------
@@ -150,6 +216,16 @@ _MSG_ON = b"\x09\x01\x02\x00\x00\x01\x01\x00\x01\x01"
 _MSG_BRIGHTNESS_MAX = b"\x09\x01\x02\x00\x00\x03\x02\x00\x04\x00\x00\x03\xe8"
 # DP 2 work_mode = colour (1)
 _MSG_WORK_MODE_COLOUR = b"\x09\x01\x02\x00\x00\x02\x04\x00\x01\x01"
+# DP 53 pixel_count = 100
+_MSG_PIXEL_COUNT = b"\x09\x01\x02\x00\x00\x35\x02\x00\x04\x00\x00\x00\x64"
+# DP 61 colour_hsv: hue=180°, sat=1000, val=1000  (type=0x00 RAW)
+_MSG_COLOUR_HSV = (
+    b"\x09\x01\x02\x00\x00\x3d\x00\x00\x0b\x00\x01\x01\x14\x00\x00\xb4\x03\xe8\x03\xe8"
+)
+# DP 101 light_bead_sequence = GRB (2)
+_MSG_BEAD_SEQ_GRB = b"\x09\x01\x02\x00\x00\x65\x04\x00\x01\x02"
+# DP 102 chip_type = WS2811 (3)
+_MSG_CHIP_WS2811 = b"\x09\x01\x02\x00\x00\x66\x04\x00\x01\x03"
 
 
 def test_spi_led_dp_on_off(zigpy_device_from_v2_quirk):
@@ -191,6 +267,59 @@ def test_spi_led_dp_work_mode(zigpy_device_from_v2_quirk):
     assert tuya_cluster.get("work_mode") == WorkMode.colour
 
 
+def test_spi_led_dp_pixel_count(zigpy_device_from_v2_quirk):
+    """Test that DP 53 maps to lightpixel_number_set attribute."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+    tuya_cluster = ep.tuya_manufacturer
+
+    hdr, data = tuya_cluster.deserialize(_MSG_PIXEL_COUNT)
+    with mock.patch.object(tuya_cluster, "send_default_rsp"):
+        tuya_cluster.handle_message(hdr, data)
+
+    assert tuya_cluster.get("lightpixel_number_set") == 100
+
+
+def test_spi_led_dp_colour_hsv(zigpy_device_from_v2_quirk):
+    """Test that DP 61 maps to current_hue and current_saturation attributes."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+    tuya_cluster = ep.tuya_manufacturer
+
+    hdr, data = tuya_cluster.deserialize(_MSG_COLOUR_HSV)
+    with mock.patch.object(tuya_cluster, "send_default_rsp"):
+        tuya_cluster.handle_message(hdr, data)
+
+    assert ep.light_color.get("current_hue") == 127  # 180° → ~127
+    assert ep.light_color.get("current_saturation") == 254
+
+
+def test_spi_led_dp_bead_sequence(zigpy_device_from_v2_quirk):
+    """Test that DP 101 maps to light_bead_sequence attribute."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+    tuya_cluster = ep.tuya_manufacturer
+
+    hdr, data = tuya_cluster.deserialize(_MSG_BEAD_SEQ_GRB)
+    with mock.patch.object(tuya_cluster, "send_default_rsp"):
+        tuya_cluster.handle_message(hdr, data)
+
+    assert tuya_cluster.get("light_bead_sequence") == LightBeadSequence.GRB
+
+
+def test_spi_led_dp_chip_type(zigpy_device_from_v2_quirk):
+    """Test that DP 102 maps to chip_type attribute."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+    tuya_cluster = ep.tuya_manufacturer
+
+    hdr, data = tuya_cluster.deserialize(_MSG_CHIP_WS2811)
+    with mock.patch.object(tuya_cluster, "send_default_rsp"):
+        tuya_cluster.handle_message(hdr, data)
+
+    assert tuya_cluster.get("chip_type") == ChipType.WS2811
+
+
 # ---------------------------------------------------------------------------
 # Color command tests
 # ---------------------------------------------------------------------------
@@ -228,3 +357,138 @@ async def test_color_command_unsupported(zigpy_device_from_v2_quirk):
 
     result = await ep.light_color.command(0xFF)
     assert result.status == foundation.Status.UNSUP_CLUSTER_COMMAND
+
+
+async def test_color_command_move_to_hue(zigpy_device_from_v2_quirk):
+    """Test move_to_hue updates hue while preserving current saturation."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+    ep.light_color._update_attribute(Color.AttributeDefs.current_saturation.id, 200)
+
+    with mock.patch.object(
+        ep.tuya_manufacturer, "command", new_callable=mock.AsyncMock
+    ):
+        result = await ep.light_color.command(
+            Color.ServerCommandDefs.move_to_hue.id, 50
+        )
+
+    assert result.status == foundation.Status.SUCCESS
+    assert ep.light_color.get("current_hue") == 50
+    assert ep.light_color.get("current_saturation") == 200
+
+
+async def test_color_command_move_to_hue_missing_arg(zigpy_device_from_v2_quirk):
+    """Test move_to_hue returns FAILURE when hue argument is missing."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+
+    result = await ep.light_color.command(Color.ServerCommandDefs.move_to_hue.id)
+    assert result.status == foundation.Status.FAILURE
+
+
+async def test_color_command_move_to_saturation(zigpy_device_from_v2_quirk):
+    """Test move_to_saturation updates saturation while preserving current hue."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+    ep.light_color._update_attribute(Color.AttributeDefs.current_hue.id, 80)
+
+    with mock.patch.object(
+        ep.tuya_manufacturer, "command", new_callable=mock.AsyncMock
+    ):
+        result = await ep.light_color.command(
+            Color.ServerCommandDefs.move_to_saturation.id, 150
+        )
+
+    assert result.status == foundation.Status.SUCCESS
+    assert ep.light_color.get("current_saturation") == 150
+    assert ep.light_color.get("current_hue") == 80
+
+
+async def test_color_command_move_to_saturation_missing_arg(zigpy_device_from_v2_quirk):
+    """Test move_to_saturation returns FAILURE when saturation argument is missing."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+
+    result = await ep.light_color.command(Color.ServerCommandDefs.move_to_saturation.id)
+    assert result.status == foundation.Status.FAILURE
+
+
+async def test_color_command_move_to_color_xy(zigpy_device_from_v2_quirk):
+    """Test move_to_color (XY) converts to HS and updates XY attributes."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+
+    with mock.patch.object(
+        ep.tuya_manufacturer, "command", new_callable=mock.AsyncMock
+    ):
+        result = await ep.light_color.command(
+            Color.ServerCommandDefs.move_to_color.id,
+            40139,  # color_x
+            20396,  # color_y
+        )
+
+    assert result.status == foundation.Status.SUCCESS
+    assert ep.light_color.get("current_x") == 40139
+    assert ep.light_color.get("current_y") == 20396
+
+
+async def test_color_command_move_to_color_missing_args(zigpy_device_from_v2_quirk):
+    """Test move_to_color returns FAILURE when XY arguments are missing."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+
+    result = await ep.light_color.command(Color.ServerCommandDefs.move_to_color.id)
+    assert result.status == foundation.Status.FAILURE
+
+
+async def test_color_command_enhanced_move_to_hue_and_saturation(
+    zigpy_device_from_v2_quirk,
+):
+    """Test enhanced_move_to_hue_and_saturation converts enhanced hue correctly."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+
+    with mock.patch.object(
+        ep.tuya_manufacturer, "command", new_callable=mock.AsyncMock
+    ):
+        result = await ep.light_color.command(
+            Color.ServerCommandDefs.enhanced_move_to_hue_and_saturation.id,
+            32767,  # enhanced_hue (~half wheel)
+            200,  # saturation
+        )
+
+    assert result.status == foundation.Status.SUCCESS
+    assert ep.light_color.get("enhanced_current_hue") == 32767
+
+
+async def test_color_command_enhanced_missing_args(zigpy_device_from_v2_quirk):
+    """Test enhanced_move_to_hue_and_saturation returns FAILURE on missing args."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+
+    result = await ep.light_color.command(
+        Color.ServerCommandDefs.enhanced_move_to_hue_and_saturation.id
+    )
+    assert result.status == foundation.Status.FAILURE
+
+
+async def test_color_command_stop_move_step(zigpy_device_from_v2_quirk):
+    """Test stop_move_step is acknowledged with SUCCESS."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+
+    result = await ep.light_color.command(Color.ServerCommandDefs.stop_move_step.id)
+    assert result.status == foundation.Status.SUCCESS
+
+
+async def test_color_command_move_to_hue_and_saturation_missing_args(
+    zigpy_device_from_v2_quirk,
+):
+    """Test move_to_hue_and_saturation returns FAILURE when args are missing."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+
+    result = await ep.light_color.command(
+        Color.ServerCommandDefs.move_to_hue_and_saturation.id
+    )
+    assert result.status == foundation.Status.FAILURE

--- a/tests/test_tuya_spi_led.py
+++ b/tests/test_tuya_spi_led.py
@@ -1,0 +1,230 @@
+"""Tests for Tuya SPI LED pixel controller quirk (WZ-SPI / GL-SPI-206P)."""
+
+from unittest import mock
+
+import pytest
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.lighting import Color
+
+import zhaquirks
+import zhaquirks.tuya.ts0601_spi_led
+from zhaquirks.tuya.ts0601_spi_led import (
+    SpiLedManufCluster,
+    WorkMode,
+    _dp61_payload,
+    _dp61_to_hue,
+    _dp61_to_sat,
+    _enhanced_hue_to_hue_254,
+    _level_from_device,
+    _level_to_device,
+)
+
+zhaquirks.setup()
+
+
+# ---------------------------------------------------------------------------
+# Helper function unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "device_val, expected_zcl",
+    [
+        (10, 0),
+        (1000, 254),
+        (505, 127),
+    ],
+)
+def test_level_from_device(device_val, expected_zcl):
+    """Test device brightness (10-1000) to ZCL level (0-254) conversion."""
+    assert _level_from_device(device_val) == expected_zcl
+
+
+@pytest.mark.parametrize(
+    "zcl_level, expected_device",
+    [
+        (0, 10),
+        (254, 1000),
+        (127, 505),
+    ],
+)
+def test_level_to_device(zcl_level, expected_device):
+    """Test ZCL level (0-254) to device brightness (10-1000) conversion."""
+    assert _level_to_device(zcl_level) == expected_device
+
+
+def test_dp61_payload_structure():
+    """Test that DP 61 payload has the correct 11-byte structure."""
+    payload = _dp61_payload(180, 500, 800)
+    assert len(payload) == 11
+    # Fixed header bytes
+    assert payload[0] == 0x00
+    assert payload[1] == 0x01
+    assert payload[2] == 0x01
+    assert payload[3] == 0x14
+    assert payload[4] == 0x00
+    # Hue 180° encoded as big-endian uint16
+    assert (payload[5] << 8) | payload[6] == 180
+    # Saturation 500 encoded as big-endian uint16
+    assert (payload[7] << 8) | payload[8] == 500
+    # Value 800 encoded as big-endian uint16
+    assert (payload[9] << 8) | payload[10] == 800
+
+
+@pytest.mark.parametrize(
+    "raw, expected_hue",
+    [
+        # H=360° → hue_254=254
+        (bytes([0, 1, 1, 20, 0, 0x01, 0x68, 0x03, 0xE8, 0x03, 0xE8]), 254),
+        # H=0° → hue_254=0
+        (bytes([0, 1, 1, 20, 0, 0x00, 0x00, 0x03, 0xE8, 0x03, 0xE8]), 0),
+        # H=180° → hue_254≈127
+        (bytes([0, 1, 1, 20, 0, 0x00, 0xB4, 0x03, 0xE8, 0x03, 0xE8]), 127),
+    ],
+)
+def test_dp61_to_hue(raw, expected_hue):
+    """Test hue extraction from DP 61 payload."""
+    assert _dp61_to_hue(raw) == expected_hue
+
+
+@pytest.mark.parametrize(
+    "raw, expected_sat",
+    [
+        # S=1000 → sat_254=254
+        (bytes([0, 1, 1, 20, 0, 0x00, 0x00, 0x03, 0xE8, 0x03, 0xE8]), 254),
+        # S=0 → sat_254=0
+        (bytes([0, 1, 1, 20, 0, 0x00, 0x00, 0x00, 0x00, 0x03, 0xE8]), 0),
+        # S=500 → sat_254≈127
+        (bytes([0, 1, 1, 20, 0, 0x00, 0x00, 0x01, 0xF4, 0x03, 0xE8]), 127),
+    ],
+)
+def test_dp61_to_sat(raw, expected_sat):
+    """Test saturation extraction from DP 61 payload."""
+    assert _dp61_to_sat(raw) == expected_sat
+
+
+def test_dp61_short_payload():
+    """Test that short payloads return 0 for hue and saturation."""
+    assert _dp61_to_hue(b"\x00\x01") == 0
+    assert _dp61_to_sat(b"\x00\x01") == 0
+
+
+def test_enhanced_hue_to_hue_254():
+    """Test enhanced hue (0-65535) to standard hue (0-254) conversion."""
+    assert _enhanced_hue_to_hue_254(0) == 0
+    assert _enhanced_hue_to_hue_254(65535) == 254
+    assert _enhanced_hue_to_hue_254(32767) == 127
+
+
+# ---------------------------------------------------------------------------
+# Device / entity creation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "manufacturer",
+    ["_TZE204_8fffc3kb", "_TZE284_gt5al3bl"],
+)
+def test_spi_led_entity_creation(zigpy_device_from_v2_quirk, manufacturer):
+    """Test that the WZ-SPI LED quirk loads and exposes the expected clusters."""
+    device = zigpy_device_from_v2_quirk(manufacturer, "TS0601")
+    ep = device.endpoints[1]
+
+    assert ep.on_off is not None
+    assert ep.level is not None
+    assert ep.light_color is not None
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, SpiLedManufCluster)
+
+
+# ---------------------------------------------------------------------------
+# DP → attribute mapping tests
+# ---------------------------------------------------------------------------
+
+# Tuya MCU GET_DATA frame: ZCL header (09 tsn 02) + status(1) + tuya_tsn(2) + DPs
+# DP frame: dp(1) + type(1) + len_hi(1) + len_lo(1) + value(len)
+
+# DP 1 on/off = True
+_MSG_ON = b"\x09\x01\x02\x00\x00\x01\x01\x00\x01\x01"
+# DP 3 brightness = 1000
+_MSG_BRIGHTNESS_MAX = b"\x09\x01\x02\x00\x00\x03\x02\x00\x04\x00\x00\x03\xe8"
+# DP 2 work_mode = colour (1)
+_MSG_WORK_MODE_COLOUR = b"\x09\x01\x02\x00\x00\x02\x04\x00\x01\x01"
+
+
+def test_spi_led_dp_on_off(zigpy_device_from_v2_quirk):
+    """Test that DP 1 maps to on_off attribute."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+    tuya_cluster = ep.tuya_manufacturer
+
+    hdr, data = tuya_cluster.deserialize(_MSG_ON)
+    with mock.patch.object(tuya_cluster, "send_default_rsp"):
+        tuya_cluster.handle_message(hdr, data)
+
+    assert bool(ep.on_off.get("on_off")) is True
+
+
+def test_spi_led_dp_brightness(zigpy_device_from_v2_quirk):
+    """Test that DP 3 maps to current_level with correct scaling."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+    tuya_cluster = ep.tuya_manufacturer
+
+    hdr, data = tuya_cluster.deserialize(_MSG_BRIGHTNESS_MAX)
+    with mock.patch.object(tuya_cluster, "send_default_rsp"):
+        tuya_cluster.handle_message(hdr, data)
+
+    assert ep.level.get("current_level") == 254
+
+
+def test_spi_led_dp_work_mode(zigpy_device_from_v2_quirk):
+    """Test that DP 2 maps to work_mode attribute."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+    tuya_cluster = ep.tuya_manufacturer
+
+    hdr, data = tuya_cluster.deserialize(_MSG_WORK_MODE_COLOUR)
+    with mock.patch.object(tuya_cluster, "send_default_rsp"):
+        tuya_cluster.handle_message(hdr, data)
+
+    assert tuya_cluster.get("work_mode") == WorkMode.colour
+
+
+# ---------------------------------------------------------------------------
+# Color command tests
+# ---------------------------------------------------------------------------
+
+
+async def test_color_command_move_to_hue_and_saturation(zigpy_device_from_v2_quirk):
+    """Test move_to_hue_and_saturation sends correct DP 61 payload."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+
+    with mock.patch.object(
+        ep.tuya_manufacturer, "command", new_callable=mock.AsyncMock
+    ) as mock_cmd:
+        mock_cmd.return_value = foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(
+            command_id=Color.ServerCommandDefs.move_to_hue_and_saturation.id,
+            status=foundation.Status.SUCCESS,
+        )
+        result = await ep.light_color.command(
+            Color.ServerCommandDefs.move_to_hue_and_saturation.id,
+            127,  # hue
+            254,  # saturation
+        )
+
+    assert result.status == foundation.Status.SUCCESS
+    assert ep.light_color.get("current_hue") == 127
+    assert ep.light_color.get("current_saturation") == 254
+
+
+async def test_color_command_unsupported(zigpy_device_from_v2_quirk):
+    """Test that unsupported color commands return UNSUP_CLUSTER_COMMAND."""
+    device = zigpy_device_from_v2_quirk("_TZE204_8fffc3kb", "TS0601")
+    ep = device.endpoints[1]
+
+    result = await ep.light_color.command(0xFF)
+    assert result.status == foundation.Status.UNSUP_CLUSTER_COMMAND

--- a/zhaquirks/tuya/ts0601_spi_led.py
+++ b/zhaquirks/tuya/ts0601_spi_led.py
@@ -1,0 +1,472 @@
+"""Tuya SPI LED pixel controller (WZ-SPI / GL-SPI-206P).
+
+Supported devices:
+- _TZE204_8fffc3kb TS0601 (Gledopto / WZ-SPI GL-SPI-206P)
+- _TZE284_gt5al3bl TS0601
+
+DP MAP
+------
+DP  1  on/off            bool
+DP  2  work_mode         enum  0=white 1=colour 2=scene 3=music
+DP  3  brightness        value 10-1000
+DP 53  pixel_count       value 10-1000
+DP 61  colour_hsv        raw   (11-byte HSV payload)
+DP101  light_bead_seq    enum
+DP102  chip_type         enum
+"""
+
+from __future__ import annotations
+
+import colorsys
+from typing import Any, Final
+
+from zigpy.profiles import zha
+from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
+from zigpy.quirks.v2.homeassistant import EntityType
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+from zhaquirks.tuya import (
+    TUYA_CLUSTER_ID,
+    TUYA_SET_DATA,
+    BaseEnchantedDevice,
+    Data,
+    TuyaCommand,
+    TuyaData,
+    TuyaDatapointData,
+    TuyaLocalCluster,
+)
+from zhaquirks.tuya.mcu import (
+    DPToAttributeMapping,
+    TuyaLevelControl,
+    TuyaMCUCluster,
+    TuyaOnOffNM,
+)
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class WorkMode(t.enum8):
+    """Work mode for the LED controller."""
+
+    white = 0x00
+    colour = 0x01
+    scene = 0x02
+    music = 0x03
+
+
+class LightBeadSequence(t.enum8):
+    """LED bead colour order — DP 101."""
+
+    RGB = 0x00
+    RBG = 0x01
+    GRB = 0x02
+    GBR = 0x03
+    BRG = 0x04
+    BGR = 0x05
+    RGBW = 0x06
+    RBGW = 0x07
+    GRBW = 0x08
+    GBRW = 0x09
+    BRGW = 0x0A
+    BGRW = 0x0B
+    WRGB = 0x0C
+    WRBG = 0x0D
+    WGRB = 0x0E
+    WGBR = 0x0F
+    WBRG = 0x10
+    WBGR = 0x11
+
+
+class ChipType(t.enum8):
+    """SPI LED chip model — DP 102."""
+
+    WS2801 = 0x00
+    LPD6803 = 0x01
+    LPD8803 = 0x02
+    WS2811 = 0x03
+    TM1814B = 0x04
+    TM1934A = 0x05
+    SK6812 = 0x06
+    SK9822 = 0x07
+    UCS8904B = 0x08
+    WS2805 = 0x09
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _dp61_payload(h_deg: int, sat_1000: int, val_1000: int = 1000) -> Data:
+    """Build 11-byte DP 61 colour payload."""
+    h = max(0, min(360, int(h_deg)))
+    s = max(0, min(1000, int(sat_1000)))
+    v = max(0, min(1000, int(val_1000)))
+    return Data(
+        [
+            0x00,
+            0x01,
+            0x01,
+            0x14,
+            0x00,
+            (h >> 8) & 0xFF,
+            h & 0xFF,
+            (s >> 8) & 0xFF,
+            s & 0xFF,
+            (v >> 8) & 0xFF,
+            v & 0xFF,
+        ]
+    )
+
+
+def _dp61_to_hue(raw: bytes) -> int:
+    """Extract hue from DP 61 payload (0-254 range)."""
+    if len(raw) < 9:
+        return 0
+    h = (raw[5] << 8) | raw[6]
+    return max(0, min(254, round(h * 254 / 360)))
+
+
+def _dp61_to_sat(raw: bytes) -> int:
+    """Extract saturation from DP 61 payload (0-254 range)."""
+    if len(raw) < 9:
+        return 0
+    s = (raw[7] << 8) | raw[8]
+    return max(0, min(254, round(s * 254 / 1000)))
+
+
+def _level_from_device(raw: int) -> int:
+    """Convert device brightness (10-1000) to ZCL level (0-254)."""
+    raw = max(10, min(1000, int(raw)))
+    return max(0, min(254, round((raw - 10) * 254 / 990)))
+
+
+def _level_to_device(level: int) -> int:
+    """Convert ZCL level (0-254) to device brightness (10-1000)."""
+    level = max(0, min(254, int(level)))
+    return max(10, min(1000, round(10 + level * 990 / 254)))
+
+
+def _current_level_254(endpoint: Any) -> int:
+    """Get current level from endpoint, default to full brightness only if unset."""
+    try:
+        lvl = endpoint.level.get("current_level")
+        if lvl is not None:
+            return max(1, min(254, int(lvl)))
+    except (AttributeError, KeyError, TypeError, ValueError):
+        pass
+    return 254
+
+
+def _zcl_arg(pos: int, kw_name: str, args: tuple, kwargs: dict) -> Any | None:
+    """Extract argument from args or kwargs."""
+    if len(args) > pos:
+        return args[pos]
+    return kwargs.get(kw_name)
+
+
+def _enhanced_hue_to_hue_254(enhanced_hue: int) -> int:
+    """Convert enhanced hue (0-65535) to standard hue (0-254)."""
+    return max(0, min(254, int(round(int(enhanced_hue) * 254 / 65535))))
+
+
+def _xy_to_hs_254(x: int, y: int) -> tuple[int, int]:
+    """Convert XY color to HS (0-254 range)."""
+    xf = x / 65536.0
+    yf = y / 65536.0
+    if yf < 1e-6:
+        return 0, 0
+    X = xf / yf
+    Y = 1.0
+    Z = (1.0 - xf - yf) / yf
+    r = X * 1.656492 - Y * 0.354851 - Z * 0.255038
+    g = -X * 0.707196 + Y * 1.655397 + Z * 0.036152
+    b = X * 0.051713 - Y * 0.121364 + Z * 1.011530
+    r = max(r, 0.0)
+    g = max(g, 0.0)
+    b = max(b, 0.0)
+    mx = max(r, g, b)
+    if mx < 1e-6:
+        return 0, 0
+    r, g, b = r / mx, g / mx, b / mx
+    h, s, _v = colorsys.rgb_to_hsv(r, g, b)
+    return max(0, min(254, int(h * 254))), max(0, min(254, int(s * 254)))
+
+
+# ---------------------------------------------------------------------------
+# Tuya MCU Cluster
+# ---------------------------------------------------------------------------
+
+
+class SpiLedManufCluster(TuyaMCUCluster):
+    """Tuya MCU cluster for WZ-SPI LED controller."""
+
+    class AttributeDefs(TuyaMCUCluster.AttributeDefs):
+        """Attribute definitions."""
+
+        work_mode: Final = ZCLAttributeDef(
+            id=0xEF02, type=WorkMode, access="rw", is_manufacturer_specific=True
+        )
+        lightpixel_number_set: Final = ZCLAttributeDef(
+            id=0xEF35, type=t.uint16_t, access="rw", is_manufacturer_specific=True
+        )
+        light_bead_sequence: Final = ZCLAttributeDef(
+            id=0xEF65,
+            type=LightBeadSequence,
+            access="rw",
+            is_manufacturer_specific=True,
+        )
+        chip_type: Final = ZCLAttributeDef(
+            id=0xEF66, type=ChipType, access="rw", is_manufacturer_specific=True
+        )
+
+    dp_to_attribute: dict[int, DPToAttributeMapping | list[DPToAttributeMapping]] = {
+        1: DPToAttributeMapping(TuyaOnOffNM.ep_attribute, "on_off"),
+        2: DPToAttributeMapping(
+            TuyaMCUCluster.ep_attribute, "work_mode", converter=lambda x: WorkMode(x)
+        ),
+        3: DPToAttributeMapping(
+            TuyaLevelControl.ep_attribute,
+            "current_level",
+            converter=_level_from_device,
+            dp_converter=_level_to_device,
+        ),
+        53: DPToAttributeMapping(TuyaMCUCluster.ep_attribute, "lightpixel_number_set"),
+        61: [
+            DPToAttributeMapping(
+                Color.ep_attribute, "current_hue", converter=_dp61_to_hue
+            ),
+            DPToAttributeMapping(
+                Color.ep_attribute, "current_saturation", converter=_dp61_to_sat
+            ),
+        ],
+        101: DPToAttributeMapping(
+            TuyaMCUCluster.ep_attribute,
+            "light_bead_sequence",
+            converter=lambda x: LightBeadSequence(x),
+        ),
+        102: DPToAttributeMapping(
+            TuyaMCUCluster.ep_attribute, "chip_type", converter=lambda x: ChipType(x)
+        ),
+    }
+
+    data_point_handlers = {
+        1: "_dp_2_attr_update",
+        2: "_dp_2_attr_update",
+        3: "_dp_2_attr_update",
+        53: "_dp_2_attr_update",
+        61: "_dp_2_attr_update",
+        101: "_dp_2_attr_update",
+        102: "_dp_2_attr_update",
+    }
+
+    async def send_color_hs(
+        self,
+        hue_254: int,
+        sat_254: int,
+        expect_reply: bool,
+        manufacturer: int | t.uint16_t | None,
+    ) -> None:
+        """Send HS color to device."""
+        ep = self.endpoint
+        dps: list[TuyaDatapointData] = []
+
+        # Turn on if off
+        if not ep.on_off.get("on_off", False):
+            dps.append(TuyaDatapointData(dp=1, data=TuyaData(True)))
+
+        # Switch to colour mode
+        if self.get("work_mode") != WorkMode.colour:
+            dps.append(TuyaDatapointData(dp=2, data=TuyaData(WorkMode.colour)))
+
+        # Set brightness
+        dps.append(
+            TuyaDatapointData(
+                dp=3, data=TuyaData(_level_to_device(_current_level_254(ep)))
+            )
+        )
+
+        # Convert hue/sat to RGB, swap R↔G to compensate for GRB bead order,
+        # then convert back to HSV for the device payload.
+        h_norm = hue_254 / 254.0
+        s_norm = sat_254 / 254.0
+        r, g, b = colorsys.hsv_to_rgb(h_norm, s_norm, 1.0)
+        r, g = g, r  # GRB compensation
+        h_new, s_new, _ = colorsys.rgb_to_hsv(r, g, b)
+        h_deg = int(h_new * 360)
+        s_1000 = int(s_new * 1000)
+
+        # Send color payload — use actual current brightness in V component
+        val_1000 = _level_to_device(_current_level_254(ep))
+        dps.append(
+            TuyaDatapointData(
+                dp=61, data=TuyaData(_dp61_payload(h_deg, s_1000, val_1000))
+            )
+        )
+
+        cmd = TuyaCommand(
+            status=0,
+            tsn=ep.device.application.get_sequence(),
+            datapoints=dps,
+        )
+        await self.command(
+            TUYA_SET_DATA, cmd, expect_reply=expect_reply, manufacturer=manufacturer
+        )
+
+        # Update attributes
+        self.update_attribute("work_mode", WorkMode.colour)
+        lc = ep.light_color
+        lc.update_attribute("current_hue", hue_254)
+        lc.update_attribute("current_saturation", sat_254)
+        lc.update_attribute("color_mode", Color.ColorMode.Hue_and_saturation)
+
+
+# ---------------------------------------------------------------------------
+# Color Cluster
+# ---------------------------------------------------------------------------
+
+
+class SpiLedColorCluster(Color, TuyaLocalCluster):
+    """Color cluster for WZ-SPI with HS color support."""
+
+    _CONSTANT_ATTRIBUTES = {
+        Color.AttributeDefs.color_capabilities.id: Color.ColorCapabilities.Hue_and_saturation
+        | Color.ColorCapabilities.Enhanced_hue
+        | Color.ColorCapabilities.XY_attributes,
+    }
+
+    async def command(
+        self,
+        command_id: foundation.GeneralCommand | int | t.uint8_t,
+        *args: Any,
+        manufacturer: int | t.uint16_t | None = None,
+        expect_reply: bool = True,
+        tsn: int | t.uint8_t | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Handle color commands."""
+        mcu: SpiLedManufCluster = self.endpoint.tuya_manufacturer
+        dr = foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema
+        cid = int(command_id)
+
+        # move_to_hue_and_saturation
+        if cid == Color.ServerCommandDefs.move_to_hue_and_saturation.id:
+            hue = _zcl_arg(0, "hue", args, kwargs)
+            sat = _zcl_arg(1, "saturation", args, kwargs)
+            if hue is None or sat is None:
+                return dr(command_id=command_id, status=foundation.Status.FAILURE)
+            await mcu.send_color_hs(int(hue), int(sat), expect_reply, manufacturer)
+            return dr(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        # move_to_hue
+        if cid == Color.ServerCommandDefs.move_to_hue.id:
+            hue = _zcl_arg(0, "hue", args, kwargs)
+            if hue is None:
+                return dr(command_id=command_id, status=foundation.Status.FAILURE)
+            sat = int(self.get("current_saturation") or 254)
+            await mcu.send_color_hs(int(hue), sat, expect_reply, manufacturer)
+            return dr(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        # move_to_saturation
+        if cid == Color.ServerCommandDefs.move_to_saturation.id:
+            sat = _zcl_arg(0, "saturation", args, kwargs)
+            if sat is None:
+                return dr(command_id=command_id, status=foundation.Status.FAILURE)
+            hue = int(self.get("current_hue") or 0)
+            await mcu.send_color_hs(hue, int(sat), expect_reply, manufacturer)
+            return dr(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        # move_to_color (XY)
+        if cid == Color.ServerCommandDefs.move_to_color.id:
+            cx = _zcl_arg(0, "color_x", args, kwargs)
+            cy = _zcl_arg(1, "color_y", args, kwargs)
+            if cx is None or cy is None:
+                return dr(command_id=command_id, status=foundation.Status.FAILURE)
+            h, s = _xy_to_hs_254(int(cx), int(cy))
+            await mcu.send_color_hs(h, s, expect_reply, manufacturer)
+            self.update_attribute("current_x", int(cx))
+            self.update_attribute("current_y", int(cy))
+            return dr(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        # enhanced_move_to_hue_and_saturation
+        if cid == Color.ServerCommandDefs.enhanced_move_to_hue_and_saturation.id:
+            eh = _zcl_arg(0, "enhanced_hue", args, kwargs)
+            sat = _zcl_arg(1, "saturation", args, kwargs)
+            if eh is None or sat is None:
+                return dr(command_id=command_id, status=foundation.Status.FAILURE)
+            h254 = _enhanced_hue_to_hue_254(int(eh))
+            await mcu.send_color_hs(h254, int(sat), expect_reply, manufacturer)
+            self.update_attribute("enhanced_current_hue", int(eh))
+            return dr(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        # stop_move_step — acknowledge only
+        if cid == Color.ServerCommandDefs.stop_move_step.id:
+            return dr(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        self.warning("Unsupported color command: %s", command_id)
+        return dr(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
+
+
+# ---------------------------------------------------------------------------
+# Device Class
+# ---------------------------------------------------------------------------
+
+
+class EnchantedSpiLed(CustomDeviceV2, BaseEnchantedDevice):
+    """Enchanted device class for WZ-SPI."""
+
+    tuya_spell_read_attributes = True
+    tuya_spell_data_query = False
+
+
+# ---------------------------------------------------------------------------
+# Quirk Registration
+# ---------------------------------------------------------------------------
+
+(
+    QuirkBuilder("_TZE204_8fffc3kb", "TS0601")
+    .also_applies_to("_TZE284_gt5al3bl", "TS0601")
+    .device_class(EnchantedSpiLed)
+    .replaces_endpoint(
+        1, profile_id=zha.PROFILE_ID, device_type=zha.DeviceType.EXTENDED_COLOR_LIGHT
+    )
+    .replaces(SpiLedManufCluster)
+    .adds(TuyaOnOffNM)
+    .adds(TuyaLevelControl)
+    .adds(SpiLedColorCluster)
+    .number(
+        attribute_name="lightpixel_number_set",
+        cluster_id=TUYA_CLUSTER_ID,
+        min_value=10,
+        max_value=1000,
+        step=1,
+        translation_key="lightpixel_number_set",
+        fallback_name="LED count",
+        entity_type=EntityType.CONFIG,
+    )
+    .enum(
+        attribute_name="light_bead_sequence",
+        enum_class=LightBeadSequence,
+        cluster_id=TUYA_CLUSTER_ID,
+        translation_key="light_bead_sequence",
+        fallback_name="LED strip order",
+        entity_type=EntityType.CONFIG,
+    )
+    .enum(
+        attribute_name="chip_type",
+        enum_class=ChipType,
+        cluster_id=TUYA_CLUSTER_ID,
+        translation_key="chip_type",
+        fallback_name="IC type",
+        entity_type=EntityType.CONFIG,
+    )
+    .skip_configuration()
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0601_spi_led.py
+++ b/zhaquirks/tuya/ts0601_spi_led.py
@@ -191,7 +191,7 @@ def _xy_to_hs_254(x: int, y: int) -> tuple[int, int]:
     g = max(g, 0.0)
     b = max(b, 0.0)
     mx = max(r, g, b)
-    if mx < 1e-6:
+    if mx < 1e-6:  # pragma: no cover
         return 0, 0
     r, g, b = r / mx, g / mx, b / mx
     h, s, _v = colorsys.rgb_to_hsv(r, g, b)


### PR DESCRIPTION
## Proposed change
Adding basic support for Tuya SPI Led driver, specifically `TS0601` `_TZE204_8fffc3kb`. 

Issues this addresses:
https://github.com/zigpy/zha-device-handlers/issues?q=is%3Aissue%20state%3Aopen%208fffc3kb

Devices like this one:
https://www.aliexpress.com/item/1005007463115043.html

## Additional information

Disclaimer: This is generated by A.I. PAIN STAKINGLY! It's taken Claude, Zed and Cursor to get this to a working point. I am not a Python dev, I do not have a Tuya bridge to do it properly as described by the documentation, and frankly, I don't have the patience or time to do all of the above. That being said, this still took a week to get a basic subset of it working for my own use. I use a `SK6812` strip, with `RBGW` order, and it works as expected. 

You can: 
- Set the strip LED count
- IC
- Order
- Adjust the brightness
- Power it on/off 
- Set the color. 

<img width="340" height="599" alt="Screenshot 2026-04-04 at 00 32 34" src="https://github.com/user-attachments/assets/f6d31301-63d0-46d1-856c-dcec43b55f31" />

I used the MQTT-Zigbee `[zigbee-herdsman-converters](https://github.com/Koenkk/zigbee-herdsman-converters/tree/master)` file for the compatible device to get to this point:
https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/gledopto.ts#L1244

**Caveat**
- I couldn't get all the modes working despite trying hard
- I could not get the white channel to work, it refuses to play nice with RGB, I am missing the core understanding needed to get that done. 

## Device diagnostics
[zha-01JE6NFS03W9K0VWXSGERY85RY-_TZE204_8fffc3kb TS0601-bf95400fde09b15f67b8362f6fce5c0f.json](https://github.com/user-attachments/files/26472686/zha-01JE6NFS03W9K0VWXSGERY85RY-_TZE204_8fffc3kb.TS0601-bf95400fde09b15f67b8362f6fce5c0f.json)

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
