### PR TITLE
Add Shelly Gen4 WiFi setup cluster

### DIFF
--- a/tests/test_shelly.py
+++ b/tests/test_shelly.py
@@ -12,7 +12,6 @@ from zigpy.zcl.foundation import ZCLAttributeAccess
 from zhaquirks.shelly.wifi import (
     SHELLY_MANUFACTURER_CODE,
     SHELLY_WIFI_SETUP_CLUSTER_ID,
-    SHELLY_WIFI_SETUP_DEVICE_TYPE,
     SHELLY_WIFI_SETUP_ENDPOINT_ID,
     SHELLY_WIFI_SETUP_PROFILE_ID,
     ShellyCustomProfileDevice,
@@ -63,14 +62,6 @@ def test_shelly_wifi_setup_cluster_replaced(zigpy_device_from_v2_quirk, model) -
     ]
 
     assert isinstance(quirked, ShellyCustomProfileDevice)
-    assert (
-        quirked.endpoints[SHELLY_WIFI_SETUP_ENDPOINT_ID].profile_id
-        == SHELLY_WIFI_SETUP_PROFILE_ID
-    )
-    assert (
-        quirked.endpoints[SHELLY_WIFI_SETUP_ENDPOINT_ID].device_type
-        == SHELLY_WIFI_SETUP_DEVICE_TYPE
-    )
     assert isinstance(cluster, ShellyWiFiSetupCluster)
     assert cluster.ep_attribute == "shelly_wifi_setup"
     assert cluster.find_attribute("status") == cluster.AttributeDefs.status

--- a/tests/test_shelly.py
+++ b/tests/test_shelly.py
@@ -3,8 +3,10 @@
 import asyncio
 
 import pytest
