### PR TITLE
Add Aqara Wall Outlet H2 UK (lumi.plug.aeu002) quirk

### DIFF
--- a/tests/test_xiaomi_aqara_plug_aeu002.py
+++ b/tests/test_xiaomi_aqara_plug_aeu002.py
@@ -1,0 +1,45 @@
+"""Tests for the Aqara Wall Outlet H2 UK (lumi.plug.aeu002)."""
+
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+
+import zhaquirks
+import zhaquirks.xiaomi.aqara.plug_aeu002  # noqa: F401
+
+zhaquirks.setup()
+
+POWER_ID = ElectricalMeasurement.AttributeDefs.active_power.id
+VOLTAGE_ID = ElectricalMeasurement.AttributeDefs.rms_voltage.id
+
+
+async def test_active_power_scaled_x10_on_all_endpoints(zigpy_device_from_v2_quirk):
+    """active_power must be multiplied by 10 on EP1, EP2 and EP3."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.plug.aeu002", endpoint_ids=[1, 2, 3]
+    )
+
+    for ep_id in (1, 2, 3):
+        cluster = device.endpoints[ep_id].electrical_measurement
+        cluster.update_attribute(POWER_ID, 22)
+        assert cluster.get(POWER_ID) == 220
+
+
+async def test_non_power_attribute_passes_through(zigpy_device_from_v2_quirk):
+    """Attributes other than active_power must not be scaled."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.plug.aeu002", endpoint_ids=[1, 2, 3]
+    )
+
+    cluster = device.endpoints[1].electrical_measurement
+    cluster.update_attribute(VOLTAGE_ID, 240)
+    assert cluster.get(VOLTAGE_ID) == 240
+
+
+async def test_none_active_power_passes_through(zigpy_device_from_v2_quirk):
+    """None must not be multiplied (would TypeError on int * None)."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.plug.aeu002", endpoint_ids=[1, 2, 3]
+    )
+
+    cluster = device.endpoints[1].electrical_measurement
+    cluster.update_attribute(POWER_ID, None)
+    assert cluster.get(POWER_ID) is None

--- a/zhaquirks/xiaomi/aqara/plug_aeu002.py
+++ b/zhaquirks/xiaomi/aqara/plug_aeu002.py
@@ -1,0 +1,71 @@
+"""Aqara Wall Outlet H2 UK (WP-P09D / lumi.plug.aeu002).
+
+Dual-socket UK wall outlet with per-socket power monitoring. All three
+endpoints expose standard ZCL ElectricalMeasurement and report active_power
+10x too low, so this quirk multiplies the reported value by 10 on the way
+in.
+
+Endpoint mapping (switch and power endpoints do not align on this device):
+  EP1: switch=socket 1, power=total
+  EP2: switch=socket 2, power=socket 1 + USB
+  EP3: switch=USB,      power=socket 2
+
+The standard Aqara plug pattern (zhaquirks.xiaomi.ElectricalMeasurementCluster,
+a LocalDataCluster with ac_power_divisor=10) is not used here. That pattern
+assumes power arrives pre-scaled x10 via the Lumi proprietary cluster or
+AnalogInput, which then divides by 10 to net x1. This device emits power
+purely via standard ZCL on all three endpoints, so the LocalDataCluster
+would block the only path that carries readings.
+
+Using _CONSTANT_ATTRIBUTES to set ac_power_multiplier or ac_power_divisor
+on a plain CustomCluster was tested and produced no scaling change. The
+device appears to adjust its reporting scale based on what ZHA reads back
+from those attributes during cluster initialisation, creating a feedback
+loop. The _update_attribute override is the only approach that produced
+correct values, validated with a reference Athom smart plug across the
+3W-2500W range.
+
+The Xiaomi BasicCluster is retained on EP1 to handle the Xiaomi-specific
+attribute payload sent during device initialisation.
+"""
+
+from typing import Any
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+
+from zhaquirks.xiaomi import BasicCluster
+
+
+class AqaraH2UKElectricalMeasurement(CustomCluster, ElectricalMeasurement):
+    """ElectricalMeasurement that scales active_power x10.
+
+    Device reports active_power 10x too low via standard ZCL on all three
+    endpoints. Scaling validated against a reference plug across 3W-2500W.
+    """
+
+    def _update_attribute(
+        self, attrid: int | t.uint16_t | foundation.ZCLAttributeDef, value: Any
+    ) -> None:
+        """Multiply active_power by 10 before caching."""
+        if (
+            self.find_attribute(attrid)
+            == ElectricalMeasurement.AttributeDefs.active_power
+            and value is not None
+        ):
+            value = value * 10
+        super()._update_attribute(attrid, value)
+
+
+(
+    QuirkBuilder("Aqara", "lumi.plug.aeu002")
+    .friendly_name(model="Wall Outlet H2 UK", manufacturer="Aqara")
+    .replaces(BasicCluster)
+    .replaces(AqaraH2UKElectricalMeasurement)
+    .replaces(AqaraH2UKElectricalMeasurement, endpoint_id=2)
+    .replaces(AqaraH2UKElectricalMeasurement, endpoint_id=3)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Adds a quirk for the Aqara Wall Outlet H2 UK (WP-P09D / `lumi.plug.aeu002`), a dual-socket UK wall outlet with per-socket and USB power monitoring.

All three endpoints emit `active_power` via standard ZCL `ElectricalMeasurement` 10x lower than the actual draw. The quirk multiplies the reported value by 10 inside `_update_attribute`. Scaling validated against a calibrated reference plug across the 3W to 2500W range.

## Additional information

This is the first Aqara plug quirk to use V2 `QuirkBuilder` and the first to use plain ZCL `ElectricalMeasurement` rather than the existing `zhaquirks.xiaomi.ElectricalMeasurementCluster` (a `LocalDataCluster`). The standard Aqara plug pattern (`ac_power_divisor: 10` on a `LocalDataCluster`) is not used here because:

- That pattern only nets x1 because power normally arrives pre-scaled x10 via the Lumi proprietary cluster or `AnalogInput`. This device emits power purely via standard ZCL on all three endpoints (no Lumi/AnalogInput hand-off), so the `LocalDataCluster` would block the only path that carries readings.
- Setting `ac_power_multiplier`/`ac_power_divisor` via `_CONSTANT_ATTRIBUTES` on a plain `CustomCluster, ElectricalMeasurement` was tested and produced no scaling change. The device appears to adjust its reporting scale based on what ZHA reads back from those attributes during cluster initialisation, creating a feedback loop. The `_update_attribute` override is the only approach that produced correct values.

The endpoint mapping is unusual: switch and power endpoints do not align.

| Endpoint | Switch | Power |
|-|-|-|
| 1 | Socket 1 | Total |
| 2 | Socket 2 | Socket 1 + USB |
| 3 | USB | Socket 2 |

The `_update_attribute` override pattern follows the precedent at `zhaquirks/sonoff/s60zbtpf.py`.

Hardware investigation and validation by absent42: https://github.com/absent42/Aqara-Wall-Outlet-H2-UK

## Device diagnostics

<!-- attach diagnostics JSON downloaded from HA before submitting -->

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached [diagnostics-trimmed.json](https://github.com/user-attachments/files/27612361/diagnostics-trimmed.json)

