### PR TITLE
Prevent battery entity creation for frient Electricity Meter Interface 2, P1 (EMIZB-151)

### DIFF
--- a/zhaquirks/develco/emi_p1.py
+++ b/zhaquirks/develco/emi_p1.py
@@ -1,6 +1,7 @@
 """Frient Electricity Meter Interface P1 variant."""
 
 from zigpy.quirks.v2 import QuirkBuilder
+from zhaquirks import PowerConfigurationCluster
 
 (
     QuirkBuilder("frient A/S", "EMIZB-151")
@@ -11,5 +12,10 @@ from zigpy.quirks.v2 import QuirkBuilder
     .prevent_default_entity_creation(endpoint_id=65)
     .prevent_default_entity_creation(endpoint_id=66)
     .prevent_default_entity_creation(endpoint_id=67)
+    # No need for battery entity as the device is powered from the meter.
+    .prevent_default_entity_creation(
+        endpoint_id=2,
+        cluster_id=PowerConfigurationCluster.cluster_id,
+    )
     .add_to_registry()
 )

--- a/zhaquirks/develco/emi_p1.py
+++ b/zhaquirks/develco/emi_p1.py
@@ -1,6 +1,7 @@
 """Frient Electricity Meter Interface P1 variant."""
 
 from zigpy.quirks.v2 import QuirkBuilder
+
 from zhaquirks import PowerConfigurationCluster
 
 (


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The quirk has been made to prevent battery entity creation for frient Electricity Meter Interface 2, P1 with model no. EMIZB-151 as the device is powered by the meters it is connected to.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
<img width="989" height="1214" alt="p1 after change" src="https://github.com/user-attachments/assets/eaee1549-c354-4e70-864b-a4f9efc94ea3" />


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-01KJYXWD9VV3FMNDJEFN115MC4-frient A_S EMIZB-151-59e8e84e3362f818451ca1156959f0ee.json](https://github.com/user-attachments/files/27467836/zha-01KJYXWD9VV3FMNDJEFN115MC4-frient.A_S.EMIZB-151-59e8e84e3362f818451ca1156959f0ee.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
