### PR TITLE
Add ZHA quirk for Engo EONE and E40 thermostats

### DIFF
--- a/tests/test_tuya_engo.py
+++ b/tests/test_tuya_engo.py
@@ -1,5 +1,6 @@
 """Tests for Engo Tuya thermostat quirks."""
 
+import zigpy.quirks
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 from zigpy.zcl.clusters.hvac import Thermostat
 
@@ -25,9 +26,17 @@ def test_engo_thermostat_entities(zigpy_device_from_v2_quirk):
         == Thermostat.ControlSequenceOfOperation.Heating_Only
     )
 
-    assert ep.humidity is not None
-    assert ep.humidity.device_class == SensorDeviceClass.HUMIDITY
-    assert ep.humidity.state_class == SensorStateClass.MEASUREMENT
+    eone_quirk = zigpy.quirks.DEVICE_REGISTRY.registry_v2[("_TZE204_ca3i8m8p", "TS0601")][
+        0
+    ]
+    humidity_entities = [
+        entity
+        for entity in eone_quirk.entity_metadata
+        if entity.translation_key == "humidity"
+    ]
+    assert len(humidity_entities) == 1
+    assert humidity_entities[0].device_class == SensorDeviceClass.HUMIDITY
+    assert humidity_entities[0].state_class == SensorStateClass.MEASUREMENT
 
 
 def test_engo_e40_has_no_humidity_sensor(zigpy_device_from_v2_quirk):
@@ -41,4 +50,8 @@ def test_engo_e40_has_no_humidity_sensor(zigpy_device_from_v2_quirk):
 
     assert ep.thermostat is not None
     assert isinstance(ep.thermostat, Thermostat)
-    assert not hasattr(ep, "humidity")
+
+    e40_quirk = zigpy.quirks.DEVICE_REGISTRY.registry_v2[("_TZE204_glk6viwg", "TS0601")][
+        0
+    ]
+    assert all(entity.translation_key != "humidity" for entity in e40_quirk.entity_metadata)

--- a/tests/test_tuya_engo.py
+++ b/tests/test_tuya_engo.py
@@ -1,0 +1,44 @@
+"""Tests for Engo Tuya thermostat quirks."""
+
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
+from zigpy.zcl.clusters.hvac import Thermostat
+
+import zhaquirks
+from zhaquirks.tuya.mcu import TuyaMCUCluster
+
+zhaquirks.setup()
+
+
+def test_engo_thermostat_entities(zigpy_device_from_v2_quirk):
+    """Test the shared Engo thermostat entities and cluster defaults."""
+
+    device = zigpy_device_from_v2_quirk("_TZE204_ca3i8m8p", "TS0601")
+    ep = device.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+
+    assert ep.thermostat is not None
+    assert isinstance(ep.thermostat, Thermostat)
+    assert (
+        ep.thermostat.get(Thermostat.AttributeDefs.ctrl_sequence_of_oper.id)
+        == Thermostat.ControlSequenceOfOperation.Heating_Only
+    )
+
+    assert ep.humidity is not None
+    assert ep.humidity.device_class == SensorDeviceClass.HUMIDITY
+    assert ep.humidity.state_class == SensorStateClass.MEASUREMENT
+
+
+def test_engo_e40_has_no_humidity_sensor(zigpy_device_from_v2_quirk):
+    """Test that the E40 variant does not expose humidity by default."""
+
+    device = zigpy_device_from_v2_quirk("_TZE204_glk6viwg", "TS0601")
+    ep = device.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+
+    assert ep.thermostat is not None
+    assert isinstance(ep.thermostat, Thermostat)
+    assert not hasattr(ep, "humidity")

--- a/tests/test_tuya_engo.py
+++ b/tests/test_tuya_engo.py
@@ -26,9 +26,9 @@ def test_engo_thermostat_entities(zigpy_device_from_v2_quirk):
         == Thermostat.ControlSequenceOfOperation.Heating_Only
     )
 
-    eone_quirk = zigpy.quirks.DEVICE_REGISTRY.registry_v2[("_TZE204_ca3i8m8p", "TS0601")][
-        0
-    ]
+    eone_quirk = zigpy.quirks.DEVICE_REGISTRY.registry_v2[
+        ("_TZE204_ca3i8m8p", "TS0601")
+    ][0]
     humidity_entities = [
         entity
         for entity in eone_quirk.entity_metadata
@@ -51,7 +51,9 @@ def test_engo_e40_has_no_humidity_sensor(zigpy_device_from_v2_quirk):
     assert ep.thermostat is not None
     assert isinstance(ep.thermostat, Thermostat)
 
-    e40_quirk = zigpy.quirks.DEVICE_REGISTRY.registry_v2[("_TZE204_glk6viwg", "TS0601")][
-        0
-    ]
-    assert all(entity.translation_key != "humidity" for entity in e40_quirk.entity_metadata)
+    e40_quirk = zigpy.quirks.DEVICE_REGISTRY.registry_v2[
+        ("_TZE204_glk6viwg", "TS0601")
+    ][0]
+    assert all(
+        entity.translation_key != "humidity" for entity in e40_quirk.entity_metadata
+    )

--- a/zhaquirks/tuya/tuya_engo.py
+++ b/zhaquirks/tuya/tuya_engo.py
@@ -1,0 +1,166 @@
+"""ZHA quirk for Engo EONE-230W and E40-230 / E40-230W TS0601 thermostats."""
+
+import zigpy.types as t
+from zigpy.zcl.clusters.hvac import RunningState, Thermostat
+
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.mcu import TuyaAttributesCluster
+
+from zigpy.quirks.v2 import EntityType
+from zigpy.quirks.v2.homeassistant.sensor import (
+    SensorDeviceClass,
+    SensorStateClass,
+)
+
+
+# ---------- ENUMS ----------
+
+class EngoSensorChoose(t.enum8):
+    Internal = 0x00
+    All = 0x01
+    External = 0x02
+
+
+class EngoRelayMode(t.enum8):
+    NO = 0x00
+    NC = 0x01
+    OFF = 0x02
+
+
+class EngoSensorError(t.enum8):
+    Normal = 0x00
+    E1 = 0x01
+    E2 = 0x02
+
+
+# ---------- CLUSTER ----------
+
+class EngoThermostat(Thermostat, TuyaAttributesCluster):
+    """Local thermostat cluster for Engo devices."""
+
+    _CONSTANT_ATTRIBUTES = {
+        Thermostat.AttributeDefs.ctrl_sequence_of_oper.id:
+            Thermostat.ControlSequenceOfOperation.Heating_Only
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.add_unsupported_attribute(
+            Thermostat.AttributeDefs.setpoint_change_source.id
+        )
+        self.add_unsupported_attribute(
+            Thermostat.AttributeDefs.setpoint_change_source_timestamp.id
+        )
+        self.add_unsupported_attribute(
+            Thermostat.AttributeDefs.pi_heating_demand.id
+        )
+
+
+# ---------- COMMON BUILDER ----------
+
+def base_builder(ieee):
+    return (
+        TuyaQuirkBuilder(ieee, "TS0601")
+
+        # DP 1: ON/OFF -> HVAC mode
+        .tuya_dp(
+            dp_id=1,
+            ep_attribute=EngoThermostat.ep_attribute,
+            attribute_name=EngoThermostat.AttributeDefs.system_mode.name,
+            converter=lambda x: (
+                Thermostat.SystemMode.Heat if x else Thermostat.SystemMode.Off
+            ),
+            dp_converter=lambda x: x != Thermostat.SystemMode.Off,
+        )
+
+        # DP 16: target temp (deci°C -> centi°C)
+        .tuya_dp(
+            dp_id=16,
+            ep_attribute=EngoThermostat.ep_attribute,
+            attribute_name=EngoThermostat.AttributeDefs.occupied_heating_setpoint.name,
+            converter=lambda x: x * 10,
+            dp_converter=lambda x: x // 10,
+        )
+
+        # DP 24: room temp
+        .tuya_dp(
+            dp_id=24,
+            ep_attribute=EngoThermostat.ep_attribute,
+            attribute_name=EngoThermostat.AttributeDefs.local_temperature.name,
+            converter=lambda x: x * 10,
+        )
+
+        # DP 3: running state
+        .tuya_dp(
+            dp_id=3,
+            ep_attribute=EngoThermostat.ep_attribute,
+            attribute_name=EngoThermostat.AttributeDefs.running_state.name,
+            converter=lambda x: {
+                1: RunningState.Heat_State_On,
+                2: RunningState.Idle,
+            }.get(x, RunningState.Idle),
+        )
+
+        # DP 40: child lock
+        .tuya_switch(
+            dp_id=40,
+            attribute_name="child_lock",
+            translation_key="child_lock",
+            fallback_name="Child lock",
+        )
+
+        # DP 44: backlight
+        .tuya_number(
+            dp_id=44,
+            attribute_name="backlight",
+            type=t.uint8_t,
+            min_value=0,
+            max_value=100,
+            step=1,
+            translation_key="backlight",
+            fallback_name="Backlight",
+        )
+
+        # DP 120: sensor error
+        .tuya_enum(
+            dp_id=120,
+            attribute_name="sensor_error",
+            enum_class=EngoSensorError,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="sensor_error",
+            fallback_name="Sensor error",
+        )
+
+        .adds(EngoThermostat)
+        .skip_configuration()
+    )
+
+
+# ---------- DEVICE 1: EONE (with humidity) ----------
+
+(
+    base_builder("_TZE204_ca3i8m8p")
+
+    # DP 34: humidity (only on EONE)
+    .tuya_sensor(
+        dp_id=34,
+        attribute_name="humidity",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit="%",
+        translation_key="humidity",
+        fallback_name="Humidity",
+    )
+
+    .add_to_registry()
+)
+
+
+# ---------- DEVICE 2: E40 (no humidity by default) ----------
+
+(
+    base_builder("_TZE204_glk6viwg")
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/tuya_engo.py
+++ b/zhaquirks/tuya/tuya_engo.py
@@ -1,19 +1,15 @@
 """ZHA quirk for Engo EONE-230W and E40-230 / E40-230W TS0601 thermostats."""
 
+from zigpy.quirks.v2 import EntityType
+from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
 from zigpy.zcl.clusters.hvac import RunningState, Thermostat
 
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zhaquirks.tuya.mcu import TuyaAttributesCluster
 
-from zigpy.quirks.v2 import EntityType
-from zigpy.quirks.v2.homeassistant.sensor import (
-    SensorDeviceClass,
-    SensorStateClass,
-)
-
-
 # ---------- ENUMS ----------
+
 
 class EngoSensorChoose(t.enum8):
     Internal = 0x00
@@ -35,12 +31,12 @@ class EngoSensorError(t.enum8):
 
 # ---------- CLUSTER ----------
 
+
 class EngoThermostat(Thermostat, TuyaAttributesCluster):
     """Local thermostat cluster for Engo devices."""
 
     _CONSTANT_ATTRIBUTES = {
-        Thermostat.AttributeDefs.ctrl_sequence_of_oper.id:
-            Thermostat.ControlSequenceOfOperation.Heating_Only
+        Thermostat.AttributeDefs.ctrl_sequence_of_oper.id: Thermostat.ControlSequenceOfOperation.Heating_Only
     }
 
     def __init__(self, *args, **kwargs):
@@ -52,17 +48,15 @@ class EngoThermostat(Thermostat, TuyaAttributesCluster):
         self.add_unsupported_attribute(
             Thermostat.AttributeDefs.setpoint_change_source_timestamp.id
         )
-        self.add_unsupported_attribute(
-            Thermostat.AttributeDefs.pi_heating_demand.id
-        )
+        self.add_unsupported_attribute(Thermostat.AttributeDefs.pi_heating_demand.id)
 
 
 # ---------- COMMON BUILDER ----------
 
+
 def base_builder(ieee):
     return (
         TuyaQuirkBuilder(ieee, "TS0601")
-
         # DP 1: ON/OFF -> HVAC mode
         .tuya_dp(
             dp_id=1,
@@ -73,7 +67,6 @@ def base_builder(ieee):
             ),
             dp_converter=lambda x: x != Thermostat.SystemMode.Off,
         )
-
         # DP 16: target temp (deci°C -> centi°C)
         .tuya_dp(
             dp_id=16,
@@ -82,7 +75,6 @@ def base_builder(ieee):
             converter=lambda x: x * 10,
             dp_converter=lambda x: x // 10,
         )
-
         # DP 24: room temp
         .tuya_dp(
             dp_id=24,
@@ -90,7 +82,6 @@ def base_builder(ieee):
             attribute_name=EngoThermostat.AttributeDefs.local_temperature.name,
             converter=lambda x: x * 10,
         )
-
         # DP 3: running state
         .tuya_dp(
             dp_id=3,
@@ -101,7 +92,6 @@ def base_builder(ieee):
                 2: RunningState.Idle,
             }.get(x, RunningState.Idle),
         )
-
         # DP 40: child lock
         .tuya_switch(
             dp_id=40,
@@ -109,7 +99,6 @@ def base_builder(ieee):
             translation_key="child_lock",
             fallback_name="Child lock",
         )
-
         # DP 44: backlight
         .tuya_number(
             dp_id=44,
@@ -121,7 +110,6 @@ def base_builder(ieee):
             translation_key="backlight",
             fallback_name="Backlight",
         )
-
         # DP 120: sensor error
         .tuya_enum(
             dp_id=120,
@@ -131,7 +119,6 @@ def base_builder(ieee):
             translation_key="sensor_error",
             fallback_name="Sensor error",
         )
-
         .adds(EngoThermostat)
         .skip_configuration()
     )
@@ -141,7 +128,6 @@ def base_builder(ieee):
 
 (
     base_builder("_TZE204_ca3i8m8p")
-
     # DP 34: humidity (only on EONE)
     .tuya_sensor(
         dp_id=34,
@@ -153,14 +139,10 @@ def base_builder(ieee):
         translation_key="humidity",
         fallback_name="Humidity",
     )
-
     .add_to_registry()
 )
 
 
 # ---------- DEVICE 2: E40 (no humidity by default) ----------
 
-(
-    base_builder("_TZE204_glk6viwg")
-    .add_to_registry()
-)
+(base_builder("_TZE204_glk6viwg").add_to_registry())

--- a/zhaquirks/tuya/tuya_engo.py
+++ b/zhaquirks/tuya/tuya_engo.py
@@ -12,18 +12,24 @@ from zhaquirks.tuya.mcu import TuyaAttributesCluster
 
 
 class EngoSensorChoose(t.enum8):
+    """Sensor selection mode."""
+
     Internal = 0x00
     All = 0x01
     External = 0x02
 
 
 class EngoRelayMode(t.enum8):
+    """Relay wiring mode."""
+
     NO = 0x00
     NC = 0x01
     OFF = 0x02
 
 
 class EngoSensorError(t.enum8):
+    """Sensor error state."""
+
     Normal = 0x00
     E1 = 0x01
     E2 = 0x02
@@ -40,6 +46,8 @@ class EngoThermostat(Thermostat, TuyaAttributesCluster):
     }
 
     def __init__(self, *args, **kwargs):
+        """Initialize unsupported thermostat attributes."""
+
         super().__init__(*args, **kwargs)
 
         self.add_unsupported_attribute(
@@ -55,6 +63,8 @@ class EngoThermostat(Thermostat, TuyaAttributesCluster):
 
 
 def base_builder(ieee):
+    """Build the shared Engo Tuya quirk definition."""
+
     return (
         TuyaQuirkBuilder(ieee, "TS0601")
         # DP 1: ON/OFF -> HVAC mode


### PR DESCRIPTION
This file implements a ZHA quirk for Engo thermostats, defining enums, a thermostat cluster, and builders for device attributes.

## Proposed change

Add support for Engo-branded Tuya TS0601 thermostats:

- `_TZE204_ca3i8m8p` (EONE-230W)
- `_TZE204_glk6viwg` (E40-230 / E40-230W)

This quirk maps Tuya datapoints (DPs) to standard ZHA thermostat attributes and entities, enabling full local control via ZHA.

### Key features

- Implements a shared `EngoThermostat` cluster based on `Thermostat` + `TuyaAttributesCluster`
- Provides correct scaling between Tuya deci-degrees and ZHA centi-degrees
- Maps core thermostat functionality:
  - System mode (heat/off)
  - Target temperature (DP 16)
  - Local temperature (DP 24)
  - Running state (DP 3)
- Exposes additional device features:
  - Child lock (DP 40)
  - Backlight brightness (DP 44)
  - Sensor error diagnostics (DP 120)
- Adds humidity sensor (DP 34) for EONE variant only

### Implementation notes

- Uses a shared builder (`base_builder`) to avoid duplication across device variants
- Only enables datapoints confirmed to work reliably across firmware variants
- Leaves optional / inconsistent DPs (sensor selection, relay mode, etc.) disabled for now to avoid regressions
- Compatible with current `TuyaQuirkBuilder` API (no unsupported arguments like `converter` on `.tuya_number()`)

## Additional information

- This quirk is based on reverse-engineering via Zigbee2MQTT mappings and device testing
- Both devices identify as `TS0601` but expose slightly different datapoints
- No breaking changes expected; this only adds support for previously unsupported devices
- May be extended in future PRs to include:
  - Preset modes
  - External sensor selection
  - Advanced control algorithms (if confirmed stable)

## Device diagnostics

```
{
  "home_assistant": {
    "installation_type": "Home Assistant OS",
    "version": "2026.4.4",
    "dev": false,
    "hassio": true,
    "virtualenv": false,
    "python_version": "3.14.2",
    "docker": true,
    "arch": "aarch64",
    "timezone": "Europe/Dublin",
    "os_name": "Linux",
    "os_version": "6.12.75-haos-raspi",
    "container_arch": "aarch64",
    "supervisor": "2026.04.2",
    "host_os": "Home Assistant OS 17.2",
    "docker_version": "29.3.1",
    "chassis": "embedded",
    "run_as_root": true
  },
  "custom_components": {
    "mammotion": {
      "documentation": "https://github.com/mikey0000/Mammotion-HA/wiki",
      "version": "0.5.35",
      "requirements": [
        "pymammotion==0.7.93"
      ]
    },
    "hacs": {
      "documentation": "https://hacs.xyz/docs/use/",
      "version": "2.0.5",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    },
    "robovac": {
      "documentation": "https://github.com/damacus/robovac",
      "version": "2.3.0-beta.1",
      "requirements": []
    },
    "sigen": {
      "documentation": "https://github.com/TypQxQ/Sigenergy-Local-Modbus",
      "version": "1.2.3",
      "requirements": [
        "pymodbus>=3.8.3"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==1.1.2",
      "serialx==0.6.2"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 8.205600897781551e-05
    },
    "01KAGMJ72F5HRMJCHAEKYR3C3F": {
      "wait_import_platforms": -0.020859501004451886,
      "config_entry_setup": 12.068986087993835
    }
  },
  "data": {
    "version": 1,
    "ieee": "**REDACTED**",
    "nwk": "0xFDB2",
    "manufacturer": "_TZE204_ca3i8m8p",
    "model": "TS0601",
    "friendly_manufacturer": "_TZE204_ca3i8m8p",
    "friendly_model": "TS0601",
    "name": "_TZE204_ca3i8m8p TS0601",
    "quirk_applied": true,
    "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
    "exposes_features": [],
    "manufacturer_code": 4098,
    "power_source": "Mains",
    "lqi": 92,
    "rssi": -88,
    "last_seen": "2026-05-04T19:20:27.285410+00:00",
    "available": true,
    "device_type": "Router",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "Router",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 142,
      "manufacturer_code": 4098,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 82,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 82,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "SMART_PLUG",
          "id": 81
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0001",
                "name": "app_version",
                "zcl_type": "uint8",
                "value": 69
              },
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "_TZE204_ca3i8m8p"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "TS0601"
              }
            ]
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x0005",
            "endpoint_attribute": "scenes",
            "attributes": []
          },
          {
            "cluster_id": "0x0201",
            "endpoint_attribute": "thermostat",
            "attributes": [
              {
                "id": "0x001b",
                "name": "ctrl_sequence_of_oper",
                "zcl_type": "enum8",
                "value": 2
              },
              {
                "id": "0x0000",
                "name": "local_temperature",
                "zcl_type": "int16",
                "value": 1800
              },
              {
                "id": "0x0012",
                "name": "occupied_heating_setpoint",
                "zcl_type": "int16",
                "value": 1550
              },
              {
                "id": "0x0008",
                "name": "pi_heating_demand",
                "zcl_type": "uint8",
                "unsupported": true
              },
              {
                "id": "0x0029",
                "name": "running_state",
                "zcl_type": "map16",
                "value": 0
              },
              {
                "id": "0x0030",
                "name": "setpoint_change_source",
                "zcl_type": "enum8",
                "unsupported": true
              },
              {
                "id": "0x0032",
                "name": "setpoint_change_source_timestamp",
                "zcl_type": "UTC",
                "unsupported": true
              },
              {
                "id": "0x001c",
                "name": "system_mode",
                "zcl_type": "enum8",
                "value": 4
              }
            ]
          },
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": "tuya_manufacturer",
            "attributes": [
              {
                "id": "0xef2c",
                "name": "backlight",
                "zcl_type": "uint8",
                "value": 50
              },
              {
                "id": "0xef28",
                "name": "child_lock",
                "zcl_type": "bool",
                "value": 0
              },
              {
                "id": "0xef22",
                "name": "humidity",
                "zcl_type": "uint16",
                "value": 60
              },
              {
                "id": "0xef00",
                "name": "mcu_version",
                "zcl_type": "uint48",
                "value": "3.0.5"
              },
              {
                "id": "0xef78",
                "name": "sensor_error",
                "zcl_type": "enum8",
                "value": 2
              }
            ]
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0006",
            "endpoint_attribute": "on_off",
            "attributes": []
          },
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 69
              }
            ],
            "last_query_cmd": {
              "manufacturer_code": 4098,
              "image_type": 5634,
              "current_file_version": 69,
              "hardware_version": null
            }
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "_TZE204_ca3i8m8p",
      "model": "TS0601",
      "node_desc": {
        "logical_type": 1,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 142,
        "manufacturer_code": 4098,
        "maximum_buffer_size": 82,
        "maximum_incoming_transfer_size": 82,
        "server_mask": 11264,
        "maximum_outgoing_transfer_size": 82,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0051",
          "input_clusters": [
            "0x0000",
            "0x0004",
            "0x0005",
            "0xef00"
          ],
          "output_clusters": [
            "0x0019",
            "0x000a",
            "0x0003",
            "0x0006"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "class_name": "Opening",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "opening",
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OnOffClientClusterHandler",
                "generic_id": "cluster_handler_0x0006_client",
                "endpoint_id": 1,
                "cluster": {
                  "id": 6,
                  "name": "On/Off",
                  "type": "client"
                },
                "id": "1:0x0006_client",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "on_off"
          },
          "state": {
            "class_name": "Opening",
            "available": true,
            "state": false
          }
        }
      ],
      "climate": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "climate",
            "class_name": "Thermostat",
            "translation_key": "thermostat",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": true,
            "cluster_handlers": [
              {
                "class_name": "ThermostatClusterHandler",
                "generic_id": "cluster_handler_0x0201",
                "endpoint_id": 1,
                "cluster": {
                  "id": 513,
                  "name": "EngoThermostat",
                  "type": "server"
                },
                "id": "1:0x0201",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "local_temperature"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "max_temp": 30.0,
            "min_temp": 7.0,
            "supported_features": 385,
            "fan_modes": null,
            "preset_modes": [],
            "hvac_modes": [
              "off",
              "heat"
            ]
          },
          "state": {
            "class_name": "Thermostat",
            "available": true,
            "current_temperature": 18.0,
            "outdoor_temperature": null,
            "target_temperature": 15.5,
            "target_temperature_high": null,
            "target_temperature_low": null,
            "hvac_action": "idle",
            "hvac_mode": "heat",
            "preset_mode": "none",
            "fan_mode": "auto",
            "system_mode": "[<SystemMode.Heat: 4>]/heat",
            "occupancy": null,
            "occupied_cooling_setpoint": null,
            "occupied_heating_setpoint": 1550,
            "pi_heating_demand": null,
            "pi_cooling_demand": null,
            "unoccupied_cooling_setpoint": null,
            "unoccupied_heating_setpoint": null
          },
          "extra_state_attributes": [
            "occupancy",
            "occupied_cooling_setpoint",
            "occupied_heating_setpoint",
            "pi_cooling_demand",
            "pi_heating_demand",
            "system_mode",
            "unoccupied_cooling_setpoint",
            "unoccupied_heating_setpoint"
          ]
        }
      ],
      "number": [
        {
          "info_object": {
            "fallback_name": "Backlight",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "NumberConfigurationEntity",
            "translation_key": "backlight",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "auto",
            "native_max_value": 100,
            "native_min_value": 0,
            "native_step": 1,
            "native_unit_of_measurement": null
          },
          "state": {
            "class_name": "NumberConfigurationEntity",
            "available": true,
            "state": 50
          }
        }
      ],
      "select": [
        {
          "info_object": {
            "fallback_name": "Sensor error",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "select",
            "class_name": "ZCLEnumSelectEntity",
            "translation_key": "sensor_error",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "enum": "EngoSensorError",
            "options": [
              "Normal",
              "E1",
              "E2"
            ]
          },
          "state": {
            "class_name": "ZCLEnumSelectEntity",
            "available": true,
            "state": "E2"
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 92
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -88
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "ThermostatHVACAction",
            "translation_key": "hvac_action",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "ThermostatClusterHandler",
                "generic_id": "cluster_handler_0x0201",
                "endpoint_id": 1,
                "cluster": {
                  "id": 513,
                  "name": "EngoThermostat",
                  "type": "server"
                },
                "id": "1:0x0201",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "local_temperature"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "ThermostatHVACAction",
            "available": true,
            "state": "idle"
          }
        },
        {
          "info_object": {
            "fallback_name": "Humidity",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Sensor",
            "translation_key": "humidity",
            "translation_placeholders": null,
            "device_class": "humidity",
            "state_class": "measurement",
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "%"
          },
          "state": {
            "class_name": "Sensor",
            "available": true,
            "state": 60
          }
        }
      ],
      "switch": [
        {
          "info_object": {
            "fallback_name": "Child lock",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "switch",
            "class_name": "ConfigurableAttributeSwitch",
            "translation_key": "child_lock",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "child_lock",
            "invert_attribute_name": null,
            "force_inverted": false,
            "off_value": 0,
            "on_value": 1
          },
          "state": {
            "class_name": "ConfigurableAttributeSwitch",
            "available": true,
            "state": false,
            "inverted": false
          }
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OtaClientClusterHandler",
                "generic_id": "cluster_handler_0x0019_client",
                "endpoint_id": 1,
                "cluster": {
                  "id": 25,
                  "name": "Ota",
                  "type": "client"
                },
                "id": "1:0x0019_client",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x00000045",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```

```
{
  "home_assistant": {
    "installation_type": "Home Assistant OS",
    "version": "2026.4.4",
    "dev": false,
    "hassio": true,
    "virtualenv": false,
    "python_version": "3.14.2",
    "docker": true,
    "arch": "aarch64",
    "timezone": "Europe/Dublin",
    "os_name": "Linux",
    "os_version": "6.12.75-haos-raspi",
    "container_arch": "aarch64",
    "supervisor": "2026.04.2",
    "host_os": "Home Assistant OS 17.2",
    "docker_version": "29.3.1",
    "chassis": "embedded",
    "run_as_root": true
  },
  "custom_components": {
    "mammotion": {
      "documentation": "https://github.com/mikey0000/Mammotion-HA/wiki",
      "version": "0.5.35",
      "requirements": [
        "pymammotion==0.7.93"
      ]
    },
    "hacs": {
      "documentation": "https://hacs.xyz/docs/use/",
      "version": "2.0.5",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    },
    "robovac": {
      "documentation": "https://github.com/damacus/robovac",
      "version": "2.3.0-beta.1",
      "requirements": []
    },
    "sigen": {
      "documentation": "https://github.com/TypQxQ/Sigenergy-Local-Modbus",
      "version": "1.2.3",
      "requirements": [
        "pymodbus>=3.8.3"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==1.1.2",
      "serialx==0.6.2"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 8.205600897781551e-05
    },
    "01KAGMJ72F5HRMJCHAEKYR3C3F": {
      "wait_import_platforms": -0.020859501004451886,
      "config_entry_setup": 12.068986087993835
    }
  },
  "data": {
    "version": 1,
    "ieee": "**REDACTED**",
    "nwk": "0x612F",
    "manufacturer": "_TZE204_glk6viwg",
    "model": "TS0601",
    "friendly_manufacturer": "_TZE204_glk6viwg",
    "friendly_model": "TS0601",
    "name": "_TZE204_glk6viwg TS0601",
    "quirk_applied": true,
    "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
    "exposes_features": [],
    "manufacturer_code": 4098,
    "power_source": "Mains",
    "lqi": 96,
    "rssi": -87,
    "last_seen": "2026-05-04T19:20:38.507502+00:00",
    "available": true,
    "device_type": "Router",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "Router",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 142,
      "manufacturer_code": 4098,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 82,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 82,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "SMART_PLUG",
          "id": 81
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0001",
                "name": "app_version",
                "zcl_type": "uint8",
                "value": 69
              },
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "_TZE204_glk6viwg"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "TS0601"
              }
            ]
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x0005",
            "endpoint_attribute": "scenes",
            "attributes": []
          },
          {
            "cluster_id": "0x0201",
            "endpoint_attribute": "thermostat",
            "attributes": [
              {
                "id": "0x001b",
                "name": "ctrl_sequence_of_oper",
                "zcl_type": "enum8",
                "value": 2
              },
              {
                "id": "0x0000",
                "name": "local_temperature",
                "zcl_type": "int16",
                "value": 1750
              },
              {
                "id": "0x0012",
                "name": "occupied_heating_setpoint",
                "zcl_type": "int16",
                "value": 1500
              },
              {
                "id": "0x0008",
                "name": "pi_heating_demand",
                "zcl_type": "uint8",
                "unsupported": true
              },
              {
                "id": "0x0029",
                "name": "running_state",
                "zcl_type": "map16",
                "value": 0
              },
              {
                "id": "0x0030",
                "name": "setpoint_change_source",
                "zcl_type": "enum8",
                "unsupported": true
              },
              {
                "id": "0x0032",
                "name": "setpoint_change_source_timestamp",
                "zcl_type": "UTC",
                "unsupported": true
              },
              {
                "id": "0x001c",
                "name": "system_mode",
                "zcl_type": "enum8",
                "value": 4
              }
            ]
          },
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": "tuya_manufacturer",
            "attributes": [
              {
                "id": "0xef2c",
                "name": "backlight",
                "zcl_type": "uint8",
                "value": 50
              },
              {
                "id": "0xef28",
                "name": "child_lock",
                "zcl_type": "bool",
                "value": 1
              },
              {
                "id": "0xef00",
                "name": "mcu_version",
                "zcl_type": "uint48",
                "value": "0.2.1"
              },
              {
                "id": "0xef78",
                "name": "sensor_error",
                "zcl_type": "enum8",
                "value": 0
              }
            ]
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0006",
            "endpoint_attribute": "on_off",
            "attributes": []
          },
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 69
              }
            ],
            "last_query_cmd": {
              "manufacturer_code": 4098,
              "image_type": 5634,
              "current_file_version": 69,
              "hardware_version": null
            }
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "_TZE204_glk6viwg",
      "model": "TS0601",
      "node_desc": {
        "logical_type": 1,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 142,
        "manufacturer_code": 4098,
        "maximum_buffer_size": 82,
        "maximum_incoming_transfer_size": 82,
        "server_mask": 11264,
        "maximum_outgoing_transfer_size": 82,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0051",
          "input_clusters": [
            "0x0000",
            "0x0004",
            "0x0005",
            "0xef00"
          ],
          "output_clusters": [
            "0x0019",
            "0x000a",
            "0x0003",
            "0x0006"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "class_name": "Opening",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "opening",
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OnOffClientClusterHandler",
                "generic_id": "cluster_handler_0x0006_client",
                "endpoint_id": 1,
                "cluster": {
                  "id": 6,
                  "name": "On/Off",
                  "type": "client"
                },
                "id": "1:0x0006_client",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "on_off"
          },
          "state": {
            "class_name": "Opening",
            "available": true,
            "state": false
          }
        }
      ],
      "climate": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "climate",
            "class_name": "Thermostat",
            "translation_key": "thermostat",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": true,
            "cluster_handlers": [
              {
                "class_name": "ThermostatClusterHandler",
                "generic_id": "cluster_handler_0x0201",
                "endpoint_id": 1,
                "cluster": {
                  "id": 513,
                  "name": "EngoThermostat",
                  "type": "server"
                },
                "id": "1:0x0201",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "local_temperature"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "max_temp": 30.0,
            "min_temp": 7.0,
            "supported_features": 385,
            "fan_modes": null,
            "preset_modes": [],
            "hvac_modes": [
              "off",
              "heat"
            ]
          },
          "state": {
            "class_name": "Thermostat",
            "available": true,
            "current_temperature": 17.5,
            "outdoor_temperature": null,
            "target_temperature": 15.0,
            "target_temperature_high": null,
            "target_temperature_low": null,
            "hvac_action": "idle",
            "hvac_mode": "heat",
            "preset_mode": "none",
            "fan_mode": "auto",
            "system_mode": "[<SystemMode.Heat: 4>]/heat",
            "occupancy": null,
            "occupied_cooling_setpoint": null,
            "occupied_heating_setpoint": 1500,
            "pi_heating_demand": null,
            "pi_cooling_demand": null,
            "unoccupied_cooling_setpoint": null,
            "unoccupied_heating_setpoint": null
          },
          "extra_state_attributes": [
            "occupancy",
            "occupied_cooling_setpoint",
            "occupied_heating_setpoint",
            "pi_cooling_demand",
            "pi_heating_demand",
            "system_mode",
            "unoccupied_cooling_setpoint",
            "unoccupied_heating_setpoint"
          ]
        }
      ],
      "number": [
        {
          "info_object": {
            "fallback_name": "Backlight",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "NumberConfigurationEntity",
            "translation_key": "backlight",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "auto",
            "native_max_value": 100,
            "native_min_value": 0,
            "native_step": 1,
            "native_unit_of_measurement": null
          },
          "state": {
            "class_name": "NumberConfigurationEntity",
            "available": true,
            "state": 50
          }
        }
      ],
      "select": [
        {
          "info_object": {
            "fallback_name": "Sensor error",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "select",
            "class_name": "ZCLEnumSelectEntity",
            "translation_key": "sensor_error",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "enum": "EngoSensorError",
            "options": [
              "Normal",
              "E1",
              "E2"
            ]
          },
          "state": {
            "class_name": "ZCLEnumSelectEntity",
            "available": true,
            "state": "Normal"
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 96
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -87
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "ThermostatHVACAction",
            "translation_key": "hvac_action",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "ThermostatClusterHandler",
                "generic_id": "cluster_handler_0x0201",
                "endpoint_id": 1,
                "cluster": {
                  "id": 513,
                  "name": "EngoThermostat",
                  "type": "server"
                },
                "id": "1:0x0201",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "local_temperature"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "ThermostatHVACAction",
            "available": true,
            "state": "idle"
          }
        }
      ],
      "switch": [
        {
          "info_object": {
            "fallback_name": "Child lock",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "switch",
            "class_name": "ConfigurableAttributeSwitch",
            "translation_key": "child_lock",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "TuyaClusterHandler",
                "generic_id": "cluster_handler_0xef00",
                "endpoint_id": 1,
                "cluster": {
                  "id": 61184,
                  "name": "Tuya Manufacturer Specific",
                  "type": "server"
                },
                "id": "1:0xef00",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "child_lock",
            "invert_attribute_name": null,
            "force_inverted": false,
            "off_value": 0,
            "on_value": 1
          },
          "state": {
            "class_name": "ConfigurableAttributeSwitch",
            "available": true,
            "state": true,
            "inverted": false
          }
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OtaClientClusterHandler",
                "generic_id": "cluster_handler_0x0019_client",
                "endpoint_id": 1,
                "cluster": {
                  "id": 25,
                  "name": "Ota",
                  "type": "client"
                },
                "id": "1:0x0019_client",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x00000045",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```

## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached