### PR TITLE
Add Aqara Curtain Driver B1 (ZNCLDJ11LM)

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -76,6 +76,7 @@ from zhaquirks.xiaomi import (
 )
 import zhaquirks.xiaomi.aqara.cube
 import zhaquirks.xiaomi.aqara.cube_aqgl01
+import zhaquirks.xiaomi.aqara.curtain_b1
 import zhaquirks.xiaomi.aqara.driver_curtain_e1
 from zhaquirks.xiaomi.aqara.feeder_acn001 import (
     FEEDER_ATTR,
@@ -2470,6 +2471,407 @@ async def test_xiaomi_e1_roller_position_updates(
         WindowCovering.AttributeDefs.current_position_lift_percentage.id,
         75,
     )
+
+
+@pytest.mark.parametrize(
+    "command, args, expected_analog_value",
+    [
+        (WindowCovering.ServerCommandDefs.up_open.id, (), 100),
+        (WindowCovering.ServerCommandDefs.down_close.id, (), 0),
+        (WindowCovering.ServerCommandDefs.go_to_lift_percentage.id, (30,), 70),
+    ],
+)
+async def test_xiaomi_b1_curtain_commands_writes(
+    zigpy_device_from_v2_quirk, command, args, expected_analog_value
+):
+    """Test Aqara B1 curtain motor commands write to AnalogOutput.present_value."""
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain")
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    analog_cluster = device.endpoints[1].analog_output
+    analog_attr_id = AnalogOutput.AttributeDefs.present_value.id
+
+    def mock_read(attributes, manufacturer=None):
+        records = [
+            foundation.ReadAttributeRecord(
+                attr, foundation.Status.SUCCESS, foundation.TypeValue(None, 1)
+            )
+            for attr in attributes
+        ]
+        return (records,)
+
+    patch_window_covering_read = mock.patch.object(
+        window_covering_cluster,
+        "_read_attributes",
+        mock.AsyncMock(side_effect=mock_read),
+    )
+    patch_analog_read = mock.patch.object(
+        analog_cluster, "_read_attributes", mock.AsyncMock(side_effect=mock_read)
+    )
+    patch_analog_write = mock.patch.object(
+        analog_cluster,
+        "_write_attributes",
+        mock.AsyncMock(
+            return_value=(
+                [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],
+            )
+        ),
+    )
+
+    with patch_window_covering_read, patch_analog_read, patch_analog_write:
+        await window_covering_cluster.command(command, *args)
+
+        # confirm the AnalogOutput write occurred with the expected value
+        assert analog_cluster._write_attributes.call_count == 1
+        assert (
+            analog_cluster._write_attributes.call_args[0][0][0].attrid == analog_attr_id
+        )
+        assert (
+            analog_cluster._write_attributes.call_args[0][0][0].value.value
+            == expected_analog_value
+        )
+
+        # confirm the follow-up read of current_position_lift_percentage was redirected
+        # to AnalogOutput.present_value (not read from the WindowCovering cluster)
+        assert len(window_covering_cluster._read_attributes.mock_calls) == 0
+        assert len(analog_cluster._read_attributes.mock_calls) == 1
+        assert analog_cluster._read_attributes.mock_calls[0][1][0] == [analog_attr_id]
+
+
+async def test_xiaomi_b1_curtain_stop_command(zigpy_device_from_v2_quirk):
+    """Test Aqara B1 curtain stop sends native command and follows with a position read."""
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain")
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    analog_cluster = device.endpoints[1].analog_output
+    analog_attr_id = AnalogOutput.AttributeDefs.present_value.id
+
+    def mock_read(attributes, manufacturer=None):
+        records = [
+            foundation.ReadAttributeRecord(
+                attr, foundation.Status.SUCCESS, foundation.TypeValue(None, 1)
+            )
+            for attr in attributes
+        ]
+        return (records,)
+
+    patch_window_covering_read = mock.patch.object(
+        window_covering_cluster,
+        "_read_attributes",
+        mock.AsyncMock(side_effect=mock_read),
+    )
+    patch_analog_read = mock.patch.object(
+        analog_cluster, "_read_attributes", mock.AsyncMock(side_effect=mock_read)
+    )
+    patch_analog_write = mock.patch.object(
+        analog_cluster, "_write_attributes", mock.AsyncMock()
+    )
+    patch_request = mock.patch.object(
+        window_covering_cluster, "request", mock.AsyncMock(return_value=[0x00])
+    )
+
+    with (
+        patch_window_covering_read,
+        patch_analog_read,
+        patch_analog_write,
+        patch_request as mock_request,
+    ):
+        await window_covering_cluster.command(WindowCovering.ServerCommandDefs.stop.id)
+
+        # confirm the native stop command was sent (no AnalogOutput write)
+        assert analog_cluster._write_attributes.call_count == 0
+        assert mock_request.call_count == 1
+
+        # confirm the follow-up read of current_position_lift_percentage
+        # was redirected to AnalogOutput.present_value
+        assert len(analog_cluster._read_attributes.mock_calls) == 1
+        assert analog_cluster._read_attributes.mock_calls[0][1][0] == [analog_attr_id]
+
+
+async def test_xiaomi_b1_curtain_unsupported_command(zigpy_device_from_v2_quirk):
+    """Test Aqara B1 curtain returns UNSUP_CLUSTER_COMMAND for non-handled commands."""
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain")
+    window_covering_cluster = device.endpoints[1].window_covering
+
+    _, status = await window_covering_cluster.go_to_tilt_percentage(50)
+    assert status == foundation.Status.UNSUP_CLUSTER_COMMAND
+
+
+@pytest.mark.parametrize(
+    "attr, expected_value, target_attr, target_cluster",
+    [
+        (
+            WindowCovering.AttributeDefs.current_position_lift_percentage,
+            99,
+            AnalogOutput.AttributeDefs.present_value,
+            AnalogOutput,
+        ),  # Redirect with read success
+        (
+            WindowCovering.AttributeDefs.current_position_lift_percentage,
+            None,
+            AnalogOutput.AttributeDefs.present_value,
+            AnalogOutput,
+        ),  # Redirect with read failure
+        (
+            WindowCovering.AttributeDefs.config_status,
+            1,
+            None,
+            None,
+        ),  # Regular read success
+    ],
+)
+async def test_xiaomi_b1_curtain_read_redirection(
+    zigpy_device_from_v2_quirk,
+    attr: foundation.ZCLAttributeDef,
+    expected_value: int | None,
+    target_attr: foundation.ZCLAttributeDef | None,
+    target_cluster: Cluster | None,
+):
+    """Test Aqara B1 WindowCovering attribute read redirection with inversion."""
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain")
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    window_covering_listener = ClusterListener(window_covering_cluster)
+
+    redirect = False
+    if target_attr and target_cluster:
+        target_cluster = getattr(device.endpoints[1], target_cluster.ep_attribute)
+        redirect = True
+
+    # mock returns value=1 on success, FAILURE status if expected_value is None
+    def mock_read(attributes, manufacturer=None):
+        records = [
+            foundation.ReadAttributeRecord(
+                a,
+                foundation.Status.SUCCESS
+                if expected_value
+                else foundation.Status.FAILURE,
+                foundation.TypeValue(None, 1),
+            )
+            for a in attributes
+        ]
+        return (records,)
+
+    patch_window_covering_read = mock.patch.object(
+        window_covering_cluster,
+        "_read_attributes",
+        mock.AsyncMock(side_effect=mock_read),
+    )
+
+    if redirect:
+        patch_target_read = mock.patch.object(
+            target_cluster,
+            "_read_attributes",
+            mock.AsyncMock(side_effect=mock_read),
+        )
+        with patch_window_covering_read, patch_target_read:
+            await window_covering_cluster.read_attributes([attr.id])
+
+            # confirm the read was redirected to the target cluster
+            assert len(window_covering_cluster._read_attributes.mock_calls) == 0
+            assert len(target_cluster._read_attributes.mock_calls) == 1
+            assert target_cluster._read_attributes.mock_calls[0][1][0] == [
+                target_attr.id
+            ]
+    else:
+        with patch_window_covering_read:
+            await window_covering_cluster.read_attributes([attr.id])
+
+            # confirm the read occurred normally on the WindowCovering cluster
+            assert len(window_covering_cluster._read_attributes.mock_calls) == 1
+            assert window_covering_cluster._read_attributes.mock_calls[0][1][0] == [
+                attr.id
+            ]
+
+    if not expected_value:
+        # failed reads should not trigger an attribute update
+        assert len(window_covering_listener.attribute_updates) == 0
+        return
+
+    # for the redirected success case the value 1 from AnalogOutput
+    # should be inverted to 99 when cached on WindowCovering
+    assert len(window_covering_listener.attribute_updates) == 1
+    assert window_covering_listener.attribute_updates[0] == (
+        attr.id,
+        expected_value,
+    )
+
+
+async def test_xiaomi_b1_curtain_analog_propagation(zigpy_device_from_v2_quirk):
+    """Test Aqara B1 AnalogOutput present_value reads and reports propagate to WindowCovering."""
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain")
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    window_covering_listener = ClusterListener(window_covering_cluster)
+    window_covering_attr_id = (
+        WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+
+    analog_cluster = device.endpoints[1].analog_output
+    analog_listener = ClusterListener(analog_cluster)
+    analog_attr = AnalogOutput.AttributeDefs.present_value
+
+    # AnalogOutput read of present_value=70 should cache WindowCovering as 30
+    patch_analog_read = mock.patch.object(
+        analog_cluster,
+        "_read_attributes",
+        mock.AsyncMock(
+            return_value=(
+                [
+                    foundation.ReadAttributeRecord(
+                        analog_attr.id,
+                        foundation.Status.SUCCESS,
+                        foundation.TypeValue(None, 70),
+                    )
+                ],
+            )
+        ),
+    )
+
+    with patch_analog_read:
+        analog_listener.attribute_updates.clear()
+        window_covering_listener.attribute_updates.clear()
+
+        await analog_cluster.read_attributes([analog_attr.id])
+
+        assert len(window_covering_listener.attribute_updates) == 1
+        assert window_covering_listener.attribute_updates[0] == (
+            window_covering_attr_id,
+            30,
+        )
+
+    # AnalogOutput autonomous report of present_value=25 should cache WindowCovering as 75
+    attr = foundation.Attribute(
+        attrid=analog_attr.id,
+        value=foundation.TypeValue(0x39, t.Single(25.0)),
+    )
+    hdr = foundation.ZCLHeader.general(
+        1,
+        foundation.GeneralCommand.Report_Attributes,
+        direction=foundation.Direction.Server_to_Client,
+    ).serialize()
+    cmd = (
+        foundation.GENERAL_COMMANDS[foundation.GeneralCommand.Report_Attributes]
+        .schema([attr])
+        .serialize()
+    )
+
+    window_covering_listener.attribute_updates.clear()
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=analog_cluster.cluster_id,
+            src_ep=analog_cluster.endpoint.endpoint_id,
+            dst_ep=analog_cluster.endpoint.endpoint_id,
+            data=t.SerializableBytes(hdr + cmd),
+        )
+    )
+
+    assert len(window_covering_listener.attribute_updates) == 1
+    assert window_covering_listener.attribute_updates[0] == (
+        window_covering_attr_id,
+        75,
+    )
+
+
+async def test_xiaomi_b1_curtain_device_report_inversion(zigpy_device_from_v2_quirk):
+    """Test device-sourced current_position_lift_percentage reports are inverted.
+
+    The B1 sends autonomous reports for current_position_lift_percentage in its
+    non-standard scale (0=closed, 100=open). The _update_attribute override
+    must invert these to the standard Zigbee scale (0=open, 100=closed).
+    """
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain")
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    window_covering_listener = ClusterListener(window_covering_cluster)
+    window_covering_attr_id = (
+        WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+
+    # device reports current_position_lift_percentage=17 (device scale = 17% open)
+    # which must be cached as 83 (standard Zigbee scale = 83% closed)
+    attr = foundation.Attribute(
+        attrid=window_covering_attr_id,
+        value=foundation.TypeValue(foundation.DataTypeId.uint8, t.uint8_t(17)),
+    )
+    hdr = foundation.ZCLHeader.general(
+        1,
+        foundation.GeneralCommand.Report_Attributes,
+        direction=foundation.Direction.Server_to_Client,
+    ).serialize()
+    cmd = (
+        foundation.GENERAL_COMMANDS[foundation.GeneralCommand.Report_Attributes]
+        .schema([attr])
+        .serialize()
+    )
+
+    window_covering_listener.attribute_updates.clear()
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=window_covering_cluster.cluster_id,
+            src_ep=window_covering_cluster.endpoint.endpoint_id,
+            dst_ep=window_covering_cluster.endpoint.endpoint_id,
+            data=t.SerializableBytes(hdr + cmd),
+        )
+    )
+
+    assert len(window_covering_listener.attribute_updates) == 1
+    assert window_covering_listener.attribute_updates[0] == (
+        window_covering_attr_id,
+        83,
+    )
+
+
+async def test_xiaomi_b1_curtain_no_double_inversion(zigpy_device_from_v2_quirk):
+    """Test that AnalogOutput propagation does not double-invert via _from_analog flag.
+
+    When AnalogOutput.present_value updates WindowCovering.current_position_lift_percentage,
+    it has already applied 100-x. The _from_analog flag must prevent _update_attribute
+    from inverting again.
+    """
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain")
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    window_covering_listener = ClusterListener(window_covering_cluster)
+    window_covering_attr_id = (
+        WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+
+    analog_cluster = device.endpoints[1].analog_output
+    analog_attr = AnalogOutput.AttributeDefs.present_value
+
+    # AnalogOutput read of present_value=40 — propagation should cache WindowCovering as 60
+    # (100-40=60), not 40 (which would be the result of double-inversion)
+    patch_analog_read = mock.patch.object(
+        analog_cluster,
+        "_read_attributes",
+        mock.AsyncMock(
+            return_value=(
+                [
+                    foundation.ReadAttributeRecord(
+                        analog_attr.id,
+                        foundation.Status.SUCCESS,
+                        foundation.TypeValue(None, 40),
+                    )
+                ],
+            )
+        ),
+    )
+
+    with patch_analog_read:
+        window_covering_listener.attribute_updates.clear()
+        await analog_cluster.read_attributes([analog_attr.id])
+
+        assert len(window_covering_listener.attribute_updates) == 1
+        assert window_covering_listener.attribute_updates[0] == (
+            window_covering_attr_id,
+            60,
+        )
+
+    # confirm the flag is reset after propagation so subsequent device reports are inverted
+    assert window_covering_cluster._from_analog is False
 
 
 @pytest.mark.parametrize("endpoint", [(1), (2)])

--- a/zhaquirks/xiaomi/aqara/curtain_b1.py
+++ b/zhaquirks/xiaomi/aqara/curtain_b1.py
@@ -1,0 +1,215 @@
+"""Aqara Curtain Driver B1 (ZNCLDJ11LM) device."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from zigpy import types as t
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl import AttributeReadEvent, AttributeReportedEvent, Cluster, foundation
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import AnalogOutput, MultistateOutput, OnOff
+from zigpy.zcl.clusters.measurement import OccupancySensing
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+from zhaquirks import CustomCluster
+from zhaquirks.xiaomi import LUMI
+
+
+class AnalogOutputCurtainB1(CustomCluster, AnalogOutput):
+    """AnalogOutput cluster used as source of truth for curtain position.
+
+    present_value semantics: 0 = fully closed, 100 = fully open.
+    """
+
+    _CONSTANT_ATTRIBUTES = {
+        AnalogOutput.AttributeDefs.max_present_value.id: 100.0,
+        AnalogOutput.AttributeDefs.min_present_value.id: 0.0,
+    }
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.on_event(
+            AttributeReadEvent.event_type, self._handle_attribute_read_or_reported
+        )
+        self.on_event(
+            AttributeReportedEvent.event_type, self._handle_attribute_read_or_reported
+        )
+
+    def _handle_attribute_read_or_reported(
+        self, event: AttributeReadEvent | AttributeReportedEvent
+    ) -> None:
+        """Propagate present_value to WindowCovering current_position_lift_percentage."""
+        if event.attribute_id == self.AttributeDefs.present_value.id:
+            wc = self.endpoint.window_covering
+            wc._from_analog = True  # pylint: disable=protected-access
+            try:
+                wc.update_attribute(
+                    WindowCovering.AttributeDefs.current_position_lift_percentage.id,
+                    t.uint8_t(100 - event.value),
+                )
+            finally:
+                wc._from_analog = False  # pylint: disable=protected-access
+
+
+class WindowCoveringCurtainB1(CustomCluster, WindowCovering):
+    """WindowCovering cluster backed by AnalogOutput.present_value.
+
+    The device reports current_position_lift_percentage in a non-standard
+    scale (0 = closed, 100 = open, same as present_value) rather than the
+    Zigbee standard (0 = open, 100 = closed). Reads are redirected to
+    AnalogOutput.present_value, autonomous reports are inverted on receipt,
+    and motor commands are translated to AnalogOutput writes.
+    """
+
+    _CONSTANT_ATTRIBUTES = {
+        WindowCovering.AttributeDefs.window_covering_type.id: WindowCovering.WindowCoveringType.Drapery,
+    }
+
+    # Redirect reads of current_position_lift_percentage to AnalogOutput.present_value.
+    _REDIRECT_ATTRIBUTES: dict[
+        ZCLAttributeDef, tuple[ZCLAttributeDef, type[Cluster], Callable]
+    ] = {
+        WindowCovering.AttributeDefs.current_position_lift_percentage: (
+            AnalogOutput.AttributeDefs.present_value,
+            AnalogOutput,
+            lambda x: t.uint8_t(100 - x),
+        ),
+    }
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self._from_analog = False
+
+    def _update_attribute(self, attrid: int, value: Any) -> None:
+        """Invert device-sourced lift_percentage to standard Zigbee scale."""
+        lift_id = self.AttributeDefs.current_position_lift_percentage.id
+        if attrid == lift_id and not self._from_analog:
+            value = t.uint8_t(100 - value)
+        super()._update_attribute(attrid, value)
+
+    async def command(
+        self,
+        command_id: foundation.GeneralCommand | int | t.uint8_t,
+        *args: Any,
+        manufacturer: int | t.uint16_t | None = None,
+        expect_reply: bool = True,
+        tsn: int | t.uint8_t | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Translate motor commands to AnalogOutput writes.
+
+        The B1 expects target positions written to AnalogOutput.present_value
+        (100 = open, 0 = closed) rather than via native WindowCovering commands.
+        Each command is followed by a read so HA's position state stays in sync.
+        """
+        if command_id == WindowCovering.ServerCommandDefs.up_open.id:
+            (res,) = await self.endpoint.analog_output.write_attributes(
+                {AnalogOutput.AttributeDefs.present_value.name: 100}
+            )
+            await self.read_attributes(
+                [self.AttributeDefs.current_position_lift_percentage.id]
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
+
+        if command_id == WindowCovering.ServerCommandDefs.down_close.id:
+            (res,) = await self.endpoint.analog_output.write_attributes(
+                {AnalogOutput.AttributeDefs.present_value.name: 0}
+            )
+            await self.read_attributes(
+                [self.AttributeDefs.current_position_lift_percentage.id]
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
+
+        if command_id == WindowCovering.ServerCommandDefs.go_to_lift_percentage.id:
+            (res,) = await self.endpoint.analog_output.write_attributes(
+                {AnalogOutput.AttributeDefs.present_value.name: (100 - args[0])}
+            )
+            await self.read_attributes(
+                [self.AttributeDefs.current_position_lift_percentage.id]
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=res[0].status)
+
+        if command_id == WindowCovering.ServerCommandDefs.stop.id:
+            result = await super().command(
+                command_id,
+                *args,
+                manufacturer=manufacturer,
+                expect_reply=expect_reply,
+                tsn=tsn,
+                **kwargs,
+            )
+            await self.read_attributes(
+                [self.AttributeDefs.current_position_lift_percentage.id]
+            )
+            return result
+
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
+
+    async def read_attributes(
+        self,
+        attributes: list[int | str | foundation.ZCLAttributeDef],
+        **kwargs,
+    ) -> Any:
+        """Redirect attribute reads to another cluster per _REDIRECT_ATTRIBUTES."""
+        success = {}
+        failure = {}
+
+        attr_defs = {self.find_attribute(attr): attr for attr in attributes}
+
+        for redirected_attr_def, (
+            target_attr,
+            target_cluster,
+            format_func,
+        ) in self._REDIRECT_ATTRIBUTES.items():
+            if redirected_attr_def not in attr_defs:
+                continue
+
+            other_cluster = getattr(self.endpoint, target_cluster.ep_attribute)
+            other_success, other_failure = await other_cluster.read_attributes(
+                [target_attr], **kwargs
+            )
+
+            attr_key = attr_defs.pop(redirected_attr_def)
+            attributes.remove(attr_key)
+
+            if target_attr in other_success:
+                success[attr_key] = format_func(other_success[target_attr])
+
+            if target_attr in other_failure:
+                failure[attr_key] = other_failure[target_attr]
+
+        other_success, other_failure = await super().read_attributes(
+            attributes, **kwargs
+        )
+        success.update(other_success)
+        failure.update(other_failure)
+
+        return success, failure
+
+
+(
+    QuirkBuilder(LUMI, "lumi.curtain")
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=AnalogOutput.cluster_id)
+    .prevent_default_entity_creation(
+        endpoint_id=1, cluster_id=MultistateOutput.cluster_id
+    )
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=OnOff.cluster_id)
+    .prevent_default_entity_creation(
+        endpoint_id=1, cluster_id=OccupancySensing.cluster_id
+    )
+    .replaces(AnalogOutputCurtainB1, endpoint_id=1)
+    .replaces(WindowCoveringCurtainB1, endpoint_id=1)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Adds a v2 QuirkBuilder quirk for the Aqara Curtain Driver B1 (`lumi.curtain`, ZNCLDJ11LM). Replaces closed PR #2523 with a complete rewrite using the v2 API and addresses the test-coverage feedback from that review.

The device reports `current_position_lift_percentage` in a non-standard scale (0 = closed, 100 = open — inverse of the Zigbee standard). Two bugs follow from this:

**After-restart position wrong**: ZHA initialises position by reading the attribute directly, so the curtain always appeared open regardless of actual state. Fixed via `_REDIRECT_ATTRIBUTES`, which redirects reads to `AnalogOutput.present_value` (same device-native scale) and inverts the result.

**Stop command showed inverted position**: ~700ms after a stop command, the device sends an autonomous `current_position_lift_percentage` report in its non-standard scale, bypassing the read redirect. Fixed via an
`_update_attribute` override that inverts device-sourced values, with a `_from_analog` flag preventing double-inversion when the update originates from our own `AnalogOutput` propagation.

The pattern follows `roller_curtain_e1.py` (lumi.curtain.acn002) closely.

Suppresses `AnalogOutput`, `OnOff`, `MultistateOutput`, and `OccupancySensing` default entity creation — these are used internally for device control.

## Additional information

Fixes #2451. Replaces #2523.

**Related work**: PR #4995 (`lumi.curtain.aq2`) is currently under review and applies the same `AnalogOutput`↔`WindowCovering` bridge pattern to a sibling device. Both devices, along with `roller_curtain_e1.py` (`lumi.curtain.acn002`), share the same architectural family. This B1 quirk uses a simpler subset of the pattern — closer to E1's "read after every command" approach — and does not require the echo-discard or transition-cap workarounds that #4995 needs.
If the maintainers prefer to wait for #4995 to settle on a consolidated approach (or for [zigpy/zha#762](https://github.com/zigpy/zha/pull/762) to land for a `Cover`-subclass solution), I'm happy to align this PR with
whatever direction is chosen.

Tested on a physical Aqara Curtain Driver B1 (ZNCLDJ11LM):
- Open/Close/GoToLiftPercentage commands work correctly
- Stop command preserves correct position
- Position state survives HA restart

Note: I'm a hobbyist, not a Python expert — Claude Code helped with the v2 rewrite and tests. I've verified the behavior on real hardware and read through the code, but if reviewers spot Python idioms or patterns that could be cleaner, I'd appreciate the feedback.

## Device diagnostics

[zha-ed35483bc4d7da37001edd1b014068a1-LUMI lumi.curtain-7affa236fa10cb61adc986d04687e8f2.json](https://github.com/user-attachments/files/28187423/zha-ed35483bc4d7da37001edd1b014068a1-LUMI.lumi.curtain-7affa236fa10cb61adc986d04687e8f2.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached