### PR TITLE
Add support for Aqara lumi switch aeu003 (H2 Shutter)

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2820,6 +2820,75 @@ async def test_lumi_switch_aeu003_quirk_applied(zigpy_device_from_v2_quirk):
 
 
 @pytest.mark.parametrize(
+    "zha_sends, device_should_receive",
+    [
+        # Fully closed: device reports 0 (its own "open" convention), HA sees 100
+        (0, 100),
+        # Fully open: device reports 100 (its own "closed" convention), HA sees 0
+        (100, 0),
+        # 20 % open from device perspective → 80 % open in HA
+        (20, 80),
+        # 80 % open from device perspective → 20 % open in HA
+        (80, 20),
+        # Midpoint is symmetric
+        (50, 50),
+    ],
+)
+async def test_go_to_lift_percentage_command_inverted(
+    zigpy_device_from_v2_quirk, zha_sends, device_should_receive
+):
+    """Outgoing go_to_lift_percentage commands must be pre-inverted.
+
+    ZHA converts the HA position (0=closed, 100=open) to Zigbee convention
+    (0=open, 100=closed) with 100-x before calling the cluster command.
+    The cluster must invert again so the device receives the original HA
+    value and moves to the correct physical position.
+
+    Flow for "set to 80 %":
+        HA 80 → ZHA inverts → cluster receives 20
+        cluster inverts → device receives 80 → moves to 80 % open  ✓
+    """
+    GO_TO_LIFT_PCT_CMD = WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
+    device = zigpy_device_from_v2_quirk(AQARA, "lumi.switch.aeu003")
+    cluster = device.endpoints[1].window_covering
+    assert isinstance(cluster, InvertedWindowCoveringCluster)
+
+    # Patch WindowCovering.request (the grandparent implementation our override
+    # calls via super()).  AsyncMock is not a descriptor so super().request
+    # resolves to the mock object itself; it is called without 'self', giving
+    # call_args.args == (general, command_id, schema, percentage, ...).
+    with mock.patch.object(
+        WindowCovering, "request", new_callable=mock.AsyncMock
+    ) as base_request:
+        base_request.return_value = foundation.Status.SUCCESS, "done"
+
+        await cluster.request(False, GO_TO_LIFT_PCT_CMD, {}, zha_sends)
+
+        base_request.assert_called_once()
+        # positional args seen by the base class: (general, cmd_id, schema, pct)
+        assert base_request.call_args.args[3] == device_should_receive
+
+
+async def test_non_position_commands_unchanged(zigpy_device_from_v2_quirk):
+    """Commands other than go_to_lift_percentage must pass through unmodified."""
+    device = zigpy_device_from_v2_quirk(AQARA, "lumi.switch.aeu003")
+    cluster = device.endpoints[1].window_covering
+
+    stop_cmd = WindowCovering.ServerCommandDefs.stop.id
+
+    with mock.patch.object(
+        WindowCovering, "request", new_callable=mock.AsyncMock
+    ) as base_request:
+        base_request.return_value = foundation.Status.SUCCESS, "done"
+
+        await cluster.request(False, stop_cmd, {})
+
+        base_request.assert_called_once()
+        # stop carries no percentage argument; command_id must be unchanged
+        assert base_request.call_args.args[1] == stop_cmd
+
+
+@pytest.mark.parametrize(
     "button, expected_command",
     [
         ("button_3", "3_single"),

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -110,6 +110,8 @@ import zhaquirks.xiaomi.aqara.plug_eu
 import zhaquirks.xiaomi.aqara.roller_curtain_e1
 import zhaquirks.xiaomi.aqara.sensor_ht_agl02
 import zhaquirks.xiaomi.aqara.smoke
+import zhaquirks.xiaomi.aqara.switch_aeu003
+from zhaquirks.xiaomi.aqara.switch_aeu003 import InvertedWindowCoveringCluster
 import zhaquirks.xiaomi.aqara.switch_t1
 from zhaquirks.xiaomi.aqara.thermostat_agl001 import ScheduleEvent, ScheduleSettings
 import zhaquirks.xiaomi.aqara.weather
@@ -2729,3 +2731,110 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
     temp = device.endpoints[1].device_temperature
     temp._update_attribute(DeviceTemperature.AttributeDefs.current_temperature.id, 25)
     assert temp.get("current_temperature") == 2500
+
+
+@pytest.mark.parametrize(
+    "device_reports, expected_in_ha",
+    [
+        # Fully closed: device reports 0 (its own "open" convention), HA sees 100
+        (0, 100),
+        # Fully open: device reports 100 (its own "closed" convention), HA sees 0
+        (100, 0),
+        # 20 % open from device perspective → 80 % open in HA
+        (20, 80),
+        # 80 % open from device perspective → 20 % open in HA
+        (80, 20),
+        # Midpoint is symmetric
+        (50, 50),
+    ],
+)
+async def test_lumi_switch_aeu003_position_inversion(
+    zigpy_device_from_v2_quirk, device_reports, expected_in_ha
+):
+    """Test that the InvertedWindowCoveringCluster corrects the position convention.
+
+    The Aqara H2 shutter switch (lumi.switch.aeu003) firmware reports
+    current_position_lift_percentage in HA convention (0 = closed,
+    100 = open), while ZHA expects Zigbee-spec convention (0 = open,
+    100 = closed) and inverts the value itself. Without the quirk this
+    produces a double inversion. The InvertedWindowCoveringCluster
+    pre-inverts the value so the two inversions cancel out.
+    """
+    LIFT_PERCENTAGE_ATTR = (
+        WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+    device = zigpy_device_from_v2_quirk(AQARA, "lumi.switch.aeu003")
+
+    window_covering_cluster = device.endpoints[1].window_covering
+    assert isinstance(window_covering_cluster, InvertedWindowCoveringCluster)
+
+    listener = ClusterListener(window_covering_cluster)
+
+    # Simulate a Zigbee attribute report arriving from the physical device.
+    window_covering_cluster._update_attribute(LIFT_PERCENTAGE_ATTR, device_reports)
+
+    assert len(listener.attribute_updates) == 1
+    attr_id, attr_value = listener.attribute_updates[0]
+    assert attr_id == LIFT_PERCENTAGE_ATTR
+    assert attr_value == expected_in_ha
+
+
+async def test_lumi_switch_aeu003_non_position_attributes_pass_through(
+    zigpy_device_from_v2_quirk,
+):
+    """Test that attributes other than lift percentage are not affected.
+
+    Only current_position_lift_percentage (0x0008) should be inverted;
+    all other WindowCovering attributes must pass through unchanged.
+    """
+    device = zigpy_device_from_v2_quirk(AQARA, "lumi.switch.aeu003")
+    window_covering_cluster = device.endpoints[1].window_covering
+    listener = ClusterListener(window_covering_cluster)
+
+    # Use the mode attribute (0x0017) as a representative non-position attribute.
+    mode_attr_id = WindowCovering.AttributeDefs.window_covering_mode.id
+    window_covering_cluster._update_attribute(mode_attr_id, 4)
+
+    assert len(listener.attribute_updates) == 1
+    attr_id, attr_value = listener.attribute_updates[0]
+    assert attr_id == mode_attr_id
+    # Value must be unchanged — no inversion applied.
+    assert attr_value == 4
+
+
+async def test_lumi_switch_aeu003_quirk_applied(zigpy_device_from_v2_quirk):
+    """Test that the quirk is applied and the device has the expected endpoints."""
+    device = zigpy_device_from_v2_quirk(AQARA, "lumi.switch.aeu003")
+
+    # Endpoints 1–4 are ON_OFF_SWITCH channels; endpoint 21 is the power meter.
+    assert 1 in device.endpoints
+    assert 2 in device.endpoints
+    assert 3 in device.endpoints
+    assert 4 in device.endpoints
+    assert 21 in device.endpoints
+
+    # Endpoint 1 must carry the inverted WindowCovering cluster.
+    assert isinstance(
+        device.endpoints[1].window_covering, InvertedWindowCoveringCluster
+    )
+
+
+@pytest.mark.parametrize(
+    "button, expected_command",
+    [
+        ("button_3", "3_single"),
+        ("button_4", "4_single"),
+    ],
+)
+async def test_lumi_switch_aeu003_automation_triggers(
+    zigpy_device_from_v2_quirk, button, expected_command
+):
+    """Test that device automation triggers are registered for both rocker buttons."""
+
+    device = zigpy_device_from_v2_quirk(AQARA, "lumi.switch.aeu003")
+
+    # Verify the trigger map contains entries for both physical rocker buttons.
+    triggers = device.device_automation_triggers
+    assert any(
+        expected_command in str(trigger_value) for trigger_value in triggers.values()
+    ), f"Expected command '{expected_command}' not found in device automation triggers"

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -1,0 +1,44 @@
+from zigpy.profiles import zha
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import Basic, Identify
+from zhaquirks.const import (
+    BUTTON_3,
+    BUTTON_4,
+    COMMAND,
+    COMMAND_SINGLE,
+)
+from zhaquirks.xiaomi import (
+    AQARA,
+    AnalogInputCluster, 
+    ElectricalMeasurementCluster,
+    MeteringCluster
+)
+from zhaquirks.xiaomi.aqara.opple_remote import (
+    COMMAND_3_SINGLE,
+    COMMAND_4_SINGLE,
+)
+from zhaquirks.xiaomi.aqara.opple_switch import MultistateInputCluster
+
+
+(
+    QuirkBuilder(AQARA, "lumi.switch.aeu003")
+    .adds_endpoint(1, zha.DeviceType.ON_OFF_SWITCH)
+    .adds_endpoint(2, zha.DeviceType.ON_OFF_SWITCH)
+    .adds_endpoint(3, zha.DeviceType.ON_OFF_SWITCH)
+    .adds_endpoint(4, zha.DeviceType.ON_OFF_SWITCH)
+    .adds_endpoint(21, zha.DeviceType.ON_OFF_SWITCH)
+    .adds(Basic, endpoint_id=1)
+    .adds(Identify, endpoint_id=1)
+    .adds(WindowCovering, endpoint_id=1)
+    .replaces(MultistateInputCluster, endpoint_id=3)
+    .replaces(MultistateInputCluster, endpoint_id=4)
+    .replaces(ElectricalMeasurementCluster, endpoint_id=1)
+    .replaces(MeteringCluster, endpoint_id=1)
+    .replaces(AnalogInputCluster, endpoint_id=21)
+    .device_automation_triggers({
+        (COMMAND_SINGLE, BUTTON_3): {COMMAND: COMMAND_3_SINGLE},
+        (COMMAND_SINGLE, BUTTON_4): {COMMAND: COMMAND_4_SINGLE},
+    })
+    .add_to_registry()
+)

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -1,4 +1,5 @@
 from zigpy.profiles import zha
+from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import Basic, Identify
@@ -10,7 +11,7 @@ from zhaquirks.const import (
 )
 from zhaquirks.xiaomi import (
     AQARA,
-    AnalogInputCluster, 
+    AnalogInputCluster,
     ElectricalMeasurementCluster,
     MeteringCluster
 )
@@ -19,6 +20,23 @@ from zhaquirks.xiaomi.aqara.opple_remote import (
     COMMAND_4_SINGLE,
 )
 from zhaquirks.xiaomi.aqara.opple_switch import MultistateInputCluster
+
+
+class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
+    """WindowCovering cluster that corrects the Aqara H2 position inversion.
+
+    The Aqara H2 shutter switch reports lift percentage in Home Assistant
+    convention (0=closed, 100=open), but ZHA expects Zigbee spec convention
+    (0=open, 100=closed) and inverts the value itself. This cluster
+    pre-inverts the value to cancel out the double-flip.
+    """
+
+    CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
+
+    def _update_attribute(self, attrid, value):
+        if attrid == self.CURRENT_POSITION_LIFT_PERCENTAGE and value is not None:
+            value = 100 - value
+        super()._update_attribute(attrid, value)
 
 
 (
@@ -30,7 +48,7 @@ from zhaquirks.xiaomi.aqara.opple_switch import MultistateInputCluster
     .adds_endpoint(21, zha.DeviceType.ON_OFF_SWITCH)
     .adds(Basic, endpoint_id=1)
     .adds(Identify, endpoint_id=1)
-    .adds(WindowCovering, endpoint_id=1)
+    .replaces(InvertedWindowCoveringCluster, endpoint_id=1)
     .replaces(MultistateInputCluster, endpoint_id=3)
     .replaces(MultistateInputCluster, endpoint_id=4)
     .replaces(ElectricalMeasurementCluster, endpoint_id=1)

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -18,20 +18,42 @@ from zhaquirks.xiaomi.aqara.opple_switch import MultistateInputCluster
 
 
 class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
-    """WindowCovering cluster that corrects the Aqara H2 position inversion.
+    """WindowCovering cluster that corrects the Aqara H2 position convention.
 
-    The Aqara H2 shutter switch reports lift percentage in Home Assistant
-    convention (0=closed, 100=open), but ZHA expects Zigbee spec convention
-    (0=open, 100=closed) and inverts the value itself. This cluster
-    pre-inverts the value to cancel out the double-flip.
+    The Aqara H2 shutter switch uses Home Assistant convention throughout
+    (0 = closed, 100 = open), while ZHA expects Zigbee spec convention
+    (0 = open, 100 = closed) and applies a 100-x inversion on both reads
+    and writes.  Without correction this produces a double inversion in
+    both directions.  This cluster pre-inverts values in both directions
+    so the two inversions cancel out:
+
+    - Incoming attribute reports (_update_attribute): device→cluster value
+      is inverted before ZHA reads it.
+    - Outgoing go_to_lift_percentage commands (request): ZHA-inverted value
+      is re-inverted before it is sent to the device.
     """
 
-    CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
+    CURRENT_POSITION_LIFT_PERCENTAGE = (
+        WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+    GO_TO_LIFT_PERCENTAGE_CMD = (
+        WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
+    )
+
+    # -- Incoming: fix reported position ------------------------------------
 
     def _update_attribute(self, attrid, value):
         if attrid == self.CURRENT_POSITION_LIFT_PERCENTAGE and value is not None:
             value = 100 - value
         super()._update_attribute(attrid, value)
+
+    # -- Outgoing: fix commanded position -----------------------------------
+
+    async def request(self, general, command_id, schema, *args, **kwargs):
+        """Extend WindowCovering.request to override Go to lift percentage commands."""
+        if not general and command_id == self.GO_TO_LIFT_PERCENTAGE_CMD and args:
+            args = (100 - args[0],) + args[1:]
+        return await super().request(general, command_id, schema, *args, **kwargs)
 
 
 (

--- a/zhaquirks/xiaomi/aqara/switch_aeu003.py
+++ b/zhaquirks/xiaomi/aqara/switch_aeu003.py
@@ -1,24 +1,19 @@
+"""Aqara H2 Shutter device."""
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import Basic, Identify
-from zhaquirks.const import (
-    BUTTON_3,
-    BUTTON_4,
-    COMMAND,
-    COMMAND_SINGLE,
-)
+
+from zhaquirks.const import BUTTON_3, BUTTON_4, COMMAND, COMMAND_SINGLE
 from zhaquirks.xiaomi import (
     AQARA,
     AnalogInputCluster,
     ElectricalMeasurementCluster,
-    MeteringCluster
+    MeteringCluster,
 )
-from zhaquirks.xiaomi.aqara.opple_remote import (
-    COMMAND_3_SINGLE,
-    COMMAND_4_SINGLE,
-)
+from zhaquirks.xiaomi.aqara.opple_remote import COMMAND_3_SINGLE, COMMAND_4_SINGLE
 from zhaquirks.xiaomi.aqara.opple_switch import MultistateInputCluster
 
 
@@ -54,9 +49,11 @@ class InvertedWindowCoveringCluster(CustomCluster, WindowCovering):
     .replaces(ElectricalMeasurementCluster, endpoint_id=1)
     .replaces(MeteringCluster, endpoint_id=1)
     .replaces(AnalogInputCluster, endpoint_id=21)
-    .device_automation_triggers({
-        (COMMAND_SINGLE, BUTTON_3): {COMMAND: COMMAND_3_SINGLE},
-        (COMMAND_SINGLE, BUTTON_4): {COMMAND: COMMAND_4_SINGLE},
-    })
+    .device_automation_triggers(
+        {
+            (COMMAND_SINGLE, BUTTON_3): {COMMAND: COMMAND_3_SINGLE},
+            (COMMAND_SINGLE, BUTTON_4): {COMMAND: COMMAND_4_SINGLE},
+        }
+    )
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change

Add support for Aqara H2 Shutter (lumi.switch.aeu003)


## Additional information
Aqara H2 Shutter is a window covering switch with two additional buttons. The intricacy of this device is that it reports and inverse position than ZHA expects which means that the position has to be inverted in the quirk.

Fixes #4410 .


## Device diagnostics
[zha-01K7P9R2SZNMYA76AKFB7BK0Q1-Aqara lumi.switch.aeu003-a7c8aac0c73d291711edd87e68542b06.json](https://github.com/user-attachments/files/28659107/zha-01K7P9R2SZNMYA76AKFB7BK0Q1-Aqara.lumi.switch.aeu003-a7c8aac0c73d291711edd87e68542b06.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [X] `pre-commit` checks pass / the code has been formatted using Black
- [X] Tests have been added to verify that the new code works
- [X] Device diagnostics data has been attached
