### PR TITLE
Add NOUS E6 temperature and humidity sensor (TS0601)

### DIFF
--- a/zhaquirks/tuya/nous_e6.py
+++ b/zhaquirks/tuya/nous_e6.py
@@ -1,0 +1,67 @@
+"""Tuya NOUS E6 temperature and humidity sensor with screen."""
+
+from zigpy.quirks.v2 import EntityType
+from zigpy.quirks.v2.homeassistant import UnitOfTemperature
+import zigpy.types as t
+
+from zhaquirks.const import BatterySize
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.tuya_sensor import NoManufTimeTuyaMCUCluster, TuyaTempUnitConvert
+
+(
+    TuyaQuirkBuilder("_TZE284_wtikaxzs", "TS0601")
+    .applies_to("_TZE200_nnrfa68v", "TS0601")
+    .tuya_temperature(dp_id=1, scale=10)
+    .tuya_humidity(dp_id=2)
+    .tuya_battery(dp_id=4, battery_type=BatterySize.AAA, battery_qty=2)
+    .tuya_enum(
+        dp_id=9,
+        attribute_name="display_unit",
+        enum_class=TuyaTempUnitConvert,
+        entity_type=EntityType.CONFIG,
+        translation_key="display_unit",
+        fallback_name="Display unit",
+    )
+    .tuya_number(
+        dp_id=10,
+        attribute_name="alarm_temperature_max",
+        type=t.uint16_t,
+        unit=UnitOfTemperature.CELSIUS,
+        min_value=-20,
+        max_value=60,
+        step=1,
+        multiplier=0.1,
+        entity_type=EntityType.CONFIG,
+        translation_key="alarm_temperature_max",
+        fallback_name="Alarm temperature max",
+    )
+    .tuya_number(
+        dp_id=11,
+        attribute_name="alarm_temperature_min",
+        type=t.uint16_t,
+        unit=UnitOfTemperature.CELSIUS,
+        min_value=-20,
+        max_value=60,
+        step=1,
+        multiplier=0.1,
+        entity_type=EntityType.CONFIG,
+        translation_key="alarm_temperature_min",
+        fallback_name="Alarm temperature min",
+    )
+    .tuya_number(
+        dp_id=19,
+        attribute_name="temperature_sensitivity",
+        type=t.uint16_t,
+        unit=UnitOfTemperature.CELSIUS,
+        min_value=0.1,
+        max_value=10,
+        step=0.1,
+        multiplier=0.1,
+        entity_type=EntityType.CONFIG,
+        translation_key="temperature_sensitivity",
+        fallback_name="Temperature sensitivity",
+    )
+    .tuya_enchantment(data_query_spell=True)
+    .skip_configuration()
+    .add_to_registry(replacement_cluster=NoManufTimeTuyaMCUCluster)
+)


### PR DESCRIPTION
## Proposed change

Add a V2 `TuyaQuirkBuilder` quirk for the NOUS E6 temperature and humidity sensor with display (`_TZE284_wtikaxzs` / `TS0601`). The newer hardware revision advertises an extra
  cluster `0xED00` that prevented the existing community workaround (based on the old `_TZE200_nnrfa68v` quirk) from matching. This quirk handles both revisions.


Entities exposed:
  - Temperature sensor (DP 1)
  - Humidity sensor (DP 2)
  - Battery sensor (DP 4, 2× AAA)
  - Display unit select — Celsius / Fahrenheit (DP 9)
  - Alarm temperature max / min (DP 10, 11)
  - Temperature sensitivity (DP 19)

Time sync for the on-device clock is handled via `NoManufTimeTuyaMCUCluster`.

## Additional information

The `_TZE200_nnrfa68v` (original NOUS E6 revision) is included via `.applies_to()` based on community reports in #3477 and #1702 confirming the same DP mapping. I do not own that revision to verify personally.

Fixes #3477

## Device diagnostics

[zha-01JP5W7S1PDKNDWCNE0ZWKH65M-_TZE284_wtikaxzs TS0601-28348dabb26f959edf3d69def5a5f5e0.json](https://github.com/user-attachments/files/27251253/zha-01JP5W7S1PDKNDWCNE0ZWKH65M-_TZE284_wtikaxzs.TS0601-28348dabb26f959edf3d69def5a5f5e0.json)

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
