### PR TITLE
Intercept IKEA BILRESA triggers and replace ZHA events

### DIFF
--- a/tests/test_ikea.py
+++ b/tests/test_ikea.py
@@ -334,9 +334,7 @@ async def test_bilresa_direction_tracking(
         (0, None),  # unrecognised param — no double-press event emitted
     ],
 )
-async def test_bilresa_double_press(
-    zigpy_device_from_v2_quirk, param1, expected_event
-):
+async def test_bilresa_double_press(zigpy_device_from_v2_quirk, param1, expected_event):
     """Test IkeaBilresaScenesCluster emits the correct event on double-press."""
     device = zigpy_device_from_v2_quirk(
         IKEA,

--- a/tests/test_ikea.py
+++ b/tests/test_ikea.py
@@ -4,12 +4,12 @@ from unittest import mock
 
 import pytest
 from zigpy.zcl import ClusterType, foundation
-from zigpy.zcl.clusters.general import Basic, LevelControl, PowerConfiguration
+from zigpy.zcl.clusters.general import Basic, LevelControl, PowerConfiguration, Scenes
 from zigpy.zcl.clusters.measurement import PM25
 
 from tests.common import ClusterListener
 import zhaquirks
-from zhaquirks.ikea import IKEA, IkeaBilresaLevelControl
+from zhaquirks.ikea import IKEA, IkeaBilresaLevelControl, IkeaBilresaScenesCluster
 import zhaquirks.ikea.starkvind
 from zhaquirks.ikea.starkvind import IkeaAirpurifier
 
@@ -324,3 +324,37 @@ async def test_bilresa_direction_tracking(
             if c == mock.call(expected_event, [])
         ]
         assert len(release_calls) == 1
+
+
+@pytest.mark.parametrize(
+    "param1,expected_event",
+    [
+        (256, "double_press_dim_up"),
+        (257, "double_press_dim_down"),
+        (0, None),  # unrecognised param — no double-press event emitted
+    ],
+)
+async def test_bilresa_double_press(
+    zigpy_device_from_v2_quirk, param1, expected_event
+):
+    """Test IkeaBilresaScenesCluster emits the correct event on double-press."""
+    device = zigpy_device_from_v2_quirk(
+        IKEA,
+        "09B9",
+        cluster_ids={1: {Scenes.cluster_id: ClusterType.Client}},
+    )
+
+    scenes_cluster = device.endpoints[1].out_clusters[Scenes.cluster_id]
+    assert isinstance(scenes_cluster, IkeaBilresaScenesCluster)
+
+    listener = mock.MagicMock()
+    scenes_cluster.add_listener(listener)
+
+    hdr = foundation.ZCLHeader.cluster(tsn=1, command_id=0x0007)
+    scenes_cluster.handle_cluster_request(hdr, [param1, 13, 0])
+
+    if expected_event is None:
+        for call in listener.zha_send_event.call_args_list:
+            assert call[0][0] not in ("double_press_dim_up", "double_press_dim_down")
+    else:
+        listener.zha_send_event.assert_any_call(expected_event, [])

--- a/zhaquirks/ikea/__init__.py
+++ b/zhaquirks/ikea/__init__.py
@@ -53,6 +53,30 @@ class ScenesCluster(CustomCluster, Scenes):
         )
 
 
+class IkeaBilresaScenesCluster(ScenesCluster):
+    """Scenes cluster for BILRESA: emits distinct events for double-press up/down.
+
+    Replaces PARAMS-based matching (broken in ZHA's device trigger layer) with
+    named synthetic commands that match the no-params pattern used by long_release.
+    """
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: t.AddrMode | None = None,
+    ):
+        """Emit double_press_dim_up or double_press_dim_down on press command."""
+        if hdr.command_id == 0x0007 and args:  # press
+            param1 = args[0]
+            if param1 == 256:
+                self.listener_event(ZHA_SEND_EVENT, "double_press_dim_up", [])
+            elif param1 == 257:
+                self.listener_event(ZHA_SEND_EVENT, "double_press_dim_down", [])
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+
 class IkeaBilresaLevelControl(CustomCluster, LevelControl):
     """Custom LevelControl cluster for IKEA remotes to track direction."""
 
@@ -79,6 +103,8 @@ class IkeaBilresaLevelControl(CustomCluster, LevelControl):
         ):
             move_mode = args[0]
             self._last_move_direction = move_mode
+            event = "move_up_press" if move_mode == 0 else "move_down_press"
+            self.listener_event(ZHA_SEND_EVENT, event, [])
         elif (
             hdr.command_id
             in (

--- a/zhaquirks/ikea/bilresa2btn.py
+++ b/zhaquirks/ikea/bilresa2btn.py
@@ -7,26 +7,23 @@ from zigpy.zcl.clusters.general import LevelControl, OnOff, Scenes
 from zhaquirks.const import (
     CLUSTER_ID,
     COMMAND,
-    COMMAND_MOVE,
     COMMAND_OFF,
     COMMAND_ON,
-    COMMAND_PRESS,
     DIM_DOWN,
     DIM_UP,
     DOUBLE_PRESS,
     ENDPOINT_ID,
     LONG_PRESS,
     LONG_RELEASE,
-    PARAMS,
     SHORT_PRESS,
     TURN_OFF,
     TURN_ON,
 )
-from zhaquirks.ikea import IKEA, IkeaBilresaLevelControl, ScenesCluster
+from zhaquirks.ikea import IKEA, IkeaBilresaLevelControl, IkeaBilresaScenesCluster
 
 (
     QuirkBuilder(IKEA, "09B9")
-    .replaces(ScenesCluster, cluster_type=ClusterType.Client)
+    .replaces(IkeaBilresaScenesCluster, cluster_type=ClusterType.Client)
     .replace_cluster_occurrences(IkeaBilresaLevelControl)
     .device_automation_triggers(
         {
@@ -36,10 +33,9 @@ from zhaquirks.ikea import IKEA, IkeaBilresaLevelControl, ScenesCluster
                 ENDPOINT_ID: 1,
             },
             (LONG_PRESS, DIM_UP): {
-                COMMAND: COMMAND_MOVE,
+                COMMAND: "move_up_press",
                 CLUSTER_ID: LevelControl.cluster_id,
                 ENDPOINT_ID: 1,
-                PARAMS: {"move_mode": 0},
             },
             (LONG_RELEASE, DIM_UP): {
                 COMMAND: "move_up_release",
@@ -52,10 +48,9 @@ from zhaquirks.ikea import IKEA, IkeaBilresaLevelControl, ScenesCluster
                 ENDPOINT_ID: 1,
             },
             (LONG_PRESS, DIM_DOWN): {
-                COMMAND: COMMAND_MOVE,
+                COMMAND: "move_down_press",
                 CLUSTER_ID: LevelControl.cluster_id,
                 ENDPOINT_ID: 1,
-                PARAMS: {"move_mode": 1},
             },
             (LONG_RELEASE, DIM_DOWN): {
                 COMMAND: "move_down_release",
@@ -63,24 +58,14 @@ from zhaquirks.ikea import IKEA, IkeaBilresaLevelControl, ScenesCluster
                 ENDPOINT_ID: 1,
             },
             (DOUBLE_PRESS, DIM_UP): {
-                COMMAND: COMMAND_PRESS,
+                COMMAND: "double_press_dim_up",
                 CLUSTER_ID: Scenes.cluster_id,
                 ENDPOINT_ID: 1,
-                PARAMS: {
-                    "param1": 256,
-                    "param2": 13,
-                    "param3": 0,
-                },
             },
             (DOUBLE_PRESS, DIM_DOWN): {
-                COMMAND: COMMAND_PRESS,
+                COMMAND: "double_press_dim_down",
                 CLUSTER_ID: Scenes.cluster_id,
                 ENDPOINT_ID: 1,
-                PARAMS: {
-                    "param1": 257,
-                    "param2": 13,
-                    "param3": 0,
-                },
             },
         }
     )


### PR DESCRIPTION
## Proposed change

Fix `remote_button_long_press` and `remote_button_double_press` device triggers for the IKEA BILRESA 2-button remote (09B9) — both never fired, only `long_release` worked.

**`long_press` fix** (`IkeaBilresaLevelControl` in `zhaquirks/ikea/__init__.py`):
The cluster was intercepting `move`/`move_with_on_off` commands and storing direction state, but never emitting a ZHA event. Added `move_up_press` / `move_down_press` synthetic event emission in the move handler. Trigger map in `bilresa2btn.py` updated to match the new named commands (removing `PARAMS`).

**`double_press` fix** (`IkeaBilresaScenesCluster` in `zhaquirks/ikea/__init__.py`):
ZHA's device trigger layer cannot match triggers that require `PARAMS` due to a bug in HA core: `CommandSchema.as_dict()` includes an inherited `command` field not present in the quirk's `PARAMS` definition, causing voluptuous `PREVENT_EXTRA` to reject the event. A fix has been submitted to HA core in [home-assistant/core#170483](https://github.com/home-assistant/core/pull/170483).

As a workaround (and to support HA versions before that fix ships), `IkeaBilresaScenesCluster` emits `double_press_dim_up` / `double_press_dim_down` as param-free named events — the same no-`PARAMS` pattern already used by `long_release`. Once the core fix is merged and released, this class can be removed and `bilresa2btn.py` reverted to use `COMMAND_PRESS` + `PARAMS`.

## Additional information

Tested on real hardware (IKEA BILRESA 09B9, HA 2026.5.x, ZHA). All 8 device trigger types verified working after the fix.

## Device diagnostics

Not included — this PR fixes existing clusters for an existing quirk, no new device registration.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached