### PR TITLE
Support light on/off for MOES ZigBee Star Feather Light Switch

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -56,6 +56,8 @@ ZCL_TUYA_BUTTON_2_DOUBLE_PRESS = b"\tj\x06\x03\x10\x02\x04\x00\x01\x01"
 ZCL_TUYA_BUTTON_2_LONG_PRESS = b"\tl\x06\x03\x12\x02\x04\x00\x01\x02"
 ZCL_TUYA_SWITCH_ON = b"\tQ\x02\x006\x01\x01\x00\x01\x01"
 ZCL_TUYA_SWITCH_OFF = b"\tQ\x02\x006\x01\x01\x00\x01\x00"
+ZCL_TUYA_SWITCH_DP24_ON = b"\tQ\x02\x006\x18\x01\x00\x01\x01"
+ZCL_TUYA_SWITCH_DP24_OFF = b"\tQ\x02\x006\x18\x01\x00\x01\x00"
 ZCL_TUYA_ATTRIBUTE_617_TO_179 = b"\tp\x02\x00\x02i\x02\x00\x04\x00\x00\x00\xb3"
 ZCL_TUYA_VALVE_TEMPERATURE = b"\tp\x02\x00\x02\x03\x02\x00\x04\x00\x00\x00\xb3"
 ZCL_TUYA_VALVE_TARGET_TEMP = b"\t3\x01\x03\x05\x02\x02\x00\x04\x00\x00\x002"
@@ -109,6 +111,32 @@ async def test_singleswitch_state_report(zigpy_device_from_quirk, quirk):
     hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_ON)
     tuya_cluster.handle_message(hdr, args)
     hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_OFF)
+    tuya_cluster.handle_message(hdr, args)
+
+    assert len(switch_listener.cluster_commands) == 0
+    assert len(switch_listener.attribute_updates) == 2
+    assert switch_listener.attribute_updates[0][0] == 0x0000
+    assert switch_listener.attribute_updates[0][1] == ON
+    assert switch_listener.attribute_updates[1][0] == 0x0000
+    assert switch_listener.attribute_updates[1][1] == OFF
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.tuya.ts0601_switch.TuyaSingleSwitchGPDP24,)
+)
+async def test_singleswitch_dp24_state_report(zigpy_device_from_quirk, quirk):
+    """Tuya single switch with on/off on DP 24 (Moes SFL02-Z-1 / _TZE200_stvgmdjz)."""
+
+    switch_dev = zigpy_device_from_quirk(quirk)
+
+    switch_cluster = switch_dev.endpoints[1].on_off
+    switch_listener = ClusterListener(switch_cluster)
+
+    tuya_cluster = switch_dev.endpoints[1].tuya_manufacturer
+
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_DP24_ON)
+    tuya_cluster.handle_message(hdr, args)
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_DP24_OFF)
     tuya_cluster.handle_message(hdr, args)
 
     assert len(switch_listener.cluster_commands) == 0
@@ -267,6 +295,55 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
             cluster=0xEF00,
             sequence=2,
             data=b"\x01\x02\x00\x00\x02\x01\x01\x00\x01\x01",
+            command_id=0x00,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
+            priority=None,
+        )
+        assert rsp.status == 0
+
+    rsp = await switch_cluster.command(0x0002)
+    await wait_for_zigpy_tasks()
+    assert rsp.status == foundation.Status.UNSUP_CLUSTER_COMMAND
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.tuya.ts0601_switch.TuyaSingleSwitchGPDP24,)
+)
+async def test_singleswitch_dp24_requests(zigpy_device_from_quirk, quirk):
+    """Tuya single switch (DP 24): on/off commands target DP 24, not DP 1."""
+
+    switch_dev = zigpy_device_from_quirk(quirk)
+
+    switch_cluster = switch_dev.endpoints[1].on_off
+    tuya_cluster = switch_dev.endpoints[1].tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as m1:
+        rsp = await switch_cluster.command(0x0000)
+        await wait_for_zigpy_tasks()
+        m1.assert_called_with(
+            cluster=0xEF00,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x18\x01\x00\x01\x00",
+            command_id=0x00,
+            timeout=5,
+            expect_reply=True,
+            use_ieee=False,
+            ask_for_ack=None,
+            priority=None,
+        )
+        assert rsp.status == 0
+
+        rsp = await switch_cluster.command(0x0001)
+        await wait_for_zigpy_tasks()
+        m1.assert_called_with(
+            cluster=0xEF00,
+            sequence=2,
+            data=b"\x01\x02\x00\x00\x02\x18\x01\x00\x01\x01",
             command_id=0x00,
             timeout=5,
             expect_reply=True,

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -58,6 +58,12 @@ ZCL_TUYA_SWITCH_ON = b"\tQ\x02\x006\x01\x01\x00\x01\x01"
 ZCL_TUYA_SWITCH_OFF = b"\tQ\x02\x006\x01\x01\x00\x01\x00"
 ZCL_TUYA_SWITCH_DP24_ON = b"\tQ\x02\x006\x18\x01\x00\x01\x01"
 ZCL_TUYA_SWITCH_DP24_OFF = b"\tQ\x02\x006\x18\x01\x00\x01\x00"
+ZCL_TUYA_SWITCH_DP25_ON = b"\tQ\x02\x006\x19\x01\x00\x01\x01"
+ZCL_TUYA_SWITCH_DP25_OFF = b"\tQ\x02\x006\x19\x01\x00\x01\x00"
+ZCL_TUYA_SWITCH_DP26_ON = b"\tQ\x02\x006\x1a\x01\x00\x01\x01"
+ZCL_TUYA_SWITCH_DP26_OFF = b"\tQ\x02\x006\x1a\x01\x00\x01\x00"
+ZCL_TUYA_SWITCH_DP27_ON = b"\tQ\x02\x006\x1b\x01\x00\x01\x01"
+ZCL_TUYA_SWITCH_DP27_OFF = b"\tQ\x02\x006\x1b\x01\x00\x01\x00"
 ZCL_TUYA_ATTRIBUTE_617_TO_179 = b"\tp\x02\x00\x02i\x02\x00\x04\x00\x00\x00\xb3"
 ZCL_TUYA_VALVE_TEMPERATURE = b"\tp\x02\x00\x02\x03\x02\x00\x04\x00\x00\x00\xb3"
 ZCL_TUYA_VALVE_TARGET_TEMP = b"\t3\x01\x03\x05\x02\x02\x00\x04\x00\x00\x002"
@@ -145,6 +151,106 @@ async def test_singleswitch_dp24_state_report(zigpy_device_from_quirk, quirk):
     assert switch_listener.attribute_updates[0][1] == ON
     assert switch_listener.attribute_updates[1][0] == 0x0000
     assert switch_listener.attribute_updates[1][1] == OFF
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.tuya.ts0601_switch.TuyaDoubleSwitchGPDP24,)
+)
+async def test_doubleswitch_dp24_state_report(zigpy_device_from_quirk, quirk):
+    """Tuya double switch with on/off on DPs 24-25 (Moes SFL02-Z-2)."""
+
+    switch_dev = zigpy_device_from_quirk(quirk)
+
+    switch1_cluster = switch_dev.endpoints[1].on_off
+    switch1_listener = ClusterListener(switch1_cluster)
+    switch2_cluster = switch_dev.endpoints[2].on_off
+    switch2_listener = ClusterListener(switch2_cluster)
+
+    tuya_cluster = switch_dev.endpoints[1].tuya_manufacturer
+
+    # DP 24 -> EP 1
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_DP24_ON)
+    tuya_cluster.handle_message(hdr, args)
+    assert len(switch1_listener.attribute_updates) == 1
+    assert len(switch2_listener.attribute_updates) == 0
+    assert switch1_listener.attribute_updates[0] == (0x0000, ON)
+
+    # DP 25 -> EP 2
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_DP25_ON)
+    tuya_cluster.handle_message(hdr, args)
+    assert len(switch1_listener.attribute_updates) == 1
+    assert len(switch2_listener.attribute_updates) == 1
+    assert switch2_listener.attribute_updates[0] == (0x0000, ON)
+
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_DP24_OFF)
+    tuya_cluster.handle_message(hdr, args)
+    hdr, args = tuya_cluster.deserialize(ZCL_TUYA_SWITCH_DP25_OFF)
+    tuya_cluster.handle_message(hdr, args)
+
+    assert switch1_listener.attribute_updates[1] == (0x0000, OFF)
+    assert switch2_listener.attribute_updates[1] == (0x0000, OFF)
+    assert len(switch1_listener.cluster_commands) == 0
+    assert len(switch2_listener.cluster_commands) == 0
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.tuya.ts0601_switch.TuyaTripleSwitchGPDP24,)
+)
+async def test_tripleswitch_dp24_state_report(zigpy_device_from_quirk, quirk):
+    """Tuya triple switch with on/off on DPs 24-26 (Moes SFL02-Z-3)."""
+
+    switch_dev = zigpy_device_from_quirk(quirk)
+
+    listeners = {
+        ep: ClusterListener(switch_dev.endpoints[ep].on_off) for ep in (1, 2, 3)
+    }
+    tuya_cluster = switch_dev.endpoints[1].tuya_manufacturer
+
+    for raw, expected_ep, expected_value in (
+        (ZCL_TUYA_SWITCH_DP24_ON, 1, ON),
+        (ZCL_TUYA_SWITCH_DP25_ON, 2, ON),
+        (ZCL_TUYA_SWITCH_DP26_ON, 3, ON),
+        (ZCL_TUYA_SWITCH_DP24_OFF, 1, OFF),
+        (ZCL_TUYA_SWITCH_DP25_OFF, 2, OFF),
+        (ZCL_TUYA_SWITCH_DP26_OFF, 3, OFF),
+    ):
+        hdr, args = tuya_cluster.deserialize(raw)
+        tuya_cluster.handle_message(hdr, args)
+        assert listeners[expected_ep].attribute_updates[-1] == (0x0000, expected_value)
+
+    assert [len(listeners[ep].attribute_updates) for ep in (1, 2, 3)] == [2, 2, 2]
+    assert all(len(listeners[ep].cluster_commands) == 0 for ep in (1, 2, 3))
+
+
+@pytest.mark.parametrize(
+    "quirk", (zhaquirks.tuya.ts0601_switch.TuyaQuadrupleSwitchGPDP24,)
+)
+async def test_quadrupleswitch_dp24_state_report(zigpy_device_from_quirk, quirk):
+    """Tuya quadruple switch with on/off on DPs 24-27 (Moes SFL02-Z-4)."""
+
+    switch_dev = zigpy_device_from_quirk(quirk)
+
+    listeners = {
+        ep: ClusterListener(switch_dev.endpoints[ep].on_off) for ep in (1, 2, 3, 4)
+    }
+    tuya_cluster = switch_dev.endpoints[1].tuya_manufacturer
+
+    for raw, expected_ep, expected_value in (
+        (ZCL_TUYA_SWITCH_DP24_ON, 1, ON),
+        (ZCL_TUYA_SWITCH_DP25_ON, 2, ON),
+        (ZCL_TUYA_SWITCH_DP26_ON, 3, ON),
+        (ZCL_TUYA_SWITCH_DP27_ON, 4, ON),
+        (ZCL_TUYA_SWITCH_DP24_OFF, 1, OFF),
+        (ZCL_TUYA_SWITCH_DP25_OFF, 2, OFF),
+        (ZCL_TUYA_SWITCH_DP26_OFF, 3, OFF),
+        (ZCL_TUYA_SWITCH_DP27_OFF, 4, OFF),
+    ):
+        hdr, args = tuya_cluster.deserialize(raw)
+        tuya_cluster.handle_message(hdr, args)
+        assert listeners[expected_ep].attribute_updates[-1] == (0x0000, expected_value)
+
+    assert [len(listeners[ep].attribute_updates) for ep in (1, 2, 3, 4)] == [2, 2, 2, 2]
+    assert all(len(listeners[ep].cluster_commands) == 0 for ep in (1, 2, 3, 4))
 
 
 @pytest.mark.parametrize(

--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -12,13 +12,30 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.quirk_ids import TUYA_PLUG_MANUFACTURER
-from zhaquirks.tuya import TuyaSwitch
+from zhaquirks.tuya import DPToAttributeMapping, TuyaSwitch
 from zhaquirks.tuya.mcu import (
     MoesSwitchManufCluster,
     TuyaOnOff,
     TuyaOnOffManufCluster,
     TuyaOnOffNM,
 )
+
+
+class MoesSwitchManufClusterDP24(MoesSwitchManufCluster):
+    """MoesSwitchManufCluster variant where on/off lives on DP 24."""
+
+    dp_to_attribute: dict[int, DPToAttributeMapping] = (
+        MoesSwitchManufCluster.dp_to_attribute.copy()
+    )
+    dp_to_attribute.pop(1, None)
+    dp_to_attribute[24] = DPToAttributeMapping(
+        ep_attribute="on_off",
+        attribute_name="on_off",
+    )
+
+    data_point_handlers = MoesSwitchManufCluster.data_point_handlers.copy()
+    data_point_handlers.pop(1, None)
+    data_point_handlers[24] = "_dp_2_attr_update"
 
 
 class TuyaSingleSwitchTI(TuyaSwitch):
@@ -172,6 +189,63 @@ class TuyaSingleSwitchGP(TuyaSwitch):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     MoesSwitchManufCluster,
+                    TuyaOnOffNM,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }
+
+
+class TuyaSingleSwitchGPDP24(TuyaSwitch):
+    """Tuya single channel switch (on/off on DP 24) with GreenPowerProxy.
+
+    Same Zigbee fingerprint as TuyaSingleSwitchGP, but the relay state is on
+    DP 24 instead of the upstream MoesSwitchManufCluster default DP 1.
+    Confirmed by capturing physical-press DP reports from a Moes SFL02-Z-1
+    1-gang touch switch (_TZE200_stvgmdjz / TS0601).
+    """
+
+    signature = {
+        MODELS_INFO: [
+            ("_TZE200_stvgmdjz", "TS0601"),  # Moes SFL02-Z-1 1-gang touch switch
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaOnOffManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    MoesSwitchManufClusterDP24,
                     TuyaOnOffNM,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],

--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -29,7 +29,7 @@ class MoesSwitchManufClusterDP24(MoesSwitchManufCluster):
     )
     dp_to_attribute.pop(1, None)
     dp_to_attribute[24] = DPToAttributeMapping(
-        ep_attribute="on_off",
+        ep_attribute=TuyaOnOff.ep_attribute,
         attribute_name="on_off",
     )
 

