### PR TITLE
Fix Schneider Electric thermostat sensor selection

### DIFF
--- a/zhaquirks/schneiderelectric/thermostat.py
+++ b/zhaquirks/schneiderelectric/thermostat.py
@@ -16,7 +16,7 @@ import zigpy.types as t
 from zigpy.zcl.clusters.hvac import SystemMode, Thermostat, UserInterface
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
-from zigpy.zcl.foundation import ZCLAttributeDef, DataTypeId, ZCLCommandDef
+from zigpy.zcl.foundation import DataTypeId, ZCLAttributeDef, ZCLCommandDef
 
 from zhaquirks.schneiderelectric import SE_MANUF_NAME, SEBasic
 

--- a/zhaquirks/schneiderelectric/thermostat.py
+++ b/zhaquirks/schneiderelectric/thermostat.py
@@ -16,7 +16,7 @@ import zigpy.types as t
 from zigpy.zcl.clusters.hvac import SystemMode, Thermostat, UserInterface
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
-from zigpy.zcl.foundation import ZCLAttributeDef, ZCLCommandDef
+from zigpy.zcl.foundation import ZCLAttributeDef, DataTypeId, ZCLCommandDef
 
 from zhaquirks.schneiderelectric import SE_MANUF_NAME, SEBasic
 
@@ -61,7 +61,7 @@ class SEControlStatus(t.enum8):
     SensorFault = 0x84
 
 
-class SELocalTemperatureSourceSelect(t.uint8_t):
+class SELocalTemperatureSourceSelect(t.enum8):
     """Local temperature source select."""
 
     # Internal temperature sensor
@@ -296,6 +296,7 @@ class SEThermostat(CustomCluster, Thermostat):
         se_local_temperature_source_select: Final = ZCLAttributeDef(
             id=0xE212,
             type=SELocalTemperatureSourceSelect,
+            zcl_type=DataTypeId.uint8,
             access="rw",
             is_manufacturer_specific=True,
         )

--- a/zhaquirks/schneiderelectric/thermostat.py
+++ b/zhaquirks/schneiderelectric/thermostat.py
@@ -61,7 +61,7 @@ class SEControlStatus(t.enum8):
     SensorFault = 0x84
 
 
-class SELocalTemperatureSourceSelect(t.enum8):
+class SELocalTemperatureSourceSelect(t.uint8_t):
     """Local temperature source select."""
 
     # Internal temperature sensor


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
The schneider electric thermostat (EKO0725x and EKO30465) has some manufacturer specific cluster attributes that allows selecting between internal or external (air, floor) sensors. The current attribute defined in the quirk is  using the wrong type, which results in failure when trying to change the source sensor.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
According to specs found in https://github.com/zigpy/zha-device-handlers/pull/3473, the `LocalTemperatureSourceSelect` is using the uint8 type and not enum8 which is used currently.
<img width="984" height="98" alt="image" src="https://github.com/user-attachments/assets/3bc5e3c5-1bf6-41f8-915e-a29296f36a1d" />


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
