### PR TITLE
Add Tuya cover `_TZE284_fzo2pocs` variant

### DIFF
--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -10,7 +10,7 @@ from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
 from zhaquirks.tuya import TuyaCommand, TuyaData, TuyaDatapointData
 from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaWindowCovering
-from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601
+from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601, TuyaZemismartSmartCover0601_4
 
 zhaquirks.setup()
 
@@ -32,6 +32,25 @@ def test_ts601_moes_signature(assert_signature_matches_quirk):
         "class": "zigpy.device.Device",
     }
     assert_signature_matches_quirk(TuyaMoesCover0601, signature)
+
+
+def test_zemismart_tze284_fzo2pocs_signature(assert_signature_matches_quirk):
+    """Test _TZE284_fzo2pocs cover signature is matched to its quirk."""
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.142: 142>, manufacturer_code=4098, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>)",
+        "endpoints": {
+            "1": {
+                "profile_id": 0x0104,
+                "device_type": "0x0051",
+                "in_clusters": ["0x0000", "0x0004", "0x0005", "0xef00", "0xed00"],
+                "out_clusters": ["0x000a", "0x0019"],
+            }
+        },
+        "manufacturer": "_TZE284_fzo2pocs",
+        "model": "TS0601",
+        "class": "zigpy.device.Device",
+    }
+    assert_signature_matches_quirk(TuyaZemismartSmartCover0601_4, signature)
 
 
 async def test_zemismart_zm16b_quirk(zigpy_device_from_v2_quirk):

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -13,6 +13,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import (
+    TUYA_CLUSTER_ED00_ID,
     TUYA_CLUSTER_ID,
     TuyaManufacturerWindowCover,
     TuyaManufCluster,
@@ -254,6 +255,49 @@ class TuyaZemismartSmartCover0601_3_inv_position(TuyaWindowCover):
                     TuyaWindowCoverControl,
                 ],
                 OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }
+
+
+class TuyaZemismartSmartCover0601_4(TuyaWindowCover):
+    """Tuya Zemismart window opener, _TZE284_* variant with 0xED00 cluster."""
+
+    signature = {
+        # input_clusters=[0x0000, 0x0004, 0x0005, 0xef00, 0xed00]
+        # output_clusters=[0x000a, 0x0019]
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=81
+        #   input_clusters=[0, 4, 5, 61184, 60672] output_clusters=[10, 25]>
+        MODELS_INFO: [
+            ("_TZE284_fzo2pocs", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufCluster.cluster_id,
+                    TUYA_CLUSTER_ED00_ID,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaManufacturerWindowCover,
+                    TuyaWindowCoverControl,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
         },
     }


### PR DESCRIPTION
## Proposed change

Add a new `TuyaZemismartSmartCover0601_4` quirk for the `_TZE284_fzo2pocs`
variant of the Zemismart TS0601 window opener. It mirrors the existing
`TuyaZemismartSmartCover0601_3` class but matches the signature actually
advertised by this newer Tuya firmware:

- the Tuya data-report cluster `0xED00` appears as an extra input cluster
  on endpoint 1
- the device announces device type `SMART_PLUG` (0x0051), so the existing
  Zemismart classes do not match
- the replacement is the same as `_3`: window covering device type with
  `TuyaManufacturerWindowCover` + `TuyaWindowCoverControl`

Without a matching quirk, ZHA only exposes a firmware update entity and
the cover cannot be operated.

## Additional information

Tested on hardware: a `_TZE284_fzo2pocs` window opener paired through a
Conbee II, ZHA 1.3.1, HA 2026.5.4. Cover entity is created on restart
without re-pairing once the quirk matches; open / close / set-position
work correctly.

## Device diagnostics

Sanitized to the fields relevant for the quirk match (signature,
endpoints, clusters, node descriptor).

<details>
<summary>zha-device-diagnostics.json</summary>

```json
{
  "home_assistant": {
    "version": "2026.5.4",
    "installation_type": "Home Assistant OS"
  },
  "integration_manifest": {
    "domain": "zha",
    "requirements": [
      "zha==1.3.1"
    ]
  },
  "data": {
    "version": 1,
    "ieee": "**REDACTED**",
    "nwk": "0x31A3",
    "manufacturer": "_TZE284_fzo2pocs",
    "model": "TS0601",
    "friendly_manufacturer": "_TZE284_fzo2pocs",
    "friendly_model": "TS0601",
    "name": "_TZE284_fzo2pocs TS0601",
    "quirk_applied": false,
    "quirk_class": "zigpy.device.Device",
    "exposes_features": [],
    "manufacturer_code": 4098,
    "power_source": "Mains",
    "lqi": 255,
    "rssi": -55,
    "last_seen": "2026-05-26T22:01:16.651503+00:00",
    "available": true,
    "device_type": "Router",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "Router",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 142,
      "manufacturer_code": 4098,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 82,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 82,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "SMART_PLUG",
          "id": 81
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0001",
                "name": "app_version",
                "zcl_type": "uint8",
                "value": 68
              },
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "_TZE284_fzo2pocs"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "TS0601"
              }
            ]
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x0005",
            "endpoint_attribute": "scenes",
            "attributes": []
          },
          {
            "cluster_id": "0xed00",
            "endpoint_attribute": null,
            "attributes": []
          },
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": null,
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 68
              }
            ],
            "last_query_cmd": {
              "manufacturer_code": 4098,
              "image_type": 5634,
              "current_file_version": 68,
              "hardware_version": null
            }
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "_TZE284_fzo2pocs",
      "model": "TS0601",
      "node_desc": {
        "logical_type": 1,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 142,
        "manufacturer_code": 4098,
        "maximum_buffer_size": 82,
        "maximum_incoming_transfer_size": 82,
        "server_mask": 11264,
        "maximum_outgoing_transfer_size": 82,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0051",
          "input_clusters": [
            "0x0000",
            "0x0004",
            "0x0005",
            "0xef00",
            "0xed00"
          ],
          "output_clusters": [
            "0x0019",
            "0x000a"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 255
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -55
          }
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OtaClientClusterHandler",
                "generic_id": "cluster_handler_0x0019_client",
                "endpoint_id": 1,
                "cluster": {
                  "id": 25,
                  "name": "Ota",
                  "type": "client"
                },
                "id": "1:0x0019_client",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x00000044",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [
      {
        "device_type": "Coordinator",
        "rx_on_when_idle": "On",
        "relationship": "Parent",
        "extended_pan_id": "**REDACTED**",
        "ieee": "**REDACTED**",
        "nwk": "0x0000",
        "permit_joining": "Unknown",
        "depth": 0,
        "lqi": 180
      }
    ],
    "routes": [
      {
        "dest_nwk": "0x0000",
        "route_status": "Active",
        "memory_constrained": true,
        "many_to_one": true,
        "route_record_required": false,
        "next_hop": "0x0000"
      }
    ]
  }
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
