### PR TITLE
Fix Tuya TRV temperature setpoint scaling (`_TZE204_rtrmfadk`, `_TZE284_ymldrmzx`)

### DIFF
--- a/zhaquirks/tuya/tuya_trv.py
+++ b/zhaquirks/tuya/tuya_trv.py
@@ -355,6 +355,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         max_value=15,
         unit=UnitOfTemperature.CELSIUS,
         step=1,
+        multiplier=0.1,
         translation_key="min_temperature",
         fallback_name="Min temperature",
     )
@@ -366,6 +367,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         max_value=35,
         unit=UnitOfTemperature.CELSIUS,
         step=1,
+        multiplier=0.1,
         translation_key="max_temperature",
         fallback_name="Max temperature",
     )
@@ -541,6 +543,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         max_value=30,
         unit=UnitOfTemperature.CELSIUS,
         step=1,
+        multiplier=0.1,
         translation_key="holiday_temperature",
         fallback_name="Holiday temperature",
     )
@@ -606,6 +609,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         max_value=30,
         unit=UnitOfTemperature.CELSIUS,
         step=1,
+        multiplier=0.1,
         translation_key="antifrost_temperature",
         fallback_name="Antifrost temperature",
     )
@@ -624,6 +628,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         max_value=30,
         unit=UnitOfTemperature.CELSIUS,
         step=1,
+        multiplier=0.1,
         translation_key="eco_temperature",
         fallback_name="Eco temperature",
     )
@@ -635,6 +640,7 @@ class TuyaThermostatV2NoSchedule(TuyaThermostatV2):
         max_value=30,
         unit=UnitOfTemperature.CELSIUS,
         step=1,
+        multiplier=0.1,
         translation_key="comfort_temperature",
         fallback_name="Comfort temperature",
     )


### PR DESCRIPTION
## Proposed change - LLM-generated

Fix six `.tuya_number()` temperature setpoints across two Tuya TRVs in `zhaquirks/tuya/tuya_trv.py`. Each was missing `multiplier=0.1` despite the device protocol using 0.1 °C steps (`divideBy10` per canonical Z2M). Without the multiplier, HA writes the value 10× too low: setting `20 °C` in HA wrote raw `20`, which the device interprets as `2 °C`.

### Affected entries

| Manufacturer / Model                          | DP  | Attribute                |
|-----------------------------------------------|-----|--------------------------|
| `_TZE204_rtrmfadk` — Moes TRV801_1            | 15  | `min_temperature`        |
| `_TZE204_rtrmfadk` — Moes TRV801_1            | 16  | `max_temperature`        |
| `_TZE284_ymldrmzx` — Tuya TRV603-WZ           | 21  | `holiday_temperature`    |
| `_TZE284_ymldrmzx` — Tuya TRV603-WZ           | 112 | `antifrost_temperature`  |
| `_TZE284_ymldrmzx` — Tuya TRV603-WZ           | 116 | `eco_temperature`        |
| `_TZE284_ymldrmzx` — Tuya TRV603-WZ           | 117 | `comfort_temperature`    |

### Verification

Canonical Z2M ([zigbee-herdsman-converters/src/devices/tuya.ts](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts)) for both fingerprints:

- `_TZE204_rtrmfadk` (TRV801_1):
  ```ts
  [15, "min_temperature", tuya.valueConverter.divideBy10],
  [16, "max_temperature", tuya.valueConverter.divideBy10],
  ```
- `_TZE284_ymldrmzx` (TRV603-WZ):
  ```ts
  [21,  "holiday_temperature",   tuya.valueConverter.divideBy10],
  [112, "antifrost_temperature", tuya.valueConverter.divideBy10],
  [116, "eco_temperature",       tuya.valueConverter.divideBy10],
  [117, "comfort_temperature",   tuya.valueConverter.divideBy10],
  ```

Each fix is a one-line `multiplier=0.1` addition; ranges (`min_value`/`max_value`) stay HA-side and don't need changing.

## Additional information

Found by a broader audit of `.tuya_number()` calls across `zhaquirks/tuya/` against canonical Z2M, after the same pattern was fixed for the Wenzi WZ-M100 in #4955 / #4957.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
