### PR TITLE
Add Aqara H1 Smart Knob (lumi.remote.rkba01) quirk

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2663,6 +2663,88 @@ def test_h1_wireless_remotes(zigpy_device_from_v2_quirk):
     assert MultistateInput.cluster_id in device.endpoints[3].in_clusters
 
 
+async def test_h1_knob_rotation_event(zigpy_device_from_v2_quirk):
+    """Test Aqara H1 knob emits zha_events derived from rotation attribute reports."""
+    from zhaquirks.xiaomi.aqara.remote_h1_knob import (
+        ROTATION_DIRECTION,
+        KnobAction,
+        KnobManuSpecificCluster,
+    )
+
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.remote.rkba01")
+
+    # quirk adds endpoints 71 and 72 with KnobManuSpecificCluster
+    assert 71 in device.endpoints
+    assert 72 in device.endpoints
+    cluster = device.endpoints[71].opple_cluster
+    assert isinstance(cluster, KnobManuSpecificCluster)
+
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    attrs = KnobManuSpecificCluster.AttributeDefs
+    hdr = foundation.ZCLHeader.general(
+        manufacturer=0x115F,
+        tsn=1,
+        command_id=foundation.GeneralCommand.Report_Attributes,
+    )
+    schema = foundation.GENERAL_COMMANDS[
+        foundation.GeneralCommand.Report_Attributes
+    ].schema
+
+    def make_report(action: KnobAction, angle: float, angle_delta: float):
+        return schema(
+            attribute_reports=[
+                Attribute(
+                    attrid=attrs.rotation_angle.id,
+                    value=TypeValue(type=DataTypeId.single, value=t.Single(angle)),
+                ),
+                Attribute(
+                    attrid=attrs.rotation_angle_delta.id,
+                    value=TypeValue(
+                        type=DataTypeId.single, value=t.Single(angle_delta)
+                    ),
+                ),
+                Attribute(
+                    attrid=attrs.action.id,
+                    value=TypeValue(type=DataTypeId.uint8, value=t.uint8_t(action)),
+                ),
+            ]
+        )
+
+    # stop_rotation: delta attrs are dropped, direction derived from final angle
+    cluster.handle_cluster_general_request(
+        hdr, make_report(KnobAction.stop_rotation, -42.5, 0.0)
+    )
+    listener.zha_send_event.assert_called_once()
+    command, event_args = listener.zha_send_event.call_args.args
+    assert command == "stop_rotation"
+    assert event_args["action"] == KnobAction.stop_rotation
+    assert event_args["rotation_angle"] == pytest.approx(-42.5)
+    assert event_args[ROTATION_DIRECTION] == -1
+    assert "rotation_angle_delta" not in event_args
+
+    # in-progress rotation: delta kept, no derived direction
+    listener.reset_mock()
+    cluster.handle_cluster_general_request(
+        hdr, make_report(KnobAction.rotation, 20.0, 5.0)
+    )
+    command, event_args = listener.zha_send_event.call_args.args
+    assert command == "rotation"
+    assert event_args["rotation_angle_delta"] == pytest.approx(5.0)
+    assert ROTATION_DIRECTION not in event_args
+
+    # hold_stop_rotation with positive angle -> direction = 1
+    listener.reset_mock()
+    cluster.handle_cluster_general_request(
+        hdr, make_report(KnobAction.hold_stop_rotation, 10.0, 3.0)
+    )
+    command, event_args = listener.zha_send_event.call_args.args
+    assert command == "hold_stop_rotation"
+    assert event_args[ROTATION_DIRECTION] == 1
+    assert "rotation_angle_delta" not in event_args
+
+
 @pytest.mark.parametrize("endpoint", [(1), (2)])
 def test_t1m_ceiling_light(zigpy_device_from_v2_quirk, endpoint):
     """Test Aqara T1M ceiling light quirk adds missing endpoints."""

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -40,6 +40,7 @@ from zigpy.zcl.clusters.measurement import (
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zcl.clusters.smartenergy import Metering
 from zigpy.zcl.foundation import Attribute, DataTypeId, TypeValue
+from zigpy.zdo.types import LogicalType, NodeDescriptor
 
 from tests.common import ZCL_OCC_ATTR_RPT_OCC, ClusterListener
 import zhaquirks
@@ -2665,13 +2666,21 @@ def test_h1_wireless_remotes(zigpy_device_from_v2_quirk):
 
 async def test_h1_knob_rotation_event(zigpy_device_from_v2_quirk):
     """Test Aqara H1 knob emits zha_events derived from rotation attribute reports."""
+    from zhaquirks.const import LEFT, RIGHT, ROTATED
     from zhaquirks.xiaomi.aqara.remote_h1_knob import (
-        ROTATION_DIRECTION,
         KnobAction,
         KnobManuSpecificCluster,
     )
 
     device = zigpy_device_from_v2_quirk(LUMI, "lumi.remote.rkba01")
+
+    # node descriptor should mark the device as a battery end device
+    # (the device advertises MainsPowered, which the quirk clears)
+    assert device.node_desc.logical_type == LogicalType.EndDevice
+    assert not (
+        device.node_desc.mac_capability_flags
+        & NodeDescriptor.MACCapabilityFlags.MainsPowered
+    )
 
     # quirk adds endpoints 71 and 72 with KnobManuSpecificCluster
     assert 71 in device.endpoints
@@ -2712,36 +2721,36 @@ async def test_h1_knob_rotation_event(zigpy_device_from_v2_quirk):
             ]
         )
 
-    # stop_rotation: delta attrs are dropped, direction derived from final angle
+    # StopRotation: delta attrs are dropped, direction derived from final angle
     cluster.handle_cluster_general_request(
-        hdr, make_report(KnobAction.stop_rotation, -42.5, 0.0)
+        hdr, make_report(KnobAction.StopRotation, -42.5, 0.0)
     )
     listener.zha_send_event.assert_called_once()
     command, event_args = listener.zha_send_event.call_args.args
-    assert command == "stop_rotation"
-    assert event_args["action"] == KnobAction.stop_rotation
+    assert command == "stopped_rotating"
+    assert event_args["action"] == KnobAction.StopRotation
     assert event_args["rotation_angle"] == pytest.approx(-42.5)
-    assert event_args[ROTATION_DIRECTION] == -1
+    assert event_args[ROTATED] == LEFT
     assert "rotation_angle_delta" not in event_args
 
-    # in-progress rotation: delta kept, no derived direction
+    # in-progress rotation: delta kept, direction derived from signed delta
     listener.reset_mock()
     cluster.handle_cluster_general_request(
-        hdr, make_report(KnobAction.rotation, 20.0, 5.0)
+        hdr, make_report(KnobAction.Rotation, 20.0, -5.0)
     )
     command, event_args = listener.zha_send_event.call_args.args
-    assert command == "rotation"
-    assert event_args["rotation_angle_delta"] == pytest.approx(5.0)
-    assert ROTATION_DIRECTION not in event_args
+    assert command == "continued_rotating"
+    assert event_args["rotation_angle_delta"] == pytest.approx(-5.0)
+    assert event_args[ROTATED] == LEFT
 
-    # hold_stop_rotation with positive angle -> direction = 1
+    # HoldStopRotation with positive angle -> RIGHT
     listener.reset_mock()
     cluster.handle_cluster_general_request(
-        hdr, make_report(KnobAction.hold_stop_rotation, 10.0, 3.0)
+        hdr, make_report(KnobAction.HoldStopRotation, 10.0, 3.0)
     )
     command, event_args = listener.zha_send_event.call_args.args
-    assert command == "hold_stop_rotation"
-    assert event_args[ROTATION_DIRECTION] == 1
+    assert command == "hold_stopped_rotating"
+    assert event_args[ROTATED] == RIGHT
     assert "rotation_angle_delta" not in event_args
 
 

--- a/zhaquirks/xiaomi/aqara/remote_h1_knob.py
+++ b/zhaquirks/xiaomi/aqara/remote_h1_knob.py
@@ -1,6 +1,5 @@
 """Aqara H1 Smart Knob (wireless)."""
 
-import math
 from typing import Any
 
 from zigpy import types as t
@@ -16,14 +15,22 @@ from zhaquirks.const import (
     ARGS,
     BUTTON,
     COMMAND,
+    COMMAND_CONTINUED_ROTATING,
     COMMAND_OFF,
+    COMMAND_STARTED_ROTATING,
+    COMMAND_STOPPED_ROTATING,
     COMMAND_TOGGLE,
+    CONTINUED_ROTATING,
     DOUBLE_PRESS,
     ENDPOINT_ID,
+    LEFT,
     LONG_PRESS,
     LONG_RELEASE,
+    RIGHT,
     ROTATED,
     SHORT_PRESS,
+    STARTED_ROTATING,
+    STOPPED_ROTATING_WITH_DIRECTION,
     ZHA_SEND_EVENT,
 )
 from zhaquirks.xiaomi import LUMI, XiaomiAqaraE1Cluster, XiaomiPowerConfiguration
@@ -57,27 +64,43 @@ H1_KNOB_NODE_DESCRIPTOR = NodeDescriptor(
     descriptor_capability_field=NodeDescriptor.DescriptorCapability.NONE,
 )
 
-ROTATION_DIRECTION = "rotation_direction"
+# "Pressed rotation": the device reports these while the knob is being rotated
+# with the button held down. No standard constants exist in zhaquirks.const, so
+# we define local ones mirroring the non-held naming convention.
+HOLD_STARTED_ROTATING = "rotary_knob_hold_started_rotating"
+HOLD_CONTINUED_ROTATING = "rotary_knob_hold_continued_rotating"
+HOLD_STOPPED_ROTATING_WITH_DIRECTION = (
+    "rotary_knob_hold_stopped_rotating_with_direction"
+)
 
-ROTATE_LEFT = "rotate_left"
-ROTATE_RIGHT = "rotate_right"
-HOLD_ROTATE_LEFT = "hold_rotate_left"
-HOLD_ROTATE_RIGHT = "hold_rotate_right"
-
-STOP_ROTATION = "stop_rotation"
-HOLD_STOP_ROTATION = "hold_stop_rotation"
+COMMAND_HOLD_STARTED_ROTATING = "hold_started_rotating"
+COMMAND_HOLD_CONTINUED_ROTATING = "hold_continued_rotating"
+COMMAND_HOLD_STOPPED_ROTATING = "hold_stopped_rotating"
 
 
 class KnobAction(t.enum8):
     """Aqara H1 knob rotation action."""
 
-    off = 0x00
-    start_rotation = 0x01
-    rotation = 0x02
-    stop_rotation = 0x03
-    hold_start_rotation = 0x81
-    hold_rotation = 0x82
-    hold_stop_rotation = 0x83
+    Off = 0x00
+    StartRotation = 0x01
+    Rotation = 0x02
+    StopRotation = 0x03
+    HoldStartRotation = 0x81
+    HoldRotation = 0x82
+    HoldStopRotation = 0x83
+
+
+# Map raw KnobAction to the zha_event command string we emit.
+KNOB_ACTION_COMMANDS: dict[KnobAction, str] = {
+    KnobAction.StartRotation: COMMAND_STARTED_ROTATING,
+    KnobAction.Rotation: COMMAND_CONTINUED_ROTATING,
+    KnobAction.StopRotation: COMMAND_STOPPED_ROTATING,
+    KnobAction.HoldStartRotation: COMMAND_HOLD_STARTED_ROTATING,
+    KnobAction.HoldRotation: COMMAND_HOLD_CONTINUED_ROTATING,
+    KnobAction.HoldStopRotation: COMMAND_HOLD_STOPPED_ROTATING,
+}
+
+_STOP_ACTIONS = {KnobAction.StopRotation, KnobAction.HoldStopRotation}
 
 
 class KnobManuSpecificCluster(XiaomiAqaraE1Cluster):
@@ -166,20 +189,37 @@ class KnobManuSpecificCluster(XiaomiAqaraE1Cluster):
         if action is None:
             return
 
-        # Delta attributes are stale on stop events; drop them and derive direction
-        # from the (signed) final rotation_angle instead.
-        if action in (KnobAction.stop_rotation, KnobAction.hold_stop_rotation):
+        command = KNOB_ACTION_COMMANDS.get(action)
+        if command is None:
+            return
+
+        # Delta attributes are stale on stop events; drop them and derive the
+        # direction from the signed final `rotation_angle`. For in-progress
+        # events use the signed delta (which reflects the most recent motion).
+        angle = event_args.get(
+            KnobManuSpecificCluster.AttributeDefs.rotation_angle.name, 0
+        )
+        if action in _STOP_ACTIONS:
             for key in list(event_args):
                 if key.endswith("_delta"):
                     del event_args[key]
-            event_args[ROTATION_DIRECTION] = math.copysign(
-                1,
-                event_args.get(
-                    KnobManuSpecificCluster.AttributeDefs.rotation_angle.name, 0
-                ),
+            direction_source = angle
+        else:
+            direction_source = event_args.get(
+                KnobManuSpecificCluster.AttributeDefs.rotation_angle_delta.name,
+                angle,
             )
 
-        self.listener_event(ZHA_SEND_EVENT, action.name, event_args)
+        if direction_source < 0:
+            event_args[ROTATED] = LEFT
+        else:
+            event_args[ROTATED] = RIGHT
+
+        self.listener_event(ZHA_SEND_EVENT, command, event_args)
+
+
+def _rotation_trigger(command: str, direction: str) -> dict[str, Any]:
+    return {COMMAND: command, ARGS: {ROTATED: direction}}
 
 
 (
@@ -202,29 +242,48 @@ class KnobManuSpecificCluster(XiaomiAqaraE1Cluster):
     )
     .device_automation_triggers(
         {
-            # operation_mode == event
+            # button presses (operation_mode == event)
             (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_1_SINGLE},
             (DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_1_DOUBLE},
             (LONG_PRESS, BUTTON): {COMMAND: COMMAND_1_HOLD},
             (LONG_RELEASE, BUTTON): {COMMAND: COMMAND_1_RELEASE},
-            (ROTATED, BUTTON): {COMMAND: STOP_ROTATION},
-            (ROTATE_LEFT, BUTTON): {
-                COMMAND: STOP_ROTATION,
-                ARGS: {ROTATION_DIRECTION: -1},
-            },
-            (ROTATE_RIGHT, BUTTON): {
-                COMMAND: STOP_ROTATION,
-                ARGS: {ROTATION_DIRECTION: 1},
-            },
-            (HOLD_ROTATE_LEFT, BUTTON): {
-                COMMAND: HOLD_STOP_ROTATION,
-                ARGS: {ROTATION_DIRECTION: -1},
-            },
-            (HOLD_ROTATE_RIGHT, BUTTON): {
-                COMMAND: HOLD_STOP_ROTATION,
-                ARGS: {ROTATION_DIRECTION: 1},
-            },
-            # operation_mode == command (single press does not emit an event)
+            # free rotation
+            (STARTED_ROTATING, LEFT): _rotation_trigger(COMMAND_STARTED_ROTATING, LEFT),
+            (STARTED_ROTATING, RIGHT): _rotation_trigger(
+                COMMAND_STARTED_ROTATING, RIGHT
+            ),
+            (CONTINUED_ROTATING, LEFT): _rotation_trigger(
+                COMMAND_CONTINUED_ROTATING, LEFT
+            ),
+            (CONTINUED_ROTATING, RIGHT): _rotation_trigger(
+                COMMAND_CONTINUED_ROTATING, RIGHT
+            ),
+            (STOPPED_ROTATING_WITH_DIRECTION, LEFT): _rotation_trigger(
+                COMMAND_STOPPED_ROTATING, LEFT
+            ),
+            (STOPPED_ROTATING_WITH_DIRECTION, RIGHT): _rotation_trigger(
+                COMMAND_STOPPED_ROTATING, RIGHT
+            ),
+            # rotation while button is held
+            (HOLD_STARTED_ROTATING, LEFT): _rotation_trigger(
+                COMMAND_HOLD_STARTED_ROTATING, LEFT
+            ),
+            (HOLD_STARTED_ROTATING, RIGHT): _rotation_trigger(
+                COMMAND_HOLD_STARTED_ROTATING, RIGHT
+            ),
+            (HOLD_CONTINUED_ROTATING, LEFT): _rotation_trigger(
+                COMMAND_HOLD_CONTINUED_ROTATING, LEFT
+            ),
+            (HOLD_CONTINUED_ROTATING, RIGHT): _rotation_trigger(
+                COMMAND_HOLD_CONTINUED_ROTATING, RIGHT
+            ),
+            (HOLD_STOPPED_ROTATING_WITH_DIRECTION, LEFT): _rotation_trigger(
+                COMMAND_HOLD_STOPPED_ROTATING, LEFT
+            ),
+            (HOLD_STOPPED_ROTATING_WITH_DIRECTION, RIGHT): _rotation_trigger(
+                COMMAND_HOLD_STOPPED_ROTATING, RIGHT
+            ),
+            # alt button presses (operation_mode == command; single does not emit an event)
             (ALT_DOUBLE_PRESS, BUTTON): {
                 COMMAND: COMMAND_TOGGLE,
                 ENDPOINT_ID: 1,

--- a/zhaquirks/xiaomi/aqara/remote_h1_knob.py
+++ b/zhaquirks/xiaomi/aqara/remote_h1_knob.py
@@ -1,0 +1,241 @@
+"""Aqara H1 Smart Knob (wireless)."""
+
+import math
+from typing import Any
+
+from zigpy import types as t
+from zigpy.profiles import zha
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl import foundation
+from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
+from zigpy.zdo.types import LogicalType, NodeDescriptor
+
+from zhaquirks.const import (
+    ALT_DOUBLE_PRESS,
+    ALT_LONG_PRESS,
+    ARGS,
+    BUTTON,
+    COMMAND,
+    COMMAND_OFF,
+    COMMAND_TOGGLE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    LONG_PRESS,
+    LONG_RELEASE,
+    ROTATED,
+    SHORT_PRESS,
+    ZHA_SEND_EVENT,
+)
+from zhaquirks.xiaomi import LUMI, XiaomiAqaraE1Cluster, XiaomiPowerConfiguration
+from zhaquirks.xiaomi.aqara.opple_remote import (
+    COMMAND_1_DOUBLE,
+    COMMAND_1_HOLD,
+    COMMAND_1_RELEASE,
+    COMMAND_1_SINGLE,
+    MultistateInputCluster,
+)
+from zhaquirks.xiaomi.aqara.remote_h1 import (
+    AqaraRemoteManuSpecificCluster,
+    AqaraSwitchOperationMode,
+)
+
+# Device advertises MainsPowered in its MAC capability flags; clear it so ZHA
+# treats it as a battery-powered end device.
+H1_KNOB_NODE_DESCRIPTOR = NodeDescriptor(
+    logical_type=LogicalType.EndDevice,
+    complex_descriptor_available=0,
+    user_descriptor_available=0,
+    reserved=0,
+    aps_flags=0,
+    frequency_band=NodeDescriptor.FrequencyBand.Freq2400MHz,
+    mac_capability_flags=NodeDescriptor.MACCapabilityFlags.AllocateAddress,
+    manufacturer_code=0x115F,
+    maximum_buffer_size=127,
+    maximum_incoming_transfer_size=100,
+    server_mask=11264,
+    maximum_outgoing_transfer_size=100,
+    descriptor_capability_field=NodeDescriptor.DescriptorCapability.NONE,
+)
+
+ROTATION_DIRECTION = "rotation_direction"
+
+ROTATE_LEFT = "rotate_left"
+ROTATE_RIGHT = "rotate_right"
+HOLD_ROTATE_LEFT = "hold_rotate_left"
+HOLD_ROTATE_RIGHT = "hold_rotate_right"
+
+STOP_ROTATION = "stop_rotation"
+HOLD_STOP_ROTATION = "hold_stop_rotation"
+
+
+class KnobAction(t.enum8):
+    """Aqara H1 knob rotation action."""
+
+    off = 0x00
+    start_rotation = 0x01
+    rotation = 0x02
+    stop_rotation = 0x03
+    hold_start_rotation = 0x81
+    hold_rotation = 0x82
+    hold_stop_rotation = 0x83
+
+
+class KnobManuSpecificCluster(XiaomiAqaraE1Cluster):
+    """Aqara H1 knob cluster that reports rotation events on endpoints 71/72."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Rotation reporting attributes."""
+
+        rotation_time_delta = ZCLAttributeDef(
+            id=0x022C,
+            type=t.uint16_t,
+            zcl_type=DataTypeId.uint16,
+            access="rp",
+            manufacturer_code=0x115F,
+        )
+        rotation_angle = ZCLAttributeDef(
+            id=0x022E,
+            type=t.Single,
+            zcl_type=DataTypeId.single,
+            access="rp",
+            manufacturer_code=0x115F,
+        )
+        rotation_angle_delta = ZCLAttributeDef(
+            id=0x0230,
+            type=t.Single,
+            zcl_type=DataTypeId.single,
+            access="rp",
+            manufacturer_code=0x115F,
+        )
+        rotation_time = ZCLAttributeDef(
+            id=0x0231,
+            type=t.uint32_t,
+            zcl_type=DataTypeId.uint32,
+            access="rp",
+            manufacturer_code=0x115F,
+        )
+        rotation_percent_delta = ZCLAttributeDef(
+            id=0x0232,
+            type=t.Single,
+            zcl_type=DataTypeId.single,
+            access="rp",
+            manufacturer_code=0x115F,
+        )
+        rotation_percent = ZCLAttributeDef(
+            id=0x0233,
+            type=t.Single,
+            zcl_type=DataTypeId.single,
+            access="rp",
+            manufacturer_code=0x115F,
+        )
+        action = ZCLAttributeDef(
+            id=0x023A,
+            type=KnobAction,
+            zcl_type=DataTypeId.uint8,
+            access="rp",
+            manufacturer_code=0x115F,
+        )
+
+    def handle_cluster_general_request(
+        self,
+        header: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing=None,
+    ) -> None:
+        """Emit a zha_event carrying rotation details when an action is reported."""
+        super().handle_cluster_general_request(
+            header, args, dst_addressing=dst_addressing
+        )
+
+        if header.command_id != foundation.GeneralCommand.Report_Attributes:
+            return
+
+        event_args: dict[str, Any] = {}
+        for attr in args.attribute_reports:
+            if attr.attrid not in self.attributes:
+                continue
+            attr_def = self.attributes[attr.attrid]
+            try:
+                value = attr_def.type(attr.value.value)
+            except ValueError:
+                value = attr.value.value
+            event_args[attr_def.name] = value
+
+        action = event_args.get(KnobManuSpecificCluster.AttributeDefs.action.name)
+        if action is None:
+            return
+
+        # Delta attributes are stale on stop events; drop them and derive direction
+        # from the (signed) final rotation_angle instead.
+        if action in (KnobAction.stop_rotation, KnobAction.hold_stop_rotation):
+            for key in list(event_args):
+                if key.endswith("_delta"):
+                    del event_args[key]
+            event_args[ROTATION_DIRECTION] = math.copysign(
+                1,
+                event_args.get(
+                    KnobManuSpecificCluster.AttributeDefs.rotation_angle.name, 0
+                ),
+            )
+
+        self.listener_event(ZHA_SEND_EVENT, action.name, event_args)
+
+
+(
+    QuirkBuilder(LUMI, "lumi.remote.rkba01")
+    .friendly_name(manufacturer="Aqara", model="Smart Knob H1 (wireless)")
+    .node_descriptor(H1_KNOB_NODE_DESCRIPTOR)
+    .replaces(XiaomiPowerConfiguration)
+    .adds(MultistateInputCluster)
+    .replaces(AqaraRemoteManuSpecificCluster)
+    .adds_endpoint(71, device_type=zha.DeviceType.DIMMER_SWITCH)
+    .adds(KnobManuSpecificCluster, endpoint_id=71)
+    .adds_endpoint(72, device_type=zha.DeviceType.SHADE_CONTROLLER)
+    .adds(KnobManuSpecificCluster, endpoint_id=72)
+    .enum(
+        attribute_name=AqaraRemoteManuSpecificCluster.AttributeDefs.operation_mode.name,
+        enum_class=AqaraSwitchOperationMode,
+        cluster_id=AqaraRemoteManuSpecificCluster.cluster_id,
+        translation_key="operation_mode",
+        fallback_name="Operation mode",
+    )
+    .device_automation_triggers(
+        {
+            # operation_mode == event
+            (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_1_SINGLE},
+            (DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_1_DOUBLE},
+            (LONG_PRESS, BUTTON): {COMMAND: COMMAND_1_HOLD},
+            (LONG_RELEASE, BUTTON): {COMMAND: COMMAND_1_RELEASE},
+            (ROTATED, BUTTON): {COMMAND: STOP_ROTATION},
+            (ROTATE_LEFT, BUTTON): {
+                COMMAND: STOP_ROTATION,
+                ARGS: {ROTATION_DIRECTION: -1},
+            },
+            (ROTATE_RIGHT, BUTTON): {
+                COMMAND: STOP_ROTATION,
+                ARGS: {ROTATION_DIRECTION: 1},
+            },
+            (HOLD_ROTATE_LEFT, BUTTON): {
+                COMMAND: HOLD_STOP_ROTATION,
+                ARGS: {ROTATION_DIRECTION: -1},
+            },
+            (HOLD_ROTATE_RIGHT, BUTTON): {
+                COMMAND: HOLD_STOP_ROTATION,
+                ARGS: {ROTATION_DIRECTION: 1},
+            },
+            # operation_mode == command (single press does not emit an event)
+            (ALT_DOUBLE_PRESS, BUTTON): {
+                COMMAND: COMMAND_TOGGLE,
+                ENDPOINT_ID: 1,
+                ARGS: [],
+            },
+            (ALT_LONG_PRESS, BUTTON): {
+                COMMAND: COMMAND_OFF,
+                ENDPOINT_ID: 1,
+                ARGS: [],
+            },
+        }
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Summary

- Adds a V2 quirk for the Aqara H1 Smart Knob wireless remote (`lumi.remote.rkba01`).
- Surfaces button events (single/double/hold/release) and knob rotation events (start/rotation/stop, plus held variants) as `zha_event`s usable from device automation triggers.
- Exposes `operation_mode` as a selectable entity and reuses the shared `AqaraRemoteManuSpecificCluster` / `AqaraSwitchOperationMode` from `remote_h1.py`.

The quirk has been migrated from the one developed in #2266 to a V2 Quirkbuilder-based one with the help of Claude Code.

> [!WARNING]
> The implementation is not compatible with the quirk from #2266, as it uses slightly different event names that better match the existing code-base. See comments for a migration guide.

## Additional information

The device advertises only endpoint 1 but reports rotation on endpoints 71 (dimmer) and 72 (shade), so the quirk adds those endpoints and attaches a manufacturer-specific `KnobManuSpecificCluster`. Its `handle_cluster_general_request` translates reported `action` / `rotation_angle` / `rotation_*` attributes into a single `zha_event` per report. On `stop_rotation` and `hold_stop_rotation` the `*_delta` values the device sends are stale or zero, so they are dropped and a `rotation_direction` arg is derived from the sign of the final `rotation_angle`.

The device's MAC capability flags incorrectly advertise `MainsPowered`; the quirk installs a node descriptor that clears the flag so ZHA treats it as a battery-powered end device (needed for the power configuration cluster to surface battery level correctly).

Fixes #2266.

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->

Without the quirk loaded (`custom_components` redacted):

[zha-9f22ed6538480a78fb1d8db1dd230b5e-LUMI lumi.remote.rkba01-1a01e6da98077019a2705886bd4c257b.json](https://github.com/user-attachments/files/26889116/zha-9f22ed6538480a78fb1d8db1dd230b5e-LUMI.lumi.remote.rkba01-1a01e6da98077019a2705886bd4c257b.json)

WITH the quirk loaded (`custom_components` redacted):
[zha-9f22ed6538480a78fb1d8db1dd230b5e-Aqara Smart Knob H1 (wireless)-1a01e6da98077019a2705886bd4c257b.json](https://github.com/user-attachments/files/26925973/zha-9f22ed6538480a78fb1d8db1dd230b5e-Aqara.Smart.Knob.H1.wireless.-1a01e6da98077019a2705886bd4c257b.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
