### PR TITLE
Add Tuya TS0601 soil sensor _TZE284_3urschql

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -32,6 +32,16 @@ class TuyaSoilLightLevel(t.enum8):
     High = 0x04
 
 
+class GiexSoilLightLevel(t.enum8):
+    """GIEX soil sensor light level enum."""
+
+    Lower = 0x00
+    Low = 0x01
+    Normal = 0x02
+    High = 0x03
+    Higher = 0x04
+
+
 class TuyaNousTempHumiAlarm(t.enum8):
     """Tuya temperature and humidity alarm enum."""
 
@@ -277,6 +287,23 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .add_to_registry()
 )
 
+(
+    TuyaQuirkBuilder("_TZE284_3urschql", "TS0601")
+    .tuya_enum(
+        dp_id=2,
+        attribute_name="brightness_level",
+        enum_class=GiexSoilLightLevel,
+        entity_type=EntityType.STANDARD,
+        entity_platform=EntityPlatform.SENSOR,
+        translation_key="brightness_level",
+        fallback_name="Brightness level",
+    )
+    .tuya_temperature(dp_id=5, scale=10)
+    .tuya_battery(dp_id=15)
+    .tuya_soil_moisture(dp_id=3)
+    .skip_configuration()
+    .add_to_registry()
+)
 
 (
     TuyaQuirkBuilder("_TZE284_nt4pquef", "TS0601")  # SG502Z


### PR DESCRIPTION
## Proposed change

Add support for a Tuya TS0601 soil sensor variant.

Manufacturer: `_TZE284_3urschql`  
Model: `TS0601`

Datapoints:
- DP 2: brightness level enum
- DP 3: soil moisture
- DP 5: temperature
- DP 15: battery percentage

## Additional information

Tested locally with ZHA. Temperature, soil moisture, battery, and brightness level entities are created successfully.

## Device diagnostics

Not attached yet.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
