### PR TITLE
Add Adeo/Lexman LDSENK08 door/window sensor

### DIFF
--- a/tests/test_adeo.py
+++ b/tests/test_adeo.py
@@ -1,0 +1,218 @@
+"""Tests for Adeo quirks."""
+
+from unittest import mock
+
+import pytest
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.security import IasZone
+
+import zhaquirks.adeo.sensor_ldsenk08
+
+
+def test_adeo_ldsenk08_v2_replaces_ias_cluster(zigpy_device_from_v2_quirk):
+    """Test V2 quirk replaces IAS cluster with custom class."""
+    device = zigpy_device_from_v2_quirk(
+        "ADEO",
+        "LDSENK08",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    assert isinstance(
+        device.endpoints[1].ias_zone,
+        zhaquirks.adeo.sensor_ldsenk08.IasMultiZoneCluster,
+    )
+
+
+def test_adeo_ldsenk08_cluster_request_updates_zone_status(zigpy_device_from_v2_quirk):
+    """Test incoming IAS status updates zone_status attribute."""
+    device = zigpy_device_from_v2_quirk(
+        "ADEO",
+        "LDSENK08",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].ias_zone
+    cluster.send_default_rsp = mock.MagicMock()
+    cluster.update_attribute = mock.MagicMock()
+
+    header = foundation.ZCLHeader()
+    header.command_id = IasZone.ClientCommandDefs.status_change_notification.id
+    header.frame_control = foundation.FrameControl.cluster()
+
+    cluster.handle_cluster_request(header, [0x07])
+    cluster.update_attribute.assert_called_with(
+        zhaquirks.adeo.sensor_ldsenk08.ZONE_STATUS, 0x07
+    )
+
+
+def test_adeo_ldsenk08_cluster_request_ignores_invalid_payload(
+    zigpy_device_from_v2_quirk,
+):
+    """Test empty payload does not update zone_status."""
+    device = zigpy_device_from_v2_quirk(
+        "ADEO",
+        "LDSENK08",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].ias_zone
+    cluster.send_default_rsp = mock.MagicMock()
+    cluster.update_attribute = mock.MagicMock()
+
+    header = foundation.ZCLHeader()
+    header.command_id = IasZone.ClientCommandDefs.status_change_notification.id
+    header.frame_control = foundation.FrameControl.cluster()
+
+    cluster.handle_cluster_request(header, [])
+    cluster.update_attribute.assert_not_called()
+
+
+def test_adeo_ldsenk08_cluster_request_ignores_invalid_zone_status_type(
+    zigpy_device_from_v2_quirk,
+):
+    """Test invalid zone status type does not update zone_status."""
+    device = zigpy_device_from_v2_quirk(
+        "ADEO",
+        "LDSENK08",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].ias_zone
+    cluster.send_default_rsp = mock.MagicMock()
+    cluster.update_attribute = mock.MagicMock()
+
+    header = foundation.ZCLHeader()
+    header.command_id = IasZone.ClientCommandDefs.status_change_notification.id
+    header.frame_control = foundation.FrameControl.cluster()
+
+    cluster.handle_cluster_request(header, [object()])
+    cluster.update_attribute.assert_not_called()
+
+
+def test_adeo_ldsenk08_cluster_request_ignores_unknown_command(
+    zigpy_device_from_v2_quirk,
+):
+    """Test unknown command id does not update zone_status."""
+    device = zigpy_device_from_v2_quirk(
+        "ADEO",
+        "LDSENK08",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].ias_zone
+    cluster.send_default_rsp = mock.MagicMock()
+    cluster.update_attribute = mock.MagicMock()
+
+    header = foundation.ZCLHeader()
+    header.command_id = 0x99
+    header.frame_control = foundation.FrameControl.cluster()
+
+    cluster.handle_cluster_request(header, [0x03])
+    cluster.update_attribute.assert_not_called()
+
+
+def test_adeo_ldsenk08_exposes_standard_sensitivity_attribute(
+    zigpy_device_from_v2_quirk,
+):
+    """Test IAS sensitivity attribute is available on endpoint 1."""
+    device = zigpy_device_from_v2_quirk(
+        "ADEO",
+        "LDSENK08",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].ias_zone
+
+    assert IasZone.AttributeDefs.current_zone_sensitivity_level.id in cluster.attributes
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("low", 0),
+        ("medium", 1),
+        ("high", 2),
+        (0, 0),
+        (4, 4),
+    ],
+)
+def test_adeo_ldsenk08_sensitivity_normalization(value, expected):
+    """Test sensitivity normalization supports labels and numeric range."""
+    assert (
+        zhaquirks.adeo.sensor_ldsenk08.IasMultiZoneCluster._normalize_sensitivity(value)
+        == expected
+    )
+
+
+@pytest.mark.parametrize("value", ["ultra", -1, 5])
+def test_adeo_ldsenk08_sensitivity_normalization_invalid(value):
+    """Test invalid sensitivity values are rejected."""
+    with pytest.raises(ValueError):
+        zhaquirks.adeo.sensor_ldsenk08.IasMultiZoneCluster._normalize_sensitivity(value)
+
+
+@pytest.mark.asyncio
+async def test_adeo_ldsenk08_write_attributes_normalizes_sensitivity_by_name(
+    zigpy_device_from_v2_quirk,
+):
+    """Test writing sensitivity by attribute name normalizes string values."""
+    device = zigpy_device_from_v2_quirk(
+        "ADEO",
+        "LDSENK08",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].ias_zone
+
+    with mock.patch(
+        "zigpy.quirks.CustomCluster.write_attributes",
+        new=mock.AsyncMock(return_value=[[mock.sentinel.ok]]),
+    ) as patched_super:
+        result = await cluster.write_attributes(
+            {IasZone.AttributeDefs.current_zone_sensitivity_level.name: "high"}
+        )
+
+    assert result == [[mock.sentinel.ok]]
+    patched_super.assert_awaited_once_with(
+        {IasZone.AttributeDefs.current_zone_sensitivity_level.name: 2},
+        manufacturer=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_adeo_ldsenk08_write_attributes_normalizes_sensitivity_by_id(
+    zigpy_device_from_v2_quirk,
+):
+    """Test writing sensitivity by attribute id keeps normalized numeric values."""
+    device = zigpy_device_from_v2_quirk(
+        "ADEO",
+        "LDSENK08",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].ias_zone
+    sensitivity_id = IasZone.AttributeDefs.current_zone_sensitivity_level.id
+
+    with mock.patch(
+        "zigpy.quirks.CustomCluster.write_attributes",
+        new=mock.AsyncMock(return_value=[[mock.sentinel.ok]]),
+    ) as patched_super:
+        result = await cluster.write_attributes({sensitivity_id: 4})
+
+    assert result == [[mock.sentinel.ok]]
+    patched_super.assert_awaited_once_with({sensitivity_id: 4}, manufacturer=None)
+
+
+@pytest.mark.asyncio
+async def test_adeo_ldsenk08_write_attributes_passthrough_non_sensitivity(
+    zigpy_device_from_v2_quirk,
+):
+    """Test non-sensitivity attributes are forwarded without normalization."""
+    device = zigpy_device_from_v2_quirk(
+        "ADEO",
+        "LDSENK08",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].ias_zone
+    zone_status_id = IasZone.AttributeDefs.zone_status.id
+
+    with mock.patch(
+        "zigpy.quirks.CustomCluster.write_attributes",
+        new=mock.AsyncMock(return_value=[[mock.sentinel.ok]]),
+    ) as patched_super:
+        result = await cluster.write_attributes({zone_status_id: 1})
+
+    assert result == [[mock.sentinel.ok]]
+    patched_super.assert_awaited_once_with({zone_status_id: 1}, manufacturer=None)

--- a/tests/test_adeo.py
+++ b/tests/test_adeo.py
@@ -159,13 +159,17 @@ async def test_adeo_ldsenk08_write_attributes_normalizes_sensitivity_by_name(
 
     with mock.patch(
         "zigpy.quirks.CustomCluster.write_attributes",
-        new=mock.AsyncMock(return_value=[[mock.sentinel.ok]]),
+        new=mock.AsyncMock(
+            return_value=[
+                [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+            ]
+        ),
     ) as patched_super:
         result = await cluster.write_attributes(
             {IasZone.AttributeDefs.current_zone_sensitivity_level.name: "high"}
         )
 
-    assert result == [[mock.sentinel.ok]]
+    assert result[0][0].status == foundation.Status.SUCCESS
     patched_super.assert_awaited_once_with(
         {IasZone.AttributeDefs.current_zone_sensitivity_level.name: 2},
         manufacturer=None,
@@ -187,11 +191,15 @@ async def test_adeo_ldsenk08_write_attributes_normalizes_sensitivity_by_id(
 
     with mock.patch(
         "zigpy.quirks.CustomCluster.write_attributes",
-        new=mock.AsyncMock(return_value=[[mock.sentinel.ok]]),
+        new=mock.AsyncMock(
+            return_value=[
+                [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+            ]
+        ),
     ) as patched_super:
         result = await cluster.write_attributes({sensitivity_id: 4})
 
-    assert result == [[mock.sentinel.ok]]
+    assert result[0][0].status == foundation.Status.SUCCESS
     patched_super.assert_awaited_once_with({sensitivity_id: 4}, manufacturer=None)
 
 
@@ -216,3 +224,67 @@ async def test_adeo_ldsenk08_write_attributes_passthrough_non_sensitivity(
 
     assert result == [[mock.sentinel.ok]]
     patched_super.assert_awaited_once_with({zone_status_id: 1}, manufacturer=None)
+
+
+@pytest.mark.asyncio
+async def test_adeo_ldsenk08_write_attributes_queues_sensitivity_on_failure(
+    zigpy_device_from_v2_quirk,
+):
+    """Test failed sensitivity writes are queued and acknowledged."""
+    device = zigpy_device_from_v2_quirk(
+        "ADEO",
+        "LDSENK08",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].ias_zone
+
+    with mock.patch(
+        "zigpy.quirks.CustomCluster.write_attributes",
+        new=mock.AsyncMock(side_effect=TimeoutError),
+    ) as patched_super:
+        result = await cluster.write_attributes(
+            {IasZone.AttributeDefs.current_zone_sensitivity_level.name: "high"}
+        )
+
+    assert result[0][0].status == foundation.Status.SUCCESS
+    assert cluster._pending_sensitivity_level == 2
+    patched_super.assert_awaited_once_with(
+        {IasZone.AttributeDefs.current_zone_sensitivity_level.name: 2},
+        manufacturer=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_adeo_ldsenk08_apply_pending_sensitivity_on_wake(
+    zigpy_device_from_v2_quirk,
+):
+    """Test pending sensitivity is retried when an IAS command is received."""
+    device = zigpy_device_from_v2_quirk(
+        "ADEO",
+        "LDSENK08",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].ias_zone
+    cluster._pending_sensitivity_level = 3
+    cluster.send_default_rsp = mock.MagicMock()
+    cluster.create_catching_task = mock.MagicMock(side_effect=lambda coro: coro.close())
+
+    with mock.patch(
+        "zigpy.quirks.CustomCluster.write_attributes",
+        new=mock.AsyncMock(
+            return_value=[
+                [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+            ]
+        ),
+    ) as patched_super:
+        header = foundation.ZCLHeader()
+        header.command_id = IasZone.ClientCommandDefs.status_change_notification.id
+        header.frame_control = foundation.FrameControl.cluster()
+        cluster.handle_cluster_request(header, [0x01])
+        await cluster._apply_pending_sensitivity()
+
+    cluster.create_catching_task.assert_called_once()
+    patched_super.assert_awaited_with(
+        {IasZone.AttributeDefs.current_zone_sensitivity_level.id: 3}
+    )
+    assert cluster._pending_sensitivity_level is None

--- a/zhaquirks/adeo/sensor_ldsenk08.py
+++ b/zhaquirks/adeo/sensor_ldsenk08.py
@@ -29,6 +29,11 @@ class IasMultiZoneCluster(CustomCluster, IasZone):
     SENSITIVITY_MIN = 0
     SENSITIVITY_MAX = 4
 
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize cluster state."""
+        super().__init__(*args, **kwargs)
+        self._pending_sensitivity_level: int | None = None
+
     @classmethod
     def _normalize_sensitivity(cls, value: Any) -> int:
         """Normalize sensitivity value accepted by this sensor."""
@@ -48,27 +53,76 @@ class IasMultiZoneCluster(CustomCluster, IasZone):
             raise ValueError(msg)
         return normalized_value
 
+    @staticmethod
+    def _write_succeeded(
+        result: list[list[foundation.WriteAttributesStatusRecord]],
+    ) -> bool:
+        """Return True if all write status records are successful."""
+        return all(
+            record.status == foundation.Status.SUCCESS
+            for group in result
+            for record in group
+        )
+
+    async def _apply_pending_sensitivity(self) -> None:
+        """Retry a queued sensitivity write when the device is awake."""
+        if self._pending_sensitivity_level is None:
+            return
+
+        pending_sensitivity = self._pending_sensitivity_level
+        result = await super().write_attributes(
+            {self.SENSITIVITY_ATTRIBUTE_ID: pending_sensitivity}
+        )
+        if self._write_succeeded(result):
+            self._pending_sensitivity_level = None
+
     async def write_attributes(
         self,
         attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
         manufacturer: int | t.uint16_t | None = None,
         **kwargs,
     ) -> list[list[foundation.WriteAttributesStatusRecord]]:
-        """Write attributes with sensitivity normalization."""
+        """Write attributes with sensitivity normalization and wake retry support."""
         normalized_attributes = {}
+        normalized_sensitivity: int | None = None
         for attr, value in attributes.items():
             attr_id = attr.id if isinstance(attr, foundation.ZCLAttributeDef) else attr
             if (
                 isinstance(attr_id, str)
                 and attr_id == IasZone.AttributeDefs.current_zone_sensitivity_level.name
             ) or attr_id == self.SENSITIVITY_ATTRIBUTE_ID:
-                normalized_attributes[attr] = self._normalize_sensitivity(value)
+                normalized_sensitivity = self._normalize_sensitivity(value)
+                normalized_attributes[attr] = normalized_sensitivity
             else:
                 normalized_attributes[attr] = value
 
-        return await super().write_attributes(
-            normalized_attributes, manufacturer=manufacturer, **kwargs
-        )
+        try:
+            result = await super().write_attributes(
+                normalized_attributes, manufacturer=manufacturer, **kwargs
+            )
+        except Exception:
+            if normalized_sensitivity is not None and len(normalized_attributes) == 1:
+                self._pending_sensitivity_level = normalized_sensitivity
+                self.update_attribute(
+                    self.SENSITIVITY_ATTRIBUTE_ID, normalized_sensitivity
+                )
+                return [
+                    [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+                ]
+            raise
+
+        if (
+            normalized_sensitivity is not None
+            and len(normalized_attributes) == 1
+            and not self._write_succeeded(result)
+        ):
+            self._pending_sensitivity_level = normalized_sensitivity
+            self.update_attribute(self.SENSITIVITY_ATTRIBUTE_ID, normalized_sensitivity)
+            return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+
+        if normalized_sensitivity is not None and self._write_succeeded(result):
+            self._pending_sensitivity_level = None
+        return result
 
     def handle_cluster_request(
         self,
@@ -80,6 +134,9 @@ class IasMultiZoneCluster(CustomCluster, IasZone):
         ) = None,
     ) -> None:
         """Handle a cluster command received on this cluster."""
+        if self._pending_sensitivity_level is not None:
+            self.create_catching_task(self._apply_pending_sensitivity())
+
         if hdr.command_id == self.STATUS_CHANGE_COMMAND_ID and args:
             try:
                 zone_status = int(args[0])

--- a/zhaquirks/adeo/sensor_ldsenk08.py
+++ b/zhaquirks/adeo/sensor_ldsenk08.py
@@ -1,0 +1,144 @@
+"""Device handler for ADEO Lexman LDSENK08 smart door/window sensor."""
+
+from typing import Any
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import EntityType, QuirkBuilder
+from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks.const import ZONE_STATUS, ZONE_TYPE
+
+
+class IasMultiZoneCluster(CustomCluster, IasZone):
+    """IAS zone cluster with LDSENK08 sensitivity handling.
+
+    `zone_status` bit mapping used by this quirk:
+    - bit 0 (`Alarm_1`): contact/opening
+    - bit 1 (`Alarm_2`): vibration
+    - bit 2 (`Tamper`): tamper/manipulation
+    - bit 3: battery low
+    """
+
+    _CONSTANT_ATTRIBUTES = {ZONE_TYPE: IasZone.ZoneType.Contact_Switch}
+    STATUS_CHANGE_COMMAND_ID = IasZone.ClientCommandDefs.status_change_notification.id
+    SENSITIVITY_ATTRIBUTE_ID = IasZone.AttributeDefs.current_zone_sensitivity_level.id
+    SENSITIVITY_LABELS = {"low": 0, "medium": 1, "high": 2}
+    SENSITIVITY_MIN = 0
+    SENSITIVITY_MAX = 4
+
+    @classmethod
+    def _normalize_sensitivity(cls, value: Any) -> int:
+        """Normalize sensitivity value accepted by this sensor."""
+        if isinstance(value, str):
+            mapped_value = cls.SENSITIVITY_LABELS.get(value.lower())
+            if mapped_value is None:
+                msg = f"Unsupported sensitivity label: {value}"
+                raise ValueError(msg)
+            return mapped_value
+
+        normalized_value = int(value)
+        if not cls.SENSITIVITY_MIN <= normalized_value <= cls.SENSITIVITY_MAX:
+            msg = (
+                "Sensitivity must be in range "
+                f"{cls.SENSITIVITY_MIN}..{cls.SENSITIVITY_MAX}"
+            )
+            raise ValueError(msg)
+        return normalized_value
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        manufacturer: int | t.uint16_t | None = None,
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
+        """Write attributes with sensitivity normalization."""
+        normalized_attributes = {}
+        for attr, value in attributes.items():
+            attr_id = attr.id if isinstance(attr, foundation.ZCLAttributeDef) else attr
+            if (
+                isinstance(attr_id, str)
+                and attr_id == IasZone.AttributeDefs.current_zone_sensitivity_level.name
+            ) or attr_id == self.SENSITIVITY_ATTRIBUTE_ID:
+                normalized_attributes[attr] = self._normalize_sensitivity(value)
+            else:
+                normalized_attributes[attr] = value
+
+        return await super().write_attributes(
+            normalized_attributes, manufacturer=manufacturer, **kwargs
+        )
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: (
+            t.Addressing.Group | t.Addressing.IEEE | t.Addressing.NWK | None
+        ) = None,
+    ) -> None:
+        """Handle a cluster command received on this cluster."""
+        if hdr.command_id == self.STATUS_CHANGE_COMMAND_ID and args:
+            try:
+                zone_status = int(args[0])
+            except (TypeError, ValueError):
+                super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+                return
+            # Keep full IAS bitmask so contact/vibration/tamper entities can derive from it.
+            self.update_attribute(ZONE_STATUS, zone_status)
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+
+(
+    QuirkBuilder("ADEO", "LDSENK08")
+    .replaces(IasMultiZoneCluster)
+    # Contact/opening from IAS zone_status Alarm_1 (bit 0).
+    .binary_sensor(
+        attribute_name=IasZone.AttributeDefs.zone_status.name,
+        cluster_id=IasZone.cluster_id,
+        device_class=BinarySensorDeviceClass.OPENING,
+        attribute_converter=lambda value: bool(value & IasZone.ZoneStatus.Alarm_1),
+        unique_id_suffix="contact",
+        entity_type=EntityType.STANDARD,
+        fallback_name="Contact",
+    )
+    # Vibration from IAS zone_status Alarm_2 (bit 1).
+    .binary_sensor(
+        attribute_name=IasZone.AttributeDefs.zone_status.name,
+        cluster_id=IasZone.cluster_id,
+        device_class=BinarySensorDeviceClass.VIBRATION,
+        attribute_converter=lambda value: bool(value & IasZone.ZoneStatus.Alarm_2),
+        unique_id_suffix="vibration",
+        entity_type=EntityType.STANDARD,
+        fallback_name="Vibration",
+    )
+    # Tamper/manipulation from IAS zone_status Tamper (bit 2).
+    .binary_sensor(
+        attribute_name=IasZone.AttributeDefs.zone_status.name,
+        cluster_id=IasZone.cluster_id,
+        device_class=BinarySensorDeviceClass.TAMPER,
+        attribute_converter=lambda value: bool(value & IasZone.ZoneStatus.Tamper),
+        unique_id_suffix="tamper",
+        entity_type=EntityType.STANDARD,
+        fallback_name="Tamper",
+    )
+    .number(
+        attribute_name=IasZone.AttributeDefs.current_zone_sensitivity_level.name,
+        cluster_id=IasZone.cluster_id,
+        min_value=0,
+        max_value=4,
+        step=1,
+        translation_key="sensitivity",
+        fallback_name="Sensitivity",
+    )
+    # Prevent ZHA's stock IAS zone binary (unique id …-1-1280). Quirk binaries use
+    # -contact / -vibration / -tamper and must not match this suffix.
+    .prevent_default_entity_creation(
+        endpoint_id=1,
+        cluster_id=IasZone.cluster_id,
+        unique_id_suffix="-1-1280",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
This PR adds a new comprehensive implementation for the ADEO/Lexman `LDSENK08` contact + vibration sensor, based on the previous approach discussed in #2298.

It replaces the IAS Zone cluster with a custom v2 cluster (`IasMultiZoneCluster`) that preserves and updates the full `zone_status` bitmask from IAS `status_change_notification` commands. 

Based on that bitmask, the quirk exposes dedicated binary sensors for:
- Contact/opening (`Alarm_1`)
- Vibration (`Alarm_2`)
- Tamper (`Tamper`)

It also exposes the IAS sensitivity attribute as a number entity and normalizes accepted write values (labels and numeric range) before forwarding attribute writes.

This addresses the original problem where contact and vibration events were mixed into a single IAS entity.

## Additional information
<img width="1014" height="778" alt="image" src="https://github.com/user-attachments/assets/4d929767-8544-4095-b06b-bf03c028197a" />

- Fixes #2249.

This implementation is based on the previous work in #2298, but is provided as a v2 quirk with dedicated tests.

No breaking change is expected for unaffected devices. 

For `ADEO/LDSENK08`, behavior improves by separating contact and vibration semantics while keeping IAS zone status handling aligned with the device reports.

## Device diagnostics
Diagnostics for `ADEO / LDSENK08` were provided in the support request context and should be attached to this PR as the downloaded diagnostics JSON from Home Assistant device page.

[zha-01KCVF5Y1M7D1DM1GHG4QQPBW9-ADEO LDSENK08-66f437b70b0e0410e026861da81e5d65.json](https://github.com/user-attachments/files/26518206/zha-01KCVF5Y1M7D1DM1GHG4QQPBW9-ADEO.LDSENK08-66f437b70b0e0410e026861da81e5d65.json)

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached