### PR TITLE
Add Tuya soil sensor model _TZE284_2nhqasjh

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -270,6 +270,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE284_awepdiwi", "TS0601")  # Solar powered
     .applies_to("_TZE284_33bwcga2", "TS0601")  # iHseno
     .applies_to("_TZE284_tgrzpqf4", "TS0601")
+    .applies_to("_TZE284_2nhqasjh", "TS0601")  # Smart Soil Sensor
     .tuya_temperature(dp_id=5, scale=10)
     .tuya_battery(dp_id=15)
     .tuya_soil_moisture(dp_id=3)


### PR DESCRIPTION
## Summary
- add  as an additional model for the existing TS0601 Tuya soil sensor quirk

## Testing
- /home/pavel/playground/zha/zha-device-handlers/.venv/bin/python -m pytest tests/test_tuya_sensor.py -q
- /home/pavel/playground/zha/zha-device-handlers/.venv/bin/python -m pytest tests/ -q