### PR TITLE
Add Sonoff MINI DUO-L - no neutral (ZB2GS-L) quirk

### DIFF
--- a/zhaquirks/sonoff/mini_zb2gs.py
+++ b/zhaquirks/sonoff/mini_zb2gs.py
@@ -1,4 +1,4 @@
-"""Sonoff MINI-ZB2GS - Zigbee Switch."""
+"""Sonoff MINI-ZB2GS and MINI-ZB2GS-L - Zigbee Switches."""
 
 from zigpy import types
 from zigpy.quirks import CustomCluster
@@ -57,8 +57,8 @@ class SonoffCluster(CustomCluster):
         )
 
 
-(
-    QuirkBuilder("SONOFF", "MINI-ZB2GS")
+zb2gs_l_quirk = (
+    QuirkBuilder("SONOFF", "MINI-ZB2GS-L")
     .replaces(SonoffCluster, endpoint_id=1)
     .replaces(SonoffCluster, endpoint_id=2)
     .enum(
@@ -85,6 +85,12 @@ class SonoffCluster(CustomCluster):
         translation_key="external_trigger_mode",
         fallback_name="External trigger mode",
     )
+)
+zb2gs_l_quirk.add_to_registry()
+
+zb2gs_quirk = (
+    zb2gs_l_quirk.clone()
+    .applies_to("SONOFF", "MINI-ZB2GS")
     .switch(
         SonoffCluster.AttributeDefs.turbo_mode.name,
         SonoffCluster.cluster_id,
@@ -101,5 +107,5 @@ class SonoffCluster(CustomCluster):
         translation_key="network_led",
         fallback_name="Network LED",
     )
-    .add_to_registry()
 )
+zb2gs_quirk.add_to_registry()


### PR DESCRIPTION
This device is basically identical to the MINI ZB2GS (which has neutral connection), but has fewer features due to missing neutral connection:
- No network LED
- No turbo mode

This is a followup PR and reuses https://github.com/zigpy/zha-device-handlers/pull/4742

## Proposed change
Reuse the quirk that's already there for the Mini-ZB2GS. As the Mini-ZB2GS-L has less features, refactor code a bit to reuse common code by first creating the smaller quirk (with less features) for the ZB2GS-L (new device) and later clone it and add the missing config entities for the ZB2GS device. This keeps code small.

## Device diagnostics
https://github.com/user-attachments/files/26517518/zha-01KN1ZMJ05EV56PWVPE42Q7WVK-SONOFF.MINI-ZB2GS-L-308e967a8cfdd208d66b895cc6e64277.json

Provided by @Crocmagnon.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached

This closes #4667