### PR TITLE
Add Tuya TS0202 (_TZ3000_bsvqrxru) PIR motion sensor quirk

### DIFF
--- a/tests/test_tuya_ts0202.py
+++ b/tests/test_tuya_ts0202.py
@@ -1,0 +1,330 @@
+"""Tests for the Tuya TS0202 (``_TZ3000_bsvqrxru``) PIR motion quirk."""
+
+from unittest import mock
+
+import pytest
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.general import OnOff
+from zigpy.zcl.clusters.security import IasZone
+
+import zhaquirks
+from zhaquirks.tuya.ts0202 import (
+    ALARM_BITS,
+    DEFAULT_MOTION_TIMEOUT_S,
+    MAX_MOTION_TIMEOUT_S,
+    MIN_MOTION_TIMEOUT_S,
+    MOTION_TIMEOUT_ATTR_ID,
+    TS0202MotionCluster,
+)
+
+zhaquirks.setup()
+
+
+ZONE_STATUS_ATTR_ID = IasZone.AttributeDefs.zone_status.id
+ZONE_TYPE_ATTR_ID = IasZone.AttributeDefs.zone_type.id
+ZONE_STATUS_CHANGE_COMMAND_ID = IasZone.ClientCommandDefs.status_change_notification.id
+
+
+def _ts0202_cluster(zigpy_device_from_v2_quirk):
+    """Build one quirked TS0202 IAS Zone cluster ready for exercise.
+
+    ``MotionWithReset.__init__`` captures the current event loop, so this has
+    to run inside a running loop (i.e. an async test or async fixture).
+    """
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="_TZ3000_bsvqrxru",
+        model="TS0202",
+        cluster_ids={1: {IasZone.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].ias_zone
+    assert isinstance(cluster, TS0202MotionCluster)
+    return cluster
+
+
+@pytest.fixture
+async def ts0202_cluster(zigpy_device_from_v2_quirk):
+    """Return the quirked TS0202 IAS Zone cluster on endpoint 1."""
+    return _ts0202_cluster(zigpy_device_from_v2_quirk)
+
+
+async def test_quirk_replaces_ias_zone_with_ts0202_cluster(ts0202_cluster):
+    """Confirm the quirk swaps in the TS0202 IAS Zone cluster."""
+    assert isinstance(ts0202_cluster, TS0202MotionCluster)
+    assert ts0202_cluster.cluster_id == IasZone.cluster_id
+
+
+async def test_zone_type_is_pinned_to_motion_sensor(ts0202_cluster):
+    """Zone type must be forced to Motion_Sensor so HA picks device_class=motion."""
+    assert (
+        ts0202_cluster._CONSTANT_ATTRIBUTES[ZONE_TYPE_ATTR_ID]
+        == IasZone.ZoneType.Motion_Sensor
+    )
+
+
+async def test_motion_timeout_attribute_is_declared(ts0202_cluster):
+    """The writable motion_timeout attribute must be declared on the cluster."""
+    attr = TS0202MotionCluster.AttributeDefs.motion_timeout
+    assert attr.id == MOTION_TIMEOUT_ATTR_ID
+    assert attr.name == "motion_timeout"
+    # In the reserved range so we can't collide with real IAS Zone attrs.
+    assert attr.id >= 0xFFF0
+    assert not attr.is_manufacturer_specific
+
+
+async def test_cluster_primes_synthetic_motion_timeout(ts0202_cluster):
+    """motion_timeout must read as DEFAULT_MOTION_TIMEOUT_S on a fresh cluster."""
+    assert ts0202_cluster.reset_s == DEFAULT_MOTION_TIMEOUT_S
+    assert (
+        ts0202_cluster._attr_cache[MOTION_TIMEOUT_ATTR_ID] == DEFAULT_MOTION_TIMEOUT_S
+    )
+
+
+async def test_attribute_report_with_alarm_1_schedules_auto_clear(ts0202_cluster):
+    """An ``Alarm_1`` zone_status report must start the auto-clear timer."""
+    with mock.patch.object(ts0202_cluster, "_loop") as mock_loop:
+        timer = mock.MagicMock()
+        mock_loop.call_later.return_value = timer
+        ts0202_cluster._update_attribute(
+            ZONE_STATUS_ATTR_ID, IasZone.ZoneStatus.Alarm_1
+        )
+
+    mock_loop.call_later.assert_called_once_with(
+        DEFAULT_MOTION_TIMEOUT_S, ts0202_cluster._turn_off
+    )
+
+
+async def test_attribute_report_with_alarm_2_schedules_auto_clear(ts0202_cluster):
+    """``Alarm_2`` is emitted by some TS0202 firmwares and must also reset."""
+    with mock.patch.object(ts0202_cluster, "_loop") as mock_loop:
+        mock_loop.call_later.return_value = mock.MagicMock()
+        ts0202_cluster._update_attribute(
+            ZONE_STATUS_ATTR_ID, IasZone.ZoneStatus.Alarm_2
+        )
+
+    mock_loop.call_later.assert_called_once_with(
+        DEFAULT_MOTION_TIMEOUT_S, ts0202_cluster._turn_off
+    )
+
+
+async def test_attribute_report_with_zero_status_does_not_schedule(ts0202_cluster):
+    """A cleared zone_status report must not (re)arm the auto-clear timer."""
+    with mock.patch.object(ts0202_cluster, "_loop") as mock_loop:
+        ts0202_cluster._update_attribute(ZONE_STATUS_ATTR_ID, 0)
+
+    mock_loop.call_later.assert_not_called()
+
+
+async def test_new_motion_cancels_pending_timer(ts0202_cluster):
+    """A second motion report must cancel the previous timer before scheduling a new one."""
+    old_timer = mock.MagicMock()
+    ts0202_cluster._timer_handle = old_timer
+    with mock.patch.object(ts0202_cluster, "_loop") as mock_loop:
+        mock_loop.call_later.return_value = mock.MagicMock()
+        ts0202_cluster._update_attribute(
+            ZONE_STATUS_ATTR_ID, IasZone.ZoneStatus.Alarm_1
+        )
+
+    old_timer.cancel.assert_called_once()
+    mock_loop.call_later.assert_called_once()
+
+
+async def test_unrelated_attribute_update_is_not_intercepted(ts0202_cluster):
+    """Updates for other attributes must pass through without arming the timer."""
+    with mock.patch.object(ts0202_cluster, "_loop") as mock_loop:
+        ts0202_cluster._update_attribute(ZONE_TYPE_ATTR_ID, 0xABCD)
+
+    mock_loop.call_later.assert_not_called()
+    assert ts0202_cluster._attr_cache[ZONE_TYPE_ATTR_ID] == 0xABCD
+
+
+async def test_command_path_still_schedules_auto_clear(ts0202_cluster):
+    """The inherited command path (``zone_status_change_notification``) must reset too.
+
+    Firmware revisions of the TS0202 differ: some push ``Alarm_1`` as a
+    ``zone_status_change_notification`` IAS command and never as an attribute
+    report. The base ``MotionWithReset.handle_cluster_request`` already handles
+    that; this test locks in the behavior for this fingerprint so the
+    attribute-report override never regresses the command path.
+    """
+    hdr = foundation.ZCLHeader.cluster(
+        tsn=0x01,
+        command_id=ZONE_STATUS_CHANGE_COMMAND_ID,
+    )
+    with mock.patch.object(ts0202_cluster, "_loop") as mock_loop:
+        mock_loop.call_later.return_value = mock.MagicMock()
+        ts0202_cluster.handle_cluster_request(
+            hdr, [IasZone.ZoneStatus.Alarm_1, 0, 0, 0]
+        )
+
+    mock_loop.call_later.assert_called_once_with(
+        DEFAULT_MOTION_TIMEOUT_S, ts0202_cluster._turn_off
+    )
+
+
+async def test_turn_off_clears_timer_handle(ts0202_cluster):
+    """After the auto-clear fires, the timer handle must be released.
+
+    ``MotionWithReset._turn_off`` emits a synthetic cluster command listener
+    event that ZHA picks up to clear its binary_sensor - we don't need to
+    re-test that here, but we do need to make sure the timer bookkeeping is
+    reset so the *next* motion event can schedule a fresh timer.
+    """
+    ts0202_cluster._timer_handle = mock.MagicMock()
+    ts0202_cluster._turn_off()
+
+    assert ts0202_cluster._timer_handle is None
+
+
+async def test_write_motion_timeout_by_name_updates_cache_without_zigbee_io(
+    ts0202_cluster,
+):
+    """Writing the synthetic attr by name must stay local (no ``request`` call)."""
+    endpoint_request = mock.AsyncMock()
+    ts0202_cluster._endpoint.request = endpoint_request
+
+    status = await ts0202_cluster.write_attributes({"motion_timeout": 120})
+
+    assert ts0202_cluster.reset_s == 120
+    assert ts0202_cluster._attr_cache[MOTION_TIMEOUT_ATTR_ID] == 120
+    endpoint_request.assert_not_awaited()
+    assert status[0][0].status == foundation.Status.SUCCESS
+
+
+async def test_write_motion_timeout_by_id_is_accepted(ts0202_cluster):
+    """Writing by raw attribute id (e.g. from ZHA internals) must also be routed local."""
+    endpoint_request = mock.AsyncMock()
+    ts0202_cluster._endpoint.request = endpoint_request
+
+    await ts0202_cluster.write_attributes({MOTION_TIMEOUT_ATTR_ID: 45})
+
+    assert ts0202_cluster.reset_s == 45
+    assert ts0202_cluster._attr_cache[MOTION_TIMEOUT_ATTR_ID] == 45
+    endpoint_request.assert_not_awaited()
+
+
+async def test_write_motion_timeout_clamps_above_maximum(ts0202_cluster):
+    """Writing a value above ``MAX_MOTION_TIMEOUT_S`` is clamped, not rejected."""
+    await ts0202_cluster.write_attributes({"motion_timeout": 99999})
+
+    assert ts0202_cluster.reset_s == MAX_MOTION_TIMEOUT_S
+    assert ts0202_cluster._attr_cache[MOTION_TIMEOUT_ATTR_ID] == MAX_MOTION_TIMEOUT_S
+
+
+async def test_write_motion_timeout_clamps_below_minimum(ts0202_cluster):
+    """Writing a value below ``MIN_MOTION_TIMEOUT_S`` is clamped, not rejected."""
+    await ts0202_cluster.write_attributes({"motion_timeout": 0})
+
+    assert ts0202_cluster.reset_s == MIN_MOTION_TIMEOUT_S
+    assert ts0202_cluster._attr_cache[MOTION_TIMEOUT_ATTR_ID] == MIN_MOTION_TIMEOUT_S
+
+
+async def test_updated_motion_timeout_is_used_on_next_event(ts0202_cluster):
+    """After a write the auto-clear timer must use the new value, not the old default."""
+    await ts0202_cluster.write_attributes({"motion_timeout": 30})
+
+    with mock.patch.object(ts0202_cluster, "_loop") as mock_loop:
+        mock_loop.call_later.return_value = mock.MagicMock()
+        ts0202_cluster._update_attribute(
+            ZONE_STATUS_ATTR_ID, IasZone.ZoneStatus.Alarm_1
+        )
+
+    mock_loop.call_later.assert_called_once_with(30, ts0202_cluster._turn_off)
+
+
+def _captured_forwarded_attrs(mocked_super: mock.AsyncMock) -> dict:
+    """Pull the ``attributes`` dict out of the patched ``super().write_attributes`` call."""
+    mocked_super.assert_awaited_once()
+    call = mocked_super.await_args
+    if "attributes" in call.kwargs:
+        return call.kwargs["attributes"]
+    # The mock isn't bound so ``self`` doesn't show up in args; ``attributes`` is args[0].
+    return call.args[0]
+
+
+async def test_non_synthetic_writes_are_forwarded_to_device(ts0202_cluster):
+    """Writes to *real* IAS Zone attrs must still be forwarded to the device."""
+    with mock.patch.object(
+        IasZone, "write_attributes", new=mock.AsyncMock(return_value=[[]])
+    ) as mocked_super:
+        await ts0202_cluster.write_attributes({IasZone.AttributeDefs.zone_id.id: 0x01})
+
+    forwarded = _captured_forwarded_attrs(mocked_super)
+    assert forwarded == {IasZone.AttributeDefs.zone_id.id: 0x01}
+
+
+async def test_mixed_write_splits_local_and_remote(ts0202_cluster):
+    """A write that mixes synthetic + real attrs must apply the synthetic locally and forward the rest."""
+    with mock.patch.object(
+        IasZone, "write_attributes", new=mock.AsyncMock(return_value=[[]])
+    ) as mocked_super:
+        await ts0202_cluster.write_attributes(
+            {
+                "motion_timeout": 75,
+                IasZone.AttributeDefs.zone_id.id: 0x02,
+            }
+        )
+
+    assert ts0202_cluster.reset_s == 75
+    assert ts0202_cluster._attr_cache[MOTION_TIMEOUT_ATTR_ID] == 75
+    forwarded = _captured_forwarded_attrs(mocked_super)
+    assert "motion_timeout" not in forwarded
+    assert MOTION_TIMEOUT_ATTR_ID not in forwarded
+    assert forwarded == {IasZone.AttributeDefs.zone_id.id: 0x02}
+
+
+async def test_is_motion_timeout_key_classifier(ts0202_cluster):
+    """The key classifier must recognise the synthetic attr via name, id, and descriptor."""
+    cls = TS0202MotionCluster
+
+    assert cls._is_motion_timeout_key("motion_timeout") is True
+    assert cls._is_motion_timeout_key(MOTION_TIMEOUT_ATTR_ID) is True
+    assert cls._is_motion_timeout_key(cls.AttributeDefs.motion_timeout) is True
+    assert cls._is_motion_timeout_key("zone_status") is False
+    assert cls._is_motion_timeout_key(ZONE_STATUS_ATTR_ID) is False
+    assert cls._is_motion_timeout_key((1, 2)) is False
+
+
+async def test_alarm_bits_mask_matches_known_firmware_values():
+    """``ALARM_BITS`` must cover the bitmask the quirk inspects at runtime."""
+    assert (IasZone.ZoneStatus.Alarm_1 | IasZone.ZoneStatus.Alarm_2) == ALARM_BITS
+
+
+async def test_quirk_removes_onoff_client_cluster(zigpy_device_from_v2_quirk):
+    """The vestigial OnOff client cluster must be stripped by the quirk.
+
+    Stock ZHA materialises that out-cluster as a permanently-off
+    ``binary_sensor.<name>_opening`` entity which only serves to confuse users.
+    """
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="_TZ3000_bsvqrxru",
+        model="TS0202",
+        cluster_ids={
+            1: {
+                IasZone.cluster_id: ClusterType.Server,
+                OnOff.cluster_id: ClusterType.Client,
+            }
+        },
+    )
+    assert OnOff.cluster_id not in device.endpoints[1].out_clusters
+
+
+async def test_quirk_swaps_power_cluster_for_aaa_variant(
+    zigpy_device_from_v2_quirk,
+):
+    """The stock PowerConfiguration cluster must be replaced by the 2xAAA variant."""
+    from zigpy.zcl.clusters.general import PowerConfiguration
+
+    from zhaquirks.tuya import TuyaPowerConfigurationCluster2AAA
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="_TZ3000_bsvqrxru",
+        model="TS0202",
+        cluster_ids={
+            1: {
+                IasZone.cluster_id: ClusterType.Server,
+                PowerConfiguration.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+    power_cluster = device.endpoints[1].in_clusters[PowerConfiguration.cluster_id]
+    assert isinstance(power_cluster, TuyaPowerConfigurationCluster2AAA)

--- a/tests/test_tuya_ts0202.py
+++ b/tests/test_tuya_ts0202.py
@@ -231,6 +231,44 @@ async def test_updated_motion_timeout_is_used_on_next_event(ts0202_cluster):
     mock_loop.call_later.assert_called_once_with(30, ts0202_cluster._turn_off)
 
 
+async def test_writing_motion_timeout_during_active_motion_reschedules_timer_live(
+    ts0202_cluster,
+):
+    """Changing ``motion_timeout`` while motion is active must cancel + reschedule the timer.
+
+    The Number entity advertises the timeout as live-configurable - if the
+    user shortens the value mid-detection we must not wait until the *next*
+    motion event for it to take effect. Cancel the in-flight clear timer
+    and arm a new one with the new delay measured from now.
+    """
+    old_timer = mock.MagicMock()
+    ts0202_cluster._timer_handle = old_timer
+    new_timer = mock.MagicMock()
+
+    with mock.patch.object(ts0202_cluster, "_loop") as mock_loop:
+        mock_loop.call_later.return_value = new_timer
+        await ts0202_cluster.write_attributes({"motion_timeout": 20})
+
+    old_timer.cancel.assert_called_once()
+    mock_loop.call_later.assert_called_once_with(20, ts0202_cluster._turn_off)
+    assert ts0202_cluster._timer_handle is new_timer
+    assert ts0202_cluster.reset_s == 20
+
+
+async def test_writing_motion_timeout_with_no_active_motion_does_not_arm_timer(
+    ts0202_cluster,
+):
+    """No active motion = no timer, and a write must not start one (only update reset_s)."""
+    assert ts0202_cluster._timer_handle is None
+
+    with mock.patch.object(ts0202_cluster, "_loop") as mock_loop:
+        await ts0202_cluster.write_attributes({"motion_timeout": 60})
+
+    mock_loop.call_later.assert_not_called()
+    assert ts0202_cluster._timer_handle is None
+    assert ts0202_cluster.reset_s == 60
+
+
 def _captured_forwarded_attrs(mocked_super: mock.AsyncMock) -> dict:
     """Pull the ``attributes`` dict out of the patched ``super().write_attributes`` call."""
     mocked_super.assert_awaited_once()
@@ -270,6 +308,43 @@ async def test_mixed_write_splits_local_and_remote(ts0202_cluster):
     assert "motion_timeout" not in forwarded
     assert MOTION_TIMEOUT_ATTR_ID not in forwarded
     assert forwarded == {IasZone.AttributeDefs.zone_id.id: 0x02}
+
+
+async def test_write_motion_timeout_via_zcl_attribute_def_descriptor(ts0202_cluster):
+    """Writing by ``ZCLAttributeDef`` descriptor (a key shape zigpy callers use) must route local."""
+    endpoint_request = mock.AsyncMock()
+    ts0202_cluster._endpoint.request = endpoint_request
+
+    descriptor = TS0202MotionCluster.AttributeDefs.motion_timeout
+    await ts0202_cluster.write_attributes({descriptor: 60})
+
+    assert ts0202_cluster.reset_s == 60
+    assert ts0202_cluster._attr_cache[MOTION_TIMEOUT_ATTR_ID] == 60
+    endpoint_request.assert_not_awaited()
+
+
+async def test_remote_writes_forward_manufacturer_and_kwargs_unchanged(ts0202_cluster):
+    """The override must pass ``manufacturer`` + arbitrary kwargs through to ``super``.
+
+    The canonical zhaquirks ``write_attributes`` signature accepts
+    ``manufacturer: int | UndefinedType | None = UNDEFINED`` plus ``**kwargs``
+    so callers and zigpy's internal plumbing can forward any extra options
+    (e.g. ``manufacturer_code``, ``update_cache``). This regresses the
+    pre-fix behavior of forcing ``manufacturer=None`` and dropping kwargs.
+    """
+    with mock.patch.object(
+        IasZone, "write_attributes", new=mock.AsyncMock(return_value=[[]])
+    ) as mocked_super:
+        await ts0202_cluster.write_attributes(
+            {IasZone.AttributeDefs.zone_id.id: 0x05},
+            manufacturer=0x1209,
+            update_cache=False,
+        )
+
+    mocked_super.assert_awaited_once()
+    call = mocked_super.await_args
+    assert call.kwargs.get("manufacturer") == 0x1209
+    assert call.kwargs.get("update_cache") is False
 
 
 async def test_is_motion_timeout_key_classifier(ts0202_cluster):

--- a/zhaquirks/tuya/ts0202.py
+++ b/zhaquirks/tuya/ts0202.py
@@ -38,6 +38,7 @@ from typing import Any, Final
 from zigpy.quirks.v2 import EntityType
 from zigpy.quirks.v2.homeassistant import UnitOfTime
 import zigpy.types as t
+from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.security import IasZone
@@ -72,9 +73,12 @@ class TS0202MotionCluster(MotionWithReset):
       attribute reports, since these TS0202 clones mix the two paths across
       firmware revisions.
     * Exposes a synthetic, writable ``motion_timeout`` attribute (seconds)
-      that backs a Number entity. Writing it updates the auto-clear timer
-      live; no Zigbee frames are sent to the device since this firmware has
-      no runtime-configurable keep_time.
+      that backs a Number entity. Writing it updates the auto-clear delay
+      used for subsequent motion events and, when motion is currently
+      active, cancels the running auto-clear timer and reschedules it with
+      the new value so the change takes effect immediately. No Zigbee
+      frames are sent to the device since this firmware has no
+      runtime-configurable keep_time.
     """
 
     class AttributeDefs(IasZone.AttributeDefs):
@@ -116,18 +120,22 @@ class TS0202MotionCluster(MotionWithReset):
 
     async def write_attributes(
         self,
-        attributes: dict[str | int, Any],
-        manufacturer: int | None = None,
-    ) -> list:
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,
+        **kwargs: Any,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
         """Intercept writes to the synthetic ``motion_timeout`` attribute.
 
         The Number entity calls ``write_attributes({"motion_timeout": N})``.
         Since the firmware has no runtime-configurable keep_time, we keep the
-        value quirk-local: clamp + cache + use it on the next motion event.
-        Any other attribute writes fall through to the device unchanged.
+        value quirk-local: clamp + cache + use it on every subsequent motion
+        event, and - if motion is currently active - reschedule the running
+        auto-clear timer so the change takes effect live. Any other
+        attribute writes fall through to the device unchanged with the
+        caller's ``manufacturer`` and ``kwargs`` preserved.
         """
-        local: dict[str | int, Any] = {}
-        remote: dict[str | int, Any] = {}
+        local: dict[str | int | foundation.ZCLAttributeDef, Any] = {}
+        remote: dict[str | int | foundation.ZCLAttributeDef, Any] = {}
         for key, value in attributes.items():
             if self._is_motion_timeout_key(key):
                 local[key] = value
@@ -141,6 +149,13 @@ class TS0202MotionCluster(MotionWithReset):
             )
             self.reset_s = clamped
             self._update_attribute(MOTION_TIMEOUT_ATTR_ID, clamped)
+            # If a clear-timer is currently running (motion is active), the
+            # docstring promises a "live" update, so cancel and reschedule
+            # with the new value from now. If no timer is pending, the new
+            # value is simply picked up on the next motion event.
+            if self._timer_handle is not None:
+                self._timer_handle.cancel()
+                self._timer_handle = self._loop.call_later(clamped, self._turn_off)
             self.debug(
                 "%s - motion_timeout set to %ss (was request for %s)",
                 self.endpoint.device.ieee,
@@ -149,7 +164,9 @@ class TS0202MotionCluster(MotionWithReset):
             )
 
         if remote:
-            return await super().write_attributes(remote, manufacturer=manufacturer)
+            return await super().write_attributes(
+                remote, manufacturer=manufacturer, **kwargs
+            )
 
         return [
             [foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]

--- a/zhaquirks/tuya/ts0202.py
+++ b/zhaquirks/tuya/ts0202.py
@@ -1,0 +1,190 @@
+"""Device handler for Tuya TS0202 PIR motion sensors.
+
+Some cheap Tuya TS0202 clones (``_TZ3000_bsvqrxru`` / HW500A is the reference
+hardware here) expose only an IAS Zone server endpoint and need two small
+tweaks before Home Assistant renders a useful motion entity:
+
+1. The device never reports its ``zone_type``, so without a quirk ZHA defaults
+   the generated binary_sensor to ``device_class: opening`` (contact switch).
+   The quirk pins ``zone_type = Motion_Sensor`` so the entity materialises as
+   ``device_class: motion`` without waiting for a ``read_attributes``
+   roundtrip.
+
+2. These firmwares need the "Tuya spell" (a read of Basic cluster attributes
+   ``0x0004, 0x0000, 0x0001, 0x0005, 0x0007, 0xFFFE``) before they'll emit ZCL
+   traffic at all. The PIR front-end keeps blinking its red LED locally on
+   motion but the radio stays silent until the spell is cast. ``TuyaQuirkBuilder
+   .tuya_enchantment()`` handles that at device init.
+
+On top of that we auto-reset ``zone_status`` after a configurable client-side
+timeout. The HW500A firmware has a hard-coded ~65 second internal keep_time
+that cannot be changed over Zigbee (the ``_TZ3000_bsvqrxru`` fingerprint
+intentionally has no ``keep_time`` exposed in zigbee2mqtt for that reason),
+so exposing a writable ``motion_timeout`` Number entity is the only knob we
+can realistically offer. The same auto-clear also covers firmwares that forget
+to send a "no motion" status change altogether - z2m's
+``fz.ias_occupancy_alarm_1_with_timeout`` does the equivalent on that side.
+
+The quirk also swaps the stock Power cluster for
+``TuyaPowerConfigurationCluster2AAA`` (these units run off 2x AAA) and removes
+the vestigial OnOff client cluster that ZHA would otherwise turn into a second,
+permanently-off binary_sensor.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from zigpy.quirks.v2 import EntityType
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+import zigpy.types as t
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.general import OnOff
+from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks import MotionWithReset
+from zhaquirks.tuya import TuyaPowerConfigurationCluster2AAA
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+#: Quirk-local attribute id used to expose the writable auto-clear timer.
+#: Sits in the 0xFFxx reserved range so it cannot collide with any real
+#: IAS Zone attribute the device might grow in a future firmware.
+MOTION_TIMEOUT_ATTR_ID: Final = 0xFFF0
+
+DEFAULT_MOTION_TIMEOUT_S: Final = 90
+MIN_MOTION_TIMEOUT_S: Final = 5
+MAX_MOTION_TIMEOUT_S: Final = 900
+
+#: Bits that indicate "motion present" in a zone_status report.
+#: Alarm_2 is included because some TS0202 firmwares use it alongside Alarm_1.
+ALARM_BITS: Final = IasZone.ZoneStatus.Alarm_1 | IasZone.ZoneStatus.Alarm_2
+
+
+class TS0202MotionCluster(MotionWithReset):
+    """IAS Zone cluster for TS0202 HW500A-family PIR motion sensors.
+
+    Adds three things on top of the base ``MotionWithReset``:
+
+    * Pins ``zone_type = Motion_Sensor`` so the binary_sensor renders as
+      ``device_class: motion`` without waiting for the device to answer.
+    * Schedules the auto-clear timer for *both* ``zone_status_change_notification``
+      commands (inherited from ``MotionWithReset``) and ``zone_status``
+      attribute reports, since these TS0202 clones mix the two paths across
+      firmware revisions.
+    * Exposes a synthetic, writable ``motion_timeout`` attribute (seconds)
+      that backs a Number entity. Writing it updates the auto-clear timer
+      live; no Zigbee frames are sent to the device since this firmware has
+      no runtime-configurable keep_time.
+    """
+
+    class AttributeDefs(IasZone.AttributeDefs):
+        """Extend IAS Zone attrs with a quirk-local ``motion_timeout``."""
+
+        motion_timeout: Final = foundation.ZCLAttributeDef(
+            id=MOTION_TIMEOUT_ATTR_ID,
+            type=t.uint16_t,
+            is_manufacturer_specific=False,
+        )
+
+    _CONSTANT_ATTRIBUTES = {
+        IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Motion_Sensor,
+    }
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.reset_s: int = DEFAULT_MOTION_TIMEOUT_S
+        self._update_attribute(MOTION_TIMEOUT_ATTR_ID, DEFAULT_MOTION_TIMEOUT_S)
+
+    def _update_attribute(self, attrid: int | t.uint16_t, value: Any) -> None:
+        """Schedule auto-clear on zone_status reports that carry an alarm bit.
+
+        ``MotionWithReset.handle_cluster_request`` already covers the command
+        path (``zone_status_change_notification``). This override covers the
+        attribute-report path so we don't care which of the two a given
+        firmware chooses to emit.
+        """
+        if (
+            attrid == IasZone.AttributeDefs.zone_status.id
+            and isinstance(value, int)
+            and value & ALARM_BITS
+        ):
+            if self._timer_handle:
+                self._timer_handle.cancel()
+            self._timer_handle = self._loop.call_later(self.reset_s, self._turn_off)
+        super()._update_attribute(attrid, value)
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int, Any],
+        manufacturer: int | None = None,
+    ) -> list:
+        """Intercept writes to the synthetic ``motion_timeout`` attribute.
+
+        The Number entity calls ``write_attributes({"motion_timeout": N})``.
+        Since the firmware has no runtime-configurable keep_time, we keep the
+        value quirk-local: clamp + cache + use it on the next motion event.
+        Any other attribute writes fall through to the device unchanged.
+        """
+        local: dict[str | int, Any] = {}
+        remote: dict[str | int, Any] = {}
+        for key, value in attributes.items():
+            if self._is_motion_timeout_key(key):
+                local[key] = value
+            else:
+                remote[key] = value
+
+        for value in local.values():
+            clamped = max(
+                MIN_MOTION_TIMEOUT_S,
+                min(MAX_MOTION_TIMEOUT_S, int(value)),
+            )
+            self.reset_s = clamped
+            self._update_attribute(MOTION_TIMEOUT_ATTR_ID, clamped)
+            self.debug(
+                "%s - motion_timeout set to %ss (was request for %s)",
+                self.endpoint.device.ieee,
+                clamped,
+                value,
+            )
+
+        if remote:
+            return await super().write_attributes(remote, manufacturer=manufacturer)
+
+        return [
+            [foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]
+        ]
+
+    @staticmethod
+    def _is_motion_timeout_key(key: str | int | foundation.ZCLAttributeDef) -> bool:
+        """Return True if ``key`` targets the synthetic motion_timeout attr."""
+        if isinstance(key, foundation.ZCLAttributeDef):
+            return key.id == MOTION_TIMEOUT_ATTR_ID
+        if isinstance(key, str):
+            return key == "motion_timeout"
+        try:
+            return int(key) == MOTION_TIMEOUT_ATTR_ID
+        except (TypeError, ValueError):
+            return False
+
+
+(
+    TuyaQuirkBuilder("_TZ3000_bsvqrxru", "TS0202")
+    .replaces(TS0202MotionCluster)
+    .replaces(TuyaPowerConfigurationCluster2AAA)
+    .removes(cluster_id=OnOff.cluster_id, cluster_type=ClusterType.Client)
+    .number(
+        attribute_name=TS0202MotionCluster.AttributeDefs.motion_timeout.name,
+        cluster_id=IasZone.cluster_id,
+        min_value=MIN_MOTION_TIMEOUT_S,
+        max_value=MAX_MOTION_TIMEOUT_S,
+        step=5,
+        unit=UnitOfTime.SECONDS,
+        entity_type=EntityType.CONFIG,
+        translation_key="motion_timeout",
+        fallback_name="Motion clear timeout",
+    )
+    .tuya_enchantment()
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
## Summary

Add a ZHA quirk for the Tuya **HW500A** PIR motion sensor (`_TZ3000_bsvqrxru` / `TS0202`). Out of the box ZHA renders this device as a `binary_sensor.<name>_opening` (contact switch) that never updates. The quirk fixes it so HA gets a proper `binary_sensor.<name>` motion entity plus a configurable `number.<name>_motion_clear_timeout`.

### Why

The HW500A is a cheap, widely-available Tuya PIR sensor. It ships with three stock-ZHA annoyances:

1. It never reports `zone_type`, so ZHA defaults the binary_sensor to `device_class: opening`.
2. Its firmware stays radio-silent until the "Tuya spell" (a read of specific Basic-cluster attributes) is cast — the PIR blinks its red LED locally on motion, but nothing leaves the device until the spell runs.
3. It exposes a vestigial `OnOff` client out-cluster that ZHA turns into a second, permanently-off binary_sensor.

### What the quirk does

* Pins `zone_type = Motion_Sensor` so the binary_sensor renders as `device_class: motion` without waiting for a `read_attributes` roundtrip.
* Uses `TuyaQuirkBuilder.tuya_enchantment()` to cast the Basic-cluster spell at device init, matching z2m's behaviour for this fingerprint.
* Adds a client-side auto-clear timer (default 90 s, min 5 s, max 900 s) — the HW500A's on-device `keep_time` is firmware-hardcoded (~65 s) and not configurable over Zigbee, which is why z2m's `_TZ3000_bsvqrxru` definition has no `keep_time` expose. Surfaces that timer as a writable `motion_timeout` synthetic attribute backed by a Number entity (HA `entity_type: CONFIG`, step 5 s, unit `s`). Writes stay quirk-local — no Zigbee frames are emitted, we just update the reset timer the next time a motion event fires.
* Handles **both** paths firmwares of the TS0202 family use to report motion: `zone_status_change_notification` commands (inherited from `MotionWithReset`) **and** `zone_status` attribute reports (z2m uses `fz.ias_occupancy_alarm_1` for the former and `fz.ias_occupancy_alarm_1_report` for the latter).
* Replaces stock `PowerConfiguration` with `TuyaPowerConfigurationCluster2AAA` (these units run on 2x AAA).
* Removes the vestigial `OnOff` client out-cluster.

### Zigbee2MQTT reference

* [`TuYa HW500A` definition](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts) — added in [Koenkk/zigbee-herdsman-converters#6230](https://github.com/Koenkk/zigbee-herdsman-converters/pull/6230), `fz.ias_occupancy_alarm_1` + `fz.ias_occupancy_alarm_1_report`, no `keep_time` expose (firmware-hardcoded), no tamper expose (no physical tamper switch on the HW500A).

## Tests

* **22 new unit tests** in `tests/test_tuya_ts0202.py` covering:
  - Quirk application (`zone_type` pinned to `Motion_Sensor`, synthetic `motion_timeout` attribute declared & primed, `OnOff` client cluster removed, `PowerConfiguration` swapped for the 2xAAA variant).
  - Motion detection via both paths: `zone_status` attribute reports (Alarm_1 + Alarm_2) and `zone_status_change_notification` commands.
  - Auto-clear timer scheduling, cancellation, and release.
  - Writable `motion_timeout`: by name, by id, clamping above max, clamping below min, propagating into the next auto-clear timer.
  - Mixed writes that combine synthetic + real attrs (synthetic stays local, real ones are forwarded to the device with `manufacturer=None`).
  - Key-classifier edge cases (`ZCLAttributeDef` input, non-numeric tuples, etc.).
* **Patch coverage: 100%** on `zhaquirks/tuya/ts0202.py`.
* Full `pytest tests/` pass: **4771 passed, 2 xfailed** (no regressions).

## Tested with

Two physical HW500A devices running firmware `0x00000046`, joined via a Texas Instruments CC2652 coordinator on ZHA. Verified:

* Device enrols as IAS Zone and binary_sensor reports motion correctly.
* Setting `number.<name>_motion_clear_timeout` via the HA UI clamps + persists the value and the next motion event clears after the new interval.
* No spurious `binary_sensor.<name>_opening` entity is created.

## ZHA diagnostics (live device)

<details><summary><code>diagnostics for _TZ3000_bsvqrxru / TS0202 on endpoint 1</code></summary>

```json
{
  "custom_components": {
    "dreame_vacuum": {
      "documentation": "https://github.com/Tasshack/dreame-vacuum/tree/dev?tab=readme-ov-file#features",
      "requirements": [
        "pillow",
        "numpy",
        "pybase64",
        "requests",
        "pycryptodome",
        "python-miio",
        "mini-racer",
        "paho-mqtt"
      ],
      "version": "v2.0.0b20"
    },
    "smartthinq_sensors": {
      "documentation": "https://github.com/ollo69/ha-smartthinq-sensors",
      "requirements": [
        "pycountry>=23.12.11",
        "xmltodict>=0.13.0",
        "charset_normalizer>=3.2.0"
      ],
      "version": "0.41.1"
    }
  },
  "data": {
    "active_coordinator": false,
    "available": true,
    "device_type": "EndDevice",
    "endpoints": {
      "1": {
        "device_type": {
          "id": 1026,
          "name": "IAS_ZONE"
        },
        "in_clusters": [
          {
            "attributes": [
              {
                "id": "0x0001",
                "name": "app_version",
                "value": 70,
                "zcl_type": "uint8"
              },
              {
                "id": "0x0004",
                "name": "manufacturer",
                "value": "_TZ3000_bsvqrxru",
                "zcl_type": "string"
              },
              {
                "id": "0x0005",
                "name": "model",
                "value": "TS0202",
                "zcl_type": "string"
              },
              {
                "id": "0x0007",
                "name": "power_source",
                "value": 3,
                "zcl_type": "enum8"
              },
              {
                "id": "0xfffe",
                "name": "reporting_status",
                "value": 0,
                "zcl_type": "enum8"
              },
              {
                "id": "0x0000",
                "name": "zcl_version",
                "value": 3,
                "zcl_type": "uint8"
              }
            ],
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic"
          },
          {
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "value": 200,
                "zcl_type": "uint8"
              },
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "value": 2,
                "zcl_type": "uint8"
              },
              {
                "id": "0x0034",
                "name": "battery_rated_voltage",
                "value": 15,
                "zcl_type": "uint8"
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "value": 4,
                "zcl_type": "enum8"
              },
              {
                "id": "0x0020",
                "name": "battery_voltage",
                "value": 30,
                "zcl_type": "uint8"
              }
            ],
            "cluster_id": "0x0001",
            "endpoint_attribute": "power"
          },
          {
            "attributes": [],
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify"
          },
          {
            "attributes": [
              {
                "id": "0x0013",
                "name": "current_zone_sensitivity_level",
                "value": 1,
                "zcl_type": "uint8"
              },
              {
                "id": "0xfff0",
                "name": "motion_timeout",
                "value": 30,
                "zcl_type": "uint16"
              },
              {
                "id": "0x0002",
                "name": "zone_status",
                "value": 1,
                "zcl_type": "map16"
              },
              {
                "id": "0x0001",
                "name": "zone_type",
                "value": 13,
                "zcl_type": "enum16"
              }
            ],
            "cluster_id": "0x0500",
            "endpoint_attribute": "ias_zone"
          }
        ],
        "out_clusters": [
          {
            "attributes": [],
            "cluster_id": "0x000a",
            "endpoint_attribute": "time"
          },
          {
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "value": 70,
                "zcl_type": "uint32"
              }
            ],
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "last_query_cmd": {
              "current_file_version": 70,
              "hardware_version": null,
              "image_type": 54179,
              "manufacturer_code": 4417
            }
          },
          {
            "attributes": [],
            "cluster_id": "0x1000",
            "endpoint_attribute": "lightlink"
          }
        ],
        "profile_id": 260
      }
    },
    "exposes_features": [],
    "friendly_manufacturer": "_TZ3000_bsvqrxru",
    "friendly_model": "TS0202",
    "ieee": "**REDACTED**",
    "last_seen": "2026-04-20T16:10:13.722491+00:00",
    "lqi": 160,
    "manufacturer": "_TZ3000_bsvqrxru",
    "manufacturer_code": 4417,
    "model": "TS0202",
    "name": "_TZ3000_bsvqrxru TS0202",
    "neighbors": [],
    "node_descriptor": {
      "aps_flags": 0,
      "complex_descriptor_available": false,
      "descriptor_capability_field": 0,
      "frequency_band": 8,
      "logical_type": "EndDevice",
      "mac_capability_flags": 128,
      "manufacturer_code": 4417,
      "maximum_buffer_size": 66,
      "maximum_incoming_transfer_size": 66,
      "maximum_outgoing_transfer_size": 66,
      "reserved": 0,
      "server_mask": 10752,
      "user_descriptor_available": false
    },
    "nwk": "0xE639",
    "original_signature": {
      "endpoints": {
        "1": {
          "device_type": "0x0402",
          "input_clusters": [
            "0x0001",
            "0x0500",
            "0x0003",
            "0x0000"
          ],
          "output_clusters": [
            "0x1000",
            "0x0006",
            "0x0019",
            "0x000a"
          ],
          "profile_id": "0x0104"
        }
      },
      "manufacturer": "_TZ3000_bsvqrxru",
      "model": "TS0202",
      "node_desc": {
        "aps_flags": 0,
        "complex_descriptor_available": 0,
        "descriptor_capability_field": 0,
        "frequency_band": 8,
        "logical_type": 2,
        "mac_capability_flags": 128,
        "manufacturer_code": 4417,
        "maximum_buffer_size": 66,
        "maximum_incoming_transfer_size": 66,
        "maximum_outgoing_transfer_size": 66,
        "reserved": 0,
        "server_mask": 10752,
        "user_descriptor_available": 0
      }
    },
    "power_source": "Battery or Unknown",
    "quirk_applied": true,
    "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
    "routes": [],
    "rssi": null,
    "version": 1,
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "info_object": {
            "attribute_name": "zone_status",
            "available": true,
            "class_name": "IASZone",
            "cluster_handlers": [
              {
                "class_name": "IASZoneClusterHandler",
                "cluster": {
                  "id": 1280,
                  "name": "IAS Zone",
                  "type": "server"
                },
                "endpoint_id": 1,
                "generic_id": "cluster_handler_0x0500",
                "id": "1:0x0500",
                "status": "INITIALIZED",
                "unique_id": "**REDACTED**",
                "value_attribute": null
              }
            ],
            "device_class": "motion",
            "device_ieee": "**REDACTED**",
            "enabled": true,
            "endpoint_id": 1,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "fallback_name": null,
            "group_id": null,
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "primary": true,
            "state_class": null,
            "translation_key": null,
            "translation_placeholders": null,
            "unique_id": "**REDACTED**"
          },
          "state": {
            "available": true,
            "class_name": "IASZone",
            "state": true
          }
        }
      ],
      "button": [
        {
          "info_object": {
            "args": [
              5
            ],
            "available": true,
            "class_name": "IdentifyButton",
            "cluster_handlers": [
              {
                "class_name": "IdentifyClusterHandler",
                "cluster": {
                  "id": 3,
                  "name": "Identify",
                  "type": "server"
                },
                "endpoint_id": 1,
                "generic_id": "cluster_handler_0x0003",
                "id": "1:0x0003",
                "status": "INITIALIZED",
                "unique_id": "**REDACTED**",
                "value_attribute": null
              }
            ],
            "command": "identify",
            "device_class": "identify",
            "device_ieee": "**REDACTED**",
            "enabled": true,
            "endpoint_id": 1,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "fallback_name": null,
            "group_id": null,
            "kwargs": {},
            "migrate_unique_ids": [],
            "platform": "button",
            "primary": false,
            "state_class": null,
            "translation_key": null,
            "translation_placeholders": null,
            "unique_id": "**REDACTED**"
          },
          "state": {
            "available": true,
            "class_name": "IdentifyButton"
          }
        }
      ],
      "number": [
        {
          "info_object": {
            "available": true,
            "class_name": "NumberConfigurationEntity",
            "cluster_handlers": [
              {
                "class_name": "IASZoneClusterHandler",
                "cluster": {
                  "id": 1280,
                  "name": "IAS Zone",
                  "type": "server"
                },
                "endpoint_id": 1,
                "generic_id": "cluster_handler_0x0500",
                "id": "1:0x0500",
                "status": "INITIALIZED",
                "unique_id": "**REDACTED**",
                "value_attribute": null
              }
            ],
            "device_class": null,
            "device_ieee": "**REDACTED**",
            "enabled": true,
            "endpoint_id": 1,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "fallback_name": "Motion clear timeout",
            "group_id": null,
            "migrate_unique_ids": [],
            "mode": "auto",
            "native_max_value": 900,
            "native_min_value": 5,
            "native_step": 5,
            "native_unit_of_measurement": "s",
            "platform": "number",
            "primary": false,
            "state_class": null,
            "translation_key": "motion_timeout",
            "translation_placeholders": null,
            "unique_id": "**REDACTED**"
          },
          "state": {
            "available": true,
            "class_name": "NumberConfigurationEntity",
            "state": 30
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "available": true,
            "class_name": "LQISensor",
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "endpoint_id": 1,
                "generic_id": "cluster_handler_0x0000",
                "id": "1:0x0000",
                "status": "INITIALIZED",
                "unique_id": "**REDACTED**",
                "value_attribute": null
              }
            ],
            "device_class": null,
            "device_ieee": "**REDACTED**",
            "enabled": true,
            "endpoint_id": 1,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "fallback_name": null,
            "group_id": null,
            "migrate_unique_ids": [],
            "platform": "sensor",
            "primary": false,
            "state_class": "measurement",
            "suggested_display_precision": null,
            "translation_key": "lqi",
            "translation_placeholders": null,
            "unique_id": "**REDACTED**",
            "unit": null
          },
          "state": {
            "available": true,
            "class_name": "LQISensor",
            "state": 160
          }
        },
        {
          "info_object": {
            "available": true,
            "class_name": "RSSISensor",
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "endpoint_id": 1,
                "generic_id": "cluster_handler_0x0000",
                "id": "1:0x0000",
                "status": "INITIALIZED",
                "unique_id": "**REDACTED**",
                "value_attribute": null
              }
            ],
            "device_class": "signal_strength",
            "device_ieee": "**REDACTED**",
            "enabled": true,
            "endpoint_id": 1,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "fallback_name": null,
            "group_id": null,
            "migrate_unique_ids": [],
            "platform": "sensor",
            "primary": false,
            "state_class": "measurement",
            "suggested_display_precision": null,
            "translation_key": "rssi",
            "translation_placeholders": null,
            "unique_id": "**REDACTED**",
            "unit": "dBm"
          },
          "state": {
            "available": true,
            "class_name": "RSSISensor",
            "state": null
          }
        },
        {
          "extra_state_attributes": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ],
          "info_object": {
            "available": true,
            "class_name": "Battery",
            "cluster_handlers": [
              {
                "class_name": "PowerConfigurationClusterHandler",
                "cluster": {
                  "id": 1,
                  "name": "Power Configuration",
                  "type": "server"
                },
                "endpoint_id": 1,
                "generic_id": "cluster_handler_0x0001",
                "id": "1:0x0001",
                "status": "INITIALIZED",
                "unique_id": "**REDACTED**",
                "value_attribute": "battery_voltage"
              }
            ],
            "device_class": "battery",
            "device_ieee": "**REDACTED**",
            "enabled": true,
            "endpoint_id": 1,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "fallback_name": null,
            "group_id": null,
            "migrate_unique_ids": [],
            "platform": "sensor",
            "primary": false,
            "state_class": "measurement",
            "suggested_display_precision": 0,
            "translation_key": null,
            "translation_placeholders": null,
            "unique_id": "**REDACTED**",
            "unit": "%"
          },
          "state": {
            "available": true,
            "battery_quantity": 2,
            "battery_size": "AAA",
            "battery_voltage": 3.0,
            "class_name": "Battery",
            "state": 100.0
          }
        }
      ],
      "update": [
        {
          "info_object": {
            "available": true,
            "class_name": "FirmwareUpdateEntity",
            "cluster_handlers": [
              {
                "class_name": "OtaClientClusterHandler",
                "cluster": {
                  "id": 25,
                  "name": "Ota",
                  "type": "client"
                },
                "endpoint_id": 1,
                "generic_id": "cluster_handler_0x0019_client",
                "id": "1:0x0019_client",
                "status": "INITIALIZED",
                "unique_id": "**REDACTED**",
                "value_attribute": null
              }
            ],
            "device_class": "firmware",
            "device_ieee": "**REDACTED**",
            "enabled": true,
            "endpoint_id": 1,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "fallback_name": null,
            "group_id": null,
            "migrate_unique_ids": [],
            "platform": "update",
            "primary": false,
            "state_class": null,
            "supported_features": 7,
            "translation_key": null,
            "translation_placeholders": null,
            "unique_id": "**REDACTED**"
          },
          "state": {
            "available": true,
            "class_name": "FirmwareUpdateEntity",
            "in_progress": false,
            "installed_version": "0x00000046",
            "latest_version": null,
            "release_notes": null,
            "release_summary": null,
            "release_url": null,
            "update_percentage": null
          }
        }
      ]
    }
  },
  "home_assistant": {
    "arch": "x86_64",
    "container_arch": "amd64",
    "dev": false,
    "docker": true,
    "hassio": false,
    "installation_type": "Home Assistant Container",
    "os_name": "Linux",
    "os_version": "6.14.0-37-generic",
    "python_version": "3.14.2",
    "run_as_root": true,
    "timezone": "Europe/Brussels",
    "version": "2026.4.1",
    "virtualenv": false
  },
  "integration_manifest": {
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "domain": "zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "is_built_in": true,
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "name": "Zigbee Home Automation",
    "overwrites_built_in": false,
    "requirements": [
      "zha==1.1.1",
      "serialx==0.6.2"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ]
  },
  "issues": [],
  "setup_times": {
    "01JQ4ER63KH4KZBMR5D7B9VW0G": {
      "config_entry_setup": 13.1637274089735,
      "wait_import_platforms": -0.016411149874329567
    },
    "null": {
      "setup": 4.594912752509117e-05
    }
  }
}
```

</details>