+from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.foundation import ZCLAttributeAccess
 
 from zhaquirks.shelly.wifi import (
@@ -122,3 +124,42 @@ def test_shelly_wifi_custom_profile_packet_processed(
     asyncio.run(deliver_packet())
 
     assert cluster.get("status") == "got ip"
+
+
+@pytest.mark.parametrize("model", ["1PM", "2PM"])
+def test_shelly_wifi_standard_profile_packet_delegated(
+    zigpy_device_from_v2_quirk, model
+) -> None:
+    """Ensure standard ZHA profile packets fall through to normal zigpy parsing."""
+
+    quirked = zigpy_device_from_v2_quirk(
+        "Shelly",
+        model,
+        endpoint_ids=[1, SHELLY_WIFI_SETUP_ENDPOINT_ID],
+        cluster_ids={
+            SHELLY_WIFI_SETUP_ENDPOINT_ID: {
+                SHELLY_WIFI_SETUP_CLUSTER_ID: ClusterType.Server,
+            }
+        },
+    )
+
+    # Standard ZHA profile packet should delegate to super()
+    zha_packet = t.ZigbeePacket(
+        profile_id=zha.PROFILE_ID,
+        cluster_id=Basic.cluster_id,
+        src_ep=1,
+        dst_ep=1,
+        data=t.SerializableBytes(
+            _attribute_report_data(
+                Basic.AttributeDefs.model,
+                t.CharacterString("1PM"),
+            )
+        ),
+    )
+
+    hdr, rsp_key = quirked._parse_packet_header(zha_packet)
+
+    assert hdr is not None
+    assert rsp_key is not None
+    assert rsp_key.endpoint_id == 1
+    assert rsp_key.cluster_id == Basic.cluster_id

--- a/tests/test_shelly.py
+++ b/tests/test_shelly.py
@@ -9,6 +9,7 @@ from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.foundation import ZCLAttributeAccess
 
+import zhaquirks
 from zhaquirks.shelly.wifi import (
     SHELLY_MANUFACTURER_CODE,
     SHELLY_WIFI_SETUP_CLUSTER_ID,
@@ -17,6 +18,8 @@ from zhaquirks.shelly.wifi import (
     ShellyCustomProfileDevice,
     ShellyWiFiSetupCluster,
 )
+
+zhaquirks.setup()
 
 
 def _attribute_report_data(

--- a/tests/test_shelly.py
+++ b/tests/test_shelly.py
@@ -1,0 +1,124 @@
+"""Tests for Shelly quirks."""
+
+import asyncio
+
+import pytest
+import zigpy.types as t
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.foundation import ZCLAttributeAccess
+
+from zhaquirks.shelly.wifi import (
+    SHELLY_MANUFACTURER_CODE,
+    SHELLY_WIFI_SETUP_CLUSTER_ID,
+    SHELLY_WIFI_SETUP_DEVICE_TYPE,
+    SHELLY_WIFI_SETUP_ENDPOINT_ID,
+    SHELLY_WIFI_SETUP_PROFILE_ID,
+    ShellyCustomProfileDevice,
+    ShellyWiFiSetupCluster,
+)
+
+
+def _attribute_report_data(
+    attribute: foundation.ZCLAttributeDef, value: object
+) -> bytes:
+    """Build a typed ZCL attribute report payload for Shelly WiFi attributes."""
+
+    header = foundation.ZCLHeader.general(
+        tsn=1,
+        command_id=foundation.GeneralCommand.Report_Attributes,
+        manufacturer=SHELLY_MANUFACTURER_CODE,
+        direction=foundation.Direction.Server_to_Client,
+    ).serialize()
+    response = foundation.Attribute(
+        attrid=attribute.id,
+        value=foundation.TypeValue(type=attribute.zcl_type, value=value),
+    )
+    command = (
+        foundation.GENERAL_COMMANDS[foundation.GeneralCommand.Report_Attributes]
+        .schema([response])
+        .serialize()
+    )
+    return t.SerializableBytes(header + command).serialize()
+
+
+@pytest.mark.parametrize("model", ["1PM", "2PM"])
+def test_shelly_wifi_setup_cluster_replaced(zigpy_device_from_v2_quirk, model) -> None:
+    """Ensure Shelly relay devices expose a typed WiFi setup cluster."""
+
+    quirked = zigpy_device_from_v2_quirk(
+        "Shelly",
+        model,
+        endpoint_ids=[1, SHELLY_WIFI_SETUP_ENDPOINT_ID],
+        cluster_ids={
+            SHELLY_WIFI_SETUP_ENDPOINT_ID: {
+                SHELLY_WIFI_SETUP_CLUSTER_ID: ClusterType.Server,
+            }
+        },
+    )
+
+    cluster = quirked.endpoints[SHELLY_WIFI_SETUP_ENDPOINT_ID].in_clusters[
+        SHELLY_WIFI_SETUP_CLUSTER_ID
+    ]
+
+    assert isinstance(quirked, ShellyCustomProfileDevice)
+    assert (
+        quirked.endpoints[SHELLY_WIFI_SETUP_ENDPOINT_ID].profile_id
+        == SHELLY_WIFI_SETUP_PROFILE_ID
+    )
+    assert (
+        quirked.endpoints[SHELLY_WIFI_SETUP_ENDPOINT_ID].device_type
+        == SHELLY_WIFI_SETUP_DEVICE_TYPE
+    )
+    assert isinstance(cluster, ShellyWiFiSetupCluster)
+    assert cluster.ep_attribute == "shelly_wifi_setup"
+    assert cluster.find_attribute("status") == cluster.AttributeDefs.status
+    assert cluster.find_attribute("ssid") == cluster.AttributeDefs.ssid
+    assert cluster.AttributeDefs.status.manufacturer_code == SHELLY_MANUFACTURER_CODE
+    assert cluster.AttributeDefs.dhcp.access == ZCLAttributeAccess.Read
+    assert cluster.AttributeDefs.enable.access == (
+        ZCLAttributeAccess.Read | ZCLAttributeAccess.Write
+    )
+    assert cluster.AttributeDefs.action.access == ZCLAttributeAccess.Write
+    assert cluster.AttributeDefs.action.type is t.uint8_t
+
+
+@pytest.mark.parametrize("model", ["1PM", "2PM"])
+def test_shelly_wifi_custom_profile_packet_processed(
+    zigpy_device_from_v2_quirk, model
+) -> None:
+    """Ensure Shelly custom profile packets are processed as ZCL for WiFi reads."""
+
+    quirked = zigpy_device_from_v2_quirk(
+        "Shelly",
+        model,
+        endpoint_ids=[1, SHELLY_WIFI_SETUP_ENDPOINT_ID],
+        cluster_ids={
+            SHELLY_WIFI_SETUP_ENDPOINT_ID: {
+                SHELLY_WIFI_SETUP_CLUSTER_ID: ClusterType.Server,
+            }
+        },
+    )
+
+    cluster = quirked.endpoints[SHELLY_WIFI_SETUP_ENDPOINT_ID].in_clusters[
+        SHELLY_WIFI_SETUP_CLUSTER_ID
+    ]
+
+    async def deliver_packet() -> None:
+        quirked.packet_received(
+            t.ZigbeePacket(
+                profile_id=SHELLY_WIFI_SETUP_PROFILE_ID,
+                cluster_id=SHELLY_WIFI_SETUP_CLUSTER_ID,
+                src_ep=SHELLY_WIFI_SETUP_ENDPOINT_ID,
+                dst_ep=SHELLY_WIFI_SETUP_ENDPOINT_ID,
+                data=t.SerializableBytes(
+                    _attribute_report_data(
+                        cluster.AttributeDefs.status,
+                        t.CharacterString("got ip"),
+                    )
+                ),
+            )
+        )
+
+    asyncio.run(deliver_packet())
+
+    assert cluster.get("status") == "got ip"

--- a/zhaquirks/shelly/wifi.py
+++ b/zhaquirks/shelly/wifi.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from zigpy.profiles import zha
+from zigpy.device import ResponseKey
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
 import zigpy.types as t
+from zigpy.zcl import foundation
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 SHELLY_MANUFACTURER_CODE = 0x1490
@@ -96,12 +97,21 @@ class ShellyWiFiSetupCluster(CustomCluster):
 class ShellyCustomProfileDevice(CustomDeviceV2):
     """Handle Shelly responses sent on their custom endpoint profile."""
 
-    def custom_profile_packet_received(self, packet: t.ZigbeePacket) -> None:
-        """Treat Shelly's custom profile packets as standard ZCL packets."""
+    def _parse_packet_header(
+        self, packet: t.ZigbeePacket
+    ) -> tuple[foundation.ZCLHeader, ResponseKey] | tuple[None, None]:
+        """Parse Shelly custom-profile packets as ZCL for normal zigpy matching."""
         if packet.profile_id != SHELLY_WIFI_SETUP_PROFILE_ID:
-            return super().custom_profile_packet_received(packet)
+            return super()._parse_packet_header(packet)
 
-        self.packet_received(packet.replace(profile_id=zha.PROFILE_ID))
+        hdr, _ = foundation.ZCLHeader.deserialize(packet.data.serialize())
+        rsp_key = ResponseKey(
+            endpoint_id=packet.src_ep,
+            cluster_id=packet.cluster_id,
+            direction=hdr.frame_control.direction,
+            tsn=hdr.tsn,
+        )
+        return hdr, rsp_key
 
 
 (

--- a/zhaquirks/shelly/wifi.py
+++ b/zhaquirks/shelly/wifi.py
@@ -12,7 +12,6 @@ from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 SHELLY_MANUFACTURER_CODE = 0x1490
 SHELLY_WIFI_SETUP_ENDPOINT_ID = 239
 SHELLY_WIFI_SETUP_PROFILE_ID = 0xC001
-SHELLY_WIFI_SETUP_DEVICE_TYPE = 0x2001
 SHELLY_WIFI_SETUP_CLUSTER_ID = 0xFC02
 
 
@@ -121,11 +120,6 @@ class ShellyCustomProfileDevice(CustomDeviceV2):
     .applies_to("Shelly", "Mini1")
     .applies_to("Shelly", "EM Mini")
     .device_class(ShellyCustomProfileDevice)
-    .replaces_endpoint(
-        SHELLY_WIFI_SETUP_ENDPOINT_ID,
-        profile_id=SHELLY_WIFI_SETUP_PROFILE_ID,
-        device_type=SHELLY_WIFI_SETUP_DEVICE_TYPE,
-    )
     .replaces(ShellyWiFiSetupCluster, endpoint_id=SHELLY_WIFI_SETUP_ENDPOINT_ID)
     .add_to_registry()
 )

--- a/zhaquirks/shelly/wifi.py
+++ b/zhaquirks/shelly/wifi.py
@@ -1,0 +1,118 @@
+"""Shelly WiFi setup cluster support."""
+
+from __future__ import annotations
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+SHELLY_MANUFACTURER_CODE = 0x1490
+SHELLY_WIFI_SETUP_ENDPOINT_ID = 239
+SHELLY_WIFI_SETUP_PROFILE_ID = 0xC001
+SHELLY_WIFI_SETUP_DEVICE_TYPE = 0x2001
+SHELLY_WIFI_SETUP_CLUSTER_ID = 0xFC02
+
+
+class ShellyWiFiSetupCluster(CustomCluster):
+    """Shelly WiFi setup cluster."""
+
+    cluster_id = SHELLY_WIFI_SETUP_CLUSTER_ID
+    name = "Shelly WiFi Setup"
+    ep_attribute = "shelly_wifi_setup"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Shelly WiFi setup attribute definitions."""
+
+        status = ZCLAttributeDef(
+            id=0x0000,
+            type=t.CharacterString,
+            access="r",
+            manufacturer_code=SHELLY_MANUFACTURER_CODE,
+        )
+        ip = ZCLAttributeDef(
+            id=0x0001,
+            type=t.CharacterString,
+            access="r",
+            manufacturer_code=SHELLY_MANUFACTURER_CODE,
+        )
+        action = ZCLAttributeDef(
+            id=0x0002,
+            type=t.uint8_t,
+            access="w",
+            manufacturer_code=SHELLY_MANUFACTURER_CODE,
+        )
+        dhcp = ZCLAttributeDef(
+            id=0x0003,
+            type=t.Bool,
+            access="r",
+            manufacturer_code=SHELLY_MANUFACTURER_CODE,
+        )
+        enable = ZCLAttributeDef(
+            id=0x0004,
+            type=t.Bool,
+            access="rw",
+            manufacturer_code=SHELLY_MANUFACTURER_CODE,
+        )
+        ssid = ZCLAttributeDef(
+            id=0x0005,
+            type=t.CharacterString,
+            access="rw",
+            manufacturer_code=SHELLY_MANUFACTURER_CODE,
+        )
+        password = ZCLAttributeDef(
+            id=0x0006,
+            type=t.CharacterString,
+            access="w",
+            manufacturer_code=SHELLY_MANUFACTURER_CODE,
+        )
+        static_ip = ZCLAttributeDef(
+            id=0x0007,
+            type=t.CharacterString,
+            access="rw",
+            manufacturer_code=SHELLY_MANUFACTURER_CODE,
+        )
+        netmask = ZCLAttributeDef(
+            id=0x0008,
+            type=t.CharacterString,
+            access="rw",
+            manufacturer_code=SHELLY_MANUFACTURER_CODE,
+        )
+        gateway = ZCLAttributeDef(
+            id=0x0009,
+            type=t.CharacterString,
+            access="rw",
+            manufacturer_code=SHELLY_MANUFACTURER_CODE,
+        )
+        nameserver = ZCLAttributeDef(
+            id=0x000A,
+            type=t.CharacterString,
+            access="rw",
+            manufacturer_code=SHELLY_MANUFACTURER_CODE,
+        )
+
+
+class ShellyCustomProfileDevice(CustomDeviceV2):
+    """Handle Shelly responses sent on their custom endpoint profile."""
+
+    def custom_profile_packet_received(self, packet: t.ZigbeePacket) -> None:
+        """Treat Shelly's custom profile packets as standard ZCL packets."""
+        if packet.profile_id != SHELLY_WIFI_SETUP_PROFILE_ID:
+            return super().custom_profile_packet_received(packet)
+
+        self.packet_received(packet.replace(profile_id=zha.PROFILE_ID))
+
+
+(
+    QuirkBuilder("Shelly", "1PM")
+    .applies_to("Shelly", "2PM")
+    .device_class(ShellyCustomProfileDevice)
+    .replaces_endpoint(
+        SHELLY_WIFI_SETUP_ENDPOINT_ID,
+        profile_id=SHELLY_WIFI_SETUP_PROFILE_ID,
+        device_type=SHELLY_WIFI_SETUP_DEVICE_TYPE,
+    )
+    .replaces(ShellyWiFiSetupCluster, endpoint_id=SHELLY_WIFI_SETUP_ENDPOINT_ID)
+    .add_to_registry()
+)

--- a/zhaquirks/shelly/wifi.py
+++ b/zhaquirks/shelly/wifi.py
@@ -117,6 +117,9 @@ class ShellyCustomProfileDevice(CustomDeviceV2):
 (
     QuirkBuilder("Shelly", "1PM")
     .applies_to("Shelly", "2PM")
+    .applies_to("Shelly", "Mini1PM")
+    .applies_to("Shelly", "Mini1")
+    .applies_to("Shelly", "EM Mini")
     .device_class(ShellyCustomProfileDevice)
     .replaces_endpoint(
         SHELLY_WIFI_SETUP_ENDPOINT_ID,


### PR DESCRIPTION
## Proposed change

Add a custom Shelly WiFi setup quirk for Shelly 1PM and 2PM devices.

This adds support for the manufacturer-specific WiFi setup cluster on endpoint 239 and maps it to a typed custom cluster instead of leaving it as an unknown manufacturer-specific cluster. The quirk also uses a custom device class to handle Shelly responses sent on custom profile `0xC001`, which allows ZHA to decode WiFi cluster attribute reads and writes correctly.


## Additional information

Shelly sends WiFi setup cluster traffic on endpoint 239 using a custom profile (`0xC001`). Without the custom device handling, zigpy ignores the replies before they reach normal ZCL decoding.

The `action` attribute is defined as `uint8_t` because the device rejects `enum8` writes with `INVALID_DATA_TYPE`.

This work directly addresses the Shelly WiFi Setup Cluster part of open issue #4125, [Device Support Request] Shelly 1 (PM) Gen 4 Specific Clusters, which explicitly calls out support for the manufacturer-specific Shelly clusters `0xFC01` and `0xFC02`. This PR adds typed support for the WiFi setup cluster (`0xFC02`) for Shelly 1PM and 2PM devices and handles the custom profile reply path that previously prevented those responses from being decoded.


## Device diagnostics

[zha-01K7SVMTH5C2G4KYQP1C177HE0-Shelly 1PM-d96b2a1622eecd723911b40997b30cb9.json](https://github.com/user-attachments/files/27603279/zha-01K7SVMTH5C2G4KYQP1C177HE0-Shelly.1PM-d96b2a1622eecd723911b40997b30cb9.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached