### PR TITLE
Add Shelly Presence quirk

### DIFF
--- a/tests/test_shelly.py
+++ b/tests/test_shelly.py
@@ -3,6 +3,8 @@
 import asyncio
 
 import pytest
+from zha.application import EntityPlatform
+from zha.quirks import DEVICE_REGISTRY
 from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.zcl import ClusterType, foundation
@@ -10,7 +12,13 @@ from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.foundation import ZCLAttributeAccess
 
 import zhaquirks
-from zhaquirks.shelly import SHELLY_MANUFACTURER_CODE
+from zhaquirks.builder.device import QuirkV2Factory
+from zhaquirks.builder.metadata import ZCLEnumMetadata
+from zhaquirks.shelly import (
+    SHELLY_MANUFACTURER_CODE,
+    LightLevel,
+    ShellyLightLevelCluster,
+)
 from zhaquirks.shelly.wifi import (
     SHELLY_WIFI_SETUP_CLUSTER_ID,
     SHELLY_WIFI_SETUP_ENDPOINT_ID,
@@ -157,3 +165,49 @@ def test_shelly_wifi_standard_profile_packet_delegated(
     assert rsp_key is not None
     assert rsp_key.endpoint_id == 1
     assert rsp_key.cluster_id == Basic.cluster_id
+
+
+def test_presence_quirk_light_level_cluster(zigpy_device_from_v2_quirk):
+    """Test that the Shelly Presence quirk replaces the ShellyLightLevelCluster."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="Shelly",
+        model="Presence",
+        cluster_ids={
+            1: {ShellyLightLevelCluster.cluster_id: ClusterType.Server},
+        },
+    )
+
+    ep = device.endpoints[1]
+    assert hasattr(ep, ShellyLightLevelCluster.ep_attribute)
+    assert isinstance(
+        ep.in_clusters[ShellyLightLevelCluster.cluster_id], ShellyLightLevelCluster
+    )
+
+
+def test_presence_quirk_light_level_sensor_entity():
+    """Test that the Shelly Presence quirk registers the light level enum sensor."""
+
+    entry = next(
+        e
+        for e in DEVICE_REGISTRY
+        if isinstance(e.zha_device_factory, QuirkV2Factory)
+        and "presence" in str(e.source.file).lower()
+    )
+
+    definition = entry.zha_device_factory.quirk_definition
+    entity_metadata = [
+        em
+        for em in definition.entity_metadata
+        if em.endpoint_id == 1
+        and em.cluster_id == ShellyLightLevelCluster.cluster_id
+        and em.entity_platform == EntityPlatform.SENSOR
+    ]
+
+    assert len(entity_metadata) == 1
+    em = entity_metadata[0]
+    assert isinstance(em, ZCLEnumMetadata)
+    assert em.entity_platform == EntityPlatform.SENSOR
+    assert em.endpoint_id == 1
+    assert em.cluster_id == ShellyLightLevelCluster.cluster_id
+    assert em.enum is LightLevel

--- a/zhaquirks/shelly/presence.py
+++ b/zhaquirks/shelly/presence.py
@@ -1,0 +1,24 @@
+"""Device handler for Shelly Presence."""
+
+from __future__ import annotations
+
+from zhaquirks.builder import EntityPlatform, EntityType, QuirkBuilder, ReportingConfig
+from zhaquirks.shelly import LightLevel, ShellyLightLevelCluster
+
+(
+    QuirkBuilder("Shelly", "Presence")
+    .replaces(ShellyLightLevelCluster, endpoint_id=1)
+    .enum(
+        attribute_name=ShellyLightLevelCluster.AttributeDefs.light_level.name,
+        enum_class=LightLevel,
+        cluster_id=ShellyLightLevelCluster.cluster_id,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.STANDARD,
+        reporting_config=ReportingConfig(
+            min_interval=15, max_interval=300, reportable_change=1
+        ),
+        translation_key="light_level",
+        fallback_name="Light level",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The MR adds a qurk for shelly presence sensor and its Zigbee light custom cluster.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Tested it locally by applying the cluster.

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-01KQFCVYRWKA4ZRQMY5Y83ZA9Z-Shelly Presence-66852e3b5af9a0fb358bd1b0fd5ae50d.json](https://github.com/user-attachments/files/27337646/zha-01KQFCVYRWKA4ZRQMY5Y83ZA9Z-Shelly.Presence-66852e3b5af9a0fb358bd1b0fd5ae50d.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
