### PR TITLE
Add Tuya soil sensor _TZE284_0ints6wl variant

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -270,6 +270,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE284_awepdiwi", "TS0601")  # Solar powered
     .applies_to("_TZE284_33bwcga2", "TS0601")  # iHseno
     .applies_to("_TZE284_tgrzpqf4", "TS0601")
+    .applies_to("_TZE284_0ints6wl", "TS0601")
     .tuya_temperature(dp_id=5, scale=10)
     .tuya_battery(dp_id=15)
     .tuya_soil_moisture(dp_id=3)


### PR DESCRIPTION
## Proposed change

Add support for model TS0601 by _TZE284_0ints6wl, as it does not provide temperature, soil moisture and battery information correctly in Home Assistant. 

Similar to Pull request #4896

## Additional information

This is sold as "Zigbee Soil Moisture Sensor Meter Temperature Humidity Light Tester For Tuya Smart Life Z2M Home Assistant Automation" from Aliexpress: https://www.aliexpress.com/item/1005010168958171.html where I choose the "4in1 zigbee Tuya" version

I have not managed to make the Illumination sensor work yet

<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics

Zigbee device signature before quirk:
```
{
  "node_descriptor": {
    "logical_type": 2,
    "complex_descriptor_available": 0,
    "user_descriptor_available": 0,
    "reserved": 0,
    "aps_flags": 0,
    "frequency_band": 8,
    "mac_capability_flags": 128,
    "manufacturer_code": 4417,
    "maximum_buffer_size": 66,
    "maximum_incoming_transfer_size": 66,
    "server_mask": 10752,
    "maximum_outgoing_transfer_size": 66,
    "descriptor_capability_field": 0
  },
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0051",
      "input_clusters": [
        "0x0000",
        "0x0004",
        "0x0005",
        "0xed00",
        "0xef00"
      ],
      "output_clusters": [
        "0x000a",
        "0x0019"
      ]
    }
  },
  "manufacturer": "_TZE284_0ints6wl",
  "model": "TS0601",
  "class": "zigpy.device.Device"
}
```

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
