### PR TITLE
Add Tuya TS0601 _TZE200_libht6ua blind motor quirk

### DIFF
--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -1,6 +1,7 @@
 """Tuya based cover and blinds."""
 
 from zigpy.profiles import zha
+from zigpy.quirks.v2 import BinarySensorDeviceClass
 import zigpy.types as t
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
 
@@ -703,5 +704,62 @@ class BorderSetting(t.enum8):
         fallback_name="Delete all limits",
     )
     .skip_configuration()
+    .add_to_registry()
+)
+
+
+class LibhtCalibration(t.enum8):
+    """Calibration (set upper limit) values for _TZE200_libht6ua."""
+
+    Start = 0x00
+    Stop = 0x01
+
+
+(
+    TuyaQuirkBuilder("_TZE200_libht6ua", "TS0601")
+    .tuya_cover(
+        control_dp=1,
+        position_state_dp=3,
+        position_control_dp=2,
+        invert=False,
+    )
+    .tuya_battery(dp_id=13)
+    .tuya_binary_sensor(
+        dp_id=12,
+        attribute_name="motor_fault",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        translation_key="motor_fault",
+        fallback_name="Motor fault",
+    )
+    .tuya_enum(
+        dp_id=101,
+        attribute_name="motor_direction",
+        enum_class=MotorDirection,
+        translation_key="motor_direction",
+        fallback_name="Motor direction",
+    )
+    .tuya_dp_attribute(
+        dp_id=102,
+        attribute_name="calibration",
+        type=LibhtCalibration,
+    )
+    .write_attr_button(
+        attribute_name="calibration",
+        attribute_value=LibhtCalibration.Start,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="calibration_start",
+        translation_key="calibration_start",
+        fallback_name="Start calibration",
+    )
+    .write_attr_button(
+        attribute_name="calibration",
+        attribute_value=LibhtCalibration.Stop,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="calibration_stop",
+        translation_key="calibration_stop",
+        fallback_name="Stop calibration",
+    )
+    .skip_configuration()
+    .tuya_enchantment(data_query_spell=True)
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
Adds a v2 TuyaQuirkBuilder definition for the battery-powered Tuya roller blind motor identified as TS0601 / _TZE200_libht6ua.

## Additional information

Based on the Zigbee2MQTT herdsman converter found here:
  https://github.com/javilopezalarcon/Blind-motor-_TZE200_libht6ua-z2m

The conversion was performed with the aid of Copilot using the Claude Opus 4.7 model.

Datapoint mapping:
  DP 1   - cover open/stop/close (standard TuyaCoverControl: 0/1/2)
  DP 2   - position set (0-100, no inversion)
  DP 3   - position state (0-100, no inversion)
  DP 12  - motor fault (binary sensor, PROBLEM device class)
  DP 13  - battery percentage
  DP 101 - motor direction (Forward/Back, reuses existing
           MotorDirection enum)
  DP 102 - calibration (Start/Stop), exposed as two write-attribute
           buttons for entering/exiting the upper-limit learning mode

The data-query 'magic packet' enchantment is enabled so the device starts publishing datapoints after pairing.

Note: the Z2M converter inverts the DP 1 control enum (OPEN=2, CLOSE=0) and inverts the DP 2 position set value while leaving the DP 3 position state un-inverted. Testing on the physical device showed that with the device's own 'Motor direction' set to Back, the standard Tuya conventions (OPEN=0, CLOSE=2, position not inverted on either DP) match the physical button behaviour and HA's expected semantics, so this quirk does not replicate the Z2M inversions. Users with motor_direction=Forward can flip it via the exposed select entity.

This is a purely declarative v2 quirk composed of existing builder helpers, so per the project's contributor guidelines no test coverage is added.

## Device diagnostics

[zha-01JBCRPCB0W3AG5JZ96SG1CREZ-_TZE200_libht6ua TS0601-d87e81e991916d33e706883e8f81d80a.json](https://github.com/user-attachments/files/27730494/zha-01JBCRPCB0W3AG5JZ96SG1CREZ-_TZE200_libht6ua.TS0601-d87e81e991916d33e706883e8f81d80a.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [X] Device diagnostics data has been attached
