### PR TITLE
Fix Tuya ZY-M100-S_1 motion sensor `fading_time` scaling

### DIFF
--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -1255,6 +1255,7 @@ base_tuya_motion = (
         min_value=1,
         max_value=1500,
         step=1,
+        multiplier=0.1,
         translation_key="fading_time",
         fallback_name="Fading time",
     )


### PR DESCRIPTION
## Proposed change - LLM-generated

Fix `fading_time` (DP 110) scaling for the Tuya ZY-M100-S_1 motion sensor (`_TZE204_sxm7l9xa`, `_TZE204_e5m9c5hl`, `TS0601`) in `zhaquirks/tuya/tuya_motion.py`.

The DP was missing `multiplier=0.1` despite the device using a `divideBy10` converter in canonical Z2M. Because `step=1` is integer there's no fractional truncation, but it was a silent unit mismatch: HA's value got written 1/10th of the user's intended duration (HA `60 s` → raw DP `60` = 6 s on the device).

The sibling DP 111 (`detection_delay`) on the same builder block already correctly sets `multiplier=0.1` — DP 110 was missed.

Verified against canonical Z2M ([zigbee-herdsman-converters/src/devices/tuya.ts](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts)):
```ts
[110, "fading_time", tuya.valueConverter.divideBy10],
```

## Additional information

Same pattern as the just-merged #4955 (DP 105 on a different motion sensor) and follow-up #4957 (DP 106 on yet another). Found by a broader audit of `.tuya_number()` calls against canonical Z2M.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
