### PR TITLE
Fix Tuya motion sensor Wenzi WZ-M100 `fading_time` scaling

### DIFF
--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -427,6 +427,7 @@ base_tuya_motion = (
         min_value=5,
         max_value=1500,
         step=5,
+        multiplier=0.1,
         translation_key="fading_time",
         fallback_name="Fading time",
     )


### PR DESCRIPTION
## Proposed change - LLM-generated

Fix `fading_time` (DP 106) scaling for the Wenzi WZ-M100 motion sensor (`_TZE204_laokfqwu`, `TS0601`).

The DP was missing `multiplier=0.1` despite the device using a `divideBy10` converter in canonical Z2M. Because `step=5` is integer there's no fractional truncation, but it was a silent unit mismatch: HA's value got written 1/10th of the user's intended duration (HA `100` → raw DP `100` = 10 s on the device, when the user expected 100 s).

Verified against canonical Z2M ([`zigbee-herdsman-converters/src/devices/tuya.ts:12825`](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts#L12825)):
```ts
[106, "fading_time", tuya.valueConverter.divideBy10],
```
Adding `multiplier=0.1` makes raw DP range 50..15000 in steps of 50, matching Z2M.

## Additional information

Follow-up to #4955 (which fixed the same bug pattern on `detection_delay` / DP 105 of the same device). The audit in #4954 didn't catch `fading_time` because its `step=5` is integer — the audit heuristic was "fractional step", but the same root cause can present as a unit mismatch with integer step too.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
