### PR TITLE
Reclassify Tuya `_TZE200_clrdrnya` to MTG075-ZB-RL family

### DIFF
--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -386,7 +386,6 @@ base_tuya_motion = (
 (
     base_tuya_motion.clone()
     .applies_to("_TZE204_laokfqwu", "TS0601")
-    .applies_to("_TZE200_clrdrnya", "TS0601")
     .tuya_dp(
         dp_id=1,
         ep_attribute=TuyaOccupancySensing.ep_attribute,
@@ -695,6 +694,7 @@ base_tuya_motion = (
     base_tuya_motion.clone()
     .applies_to("_TZE204_sbyx0lm6", "TS0601")
     .applies_to("_TZE204_clrdrnya", "TS0601")
+    .applies_to("_TZE200_clrdrnya", "TS0601")
     .applies_to("_TZE204_dtzziy1e", "TS0601")
     .applies_to("_TZE204_iaeejhvf", "TS0601")
     .applies_to("_TZE204_mtoaryre", "TS0601")


### PR DESCRIPTION
## Proposed change - LLM-generated

Reclassify `_TZE200_clrdrnya` from the Wenzi WZ-M100 quirk to the existing MTG075-ZB-RL quirk family in `zhaquirks/tuya/tuya_motion.py`.

PR #3807 grouped `_TZE200_clrdrnya` with the WZ-M100 quirk because canonical Z2M did the same at the time. Z2M has since reclassified it: commit [Koenkk/zigbee-herdsman-converters@3976c8d](https://github.com/Koenkk/zigbee-herdsman-converters/commit/3976c8db0c3ce5e76b11d8f8e628a61156957a06) (March 2025), titled `fix(detect): Detect _TZE200_clrdrnya as Tuya MTG235-ZB-RL`, moves it to the MTG075-ZB-RL group based on user reports in [Koenkk/zigbee2mqtt#25712](https://github.com/Koenkk/zigbee2mqtt/discussions/25712).

The MTG075-ZB-RL has totally different DPs — radar/breaker controls on DPs 107-115 that don't exist on the WZ-M100, and the WZ-M100 DPs don't apply — so applying the WZ-M100 quirk to a `_TZE200_clrdrnya` device gives users the wrong entities backed by the wrong DPs.

This PR moves `_TZE200_clrdrnya` to the existing MTG075-ZB-RL quirk family at [`tuya_motion.py:694-704`](https://github.com/zigpy/zha-device-handlers/blob/dev/zhaquirks/tuya/tuya_motion.py#L694-L704), which already covers the sibling `_TZE204_clrdrnya`.

## Additional information

Split out from #4955 so the model reclassification can be reviewed/merged independently from the unrelated `detection_delay` scaling fix.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
