### PR TITLE
Fix Tuya motion sensor Wenzi WZ-M100 `detection_delay` scaling

### DIFF
--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -412,9 +412,10 @@ base_tuya_motion = (
         type=t.uint16_t,
         device_class=SensorDeviceClass.DURATION,
         unit=UnitOfTime.SECONDS,
-        min_value=0.1,
+        min_value=0,
         max_value=10,
         step=0.1,
+        multiplier=0.1,
         translation_key="detection_delay",
         fallback_name="Detection delay",
     )


### PR DESCRIPTION
## Proposed change - LLM-generated

Fix `detection_delay` scaling for the Wenzi WZ-M100 motion sensor (`_TZE204_laokfqwu`, `TS0601`). DP 105 was missing `multiplier=0.1` despite using `step=0.1`, so:
- Fractional input from HA was silently truncated on write — `int(2.5 / 1) = 2` was sent to the device.
- The raw integer was displayed unscaled — raw `25` showed as `"25"` instead of `"2.5"`.

Verified against canonical Z2M ([`zigbee-herdsman-converters/src/devices/tuya.ts:12824`](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts#L12824)):
```ts
[105, "detection_delay", tuya.valueConverter.divideBy10],
```

Adding `multiplier=0.1` aligns the quirk with `divideBy10` (raw 0..100 ↔ HA 0..10s). Also changed `min_value` from `0.1` to `0` to match Z2M, since `detection_delay` is the dwell-before-trigger filter (no-motion → motion direction; `fading_time` is the post-motion timeout) and `0` is a valid "report immediately" setting.

The same file already has the correct pattern on a sibling Tuya motion sensor at [`tuya_motion.py:354-366`](https://github.com/zigpy/zha-device-handlers/blob/dev/zhaquirks/tuya/tuya_motion.py#L354-L366) (`_TZE204_qasjif9e` / `_TZE204_ztqnh5cg`, also DP 101 `detection_delay`), which uses `step=0.1, multiplier=0.1`.

Closes #4954.

## Additional information

A follow-up PR (#4957) fixes the same bug pattern on `fading_time` (DP 106) of this device.

The `_TZE200_clrdrnya` reclassification was split out into #4956 (now merged).

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
