### PR TITLE
Add Tuya 4-in-1 mmWave radar sensor `_TZE284_gnpflcoq`

### DIFF
--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -1629,3 +1629,62 @@ base_tuya_motion = (
     .skip_configuration()
     .add_to_registry()
 )
+
+# Tuya 4-in-1 mmWave Radar Sensor
+# https://github.com/Koenkk/zigbee2mqtt/issues/31892
+(
+    TuyaQuirkBuilder("_TZE284_gnpflcoq", "TS0601")
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=TuyaOccupancySensing.ep_attribute,
+        attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
+        converter=lambda x: x == 1,
+    )
+    .adds(TuyaOccupancySensing)
+    .tuya_battery(dp_id=4)
+    .tuya_temperature(dp_id=7, scale=10)
+    .tuya_humidity(dp_id=8)
+    .tuya_illuminance(dp_id=11)
+    .tuya_number(
+        dp_id=2,
+        attribute_name="radar_sensitivity",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=10,
+        step=1,
+        translation_key="radar_sensitivity",
+        fallback_name="Radar sensitivity",
+    )
+    .tuya_enum(
+        dp_id=9,
+        attribute_name="pir_sensitivity",
+        enum_class=TuyaSensitivityMode,
+        translation_key="pir_sensitivity",
+        fallback_name="PIR sensitivity",
+    )
+    .tuya_number(
+        dp_id=12,
+        attribute_name="pir_delay",
+        type=t.uint16_t,
+        min_value=10,
+        max_value=180,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        device_class=SensorDeviceClass.DURATION,
+        translation_key="pir_delay",
+        fallback_name="PIR delay",
+    )
+    .tuya_number(
+        dp_id=13,
+        attribute_name="detection_range",
+        type=t.uint16_t,
+        min_value=1,
+        max_value=10,
+        step=1,
+        unit=UnitOfLength.METERS,
+        translation_key="detection_range",
+        fallback_name="Detection range",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Add a quirk for the Tuya TS0601 4-in-1 mmWave radar sensor (`_TZE284_gnpflcoq`).

This battery-powered device combines mmWave presence detection with environmental sensors. The quirk uses `TuyaQuirkBuilder` and reuses existing cluster classes (`TuyaOccupancySensing`, `TuyaSensitivityMode`) from `tuya_motion.py`.

**Sensor entities:**
- Occupancy / presence (DP 1)
- Temperature (DP 7)
- Humidity (DP 8)
- Illuminance (DP 11)
- Battery (DP 4)

**Configuration entities:**
- Radar sensitivity (DP 2, number, range 0–10)
- PIR sensitivity (DP 9, enum: Low / Medium / High)
- PIR delay (DP 12, number, range 10–180 s)
- Detection range (DP 13, number, range 1–10 m)

## Additional information

DP mapping is based on sniffed datapoints documented in https://github.com/Koenkk/zigbee2mqtt/issues/31892.

This is a purely declarative v2 quirk with no custom clusters or overridden methods, so no additional tests are required per contribution guidelines.

## Device diagnostics

[zha-01KA6AX1GP9ZH5H5SY6ACHEXDA-_TZE284_gnpflcoq TS0601-7f7927bee5855b46d97f06d77a894d24.json](https://github.com/user-attachments/files/28479320/zha-01KA6AX1GP9ZH5H5SY6ACHEXDA-_TZE284_gnpflcoq.TS0601-7f7927bee5855b46d97f06d77a894d24.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached