### PR TITLE
Add Sonoff MINI-ZBD support

### DIFF
--- a/zhaquirks/sonoff/zbminir2.py
+++ b/zhaquirks/sonoff/zbminir2.py
@@ -1,4 +1,4 @@
-"""Sonoff ZBMINIR2 - Zigbee Switch."""
+"""Sonoff ZBMINIR2 and MINI-ZBD - Zigbee Switches."""
 
 from zigpy import types
 from zigpy.quirks import CustomCluster
@@ -49,6 +49,7 @@ class SonoffCluster(CustomCluster):
 
 (
     QuirkBuilder("SONOFF", "ZBMINIR2")
+    .applies_to("SONOFF", "MINI-ZBD")
     .replaces(SonoffCluster)
     .enum(
         SonoffCluster.AttributeDefs.external_trigger_mode.name,


### PR DESCRIPTION
Add support for Sonoff MINI-ZBD

## Proposed change
add support to SONOFF MINI-ZBD


## Additional information



## Device diagnostics
[zha-01KMMERCZVFYFBG4NM419SXTVA-SONOFF MINI-ZBD-7bdfe017f37ae54273120e019c5822b1.json](https://github.com/user-attachments/files/26884846/zha-01KMMERCZVFYFBG4NM419SXTVA-SONOFF.MINI-ZBD-7bdfe017f37ae54273120e019c5822b1.json)



## Checklist
- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
