### PR TITLE
Add support for Tuya soil sensor _TZE284_0ints6wl (TS0601)

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -279,6 +279,18 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
 
 
 (
+    TuyaQuirkBuilder("_TZE284_0ints6wl", "TS0601")
+    .tuya_soil_moisture(dp_id=3)
+    .tuya_temperature(dp_id=5, scale=10)
+    .tuya_humidity(dp_id=101)
+    .tuya_illuminance(dp_id=102)
+    .tuya_battery(dp_id=14, scale=100)  # enum: 0=low, 1=medium, 2=high
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+(
     TuyaQuirkBuilder("_TZE284_nt4pquef", "TS0601")  # SG502Z
     .tuya_temperature(dp_id=5, scale=10)
     .tuya_enum(


### PR DESCRIPTION
## Summary

Adds a quirk for the `_TZE284_0ints6wl` / `TS0601` Tuya soil moisture sensor, sold as "Bundle4in1 tuyazigbee" and similar names.

This device is not a variant of the existing `_TZE284_aao3yzhs` family — it uses different data points and includes ambient humidity and illuminance sensors that the `aao3yzhs` family does not have.

## Data points confirmed by live packet capture

| DP  | Sensor        | Notes                              |
|-----|---------------|------------------------------------|
| 3   | soil_moisture | %                                  |
| 5   | temperature   | div 10 deg C                       |
| 14  | battery       | enum: 0=low, 1=medium, 2=high      |
| 101 | humidity      | ambient air %                      |
| 102 | illuminance   | raw lux                            |

**Battery note:** DP 14 uses the `batteryState` enum (0/1/2), not a direct percentage. `scale=100` maps it to 0%/50%/100%, consistent with how `tuya.valueConverter.batteryState` is handled in Zigbee2MQTT.

## Checklist

- [x] Device confirmed working with a ZHA custom quirk before submitting
- [x] DP mapping verified from live Zigbee packet capture (decoded from raw EF00 frames)
- [x] Battery enum behaviour confirmed: value 2 = fresh/full batteries
