### PR TITLE
Add Shelly BLU Button Tough 1 ZB device triggers

### DIFF
--- a/zhaquirks/shelly/shelly_blu_button_tough_zb.py
+++ b/zhaquirks/shelly/shelly_blu_button_tough_zb.py
@@ -4,27 +4,27 @@ from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
     Basic,
-    PowerConfiguration,
-    Identify,
     Groups,
-    Scenes,
-    OnOff,
+    Identify,
     LevelControl,
+    OnOff,
+    PowerConfiguration,
+    Scenes,
 )
 
 from zhaquirks.const import (
-    COMMAND,
+    BUTTON,
     CLUSTER_ID,
-    ENDPOINT_ID,
+    COMMAND,
+    COMMAND_TOGGLE,
     DEVICE_TYPE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
     INPUT_CLUSTERS,
+    LONG_PRESS,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
-    DOUBLE_PRESS,
-    LONG_PRESS,
     SHORT_PRESS,
-    BUTTON,
-    COMMAND_TOGGLE
 )
 
 

--- a/zhaquirks/shelly/shelly_blu_button_tough_zb.py
+++ b/zhaquirks/shelly/shelly_blu_button_tough_zb.py
@@ -1,0 +1,99 @@
+"""ZHA Quirk for Shelly BLU Button Tough 1 ZB"""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    PowerConfiguration,
+    Identify,
+    Groups,
+    Scenes,
+    OnOff,
+    LevelControl,
+)
+
+from zhaquirks.const import (
+    COMMAND,
+    CLUSTER_ID,
+    ENDPOINT_ID,
+    DEVICE_TYPE,
+    INPUT_CLUSTERS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    DOUBLE_PRESS,
+    LONG_PRESS,
+    SHORT_PRESS,
+    BUTTON,
+    COMMAND_TOGGLE
+)
+
+
+class ShellyBluButtonTough1(CustomDevice):
+    """Shelly BLU Button Tough 1 ZB"""
+
+    signature = {
+        "models_info": [
+            ("Shelly", "BLU Button Tough 1 ZB"),
+        ],
+        "endpoints": {
+            1: {
+                "profile_id": 0x0104,
+                "device_type": 0x0000,
+                "input_clusters": [0x0000, 0x0001, 0x0003],
+                "output_clusters": [0x0003, 0x0005, 0x0006, 0x0008],
+            },
+            2: {
+                "profile_id": 0x0104,
+                "device_type": 0x0000,
+                "input_clusters": [0x0000, 0x0003],
+                "output_clusters": [0x0003, 0x0005, 0x0006],
+            },
+            3: {
+                "profile_id": 0x0104,
+                "device_type": 0x0000,
+                "input_clusters": [0x0000, 0x0003],
+                "output_clusters": [0x0003, 0x0005, 0x0006],
+            },
+        },
+    }
+
+    replacement = {
+        "endpoints": {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [Basic, PowerConfiguration, Identify],
+                OUTPUT_CLUSTERS: [Identify, Groups, Scenes, OnOff, LevelControl],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [Basic, Identify],
+                OUTPUT_CLUSTERS: [Identify, Groups, Scenes, OnOff],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [Basic, Identify],
+                OUTPUT_CLUSTERS: [Identify, Groups, Scenes, OnOff],
+            },
+        }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: 6,
+            ENDPOINT_ID: 1,
+        },
+        (DOUBLE_PRESS, BUTTON): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: 6,
+            ENDPOINT_ID: 2,
+        },
+        (LONG_PRESS, BUTTON): {
+            COMMAND: "recall",
+            CLUSTER_ID: 5,
+            ENDPOINT_ID: 1,
+        },
+    }

--- a/zhaquirks/shelly/shelly_blu_button_tough_zb.py
+++ b/zhaquirks/shelly/shelly_blu_button_tough_zb.py
@@ -1,4 +1,4 @@
-"""ZHA Quirk for Shelly BLU Button Tough 1 ZB"""
+"""ZHA Quirk for Shelly BLU Button Tough 1 ZB."""
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -29,7 +29,7 @@ from zhaquirks.const import (
 
 
 class ShellyBluButtonTough1(CustomDevice):
-    """Shelly BLU Button Tough 1 ZB"""
+    """Shelly BLU Button Tough 1 ZB."""
 
     signature = {
         "models_info": [


### PR DESCRIPTION
## Proposed change
Add support for the `Shelly Blu Button Tough ZB` - Shelly's Zigbee Button


## Device diagnostics
```json
{
  "node_descriptor": {
    "logical_type": 2,
    "complex_descriptor_available": 0,
    "user_descriptor_available": 0,
    "reserved": 0,
    "aps_flags": 0,
    "frequency_band": 8,
    "mac_capability_flags": 128,
    "manufacturer_code": 5264,
    "maximum_buffer_size": 82,
    "maximum_incoming_transfer_size": 82,
    "server_mask": 11264,
    "maximum_outgoing_transfer_size": 82,
    "descriptor_capability_field": 0
  },
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0006",
      "input_clusters": [
        "0x0000",
        "0x0001",
        "0x0003"
      ],
      "output_clusters": [
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006",
        "0x0008"
      ]
    },
    "2": {
      "profile_id": "0x0104",
      "device_type": "0x0006",
      "input_clusters": [
        "0x0000",
        "0x0003"
      ],
      "output_clusters": [
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006"
      ]
    },
    "3": {
      "profile_id": "0x0104",
      "device_type": "0x0006",
      "input_clusters": [
        "0x0000",
        "0x0003"
      ],
      "output_clusters": [
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006"
      ]
    }
  },
  "manufacturer": "Shelly",
  "model": "BLU Button Tough 1 ZB",
  "class": "shelly_blu_button_tough_1_zb.ShellyBluButtonTough1"
}
```


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
