### PR TITLE
Add Bosch RBSH-SD-ZB-EU / BSD-2 smoke detector quirk (unicast + broadcast manual alarm)

### DIFF
--- a/tests/test_bosch_rbsh_sd_zb_eu.py
+++ b/tests/test_bosch_rbsh_sd_zb_eu.py
@@ -1,0 +1,465 @@
+"""Tests for the Bosch RBSH-SD-ZB-EU / BSD-2 smoke detector quirk."""
+
+from unittest import mock
+
+import pytest
+import zigpy.types as t
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.security import IasZone
+from zigpy.zcl.foundation import WriteAttributesStatusRecord
+
+import zhaquirks
+from zhaquirks.bosch.rbsh_sd_zb_eu import (
+    ALARM_TIMEOUT_SECONDS,
+    BOSCH_MANUFACTURER_CODE,
+    BROADCAST_BURGLAR_ALARM_ATTR_ID,
+    BROADCAST_DST_ENDPOINT,
+    BROADCAST_SMOKE_ALARM_ATTR_ID,
+    HA_PROFILE_ID,
+    INTER_BROADCAST_DELAY_S,
+    MANUAL_BURGLAR_ALARM_ATTR_ID,
+    MANUAL_SMOKE_ALARM_ATTR_ID,
+    BoschAlarmMode,
+    BoschIasZoneCluster,
+)
+
+zhaquirks.setup()
+
+
+def _bsd2_cluster(zigpy_device_from_v2_quirk):
+    """Build one quirked Bosch IAS Zone cluster ready for exercise."""
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="Bosch",
+        model="RBSH-SD-ZB-EU",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].ias_zone
+    assert isinstance(cluster, BoschIasZoneCluster)
+    return cluster
+
+
+@pytest.fixture
+def bosch_bsd2_cluster(zigpy_device_from_v2_quirk):
+    """Return the quirked Bosch IAS Zone cluster on endpoint 1."""
+    return _bsd2_cluster(zigpy_device_from_v2_quirk)
+
+
+@pytest.fixture
+def _mocked_app_broadcast(bosch_bsd2_cluster):
+    """Patch ``application.get_sequence`` and ``application.broadcast`` on a cluster's device."""
+    app = bosch_bsd2_cluster.endpoint.device.application
+    app.get_sequence = mock.MagicMock(return_value=0x42)
+    app.broadcast = mock.AsyncMock()
+    return app
+
+
+async def test_quirk_replaces_ias_zone_with_bosch_cluster(bosch_bsd2_cluster):
+    """Confirm the quirk swaps in the Bosch IAS Zone cluster."""
+    assert isinstance(bosch_bsd2_cluster, BoschIasZoneCluster)
+    assert bosch_bsd2_cluster.cluster_id == IasZone.cluster_id
+
+
+async def test_cluster_primes_synthetic_attribute_cache(bosch_bsd2_cluster):
+    """All four synthetic switches must start in the off state on a fresh cluster."""
+    assert bosch_bsd2_cluster._attr_cache[MANUAL_SMOKE_ALARM_ATTR_ID] == 0
+    assert bosch_bsd2_cluster._attr_cache[MANUAL_BURGLAR_ALARM_ATTR_ID] == 0
+    assert bosch_bsd2_cluster._attr_cache[BROADCAST_SMOKE_ALARM_ATTR_ID] == 0
+    assert bosch_bsd2_cluster._attr_cache[BROADCAST_BURGLAR_ALARM_ATTR_ID] == 0
+
+
+async def test_control_alarm_command_is_manufacturer_specific(bosch_bsd2_cluster):
+    """The control_alarm command is Bosch-specific and must carry the Bosch code."""
+    cmd = BoschIasZoneCluster.ServerCommandDefs.control_alarm
+    assert cmd.id == 0x80
+    assert cmd.is_manufacturer_specific is True
+    # Schema verifies the wire payload shape: ENUM8 mode + UINT8 timeout.
+    field_names = [field.name for field in cmd.schema.fields]
+    field_types = [field.type for field in cmd.schema.fields]
+    assert field_names == ["alarm_mode", "alarm_timeout"]
+    assert field_types[0] is BoschAlarmMode
+    assert field_types[1].__name__ == "uint8_t"
+
+
+async def test_synthetic_attributes_carry_bosch_manufacturer_code(bosch_bsd2_cluster):
+    """All four synthetic attributes advertise the Bosch manufacturer code."""
+    for attr in (
+        BoschIasZoneCluster.AttributeDefs.manual_smoke_alarm,
+        BoschIasZoneCluster.AttributeDefs.manual_burglar_alarm,
+        BoschIasZoneCluster.AttributeDefs.broadcast_smoke_alarm,
+        BoschIasZoneCluster.AttributeDefs.broadcast_burglar_alarm,
+    ):
+        assert attr.manufacturer_code == BOSCH_MANUFACTURER_CODE
+
+
+async def test_synthetic_attributes_use_expected_ids(bosch_bsd2_cluster):
+    """The synthetic attribute ids are stable so the on-wire frame layout is predictable."""
+    assert BoschIasZoneCluster.AttributeDefs.manual_smoke_alarm.id == 0xF000
+    assert BoschIasZoneCluster.AttributeDefs.manual_burglar_alarm.id == 0xF001
+    assert BoschIasZoneCluster.AttributeDefs.broadcast_smoke_alarm.id == 0xF002
+    assert BoschIasZoneCluster.AttributeDefs.broadcast_burglar_alarm.id == 0xF003
+
+
+@pytest.mark.parametrize(
+    ("attr_name", "expected_mode", "attr_id"),
+    [
+        ("manual_burglar_alarm", BoschAlarmMode.Burglar, MANUAL_BURGLAR_ALARM_ATTR_ID),
+        ("manual_smoke_alarm", BoschAlarmMode.Smoke, MANUAL_SMOKE_ALARM_ATTR_ID),
+    ],
+)
+async def test_write_true_sends_arm_control_alarm_and_caches_on(
+    bosch_bsd2_cluster, attr_name, expected_mode, attr_id
+):
+    """Writing True to a manual_*_alarm attr arms the siren for 240s and updates the cache."""
+    with mock.patch.object(
+        bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()
+    ) as mock_cmd:
+        await bosch_bsd2_cluster.write_attributes({attr_name: True})
+
+    mock_cmd.assert_awaited_once_with(expected_mode, ALARM_TIMEOUT_SECONDS)
+    assert bosch_bsd2_cluster._attr_cache[attr_id] == 1
+
+
+@pytest.mark.parametrize(
+    ("attr_name", "expected_mode", "attr_id"),
+    [
+        ("manual_burglar_alarm", BoschAlarmMode.Burglar, MANUAL_BURGLAR_ALARM_ATTR_ID),
+        ("manual_smoke_alarm", BoschAlarmMode.Smoke, MANUAL_SMOKE_ALARM_ATTR_ID),
+    ],
+)
+async def test_write_false_sends_stop_control_alarm_and_caches_off(
+    bosch_bsd2_cluster, attr_name, expected_mode, attr_id
+):
+    """Writing False to a manual_*_alarm attr stops the siren and caches off."""
+    # Pretend the siren was already armed so we're genuinely toggling off.
+    bosch_bsd2_cluster._update_attribute(attr_id, 1)
+
+    with mock.patch.object(
+        bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()
+    ) as mock_cmd:
+        await bosch_bsd2_cluster.write_attributes({attr_name: False})
+
+    mock_cmd.assert_awaited_once_with(expected_mode, 0)
+    assert bosch_bsd2_cluster._attr_cache[attr_id] == 0
+
+
+async def test_arming_burglar_mirrors_smoke_off_in_cache(bosch_bsd2_cluster):
+    """The BSD-2 can only run one alarm mode at a time; mirror that in the cache."""
+    bosch_bsd2_cluster._update_attribute(MANUAL_SMOKE_ALARM_ATTR_ID, 1)
+
+    with mock.patch.object(bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()):
+        await bosch_bsd2_cluster.write_attributes({"manual_burglar_alarm": True})
+
+    assert bosch_bsd2_cluster._attr_cache[MANUAL_BURGLAR_ALARM_ATTR_ID] == 1
+    assert bosch_bsd2_cluster._attr_cache[MANUAL_SMOKE_ALARM_ATTR_ID] == 0
+
+
+async def test_arming_smoke_mirrors_burglar_off_in_cache(bosch_bsd2_cluster):
+    """Same mirror logic, flipped: arming smoke disarms burglar in the cache."""
+    bosch_bsd2_cluster._update_attribute(MANUAL_BURGLAR_ALARM_ATTR_ID, 1)
+
+    with mock.patch.object(bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()):
+        await bosch_bsd2_cluster.write_attributes({"manual_smoke_alarm": True})
+
+    assert bosch_bsd2_cluster._attr_cache[MANUAL_SMOKE_ALARM_ATTR_ID] == 1
+    assert bosch_bsd2_cluster._attr_cache[MANUAL_BURGLAR_ALARM_ATTR_ID] == 0
+
+
+async def test_disarming_does_not_touch_the_sibling_cache(bosch_bsd2_cluster):
+    """Turning a siren OFF leaves the other type's cached value alone."""
+    bosch_bsd2_cluster._update_attribute(MANUAL_BURGLAR_ALARM_ATTR_ID, 1)
+    bosch_bsd2_cluster._update_attribute(MANUAL_SMOKE_ALARM_ATTR_ID, 1)
+
+    with mock.patch.object(bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()):
+        await bosch_bsd2_cluster.write_attributes({"manual_burglar_alarm": False})
+
+    assert bosch_bsd2_cluster._attr_cache[MANUAL_BURGLAR_ALARM_ATTR_ID] == 0
+    # Smoke stays 1 - disarming burglar over-the-air does not stop a smoke siren.
+    assert bosch_bsd2_cluster._attr_cache[MANUAL_SMOKE_ALARM_ATTR_ID] == 1
+
+
+async def test_write_accepts_synthetic_attributes_by_id(bosch_bsd2_cluster):
+    """Writing the attributes by raw id (not name) still triggers the translation."""
+    with mock.patch.object(
+        bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()
+    ) as mock_cmd:
+        await bosch_bsd2_cluster.write_attributes({MANUAL_BURGLAR_ALARM_ATTR_ID: True})
+
+    mock_cmd.assert_awaited_once_with(BoschAlarmMode.Burglar, ALARM_TIMEOUT_SECONDS)
+    assert bosch_bsd2_cluster._attr_cache[MANUAL_BURGLAR_ALARM_ATTR_ID] == 1
+
+
+async def test_non_synthetic_attribute_writes_are_passed_through(bosch_bsd2_cluster):
+    """Writes of real IAS Zone attributes fall through to the base cluster unchanged."""
+
+    def _mock_write(attributes, manufacturer=None):
+        return [
+            [
+                WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+                for _ in attributes
+            ],
+            [],
+        ]
+
+    patch_low_level = mock.patch.object(
+        bosch_bsd2_cluster,
+        "_write_attributes",
+        mock.AsyncMock(side_effect=_mock_write),
+    )
+    patch_command = mock.patch.object(
+        bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()
+    )
+
+    real_attr = IasZone.AttributeDefs.current_zone_sensitivity_level
+
+    with patch_low_level as mock_ll, patch_command as mock_cmd:
+        await bosch_bsd2_cluster.write_attributes({real_attr.name: 1})
+
+    mock_cmd.assert_not_called()
+    mock_ll.assert_awaited()
+
+
+async def test_mixed_synthetic_and_real_write_splits_correctly(bosch_bsd2_cluster):
+    """A single write touching both a synthetic attr and a real one must dispatch both paths."""
+
+    def _mock_write(attributes, manufacturer=None):
+        return [
+            [
+                WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+                for _ in attributes
+            ],
+            [],
+        ]
+
+    patch_low_level = mock.patch.object(
+        bosch_bsd2_cluster,
+        "_write_attributes",
+        mock.AsyncMock(side_effect=_mock_write),
+    )
+    patch_command = mock.patch.object(
+        bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()
+    )
+
+    real_attr = IasZone.AttributeDefs.current_zone_sensitivity_level
+
+    with patch_low_level as mock_ll, patch_command as mock_cmd:
+        await bosch_bsd2_cluster.write_attributes(
+            {
+                "manual_burglar_alarm": True,
+                real_attr.name: 2,
+            }
+        )
+
+    mock_cmd.assert_awaited_once_with(BoschAlarmMode.Burglar, ALARM_TIMEOUT_SECONDS)
+    assert bosch_bsd2_cluster._attr_cache[MANUAL_BURGLAR_ALARM_ATTR_ID] == 1
+    mock_ll.assert_awaited()
+    # _write_attributes must see only the real attr, never the synthetic one.
+    real_write_call = mock_ll.await_args_list[-1]
+    written_attrs = real_write_call.args[0]
+    written_ids = {
+        (entry.attrid if hasattr(entry, "attrid") else entry) for entry in written_attrs
+    }
+    assert MANUAL_BURGLAR_ALARM_ATTR_ID not in written_ids
+
+
+# --- broadcast path -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("attr_name", "expected_mode", "expected_tail"),
+    [
+        ("broadcast_burglar_alarm", BoschAlarmMode.Burglar, "01f0"),
+        ("broadcast_smoke_alarm", BoschAlarmMode.Smoke, "00f0"),
+    ],
+)
+async def test_broadcast_true_emits_two_zigbee_broadcasts_with_arm_payload(
+    bosch_bsd2_cluster, _mocked_app_broadcast, attr_name, expected_mode, expected_tail
+):
+    """Writing True to broadcast_*_alarm sends (mode, 240) twice to every BSD-2 on the mesh."""
+    with (
+        mock.patch.object(
+            bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()
+        ) as mock_unicast,
+        mock.patch(
+            "zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()
+        ) as mock_sleep,
+    ):
+        await bosch_bsd2_cluster.write_attributes({attr_name: True})
+
+    # Unicast control_alarm must NOT be used for broadcast writes.
+    mock_unicast.assert_not_called()
+
+    # Bosch firmware / z2m send the broadcast twice, 4 s apart, to cover
+    # sleepy BSD-2s that miss the first one.
+    assert _mocked_app_broadcast.broadcast.await_count == 2
+    mock_sleep.assert_awaited_once_with(INTER_BROADCAST_DELAY_S)
+
+    for call in _mocked_app_broadcast.broadcast.await_args_list:
+        kwargs = call.kwargs
+        assert kwargs["cluster"] == IasZone.cluster_id
+        assert kwargs["profile"] == HA_PROFILE_ID
+        assert kwargs["src_ep"] == 1
+        assert kwargs["dst_ep"] == BROADCAST_DST_ENDPOINT
+        assert kwargs["broadcast_address"] == t.BroadcastAddress.ALL_DEVICES
+        # Frame tail: mode + timeout (arm payload ends with "...<mode><F0>").
+        assert kwargs["data"].hex().endswith(expected_tail)
+
+
+async def test_broadcast_false_emits_stop_broadcasts(
+    bosch_bsd2_cluster, _mocked_app_broadcast
+):
+    """Writing False to broadcast_burglar_alarm sends (burglar, 0) twice (stop command)."""
+    with (
+        mock.patch.object(bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()),
+        mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
+    ):
+        await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": False})
+
+    assert _mocked_app_broadcast.broadcast.await_count == 2
+    for call in _mocked_app_broadcast.broadcast.await_args_list:
+        assert call.kwargs["data"].hex().endswith("0100")
+
+
+async def test_broadcast_frame_matches_herdsman_wire_format(
+    bosch_bsd2_cluster, _mocked_app_broadcast
+):
+    """The serialized frame must byte-exactly match herdsman's boschSmokeAlarmExtend.
+
+    Expected layout: ``15 09 12 <tsn> 80 <mode> <timeout>``
+        15    = cluster-specific + manufacturer-specific + client->server + dis-def-resp
+        09 12 = manufacturer code 0x1209 (little-endian)
+        <tsn> = zigpy-assigned transaction sequence
+        80    = control_alarm command id
+        <m>   = alarm mode (0x00 smoke / 0x01 burglar)
+        <t>   = alarm timeout in seconds
+    """
+    with (
+        mock.patch.object(bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()),
+        mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
+    ):
+        await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": True})
+
+    frame = _mocked_app_broadcast.broadcast.await_args_list[0].kwargs["data"]
+    # TSN 0x42 comes from the fixture's get_sequence mock.
+    assert frame.hex() == "1509124280" + "01" + "f0"
+
+
+async def test_broadcast_on_primes_cache_locally(
+    bosch_bsd2_cluster, _mocked_app_broadcast
+):
+    """Arming a broadcast flavour updates the initiating cluster's cache to 1."""
+    with (
+        mock.patch.object(bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()),
+        mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
+    ):
+        await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": True})
+
+    assert bosch_bsd2_cluster._attr_cache[BROADCAST_BURGLAR_ALARM_ATTR_ID] == 1
+    assert bosch_bsd2_cluster._attr_cache[BROADCAST_SMOKE_ALARM_ATTR_ID] == 0
+
+
+async def test_broadcast_arm_mirrors_sibling_off(
+    bosch_bsd2_cluster, _mocked_app_broadcast
+):
+    """Arming broadcast_smoke must disarm broadcast_burglar across the mesh."""
+    bosch_bsd2_cluster._update_attribute(BROADCAST_BURGLAR_ALARM_ATTR_ID, 1)
+
+    with (
+        mock.patch.object(bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()),
+        mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
+    ):
+        await bosch_bsd2_cluster.write_attributes({"broadcast_smoke_alarm": True})
+
+    assert bosch_bsd2_cluster._attr_cache[BROADCAST_SMOKE_ALARM_ATTR_ID] == 1
+    assert bosch_bsd2_cluster._attr_cache[BROADCAST_BURGLAR_ALARM_ATTR_ID] == 0
+
+
+async def test_broadcast_state_syncs_across_every_live_bsd2(
+    bosch_bsd2_cluster, zigpy_device_from_v2_quirk, _mocked_app_broadcast
+):
+    """Broadcast write on one BSD-2 mirrors cached state on every other BSD-2."""
+    peer_a = _bsd2_cluster(zigpy_device_from_v2_quirk)
+    peer_b = _bsd2_cluster(zigpy_device_from_v2_quirk)
+
+    with (
+        mock.patch.object(bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()),
+        mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
+    ):
+        await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": True})
+
+    for cluster in (bosch_bsd2_cluster, peer_a, peer_b):
+        assert cluster._attr_cache[BROADCAST_BURGLAR_ALARM_ATTR_ID] == 1
+        # Cross-cluster sibling mirror: arming burglar disarms smoke everywhere.
+        assert cluster._attr_cache[BROADCAST_SMOKE_ALARM_ATTR_ID] == 0
+
+
+async def test_broadcast_off_syncs_across_mesh_but_leaves_sibling(
+    bosch_bsd2_cluster, zigpy_device_from_v2_quirk, _mocked_app_broadcast
+):
+    """Disarming one broadcast flavour only clears that flavour, preserving the sibling."""
+    peer = _bsd2_cluster(zigpy_device_from_v2_quirk)
+
+    # Pretend both flavours are armed everywhere so we can prove the stop
+    # only touches its own flavour's cache.
+    for cluster in (bosch_bsd2_cluster, peer):
+        cluster._update_attribute(BROADCAST_BURGLAR_ALARM_ATTR_ID, 1)
+        cluster._update_attribute(BROADCAST_SMOKE_ALARM_ATTR_ID, 1)
+
+    with (
+        mock.patch.object(bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()),
+        mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
+    ):
+        await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": False})
+
+    for cluster in (bosch_bsd2_cluster, peer):
+        assert cluster._attr_cache[BROADCAST_BURGLAR_ALARM_ATTR_ID] == 0
+        assert cluster._attr_cache[BROADCAST_SMOKE_ALARM_ATTR_ID] == 1
+
+
+# --- _resolve_synthetic_attr_id classification table ----------------------
+
+
+async def test_resolve_synthetic_attr_id_accepts_zcl_attribute_def(bosch_bsd2_cluster):
+    """Passing a ``ZCLAttributeDef`` descriptor as key routes through the synthetic path.
+
+    zigpy callers are allowed to pass an attribute descriptor (``cluster.AttributeDefs.<x>``)
+    instead of the attribute's name or id, so the classifier must recognize that shape.
+    """
+    attr_def = BoschIasZoneCluster.AttributeDefs.broadcast_smoke_alarm
+    assert (
+        bosch_bsd2_cluster._resolve_synthetic_attr_id(attr_def)
+        == BROADCAST_SMOKE_ALARM_ATTR_ID
+    )
+
+
+async def test_resolve_synthetic_attr_id_returns_none_for_non_numeric_key(
+    bosch_bsd2_cluster,
+):
+    """Keys that aren't str/int/ZCLAttributeDef fall through to ``None`` (defensive catch).
+
+    A tuple isn't any of those shapes and ``int((1, 2))`` raises ``TypeError``, which is
+    exactly the ``except`` branch that keeps an opaque key from being mis-classified as
+    a synthetic attr. It must return ``None`` so the quirk forwards the write unchanged.
+    """
+    assert bosch_bsd2_cluster._resolve_synthetic_attr_id((1, 2)) is None
+
+
+async def test_broadcast_does_not_affect_manual_cache(
+    bosch_bsd2_cluster, _mocked_app_broadcast
+):
+    """Broadcast writes leave the per-device manual_* cache untouched.
+
+    Broadcast state tracks "what was last broadcast to the mesh"; manual state
+    tracks "what was last unicast to this specific device". The two views are
+    intentionally independent.
+    """
+    bosch_bsd2_cluster._update_attribute(MANUAL_BURGLAR_ALARM_ATTR_ID, 0)
+    bosch_bsd2_cluster._update_attribute(MANUAL_SMOKE_ALARM_ATTR_ID, 0)
+
+    with (
+        mock.patch.object(bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()),
+        mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
+    ):
+        await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": True})
+
+    assert bosch_bsd2_cluster._attr_cache[MANUAL_BURGLAR_ALARM_ATTR_ID] == 0
+    assert bosch_bsd2_cluster._attr_cache[MANUAL_SMOKE_ALARM_ATTR_ID] == 0

--- a/tests/test_bosch_rbsh_sd_zb_eu.py
+++ b/tests/test_bosch_rbsh_sd_zb_eu.py
@@ -1,5 +1,6 @@
 """Tests for the Bosch RBSH-SD-ZB-EU / BSD-2 smoke detector quirk."""
 
+import asyncio
 from unittest import mock
 
 import pytest
@@ -22,6 +23,20 @@ from zhaquirks.bosch.rbsh_sd_zb_eu import (
     BoschAlarmMode,
     BoschIasZoneCluster,
 )
+
+
+async def _drain_broadcast_followups(cluster: BoschIasZoneCluster) -> None:
+    """Await every pending broadcast follow-up task on ``cluster``.
+
+    The quirk fires the second broadcast frame from a background task so the
+    caller (HA, scripts, automations) does not block 4 s on every toggle.
+    Tests need to wait for that task before asserting on broadcast counts /
+    sleep calls / final wire frames.
+    """
+    pending = list(cluster._pending_broadcast_followups)
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
 
 zhaquirks.setup()
 
@@ -284,6 +299,9 @@ async def test_broadcast_true_emits_two_zigbee_broadcasts_with_arm_payload(
         ) as mock_sleep,
     ):
         await bosch_bsd2_cluster.write_attributes({attr_name: True})
+        # The duplicate frame fires from a background task; let it complete
+        # before we assert on the broadcast count.
+        await _drain_broadcast_followups(bosch_bsd2_cluster)
 
     # Unicast control_alarm must NOT be used for broadcast writes.
     mock_unicast.assert_not_called()
@@ -313,6 +331,7 @@ async def test_broadcast_false_emits_stop_broadcasts(
         mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
     ):
         await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": False})
+        await _drain_broadcast_followups(bosch_bsd2_cluster)
 
     assert _mocked_app_broadcast.broadcast.await_count == 2
     for call in _mocked_app_broadcast.broadcast.await_args_list:
@@ -337,10 +356,42 @@ async def test_broadcast_frame_matches_herdsman_wire_format(
         mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
     ):
         await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": True})
+        await _drain_broadcast_followups(bosch_bsd2_cluster)
 
     frame = _mocked_app_broadcast.broadcast.await_args_list[0].kwargs["data"]
     # TSN 0x42 comes from the fixture's get_sequence mock.
     assert frame.hex() == "1509124280" + "01" + "f0"
+
+
+async def test_broadcast_returns_before_duplicate_frame_is_sent(
+    bosch_bsd2_cluster, _mocked_app_broadcast
+):
+    """``write_attributes`` must return after the first broadcast, not after the second.
+
+    The duplicate fires from a background task ~4 s later. Blocking the caller
+    for 4 s would freeze HA scripts/automations and risk service-call timeouts,
+    so we verify the synchronous portion only emits the first frame and leaves
+    the second pending in ``_pending_broadcast_followups``.
+    """
+    with (
+        mock.patch.object(bosch_bsd2_cluster, "control_alarm", mock.AsyncMock()),
+        mock.patch(
+            "zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()
+        ) as mock_sleep,
+    ):
+        await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": True})
+
+        # First frame is inline; second is scheduled but not yet awaited.
+        assert _mocked_app_broadcast.broadcast.await_count == 1
+        mock_sleep.assert_not_awaited()
+        assert len(bosch_bsd2_cluster._pending_broadcast_followups) == 1
+
+        await _drain_broadcast_followups(bosch_bsd2_cluster)
+
+        # Once we let the follow-up run, the second frame goes out.
+        assert _mocked_app_broadcast.broadcast.await_count == 2
+        mock_sleep.assert_awaited_once_with(INTER_BROADCAST_DELAY_S)
+        assert not bosch_bsd2_cluster._pending_broadcast_followups
 
 
 async def test_broadcast_on_primes_cache_locally(
@@ -352,6 +403,7 @@ async def test_broadcast_on_primes_cache_locally(
         mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
     ):
         await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": True})
+        await _drain_broadcast_followups(bosch_bsd2_cluster)
 
     assert bosch_bsd2_cluster._attr_cache[BROADCAST_BURGLAR_ALARM_ATTR_ID] == 1
     assert bosch_bsd2_cluster._attr_cache[BROADCAST_SMOKE_ALARM_ATTR_ID] == 0
@@ -368,6 +420,7 @@ async def test_broadcast_arm_mirrors_sibling_off(
         mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
     ):
         await bosch_bsd2_cluster.write_attributes({"broadcast_smoke_alarm": True})
+        await _drain_broadcast_followups(bosch_bsd2_cluster)
 
     assert bosch_bsd2_cluster._attr_cache[BROADCAST_SMOKE_ALARM_ATTR_ID] == 1
     assert bosch_bsd2_cluster._attr_cache[BROADCAST_BURGLAR_ALARM_ATTR_ID] == 0
@@ -385,6 +438,7 @@ async def test_broadcast_state_syncs_across_every_live_bsd2(
         mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
     ):
         await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": True})
+        await _drain_broadcast_followups(bosch_bsd2_cluster)
 
     for cluster in (bosch_bsd2_cluster, peer_a, peer_b):
         assert cluster._attr_cache[BROADCAST_BURGLAR_ALARM_ATTR_ID] == 1
@@ -409,6 +463,7 @@ async def test_broadcast_off_syncs_across_mesh_but_leaves_sibling(
         mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
     ):
         await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": False})
+        await _drain_broadcast_followups(bosch_bsd2_cluster)
 
     for cluster in (bosch_bsd2_cluster, peer):
         assert cluster._attr_cache[BROADCAST_BURGLAR_ALARM_ATTR_ID] == 0
@@ -460,6 +515,110 @@ async def test_broadcast_does_not_affect_manual_cache(
         mock.patch("zhaquirks.bosch.rbsh_sd_zb_eu.asyncio.sleep", mock.AsyncMock()),
     ):
         await bosch_bsd2_cluster.write_attributes({"broadcast_burglar_alarm": True})
+        await _drain_broadcast_followups(bosch_bsd2_cluster)
 
     assert bosch_bsd2_cluster._attr_cache[MANUAL_BURGLAR_ALARM_ATTR_ID] == 0
     assert bosch_bsd2_cluster._attr_cache[MANUAL_SMOKE_ALARM_ATTR_ID] == 0
+
+
+# --- read_attributes_raw cache-only short-circuit -------------------------
+
+
+async def test_read_synthetic_attribute_is_served_from_cache(bosch_bsd2_cluster):
+    """Reading a synthetic id never hits the wire and reflects the cached state."""
+    bosch_bsd2_cluster._update_attribute(MANUAL_BURGLAR_ALARM_ATTR_ID, 1)
+
+    with mock.patch.object(
+        IasZone,
+        "read_attributes_raw",
+        mock.AsyncMock(side_effect=AssertionError("must not be called")),
+    ) as mock_super:
+        result = await bosch_bsd2_cluster.read_attributes_raw(
+            [MANUAL_BURGLAR_ALARM_ATTR_ID]
+        )
+
+    mock_super.assert_not_called()
+    records = result[0]
+    assert len(records) == 1
+    record = records[0]
+    assert record.attrid == MANUAL_BURGLAR_ALARM_ATTR_ID
+    assert record.status == foundation.Status.SUCCESS
+    assert record.value.value == 1
+
+
+async def test_read_real_attribute_forwards_to_super(bosch_bsd2_cluster):
+    """Real IasZone attribute reads are forwarded to the base cluster unchanged."""
+    real_attr_id = IasZone.AttributeDefs.zone_status.id
+    fake_record = foundation.ReadAttributeRecord(
+        attrid=real_attr_id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(),
+    )
+    fake_record.value.value = 0
+
+    with mock.patch.object(
+        IasZone,
+        "read_attributes_raw",
+        mock.AsyncMock(return_value=([fake_record],)),
+    ) as mock_super:
+        result = await bosch_bsd2_cluster.read_attributes_raw(
+            [real_attr_id], manufacturer=BOSCH_MANUFACTURER_CODE
+        )
+
+    mock_super.assert_awaited_once()
+    forwarded_ids = mock_super.await_args.args[0]
+    assert list(forwarded_ids) == [real_attr_id]
+    assert mock_super.await_args.kwargs["manufacturer"] == BOSCH_MANUFACTURER_CODE
+    assert result[0] == [fake_record]
+
+
+async def test_read_mixed_attributes_serves_synthetic_from_cache_and_forwards_real(
+    bosch_bsd2_cluster,
+):
+    """A mixed read must split: synthetic from cache, real to super, then merge."""
+    bosch_bsd2_cluster._update_attribute(BROADCAST_SMOKE_ALARM_ATTR_ID, 1)
+    real_attr_id = IasZone.AttributeDefs.zone_status.id
+    fake_record = foundation.ReadAttributeRecord(
+        attrid=real_attr_id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(),
+    )
+    fake_record.value.value = 0
+
+    with mock.patch.object(
+        IasZone,
+        "read_attributes_raw",
+        mock.AsyncMock(return_value=([fake_record],)),
+    ) as mock_super:
+        result = await bosch_bsd2_cluster.read_attributes_raw(
+            [BROADCAST_SMOKE_ALARM_ATTR_ID, real_attr_id]
+        )
+
+    # Only the real id should reach the wire.
+    forwarded_ids = list(mock_super.await_args.args[0])
+    assert forwarded_ids == [real_attr_id]
+
+    record_by_id = {rec.attrid: rec for rec in result[0]}
+    assert set(record_by_id) == {BROADCAST_SMOKE_ALARM_ATTR_ID, real_attr_id}
+    assert record_by_id[BROADCAST_SMOKE_ALARM_ATTR_ID].value.value == 1
+    assert (
+        record_by_id[BROADCAST_SMOKE_ALARM_ATTR_ID].status == foundation.Status.SUCCESS
+    )
+    assert record_by_id[real_attr_id] is fake_record
+
+
+async def test_read_real_attribute_propagates_whole_batch_failure(bosch_bsd2_cluster):
+    """If the radio reports a global error, every real id mirrors that status."""
+    real_attr_id = IasZone.AttributeDefs.zone_status.id
+
+    with mock.patch.object(
+        IasZone,
+        "read_attributes_raw",
+        mock.AsyncMock(return_value=(foundation.Status.FAILURE,)),
+    ):
+        result = await bosch_bsd2_cluster.read_attributes_raw([real_attr_id])
+
+    records = result[0]
+    assert len(records) == 1
+    assert records[0].attrid == real_attr_id
+    assert records[0].status == foundation.Status.FAILURE

--- a/zhaquirks/bosch/rbsh_sd_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_sd_zb_eu.py
@@ -18,7 +18,11 @@ quirk surfaces *synthetic* manufacturer-specific attributes on the IAS
 Zone cluster and translates writes to them into ``control_alarm`` frames.
 The attributes do not exist on the wire; their values live only in the
 zigpy cluster cache and are primed to ``0`` when the cluster is
-constructed. That gives HA four ordinary switch entities per detector:
+constructed. Reads of these synthetic ids are served straight from the
+cache - the quirk's ``read_attributes_raw`` override never forwards them
+to the device, so HA's entity-refresh polling does not generate
+unsupported-attribute traffic. That gives HA four ordinary switch
+entities per detector:
 
     switch.<device>_manual_smoke_alarm       unicast arm - this device only
     switch.<device>_manual_burglar_alarm     unicast arm - this device only
@@ -29,9 +33,12 @@ The ``manual_*`` switches send a normal unicast ``control_alarm`` to the
 specific device. The ``broadcast_*`` switches emit the same frame as a
 Zigbee broadcast (destination ``0xFFFF`` / endpoint ``0xFF``) reaching
 every BSD-2 on the mesh, including sleepy battery-powered ones, matching
-zigbee2mqtt's ``broadcast_alarms`` feature. Because Bosch's firmware and
-herdsman send the broadcast twice with a 4-second gap so sleepy detectors
-that miss the first packet still arm on the second, so does this quirk.
+zigbee2mqtt's ``broadcast_alarms`` feature. Bosch's firmware and herdsman
+send the broadcast twice with a 4-second gap so sleepy detectors that
+miss the first packet still arm on the second; this quirk does the same.
+The first broadcast and the cache/mesh-state update happen synchronously,
+the duplicate is fired from a background task so HA scripts and
+automations do not block for 4 s on every toggle.
 
 Semantics:
 
@@ -61,6 +68,7 @@ import weakref
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 import zigpy.types as t
+from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zcl.foundation import ZCLAttributeDef, ZCLCommandDef
@@ -180,6 +188,10 @@ class BoschIasZoneCluster(CustomCluster, IasZone):
         """Prime the synthetic attribute cache so every switch defaults to off."""
         super().__init__(*args, **kwargs)
         _LIVE_CLUSTERS.add(self)
+        # Background follow-up tasks for the second broadcast frame. We track
+        # them so the cluster (and tests) can observe / await completion; each
+        # task removes itself once it finishes.
+        self._pending_broadcast_followups: set[asyncio.Task[None]] = set()
         for attr_id in _SYNTHETIC_ATTR_IDS:
             self._update_attribute(attr_id, 0)
 
@@ -198,6 +210,56 @@ class BoschIasZoneCluster(CustomCluster, IasZone):
         if attr_id in _SYNTHETIC_ATTR_IDS:
             return attr_id
         return None
+
+    async def read_attributes_raw(
+        self,
+        attributes: list[int],
+        manufacturer: int | None = None,
+        **kwargs: Any,
+    ) -> tuple[list[foundation.ReadAttributeRecord]]:
+        """Serve synthetic attribute reads from the local cache.
+
+        These ids only exist client-side - they back the four HA switch
+        entities and have no on-wire counterpart. Forwarding a read for them
+        would generate ``UNSUPPORTED_ATTRIBUTE`` traffic, log noise, and
+        contradict the cache-only contract documented at the top of this
+        module. Real IasZone attribute ids are forwarded to the base cluster
+        unchanged so the rest of the on-wire surface keeps working.
+        """
+        synthetic_ids = [int(a) for a in attributes if int(a) in _SYNTHETIC_ATTR_IDS]
+        real_ids = [a for a in attributes if int(a) not in _SYNTHETIC_ATTR_IDS]
+
+        records: list[foundation.ReadAttributeRecord] = []
+        for attr_id in synthetic_ids:
+            record = foundation.ReadAttributeRecord(
+                attrid=attr_id,
+                status=foundation.Status.SUCCESS,
+                value=foundation.TypeValue(),
+            )
+            # ``_attr_cache`` is primed in ``__init__`` so a missing key here
+            # would be a logic bug - fall back to ``0`` (off) defensively.
+            record.value.value = self._attr_cache.get(attr_id, 0)
+            records.append(record)
+
+        if real_ids:
+            result = await super().read_attributes_raw(
+                real_ids, manufacturer=manufacturer, **kwargs
+            )
+            if isinstance(result[0], list):
+                records.extend(result[0])
+            else:
+                # Whole-batch failure status from the radio: synthesize a
+                # matching record per real id. Synthetic ids are unaffected,
+                # they were already served from cache above.
+                for raw_id in real_ids:
+                    rec = foundation.ReadAttributeRecord(
+                        attrid=int(raw_id),
+                        status=result[0],
+                        value=foundation.TypeValue(),
+                    )
+                    records.append(rec)
+
+        return (records,)
 
     async def _broadcast_control_alarm(self, alarm_mode: int, timeout: int) -> None:
         """Emit a single ``control_alarm`` frame as a mesh-wide Zigbee broadcast."""
@@ -228,14 +290,28 @@ class BoschIasZoneCluster(CustomCluster, IasZone):
             broadcast_address=t.BroadcastAddress.ALL_DEVICES,
         )
 
+    async def _emit_duplicate_broadcast(self, alarm_mode: int, timeout: int) -> None:
+        """Wait ``INTER_BROADCAST_DELAY_S`` then send the second broadcast frame.
+
+        Sleepy BSD-2 end-devices may miss the first packet during a poll-cycle
+        gap; firing the same frame ~4 s later closes that window. Failures are
+        swallowed because the user's intent is already reflected in the cache
+        and the first broadcast has already been sent.
+        """
+        await asyncio.sleep(INTER_BROADCAST_DELAY_S)
+        try:
+            await self._broadcast_control_alarm(alarm_mode, timeout)
+        except Exception as err:  # pragma: no cover - defensive
+            self.warning("Bosch broadcast follow-up failed: %s", err)
+
     async def write_attributes(
         self,
-        attributes: dict[str | int | ZCLAttributeDef, Any],
-        manufacturer: int | None = None,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,
         **kwargs: Any,
     ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Route writes of synthetic attrs to unicast or broadcast control_alarm frames."""
-        remaining: dict[str | int | ZCLAttributeDef, Any] = {}
+        remaining: dict[str | int | foundation.ZCLAttributeDef, Any] = {}
         synthetic_writes: list[tuple[int, bool]] = []
 
         for attr, value in attributes.items():
@@ -250,12 +326,20 @@ class BoschIasZoneCluster(CustomCluster, IasZone):
             alarm_timeout = ALARM_TIMEOUT_SECONDS if on else 0
 
             if attr_id in _BROADCAST_ATTR_IDS:
-                # Send twice 4 s apart to match Bosch firmware / z2m so sleepy
-                # BSD-2s that miss the first broadcast still pick up the second.
-                await self._broadcast_control_alarm(alarm_mode, alarm_timeout)
-                await asyncio.sleep(INTER_BROADCAST_DELAY_S)
+                # Bosch firmware / z2m send the broadcast twice with a 4 s gap
+                # so sleepy BSD-2s that miss the first packet still arm on the
+                # second. Send the first frame inline, sync the cache + mesh
+                # state immediately so HA's switch reflects user intent right
+                # away, and schedule the duplicate in a background task so the
+                # caller (a script, automation, or service call) is not held
+                # for ~4 s on every toggle.
                 await self._broadcast_control_alarm(alarm_mode, alarm_timeout)
                 _sync_broadcast_state_across_mesh(attr_id, 1 if on else 0)
+                followup = asyncio.create_task(
+                    self._emit_duplicate_broadcast(alarm_mode, alarm_timeout)
+                )
+                self._pending_broadcast_followups.add(followup)
+                followup.add_done_callback(self._pending_broadcast_followups.discard)
             else:
                 await self.control_alarm(alarm_mode, alarm_timeout)
                 self._update_attribute(attr_id, 1 if on else 0)

--- a/zhaquirks/bosch/rbsh_sd_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_sd_zb_eu.py
@@ -1,0 +1,315 @@
+"""Device handler for Bosch RBSH-SD-ZB-EU (aka BSD-2) smoke detector + indoor siren.
+
+The BSD-2 sends standard IAS Zone status notifications for smoke and tamper,
+but the two "manually sound the alarm" features - smoke test and
+burglar-alarm siren - are exposed over the IAS Zone (0x0500) cluster via a
+Bosch manufacturer-specific ``control_alarm`` command (id 0x80), not via
+any ZCL-standard attribute or command. The device accepts
+
+    control_alarm(alarm_mode, alarm_timeout)
+
+with manufacturer code ``0x1209`` (Robert Bosch GmbH), where ``alarm_mode``
+selects smoke (``0x00``) or burglar (``0x01``) and ``alarm_timeout`` is a
+timeout in seconds (``0x00`` stops, ``0xF0`` = 240 s is what the Bosch
+firmware and zigbee2mqtt use for "arm").
+
+Because Home Assistant drives switches via writes to ZCL attributes, this
+quirk surfaces *synthetic* manufacturer-specific attributes on the IAS
+Zone cluster and translates writes to them into ``control_alarm`` frames.
+The attributes do not exist on the wire; their values live only in the
+zigpy cluster cache and are primed to ``0`` when the cluster is
+constructed. That gives HA four ordinary switch entities per detector:
+
+    switch.<device>_manual_smoke_alarm       unicast arm - this device only
+    switch.<device>_manual_burglar_alarm     unicast arm - this device only
+    switch.<device>_broadcast_smoke_alarm    mesh-wide arm - every BSD-2
+    switch.<device>_broadcast_burglar_alarm  mesh-wide arm - every BSD-2
+
+The ``manual_*`` switches send a normal unicast ``control_alarm`` to the
+specific device. The ``broadcast_*`` switches emit the same frame as a
+Zigbee broadcast (destination ``0xFFFF`` / endpoint ``0xFF``) reaching
+every BSD-2 on the mesh, including sleepy battery-powered ones, matching
+zigbee2mqtt's ``broadcast_alarms`` feature. Because Bosch's firmware and
+herdsman send the broadcast twice with a 4-second gap so sleepy detectors
+that miss the first packet still arm on the second, so does this quirk.
+
+Semantics:
+
+* ``True`` -> ``control_alarm(mode, 240)``; ``False`` -> ``control_alarm(mode, 0)``.
+* The hardware can only run one alarm mode at a time, so arming smoke
+  flips the burglar sibling off in the cache (and vice versa) without a
+  second command.
+* Broadcast switches additionally synchronize their cached state across
+  every live ``BoschIasZoneCluster`` instance on the controller, so
+  flipping the switch on one BSD-2 is reflected on the other four (HA
+  tracks the mesh-wide state, not per-device intent, for broadcasts).
+* The device does not report alarm state back, so all switch state is
+  purely local; it will go stale if the 240 s auto-stop on the device
+  fires without the user flipping the switch off. Flipping it off in HA
+  re-syncs by sending ``control_alarm(mode, 0)``.
+
+Reference implementation (zigbee-herdsman-converters):
+    https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/bosch.ts
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Final
+import weakref
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.security import IasZone
+from zigpy.zcl.foundation import ZCLAttributeDef, ZCLCommandDef
+
+BOSCH_MANUFACTURER_CODE = 0x1209
+
+# IAS Zone command id of the Bosch "control_alarm" manufacturer-specific command.
+CONTROL_ALARM_CMD_ID = 0x80
+
+# Synthetic manufacturer-specific IAS Zone attribute ids backing the HA switches.
+# These attributes do not exist on the wire; they are cache-only handles that
+# the quirk translates into control_alarm commands in ``write_attributes``.
+MANUAL_SMOKE_ALARM_ATTR_ID = 0xF000
+MANUAL_BURGLAR_ALARM_ATTR_ID = 0xF001
+BROADCAST_SMOKE_ALARM_ATTR_ID = 0xF002
+BROADCAST_BURGLAR_ALARM_ATTR_ID = 0xF003
+
+# Timeout value (in seconds) the Bosch firmware and zigbee2mqtt use when
+# arming the siren; writing 0 stops a running alarm.
+ALARM_TIMEOUT_SECONDS = 240
+
+# Sleepy end-device broadcasts are routinely lost; Bosch's firmware and
+# zigbee2mqtt's boschSmokeAlarmExtend emit every broadcast twice with a 4 s
+# gap so BSD-2s that miss the first packet still arm on the second.
+INTER_BROADCAST_DELAY_S = 4.0
+
+# Frame constants for the broadcast path.
+HA_PROFILE_ID = 0x0104
+BROADCAST_SRC_ENDPOINT = 1
+BROADCAST_DST_ENDPOINT = 0xFF
+BROADCAST_RADIUS = 30
+
+_MANUAL_ATTR_IDS: Final = frozenset(
+    {MANUAL_SMOKE_ALARM_ATTR_ID, MANUAL_BURGLAR_ALARM_ATTR_ID}
+)
+_BROADCAST_ATTR_IDS: Final = frozenset(
+    {BROADCAST_SMOKE_ALARM_ATTR_ID, BROADCAST_BURGLAR_ALARM_ATTR_ID}
+)
+_SYNTHETIC_ATTR_IDS: Final = _MANUAL_ATTR_IDS | _BROADCAST_ATTR_IDS
+
+# Each synthetic attribute is paired with its opposite on the same device
+# (smoke <-> burglar, unicast <-> unicast and broadcast <-> broadcast).
+_SIBLING_ATTR_ID: Final[dict[int, int]] = {
+    MANUAL_SMOKE_ALARM_ATTR_ID: MANUAL_BURGLAR_ALARM_ATTR_ID,
+    MANUAL_BURGLAR_ALARM_ATTR_ID: MANUAL_SMOKE_ALARM_ATTR_ID,
+    BROADCAST_SMOKE_ALARM_ATTR_ID: BROADCAST_BURGLAR_ALARM_ATTR_ID,
+    BROADCAST_BURGLAR_ALARM_ATTR_ID: BROADCAST_SMOKE_ALARM_ATTR_ID,
+}
+
+# Which on-wire alarm_mode each synthetic attribute maps to.
+_ATTR_ID_TO_ALARM_MODE: Final[dict[int, int]] = {
+    MANUAL_SMOKE_ALARM_ATTR_ID: 0x00,
+    MANUAL_BURGLAR_ALARM_ATTR_ID: 0x01,
+    BROADCAST_SMOKE_ALARM_ATTR_ID: 0x00,
+    BROADCAST_BURGLAR_ALARM_ATTR_ID: 0x01,
+}
+
+# Weak set of all live ``BoschIasZoneCluster`` instances so a broadcast
+# write on one detector can mirror its cached state onto every other BSD-2.
+_LIVE_CLUSTERS: weakref.WeakSet[BoschIasZoneCluster] = weakref.WeakSet()
+
+
+class BoschAlarmMode(t.enum8):
+    """Alarm mode selector for the Bosch control_alarm command."""
+
+    Smoke = 0x00
+    Burglar = 0x01
+
+
+class BoschIasZoneCluster(CustomCluster, IasZone):
+    """IAS Zone cluster with Bosch's manual-alarm command + unicast/broadcast switches."""
+
+    class AttributeDefs(IasZone.AttributeDefs):
+        """Bosch manufacturer-specific synthetic attributes backing the HA switches."""
+
+        manual_smoke_alarm: Final = ZCLAttributeDef(
+            id=MANUAL_SMOKE_ALARM_ATTR_ID,
+            type=t.Bool,
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+            access="rw",
+        )
+
+        manual_burglar_alarm: Final = ZCLAttributeDef(
+            id=MANUAL_BURGLAR_ALARM_ATTR_ID,
+            type=t.Bool,
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+            access="rw",
+        )
+
+        broadcast_smoke_alarm: Final = ZCLAttributeDef(
+            id=BROADCAST_SMOKE_ALARM_ATTR_ID,
+            type=t.Bool,
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+            access="rw",
+        )
+
+        broadcast_burglar_alarm: Final = ZCLAttributeDef(
+            id=BROADCAST_BURGLAR_ALARM_ATTR_ID,
+            type=t.Bool,
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+            access="rw",
+        )
+
+    class ServerCommandDefs(IasZone.ServerCommandDefs):
+        """Bosch manufacturer-specific IAS Zone commands."""
+
+        control_alarm: Final = ZCLCommandDef(
+            id=CONTROL_ALARM_CMD_ID,
+            schema={
+                "alarm_mode": BoschAlarmMode,
+                "alarm_timeout": t.uint8_t,
+            },
+            is_manufacturer_specific=True,
+        )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Prime the synthetic attribute cache so every switch defaults to off."""
+        super().__init__(*args, **kwargs)
+        _LIVE_CLUSTERS.add(self)
+        for attr_id in _SYNTHETIC_ATTR_IDS:
+            self._update_attribute(attr_id, 0)
+
+    def _resolve_synthetic_attr_id(self, attr: Any) -> int | None:
+        """Return the synthetic attribute id for ``attr`` (name / id / def), or None."""
+        if isinstance(attr, ZCLAttributeDef):
+            attr_id = attr.id
+        elif isinstance(attr, str):
+            attr_def = self.attributes_by_name.get(attr)
+            attr_id = attr_def.id if attr_def else None
+        else:
+            try:
+                attr_id = int(attr)
+            except (TypeError, ValueError):
+                attr_id = None
+        if attr_id in _SYNTHETIC_ATTR_IDS:
+            return attr_id
+        return None
+
+    async def _broadcast_control_alarm(self, alarm_mode: int, timeout: int) -> None:
+        """Emit a single ``control_alarm`` frame as a mesh-wide Zigbee broadcast."""
+        app = self.endpoint.device.application
+        tsn = app.get_sequence()
+        header = foundation.ZCLHeader(
+            frame_control=foundation.FrameControl(
+                frame_type=foundation.FrameType.CLUSTER_COMMAND,
+                is_manufacturer_specific=True,
+                direction=foundation.Direction.Client_to_Server,
+                disable_default_response=True,
+                reserved=0,
+            ),
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+            tsn=tsn,
+            command_id=CONTROL_ALARM_CMD_ID,
+        )
+        data = header.serialize() + bytes([alarm_mode & 0xFF, timeout & 0xFF])
+        await app.broadcast(
+            profile=HA_PROFILE_ID,
+            cluster=IasZone.cluster_id,
+            src_ep=BROADCAST_SRC_ENDPOINT,
+            dst_ep=BROADCAST_DST_ENDPOINT,
+            grpid=0,
+            radius=BROADCAST_RADIUS,
+            sequence=tsn,
+            data=data,
+            broadcast_address=t.BroadcastAddress.ALL_DEVICES,
+        )
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | ZCLAttributeDef, Any],
+        manufacturer: int | None = None,
+        **kwargs: Any,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
+        """Route writes of synthetic attrs to unicast or broadcast control_alarm frames."""
+        remaining: dict[str | int | ZCLAttributeDef, Any] = {}
+        synthetic_writes: list[tuple[int, bool]] = []
+
+        for attr, value in attributes.items():
+            synth_id = self._resolve_synthetic_attr_id(attr)
+            if synth_id is None:
+                remaining[attr] = value
+            else:
+                synthetic_writes.append((synth_id, bool(int(value))))
+
+        for attr_id, on in synthetic_writes:
+            alarm_mode = BoschAlarmMode(_ATTR_ID_TO_ALARM_MODE[attr_id])
+            alarm_timeout = ALARM_TIMEOUT_SECONDS if on else 0
+
+            if attr_id in _BROADCAST_ATTR_IDS:
+                # Send twice 4 s apart to match Bosch firmware / z2m so sleepy
+                # BSD-2s that miss the first broadcast still pick up the second.
+                await self._broadcast_control_alarm(alarm_mode, alarm_timeout)
+                await asyncio.sleep(INTER_BROADCAST_DELAY_S)
+                await self._broadcast_control_alarm(alarm_mode, alarm_timeout)
+                _sync_broadcast_state_across_mesh(attr_id, 1 if on else 0)
+            else:
+                await self.control_alarm(alarm_mode, alarm_timeout)
+                self._update_attribute(attr_id, 1 if on else 0)
+                if on:
+                    self._update_attribute(_SIBLING_ATTR_ID[attr_id], 0)
+
+        if remaining:
+            return await super().write_attributes(
+                remaining, manufacturer=manufacturer, **kwargs
+            )
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+
+
+def _sync_broadcast_state_across_mesh(attr_id: int, value: int) -> None:
+    """Mirror the broadcast attr value onto every live ``BoschIasZoneCluster``.
+
+    The BSD-2 firmware can only run one alarm mode at a time. Arming one
+    broadcast flavour therefore implicitly stops the other across the whole
+    mesh, and a stop for one flavour leaves the other's cached state alone.
+    """
+    sibling = _SIBLING_ATTR_ID[attr_id]
+    for cluster in list(_LIVE_CLUSTERS):
+        cluster._update_attribute(attr_id, value)
+        if value:
+            cluster._update_attribute(sibling, 0)
+
+
+(
+    QuirkBuilder("Bosch", "RBSH-SD-ZB-EU")
+    .applies_to("BOSCH", "RBSH-SD-ZB-EU")
+    .replaces(BoschIasZoneCluster)
+    .switch(
+        attribute_name=BoschIasZoneCluster.AttributeDefs.manual_smoke_alarm.name,
+        cluster_id=BoschIasZoneCluster.cluster_id,
+        translation_key="manual_smoke_alarm",
+        fallback_name="Manual smoke alarm",
+    )
+    .switch(
+        attribute_name=BoschIasZoneCluster.AttributeDefs.manual_burglar_alarm.name,
+        cluster_id=BoschIasZoneCluster.cluster_id,
+        translation_key="manual_burglar_alarm",
+        fallback_name="Manual burglar alarm",
+    )
+    .switch(
+        attribute_name=BoschIasZoneCluster.AttributeDefs.broadcast_smoke_alarm.name,
+        cluster_id=BoschIasZoneCluster.cluster_id,
+        translation_key="broadcast_smoke_alarm",
+        fallback_name="Broadcast smoke alarm",
+    )
+    .switch(
+        attribute_name=BoschIasZoneCluster.AttributeDefs.broadcast_burglar_alarm.name,
+        cluster_id=BoschIasZoneCluster.cluster_id,
+        translation_key="broadcast_burglar_alarm",
+        fallback_name="Broadcast burglar alarm",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

<img width="1043" height="931" alt="image" src="https://github.com/user-attachments/assets/a0472859-fb08-4b08-a17e-10cd10f1edbe" />


Adds a ZHA quirk for the Bosch **RBSH-SD-ZB-EU** (aka **BSD-2**) smoke detector / indoor siren.

The BSD-2 ships two "manually sound the alarm" features (smoke test + burglar-alarm siren) that are **not** exposed over any standard ZCL attribute. Instead they live as a Bosch manufacturer-specific `control_alarm` command (id `0x80`) on the IAS Zone cluster (`0x0500`), with manufacturer code `0x1209`. zigbee2mqtt has supported this for years via [`boschSmokeAlarmExtend`](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/bosch.ts); without a quirk ZHA cannot surface any of it.

This quirk adds a `BoschIasZoneCluster` (IAS Zone + Bosch `control_alarm` command + four synthetic manufacturer-specific `t.Bool` attributes at `0xF000..0xF003`) and registers a V2 `QuirkBuilder` that exposes them as **four switch entities per detector**:

```
switch.<device>_manual_smoke_alarm       unicast arm, this device only
switch.<device>_manual_burglar_alarm     unicast arm, this device only
switch.<device>_broadcast_smoke_alarm    mesh broadcast, every BSD-2
switch.<device>_broadcast_burglar_alarm  mesh broadcast, every BSD-2
```

### Unicast path (`manual_*`)

Writing the attribute translates into `control_alarm(mode, timeout)`:

- `True`  → `control_alarm(mode, 240)` (Bosch's and z2m's "arm for 4 minutes" shape).
- `False` → `control_alarm(mode, 0)` (stop).

The hardware can only run one alarm mode at a time, so arming one flavour is mirrored in the cache to disarm the other - the sibling switch tracks reality without a second write. State is cache-only (primed to `0` in `__init__`); reads never go to the device.

### Broadcast path (`broadcast_*`)

The `broadcast_*` switches emit the exact same `control_alarm` frame as a **Zigbee broadcast** on address `0xFFFF` / dst endpoint `0xFF`, so every BSD-2 on the mesh picks it up - including sleepy battery-powered detectors. This is the ZHA counterpart of zigbee2mqtt's `broadcast_alarms` feature.

Bosch's firmware and herdsman send the broadcast **twice** with a 4-second gap so sleepy detectors that miss the first frame still arm on the second; this quirk does the same.

The on-wire frame matches herdsman byte-for-byte:

```
15 09 12 <tsn> 80 <mode> <timeout>

15    = cluster-specific + manufacturer-specific + client→server + dis-def-resp
09 12 = manufacturer code 0x1209, little-endian
<tsn> = zigpy-assigned transaction sequence
80    = control_alarm command id
<m>   = alarm mode (0x00 smoke / 0x01 burglar)
<t>   = alarm timeout in seconds
```

A module-level `weakref.WeakSet` of live `BoschIasZoneCluster` instances lets a broadcast write synchronize cached state across every BSD-2 the controller knows about, so all detectors' `broadcast_*` switch states flip together when any one of them is toggled.

## Additional information

- Manufacturer strings: `Bosch` and `BOSCH` (both observed in the wild for the same model).
- `manufacturer_code = 0x1209` (Robert Bosch GmbH).
- Timeout `0xF0` = 240 s is what Bosch and z2m use for "arm"; `0x00` stops.
- 24 unit tests included (see the commit message for a full list); `ruff`, `pre-commit`, and the full `pytest` suite all pass locally (`4773 passed`).
- Verified end-to-end against 4 physical BSD-2 detectors on a running Home Assistant / ZHA setup: per-device `manual_*` switches arm/stop each detector independently, and `broadcast_*` switches arm/stop every detector on the mesh from any of their device cards.

### Reference

- [`boschSmokeAlarmExtend` in zigbee-herdsman-converters](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/bosch.ts)
- [Koenkk/zigbee-herdsman#1028](https://github.com/Koenkk/zigbee-herdsman/pull/1028) and [Koenkk/zigbee-herdsman-converters#7427](https://github.com/Koenkk/zigbee-herdsman-converters/issues/7427) (prior art for the broadcast path).

### Device signature

Full diagnostics JSON from a real BSD-2 on Home Assistant 2026.4.1, inline in a collapsible block so the CI / reviewers don't need to fish out an attachment.

<details>
<summary>bosch-bsd2-diagnostics.json (click to expand)</summary>

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Container",
    "version": "2026.4.1",
    "dev": false,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.14.2",
    "docker": true,
    "arch": "x86_64",
    "timezone": "Europe/Brussels",
    "os_name": "Linux",
    "os_version": "6.14.0-37-generic",
    "container_arch": "amd64",
    "run_as_root": true
  },
  "custom_components": {
    "bosch_alarm_broadcast": {
      "documentation": "https://github.com/zigpy/zha-device-handlers",
      "version": "0.1.0",
      "requirements": []
    },
    "smartthinq_sensors": {
      "documentation": "https://github.com/ollo69/ha-smartthinq-sensors",
      "version": "0.41.1",
      "requirements": [
        "pycountry>=23.12.11",
        "xmltodict>=0.13.0",
        "charset_normalizer>=3.2.0"
      ]
    },
    "dreame_vacuum": {
      "documentation": "https://github.com/Tasshack/dreame-vacuum/tree/dev?tab=readme-ov-file#features",
      "version": "v2.0.0b20",
      "requirements": [
        "pillow",
        "numpy",
        "pybase64",
        "requests",
        "pycryptodome",
        "python-miio",
        "mini-racer",
        "paho-mqtt"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==1.1.1",
      "serialx==0.6.2"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 4.269205965101719e-05
    },
    "01JQ4ER63KH4KZBMR5D7B9VW0G": {
      "wait_import_platforms": -0.017488986952230334,
      "config_entry_setup": 13.553204162977636
    }
  },
  "data": {
    "version": 1,
    "ieee": "**REDACTED**",
    "nwk": "0x0131",
    "manufacturer": "Bosch",
    "model": "RBSH-SD-ZB-EU",
    "friendly_manufacturer": "Bosch",
    "friendly_model": "RBSH-SD-ZB-EU",
    "name": "Bosch RBSH-SD-ZB-EU",
    "quirk_applied": true,
    "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
    "exposes_features": [],
    "manufacturer_code": 4617,
    "power_source": "Battery or Unknown",
    "lqi": 80,
    "rssi": null,
    "last_seen": "2026-04-19T16:28:17.098329+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4617,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 82,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 82,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "IAS_ZONE",
          "id": 1026
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "Bosch"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "RBSH-SD-ZB-EU"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x003e",
                "name": "battery_alarm_state",
                "zcl_type": "map32",
                "value": 0
              }
            ]
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0020",
            "endpoint_attribute": "poll_control",
            "attributes": [
              {
                "id": "0x0003",
                "name": "fast_poll_timeout",
                "zcl_type": "uint16",
                "value": 120
              }
            ]
          },
          {
            "cluster_id": "0x0500",
            "endpoint_attribute": "ias_zone",
            "attributes": [
              {
                "id": "0x0002",
                "name": "zone_status",
                "zcl_type": "map16",
                "value": 48
              }
            ]
          },
          {
            "cluster_id": "0x0b05",
            "endpoint_attribute": "diagnostic",
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 286287744
              }
            ],
            "last_query_cmd": {
              "manufacturer_code": 4617,
              "image_type": 12303,
              "current_file_version": 286287744,
              "hardware_version": null
            }
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "Bosch",
      "model": "RBSH-SD-ZB-EU",
      "node_desc": {
        "logical_type": 2,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 128,
        "manufacturer_code": 4617,
        "maximum_buffer_size": 82,
        "maximum_incoming_transfer_size": 82,
        "server_mask": 11264,
        "maximum_outgoing_transfer_size": 82,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0402",
          "input_clusters": [
            "0x0000",
            "0x0001",
            "0x0003",
            "0x0020",
            "0x0500",
            "0x0b05"
          ],
          "output_clusters": [
            "0x0019"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "class_name": "IASZone",
            "translation_key": "ias_zone",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": true,
            "cluster_handlers": [
              {
                "class_name": "IASZoneClusterHandler",
                "generic_id": "cluster_handler_0x0500",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1280,
                  "name": "IAS Zone",
                  "type": "server"
                },
                "id": "1:0x0500",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "zone_status"
          },
          "state": {
            "class_name": "IASZone",
            "available": true,
            "state": false
          }
        }
      ],
      "button": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "button",
            "class_name": "IdentifyButton",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "identify",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "IdentifyClusterHandler",
                "generic_id": "cluster_handler_0x0003",
                "endpoint_id": 1,
                "cluster": {
                  "id": 3,
                  "name": "Identify",
                  "type": "server"
                },
                "id": "1:0x0003",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "command": "identify",
            "args": [
              5
            ],
            "kwargs": {}
          },
          "state": {
            "class_name": "IdentifyButton",
            "available": true
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 80
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Battery",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "battery",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "PowerConfigurationClusterHandler",
                "generic_id": "cluster_handler_0x0001",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1,
                  "name": "Power Configuration",
                  "type": "server"
                },
                "id": "1:0x0001",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "battery_voltage"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": 0,
            "unit": "%"
          },
          "state": {
            "class_name": "Battery",
            "available": true,
            "state": null
          },
          "extra_state_attributes": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ]
        }
      ],
      "switch": [
        {
          "info_object": {
            "fallback_name": "Manual burglar alarm",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "switch",
            "class_name": "ConfigurableAttributeSwitch",
            "translation_key": "manual_burglar_alarm",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "IASZoneClusterHandler",
                "generic_id": "cluster_handler_0x0500",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1280,
                  "name": "IAS Zone",
                  "type": "server"
                },
                "id": "1:0x0500",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "manual_burglar_alarm",
            "invert_attribute_name": null,
            "force_inverted": false,
            "off_value": 0,
            "on_value": 1
          },
          "state": {
            "class_name": "ConfigurableAttributeSwitch",
            "available": true,
            "state": false,
            "inverted": false
          }
        },
        {
          "info_object": {
            "fallback_name": "Manual smoke alarm",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "switch",
            "class_name": "ConfigurableAttributeSwitch",
            "translation_key": "manual_smoke_alarm",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "IASZoneClusterHandler",
                "generic_id": "cluster_handler_0x0500",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1280,
                  "name": "IAS Zone",
                  "type": "server"
                },
                "id": "1:0x0500",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "manual_smoke_alarm",
            "invert_attribute_name": null,
            "force_inverted": false,
            "off_value": 0,
            "on_value": 1
          },
          "state": {
            "class_name": "ConfigurableAttributeSwitch",
            "available": true,
            "state": false,
            "inverted": false
          }
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OtaClientClusterHandler",
                "generic_id": "cluster_handler_0x0019_client",
                "endpoint_id": 1,
                "cluster": {
                  "id": 25,
                  "name": "Ota",
                  "type": "client"
                },
                "id": "1:0x0019_client",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x11106780",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly on a real device
- [x] `pre-commit` doesn't generate any errors
- [x] `ruff check` passes
- [x] `mypy` passes
- [x] The full test suite passes (`4773 passed, 2 xfailed`)
- [x] Tests for the changes have been added
