### PR TITLE
Document number entity `multiplier` semantics in AI instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -200,11 +200,39 @@ from zigpy.quirks.v2 import ReportingConfig
     step=1,                           # Optional: step increment
     unit=UnitOfTime.SECONDS,          # Optional: unit constant
     mode="box",                       # Optional: "box" for text input, "slider" for slider
-    multiplier=1,                     # Optional: multiply value before writing to device
+    multiplier=1,                     # Optional: scale between HA value and raw attribute (default 1)
     device_class=NumberDeviceClass.DURATION,  # Optional: HA device class
     translation_key="turn_on_delay",
     fallback_name="Turn on delay",
 )
+```
+
+**Number `multiplier` semantics:** Defined on the entity by ZHA. HA Core is a pure pass-through — it does no scaling itself. The conversion is:
+- Display: `native_value = raw_attr_value * multiplier`
+- Write: `raw_attr_value = int(ha_value / multiplier)`
+
+If the device's underlying attribute is an integer representing a fractional unit (e.g., tenths of a degree stored as `int32s`), pair fractional `step` with the matching `multiplier` so HA values are scaled correctly. Without it (default `multiplier=1`), `int()` silently truncates fractional input on write and raw values are displayed unscaled.
+
+```python
+# Calibration where the device stores tenths of a degree as int32s.
+# HA range -9.9..9.9 °C ↔ raw attribute value -99..99
+.number(
+    attribute_name="local_temperature_calibration",
+    cluster_id=Thermostat.cluster_id,
+    type=t.int32s,
+    min_value=-9.9,
+    max_value=9.9,
+    step=0.1,
+    multiplier=0.1,   # required: pairs with step=0.1
+    unit=UnitOfTemperature.CELSIUS,
+    translation_key="local_temperature_calibration",
+    fallback_name="Local temperature calibration",
+)
+```
+
+`min_value`/`max_value` are HA-side values (after the multiplier), not raw attribute values. Confirm the device's raw value range and pick HA-side limits accordingly.
+
+```python
 
 # Enum as SELECT (dropdown, default) - user can change value
 .enum(

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -211,17 +211,16 @@ from zigpy.quirks.v2 import ReportingConfig
 - Display: `native_value = raw_attr_value * multiplier`
 - Write: `raw_attr_value = int(ha_value / multiplier)`
 
-If the device's underlying attribute is an integer representing a fractional unit (e.g., tenths of a degree stored as `int32s`), pair fractional `step` with the matching `multiplier` so HA values are scaled correctly. Without it (default `multiplier=1`), `int()` silently truncates fractional input on write and raw values are displayed unscaled.
+If the underlying attribute is an integer representing a fractional unit (e.g., the ZCL `local_temperature_calibration` attribute is `int8s` storing tenths of a degree), pair fractional `step` with the matching `multiplier` so HA values are scaled correctly. The attribute's raw type comes from the cluster's `AttributeDefs` — for `.number()` (unlike `.tuya_number()`) you don't pass a `type`. Without a `multiplier` (default `1`), `int()` silently truncates fractional input on write and raw values are displayed unscaled.
 
 ```python
-# Calibration where the device stores tenths of a degree as int32s.
-# HA range -9.9..9.9 °C ↔ raw attribute value -99..99
+# ZCL Thermostat local_temperature_calibration: int8s, tenths of a degree.
+# HA range -2.5..2.5 °C ↔ raw attribute value -25..25
 .number(
-    attribute_name="local_temperature_calibration",
+    attribute_name=Thermostat.AttributeDefs.local_temperature_calibration.name,
     cluster_id=Thermostat.cluster_id,
-    type=t.int32s,
-    min_value=-9.9,
-    max_value=9.9,
+    min_value=-2.5,
+    max_value=2.5,
     step=0.1,
     multiplier=0.1,   # required: pairs with step=0.1
     unit=UnitOfTemperature.CELSIUS,


### PR DESCRIPTION
## Proposed change - LLM-generated

Document how the `multiplier` argument on v2 number entities works, so AI coding agents (and humans skimming the instructions) get this right when adding number entities backed by integer attributes that represent fractional units.

The conversion lives in ZHA's number entity (HA Core just proxies through it):
- Display: `native_value = raw_attr_value * multiplier`
- Write: `raw_attr_value = int(ha_value / multiplier)`

So a fractional `step` without a matching `multiplier` silently truncates fractional input on write (`int(1.5 / 1) = 1`) and displays raw values unscaled. Also clarifies that `min_value`/`max_value` are HA-side values (after the multiplier), not raw attribute values.

Prompted by review of #4867, where `step=0.1` was set without `multiplier=0.1` on a `local_temperature_calibration` number — the same file already has the correct pattern at the existing `dp_id=19` quirk, so this is just making the convention explicit in the instructions.

## Additional information

Docs-only change to `.github/copilot-instructions.md` (which `CLAUDE.md` symlinks to).

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached