### PR TITLE
Add Novato ZPV-01 battery powered smart valve quirk

### DIFF
--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -11,6 +11,7 @@ from zigpy.quirks.v2.homeassistant import (
 )
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types as t
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.smartenergy import Metering
 
 from zhaquirks.const import BatterySize
@@ -763,6 +764,37 @@ class GiexIrrigationStatus(t.enum8):
         fallback_name="Last watering duration",
     )
     .tuya_battery(dp_id=110, battery_type=BatterySize.AA, battery_qty=2)
+    .tuya_enchantment()
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+# Novato ZPV-01 battery powered smart valve
+class NovatoValveState(t.enum8):
+    """Novato ZPV-01 valve status reported by DP 8."""
+
+    Unknown = 0x00
+    Open = 0x01
+    Closed = 0x02
+
+
+(
+    TuyaQuirkBuilder("_TZE204_dsagrkvg", "TS0601")
+    .applies_to("_TZE284_zm8zpwas", "TS0601")
+    .applies_to("_TZE284_sdvbnmj5", "TS0601")
+    .tuya_onoff(dp_id=1)
+    .tuya_enum(
+        dp_id=8,
+        attribute_name="valve_state",
+        enum_class=NovatoValveState,
+        access=foundation.ZCLAttributeAccess.Read,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.STANDARD,
+        translation_key="valve_state",
+        fallback_name="Valve state",
+    )
+    .tuya_battery(dp_id=101, battery_type=BatterySize.AA, battery_qty=2)
     .tuya_enchantment()
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
## Proposed change

Add a `TuyaQuirkBuilder` (quirks v2) definition for the **Novato ZPV-01** battery powered smart valve (Tuya TS0601) to `zhaquirks/tuya/tuya_valve.py`, covering manufacturers `_TZE204_dsagrkvg`, `_TZE284_zm8zpwas` and the new chip revision `_TZE284_sdvbnmj5`, which currently pairs with no entities.

Datapoints (verified against the Zigbee2MQTT converter for this device):

- DP 1: on/off valve control (`tuya_onoff`)
- DP 8: valve state enum 0=Unknown/1=Open/2=Closed (read-only sensor)
- DP 101: battery percentage (`tuya_battery`)

## Additional information

The same device/fingerprints are supported in Zigbee2MQTT (model `ZPV-01`, vendor Novato); the new `_TZE284_sdvbnmj5` manufacturer was just added there in Koenkk/zigbee-herdsman-converters#12374.

## Device diagnostics

Device diagnostics for the `_TZE284_sdvbnmj5` variant will be attached in a follow-up comment.

## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
