### PR TITLE
Add Tuya TS0601 pilot wire (fil pilote) heating controller (_TZE204_3q3maeoo)

### DIFF
--- a/zhaquirks/tuya/ts0601_pilot_wire.py
+++ b/zhaquirks/tuya/ts0601_pilot_wire.py
@@ -1,0 +1,80 @@
+"""Tuya TS0601 pilot wire (fil pilote) heating controller.
+
+Tested with:
+  - _TZE204_3q3maeoo TS0601 (6-mode French pilot wire controller)
+
+The French "fil pilote" standard defines up to 6 heating modes sent over a
+dedicated wire using AC phase modulation. This controller bridges Zigbee to
+that standard.
+
+Observed data points:
+  DP  2  - Operating mode (Auto / Manual)
+  DP 16  - Current temperature in 0.1 °C (e.g. 205 → 20.5 °C)
+  DP 127 - Pilot wire mode (6 modes: Comfort, Comfort-1, Comfort-2, Eco,
+            Anti-frost, Off)
+"""
+
+import zigpy.types as t
+from zigpy.quirks.v2 import EntityPlatform, EntityType
+
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+
+class OperatingMode(t.enum8):
+    """Operating mode: automatic schedule vs. manual override."""
+
+    Auto = 0x00
+    Manual = 0x01
+
+
+class PilotWireMode(t.enum8):
+    """French fil pilote 6-mode heating setpoint."""
+
+    Comfort = 0x00
+    Comfort_minus_1 = 0x01
+    Comfort_minus_2 = 0x02
+    Eco = 0x03
+    Anti_frost = 0x04
+    Off = 0x05
+
+
+(
+    TuyaQuirkBuilder("_TZE204_3q3maeoo", "TS0601")
+    .tuya_enum(
+        dp_id=2,
+        attribute_name="operating_mode",
+        enum_class=OperatingMode,
+        translation_key="operating_mode",
+        fallback_name="Operating Mode",
+        entity_type=EntityType.CONFIG,
+        entity_platform=EntityPlatform.SELECT,
+    )
+    .tuya_temperature(dp_id=16, scale=10)
+    .tuya_enum(
+        dp_id=127,
+        attribute_name="pilot_wire_mode",
+        enum_class=PilotWireMode,
+        translation_key="pilot_wire_mode",
+        fallback_name="Pilot Wire Mode",
+        entity_type=EntityType.CONFIG,
+        entity_platform=EntityPlatform.SELECT,
+    )
+    .tuya_sensor(
+        dp_id=8,
+        attribute_name="dp8_unknown",
+        type=t.uint8_t,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="dp8_unknown",
+        fallback_name="DP8 (unknown)",
+    )
+    .tuya_sensor(
+        dp_id=126,
+        attribute_name="dp126_unknown",
+        type=t.uint8_t,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="dp126_unknown",
+        fallback_name="DP126 (unknown)",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0601_pilot_wire.py
+++ b/zhaquirks/tuya/ts0601_pilot_wire.py
@@ -14,8 +14,8 @@ Observed data points:
             Anti-frost, Off)
 """
 
-import zigpy.types as t
 from zigpy.quirks.v2 import EntityPlatform, EntityType
+import zigpy.types as t
 
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 


### PR DESCRIPTION
## Summary

Adds a v2 quirk for the `_TZE204_3q3maeoo` TS0601, a Zigbee controller for the French standard 6-mode *fil pilote* (pilot wire) electric heating system.

### Device

- **Manufacturer:** `_TZE204_3q3maeoo`
- **Model:** `TS0601`
- **Function:** Bridges Zigbee to the French [fil pilote](https://fr.wikipedia.org/wiki/Fil_pilote) heating protocol (AC phase modulation), controlling electric panel heaters in 6 modes.

### Data points observed

| DP | Type | Description |
|----|------|-------------|
| 2 | enum8 | Operating mode: `Auto` (0) / `Manual` (1) |
| 16 | int | Current temperature in 0.1 °C (e.g. 205 → 20.5 °C) |
| 127 | enum8 | Pilot wire mode: `Comfort` / `Comfort-1` / `Comfort-2` / `Eco` / `Anti-frost` / `Off` |
| 8 | uint8 | Unknown (observed values 41–42), exposed as diagnostic |
| 126 | uint8 | Unknown, exposed as diagnostic |

### Entities created

- **Select** – Operating Mode (Config)
- **Select** – Pilot Wire Mode (Config)
- **Sensor** – Temperature (Standard)
- **Sensor** – DP8 unknown (Diagnostic)
- **Sensor** – DP126 unknown (Diagnostic)

### Testing

Tested on Home Assistant 2025.x with ZHA. The device pairs correctly, all entities appear and update in real time. The two diagnostic sensors (DP 8 and DP 126) report stable values; their meaning is unknown and feedback from other users is welcome.

## Checklist

- [x] New device, no existing quirk for this manufacturer code
- [x] Uses `TuyaQuirkBuilder` v2 pattern
- [x] Follows existing code style in `zhaquirks/tuya/`
- [x] Diagnostic entities for unidentified DPs