### PR TITLE
Add Tuya TS0049 `_TZ3000_kz1anoi8` water valve with irrigation timer

### DIFF
--- a/tests/test_tuya_ts0049_kz1anoi8.py
+++ b/tests/test_tuya_ts0049_kz1anoi8.py
@@ -111,12 +111,13 @@ async def test_non_timer_attr_uses_super(water_valve):
     tuya_cluster = water_valve.endpoints[1].tuya_manufacturer
     success = [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
-    with mock.patch.object(
-        tuya_cluster.endpoint.device, "request", return_value=None
-    ), mock.patch(
-        "zhaquirks.tuya.mcu.TuyaMCUCluster.write_attributes",
-        return_value=success,
-    ) as super_mock:
+    with (
+        mock.patch.object(tuya_cluster.endpoint.device, "request", return_value=None),
+        mock.patch(
+            "zhaquirks.tuya.mcu.TuyaMCUCluster.write_attributes",
+            return_value=success,
+        ) as super_mock,
+    ):
         # 0x0000 is not the irrigation_time attr id, so it goes to other_attrs
         await tuya_cluster.write_attributes({0x0000: 1})
         await wait_for_zigpy_tasks()

--- a/tests/test_tuya_ts0049_kz1anoi8.py
+++ b/tests/test_tuya_ts0049_kz1anoi8.py
@@ -1,0 +1,75 @@
+"""Tests for Tuya TS0049 (_TZ3000_kz1anoi8) water valve quirk."""
+
+from unittest import mock
+
+import pytest
+
+from tests.common import wait_for_zigpy_tasks
+import zhaquirks
+import zhaquirks.tuya.ts0049_kz1anoi8
+
+zhaquirks.setup()
+
+MANUFACTURER = "_TZ3000_kz1anoi8"
+MODEL = "TS0049"
+CLUSTER_E001 = 0xE001
+
+
+@pytest.fixture
+def water_valve(zigpy_device_from_v2_quirk):
+    """Return quirked TS0049 water valve device."""
+    return zigpy_device_from_v2_quirk(MANUFACTURER, MODEL)
+
+
+async def test_irrigation_time_sends_e001_frame(water_valve):
+    """Test write irrigation_time (seconds) sends correct 0xE001 frame."""
+    tuya_cluster = water_valve.endpoints[1].tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint.device, "request", return_value=None
+    ) as m:
+        await tuya_cluster.write_attributes({"irrigation_time": 300})
+        await wait_for_zigpy_tasks()
+
+    assert m.called
+    call_kwargs = m.call_args.kwargs
+    assert call_kwargs["cluster"] == CLUSTER_E001
+    assert call_kwargs["expect_reply"] is False
+    # ZCL frame: [0x11, tsn, 0xFE, DP=11, 0x00, 0x00, 0x01, 0x2C]
+    data = call_kwargs["data"]
+    assert data[0] == 0x11
+    assert data[2] == 0xFE
+    assert data[3] == 11
+    assert int.from_bytes(data[4:8], "big") == 300
+
+    # irrigation_time stored in seconds
+    attr_id = tuya_cluster.attributes_by_name["irrigation_time"].id
+    assert tuya_cluster.get(attr_id) == 300
+
+
+async def test_irrigation_time_zero_disables_autooff(water_valve):
+    """Test that value 0 disables auto-off by sending 0 seconds."""
+    tuya_cluster = water_valve.endpoints[1].tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint.device, "request", return_value=None
+    ) as m:
+        await tuya_cluster.write_attributes({"irrigation_time": 0})
+        await wait_for_zigpy_tasks()
+
+    data = m.call_args.kwargs["data"]
+    assert int.from_bytes(data[4:8], "big") == 0
+
+
+async def test_irrigation_time_clamped(water_valve):
+    """Test that values are clamped to 86400 seconds."""
+    tuya_cluster = water_valve.endpoints[1].tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint.device, "request", return_value=None
+    ) as m:
+        await tuya_cluster.write_attributes({"irrigation_time": 99999})
+        await wait_for_zigpy_tasks()
+
+    data = m.call_args.kwargs["data"]
+    assert int.from_bytes(data[4:8], "big") == 86400

--- a/tests/test_tuya_ts0049_kz1anoi8.py
+++ b/tests/test_tuya_ts0049_kz1anoi8.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+from zigpy.zcl import foundation
 
 from tests.common import wait_for_zigpy_tasks
 import zhaquirks
@@ -73,3 +74,51 @@ async def test_irrigation_time_clamped(water_valve):
 
     data = m.call_args.kwargs["data"]
     assert int.from_bytes(data[4:8], "big") == 86400
+
+
+async def test_irrigation_time_int_key(water_valve):
+    """Test write_attributes with integer attribute ID key."""
+    tuya_cluster = water_valve.endpoints[1].tuya_manufacturer
+    attr_id = tuya_cluster.attributes_by_name["irrigation_time"].id
+
+    with mock.patch.object(
+        tuya_cluster.endpoint.device, "request", return_value=None
+    ) as m:
+        await tuya_cluster.write_attributes({attr_id: 60})
+        await wait_for_zigpy_tasks()
+
+    data = m.call_args.kwargs["data"]
+    assert int.from_bytes(data[4:8], "big") == 60
+
+
+async def test_irrigation_time_zcl_attr_def_key(water_valve):
+    """Test write_attributes with ZCLAttributeDef key."""
+    tuya_cluster = water_valve.endpoints[1].tuya_manufacturer
+    attr_def = tuya_cluster.attributes_by_name["irrigation_time"]
+
+    with mock.patch.object(
+        tuya_cluster.endpoint.device, "request", return_value=None
+    ) as m:
+        await tuya_cluster.write_attributes({attr_def: 120})
+        await wait_for_zigpy_tasks()
+
+    data = m.call_args.kwargs["data"]
+    assert int.from_bytes(data[4:8], "big") == 120
+
+
+async def test_non_timer_attr_uses_super(water_valve):
+    """Test that non-timer attributes are forwarded to the base class."""
+    tuya_cluster = water_valve.endpoints[1].tuya_manufacturer
+    success = [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+
+    with mock.patch.object(
+        tuya_cluster.endpoint.device, "request", return_value=None
+    ), mock.patch(
+        "zhaquirks.tuya.mcu.TuyaMCUCluster.write_attributes",
+        return_value=success,
+    ) as super_mock:
+        # 0x0000 is not the irrigation_time attr id, so it goes to other_attrs
+        await tuya_cluster.write_attributes({0x0000: 1})
+        await wait_for_zigpy_tasks()
+
+    assert super_mock.called

--- a/zhaquirks/tuya/ts0049_kz1anoi8.py
+++ b/zhaquirks/tuya/ts0049_kz1anoi8.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 
 from typing import Any
 
-import zigpy.types as t
 from zigpy.quirks.v2.homeassistant import UnitOfTime
+import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.foundation import UNDEFINED, UndefinedType
 
@@ -81,9 +81,7 @@ class TuyaWaterValveCluster(TuyaMCUCluster):
                 data=zcl_frame,
                 expect_reply=False,
             )
-            self._update_attribute(
-                self.attributes_by_name["irrigation_time"].id, sec
-            )
+            self._update_attribute(self.attributes_by_name["irrigation_time"].id, sec)
 
         if other_attrs:
             results = await super().write_attributes(

--- a/zhaquirks/tuya/ts0049_kz1anoi8.py
+++ b/zhaquirks/tuya/ts0049_kz1anoi8.py
@@ -1,10 +1,10 @@
-"""Tuya TS0049 (_TZ3000_kz1anoi8) water valve with configurable irrigation timer.
+"""Tuya TS0049 (_TZ3000_kz1anoi8) battery-powered water valve.
 
 Protocol notes (reverse-engineered):
-  - On/Off:  Standard ZCL OnOff cluster (0x0006), DP 1 reported via 0xEF00
-  - Timer:   Cluster 0xE001 (TUYA_CLUSTER_E001_ID), Command 0xFE
+  - On/Off:  Standard ZCL OnOff cluster (0x0006)
+  - Timer:   Cluster 0xE001, Command 0xFE
              Payload: [DP=11, val_b3, val_b2, val_b1, val_b0]  (5 bytes, Big-Endian)
-             Valid range: 0 – 86400 seconds (0 = kein Auto-Aus)
+             Valid range: 0 - 86400 seconds (0 = no auto-off, valve stays open)
              Persistent: the device stores the value until changed.
 
 Tuya DP mapping:
@@ -14,9 +14,12 @@ Tuya DP mapping:
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any
 
 import zigpy.types as t
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.zcl import foundation
+from zigpy.zcl.foundation import UNDEFINED, UndefinedType
 
 from zhaquirks.tuya import TUYA_CLUSTER_E001_ID
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
@@ -26,51 +29,41 @@ from zhaquirks.tuya.mcu import TuyaMCUCluster
 class TuyaWaterValveCluster(TuyaMCUCluster):
     """Tuya Water Valve MCU Cluster for _TZ3000_kz1anoi8.
 
-    0xEF0B (irrigation_time):     Eingabe in Minuten, sendet Minuten * 60 Sekunden
-    0xEF0C (irrigation_time_sec): Eingabe in Sekunden, sendet direkt
+    Intercepts writes to ``irrigation_time`` (attr 0xEF0B) and sends them via
+    Cluster 0xE001 / Command 0xFE with Big-Endian 4-byte encoding - the only
+    protocol this device accepts for DP 11.
+    Value 0 disables the auto-off timer (valve stays open indefinitely).
     """
 
     async def write_attributes(
         self,
-        attributes: dict,
-        allow_cache: bool = False,
-        only_cache: bool = False,
-        manufacturer: Optional[int] = None,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,
+        **kwargs: Any,
     ):
         """Write attributes, routing irrigation timer writes to Cluster 0xE001 / Command 0xFE."""
         e001_attrs = {}
         other_attrs = {}
 
         for attr, value in attributes.items():
-            attr_id = (
-                self.attributes_by_name[attr].id if isinstance(attr, str) else attr
-            )
-            if attr_id in (0xEF0B, 0xEF0C):
+            if isinstance(attr, str):
+                attr_id = self.attributes_by_name[attr].id
+            elif isinstance(attr, foundation.ZCLAttributeDef):
+                attr_id = attr.id
+            else:
+                attr_id = attr
+            if attr_id == 0xEF0B:
                 e001_attrs[attr] = value
             else:
                 other_attrs[attr] = value
 
-        results = [{}, {}]
+        results = [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
         for attr, value in e001_attrs.items():
-            attr_id = (
-                self.attributes_by_name[attr].id if isinstance(attr, str) else attr
-            )
-            if attr_id == 0xEF0B:
-                # Minuten-Feld: Umrechnung in Sekunden
-                minutes = max(0, min(1440, int(value)))
-                sec = minutes * 60
-                stored_attr = "irrigation_time"
-                stored_val = minutes
-            else:
-                # Sekunden-Feld: direkt senden
-                sec = max(0, min(86400, int(value)))
-                stored_attr = "irrigation_time_sec"
-                stored_val = sec
-
+            sec = max(0, min(86400, int(value)))
             payload = bytes(
                 [
-                    11,
+                    11,  # DP 11 = irrigation time
                     (sec >> 24) & 0xFF,
                     (sec >> 16) & 0xFF,
                     (sec >> 8) & 0xFF,
@@ -88,23 +81,15 @@ class TuyaWaterValveCluster(TuyaMCUCluster):
                 data=zcl_frame,
                 expect_reply=False,
             )
-            self._update_attribute(self.attributes_by_name[stored_attr].id, stored_val)
-            # Gegenseitige Aktualisierung
-            if attr_id == 0xEF0B:
-                self._update_attribute(
-                    self.attributes_by_name["irrigation_time_sec"].id, sec
-                )
-            else:
-                self._update_attribute(
-                    self.attributes_by_name["irrigation_time"].id, sec // 60
-                )
+            self._update_attribute(
+                self.attributes_by_name["irrigation_time"].id, sec
+            )
 
         if other_attrs:
             results = await super().write_attributes(
                 other_attrs,
-                allow_cache=allow_cache,
-                only_cache=only_cache,
                 manufacturer=manufacturer,
+                **kwargs,
             )
 
         return results
@@ -117,22 +102,11 @@ class TuyaWaterValveCluster(TuyaMCUCluster):
         type=t.uint32_t,
         attribute_name="irrigation_time",
         min_value=0,
-        max_value=1440,
-        step=1,
-        unit="min",
-        translation_key="irrigation_time",
-        fallback_name="Bewässerungszeit",
-    )
-    .tuya_number(
-        dp_id=12,
-        type=t.uint32_t,
-        attribute_name="irrigation_time_sec",
-        min_value=0,
         max_value=86400,
         step=1,
-        unit="s",
-        translation_key="irrigation_time_sec",
-        fallback_name="Bewässerungszeit (Sek.)",
+        unit=UnitOfTime.SECONDS,
+        translation_key="irrigation_time",
+        fallback_name="Irrigation Time",
     )
     .add_to_registry(replacement_cluster=TuyaWaterValveCluster)
 )

--- a/zhaquirks/tuya/ts0049_kz1anoi8.py
+++ b/zhaquirks/tuya/ts0049_kz1anoi8.py
@@ -59,7 +59,7 @@ class TuyaWaterValveCluster(TuyaMCUCluster):
 
         results = [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
-        for attr, value in e001_attrs.items():
+        for value in e001_attrs.values():
             sec = max(0, min(86400, int(value)))
             payload = bytes(
                 [

--- a/zhaquirks/tuya/ts0049_kz1anoi8.py
+++ b/zhaquirks/tuya/ts0049_kz1anoi8.py
@@ -87,9 +87,7 @@ class TuyaWaterValveCluster(TuyaMCUCluster):
                 data=zcl_frame,
                 expect_reply=False,
             )
-            self._update_attribute(
-                self.attributes_by_name[stored_attr].id, stored_val
-            )
+            self._update_attribute(self.attributes_by_name[stored_attr].id, stored_val)
             # Gegenseitige Aktualisierung
             if attr_id == 0xEF0B:
                 self._update_attribute(

--- a/zhaquirks/tuya/ts0049_kz1anoi8.py
+++ b/zhaquirks/tuya/ts0049_kz1anoi8.py
@@ -37,6 +37,7 @@ class TuyaWaterValveCluster(TuyaMCUCluster):
         only_cache: bool = False,
         manufacturer: Optional[int] = None,
     ):
+        """Write attributes, routing irrigation timer writes to Cluster 0xE001 / Command 0xFE."""
         e001_attrs = {}
         other_attrs = {}
 

--- a/zhaquirks/tuya/ts0049_kz1anoi8.py
+++ b/zhaquirks/tuya/ts0049_kz1anoi8.py
@@ -1,0 +1,139 @@
+"""Tuya TS0049 (_TZ3000_kz1anoi8) water valve with configurable irrigation timer.
+
+Protocol notes (reverse-engineered):
+  - On/Off:  Standard ZCL OnOff cluster (0x0006), DP 1 reported via 0xEF00
+  - Timer:   Cluster 0xE001 (TUYA_CLUSTER_E001_ID), Command 0xFE
+             Payload: [DP=11, val_b3, val_b2, val_b1, val_b0]  (5 bytes, Big-Endian)
+             Valid range: 0 – 86400 seconds (0 = kein Auto-Aus)
+             Persistent: the device stores the value until changed.
+
+Tuya DP mapping:
+  DP  1: On/Off (Boolean)
+  DP 11: Irrigation time in seconds (uint32, Big-Endian via 0xE001/0xFE)
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import zigpy.types as t
+
+from zhaquirks.tuya import TUYA_CLUSTER_E001_ID
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.mcu import TuyaMCUCluster
+
+
+class TuyaWaterValveCluster(TuyaMCUCluster):
+    """Tuya Water Valve MCU Cluster for _TZ3000_kz1anoi8.
+
+    0xEF0B (irrigation_time):     Eingabe in Minuten, sendet Minuten * 60 Sekunden
+    0xEF0C (irrigation_time_sec): Eingabe in Sekunden, sendet direkt
+    """
+
+    async def write_attributes(
+        self,
+        attributes: dict,
+        allow_cache: bool = False,
+        only_cache: bool = False,
+        manufacturer: Optional[int] = None,
+    ):
+        e001_attrs = {}
+        other_attrs = {}
+
+        for attr, value in attributes.items():
+            attr_id = (
+                self.attributes_by_name[attr].id if isinstance(attr, str) else attr
+            )
+            if attr_id in (0xEF0B, 0xEF0C):
+                e001_attrs[attr] = value
+            else:
+                other_attrs[attr] = value
+
+        results = [{}, {}]
+
+        for attr, value in e001_attrs.items():
+            attr_id = (
+                self.attributes_by_name[attr].id if isinstance(attr, str) else attr
+            )
+            if attr_id == 0xEF0B:
+                # Minuten-Feld: Umrechnung in Sekunden
+                minutes = max(0, min(1440, int(value)))
+                sec = minutes * 60
+                stored_attr = "irrigation_time"
+                stored_val = minutes
+            else:
+                # Sekunden-Feld: direkt senden
+                sec = max(0, min(86400, int(value)))
+                stored_attr = "irrigation_time_sec"
+                stored_val = sec
+
+            payload = bytes(
+                [
+                    11,
+                    (sec >> 24) & 0xFF,
+                    (sec >> 16) & 0xFF,
+                    (sec >> 8) & 0xFF,
+                    sec & 0xFF,
+                ]
+            )
+            tsn = self.endpoint.device.application.get_sequence()
+            zcl_frame = bytes([0x11, tsn, 0xFE]) + payload
+            await self.endpoint.device.request(
+                profile=self.endpoint.profile_id,
+                cluster=TUYA_CLUSTER_E001_ID,
+                src_ep=self.endpoint.endpoint_id,
+                dst_ep=self.endpoint.endpoint_id,
+                sequence=tsn,
+                data=zcl_frame,
+                expect_reply=False,
+            )
+            self._update_attribute(
+                self.attributes_by_name[stored_attr].id, stored_val
+            )
+            # Gegenseitige Aktualisierung
+            if attr_id == 0xEF0B:
+                self._update_attribute(
+                    self.attributes_by_name["irrigation_time_sec"].id, sec
+                )
+            else:
+                self._update_attribute(
+                    self.attributes_by_name["irrigation_time"].id, sec // 60
+                )
+
+        if other_attrs:
+            results = await super().write_attributes(
+                other_attrs,
+                allow_cache=allow_cache,
+                only_cache=only_cache,
+                manufacturer=manufacturer,
+            )
+
+        return results
+
+
+(
+    TuyaQuirkBuilder("_TZ3000_kz1anoi8", "TS0049")
+    .tuya_number(
+        dp_id=11,
+        type=t.uint32_t,
+        attribute_name="irrigation_time",
+        min_value=0,
+        max_value=1440,
+        step=1,
+        unit="min",
+        translation_key="irrigation_time",
+        fallback_name="Bewässerungszeit",
+    )
+    .tuya_number(
+        dp_id=12,
+        type=t.uint32_t,
+        attribute_name="irrigation_time_sec",
+        min_value=0,
+        max_value=86400,
+        step=1,
+        unit="s",
+        translation_key="irrigation_time_sec",
+        fallback_name="Bewässerungszeit (Sek.)",
+    )
+    .add_to_registry(replacement_cluster=TuyaWaterValveCluster)
+)


### PR DESCRIPTION
## Proposed change

Add a quirk for the Tuya TS0049 (`_TZ3000_kz1anoi8`) battery-powered water valve.

This device uses the standard ZCL OnOff cluster (0x0006) for on/off control, but requires a
non-standard protocol for its irrigation timer: DP 11 must be sent via Cluster 0xE001 /
Command 0xFE with a Big-Endian 4-byte payload. The standard `TuyaMCUCluster` write path does
not reach this cluster, so `TuyaWaterValveCluster` intercepts writes to the `irrigation_time`
attribute and dispatches the correct frame directly.

Setting the timer to 0 disables the auto-off function (valve stays open indefinitely).

## Additional information

The device's timer DP (DP 11) only accepts commands via Cluster 0xE001 / Command 0xFE.
Sending via the normal Tuya MCU protocol (0xEF00) has no effect on the timer.

## Device diagnostics

<details>
<summary>Diagnostics (click to expand)</summary>

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant OS",
    "version": "2026.4.4",
    "dev": false,
    "hassio": true,
    "virtualenv": false,
    "python_version": "3.14.2",
    "docker": true,
    "arch": "aarch64",
    "timezone": "Europe/Berlin",
    "os_name": "Linux",
    "os_version": "6.12.75-haos-raspi",
    "container_arch": "aarch64",
    "supervisor": "2026.04.1",
    "host_os": "Home Assistant OS 17.2",
    "docker_version": "29.3.1",
    "chassis": "embedded",
    "run_as_root": true
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "requirements": [
      "zha==1.1.2"
    ],
    "is_built_in": true
  },
  "data": {
    "ieee": "**REDACTED**",
    "nwk": "0x58D5",
    "manufacturer": "_TZ3000_kz1anoi8",
    "model": "TS0049",
    "quirk_applied": true,
    "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
    "exposes_features": [],
    "manufacturer_code": 4417,
    "power_source": "Battery or Unknown",
    "lqi": 255,
    "rssi": -32,
    "available": true,
    "device_type": "EndDevice",
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4417,
      "maximum_buffer_size": 66,
      "maximum_incoming_transfer_size": 66,
      "server_mask": 10752,
      "maximum_outgoing_transfer_size": 66,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "ON_OFF_SWITCH",
          "id": 0
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {"id": "0x0004", "name": "manufacturer", "zcl_type": "string", "value": "_TZ3000_kz1anoi8"},
              {"id": "0x0005", "name": "model", "zcl_type": "string", "value": "TS0049"}
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {"id": "0x0021", "name": "battery_percentage_remaining", "zcl_type": "uint8", "value": 200},
              {"id": "0x0020", "name": "battery_voltage", "zcl_type": "uint8", "value": 30}
            ]
          },
          {"cluster_id": "0x0003", "endpoint_attribute": "identify", "attributes": []},
          {"cluster_id": "0x0004", "endpoint_attribute": "groups", "attributes": []},
          {"cluster_id": "0x0005", "endpoint_attribute": "scenes", "attributes": []},
          {
            "cluster_id": "0x0006",
            "endpoint_attribute": "on_off",
            "attributes": [
              {"id": "0x0000", "name": "on_off", "zcl_type": "bool", "value": 0}
            ]
          },
          {"cluster_id": "0xe001", "endpoint_attribute": null, "attributes": []},
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": "tuya_manufacturer",
            "attributes": [
              {"id": "0xef0b", "name": "irrigation_time", "zcl_type": "uint32", "value": 180}
            ]
          }
        ],
        "out_clusters": [
          {"cluster_id": "0x000a", "endpoint_attribute": "time", "attributes": []},
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {"id": "0x0002", "name": "current_file_version", "zcl_type": "uint32", "value": 72}
            ]
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "_TZ3000_kz1anoi8",
      "model": "TS0049",
      "node_desc": {
        "logical_type": 2,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 128,
        "manufacturer_code": 4417,
        "maximum_buffer_size": 66,
        "maximum_incoming_transfer_size": 66,
        "server_mask": 10752,
        "maximum_outgoing_transfer_size": 66,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0000",
          "input_clusters": ["0x0003","0x0004","0x0005","0x0001","0x0006","0xe001","0x0000"],
          "output_clusters": ["0x0019","0x000a"]
        }
      }
    },
    "zha_lib_entities": {
      "button": [
        {
          "info_object": {
            "platform": "button",
            "class_name": "IdentifyButton",
            "translation_key": null,
            "device_class": "identify",
            "entity_category": "diagnostic"
          }
        }
      ],
      "number": [
        {
          "info_object": {
            "fallback_name": "Irrigation Time",
            "platform": "number",
            "class_name": "NumberConfigurationEntity",
            "translation_key": "irrigation_time",
            "entity_category": "config",
            "mode": "auto",
            "native_max_value": 86400,
            "native_min_value": 0,
            "native_step": 1,
            "native_unit_of_measurement": "s"
          },
          "state": {
            "class_name": "NumberConfigurationEntity",
            "available": true,
            "state": 180
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "platform": "sensor",
            "class_name": "Battery",
            "device_class": "battery",
            "state_class": "measurement",
            "entity_category": "diagnostic"
          },
          "state": {"state": 100.0, "battery_voltage": 3.0}
        }
      ],
      "switch": [
        {
          "info_object": {
            "platform": "switch",
            "class_name": "Switch",
            "translation_key": "switch",
            "primary": true,
            "cluster_handlers": [
              {"class_name": "OnOffClusterHandler", "cluster": {"id": 6, "name": "On/Off"}}
            ]
          },
          "state": {"state": 0, "available": true}
        }
      ]
    }
  }
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