--- a/zhaquirks/tuya/ts0601_switch.py
+++ b/zhaquirks/tuya/ts0601_switch.py
@@ -22,20 +22,50 @@ from zhaquirks.tuya.mcu import (
 
 
 class MoesSwitchManufClusterDP24(MoesSwitchManufCluster):
-    """MoesSwitchManufCluster variant where on/off lives on DP 24."""
+    """MoesSwitchManufCluster variant where per-gang on/off lives on DPs 24-27.
+
+    Used by the Moes Star Feather family (SFL02-Z-1/2/3/4): the relay state for
+    gang N is reported and accepted on DP (23 + N), not the upstream default DP N.
+    Mappings for unused gangs are inert when the device's replacement does not
+    include that endpoint.
+    """
 
     dp_to_attribute: dict[int, DPToAttributeMapping] = (
         MoesSwitchManufCluster.dp_to_attribute.copy()
     )
     dp_to_attribute.pop(1, None)
+    dp_to_attribute.pop(2, None)
+    dp_to_attribute.pop(3, None)
+    dp_to_attribute.pop(4, None)
     dp_to_attribute[24] = DPToAttributeMapping(
         ep_attribute=TuyaOnOff.ep_attribute,
         attribute_name="on_off",
     )
+    dp_to_attribute[25] = DPToAttributeMapping(
+        ep_attribute=TuyaOnOff.ep_attribute,
+        attribute_name="on_off",
+        endpoint_id=2,
+    )
+    dp_to_attribute[26] = DPToAttributeMapping(
+        ep_attribute=TuyaOnOff.ep_attribute,
+        attribute_name="on_off",
+        endpoint_id=3,
+    )
+    dp_to_attribute[27] = DPToAttributeMapping(
+        ep_attribute=TuyaOnOff.ep_attribute,
+        attribute_name="on_off",
+        endpoint_id=4,
+    )
 
     data_point_handlers = MoesSwitchManufCluster.data_point_handlers.copy()
     data_point_handlers.pop(1, None)
+    data_point_handlers.pop(2, None)
+    data_point_handlers.pop(3, None)
+    data_point_handlers.pop(4, None)
     data_point_handlers[24] = "_dp_2_attr_update"
+    data_point_handlers[25] = "_dp_2_attr_update"
+    data_point_handlers[26] = "_dp_2_attr_update"
+    data_point_handlers[27] = "_dp_2_attr_update"
 
 
 class TuyaSingleSwitchTI(TuyaSwitch):
@@ -249,6 +279,228 @@ class TuyaSingleSwitchGPDP24(TuyaSwitch):
                     TuyaOnOffNM,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }
+
+
+class TuyaDoubleSwitchGPDP24(TuyaSwitch):
+    """Tuya double channel switch (on/off on DPs 24-25) with GreenPowerProxy.
+
+    Same Zigbee fingerprint as TuyaDoubleSwitchGP, but the per-gang relay state
+    is on DPs 24 (gang 1) and 25 (gang 2) instead of the upstream defaults
+    DPs 1 and 2. Used by the Moes Star Feather SFL02-Z-2 2-gang touch switch.
+    """
+
+    signature = {
+        MODELS_INFO: [
+            ("_TZE200_uenof8jd", "TS0601"),  # Moes SFL02-Z-2
+            ("_TZE200_tzyy0rtq", "TS0601"),  # Moes SFL02-Z-2
+            ("_TZE200_hktk6hze", "TS0601"),  # Nova Digital TPZ-2 (whitelabel)
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaOnOffManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    MoesSwitchManufClusterDP24,
+                    TuyaOnOffNM,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOffNM,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }
+
+
+class TuyaTripleSwitchGPDP24(TuyaSwitch):
+    """Tuya triple channel switch (on/off on DPs 24-26) with GreenPowerProxy.
+
+    Same Zigbee fingerprint as TuyaTripleSwitchGP, but the per-gang relay state
+    is on DPs 24, 25, and 26 instead of the upstream defaults DPs 1, 2, 3.
+    Used by the Moes Star Feather SFL02-Z-3 3-gang touch switch.
+    """
+
+    signature = {
+        MODELS_INFO: [
+            ("_TZE200_rd8cdssd", "TS0601"),  # Nova Digital TPZ-3 (whitelabel)
+            ("_TZE200_wv9ukqca", "TS0601"),  # Moes SFL02-Z-3
+            ("_TZE200_zo0cfekv", "TS0601"),  # Moes SFL02-Z-3
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaOnOffManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    MoesSwitchManufClusterDP24,
+                    TuyaOnOffNM,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOffNM,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOffNM,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }
+
+
+class TuyaQuadrupleSwitchGPDP24(TuyaSwitch):
+    """Tuya quadruple channel switch (on/off on DPs 24-27) with GreenPowerProxy.
+
+    Same Zigbee fingerprint as TuyaQuadrupleSwitchGP, but the per-gang relay
+    state is on DPs 24, 25, 26, and 27 instead of the upstream defaults DPs
+    1, 2, 3, 4. Used by the Moes Star Feather SFL02-Z-4 4-gang touch switch.
+    """
+
+    signature = {
+        MODELS_INFO: [
+            ("_TZE200_dq8bu0pt", "TS0601"),  # Moes SFL02-Z-4
+            ("_TZE200_hmabvy81", "TS0601"),  # Nova Digital TPZ-4 (whitelabel)
+            ("_TZE200_9dhenr94", "TS0601"),  # Moes SFL02-Z-4
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaOnOffManufCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    MoesSwitchManufClusterDP24,
+                    TuyaOnOffNM,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOffNM,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOffNM,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT,
+                INPUT_CLUSTERS: [
+                    TuyaOnOffNM,
+                ],
+                OUTPUT_CLUSTERS: [],
             },
             242: {
                 PROFILE_ID: zgp.PROFILE_ID,


### PR DESCRIPTION
## Proposed change
Support light on/off for [MOES ZigBee Star Feather Wall Light Switch](https://www.amazon.com/MOES-Touch-Way-Smart-Switch/dp/B0FGPP39N9)
I've tested the 1 and 2 Gang versions, and asked Claude to assume 3-4 follow a similar pattern.

## Additional information
This PR's code is generated by Claude (max effort).
My light switch wasn't working in HomeAssistant so I gave Claude ssh access to HomeAssistant and we debugged the switch together.
The light switch is now working, so I asked Claude to see if we can upstream the fixes.

Feel free to modify the PR or reject it and do it another way you think is better.

## Device diagnostics
[Home Assistant Devices.json](https://github.com/user-attachments/files/27987656/Home.Assistant.Devices.json)

## Checklist
- [x] The changes are tested and work correctly
  - Manually through HomeAssistant
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
