### PR TITLE
Add Aqara roller shade controller lumi.curtain.aq2

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2596,6 +2596,64 @@ async def test_aqara_aq2_roller_command_stop(zigpy_device_from_v2_quirk):
         )
 
 
+async def test_aqara_aq2_roller_failed_command_leaves_flag_clear(
+    zigpy_device_from_v2_quirk,
+):
+    """A failed movement-command write must not leave _is_moving set."""
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.aq2")
+    window_covering_cluster = device.endpoints[1].window_covering
+    analog_cluster = device.endpoints[1].analog_output
+
+    patch_analog_write = mock.patch.object(
+        analog_cluster,
+        "_write_attributes",
+        mock.AsyncMock(
+            return_value=(
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        status=foundation.Status.FAILURE,
+                        attrid=AnalogOutput.AttributeDefs.present_value.id,
+                    )
+                ],
+            )
+        ),
+    )
+
+    with patch_analog_write:
+        await window_covering_cluster.command(
+            WindowCovering.ServerCommandDefs.go_to_lift_percentage.id, 50
+        )
+        assert window_covering_cluster._is_moving is False
+
+
+async def test_aqara_aq2_roller_failed_stop_keeps_flag_set(zigpy_device_from_v2_quirk):
+    """A NACK'd stop must leave _is_moving set so reads remain suppressed."""
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.aq2")
+    window_covering_cluster = device.endpoints[1].window_covering
+
+    patch_request = mock.patch.object(
+        window_covering_cluster,
+        "request",
+        mock.AsyncMock(
+            return_value=foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(
+                command_id=WindowCovering.ServerCommandDefs.stop.id,
+                status=foundation.Status.FAILURE,
+            )
+        ),
+    )
+
+    with patch_request:
+        # simulate a curtain that is currently moving
+        window_covering_cluster._is_moving = True
+
+        await window_covering_cluster.stop()
+
+        # stop NACK'd → curtain is still moving, flag must stay set
+        assert window_covering_cluster._is_moving is True
+
+
 @pytest.mark.parametrize(
     "read_status, expected_updates",
     [

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -76,6 +76,7 @@ from zhaquirks.xiaomi import (
 )
 import zhaquirks.xiaomi.aqara.cube
 import zhaquirks.xiaomi.aqara.cube_aqgl01
+import zhaquirks.xiaomi.aqara.curtain_aq2
 import zhaquirks.xiaomi.aqara.driver_curtain_e1
 from zhaquirks.xiaomi.aqara.feeder_acn001 import (
     FEEDER_ATTR,
@@ -2470,6 +2471,447 @@ async def test_xiaomi_e1_roller_position_updates(
         WindowCovering.AttributeDefs.current_position_lift_percentage.id,
         75,
     )
+
+
+@pytest.mark.parametrize(
+    "command, command_args, analog_value",
+    [
+        (WindowCovering.ServerCommandDefs.up_open.id, (), 100.0),
+        (WindowCovering.ServerCommandDefs.down_close.id, (), 0.0),
+        # go_to_lift_percentage(60) → writes 40.0 (100 - 60)
+        (WindowCovering.ServerCommandDefs.go_to_lift_percentage.id, (60,), 40.0),
+    ],
+)
+async def test_aqara_aq2_roller_commands(
+    zigpy_device_from_v2_quirk, command, command_args, analog_value
+):
+    """Test Aqara aq2 roller commands that write to AnalogOutput."""
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.aq2")
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    window_covering_listener = ClusterListener(window_covering_cluster)
+
+    analog_cluster = device.endpoints[1].analog_output
+    analog_attr_id = AnalogOutput.AttributeDefs.present_value.id
+
+    # fake read response for attributes: return 1 for all attributes
+    def mock_read(attributes, manufacturer=None):
+        records = [
+            foundation.ReadAttributeRecord(
+                attr, foundation.Status.SUCCESS, foundation.TypeValue(None, 1)
+            )
+            for attr in attributes
+        ]
+        return (records,)
+
+    patch_window_covering_read = mock.patch.object(
+        window_covering_cluster,
+        "_read_attributes",
+        mock.AsyncMock(side_effect=mock_read),
+    )
+    patch_analog_read = mock.patch.object(
+        analog_cluster, "_read_attributes", mock.AsyncMock(side_effect=mock_read)
+    )
+    patch_analog_write = mock.patch.object(
+        analog_cluster,
+        "_write_attributes",
+        mock.AsyncMock(
+            return_value=(
+                [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],
+            )
+        ),
+    )
+
+    with (
+        patch_window_covering_read,
+        patch_analog_read,
+        patch_analog_write,
+    ):
+        await window_covering_cluster.command(command, *command_args)
+
+        # confirm write to AnalogOutput with correct value
+        assert analog_cluster._write_attributes.call_count == 1
+        assert (
+            analog_cluster._write_attributes.call_args[0][0][0].attrid == analog_attr_id
+        )
+        assert (
+            analog_cluster._write_attributes.call_args[0][0][0].value.value
+            == analog_value
+        )
+
+        # confirm _is_moving is set so ZHA's post-command poll is suppressed
+        assert window_covering_cluster._is_moving is True
+
+        # confirm no immediate position read after movement commands
+        assert len(window_covering_cluster._read_attributes.mock_calls) == 0
+        assert len(analog_cluster._read_attributes.mock_calls) == 0
+
+        # confirm no position update occurred (device reports will update it later)
+        assert len(window_covering_listener.attribute_updates) == 0
+
+    # confirm non-mapped commands return status UNSUP_CLUSTER_COMMAND
+    _, status = await window_covering_cluster.go_to_tilt_percentage(0)
+    assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
+
+
+async def test_aqara_aq2_roller_command_stop(zigpy_device_from_v2_quirk):
+    """Test Aqara aq2 roller stop command uses standard ZCL stop.
+
+    No explicit position read is issued after stop: feeding a position update
+    to ZHA at this point would cap its transition timer at 5 s.  The natural
+    position report ~1 s after stopping drives the WindowCovering update
+    instead.
+    """
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.aq2")
+
+    window_covering_cluster = device.endpoints[1].window_covering
+
+    patch_window_covering_request = mock.patch.object(
+        window_covering_cluster,
+        "request",
+        mock.AsyncMock(
+            return_value=foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(
+                command_id=WindowCovering.ServerCommandDefs.stop.id,
+                status=foundation.Status.SUCCESS,
+            )
+        ),
+    )
+
+    with patch_window_covering_request:
+        # simulate a curtain that is currently moving
+        window_covering_cluster._is_moving = True
+
+        await window_covering_cluster.stop()
+
+        # confirm _is_moving is cleared so position reads are no longer suppressed
+        assert window_covering_cluster._is_moving is False
+
+        # confirm the standard ZCL stop command was sent
+        assert window_covering_cluster.request.call_count == 1
+        assert (
+            window_covering_cluster.request.call_args[0][1]
+            == WindowCovering.ServerCommandDefs.stop.id
+        )
+
+
+@pytest.mark.parametrize(
+    "read_status, expected_updates",
+    [
+        (
+            foundation.Status.SUCCESS,
+            [
+                (
+                    WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+                    99,
+                ),
+                (
+                    WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+                    99,
+                ),
+            ],
+        ),
+        (foundation.Status.FAILURE, []),
+    ],
+)
+async def test_aqara_aq2_roller_window_covering_read_redirection(
+    zigpy_device_from_v2_quirk,
+    read_status: foundation.Status,
+    expected_updates: list[tuple[int, int]],
+):
+    """Test Aqara aq2 roller current_position_lift_percentage reads redirect to AnalogOutput."""
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.aq2")
+
+    attr = WindowCovering.AttributeDefs.current_position_lift_percentage
+    target_attr = AnalogOutput.AttributeDefs.present_value
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    window_covering_listener = ClusterListener(window_covering_cluster)
+    analog_cluster = device.endpoints[1].analog_output
+
+    def mock_read(attributes, manufacturer=None):
+        records = [
+            foundation.ReadAttributeRecord(
+                a, read_status, foundation.TypeValue(None, 1)
+            )
+            for a in attributes
+        ]
+        return (records,)
+
+    patch_window_covering_read = mock.patch.object(
+        window_covering_cluster,
+        "_read_attributes",
+        mock.AsyncMock(side_effect=mock_read),
+    )
+    patch_analog_read = mock.patch.object(
+        analog_cluster,
+        "_read_attributes",
+        mock.AsyncMock(side_effect=mock_read),
+    )
+
+    with patch_window_covering_read, patch_analog_read:
+        await window_covering_cluster.read_attributes([attr.id])
+        await window_covering_cluster.read_attributes([attr.name])
+
+        assert len(window_covering_cluster._read_attributes.mock_calls) == 0
+        assert len(analog_cluster._read_attributes.mock_calls) == 2
+        assert analog_cluster._read_attributes.mock_calls[0][1][0] == [target_attr.id]
+        assert analog_cluster._read_attributes.mock_calls[1][1][0] == [target_attr.id]
+
+    assert window_covering_listener.attribute_updates == expected_updates
+
+
+@pytest.mark.parametrize(
+    "read_status, expected_updates",
+    [
+        (
+            foundation.Status.SUCCESS,
+            [
+                (WindowCovering.AttributeDefs.config_status.id, 1),
+                (WindowCovering.AttributeDefs.config_status.id, 1),
+            ],
+        ),
+        (foundation.Status.FAILURE, []),
+    ],
+)
+async def test_aqara_aq2_roller_window_covering_read_passthrough(
+    zigpy_device_from_v2_quirk,
+    read_status: foundation.Status,
+    expected_updates: list[tuple[int, int]],
+):
+    """Test Aqara aq2 roller non-position WindowCovering attribute reads pass through."""
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.aq2")
+
+    attr = WindowCovering.AttributeDefs.config_status
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    window_covering_listener = ClusterListener(window_covering_cluster)
+
+    def mock_read(attributes, manufacturer=None):
+        records = [
+            foundation.ReadAttributeRecord(
+                a, read_status, foundation.TypeValue(None, 1)
+            )
+            for a in attributes
+        ]
+        return (records,)
+
+    patch_window_covering_read = mock.patch.object(
+        window_covering_cluster,
+        "_read_attributes",
+        mock.AsyncMock(side_effect=mock_read),
+    )
+
+    with patch_window_covering_read:
+        await window_covering_cluster.read_attributes([attr.id])
+        await window_covering_cluster.read_attributes([attr.name])
+
+        assert len(window_covering_cluster._read_attributes.mock_calls) == 2
+        assert window_covering_cluster._read_attributes.mock_calls[0][1][0] == [attr.id]
+        assert window_covering_cluster._read_attributes.mock_calls[1][1][0] == [attr.id]
+
+    assert window_covering_listener.attribute_updates == expected_updates
+
+
+async def test_aqara_aq2_roller_position_updates(zigpy_device_from_v2_quirk):
+    """Test Aqara aq2 roller lift position updates on read/report only."""
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.aq2")
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    window_covering_listener = ClusterListener(window_covering_cluster)
+
+    analog_cluster = device.endpoints[1].analog_output
+    analog_listener = ClusterListener(analog_cluster)
+    analog_attr = AnalogOutput.AttributeDefs.present_value
+
+    patch_analog_read = mock.patch.object(
+        analog_cluster,
+        "_read_attributes",
+        mock.AsyncMock(
+            return_value=(
+                [
+                    foundation.ReadAttributeRecord(
+                        analog_attr.id,
+                        foundation.Status.SUCCESS,
+                        foundation.TypeValue(None, 40),
+                    )
+                ],
+            )
+        ),
+    )
+
+    with patch_analog_read:
+        analog_listener.attribute_updates.clear()
+        window_covering_listener.attribute_updates.clear()
+
+        await analog_cluster.read_attributes([analog_attr.id])
+
+        # read events should update the WindowCovering position
+        assert len(window_covering_listener.attribute_updates) == 1
+        assert window_covering_listener.attribute_updates[0] == (
+            WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+            60,
+        )
+
+    # Echo reports (was_moving=True) clear _is_moving and return without
+    # updating WindowCovering — see the quirk's _handle_attribute_reported
+    # for why.  The final-position path is covered by
+    # test_aqara_aq2_roller_final_position_report.
+    window_covering_cluster._is_moving = True
+
+    aq2_attr = foundation.Attribute(
+        attrid=analog_attr.id,
+        value=foundation.TypeValue(0x39, t.Single(25.0)),
+    )
+    hdr = foundation.ZCLHeader.general(
+        1,
+        foundation.GeneralCommand.Report_Attributes,
+        direction=foundation.Direction.Server_to_Client,
+    ).serialize()
+    cmd = (
+        foundation.GENERAL_COMMANDS[foundation.GeneralCommand.Report_Attributes]
+        .schema([aq2_attr])
+        .serialize()
+    )
+
+    window_covering_listener.attribute_updates.clear()
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=analog_cluster.cluster_id,
+            src_ep=analog_cluster.endpoint.endpoint_id,
+            dst_ep=analog_cluster.endpoint.endpoint_id,
+            data=t.SerializableBytes(hdr + cmd),
+        )
+    )
+
+    # No position update — echo discarded
+    assert len(window_covering_listener.attribute_updates) == 0
+    # confirm the report cleared the moving flag
+    assert window_covering_cluster._is_moving is False
+
+
+async def test_aqara_aq2_roller_final_position_report(
+    zigpy_device_from_v2_quirk,
+):
+    """Test that a final/post-stop position report drives two identical WC updates.
+
+    With _is_moving=False the quirk emits two update_attribute calls at the same
+    value so ZHA's _lift_position_history ends at [v, v].  This skips the
+    "infer target from direction" branch in _determine_state, which would
+    otherwise mark the cover as CLOSING/OPENING after a post-stop report.
+    """
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.aq2")
+
+    analog_cluster = device.endpoints[1].analog_output
+    window_covering_cluster = device.endpoints[1].window_covering
+    window_covering_listener = ClusterListener(window_covering_cluster)
+
+    # _is_moving is False: this is the final-position report (curtain arrived)
+    window_covering_cluster._is_moving = False
+
+    # Simulate the device's final-position report: present_value=60 (40% open)
+    report_attr = foundation.Attribute(
+        attrid=AnalogOutput.AttributeDefs.present_value.id,
+        value=foundation.TypeValue(0x39, t.Single(60.0)),
+    )
+    hdr = foundation.ZCLHeader.general(
+        1,
+        foundation.GeneralCommand.Report_Attributes,
+        direction=foundation.Direction.Server_to_Client,
+    ).serialize()
+    cmd = (
+        foundation.GENERAL_COMMANDS[foundation.GeneralCommand.Report_Attributes]
+        .schema([report_attr])
+        .serialize()
+    )
+
+    window_covering_listener.attribute_updates.clear()
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=analog_cluster.cluster_id,
+            src_ep=analog_cluster.endpoint.endpoint_id,
+            dst_ep=analog_cluster.endpoint.endpoint_id,
+            data=t.SerializableBytes(hdr + cmd),
+        )
+    )
+
+    expected = (
+        WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+        40,  # 100 - 60
+    )
+    assert window_covering_cluster._is_moving is False
+    assert window_covering_listener.attribute_updates == [expected, expected]
+
+
+async def test_aqara_aq2_roller_read_suppressed_during_movement(
+    zigpy_device_from_v2_quirk,
+):
+    """Test position reads via WindowCovering are suppressed while moving.
+
+    The redirect to AnalogOutput is suppressed because feeding a position
+    update to ZHA mid-movement would cap its transition timer at 5 s.  Callers
+    still receive a defined response: the cached position when available,
+    otherwise FAILURE — never a silently dropped attribute.
+    """
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.aq2")
+
+    pos_attr = WindowCovering.AttributeDefs.current_position_lift_percentage
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    window_covering_listener = ClusterListener(window_covering_cluster)
+
+    analog_cluster = device.endpoints[1].analog_output
+
+    def mock_read(attributes, manufacturer=None):
+        return (
+            [
+                foundation.ReadAttributeRecord(
+                    a, foundation.Status.SUCCESS, foundation.TypeValue(None, 50)
+                )
+                for a in attributes
+            ],
+        )
+
+    patch_analog_read = mock.patch.object(
+        analog_cluster, "_read_attributes", mock.AsyncMock(side_effect=mock_read)
+    )
+
+    with patch_analog_read:
+        # simulate curtain in motion with no cached position yet
+        window_covering_cluster._is_moving = True
+
+        success, failure = await window_covering_cluster.read_attributes([pos_attr.id])
+
+        # redirect suppressed — device was not read and no listener update fired
+        assert len(analog_cluster._read_attributes.mock_calls) == 0
+        assert len(window_covering_listener.attribute_updates) == 0
+        # no cache → defined FAILURE response, not a silent drop
+        assert pos_attr.id in failure
+        assert pos_attr.id not in success
+
+        # populate the cache with a known position (e.g. from an earlier report)
+        window_covering_cluster._attr_cache[pos_attr.id] = 42
+
+        success, failure = await window_covering_cluster.read_attributes([pos_attr.id])
+
+        # still no device read; the cached value is returned via success
+        assert len(analog_cluster._read_attributes.mock_calls) == 0
+        assert success == {pos_attr.id: 42}
+        assert pos_attr.id not in failure
+
+        # once movement stops, the redirect works normally again
+        window_covering_cluster._is_moving = False
+
+        await window_covering_cluster.read_attributes([pos_attr.id])
+
+        assert len(analog_cluster._read_attributes.mock_calls) == 1
+        assert window_covering_listener.attribute_updates[-1] == (
+            pos_attr.id,
+            50,  # 100 - 50
+        )
 
 
 @pytest.mark.parametrize("endpoint", [(1), (2)])

--- a/zhaquirks/xiaomi/aqara/curtain_aq2.py
+++ b/zhaquirks/xiaomi/aqara/curtain_aq2.py
@@ -106,28 +106,31 @@ class WindowCoveringCurtainAq2(CustomCluster, WindowCovering):
         transition timer at 5 s (see read_attributes).
         """
         if command_id == WindowCovering.ServerCommandDefs.up_open.id:
-            self._is_moving = True
             (res,) = await self.endpoint.analog_output.write_attributes(
                 {AnalogOutput.AttributeDefs.present_value.name: 100.0}
             )
+            if res[0].status == foundation.Status.SUCCESS:
+                self._is_moving = True
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=res[0].status)
 
         if command_id == WindowCovering.ServerCommandDefs.down_close.id:
-            self._is_moving = True
             (res,) = await self.endpoint.analog_output.write_attributes(
                 {AnalogOutput.AttributeDefs.present_value.name: 0.0}
             )
+            if res[0].status == foundation.Status.SUCCESS:
+                self._is_moving = True
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=res[0].status)
 
         if command_id == WindowCovering.ServerCommandDefs.go_to_lift_percentage.id:
-            self._is_moving = True
             (res,) = await self.endpoint.analog_output.write_attributes(
                 {AnalogOutput.AttributeDefs.present_value.name: float(100 - args[0])}
             )
+            if res[0].status == foundation.Status.SUCCESS:
+                self._is_moving = True
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=res[0].status)
@@ -141,9 +144,10 @@ class WindowCoveringCurtainAq2(CustomCluster, WindowCovering):
                 tsn=tsn,
                 **kwargs,
             )
-            # Clear only after the stop is acknowledged: a failed send leaves
-            # the curtain moving and reads should stay suppressed.
-            self._is_moving = False
+            # Only clear when the stop actually succeeded: a NACK'd or failed
+            # stop leaves the curtain moving and reads should stay suppressed.
+            if getattr(result, "status", None) == foundation.Status.SUCCESS:
+                self._is_moving = False
             return result
 
         return foundation.GENERAL_COMMANDS[

--- a/zhaquirks/xiaomi/aqara/curtain_aq2.py
+++ b/zhaquirks/xiaomi/aqara/curtain_aq2.py
@@ -1,0 +1,216 @@
+"""Aqara Roller Shade Controller (lumi.curtain.aq2) device."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from zigpy import types as t
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl import AttributeReadEvent, AttributeReportedEvent, foundation
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import AnalogOutput
+
+from zhaquirks import CustomCluster
+from zhaquirks.xiaomi import LUMI, BasicCluster
+
+
+class AnalogOutputCurtainAq2(CustomCluster, AnalogOutput):
+    """AnalogOutput cluster reporting current position and used for writing target position."""
+
+    _CONSTANT_ATTRIBUTES = {
+        AnalogOutput.AttributeDefs.description.id: "Current position",
+        AnalogOutput.AttributeDefs.max_present_value.id: 100.0,
+        AnalogOutput.AttributeDefs.min_present_value.id: 0.0,
+        AnalogOutput.AttributeDefs.out_of_service.id: 0,
+        AnalogOutput.AttributeDefs.resolution.id: 1.0,
+        AnalogOutput.AttributeDefs.status_flags.id: 0x00,
+    }
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.on_event(AttributeReadEvent.event_type, self._handle_attribute_read)
+        self.on_event(
+            AttributeReportedEvent.event_type, self._handle_attribute_reported
+        )
+
+    def _handle_attribute_read(self, event: AttributeReadEvent) -> None:
+        """Handle attribute read events — update WindowCovering position."""
+        if event.attribute_id == self.AttributeDefs.present_value.id:
+            self.endpoint.window_covering.update_attribute(
+                WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+                t.uint8_t(100 - event.value),
+            )
+
+    def _handle_attribute_reported(self, event: AttributeReportedEvent) -> None:
+        """Handle present_value reports.
+
+        Device reporting protocol:
+          - Commanded movement: an echo (~30 ms after the write ACK, with the
+            position slightly advanced from the start) and a final-position
+            report on arrival.
+          - Stop or physical movement: a single natural report ~1 s later.
+        """
+        if event.attribute_id == self.AttributeDefs.present_value.id:
+            wc = self.endpoint.window_covering
+            was_moving = wc._is_moving
+            wc._is_moving = False
+            if was_moving:
+                # Discard the echo: feeding a position update to ZHA mid-movement
+                # caps its transition timer at DEFAULT_MOVEMENT_TIMEOUT (5 s) via
+                # _start_lift_transition(is_position_update=True), shorter than
+                # this device's travel time — the entity would flip to OPEN/
+                # CLOSED before the curtain arrives.
+                return
+            wc_attr = WindowCovering.AttributeDefs.current_position_lift_percentage.id
+            wc_pos = t.uint8_t(100 - event.value)
+            # Update twice to defeat ZHA's direction inference.  When
+            # _target_lift_position is None (post-stop or unsolicited reports),
+            # _determine_state otherwise marks the cover CLOSING/OPENING from
+            # the previous→current change.  Identical updates leave
+            # _lift_position_history=[v, v] so the inference branch — which
+            # requires previous != current — is skipped.
+            wc.update_attribute(wc_attr, wc_pos)
+            wc.update_attribute(wc_attr, wc_pos)
+
+
+class WindowCoveringCurtainAq2(CustomCluster, WindowCovering):
+    """Window covering cluster for handling motor commands."""
+
+    _CONSTANT_ATTRIBUTES = {
+        WindowCovering.AttributeDefs.window_covering_type.id: WindowCovering.WindowCoveringType.Rollershade,
+    }
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        # True between a movement command and the echo report (or a successful
+        # stop).  Read by AO._handle_attribute_reported to identify the echo
+        # and by read_attributes to suppress the post-command poll.
+        self._is_moving = False
+
+    async def command(
+        self,
+        command_id: foundation.GeneralCommand | int | t.uint8_t,
+        *args: Any,
+        manufacturer: int | t.uint16_t | None = None,
+        expect_reply: bool = True,
+        tsn: int | t.uint8_t | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Route movement commands to AnalogOutput writes; stop uses standard ZCL stop.
+
+        No explicit position read is issued after a command — position updates
+        come from device reports (see AO._handle_attribute_reported).  A read
+        here would propagate a mid-movement position update to ZHA and cap its
+        transition timer at 5 s (see read_attributes).
+        """
+        if command_id == WindowCovering.ServerCommandDefs.up_open.id:
+            self._is_moving = True
+            (res,) = await self.endpoint.analog_output.write_attributes(
+                {AnalogOutput.AttributeDefs.present_value.name: 100.0}
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
+
+        if command_id == WindowCovering.ServerCommandDefs.down_close.id:
+            self._is_moving = True
+            (res,) = await self.endpoint.analog_output.write_attributes(
+                {AnalogOutput.AttributeDefs.present_value.name: 0.0}
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
+
+        if command_id == WindowCovering.ServerCommandDefs.go_to_lift_percentage.id:
+            self._is_moving = True
+            (res,) = await self.endpoint.analog_output.write_attributes(
+                {AnalogOutput.AttributeDefs.present_value.name: float(100 - args[0])}
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
+
+        if command_id == WindowCovering.ServerCommandDefs.stop.id:
+            result = await super().command(
+                command_id,
+                *args,
+                manufacturer=manufacturer,
+                expect_reply=expect_reply,
+                tsn=tsn,
+                **kwargs,
+            )
+            # Clear only after the stop is acknowledged: a failed send leaves
+            # the curtain moving and reads should stay suppressed.
+            self._is_moving = False
+            return result
+
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
+
+    async def read_attributes(
+        self,
+        attributes: list[int | str | foundation.ZCLAttributeDef],
+        **kwargs,
+    ) -> Any:
+        """Redirect current_position_lift_percentage reads to AnalogOutput.
+
+        While _is_moving is True the redirect is suppressed: a mid-movement
+        read would feed a position update to ZHA via
+        _start_lift_transition(is_position_update=True), capping its
+        transition timer at DEFAULT_MOVEMENT_TIMEOUT (5 s) — shorter than this
+        device's travel time, causing a premature OPEN/CLOSED transition.
+        The cached position is returned instead so the caller always gets a
+        defined response.
+        """
+        success = {}
+        failure = {}
+
+        pos_attr_def = WindowCovering.AttributeDefs.current_position_lift_percentage
+        pos_attr_key = next(
+            (attr for attr in attributes if self.find_attribute(attr) == pos_attr_def),
+            None,
+        )
+
+        if pos_attr_key is not None:
+            remaining = [a for a in attributes if a != pos_attr_key]
+            if not self._is_moving:
+                pv = AnalogOutput.AttributeDefs.present_value
+                (
+                    ao_success,
+                    ao_failure,
+                ) = await self.endpoint.analog_output.read_attributes([pv], **kwargs)
+                if pv in ao_success:
+                    success[pos_attr_key] = t.uint8_t(100 - ao_success[pv])
+                if pv in ao_failure:
+                    failure[pos_attr_key] = ao_failure[pv]
+            else:
+                # No cache yet → surface a defined failure rather than
+                # silently dropping the attribute from the response.
+                cached = self._attr_cache.get(pos_attr_def.id)
+                if cached is not None:
+                    success[pos_attr_key] = cached
+                else:
+                    failure[pos_attr_key] = foundation.Status.FAILURE
+        else:
+            remaining = attributes
+
+        other_success, other_failure = await super().read_attributes(
+            remaining, **kwargs
+        )
+        success.update(other_success)
+        failure.update(other_failure)
+
+        return success, failure
+
+
+(
+    QuirkBuilder(LUMI, "lumi.curtain.aq2")
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=AnalogOutput.cluster_id)
+    .replaces(AnalogOutputCurtainAq2, endpoint_id=1)
+    .replaces(BasicCluster, endpoint_id=1)
+    .replaces(WindowCoveringCurtainAq2, endpoint_id=1)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Add support for the Aqara Roller Shade Controller `lumi.curtain.aq2` (ZNGZDJ11LM). The device drives movement and reports position via `AnalogOutput.present_value` instead of the standard `WindowCovering` attributes; the quirk bridges the two so HA sees a normal cover entity.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

The device's report timing and ZHA's cover state machine interact in two ways that need workarounds at the quirk level (rationale and references to ZHA internals are inline in the quirk). The cleaner fix for both would live in ZHA rather than in a quirk. This same pattern is observed in other quirks as well.

Tested on real hardware: open, close, set-position, stop, and stop-mid-movement all settle on the correct state and position.


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
The diagnostics file is from the device when it was implemented as a custom quirk via the `custom_quirks` folder.

[zha-b1f10bb60a5a672b6dac52f21bd7f5b5-LUMI lumi.curtain.aq2-6d2daefc911b78de85d772be9edc6ae0.json](https://github.com/user-attachments/files/27642035/zha-b1f10bb60a5a672b6dac52f21bd7f5b5-LUMI.lumi.curtain.aq2-6d2daefc911b78de85d772be9edc6ae0.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
