### PR TITLE
Allow triggering CI checks manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - dev
       - master
   pull_request: ~
+  workflow_dispatch:
 
 jobs:
   shared-ci:


### PR DESCRIPTION
This allows contributors to manually trigger CI run in their forks before opening a PR upstream and annoying everyone with potential force-pushes, etc.