### PR TITLE
Ignore missing default reply for Leviton dimmer

### DIFF
--- a/tests/test_leviton.py
+++ b/tests/test_leviton.py
@@ -1,0 +1,52 @@
+"""Tests for Leviton dimmers."""
+
+from unittest import mock
+
+import pytest
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import LevelControl
+import zigpy.zdo.types as zdo_t
+
+from zhaquirks.leviton.dimmer import LevitonLevelControl
+
+Default_Response = foundation.GENERAL_COMMANDS[
+    foundation.GeneralCommand.Default_Response
+].schema
+
+
+@pytest.mark.parametrize(
+    "manufacturer, model",
+    [
+        ("LEVITON", "ZK700-D0W"),
+        ("Leviton Inc", "LU107"),
+    ],
+)
+async def test_leviton_dimmer_level_control(
+    zigpy_device_from_v2_quirk, manufacturer, model
+):
+    """Test Leviton dimmer replaces LevelControl with NoReplyMixin variant."""
+
+    device = zigpy_device_from_v2_quirk(manufacturer, model)
+    level_cluster = device.endpoints[1].in_clusters[LevelControl.cluster_id]
+
+    assert isinstance(level_cluster, LevitonLevelControl)
+
+    # All LevelControl server commands should be in void_input_commands
+    for cmd in LevelControl.commands_by_name.values():
+        assert cmd.id in level_cluster.void_input_commands
+
+    # Verify a representative command uses expect_reply=False via NoReplyMixin
+    ep = level_cluster.endpoint
+    ep.request = mock.AsyncMock(return_value=None)
+
+    rsp = await level_cluster.command(
+        LevelControl.ServerCommandDefs.move_to_level.id, 128, 10
+    )
+
+    assert ep.request.call_count == 1
+    assert ep.request.call_args.kwargs["expect_reply"] is False
+
+    assert rsp == Default_Response(
+        command_id=LevelControl.ServerCommandDefs.move_to_level.id,
+        status=zdo_t.Status.SUCCESS,
+    )

--- a/tests/test_leviton.py
+++ b/tests/test_leviton.py
@@ -7,7 +7,10 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import LevelControl
 import zigpy.zdo.types as zdo_t
 
+import zhaquirks
 from zhaquirks.leviton.dimmer import LevitonLevelControl
+
+zhaquirks.setup()
 
 Default_Response = foundation.GENERAL_COMMANDS[
     foundation.GeneralCommand.Default_Response

--- a/zhaquirks/leviton/__init__.py
+++ b/zhaquirks/leviton/__init__.py
@@ -1,0 +1,1 @@
+"""Module for Leviton devices."""

--- a/zhaquirks/leviton/dimmer.py
+++ b/zhaquirks/leviton/dimmer.py
@@ -1,0 +1,22 @@
+"""Module for Leviton dimmers."""
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.general import LevelControl
+
+from zhaquirks import NoReplyMixin
+
+
+class LevitonLevelControl(NoReplyMixin, CustomCluster, LevelControl):
+    """Leviton LevelControl cluster."""
+
+    void_input_commands = {cmd.id for cmd in LevelControl.commands_by_name.values()}
+
+
+(
+    QuirkBuilder()
+    .applies_to("LEVITON", "ZK700-D0W")
+    .applies_to("Leviton Inc", "LU107")
+    .replaces(LevitonLevelControl)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Leviton Load Controller dimmer modules LU107, ZK700-D0W both don't respond to input commands on their LevelControl clusters.

Add a simple quirk using the NoReplyMixin to fix LevelControl behavior.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
These are two generations of the same 0-10V dimmer load controller. I suspect the same quirk is needed by other LuminaRF or GreenConnect load controllers, but these are the two I have on-hand.

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-fe3d142bb254218f191475085bd9eaa1-LEVITON ZK700-D0W-4b70c9f394b8093dd900b632d84c3888.json](https://github.com/user-attachments/files/26876334/zha-fe3d142bb254218f191475085bd9eaa1-LEVITON.ZK700-D0W-4b70c9f394b8093dd900b632d84c3888.json)
[zha-fe3d142bb254218f191475085bd9eaa1-Leviton Inc LU107-6c9cc0605f063dcd07a70bfc9d438488 (1).json](https://github.com/user-attachments/files/26876336/zha-fe3d142bb254218f191475085bd9eaa1-Leviton.Inc.LU107-6c9cc0605f063dcd07a70bfc9d438488.1.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
