### PR TITLE
Add quirks for Zemismart TS0601 screen switches

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -39,6 +39,7 @@ import zhaquirks.tuya.ts0043
 import zhaquirks.tuya.ts011f_plug
 import zhaquirks.tuya.ts0501_fan_switch
 import zhaquirks.tuya.ts0601_electric_heating
+import zhaquirks.tuya.ts0601_screen_switch
 import zhaquirks.tuya.ts0601_trv
 import zhaquirks.tuya.ts1201
 import zhaquirks.tuya.tuya_motion
@@ -305,6 +306,103 @@ def test_ts0121_signature(assert_signature_matches_quirk):
         "class": "zhaquirks.tuya.ts0121_plug.Plug",
     }
     assert_signature_matches_quirk(zhaquirks.tuya.ts0121_plug.Plug, signature)
+
+
+@pytest.mark.parametrize(
+    ("quirk", "signature"),
+    (
+        (
+            zhaquirks.tuya.ts0601_screen_switch.TuyaDualScreenSwitchTZE28C1000000,
+            {
+                "manufacturer": "_TZE28C1000000_a2teqi5u",
+                "model": "TS0601",
+                "endpoints": {
+                    "1": {
+                        "profile_id": 260,
+                        "device_type": "0x0051",
+                        "input_clusters": [
+                            "0x0000",
+                            "0xe000",
+                            "0xeb00",
+                            "0xed00",
+                            "0x0004",
+                            "0x0005",
+                            "0x0003",
+                            "0xef00",
+                        ],
+                        "output_clusters": ["0x000a", "0x0019"],
+                    },
+                    "242": {
+                        "profile_id": 41440,
+                        "device_type": "0x0061",
+                        "input_clusters": [],
+                        "output_clusters": ["0x0021"],
+                    },
+                },
+            },
+        ),
+        (
+            zhaquirks.tuya.ts0601_screen_switch.TuyaDualScreenSwitchTZE204EF00,
+            {
+                "manufacturer": "_TZE204_3ctwoaip",
+                "model": "TS0601",
+                "endpoints": {
+                    "1": {
+                        "profile_id": 260,
+                        "device_type": "0x0051",
+                        "input_clusters": [
+                            "0x0004",
+                            "0x0005",
+                            "0xef00",
+                            "0x0000",
+                        ],
+                        "output_clusters": ["0x0019", "0x000a"],
+                    },
+                    "242": {
+                        "profile_id": 41440,
+                        "device_type": "0x0061",
+                        "input_clusters": [],
+                        "output_clusters": ["0x0021"],
+                    },
+                },
+            },
+        ),
+        (
+            zhaquirks.tuya.ts0601_screen_switch.TuyaQuadrupleScreenSwitchTZE28C1000000,
+            {
+                "manufacturer": "_TZE28C1000000_xibaabmu",
+                "model": "TS0601",
+                "endpoints": {
+                    "1": {
+                        "profile_id": 260,
+                        "device_type": "0x0051",
+                        "input_clusters": [
+                            "0x0000",
+                            "0xe000",
+                            "0xeb00",
+                            "0xed00",
+                            "0x0004",
+                            "0x0005",
+                            "0x0003",
+                            "0xef00",
+                        ],
+                        "output_clusters": ["0x000a", "0x0019"],
+                    },
+                    "242": {
+                        "profile_id": 41440,
+                        "device_type": "0x0061",
+                        "input_clusters": [],
+                        "output_clusters": ["0x0021"],
+                    },
+                },
+            },
+        ),
+    ),
+)
+def test_ts0601_screen_switch_signatures(assert_signature_matches_quirk, quirk, signature):
+    """Test TS0601 screen switch signatures are matched to their quirks."""
+
+    assert_signature_matches_quirk(quirk, signature)
 
 
 async def test_tuya_data_conversion():

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -317,29 +317,29 @@ def test_ts0121_signature(assert_signature_matches_quirk):
                 "manufacturer": "_TZE28C1000000_a2teqi5u",
                 "model": "TS0601",
                 "endpoints": {
-                        "1": {
-                            "profile_id": 260,
-                            "device_type": "0x0051",
-                            "in_clusters": [
-                                "0x0000",
-                                "0xe000",
-                                "0xeb00",
+                    "1": {
+                        "profile_id": 260,
+                        "device_type": "0x0051",
+                        "in_clusters": [
+                            "0x0000",
+                            "0xe000",
+                            "0xeb00",
                             "0xed00",
                             "0x0004",
                             "0x0005",
-                                "0x0003",
-                                "0xef00",
-                            ],
-                            "out_clusters": ["0x000a", "0x0019"],
-                        },
-                        "242": {
-                            "profile_id": 41440,
-                            "device_type": "0x0061",
-                            "in_clusters": [],
-                            "out_clusters": ["0x0021"],
-                        },
+                            "0x0003",
+                            "0xef00",
+                        ],
+                        "out_clusters": ["0x000a", "0x0019"],
+                    },
+                    "242": {
+                        "profile_id": 41440,
+                        "device_type": "0x0061",
+                        "in_clusters": [],
+                        "out_clusters": ["0x0021"],
                     },
                 },
+            },
         ),
         (
             zhaquirks.tuya.ts0601_screen_switch.TuyaDualScreenSwitchTZE204EF00,
@@ -347,25 +347,25 @@ def test_ts0121_signature(assert_signature_matches_quirk):
                 "manufacturer": "_TZE204_3ctwoaip",
                 "model": "TS0601",
                 "endpoints": {
-                        "1": {
-                            "profile_id": 260,
-                            "device_type": "0x0051",
-                            "in_clusters": [
-                                "0x0004",
-                                "0x0005",
-                                "0xef00",
-                                "0x0000",
-                            ],
-                            "out_clusters": ["0x0019", "0x000a"],
-                        },
-                        "242": {
-                            "profile_id": 41440,
-                            "device_type": "0x0061",
-                            "in_clusters": [],
-                            "out_clusters": ["0x0021"],
-                        },
+                    "1": {
+                        "profile_id": 260,
+                        "device_type": "0x0051",
+                        "in_clusters": [
+                            "0x0004",
+                            "0x0005",
+                            "0xef00",
+                            "0x0000",
+                        ],
+                        "out_clusters": ["0x0019", "0x000a"],
+                    },
+                    "242": {
+                        "profile_id": 41440,
+                        "device_type": "0x0061",
+                        "in_clusters": [],
+                        "out_clusters": ["0x0021"],
                     },
                 },
+            },
         ),
         (
             zhaquirks.tuya.ts0601_screen_switch.TuyaQuadrupleScreenSwitchTZE28C1000000,
@@ -373,29 +373,29 @@ def test_ts0121_signature(assert_signature_matches_quirk):
                 "manufacturer": "_TZE28C1000000_xibaabmu",
                 "model": "TS0601",
                 "endpoints": {
-                        "1": {
-                            "profile_id": 260,
-                            "device_type": "0x0051",
-                            "in_clusters": [
-                                "0x0000",
-                                "0xe000",
-                                "0xeb00",
+                    "1": {
+                        "profile_id": 260,
+                        "device_type": "0x0051",
+                        "in_clusters": [
+                            "0x0000",
+                            "0xe000",
+                            "0xeb00",
                             "0xed00",
                             "0x0004",
                             "0x0005",
-                                "0x0003",
-                                "0xef00",
-                            ],
-                            "out_clusters": ["0x000a", "0x0019"],
-                        },
-                        "242": {
-                            "profile_id": 41440,
-                            "device_type": "0x0061",
-                            "in_clusters": [],
-                            "out_clusters": ["0x0021"],
-                        },
+                            "0x0003",
+                            "0xef00",
+                        ],
+                        "out_clusters": ["0x000a", "0x0019"],
+                    },
+                    "242": {
+                        "profile_id": 41440,
+                        "device_type": "0x0061",
+                        "in_clusters": [],
+                        "out_clusters": ["0x0021"],
                     },
                 },
+            },
         ),
     ),
 )

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -13,7 +13,7 @@ from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice, get_device
 import zigpy.types as t
-from zigpy.zcl import foundation
+from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import PowerConfiguration
 from zigpy.zcl.clusters.security import IasZone, ZoneStatus
 from zigpy.zcl.foundation import ZCLAttributeDef
@@ -30,7 +30,14 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
-from zhaquirks.tuya import Data, TuyaManufClusterAttributes, TuyaNewManufCluster
+from zhaquirks.tuya import (
+    Data,
+    TuyaCommand,
+    TuyaDatapointData,
+    TuyaManufClusterAttributes,
+    TuyaNewManufCluster,
+)
+from zhaquirks.tuya.mcu import TuyaMCUCluster
 import zhaquirks.tuya.sm0202_motion
 import zhaquirks.tuya.ts0021
 import zhaquirks.tuya.ts0041
@@ -309,102 +316,87 @@ def test_ts0121_signature(assert_signature_matches_quirk):
 
 
 @pytest.mark.parametrize(
-    ("quirk", "signature"),
-    (
-        (
-            zhaquirks.tuya.ts0601_screen_switch.TuyaDualScreenSwitchTZE28C1000000,
-            {
-                "manufacturer": "_TZE28C1000000_a2teqi5u",
-                "model": "TS0601",
-                "endpoints": {
-                    "1": {
-                        "profile_id": 260,
-                        "device_type": "0x0051",
-                        "in_clusters": [
-                            "0x0000",
-                            "0xe000",
-                            "0xeb00",
-                            "0xed00",
-                            "0x0004",
-                            "0x0005",
-                            "0x0003",
-                            "0xef00",
-                        ],
-                        "out_clusters": ["0x000a", "0x0019"],
-                    },
-                    "242": {
-                        "profile_id": 41440,
-                        "device_type": "0x0061",
-                        "in_clusters": [],
-                        "out_clusters": ["0x0021"],
-                    },
-                },
-            },
-        ),
-        (
-            zhaquirks.tuya.ts0601_screen_switch.TuyaDualScreenSwitchTZE204EF00,
-            {
-                "manufacturer": "_TZE204_3ctwoaip",
-                "model": "TS0601",
-                "endpoints": {
-                    "1": {
-                        "profile_id": 260,
-                        "device_type": "0x0051",
-                        "in_clusters": [
-                            "0x0004",
-                            "0x0005",
-                            "0xef00",
-                            "0x0000",
-                        ],
-                        "out_clusters": ["0x0019", "0x000a"],
-                    },
-                    "242": {
-                        "profile_id": 41440,
-                        "device_type": "0x0061",
-                        "in_clusters": [],
-                        "out_clusters": ["0x0021"],
-                    },
-                },
-            },
-        ),
-        (
-            zhaquirks.tuya.ts0601_screen_switch.TuyaQuadrupleScreenSwitchTZE28C1000000,
-            {
-                "manufacturer": "_TZE28C1000000_xibaabmu",
-                "model": "TS0601",
-                "endpoints": {
-                    "1": {
-                        "profile_id": 260,
-                        "device_type": "0x0051",
-                        "in_clusters": [
-                            "0x0000",
-                            "0xe000",
-                            "0xeb00",
-                            "0xed00",
-                            "0x0004",
-                            "0x0005",
-                            "0x0003",
-                            "0xef00",
-                        ],
-                        "out_clusters": ["0x000a", "0x0019"],
-                    },
-                    "242": {
-                        "profile_id": 41440,
-                        "device_type": "0x0061",
-                        "in_clusters": [],
-                        "out_clusters": ["0x0021"],
-                    },
-                },
-            },
-        ),
-    ),
+    ("manufacturer", "gang_count"),
+    zhaquirks.tuya.ts0601_screen_switch.SCREEN_SWITCH_SIGNATURES,
 )
-def test_ts0601_screen_switch_signatures(
-    assert_signature_matches_quirk, quirk, signature
+async def test_ts0601_screen_switch_v2_quirks(
+    zigpy_device_from_v2_quirk, manufacturer, gang_count
 ):
-    """Test TS0601 screen switch signatures are matched to their quirks."""
+    """Test TS0601 screen switches are matched to their v2 quirks."""
 
-    assert_signature_matches_quirk(quirk, signature)
+    quirked = zigpy_device_from_v2_quirk(manufacturer, "TS0601")
+    tuya_cluster = quirked.endpoints[1].tuya_manufacturer
+
+    assert isinstance(tuya_cluster, TuyaMCUCluster)
+
+    for gang in range(1, gang_count + 1):
+        assert f"state_l{gang}" in tuya_cluster.attributes_by_name
+        assert f"name_l{gang}" in tuya_cluster.attributes_by_name
+
+    entity_metadata = quirked.exposes_metadata[
+        (1, zhaquirks.tuya.TUYA_CLUSTER_ID, ClusterType.Server)
+    ]
+    assert {entity.fallback_name for entity in entity_metadata} == {
+        f"Switch {gang}" for gang in range(1, gang_count + 1)
+    }
+
+
+async def test_ts0601_screen_switch_dp_updates(zigpy_device_from_v2_quirk):
+    """Test TS0601 screen switch state and name DP reports."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_y4jqpry8", "TS0601")
+    tuya_cluster = quirked.endpoints[1].tuya_manufacturer
+    listener = ClusterListener(tuya_cluster)
+
+    status = tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[
+                TuyaDatapointData(1, True),
+                TuyaDatapointData(105, "Kitchen"),
+            ],
+        )
+    )
+
+    assert status == foundation.Status.SUCCESS
+    assert tuya_cluster.get("state_l1") == t.Bool.true
+    assert tuya_cluster.get("name_l1") == "Kitchen"
+    assert listener.attribute_updates == [
+        (tuya_cluster.attributes_by_name["state_l1"].id, t.Bool.true),
+        (tuya_cluster.attributes_by_name["name_l1"].id, "Kitchen"),
+    ]
+
+
+async def test_ts0601_screen_switch_name_write(zigpy_device_from_v2_quirk):
+    """Test writing a TS0601 screen switch display name."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_y4jqpry8", "TS0601")
+    tuya_cluster = quirked.endpoints[1].tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as request:
+        (status,) = await tuya_cluster.write_attributes(
+            {
+                "name_l1": "Very long kitchen name",
+            }
+        )
+        await wait_for_zigpy_tasks()
+
+    request.assert_called_once_with(
+        cluster=61184,
+        sequence=1,
+        data=b"\x01\x01\x00\x00\x01i\x03\x00\x0cVery long ki",
+        command_id=0,
+        timeout=5,
+        expect_reply=False,
+        use_ieee=False,
+        ask_for_ack=None,
+        priority=None,
+    )
+    assert status == [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+    assert tuya_cluster.get("name_l1") == "Very long kitchen name"
 
 
 async def test_tuya_data_conversion():

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -399,7 +399,9 @@ def test_ts0121_signature(assert_signature_matches_quirk):
         ),
     ),
 )
-def test_ts0601_screen_switch_signatures(assert_signature_matches_quirk, quirk, signature):
+def test_ts0601_screen_switch_signatures(
+    assert_signature_matches_quirk, quirk, signature
+):
     """Test TS0601 screen switch signatures are matched to their quirks."""
 
     assert_signature_matches_quirk(quirk, signature)

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -317,29 +317,29 @@ def test_ts0121_signature(assert_signature_matches_quirk):
                 "manufacturer": "_TZE28C1000000_a2teqi5u",
                 "model": "TS0601",
                 "endpoints": {
-                    "1": {
-                        "profile_id": 260,
-                        "device_type": "0x0051",
-                        "input_clusters": [
-                            "0x0000",
-                            "0xe000",
-                            "0xeb00",
+                        "1": {
+                            "profile_id": 260,
+                            "device_type": "0x0051",
+                            "in_clusters": [
+                                "0x0000",
+                                "0xe000",
+                                "0xeb00",
                             "0xed00",
                             "0x0004",
                             "0x0005",
-                            "0x0003",
-                            "0xef00",
-                        ],
-                        "output_clusters": ["0x000a", "0x0019"],
-                    },
-                    "242": {
-                        "profile_id": 41440,
-                        "device_type": "0x0061",
-                        "input_clusters": [],
-                        "output_clusters": ["0x0021"],
+                                "0x0003",
+                                "0xef00",
+                            ],
+                            "out_clusters": ["0x000a", "0x0019"],
+                        },
+                        "242": {
+                            "profile_id": 41440,
+                            "device_type": "0x0061",
+                            "in_clusters": [],
+                            "out_clusters": ["0x0021"],
+                        },
                     },
                 },
-            },
         ),
         (
             zhaquirks.tuya.ts0601_screen_switch.TuyaDualScreenSwitchTZE204EF00,
@@ -347,25 +347,25 @@ def test_ts0121_signature(assert_signature_matches_quirk):
                 "manufacturer": "_TZE204_3ctwoaip",
                 "model": "TS0601",
                 "endpoints": {
-                    "1": {
-                        "profile_id": 260,
-                        "device_type": "0x0051",
-                        "input_clusters": [
-                            "0x0004",
-                            "0x0005",
-                            "0xef00",
-                            "0x0000",
-                        ],
-                        "output_clusters": ["0x0019", "0x000a"],
-                    },
-                    "242": {
-                        "profile_id": 41440,
-                        "device_type": "0x0061",
-                        "input_clusters": [],
-                        "output_clusters": ["0x0021"],
+                        "1": {
+                            "profile_id": 260,
+                            "device_type": "0x0051",
+                            "in_clusters": [
+                                "0x0004",
+                                "0x0005",
+                                "0xef00",
+                                "0x0000",
+                            ],
+                            "out_clusters": ["0x0019", "0x000a"],
+                        },
+                        "242": {
+                            "profile_id": 41440,
+                            "device_type": "0x0061",
+                            "in_clusters": [],
+                            "out_clusters": ["0x0021"],
+                        },
                     },
                 },
-            },
         ),
         (
             zhaquirks.tuya.ts0601_screen_switch.TuyaQuadrupleScreenSwitchTZE28C1000000,
@@ -373,29 +373,29 @@ def test_ts0121_signature(assert_signature_matches_quirk):
                 "manufacturer": "_TZE28C1000000_xibaabmu",
                 "model": "TS0601",
                 "endpoints": {
-                    "1": {
-                        "profile_id": 260,
-                        "device_type": "0x0051",
-                        "input_clusters": [
-                            "0x0000",
-                            "0xe000",
-                            "0xeb00",
+                        "1": {
+                            "profile_id": 260,
+                            "device_type": "0x0051",
+                            "in_clusters": [
+                                "0x0000",
+                                "0xe000",
+                                "0xeb00",
                             "0xed00",
                             "0x0004",
                             "0x0005",
-                            "0x0003",
-                            "0xef00",
-                        ],
-                        "output_clusters": ["0x000a", "0x0019"],
-                    },
-                    "242": {
-                        "profile_id": 41440,
-                        "device_type": "0x0061",
-                        "input_clusters": [],
-                        "output_clusters": ["0x0021"],
+                                "0x0003",
+                                "0xef00",
+                            ],
+                            "out_clusters": ["0x000a", "0x0019"],
+                        },
+                        "242": {
+                            "profile_id": 41440,
+                            "device_type": "0x0061",
+                            "in_clusters": [],
+                            "out_clusters": ["0x0021"],
+                        },
                     },
                 },
-            },
         ),
     ),
 )

--- a/zhaquirks/tuya/ts0601_screen_switch.py
+++ b/zhaquirks/tuya/ts0601_screen_switch.py
@@ -27,6 +27,7 @@ class RawBytes(TuyaData):
     """Raw bytes helper for Tuya string payloads."""
 
     def __init__(self, value: bytes):
+        """Init raw byte payload."""
         self.raw = value
 
     def serialize(self) -> bytes:

--- a/zhaquirks/tuya/ts0601_screen_switch.py
+++ b/zhaquirks/tuya/ts0601_screen_switch.py
@@ -1,6 +1,6 @@
 """Tuya TS0601 screen switch quirks."""
 
-from zigpy.profiles import zha, zgp
+from zigpy.profiles import zgp, zha
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
@@ -20,11 +20,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import TuyaData, TuyaSwitch
-from zhaquirks.tuya.mcu import (
-    DPToAttributeMapping,
-    MoesSwitchManufCluster,
-    TuyaOnOffNM,
-)
+from zhaquirks.tuya.mcu import DPToAttributeMapping, MoesSwitchManufCluster, TuyaOnOffNM
 
 
 class RawBytes(TuyaData):
@@ -108,7 +104,9 @@ class ScreenSwitchManufCluster4G(MoesSwitchManufCluster):
     data_point_handlers = MoesSwitchManufCluster.data_point_handlers.copy()
 
 
-def _signature(models_info: list[tuple[str, str]], input_clusters: list[int] | None = None):
+def _signature(
+    models_info: list[tuple[str, str]], input_clusters: list[int] | None = None
+):
     """Build the base signature for screen switches."""
     if input_clusters is None:
         input_clusters = [

--- a/zhaquirks/tuya/ts0601_screen_switch.py
+++ b/zhaquirks/tuya/ts0601_screen_switch.py
@@ -54,7 +54,9 @@ def _name_dp_mapping(attribute_name: str) -> DPToAttributeMapping:
 class ScreenSwitchManufCluster1G(MoesSwitchManufCluster):
     """Custom Moes cluster with single-gang screen name support."""
 
-    dp_to_attribute = MoesSwitchManufCluster.dp_to_attribute.copy()
+    dp_to_attribute: dict[int, DPToAttributeMapping] = (
+        MoesSwitchManufCluster.dp_to_attribute.copy()
+    )
     dp_to_attribute.update(
         {
             105: _name_dp_mapping("name_update_1"),
@@ -66,7 +68,9 @@ class ScreenSwitchManufCluster1G(MoesSwitchManufCluster):
 class ScreenSwitchManufCluster2G(MoesSwitchManufCluster):
     """Custom Moes cluster with dual-gang screen name support."""
 
-    dp_to_attribute = MoesSwitchManufCluster.dp_to_attribute.copy()
+    dp_to_attribute: dict[int, DPToAttributeMapping] = (
+        MoesSwitchManufCluster.dp_to_attribute.copy()
+    )
     dp_to_attribute.update(
         {
             105: _name_dp_mapping("name_update_1"),
@@ -79,7 +83,9 @@ class ScreenSwitchManufCluster2G(MoesSwitchManufCluster):
 class ScreenSwitchManufCluster3G(MoesSwitchManufCluster):
     """Custom Moes cluster with triple-gang screen name support."""
 
-    dp_to_attribute = MoesSwitchManufCluster.dp_to_attribute.copy()
+    dp_to_attribute: dict[int, DPToAttributeMapping] = (
+        MoesSwitchManufCluster.dp_to_attribute.copy()
+    )
     dp_to_attribute.update(
         {
             105: _name_dp_mapping("name_update_1"),
@@ -93,7 +99,9 @@ class ScreenSwitchManufCluster3G(MoesSwitchManufCluster):
 class ScreenSwitchManufCluster4G(MoesSwitchManufCluster):
     """Custom Moes cluster with quadruple-gang screen name support."""
 
-    dp_to_attribute = MoesSwitchManufCluster.dp_to_attribute.copy()
+    dp_to_attribute: dict[int, DPToAttributeMapping] = (
+        MoesSwitchManufCluster.dp_to_attribute.copy()
+    )
     dp_to_attribute.update(
         {
             105: _name_dp_mapping("name_update_1"),

--- a/zhaquirks/tuya/ts0601_screen_switch.py
+++ b/zhaquirks/tuya/ts0601_screen_switch.py
@@ -1,290 +1,102 @@
-"""Tuya TS0601 screen switch quirks."""
+"""Tuya TS0601 Zemismart screen switch quirks."""
 
-from zigpy.profiles import zgp, zha
-from zigpy.zcl.clusters.general import (
-    Basic,
-    GreenPowerProxy,
-    Groups,
-    Identify,
-    Ota,
-    Scenes,
-    Time,
+from typing import Any
+
+from zigpy.quirks.v2.homeassistant import EntityType
+import zigpy.types as t
+from zigpy.typing import UNDEFINED, UndefinedType
+from zigpy.zcl import foundation
+
+from zhaquirks.tuya import TuyaCommand, TuyaDatapointData
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.mcu import TuyaMCUCluster
+
+SCREEN_SWITCH_SIGNATURES: tuple[tuple[str, int], ...] = (
+    ("_TZE284_lnyz4a6v", 1),
+    ("_TZE284_1tnysxwl", 1),
+    ("_TZE284_dmckrsxg", 2),
+    ("_TZE284_a2teqi5u", 2),
+    ("_TZE28C1000000_a2teqi5u", 2),
+    ("_TZE204_3ctwoaip", 2),
+    ("_TZE284_e4pf6l87", 3),
+    ("_TZE284_xvywzhmi", 3),
+    ("_TZE284_y4jqpry8", 4),
+    ("_TZE284_xibaabmu", 4),
+    ("_TZE28C1000000_xibaabmu", 4),
 )
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-from zhaquirks.tuya import TuyaData, TuyaSwitch
-from zhaquirks.tuya.mcu import DPToAttributeMapping, MoesSwitchManufCluster, TuyaOnOffNM
+
+class ScreenSwitchTuyaCluster(TuyaMCUCluster):
+    """Tuya MCU cluster with string datapoint write support."""
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
+        """Defer attribute writes to Tuya set_data commands."""
+        records = self._write_attr_records(attributes)
+
+        for record in records:
+            attr_name = self.attributes[record.attrid].name
+            attr_value = record.value.value
+            self.debug("write_attributes --> record: %s", record)
+
+            for dp in self.get_dp_mapping(self.endpoint.endpoint_id, attr_name):
+                value = attr_value
+
+                if attr_to_dp_converter := self._attributes_to_dp_converters.get(dp):
+                    value = attr_to_dp_converter(value)
+
+                self.create_catching_task(
+                    self.command(
+                        self.mcu_write_command,
+                        TuyaCommand(
+                            status=0,
+                            tsn=self.endpoint.device.application.get_sequence(),
+                            datapoints=[TuyaDatapointData(dp, value)],
+                        ),
+                        expect_reply=False,
+                        manufacturer=manufacturer,
+                    )
+                )
+
+            self._update_attribute(record.attrid, attr_value)
+
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
 
-class RawBytes(TuyaData):
-    """Raw bytes helper for Tuya string payloads."""
-
-    def __init__(self, value: bytes):
-        """Init raw byte payload."""
-        self.raw = value
-
-    def serialize(self) -> bytes:
-        """Serialize raw bytes with Tuya string header."""
-        length = len(self.raw)
-        return b"\x00" + length.to_bytes(2, "big") + self.raw
-
-    def __repr__(self) -> str:
-        """Represent raw bytes."""
-        return f"<RawBytes {self.raw!r}>"
+def _screen_name(value: str) -> str:
+    """Convert a screen name to the device-supported length."""
+    return value[:12]
 
 
-def _name_dp_mapping(attribute_name: str) -> DPToAttributeMapping:
-    """Create a DP mapping for screen name updates."""
-    return DPToAttributeMapping(
-        ep_attribute="tuya_mcu",
-        attribute_name=attribute_name,
-        converter=lambda value: value.decode("utf-8"),
-        dp_converter=lambda value: RawBytes(value.encode("utf-8")),
-        endpoint_id=1,
+def _builder(manufacturer: str, gang_count: int) -> TuyaQuirkBuilder:
+    """Build a screen switch quirk for a Zemismart TS0601 variant."""
+    builder = TuyaQuirkBuilder(manufacturer, "TS0601")
+
+    for gang in range(1, gang_count + 1):
+        builder.tuya_switch(
+            dp_id=gang,
+            attribute_name=f"state_l{gang}",
+            entity_type=EntityType.STANDARD,
+            translation_key=f"state_l{gang}",
+            fallback_name=f"Switch {gang}",
+        )
+        builder.tuya_dp_attribute(
+            dp_id=104 + gang,
+            attribute_name=f"name_l{gang}",
+            type=t.CharacterString,
+            access=foundation.ZCLAttributeAccess.Read
+            | foundation.ZCLAttributeAccess.Write,
+            dp_converter=_screen_name,
+        )
+
+    return builder.skip_configuration().tuya_enchantment(data_query_spell=True)
+
+
+for _manufacturer, _gang_count in SCREEN_SWITCH_SIGNATURES:
+    _builder(_manufacturer, _gang_count).add_to_registry(
+        replacement_cluster=ScreenSwitchTuyaCluster
     )
-
-
-class ScreenSwitchManufCluster1G(MoesSwitchManufCluster):
-    """Custom Moes cluster with single-gang screen name support."""
-
-    dp_to_attribute: dict[int, DPToAttributeMapping] = (
-        MoesSwitchManufCluster.dp_to_attribute.copy()
-    )
-    dp_to_attribute.update(
-        {
-            105: _name_dp_mapping("name_update_1"),
-        }
-    )
-    data_point_handlers = MoesSwitchManufCluster.data_point_handlers.copy()
-
-
-class ScreenSwitchManufCluster2G(MoesSwitchManufCluster):
-    """Custom Moes cluster with dual-gang screen name support."""
-
-    dp_to_attribute: dict[int, DPToAttributeMapping] = (
-        MoesSwitchManufCluster.dp_to_attribute.copy()
-    )
-    dp_to_attribute.update(
-        {
-            105: _name_dp_mapping("name_update_1"),
-            106: _name_dp_mapping("name_update_2"),
-        }
-    )
-    data_point_handlers = MoesSwitchManufCluster.data_point_handlers.copy()
-
-
-class ScreenSwitchManufCluster3G(MoesSwitchManufCluster):
-    """Custom Moes cluster with triple-gang screen name support."""
-
-    dp_to_attribute: dict[int, DPToAttributeMapping] = (
-        MoesSwitchManufCluster.dp_to_attribute.copy()
-    )
-    dp_to_attribute.update(
-        {
-            105: _name_dp_mapping("name_update_1"),
-            106: _name_dp_mapping("name_update_2"),
-            107: _name_dp_mapping("name_update_3"),
-        }
-    )
-    data_point_handlers = MoesSwitchManufCluster.data_point_handlers.copy()
-
-
-class ScreenSwitchManufCluster4G(MoesSwitchManufCluster):
-    """Custom Moes cluster with quadruple-gang screen name support."""
-
-    dp_to_attribute: dict[int, DPToAttributeMapping] = (
-        MoesSwitchManufCluster.dp_to_attribute.copy()
-    )
-    dp_to_attribute.update(
-        {
-            105: _name_dp_mapping("name_update_1"),
-            106: _name_dp_mapping("name_update_2"),
-            107: _name_dp_mapping("name_update_3"),
-            108: _name_dp_mapping("name_update_4"),
-        }
-    )
-    data_point_handlers = MoesSwitchManufCluster.data_point_handlers.copy()
-
-
-def _signature(
-    models_info: list[tuple[str, str]], input_clusters: list[int] | None = None
-):
-    """Build the base signature for screen switches."""
-    if input_clusters is None:
-        input_clusters = [
-            Basic.cluster_id,
-            Groups.cluster_id,
-            Scenes.cluster_id,
-            MoesSwitchManufCluster.cluster_id,
-            0xED00,
-        ]
-
-    return {
-        MODELS_INFO: models_info,
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
-                INPUT_CLUSTERS: input_clusters,
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
-    }
-
-
-def _replacement(manufacturer_cluster: type[MoesSwitchManufCluster], channels: int):
-    """Build the replacement definition for screen switches."""
-    endpoints = {
-        1: {
-            PROFILE_ID: zha.PROFILE_ID,
-            DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-            INPUT_CLUSTERS: [
-                Basic.cluster_id,
-                Groups.cluster_id,
-                Scenes.cluster_id,
-                manufacturer_cluster,
-                TuyaOnOffNM,
-            ],
-            OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-        },
-        242: {
-            PROFILE_ID: zgp.PROFILE_ID,
-            DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-            INPUT_CLUSTERS: [],
-            OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-        },
-    }
-
-    for endpoint_id in range(2, channels + 1):
-        endpoints[endpoint_id] = {
-            PROFILE_ID: zha.PROFILE_ID,
-            DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
-            INPUT_CLUSTERS: [TuyaOnOffNM],
-            OUTPUT_CLUSTERS: [],
-        }
-
-    return {ENDPOINTS: endpoints}
-
-
-def _tze28c1000000_signature(models_info: list[tuple[str, str]]):
-    """Signature variant for TZE28C1000000 devices."""
-    return _signature(
-        models_info,
-        [
-            Basic.cluster_id,
-            0xE000,
-            0xEB00,
-            0xED00,
-            Groups.cluster_id,
-            Scenes.cluster_id,
-            Identify.cluster_id,
-            0xEF00,
-        ],
-    )
-
-
-def _tze204_ef00_signature(models_info: list[tuple[str, str]]):
-    """Signature variant for EF00-only TZE204 devices."""
-    return _signature(
-        models_info,
-        [
-            Groups.cluster_id,
-            Scenes.cluster_id,
-            0xEF00,
-            Basic.cluster_id,
-        ],
-    )
-
-
-class TuyaSingleScreenSwitchGP(TuyaSwitch):
-    """Tuya single channel screen switch."""
-
-    signature = _signature(
-        [
-            ("_TZE284_lnyz4a6v", "TS0601"),
-            ("_TZE284_1tnysxwl", "TS0601"),
-        ]
-    )
-    replacement = _replacement(ScreenSwitchManufCluster1G, 1)
-
-
-class TuyaDualScreenSwitchGP(TuyaSwitch):
-    """Tuya dual channel screen switch."""
-
-    signature = _signature(
-        [
-            ("_TZE284_dmckrsxg", "TS0601"),
-            ("_TZE284_a2teqi5u", "TS0601"),
-        ]
-    )
-    replacement = _replacement(ScreenSwitchManufCluster2G, 2)
-
-
-class TuyaDualScreenSwitchTZE28C1000000(TuyaSwitch):
-    """Tuya dual channel screen switch with TZE28C1000000 signature."""
-
-    signature = _tze28c1000000_signature(
-        [
-            ("_TZE28C1000000_a2teqi5u", "TS0601"),
-        ]
-    )
-    replacement = _replacement(ScreenSwitchManufCluster2G, 2)
-
-
-class TuyaDualScreenSwitchTZE204EF00(TuyaSwitch):
-    """Tuya dual channel screen switch with EF00-only TZE204 signature."""
-
-    signature = _tze204_ef00_signature(
-        [
-            ("_TZE204_3ctwoaip", "TS0601"),
-        ]
-    )
-    replacement = _replacement(ScreenSwitchManufCluster2G, 2)
-
-
-class TuyaTripleScreenSwitchGP(TuyaSwitch):
-    """Tuya triple channel screen switch."""
-
-    signature = _signature(
-        [
-            ("_TZE284_e4pf6l87", "TS0601"),
-            ("_TZE284_xvywzhmi", "TS0601"),
-        ]
-    )
-    replacement = _replacement(ScreenSwitchManufCluster3G, 3)
-
-
-class TuyaQuadrupleScreenSwitchGP(TuyaSwitch):
-    """Tuya quadruple channel screen switch."""
-
-    signature = _signature(
-        [
-            ("_TZE284_y4jqpry8", "TS0601"),
-            ("_TZE284_xibaabmu", "TS0601"),
-        ]
-    )
-    replacement = _replacement(ScreenSwitchManufCluster4G, 4)
-
-
-class TuyaQuadrupleScreenSwitchTZE28C1000000(TuyaSwitch):
-    """Tuya quadruple channel screen switch with TZE28C1000000 signature."""
-
-    signature = _tze28c1000000_signature(
-        [
-            ("_TZE28C1000000_xibaabmu", "TS0601"),
-        ]
-    )
-    replacement = _replacement(ScreenSwitchManufCluster4G, 4)

--- a/zhaquirks/tuya/ts0601_screen_switch.py
+++ b/zhaquirks/tuya/ts0601_screen_switch.py
@@ -1,0 +1,283 @@
+"""Tuya TS0601 screen switch quirks."""
+
+from zigpy.profiles import zha, zgp
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    Ota,
+    Scenes,
+    Time,
+)
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.tuya import TuyaData, TuyaSwitch
+from zhaquirks.tuya.mcu import (
+    DPToAttributeMapping,
+    MoesSwitchManufCluster,
+    TuyaOnOffNM,
+)
+
+
+class RawBytes(TuyaData):
+    """Raw bytes helper for Tuya string payloads."""
+
+    def __init__(self, value: bytes):
+        self.raw = value
+
+    def serialize(self) -> bytes:
+        """Serialize raw bytes with Tuya string header."""
+        length = len(self.raw)
+        return b"\x00" + length.to_bytes(2, "big") + self.raw
+
+    def __repr__(self) -> str:
+        """Represent raw bytes."""
+        return f"<RawBytes {self.raw!r}>"
+
+
+def _name_dp_mapping(attribute_name: str) -> DPToAttributeMapping:
+    """Create a DP mapping for screen name updates."""
+    return DPToAttributeMapping(
+        ep_attribute="tuya_mcu",
+        attribute_name=attribute_name,
+        converter=lambda value: value.decode("utf-8"),
+        dp_converter=lambda value: RawBytes(value.encode("utf-8")),
+        endpoint_id=1,
+    )
+
+
+class ScreenSwitchManufCluster1G(MoesSwitchManufCluster):
+    """Custom Moes cluster with single-gang screen name support."""
+
+    dp_to_attribute = MoesSwitchManufCluster.dp_to_attribute.copy()
+    dp_to_attribute.update(
+        {
+            105: _name_dp_mapping("name_update_1"),
+        }
+    )
+    data_point_handlers = MoesSwitchManufCluster.data_point_handlers.copy()
+
+
+class ScreenSwitchManufCluster2G(MoesSwitchManufCluster):
+    """Custom Moes cluster with dual-gang screen name support."""
+
+    dp_to_attribute = MoesSwitchManufCluster.dp_to_attribute.copy()
+    dp_to_attribute.update(
+        {
+            105: _name_dp_mapping("name_update_1"),
+            106: _name_dp_mapping("name_update_2"),
+        }
+    )
+    data_point_handlers = MoesSwitchManufCluster.data_point_handlers.copy()
+
+
+class ScreenSwitchManufCluster3G(MoesSwitchManufCluster):
+    """Custom Moes cluster with triple-gang screen name support."""
+
+    dp_to_attribute = MoesSwitchManufCluster.dp_to_attribute.copy()
+    dp_to_attribute.update(
+        {
+            105: _name_dp_mapping("name_update_1"),
+            106: _name_dp_mapping("name_update_2"),
+            107: _name_dp_mapping("name_update_3"),
+        }
+    )
+    data_point_handlers = MoesSwitchManufCluster.data_point_handlers.copy()
+
+
+class ScreenSwitchManufCluster4G(MoesSwitchManufCluster):
+    """Custom Moes cluster with quadruple-gang screen name support."""
+
+    dp_to_attribute = MoesSwitchManufCluster.dp_to_attribute.copy()
+    dp_to_attribute.update(
+        {
+            105: _name_dp_mapping("name_update_1"),
+            106: _name_dp_mapping("name_update_2"),
+            107: _name_dp_mapping("name_update_3"),
+            108: _name_dp_mapping("name_update_4"),
+        }
+    )
+    data_point_handlers = MoesSwitchManufCluster.data_point_handlers.copy()
+
+
+def _signature(models_info: list[tuple[str, str]], input_clusters: list[int] | None = None):
+    """Build the base signature for screen switches."""
+    if input_clusters is None:
+        input_clusters = [
+            Basic.cluster_id,
+            Groups.cluster_id,
+            Scenes.cluster_id,
+            MoesSwitchManufCluster.cluster_id,
+            0xED00,
+        ]
+
+    return {
+        MODELS_INFO: models_info,
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: input_clusters,
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+
+def _replacement(manufacturer_cluster: type[MoesSwitchManufCluster], channels: int):
+    """Build the replacement definition for screen switches."""
+    endpoints = {
+        1: {
+            PROFILE_ID: zha.PROFILE_ID,
+            DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+            INPUT_CLUSTERS: [
+                Basic.cluster_id,
+                Groups.cluster_id,
+                Scenes.cluster_id,
+                manufacturer_cluster,
+                TuyaOnOffNM,
+            ],
+            OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+        },
+        242: {
+            PROFILE_ID: zgp.PROFILE_ID,
+            DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+            INPUT_CLUSTERS: [],
+            OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+        },
+    }
+
+    for endpoint_id in range(2, channels + 1):
+        endpoints[endpoint_id] = {
+            PROFILE_ID: zha.PROFILE_ID,
+            DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+            INPUT_CLUSTERS: [TuyaOnOffNM],
+            OUTPUT_CLUSTERS: [],
+        }
+
+    return {ENDPOINTS: endpoints}
+
+
+def _tze28c1000000_signature(models_info: list[tuple[str, str]]):
+    """Signature variant for TZE28C1000000 devices."""
+    return _signature(
+        models_info,
+        [
+            Basic.cluster_id,
+            0xE000,
+            0xEB00,
+            0xED00,
+            Groups.cluster_id,
+            Scenes.cluster_id,
+            Identify.cluster_id,
+            0xEF00,
+        ],
+    )
+
+
+def _tze204_ef00_signature(models_info: list[tuple[str, str]]):
+    """Signature variant for EF00-only TZE204 devices."""
+    return _signature(
+        models_info,
+        [
+            Groups.cluster_id,
+            Scenes.cluster_id,
+            0xEF00,
+            Basic.cluster_id,
+        ],
+    )
+
+
+class TuyaSingleScreenSwitchGP(TuyaSwitch):
+    """Tuya single channel screen switch."""
+
+    signature = _signature(
+        [
+            ("_TZE284_lnyz4a6v", "TS0601"),
+            ("_TZE284_1tnysxwl", "TS0601"),
+        ]
+    )
+    replacement = _replacement(ScreenSwitchManufCluster1G, 1)
+
+
+class TuyaDualScreenSwitchGP(TuyaSwitch):
+    """Tuya dual channel screen switch."""
+
+    signature = _signature(
+        [
+            ("_TZE284_dmckrsxg", "TS0601"),
+            ("_TZE284_a2teqi5u", "TS0601"),
+        ]
+    )
+    replacement = _replacement(ScreenSwitchManufCluster2G, 2)
+
+
+class TuyaDualScreenSwitchTZE28C1000000(TuyaSwitch):
+    """Tuya dual channel screen switch with TZE28C1000000 signature."""
+
+    signature = _tze28c1000000_signature(
+        [
+            ("_TZE28C1000000_a2teqi5u", "TS0601"),
+        ]
+    )
+    replacement = _replacement(ScreenSwitchManufCluster2G, 2)
+
+
+class TuyaDualScreenSwitchTZE204EF00(TuyaSwitch):
+    """Tuya dual channel screen switch with EF00-only TZE204 signature."""
+
+    signature = _tze204_ef00_signature(
+        [
+            ("_TZE204_3ctwoaip", "TS0601"),
+        ]
+    )
+    replacement = _replacement(ScreenSwitchManufCluster2G, 2)
+
+
+class TuyaTripleScreenSwitchGP(TuyaSwitch):
+    """Tuya triple channel screen switch."""
+
+    signature = _signature(
+        [
+            ("_TZE284_e4pf6l87", "TS0601"),
+            ("_TZE284_xvywzhmi", "TS0601"),
+        ]
+    )
+    replacement = _replacement(ScreenSwitchManufCluster3G, 3)
+
+
+class TuyaQuadrupleScreenSwitchGP(TuyaSwitch):
+    """Tuya quadruple channel screen switch."""
+
+    signature = _signature(
+        [
+            ("_TZE284_y4jqpry8", "TS0601"),
+            ("_TZE284_xibaabmu", "TS0601"),
+        ]
+    )
+    replacement = _replacement(ScreenSwitchManufCluster4G, 4)
+
+
+class TuyaQuadrupleScreenSwitchTZE28C1000000(TuyaSwitch):
+    """Tuya quadruple channel screen switch with TZE28C1000000 signature."""
+
+    signature = _tze28c1000000_signature(
+        [
+            ("_TZE28C1000000_xibaabmu", "TS0601"),
+        ]
+    )
+    replacement = _replacement(ScreenSwitchManufCluster4G, 4)


### PR DESCRIPTION
## Proposed change

Add v2 ZHA quirks for Zemismart TS0601 screen switches, including 1-gang, 2-gang, 3-gang, and 4-gang variants.

The implementation uses `TuyaQuirkBuilder` and registers the supported manufacturer/model signatures with a shared `TuyaMCUCluster` replacement. It maps relay state datapoints `1..4` to switch entities and screen label datapoints `105..108` to writable cluster attributes.

## Additional information

Supported manufacturer variants:

- 1-gang: `_TZE284_lnyz4a6v`, `_TZE284_1tnysxwl`
- 2-gang: `_TZE284_dmckrsxg`, `_TZE284_a2teqi5u`, `_TZE28C1000000_a2teqi5u`, `_TZE204_3ctwoaip`
- 3-gang: `_TZE284_e4pf6l87`, `_TZE284_xvywzhmi`
- 4-gang: `_TZE284_y4jqpry8`, `_TZE284_xibaabmu`, `_TZE28C1000000_xibaabmu`

Validation run locally:

- `uv run pytest tests/ -q`
- `uv run pytest tests/test_tuya.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy zhaquirks/tuya/ts0601_screen_switch.py`
- `pre-commit run --all-files`

## Device diagnostics

Device diagnostics are not attached yet. The quirk behavior is covered by unit tests for v2 quirk matching, Tuya DP updates, generated switch entity metadata, and writable screen-name datapoints.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
