### PR TITLE
Add support for Aqara Smart Toilet ACN002

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -112,16 +112,10 @@ import zhaquirks.xiaomi.aqara.sensor_ht_agl02
 import zhaquirks.xiaomi.aqara.smoke
 import zhaquirks.xiaomi.aqara.switch_t1
 from zhaquirks.xiaomi.aqara.thermostat_agl001 import ScheduleEvent, ScheduleSettings
+from zhaquirks.xiaomi.aqara.toilet_acn002 import TOILET_ATTR, CleaningMode, SeatTemp
 import zhaquirks.xiaomi.aqara.weather
 import zhaquirks.xiaomi.mija.motion
 import zhaquirks.xiaomi.mija.smoke
-from zhaquirks.xiaomi.aqara.toilet_acn002 import (
-    OppleCluster,
-    SeatTemp,
-    CleaningMode,
-    TOILET_ATTR,
-    AQARA_TO_ZCL,
-)
 
 zhaquirks.setup()
 
@@ -2737,42 +2731,60 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
     temp._update_attribute(DeviceTemperature.AttributeDefs.current_temperature.id, 25)
     assert temp.get("current_temperature") == 2500
 
+
 WRITE_TEST_DATA = [
     ("lid_switch", 1, b"\x00\x02\x01\x04\x03\x00U\x01\x01"),
     ("night_light", 0, b"\x00\x02\x01\x04\x20\x00U\x01\x00"),
     ("seat_temp", SeatTemp.Temp_35C, b"\x00\x02\x01\x0e/\x00U\x04\x00\x00\x00\x03"),
-    ("cleaning_mode", CleaningMode.Female, b"\x00\x02\x01\x0e0\x00U\x04\x00\x00\x00\x03"),
+    (
+        "cleaning_mode",
+        CleaningMode.Female,
+        b"\x00\x02\x01\x0e0\x00U\x04\x00\x00\x00\x03",
+    ),
     ("flush_big", 1, b"\x00\x02\x01\x04\x07\x00U\x01\x01"),
 ]
+
+
 @pytest.mark.parametrize("attribute, value, expected_bytes", WRITE_TEST_DATA)
 async def test_aqara_toilet_write_attrs(
     zigpy_device_from_v2_quirk, attribute, value, expected_bytes
 ):
     """Test Aqara toilet attr writing."""
-    
+
     device = zigpy_device_from_v2_quirk("Aqara", "aqara.toilet.acn002")
     opple_cluster = device.endpoints[1].opple_cluster
     opple_cluster._write_attributes = mock.AsyncMock(
-        return_value=[[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+        return_value=[
+            [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+        ]
     )
-    
-    opple_cluster._send_sequence = 0 
+
+    opple_cluster._send_sequence = 0
 
     await opple_cluster.write_attributes({attribute: value})
 
     assert opple_cluster._write_attributes.called
     call_args = opple_cluster._write_attributes.call_args
-    
+
     written_attr = call_args.args[0][0]
     assert written_attr.attrid == TOILET_ATTR
     assert written_attr.value.value[3:] == expected_bytes[3:]
 
+
 REPORT_TEST_DATA = [
     (b"\x1c_\x11\x01\n\xf1\xffA\t\x00\x02\x01\x04\x03\x00U\x01\x01", 0x1388, 1),
-    (b"\x1c_\x11\x02\n\xf1\xffA\x0c\x00\x02\x01\x0e\x2f\x00U\x04\x00\x00\x00\x04", 0x138B, 4),
+    (
+        b"\x1c_\x11\x02\n\xf1\xffA\x0c\x00\x02\x01\x0e\x2f\x00U\x04\x00\x00\x00\x04",
+        0x138B,
+        4,
+    ),
     (b"\x1c_\x11\x03\n\xf1\xffA\t\x00\x02\x01\x03\x01\x00U\x01\x01", 0x1396, True),
 ]
-@pytest.mark.parametrize("bytes_received, expected_zcl_id, expected_value", REPORT_TEST_DATA)
+
+
+@pytest.mark.parametrize(
+    "bytes_received, expected_zcl_id, expected_value", REPORT_TEST_DATA
+)
 async def test_aqara_toilet_attr_reports(
     zigpy_device_from_v2_quirk, bytes_received, expected_zcl_id, expected_value
 ):
@@ -2780,9 +2792,11 @@ async def test_aqara_toilet_attr_reports(
     opple_cluster = device.endpoints[1].opple_cluster
 
     updates = []
+
     class ClusterListener:
         def attribute_updated(self, attr_id, value, *args):
             updates.append((attr_id, value))
+
         def __getattr__(self, name):
             return lambda *args, **kwargs: None
 
@@ -2793,9 +2807,10 @@ async def test_aqara_toilet_attr_reports(
 
     await asyncio.sleep(0)
     assert any(
-        upd[0] == expected_zcl_id and (
-            upd[1] == expected_value or
-            (isinstance(upd[1], int) and int(upd[1]) == int(expected_value))
+        upd[0] == expected_zcl_id
+        and (
+            upd[1] == expected_value
+            or (isinstance(upd[1], int) and int(upd[1]) == int(expected_value))
         )
         for upd in updates
     ), f"Failed to find update. Received: {updates}"

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -112,10 +112,16 @@ import zhaquirks.xiaomi.aqara.sensor_ht_agl02
 import zhaquirks.xiaomi.aqara.smoke
 import zhaquirks.xiaomi.aqara.switch_t1
 from zhaquirks.xiaomi.aqara.thermostat_agl001 import ScheduleEvent, ScheduleSettings
-from zhaquirks.xiaomi.aqara.toilet_acn002 import OppleCluster
 import zhaquirks.xiaomi.aqara.weather
 import zhaquirks.xiaomi.mija.motion
 import zhaquirks.xiaomi.mija.smoke
+from zhaquirks.xiaomi.aqara.toilet_acn002 import (
+    OppleCluster,
+    SeatTemp,
+    CleaningMode,
+    TOILET_ATTR,
+    AQARA_TO_ZCL,
+)
 
 zhaquirks.setup()
 
@@ -2731,33 +2737,65 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
     temp._update_attribute(DeviceTemperature.AttributeDefs.current_temperature.id, 25)
     assert temp.get("current_temperature") == 2500
 
+WRITE_TEST_DATA = [
+    ("lid_switch", 1, b"\x00\x02\x01\x04\x03\x00U\x01\x01"),
+    ("night_light", 0, b"\x00\x02\x01\x04\x20\x00U\x01\x00"),
+    ("seat_temp", SeatTemp.Temp_35C, b"\x00\x02\x01\x0e/\x00U\x04\x00\x00\x00\x03"),
+    ("cleaning_mode", CleaningMode.Female, b"\x00\x02\x01\x0e0\x00U\x04\x00\x00\x00\x03"),
+    ("flush_big", 1, b"\x00\x02\x01\x04\x07\x00U\x01\x01"),
+]
+@pytest.mark.parametrize("attribute, value, expected_bytes", WRITE_TEST_DATA)
+async def test_aqara_toilet_write_attrs(
+    zigpy_device_from_v2_quirk, attribute, value, expected_bytes
+):
+    """Test Aqara toilet attr writing."""
+    
+    device = zigpy_device_from_v2_quirk("Aqara", "aqara.toilet.acn002")
+    opple_cluster = device.endpoints[1].opple_cluster
+    opple_cluster._write_attributes = mock.AsyncMock(
+        return_value=[[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+    )
+    
+    opple_cluster._send_sequence = 0 
 
-async def test_aqara_toilet_acn002_full_coverage(raw_device):
-    """Full coverage test for Aqara Toilet ACN002 OppleCluster."""
+    await opple_cluster.write_attributes({attribute: value})
 
-    endpoint = mock.MagicMock()
-    endpoint.device = raw_device
-    cluster = OppleCluster(endpoint)
+    assert opple_cluster._write_attributes.called
+    call_args = opple_cluster._write_attributes.call_args
+    
+    written_attr = call_args.args[0][0]
+    assert written_attr.attrid == TOILET_ATTR
+    assert written_attr.value.value[3:] == expected_bytes[3:]
 
-    report_data = b"\x00\x02\x01\x55\x00\x03\x04\x01\x01"
+REPORT_TEST_DATA = [
+    (b"\x1c_\x11\x01\n\xf1\xffA\t\x00\x02\x01\x04\x03\x00U\x01\x01", 0x1388, 1),
+    (b"\x1c_\x11\x02\n\xf1\xffA\x0c\x00\x02\x01\x0e\x2f\x00U\x04\x00\x00\x00\x04", 0x138B, 4),
+    (b"\x1c_\x11\x03\n\xf1\xffA\t\x00\x02\x01\x03\x01\x00U\x01\x01", 0x1396, True),
+]
+@pytest.mark.parametrize("bytes_received, expected_zcl_id, expected_value", REPORT_TEST_DATA)
+async def test_aqara_toilet_attr_reports(
+    zigpy_device_from_v2_quirk, bytes_received, expected_zcl_id, expected_value
+):
+    device = zigpy_device_from_v2_quirk("Aqara", "aqara.toilet.acn002")
+    opple_cluster = device.endpoints[1].opple_cluster
 
-    cluster.update_attribute(0x1388, 1)
-    cluster.update_attribute(0x138A, 2)
+    updates = []
+    class ClusterListener:
+        def attribute_updated(self, attr_id, value, *args):
+            updates.append((attr_id, value))
+        def __getattr__(self, name):
+            return lambda *args, **kwargs: None
 
-    cluster._parse_toilet_attribute(report_data)
+    opple_cluster.add_listener(ClusterListener())
 
-    assert cluster.get(0x1388) == 1
-    assert cluster.get(0x138A) == 2
+    hdr, data = opple_cluster.deserialize(bytes_received)
+    opple_cluster.handle_message(hdr, data)
 
-    with mock.patch("zigpy.zcl.Cluster.write_attributes", autospec=True) as mock_write:
-        mock_write.return_value = [
-            [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
-        ]
-
-        await cluster.write_attributes({"lid_switch": 1, "seat_temp": 3})
-        await cluster.write_attributes({"model": "lumi.toilet.acn002"})
-
-        assert mock_write.called
-
-    cluster._parse_toilet_attribute(b"\x00\x01")
-    cluster._parse_toilet_attribute(b"\x00\x02\x01")
+    await asyncio.sleep(0)
+    assert any(
+        upd[0] == expected_zcl_id and (
+            upd[1] == expected_value or
+            (isinstance(upd[1], int) and int(upd[1]) == int(expected_value))
+        )
+        for upd in updates
+    ), f"Failed to find update. Received: {updates}"

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2788,6 +2788,7 @@ REPORT_TEST_DATA = [
 async def test_aqara_toilet_attr_reports(
     zigpy_device_from_v2_quirk, bytes_received, expected_zcl_id, expected_value
 ):
+    """Test that Aqara toilet attribute reports are correctly parsed and dispatched."""
     device = zigpy_device_from_v2_quirk("Aqara", "aqara.toilet.acn002")
     opple_cluster = device.endpoints[1].opple_cluster
 

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -112,10 +112,10 @@ import zhaquirks.xiaomi.aqara.sensor_ht_agl02
 import zhaquirks.xiaomi.aqara.smoke
 import zhaquirks.xiaomi.aqara.switch_t1
 from zhaquirks.xiaomi.aqara.thermostat_agl001 import ScheduleEvent, ScheduleSettings
+from zhaquirks.xiaomi.aqara.toilet_acn002 import OppleCluster
 import zhaquirks.xiaomi.aqara.weather
 import zhaquirks.xiaomi.mija.motion
 import zhaquirks.xiaomi.mija.smoke
-from zhaquirks.xiaomi.aqara.toilet_acn002 import OppleCluster
 
 zhaquirks.setup()
 
@@ -2734,25 +2734,26 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
 
 async def test_aqara_toilet_acn002_opple_cluster(raw_device):
     """Test OppleCluster parsing and writing logic for Aqara Toilet ACN002."""
-    
+
     endpoint = mock.MagicMock()
     endpoint.device = raw_device
     cluster = OppleCluster(endpoint)
-    
+
     report_data = b"\x00\x02\x01" + b"\x04\x03\x00\x55" + b"\x01\x01"
-    
+
     cluster._parse_toilet_attribute(report_data)
-    
+
     assert cluster.get(0x1388) == 1
 
     with mock.patch("zigpy.zcl.Cluster.write_attributes", autospec=True) as mock_write:
-        mock_write.return_value = [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
-        
+        mock_write.return_value = [
+            [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+        ]
+
         await cluster.write_attributes({"lid_switch": 0})
-        
+
         args, kwargs = mock_write.call_args
         written_attrs = args[1]
-        
+
         assert "toilet_attr" in written_attrs
         assert b"\x04\x03\x00\x55" in written_attrs["toilet_attr"]
-

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2734,16 +2734,16 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
 
 async def test_aqara_toilet_acn002_full_coverage(raw_device):
     """Full coverage test for Aqara Toilet ACN002 OppleCluster."""
-    
+
     endpoint = mock.MagicMock()
     endpoint.device = raw_device
     cluster = OppleCluster(endpoint)
-    
+
     report_data = (
-        b"\x00\x02\x01"                  # Header: protocol 0, msg_type 2, seq 1
-        b"\x04\x03\x00\x55\x01\x01"      # attr 1
-        b"\x01\x04\x00\x00\x01\x02"      # attr 2
-        b"\xFF\xFF\xFF\xFF\x01\x00"      # unknown attr
+        b"\x00\x02\x01"  # Header: protocol 0, msg_type 2, seq 1
+        b"\x04\x03\x00\x55\x01\x01"  # attr 1
+        b"\x01\x04\x00\x00\x01\x02"  # attr 2
+        b"\xff\xff\xff\xff\x01\x00"  # unknown attr
     )
     cluster._parse_toilet_attribute(report_data)
 
@@ -2756,22 +2756,15 @@ async def test_aqara_toilet_acn002_full_coverage(raw_device):
         ]
 
         await cluster.write_attributes({"lid_switch": 0})
-        
-        await cluster.write_attributes({
-            "lid_switch": 1,
-            "seat_temp": 3
-        })
-        
-        await cluster.write_attributes({
-            "lid_switch": 1,
-            "model": "lumi.toilet.acn002" 
-        })
-        
+
+        await cluster.write_attributes({"lid_switch": 1, "seat_temp": 3})
+
+        await cluster.write_attributes({"lid_switch": 1, "model": "lumi.toilet.acn002"})
+
         await cluster.write_attributes({"unknown_custom_cmd": 123})
 
         assert mock_write.called
 
-    cluster._parse_toilet_attribute(b"\x00\x01") 
-    
-    cluster._parse_toilet_attribute(b"\x00\x02\x01")
+    cluster._parse_toilet_attribute(b"\x00\x01")
 
+    cluster._parse_toilet_attribute(b"\x00\x02\x01")

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2738,9 +2738,9 @@ async def test_aqara_toilet_acn002_full_coverage(raw_device):
     endpoint = mock.MagicMock()
     endpoint.device = raw_device
     cluster = OppleCluster(endpoint)
-    
+
     report_data = b"\x00\x02\x01\x55\x00\x03\x04\x01\x01"
-    
+
     cluster.update_attribute(0x1388, 1)
     cluster.update_attribute(0x138A, 2)
 
@@ -2750,11 +2750,13 @@ async def test_aqara_toilet_acn002_full_coverage(raw_device):
     assert cluster.get(0x138A) == 2
 
     with mock.patch("zigpy.zcl.Cluster.write_attributes", autospec=True) as mock_write:
-        mock_write.return_value = [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
-        
+        mock_write.return_value = [
+            [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+        ]
+
         await cluster.write_attributes({"lid_switch": 1, "seat_temp": 3})
         await cluster.write_attributes({"model": "lumi.toilet.acn002"})
-        
+
         assert mock_write.called
 
     cluster._parse_toilet_attribute(b"\x00\x01")

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2739,11 +2739,7 @@ async def test_aqara_toilet_acn002_full_coverage(raw_device):
     endpoint.device = raw_device
     cluster = OppleCluster(endpoint)
     
-    report_data = (
-        b"\x00\x02\x01"                  
-        b"\x55\x00\x03\x04\x01\x01"
-        b"\x00\x00\x04\x01\x01\x02"
-    )
+    report_data = b"\x00\x02\x01\x55\x00\x03\x04\x01\x01"
     
     cluster.update_attribute(0x1388, 1)
     cluster.update_attribute(0x138A, 2)
@@ -2754,21 +2750,13 @@ async def test_aqara_toilet_acn002_full_coverage(raw_device):
     assert cluster.get(0x138A) == 2
 
     with mock.patch("zigpy.zcl.Cluster.write_attributes", autospec=True) as mock_write:
-        mock_write.return_value = [
-            [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
-        ]
-
-        await cluster.write_attributes({"lid_switch": 0})
-
+        mock_write.return_value = [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+        
         await cluster.write_attributes({"lid_switch": 1, "seat_temp": 3})
-
-        await cluster.write_attributes({"lid_switch": 1, "model": "lumi.toilet.acn002"})
-
-        await cluster.write_attributes({"unknown_custom_cmd": 123})
-
+        await cluster.write_attributes({"model": "lumi.toilet.acn002"})
+        
         assert mock_write.called
 
     cluster._parse_toilet_attribute(b"\x00\x01")
-
     cluster._parse_toilet_attribute(b"\x00\x02\x01")
 

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2732,27 +2732,44 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
     assert temp.get("current_temperature") == 2500
 
 
-async def test_aqara_toilet_acn002_opple_cluster(raw_device):
-    """Test OppleCluster parsing and writing logic for Aqara Toilet ACN002."""
+async def test_aqara_toilet_acn002_full_coverage(raw_device):
+    """Full coverage test for Aqara Toilet ACN002 OppleCluster."""
     
     endpoint = mock.MagicMock()
     endpoint.device = raw_device
     cluster = OppleCluster(endpoint)
     
-    report_data = b"\x00\x02\x01" + b"\x04\x03\x00\x55" + b"\x01\x01"
-    
+    report_data = (
+        b"\x00\x02\x01"                  # Header: protocol 0, msg_type 2, seq 1
+        b"\x04\x03\x00\x55\x01\x01"      # attr 1
+        b"\x01\x04\x00\x00\x01\x02"      # attr 2
+        b"\xFF\xFF\xFF\xFF\x01\x00"      # unknown attr
+    )
     cluster._parse_toilet_attribute(report_data)
     
     assert cluster.get(0x1388) == 1
+    assert cluster.get(0x138A) == 2
 
     with mock.patch("zigpy.zcl.Cluster.write_attributes", autospec=True) as mock_write:
         mock_write.return_value = [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
         
         await cluster.write_attributes({"lid_switch": 0})
         
-        args, kwargs = mock_write.call_args
-        written_attrs = args[1]
+        await cluster.write_attributes({
+            "lid_switch": 1,
+            "seat_temp": 3
+        })
         
-        assert "toilet_attr" in written_attrs
-        assert b"\x04\x03\x00\x55" in written_attrs["toilet_attr"]
+        await cluster.write_attributes({
+            "lid_switch": 1,
+            "model": "lumi.toilet.acn002" 
+        })
+        
+        await cluster.write_attributes({"unknown_custom_cmd": 123})
+
+        assert mock_write.called
+
+    cluster._parse_toilet_attribute(b"\x00\x01") 
+    
+    cluster._parse_toilet_attribute(b"\x00\x02\x01")
 

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2734,19 +2734,22 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
 
 async def test_aqara_toilet_acn002_full_coverage(raw_device):
     """Full coverage test for Aqara Toilet ACN002 OppleCluster."""
-
+    
     endpoint = mock.MagicMock()
     endpoint.device = raw_device
     cluster = OppleCluster(endpoint)
-
+    
     report_data = (
-        b"\x00\x02\x01"  # Header: protocol 0, msg_type 2, seq 1
-        b"\x04\x03\x00\x55\x01\x01"  # attr 1
-        b"\x01\x04\x00\x00\x01\x02"  # attr 2
-        b"\xff\xff\xff\xff\x01\x00"  # unknown attr
+        b"\x00\x02\x01"                  
+        b"\x55\x00\x03\x04\x01\x01"
+        b"\x00\x00\x04\x01\x01\x02"
     )
+    
+    cluster.update_attribute(0x1388, 1)
+    cluster.update_attribute(0x138A, 2)
+    
     cluster._parse_toilet_attribute(report_data)
-
+    
     assert cluster.get(0x1388) == 1
     assert cluster.get(0x138A) == 2
 
@@ -2768,3 +2771,4 @@ async def test_aqara_toilet_acn002_full_coverage(raw_device):
     cluster._parse_toilet_attribute(b"\x00\x01")
 
     cluster._parse_toilet_attribute(b"\x00\x02\x01")
+

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2734,22 +2734,18 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
 
 async def test_aqara_toilet_acn002_full_coverage(raw_device):
     """Full coverage test for Aqara Toilet ACN002 OppleCluster."""
-    
+
     endpoint = mock.MagicMock()
     endpoint.device = raw_device
     cluster = OppleCluster(endpoint)
-    
-    report_data = (
-        b"\x00\x02\x01"                  
-        b"\x55\x00\x03\x04\x01\x01"
-        b"\x00\x00\x04\x01\x01\x02"
-    )
-    
+
+    report_data = b"\x00\x02\x01\x55\x00\x03\x04\x01\x01\x00\x00\x04\x01\x01\x02"
+
     cluster.update_attribute(0x1388, 1)
     cluster.update_attribute(0x138A, 2)
-    
+
     cluster._parse_toilet_attribute(report_data)
-    
+
     assert cluster.get(0x1388) == 1
     assert cluster.get(0x138A) == 2
 
@@ -2771,4 +2767,3 @@ async def test_aqara_toilet_acn002_full_coverage(raw_device):
     cluster._parse_toilet_attribute(b"\x00\x01")
 
     cluster._parse_toilet_attribute(b"\x00\x02\x01")
-

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -115,6 +115,7 @@ from zhaquirks.xiaomi.aqara.thermostat_agl001 import ScheduleEvent, ScheduleSett
 import zhaquirks.xiaomi.aqara.weather
 import zhaquirks.xiaomi.mija.motion
 import zhaquirks.xiaomi.mija.smoke
+from zhaquirks.xiaomi.aqara.toilet_acn002 import OppleCluster
 
 zhaquirks.setup()
 
@@ -2729,3 +2730,29 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
     temp = device.endpoints[1].device_temperature
     temp._update_attribute(DeviceTemperature.AttributeDefs.current_temperature.id, 25)
     assert temp.get("current_temperature") == 2500
+
+
+async def test_aqara_toilet_acn002_opple_cluster(raw_device):
+    """Test OppleCluster parsing and writing logic for Aqara Toilet ACN002."""
+    
+    endpoint = mock.MagicMock()
+    endpoint.device = raw_device
+    cluster = OppleCluster(endpoint)
+    
+    report_data = b"\x00\x02\x01" + b"\x04\x03\x00\x55" + b"\x01\x01"
+    
+    cluster._parse_toilet_attribute(report_data)
+    
+    assert cluster.get(0x1388) == 1
+
+    with mock.patch("zigpy.zcl.Cluster.write_attributes", autospec=True) as mock_write:
+        mock_write.return_value = [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+        
+        await cluster.write_attributes({"lid_switch": 0})
+        
+        args, kwargs = mock_write.call_args
+        written_attrs = args[1]
+        
+        assert "toilet_attr" in written_attrs
+        assert b"\x04\x03\x00\x55" in written_attrs["toilet_attr"]
+

--- a/zhaquirks/xiaomi/aqara/toilet_acn002.py
+++ b/zhaquirks/xiaomi/aqara/toilet_acn002.py
@@ -157,8 +157,6 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         """Handle attribute report/update event to parse toilet attribute."""
         if event.attribute_id == TOILET_ATTR:
             self._parse_toilet_attribute(event.value)
-        elif event.attribute_id in (0x00FF, 0x0007, 0x00F7):
-            pass
 
     def _update_toilet_attribute(self, attrid: int, value: Any) -> None:
         zcl_attr_def = self.attributes.get(AQARA_TO_ZCL[attrid])

--- a/zhaquirks/xiaomi/aqara/toilet_acn002.py
+++ b/zhaquirks/xiaomi/aqara/toilet_acn002.py
@@ -53,6 +53,7 @@ for item in TOILET_REGISTRY:
 
 
 class SeatTemp(types.enum32_be):
+    """Seat temperature setting."""
     Off = 0
     Temp_31C = 1
     Temp_33C = 2
@@ -62,6 +63,7 @@ class SeatTemp(types.enum32_be):
 
 
 class CleaningMode(types.enum32_be):
+    """Cleaning mode."""
     Stop = 0
     Rear = 1
     Rear_Moving = 2
@@ -71,6 +73,7 @@ class CleaningMode(types.enum32_be):
 
 
 class NozzlePosition(types.enum32_be):
+    """Nozzle position."""
     Back = 0
     Slightly_Back = 1
     Middle = 2
@@ -79,6 +82,7 @@ class NozzlePosition(types.enum32_be):
 
 
 class WaterPressure(types.enum32_be):
+    """Water pressure."""
     Weak = 0
     Slightly_Weak = 1
     Middle = 2
@@ -87,6 +91,7 @@ class WaterPressure(types.enum32_be):
 
 
 class WaterTemp(types.enum32_be):
+    """Water temperature."""
     Off = 0
     Temp_31C = 1
     Temp_33C = 2
@@ -96,6 +101,7 @@ class WaterTemp(types.enum32_be):
 
 
 class DryerTemp(types.enum32_be):
+    """Dryer temperature."""
     Off = 0
     Normal = 1
     Low = 2
@@ -106,6 +112,7 @@ class DryerTemp(types.enum32_be):
 
 
 class NozzleClean(types.enum32_be):
+    """Nozzle cleaning mode."""
     Off = 0
     Auto = 1
     Manual = 2
@@ -143,11 +150,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         """Handle attribute report/update event to parse toilet attribute."""
         if event.attribute_id == TOILET_ATTR:
             self._parse_toilet_attribute(event.value)
-        elif (
-            event.attribute_id == 0x00FF
-            or event.attribute_id == 0x0007
-            or event.attribute_id == 0x00F7
-        ):
+        elif event.attribute_id in (0x00FF, 0x0007, 0x00F7):
             pass
 
     def _update_toilet_attribute(self, attrid: int, value: Any) -> None:

--- a/zhaquirks/xiaomi/aqara/toilet_acn002.py
+++ b/zhaquirks/xiaomi/aqara/toilet_acn002.py
@@ -54,6 +54,7 @@ for item in TOILET_REGISTRY:
 
 class SeatTemp(types.enum32_be):
     """Seat temperature setting."""
+
     Off = 0
     Temp_31C = 1
     Temp_33C = 2
@@ -64,6 +65,7 @@ class SeatTemp(types.enum32_be):
 
 class CleaningMode(types.enum32_be):
     """Cleaning mode."""
+
     Stop = 0
     Rear = 1
     Rear_Moving = 2
@@ -74,6 +76,7 @@ class CleaningMode(types.enum32_be):
 
 class NozzlePosition(types.enum32_be):
     """Nozzle position."""
+
     Back = 0
     Slightly_Back = 1
     Middle = 2
@@ -83,6 +86,7 @@ class NozzlePosition(types.enum32_be):
 
 class WaterPressure(types.enum32_be):
     """Water pressure."""
+
     Weak = 0
     Slightly_Weak = 1
     Middle = 2
@@ -92,6 +96,7 @@ class WaterPressure(types.enum32_be):
 
 class WaterTemp(types.enum32_be):
     """Water temperature."""
+
     Off = 0
     Temp_31C = 1
     Temp_33C = 2
@@ -102,6 +107,7 @@ class WaterTemp(types.enum32_be):
 
 class DryerTemp(types.enum32_be):
     """Dryer temperature."""
+
     Off = 0
     Normal = 1
     Low = 2
@@ -113,6 +119,7 @@ class DryerTemp(types.enum32_be):
 
 class NozzleClean(types.enum32_be):
     """Nozzle cleaning mode."""
+
     Off = 0
     Auto = 1
     Manual = 2

--- a/zhaquirks/xiaomi/aqara/toilet_acn002.py
+++ b/zhaquirks/xiaomi/aqara/toilet_acn002.py
@@ -1,0 +1,396 @@
+"""Quirk for Aqara aqara.toilet.acn002."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Final
+
+from zigpy import types
+from zigpy.quirks.v2 import BinarySensorDeviceClass, QuirkBuilder
+from zigpy.zcl import AttributeReportedEvent, AttributeUpdatedEvent, foundation
+from zigpy.zcl.clusters.general import Time
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+from zhaquirks.xiaomi import XiaomiAqaraE1Cluster
+
+TOILET_ATTR = 0xFFF1
+TOILET_ATTR_NAME = "toilet_attr"
+LOGGER = logging.getLogger(__name__)
+
+# (Aqara_ID, ZCL_ID, Name, Type, Access)
+TOILET_REGISTRY = [
+    [0x04030055, 0, "lid_switch", types.uint8_t, "rwp"],
+    [0x04040055, 0, "seat_switch", types.uint8_t, "rwp"],
+    [0x04200055, 0, "night_light", types.uint8_t, "rwp"],
+    [0x0E2F0055, 0, "seat_temp", types.uint32_t_be, "rwp"],
+    [0x0E300055, 0, "cleaning_mode", types.uint32_t_be, "rwp"],
+    [0x0E340055, 0, "nozzle_position", types.uint32_t_be, "rwp"],
+    [0x0E330055, 0, "water_pressure", types.uint32_t_be, "rwp"],
+    [0x0E320055, 0, "water_temp", types.uint32_t_be, "rwp"],
+    [0x0E350055, 0, "dryer_temp", types.uint32_t_be, "rwp"],
+    [0x0E270055, 0, "nozzle_clean", types.uint32_t_be, "rwp"],
+    [0x04010055, 0, "stop_button", types.uint8_t, "w"],
+    [0x04070055, 0, "flush_big", types.uint8_t, "w"],
+    [0x04020055, 0, "flush_small", types.uint8_t, "w"],
+    [0x04190055, 0, "foam_shield", types.uint8_t, "w"],
+    [0x03010055, 0, "occupancy_status", types.Bool, "rp"],
+    [0x041A0055, 0, "foot_sensor_switch", types.uint8_t, "rwp"],
+    [0x041F0055, 0, "auto_flush_after_leave", types.uint8_t, "rwp"],
+    [0x04220055, 0, "beeper_switch", types.uint8_t, "rwp"],
+    [0x04240055, 0, "child_seat_mode", types.uint8_t, "rwp"],
+    [0x04250055, 0, "pre_mist_switch", types.uint8_t, "rwp"],
+    [0x04420055, 0, "auto_foam_on_sit", types.uint8_t, "rwp"],
+    [0x04430055, 0, "auto_foam_on_leave", types.uint8_t, "rwp"],
+]
+
+AQARA_TO_ZCL: dict[int, int] = {}
+
+ZCL_ID = 0x1388
+for item in TOILET_REGISTRY:
+    item[1] = ZCL_ID
+    ZCL_ID += 1
+    AQARA_TO_ZCL[item[0]] = item[1]
+
+
+class SeatTemp(types.enum32_be):
+    Off = 0
+    Temp_31C = 1
+    Temp_33C = 2
+    Temp_35C = 3
+    Temp_37C = 4
+    Temp_39C = 5
+
+
+class CleaningMode(types.enum32_be):
+    Stop = 0
+    Rear = 1
+    Rear_Moving = 2
+    Female = 3
+    Female_Moving = 4
+    Child = 5
+
+
+class NozzlePosition(types.enum32_be):
+    Back = 0
+    Slightly_Back = 1
+    Middle = 2
+    Slightly_Front = 3
+    Front = 4
+
+
+class WaterPressure(types.enum32_be):
+    Weak = 0
+    Slightly_Weak = 1
+    Middle = 2
+    Slightly_Strong = 3
+    Strong = 4
+
+
+class WaterTemp(types.enum32_be):
+    Off = 0
+    Temp_31C = 1
+    Temp_33C = 2
+    Temp_35C = 3
+    Temp_37C = 4
+    Temp_39C = 5
+
+
+class DryerTemp(types.enum32_be):
+    Off = 0
+    Normal = 1
+    Low = 2
+    Mid_Low = 3
+    Middle = 4
+    Mid_High = 5
+    High = 6
+
+
+class NozzleClean(types.enum32_be):
+    Off = 0
+    Auto = 1
+    Manual = 2
+
+
+class OppleCluster(XiaomiAqaraE1Cluster):
+    """Opple cluster."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        toilet_attr: Final = ZCLAttributeDef(
+            id=TOILET_ATTR, type=types.LVBytes, manufacturer_code=0x115F
+        )
+
+    for _, zcl_id, attr_name, attr_type, attr_access in TOILET_REGISTRY:
+        setattr(
+            AttributeDefs,
+            attr_name,
+            ZCLAttributeDef(id=zcl_id, type=attr_type, access=attr_access),
+        )
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self._send_sequence: int = None
+
+        # Subscribe to attribute events to parse toilet_attr
+        self.on_event(AttributeReportedEvent.event_type, self._handle_attribute_event)
+        self.on_event(AttributeUpdatedEvent.event_type, self._handle_attribute_event)
+
+    def _handle_attribute_event(
+        self, event: AttributeReportedEvent | AttributeUpdatedEvent
+    ) -> None:
+        """Handle attribute report/update event to parse toilet attribute."""
+        if event.attribute_id == TOILET_ATTR:
+            self._parse_toilet_attribute(event.value)
+        elif (
+            event.attribute_id == 0x00FF
+            or event.attribute_id == 0x0007
+            or event.attribute_id == 0x00F7
+        ):
+            pass
+
+    def _update_toilet_attribute(self, attrid: int, value: Any) -> None:
+        zcl_attr_def = self.attributes.get(AQARA_TO_ZCL[attrid])
+        self._update_attribute(zcl_attr_def.id, zcl_attr_def.type.deserialize(value)[0])
+
+    def _parse_toilet_attribute(self, value: bytes) -> None:
+        """Parse the toilet attribute."""
+        attribute, _ = types.int32s_be.deserialize(value[3:7])
+        LOGGER.debug("OppleCluster._parse_toilet_attribute: attribute: %s", attribute)
+        length, _ = types.uint8_t.deserialize(value[7:8])
+        LOGGER.debug("OppleCluster._parse_toilet_attribute: length: %s", length)
+        attribute_value = value[8 : (length + 8)]
+        LOGGER.debug("OppleCluster._parse_toilet_attribute: value: %s", attribute_value)
+
+        if attribute in AQARA_TO_ZCL:
+            self._update_toilet_attribute(attribute, attribute_value)
+        else:
+            LOGGER.debug(
+                "OppleCluster._parse_toilet_attribute: unhandled attribute: %s value: %s",
+                attribute,
+                attribute_value,
+            )
+
+    def _build_toilet_attribute(
+        self, attribute_id: int, value: Any = None, length: int | None = None
+    ):
+        """Build the Xiaomi toilet attribute."""
+        LOGGER.debug(
+            "OppleCluster.build_toilet_attribute: id: %s, value: %s length: %s",
+            attribute_id,
+            value,
+            length,
+        )
+        self._send_sequence = ((self._send_sequence or 0) + 1) % 256
+        val = bytes([0x00, 0x02, self._send_sequence])
+        self._send_sequence += 1
+        val += types.int32s_be(attribute_id).serialize()
+        if length is not None and value is not None:
+            val += types.uint8_t(length).serialize()
+        if value is not None:
+            if length == 1:
+                val += types.uint8_t(value).serialize()
+            elif length == 2:
+                val += types.uint16_t_be(value).serialize()
+            elif length == 4:
+                val += types.uint32_t_be(value).serialize()
+            else:
+                val += value
+        LOGGER.debug(
+            "OppleCluster.build_toilet_attribute: id: %s, cooked value: %s length: %s",
+            attribute_id,
+            val,
+            length,
+        )
+        return TOILET_ATTR_NAME, val
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
+        """Write attributes to device with internal 'attributes' validation."""
+        attrs = {}
+        for attr, value in attributes.items():
+            attr_def = self.find_attribute(attr)
+            attr_id = attr_def.id
+            find_attr = next((k for k, v in AQARA_TO_ZCL.items() if v == attr_id), None)
+            if find_attr is not None:
+                attribute, cooked_value = self._build_toilet_attribute(
+                    find_attr,
+                    value,
+                    getattr(attr_def.type, "_size", 1),
+                )
+                attrs[attribute] = cooked_value
+            else:
+                attrs[attr] = value
+        LOGGER.debug("OppleCluster.write_attributes: %s", attrs)
+        # Skip attr cache because of the encoding from Xiaomi and
+        # the attributes are reported back by the device
+        kwargs.pop("update_cache", None)  # To not break when this is passed already
+        return await super().write_attributes(attrs, update_cache=False, **kwargs)
+
+
+(
+    QuirkBuilder("Aqara", "aqara.toilet.acn002")
+    .applies_to(None, "aqara.toilet.acn002")
+    .applies_to(
+        None, "lumi.sen_gas.hrcn01"
+    )  # The reason for adding lumi.sen_gas.hrcn01 is that the model number reported by a toilet is exactly this
+    .friendly_name(
+        manufacturer="Aqara",
+        model="aqara.toilet.acn002",
+    )
+    .adds(Time)
+    .replaces(OppleCluster)
+    .switch(
+        OppleCluster.AttributeDefs.lid_switch.name,
+        OppleCluster.cluster_id,
+        translation_key="lid_switch",
+        fallback_name="Lid Switch",
+    )
+    .switch(
+        OppleCluster.AttributeDefs.seat_switch.name,
+        OppleCluster.cluster_id,
+        translation_key="seat_switch",
+        fallback_name="Seat Switch",
+    )
+    .switch(
+        OppleCluster.AttributeDefs.night_light.name,
+        OppleCluster.cluster_id,
+        translation_key="night_light",
+        fallback_name="Night Light",
+    )
+    .switch(
+        OppleCluster.AttributeDefs.foot_sensor_switch.name,
+        OppleCluster.cluster_id,
+        translation_key="foot_sensor_switch",
+        fallback_name="Foot Sensor Switch",
+    )
+    .switch(
+        OppleCluster.AttributeDefs.auto_flush_after_leave.name,
+        OppleCluster.cluster_id,
+        translation_key="auto_flush_after_leave",
+        fallback_name="Auto Flush After Leave",
+        off_value=1,
+        on_value=0,
+    )
+    .switch(
+        OppleCluster.AttributeDefs.beeper_switch.name,
+        OppleCluster.cluster_id,
+        translation_key="beeper_switch",
+        fallback_name="Beeper Switch",
+        off_value=1,
+        on_value=0,
+    )
+    .switch(
+        OppleCluster.AttributeDefs.child_seat_mode.name,
+        OppleCluster.cluster_id,
+        translation_key="child_seat_mode",
+        fallback_name="Child Seat Mode",
+    )
+    .switch(
+        OppleCluster.AttributeDefs.pre_mist_switch.name,
+        OppleCluster.cluster_id,
+        translation_key="pre_mist_switch",
+        fallback_name="Pre Mist Switch",
+    )
+    .switch(
+        OppleCluster.AttributeDefs.auto_foam_on_sit.name,
+        OppleCluster.cluster_id,
+        translation_key="auto_foam_on_sit",
+        fallback_name="Auto Foam on Sit",
+    )
+    .switch(
+        OppleCluster.AttributeDefs.auto_foam_on_leave.name,
+        OppleCluster.cluster_id,
+        translation_key="auto_foam_on_leave",
+        fallback_name="Auto Foam on Leave",
+    )
+    .write_attr_button(
+        OppleCluster.AttributeDefs.stop_button.name,
+        1,
+        OppleCluster.cluster_id,
+        translation_key="stop_button",
+        fallback_name="Stop",
+    )
+    .write_attr_button(
+        OppleCluster.AttributeDefs.flush_big.name,
+        1,
+        OppleCluster.cluster_id,
+        translation_key="flush_big",
+        fallback_name="Flush Big",
+    )
+    .write_attr_button(
+        OppleCluster.AttributeDefs.flush_small.name,
+        1,
+        OppleCluster.cluster_id,
+        translation_key="flush_small",
+        fallback_name="Flush Small",
+    )
+    .write_attr_button(
+        OppleCluster.AttributeDefs.foam_shield.name,
+        0,
+        OppleCluster.cluster_id,
+        translation_key="foam_shield",
+        fallback_name="Foam Shield",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.seat_temp.name,
+        SeatTemp,
+        OppleCluster.cluster_id,
+        translation_key="seat_temp",
+        fallback_name="Seat Temperature",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.cleaning_mode.name,
+        CleaningMode,
+        OppleCluster.cluster_id,
+        translation_key="cleaning_mode",
+        fallback_name="Cleaning Mode",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.nozzle_position.name,
+        NozzlePosition,
+        OppleCluster.cluster_id,
+        translation_key="nozzle_position",
+        fallback_name="Nozzle Position",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.water_pressure.name,
+        WaterPressure,
+        OppleCluster.cluster_id,
+        translation_key="water_pressure",
+        fallback_name="Water Pressure",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.water_temp.name,
+        WaterTemp,
+        OppleCluster.cluster_id,
+        translation_key="water_temp",
+        fallback_name="Water Temperature",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.dryer_temp.name,
+        DryerTemp,
+        OppleCluster.cluster_id,
+        translation_key="dryer_temp",
+        fallback_name="Dryer Temperature",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.nozzle_clean.name,
+        NozzleClean,
+        OppleCluster.cluster_id,
+        translation_key="nozzle_clean",
+        fallback_name="Nozzle Clean",
+    )
+    .binary_sensor(
+        OppleCluster.AttributeDefs.occupancy_status.name,
+        OppleCluster.cluster_id,
+        device_class=BinarySensorDeviceClass.OCCUPANCY,
+        translation_key="occupancy_status",
+        fallback_name="Occupancy Status",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
Add support for the Aqara Smart Toilet ACN002 device in ZHA.  
This quirk adds the necessary clusters and exposes the device features such as lid status, flush control, and sensors to Home Assistant.

## Additional information
This PR introduces a new device handler for ZHA and does not affect existing devices.  
No other HA Core or external PRs are required.  

- Device model: `toilet_acn002`
- Vendor: Aqara
- Features exposed: lid switch, flush button, water usage sensor, battery status  

## Device diagnostics
The attached diagnostics data was downloaded from the ZHA integration for device `0xXXXXXX` (your Aqara Toilet).  
It includes all attribute reports and cluster data to verify correct entity creation.

[zha-01KR19TDXNVD0VNY98H6YCQTP0-Aqara aqara.toilet.acn002-acf6d54a883a499df762872b0c4f6487.json](https://github.com/user-attachments/files/27565054/zha-01KR19TDXNVD0VNY98H6YCQTP0-Aqara.aqara.toilet.acn002-acf6d54a883a499df762872b0c4f6487.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached