### PR TITLE
Add quirk for Excellux PIRIV-01 motion sensor

### DIFF
--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -186,6 +186,14 @@ class TuyaMotionDetectionMode(t.enum8):
     Only_radar = 0x03
 
 
+class ExcelluxIlluminanceLevel(t.enum8):
+    """Tuya illuminance level enum."""
+
+    Dark = 0x00
+    Dim = 0x01
+    Bright = 0x02
+
+
 base_tuya_motion = (
     TuyaQuirkBuilder()
     .adds(TuyaOccupancySensing)
@@ -1632,6 +1640,91 @@ base_tuya_motion = (
     .replaces(MotionWithReset)
     .replaces(TuyaPowerConfigurationCluster2AAA)
     .tuya_enchantment()
+    .skip_configuration()
+    .add_to_registry()
+)
+
+# Excellux PIRIV-01
+(
+    TuyaQuirkBuilder("PIRIV01", "Excellux")
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=TuyaOccupancySensing.ep_attribute,
+        attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
+        converter=lambda x: x == 1,
+    )
+    .adds(TuyaOccupancySensing)
+    .tuya_vibration(dp_id=3)
+    .tuya_battery(dp_id=4, scale=2)
+    .tuya_number(
+        dp_id=6,
+        attribute_name="vibration_sensitivity",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=50,
+        step=1,
+        translation_key="vibration_sensitivity",
+        fallback_name="Vibration sensitivity",
+    )
+    .tuya_illuminance(dp_id=20)
+    .tuya_number(
+        dp_id=101,
+        attribute_name="report_interval",
+        type=t.uint16_t,
+        unit=UnitOfTime.SECONDS,
+        min_value=5,
+        max_value=1200,
+        step=5,
+        device_class=SensorDeviceClass.DURATION,
+        translation_key="report_interval",
+        fallback_name="Report interval",
+    )
+    .tuya_number(
+        dp_id=104,
+        attribute_name="dark_to_dim_threshold",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        unit=LIGHT_LUX,
+        min_value=0,
+        max_value=10000,
+        step=1,
+        translation_key="dark_to_dim_threshold",
+        fallback_name="Dark to dim threshold",
+    )
+    .tuya_number(
+        dp_id=105,
+        attribute_name="dim_to_bright_threshold",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        unit=LIGHT_LUX,
+        min_value=0,
+        max_value=10000,
+        step=1,
+        translation_key="dim_to_bright_threshold",
+        fallback_name="Dim to bright threshold",
+    )
+    .tuya_number(
+        dp_id=106,
+        attribute_name="illuminance_offset",
+        type=t.int16s,
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        unit=LIGHT_LUX,
+        min_value=-1000,
+        max_value=1000,
+        step=1,
+        translation_key="illuminance_offset",
+        fallback_name="Illuminance offset",
+    )
+    .tuya_enum(
+        dp_id=107,
+        attribute_name="ambient_light_category",
+        enum_class=ExcelluxIlluminanceLevel,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.STANDARD,
+        translation_key="ambient_light_category",
+        fallback_name="Ambient light category",
+    )
+    .tuya_enchantment(data_query_spell=True)
     .skip_configuration()
     .add_to_registry()
 )


### PR DESCRIPTION
This adds a new Tuya v2 quirk for the [Excellux PIRIV-01 motion sensor](https://www.aliexpress.us/item/3256811905051357.html), marketed as a `Zigbee 3.0 Smart PIR Motion Sensor Human Body Movement Vibration Detection &Light Lux Sensor Optional Support Home Assistant Z2M
`, mapping occupancy, vibration, battery, sensitivity, illuminance, report interval, thresholds, and light category.

## Proposed change
This PR adds a new Tuya v2 quirk for the **Excellux PIRIV-01** motion sensor. Using the `TuyaQuirkBuilder`, this implementation maps several Tuya Data Points (DPs) to standard Zigbee clusters and attributes:

*   **Occupancy (DP 1):** Maps to the OccupancySensing cluster.
*   **Vibration (DP 3):** Adds vibration detection support.
*   **Battery (DP 4):** Maps battery levels with a scaling factor of 2.
*   **Vibration Sensitivity (DP 6):** Provides a configuration entity (0–50).
*   **Illuminance (DP 20):** Standard lux reporting.
*   **Report Interval (DP 101):** Adjustable reporting frequency (5–1200s).
*   **Thresholds (DP 104, 105):** Configurable lux thresholds for light categories.
*   **Offset (DP 106):** Illuminance calibration offset.
*   **Ambient Light Category (DP 107):** Enum sensor for Dark, Dim, and Bright states.


## Additional information
- This device follows the Tuya v2 protocol and requires the `tuya_enchantment` (data query spell) to initialize correctly.
- Fixes support for the Excellux PIRIV-01.
<img width="348" height="1001" alt="image" src="https://github.com/user-attachments/assets/dca4204d-b707-448d-9830-ce6ecfd16750" />


## Device diagnostics

[zha-01K8BQMJSKZFPA3YC43C2Q4TB0-PIRIV01 Excellux-367beb137d09c32767d493554e14c30c.json](https://github.com/user-attachments/files/27295204/zha-01K8BQMJSKZFPA3YC43C2Q4TB0-PIRIV01.Excellux-367beb137d09c32767d493554e14c30c.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
