### PR TITLE
Fix some Moes light switches unresponsiveness

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -32,6 +32,7 @@ from zhaquirks.const import (
 )
 from zhaquirks.tuya import Data, TuyaManufClusterAttributes, TuyaNewManufCluster
 import zhaquirks.tuya.sm0202_motion
+import zhaquirks.tuya.ts001x
 import zhaquirks.tuya.ts0021
 import zhaquirks.tuya.ts0041
 import zhaquirks.tuya.ts0042
@@ -279,6 +280,34 @@ async def test_singleswitch_requests(zigpy_device_from_quirk, quirk):
     rsp = await switch_cluster.command(0x0002)
     await wait_for_zigpy_tasks()
     assert rsp.status == foundation.Status.UNSUP_CLUSTER_COMMAND
+
+
+@pytest.mark.parametrize(
+    "quirk",
+    (
+        zhaquirks.tuya.ts001x.TuyaSingleNoNeutralSwitch_TZ3000_hhiodade,
+        zhaquirks.tuya.ts001x.TuyaDoubleNoNeutralSwitch_TZ3000_18ejxno0,
+    ),
+)
+async def test_ts001x_no_await_default_response(zigpy_device_from_quirk, quirk):
+    """OnOff commands return synthetic SUCCESS and don't await the ZCL DefaultResponse.
+
+    Verifies that the workaround for the _TZ3000_hhiodade / _TZ3000_18ejxno0
+    firmware bug (intermittent missing DefaultResponse) sends with
+    ``expect_reply=False`` and returns ``[command_id, Status.SUCCESS]`` so
+    ZHA's light handler's ``result[1] is Status.SUCCESS`` check passes.
+    """
+    dev = zigpy_device_from_quirk(quirk)
+    cluster = dev.endpoints[1].on_off
+
+    with mock.patch.object(cluster.endpoint, "request", mock.AsyncMock()) as req:
+        for cmd_id in (0x00, 0x01, 0x02):  # off, on, toggle
+            req.reset_mock()
+            rsp = await cluster.command(cmd_id)
+            await wait_for_zigpy_tasks()
+            assert rsp == [cmd_id, foundation.Status.SUCCESS]
+            assert req.call_count == 1
+            assert req.call_args.kwargs.get("expect_reply") is False
 
 
 def test_ts0121_signature(assert_signature_matches_quirk):

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -1045,6 +1045,44 @@ class TuyaZBOnOffAttributeCluster(CustomCluster, OnOff):
         switch_mode: Final = ZCLAttributeDef(id=0x8004, type=SwitchMode)
 
 
+class TuyaZBOnOffAttributeClusterNoAwait(TuyaZBOnOffAttributeCluster):
+    """Tuya OnOff cluster that does not await the ZCL Default Response.
+
+    Some _TZ3000_* TS001x firmwares intermittently fail to emit a ZCL
+    DefaultResponse after an on/off cluster command. The relay still actuates
+    and an attribute report is still sent; only the DefaultResponse is dropped.
+    zigpy's default ``expect_reply=True`` then awaits the missing response for
+    ~28 s while holding the per-device concurrency lock, blocking every queued
+    request behind it (in Home Assistant the symptom is that the entity stops
+    responding to service calls until the timeout fires).
+
+    This subclass forwards on/off cluster commands with ``expect_reply=False``
+    and synthesizes the ``[command_id, Status.SUCCESS]`` return value the ZHA
+    light handler reads. Delivery is still confirmed at the APS layer (the
+    coordinator's ``DataConfirm`` ack) before this returns, and state is still
+    sync'd via the device's unsolicited attribute report.
+    """
+
+    async def command(
+        self,
+        command_id,
+        *args,
+        manufacturer=None,
+        expect_reply=True,
+        **kwargs,
+    ):
+        """Send a cluster command without awaiting a ZCL DefaultResponse."""
+        await super().command(
+            command_id,
+            *args,
+            manufacturer=manufacturer,
+            expect_reply=False,
+            **kwargs,
+        )
+        cmd = self.server_commands[command_id]
+        return [cmd.id, foundation.Status.SUCCESS]
+
+
 class TuyaSmartRemoteOnOffCluster(OnOff, EventableCluster):
     """TuyaSmartRemoteOnOffCluster: fire events corresponding to press type."""
 

--- a/zhaquirks/tuya/ts001x.py
+++ b/zhaquirks/tuya/ts001x.py
@@ -8,6 +8,7 @@ from zhaquirks.const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODEL,
+    MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
@@ -17,7 +18,24 @@ from zhaquirks.tuya import (
     TuyaZBE000Cluster,
     TuyaZBExternalSwitchTypeCluster,
     TuyaZBOnOffAttributeCluster,
+    TuyaZBOnOffAttributeClusterNoAwait,
 )
+
+
+def _replace_onoff_with_no_await(endpoints_dict):
+    """Swap TuyaZBOnOffAttributeCluster for the No-Await variant in a replacement dict."""
+    return {
+        ep_id: {
+            **ep_def,
+            INPUT_CLUSTERS: [
+                TuyaZBOnOffAttributeClusterNoAwait
+                if c is TuyaZBOnOffAttributeCluster
+                else c
+                for c in ep_def[INPUT_CLUSTERS]
+            ],
+        }
+        for ep_id, ep_def in endpoints_dict.items()
+    }
 
 
 # NoNeutralSwitch family = without tuya cluster and Identify.
@@ -444,6 +462,41 @@ class TuyaTripleNoNeutralSwitch_2(EnchantedDevice, TuyaSwitch):
                 OUTPUT_CLUSTERS: [],
             },
         },
+    }
+
+
+# Some _TZ3000_* firmwares intermittently fail to send the ZCL DefaultResponse
+# after an on/off command, which makes zigpy wait ~28 s on the per-device
+# concurrency lock; see TuyaZBOnOffAttributeClusterNoAwait for details.
+class TuyaSingleNoNeutralSwitch_TZ3000_hhiodade(TuyaSingleNoNeutralSwitch_2):
+    """_TZ3000_hhiodade TS0011 — skip OnOff ZCL DefaultResponse wait."""
+
+    signature = {
+        **TuyaSingleNoNeutralSwitch_2.signature,
+        MODELS_INFO: [("_TZ3000_hhiodade", "TS0011")],
+    }
+
+    replacement = {
+        **TuyaSingleNoNeutralSwitch_2.replacement,
+        ENDPOINTS: _replace_onoff_with_no_await(
+            TuyaSingleNoNeutralSwitch_2.replacement[ENDPOINTS]
+        ),
+    }
+
+
+class TuyaDoubleNoNeutralSwitch_TZ3000_18ejxno0(TuyaDoubleNoNeutralSwitch_2):
+    """_TZ3000_18ejxno0 TS0012 — skip OnOff ZCL DefaultResponse wait."""
+
+    signature = {
+        **TuyaDoubleNoNeutralSwitch_2.signature,
+        MODELS_INFO: [("_TZ3000_18ejxno0", "TS0012")],
+    }
+
+    replacement = {
+        **TuyaDoubleNoNeutralSwitch_2.replacement,
+        ENDPOINTS: _replace_onoff_with_no_await(
+            TuyaDoubleNoNeutralSwitch_2.replacement[ENDPOINTS]
+        ),
     }
 
 


### PR DESCRIPTION
**This PR is generated by Claude (max effort). I've confirmed it does actually work.
It fixes a VERY ANNOYING issue for me, which is my light switches going unresponsive. I can notice no downsides.**

Specifically, these are the switches exhibiting the issue: [MOES Zigbee Smart Switch 1 Gang](https://www.amazon.com/MOES-Require-Neutral-Inteligente-Support/dp/B0CTZRTS12) (and 2 Gang, from what I have).

Feel free to modify the PR or reject it and do it another way you think is better.

EDIT:
I've noticed there is an issue with the actual devices having connection issues (the "Moes Star Feather" ones are WAY better in every way, they don't have these conn issues and they can act as a router too). These changes don't fix those connection issues, but they make them easier to live with.
##

### Device diagnostics

[Diagnostics.json](https://github.com/user-attachments/files/28008742/Home.Assistant.Devices.TS0011.json)

### Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached

##

**The text below is generated by Claude as some explanation about the PR. I've read it and it does sound correct AFAICT.**

##

### Problem

Some `_TZ3000_*` TS001x firmwares intermittently drop the ZCL `DefaultResponse` after an on/off command (~5% of commands in a 40-toggle test on `_TZ3000_18ejxno0`). The relay still actuates and an attribute report is still sent — only the `DefaultResponse` is missing.

zigpy's default `expect_reply=True` then awaits the response for ~28 s while holding the per-device concurrency lock, blocking every queued request. In Home Assistant the entity appears stuck for that window.

### Fix

New `TuyaZBOnOffAttributeClusterNoAwait` in `zhaquirks/tuya/__init__.py`:
- Forwards on/off commands with `expect_reply=False` so zigpy returns as soon as the APS `DataConfirm` ack arrives.
- Synthesizes `[command_id, Status.SUCCESS]` so ZHA's `result[1] is Status.SUCCESS` check passes.

Delivery is still confirmed at the APS layer; state is still sync'd via attribute reports. `disable_default_response` is left at its default — the device still sends a response when it can, zigpy just doesn't block on it.

Two manufacturer-restricted device classes in `zhaquirks/tuya/ts001x.py` opt into the new cluster via `MODELS_INFO`:
- `TuyaSingleNoNeutralSwitch_TZ3000_hhiodade` (TS0011)
- `TuyaDoubleNoNeutralSwitch_TZ3000_18ejxno0` (TS0012)

Scope is intentionally narrow — these are the manufacturers where the bug was reproduced. Other `_TZ3000_*` users can opt in later.

### Verification

- 40 toggles at 0.7 s spacing post-fix: every call ≤1 s. Pre-fix the same test hung 28 s within the first 5 toggles.
- 2 added parametrized tests assert `expect_reply=False` is propagated and the return is `[command_id, Status.SUCCESS]`.
- `tests/test_tuya.py` 66/66 green; `tests/test_tuya_spells.py` 2/2 green.
- `pre-commit run --files …` passes codespell, mypy, ruff, ruff-format.
