### PR TITLE
Add Tuya soil sensor `_TZE284_oitavov2` variant

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -324,6 +324,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE204_myd45weu", "TS0601")
     .applies_to("_TZE284_myd45weu", "TS0601")
     .applies_to("_TZE200_2se8efxh", "TS0601")  # Immax Neo
+    .applies_to("_TZE284_oitavov2", "TS0601")
     .tuya_temperature(dp_id=5)
     .tuya_battery(dp_id=15)
     .tuya_soil_moisture(dp_id=3)


### PR DESCRIPTION
Adds the soil sensor _TZE284_oitavov2 to all the other soil sensors.

## Proposed change

#4282 noted that adding soil sensor `_TZE284_oitavov2` to the section containing `_TZE200_myd45weu` caused it to work. I have confirmed that my own `_TZE284_oitavov2` started working once I followed suit. I propose adding it so that it automatically works for others, as this soil sensor is widely available.

## Additional information

Fixes #4282. 

## Device diagnostics

[zha-01KSNVH0WW16JJPTCH176SNNW2-_TZE284_oitavov2 TS0601-be2d3e5dac8fd81af94f31a8faf75090.json](https://github.com/user-attachments/files/28327538/zha-01KSNVH0WW16JJPTCH176SNNW2-_TZE284_oitavov2.TS0601-be2d3e5dac8fd81af94f31a8faf75090.json)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
