### PR TITLE
Add manuSpecific 0xFC03 cluster to 8 more Philips Hue bulb models

### DIFF
--- a/zhaquirks/philips/hue_light.py
+++ b/zhaquirks/philips/hue_light.py
@@ -261,3 +261,91 @@ from zhaquirks.philips import PHILIPS, SIGNIFY, PhilipsHueLightCluster
     .replaces(PhilipsHueLightCluster, endpoint_id=11)
     .add_to_registry()
 )
+
+(
+    QuirkBuilder()
+    .applies_to(SIGNIFY, "LCT016")
+    .friendly_name(
+        model="Hue white and color ambiance E26/E27/E14",
+        manufacturer="Philips",
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder()
+    .applies_to(SIGNIFY, "LCA009")
+    .friendly_name(
+        model="Hue white and color ambiance E26/A19 1600lm",
+        manufacturer="Philips",
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder()
+    .applies_to(SIGNIFY, "LCL001")
+    .friendly_name(
+        model="Hue white and color ambiance LightStrip plus",
+        manufacturer="Philips",
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder()
+    .applies_to(SIGNIFY, "929003528702")
+    .friendly_name(
+        model="Hue Sana wall light",
+        manufacturer="Philips",
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder()
+    .applies_to(SIGNIFY, "LTA008")
+    .friendly_name(
+        model="Hue white ambiance E27 with Bluetooth",
+        manufacturer="Philips",
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder()
+    .applies_to(SIGNIFY, "LTW004")
+    .friendly_name(
+        model="Hue white ambiance E26/E27",
+        manufacturer="Philips",
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder()
+    .applies_to(SIGNIFY, "LTO005")
+    .friendly_name(
+        model="Hue white ambiance G40 E26 filament globe with Bluetooth",
+        manufacturer="Philips",
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder()
+    .applies_to(SIGNIFY, "929003531502")
+    .friendly_name(
+        model="Hue white ambiance ceiling white Enrave M with Bluetooth",
+        manufacturer="Philips",
+    )
+    .replaces(PhilipsHueLightCluster, endpoint_id=11)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Registers the existing `PhilipsHueLightCluster` (manufacturer-specific cluster `0xFC03`, endpoint 11) for 8 more Philips Hue bulb models that currently fall through to a generic cluster. This exposes the `multiColor` command (id `0x00`) — Hue native firmware effects (candle, fireplace, sunrise, …) plus atomic brightness + color-temp in a single frame.

| Model | Name |
|---|---|
| LCT016 | Hue white and color ambiance E26/E27/E14 |
| LCA009 | Hue white and color ambiance E26/A19 1600lm |
| LCL001 | Hue white and color ambiance LightStrip plus |
| 929003528702 | Hue Sana wall light |
| LTA008 | Hue white ambiance E27 with Bluetooth |
| LTW004 | Hue white ambiance E26/E27 |
| LTO005 | Hue white ambiance G40 E26 filament globe with Bluetooth |
| 929003531502 | Hue white ambiance ceiling white Enrave M with Bluetooth |

All 8 declare `0xFC03` on endpoint 11. This is a purely declarative addition that reuses the existing (already-tested) `PhilipsHueLightCluster`, matching the pattern used for the other models already in `hue_light.py`.

## Additional information

Each model was verified on real hardware: the `multiColor` command sends successfully and is acted on by the bulb. 7 of the 8 run the dynamic firmware effects (verified with candle). **LTW004** (firmware `67.116.12`) accepts `multiColor` state-writes (atomic brightness/color-temp confirmed) but its older firmware does not animate the dynamic effects — the cluster and command still function, so the quirk is correct for it.

Note: `929003528702` is the **Hue Sana** wall light; it isn't present in the zigbee-herdsman device database, so the friendly name is from the product, not the DB.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using ruff
- [ ] Tests have been added to verify that the new code works — N/A: purely declarative v2 quirk reusing an existing custom cluster (per the contributing guide, declarative quirks with no custom logic don't require tests)
- [x] Device diagnostics data has been attached
