### PR TITLE
Add Powernity PO-BOCO-ELEC pilot wire module

### DIFF
--- a/zhaquirks/tuya/ts0601_pilot_wire.py
+++ b/zhaquirks/tuya/ts0601_pilot_wire.py
@@ -1,0 +1,65 @@
+"""Tuya Quirk for support of electric heating pilot wire modules."""
+
+from zigpy.quirks.v2 import EntityPlatform, EntityType
+import zigpy.types as t
+
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+
+class PowernityPOBOCOELECPreset(t.enum8):
+    """Enum for preset mode of Powernity PO-BOCO-ELEC pilot wire module."""
+
+    Auto = 0x00
+    Manual = 0x01
+    Holiday = 0x02
+
+
+class PowernityPOBOCOELECMode(t.enum8):
+    """Enum for mode of Powernity PO-BOCO-ELEC pilot wire module."""
+
+    Off = 0x05
+    AntiFrost = 0x04
+    Eco = 0x03
+    ComfortMinus2 = 0x02
+    ComfortMinus1 = 0x01
+    Comfort = 0x00
+
+
+(
+    TuyaQuirkBuilder("_TZE204_d6i25bwg", "TS0601")
+    .tuya_enum(
+        dp_id=2,
+        attribute_name="preset",
+        enum_class=PowernityPOBOCOELECPreset,
+        entity_platform=EntityPlatform.SELECT,
+        entity_type=EntityType.STANDARD,
+        translation_key="preset",
+        fallback_name="Preset",
+    )
+    .tuya_temperature(dp_id=16, scale=10)
+    .tuya_humidity(dp_id=8)
+    .tuya_enum(
+        dp_id=126,
+        attribute_name="auto_mode",
+        enum_class=PowernityPOBOCOELECMode,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.STANDARD,
+        translation_key="auto_mode",
+        fallback_name="Auto mode",
+    )
+    .tuya_enum(
+        dp_id=127,
+        attribute_name="manual_mode",
+        enum_class=PowernityPOBOCOELECMode,
+        entity_platform=EntityPlatform.SELECT,
+        entity_type=EntityType.STANDARD,
+        translation_key="manual_mode",
+        fallback_name="Manual mode",
+    )
+    .friendly_name(
+        model="PO-BOCO-ELEC",
+        manufacturer="Powernity",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
…ic heating.

## Proposed change
I developed a quirk for the management of my Powernity PO-BOCO-ELEC pilot wire modules, that control the modes of the electric radiators in my house. As the "custom quirk loaded" message suggests, it's time for me to contribute for the community ! 

## Additional information
This PR responds to the issue #4718 I opened last February. As I described in this ticket, I managed to handle the basic manual mode selection (that is what most user might need) as well as temperature and humidity sensors by translating the code from the pre-existing [Herdsman converter](https://github.com/Koenkk/zigbee-herdsman-converters/blob/427294ab4912f6f5038909c106e838228e71b5d4/src/devices/tuya.ts#L19808). This works well, however, I did not make the effort to figure how to handle other features such as automatic mode scheduling, which should also be useful to have. That being said, I think the manual mode handling is already worth contributing.

## Device diagnostics
[zha-01JWYCKB9H6RD2ED5NQ8R0KXTT-Powernity.PO-BOCO-ELEC-5468d5ee2eaf085a74bae199a72383c0.json](https://github.com/user-attachments/files/26857642/zha-01JWYCKB9H6RD2ED5NQ8R0KXTT-Powernity.PO-BOCO-ELEC-5468d5ee2eaf085a74bae199a72383c0.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
