### PR TITLE
Add Aqara Wall Outlet H2 UK (lumi.plug.aeu002)

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -45,12 +45,17 @@ from tests.common import ZCL_OCC_ATTR_RPT_OCC, ClusterListener
 import zhaquirks
 from zhaquirks.const import (
     ATTR_ID,
+    BUTTON,
     BUTTON_1,
     BUTTON_2,
+    COMMAND,
     DEVICE_TYPE,
+    DOUBLE_PRESS,
     ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
+    LONG_PRESS,
+    LONG_RELEASE,
     MANUFACTURER,
     MODEL,
     NODE_DESCRIPTOR,
@@ -59,6 +64,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PRESS_TYPE,
     PROFILE_ID,
+    SHORT_PRESS,
     VALUE,
     ZONE_STATUS_CHANGE_COMMAND,
     BatterySize,
@@ -106,6 +112,7 @@ import zhaquirks.xiaomi.aqara.motion_agl04
 import zhaquirks.xiaomi.aqara.motion_aq2
 import zhaquirks.xiaomi.aqara.motion_aq2b
 import zhaquirks.xiaomi.aqara.plug
+from zhaquirks.xiaomi.aqara.plug_aeu002 import AqaraPlugH2Cluster
 import zhaquirks.xiaomi.aqara.plug_eu
 import zhaquirks.xiaomi.aqara.roller_curtain_e1
 import zhaquirks.xiaomi.aqara.sensor_ht_agl02
@@ -2729,3 +2736,101 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
     temp = device.endpoints[1].device_temperature
     temp._update_attribute(DeviceTemperature.AttributeDefs.current_temperature.id, 25)
     assert temp.get("current_temperature") == 2500
+
+
+def test_aqara_h2_outlet(zigpy_device_from_v2_quirk):
+    """Test the Aqara Wall Outlet H2 UK quirk."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara",
+        "lumi.plug.aeu002",
+        endpoint_ids=[1, 2, 3],
+        cluster_ids={
+            1: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                AqaraPlugH2Cluster.cluster_id: ClusterType.Server,
+            },
+            2: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                AqaraPlugH2Cluster.cluster_id: ClusterType.Server,
+            },
+            3: {AqaraPlugH2Cluster.cluster_id: ClusterType.Server},
+        },
+    )
+
+    # The manufacturer cluster is bound on every output endpoint.
+    for ep in (1, 2, 3):
+        assert isinstance(device.endpoints[ep].opple_cluster, AqaraPlugH2Cluster)
+
+    attrs = AqaraPlugH2Cluster.AttributeDefs
+    for name, attr_id in (
+        ("power_outage_memory", 0x0201),
+        ("led_indicator", 0x0203),
+        ("overload_protection", 0x020B),
+        ("child_lock", 0x0285),
+        ("multi_click", 0x0286),
+        ("flip_indicator_light", 0x00F0),
+    ):
+        assert getattr(attrs, name).id == attr_id
+
+    # Both sockets expose all four press types as device automation triggers.
+    assert device.device_automation_triggers == {
+        (SHORT_PRESS, BUTTON_1): {COMMAND: "1_single"},
+        (DOUBLE_PRESS, BUTTON_1): {COMMAND: "1_double"},
+        (LONG_PRESS, BUTTON_1): {COMMAND: "1_hold"},
+        (LONG_RELEASE, BUTTON_1): {COMMAND: "1_release"},
+        (SHORT_PRESS, BUTTON_2): {COMMAND: "2_single"},
+        (DOUBLE_PRESS, BUTTON_2): {COMMAND: "2_double"},
+        (LONG_PRESS, BUTTON_2): {COMMAND: "2_hold"},
+        (LONG_RELEASE, BUTTON_2): {COMMAND: "2_release"},
+    }
+
+
+@pytest.mark.parametrize("button_ep", [1, 2])
+@pytest.mark.parametrize(
+    ("present_value", "press_type"),
+    [
+        (0, "hold"),
+        (1, "single"),
+        (2, "double"),
+        (3, "triple"),
+        (255, "release"),
+    ],
+)
+def test_aqara_h2_outlet_button_events(
+    zigpy_device_from_v2_quirk, button_ep, present_value, press_type
+):
+    """Each socket button press maps present_value to the right zha_send_event."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara",
+        "lumi.plug.aeu002",
+        endpoint_ids=[1, 2, 3],
+        cluster_ids={
+            1: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                AqaraPlugH2Cluster.cluster_id: ClusterType.Server,
+            },
+            2: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                AqaraPlugH2Cluster.cluster_id: ClusterType.Server,
+            },
+            3: {AqaraPlugH2Cluster.cluster_id: ClusterType.Server},
+        },
+    )
+
+    mi_cluster = device.endpoints[button_ep].multistate_input
+    zha_listener = mock.MagicMock()
+    mi_cluster.add_listener(zha_listener)
+    mi_cluster.update_attribute(
+        MultistateInput.AttributeDefs.present_value.id, present_value
+    )
+    assert zha_listener.zha_send_event.mock_calls == [
+        mock.call(
+            f"{button_ep}_{press_type}",
+            {
+                BUTTON: button_ep,
+                PRESS_TYPE: press_type,
+                ATTR_ID: MultistateInput.AttributeDefs.present_value.id,
+                VALUE: present_value,
+            },
+        )
+    ]

--- a/zhaquirks/xiaomi/aqara/plug_aeu002.py
+++ b/zhaquirks/xiaomi/aqara/plug_aeu002.py
@@ -1,0 +1,184 @@
+"""Aqara Wall Outlet H2 UK (lumi.plug.aeu002 / WP-P09D).
+
+A three-output mains outlet: socket 1 (endpoint 1), socket 2 (endpoint 2) and
+USB (endpoint 3). Sockets 1 and 2 have a physical button that reports press
+actions over genMultistateInput. Attribute IDs and value mappings for the
+manufacturer-specific cluster (0xFCC0) are ported from the
+zigbee-herdsman-converters definition for this model.
+"""
+
+from __future__ import annotations
+
+from zigpy import types as t
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import EntityType, UnitOfPower
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+from zigpy.zcl.clusters.general import MultistateInput
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+from zhaquirks.const import (
+    BUTTON_1,
+    BUTTON_2,
+    COMMAND,
+    DOUBLE_PRESS,
+    LONG_PRESS,
+    LONG_RELEASE,
+    SHORT_PRESS,
+)
+from zhaquirks.xiaomi import LUMI, XiaomiAqaraE1Cluster
+from zhaquirks.xiaomi.aqara.opple_remote import (
+    COMMAND_1_DOUBLE,
+    COMMAND_1_HOLD,
+    COMMAND_1_RELEASE,
+    COMMAND_1_SINGLE,
+    COMMAND_2_DOUBLE,
+    COMMAND_2_HOLD,
+    COMMAND_2_RELEASE,
+    COMMAND_2_SINGLE,
+    MultistateInputCluster,
+)
+
+XIAOMI_MFG_CODE = 0x115F
+
+# Overload protection range in watts, ported from the zigbee-herdsman-converters
+# definition for lumi.plug.aeu002 (numeric min 100, max 3840).
+OVERLOAD_PROTECTION_MIN_WATTS = 100
+OVERLOAD_PROTECTION_MAX_WATTS = 3840
+
+
+class AqaraPlugH2Cluster(XiaomiAqaraE1Cluster):
+    """Aqara manufacturer cluster for the H2 wall outlet."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Manufacturer specific attributes."""
+
+        power_outage_memory = ZCLAttributeDef(
+            id=0x0201,
+            type=t.Bool,
+            access="rwp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+        led_indicator = ZCLAttributeDef(
+            id=0x0203,
+            type=t.Bool,
+            access="rwp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+        overload_protection = ZCLAttributeDef(
+            id=0x020B,
+            type=t.Single,
+            access="rwp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+        child_lock = ZCLAttributeDef(
+            id=0x0285,
+            type=t.Bool,
+            access="rwp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+        multi_click = ZCLAttributeDef(
+            id=0x0286,
+            type=t.Bool,
+            access="rwp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+        flip_indicator_light = ZCLAttributeDef(
+            id=0x00F0,
+            type=t.Bool,
+            access="rwp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+
+(
+    QuirkBuilder(LUMI, "lumi.plug.aeu002")
+    .applies_to("Aqara", "lumi.plug.aeu002")
+    .replaces(AqaraPlugH2Cluster, endpoint_id=1)
+    .replaces(AqaraPlugH2Cluster, endpoint_id=2)
+    .replaces(AqaraPlugH2Cluster, endpoint_id=3)
+    .replaces(MultistateInputCluster, endpoint_id=1)
+    .replaces(MultistateInputCluster, endpoint_id=2)
+    # Hide the raw MultistateInput sensors; the buttons are exposed via events.
+    .prevent_default_entity_creation(
+        endpoint_id=1, cluster_id=MultistateInput.cluster_id
+    )
+    .prevent_default_entity_creation(
+        endpoint_id=2, cluster_id=MultistateInput.cluster_id
+    )
+    .switch(
+        AqaraPlugH2Cluster.AttributeDefs.child_lock.name,
+        AqaraPlugH2Cluster.cluster_id,
+        endpoint_id=1,
+        translation_key="child_lock_socket_1",
+        fallback_name="Socket 1 child lock",
+    )
+    .switch(
+        AqaraPlugH2Cluster.AttributeDefs.child_lock.name,
+        AqaraPlugH2Cluster.cluster_id,
+        endpoint_id=2,
+        translation_key="child_lock_socket_2",
+        fallback_name="Socket 2 child lock",
+    )
+    .switch(
+        AqaraPlugH2Cluster.AttributeDefs.multi_click.name,
+        AqaraPlugH2Cluster.cluster_id,
+        endpoint_id=1,
+        translation_key="multi_click_socket_1",
+        fallback_name="Socket 1 multi-click mode",
+    )
+    .switch(
+        AqaraPlugH2Cluster.AttributeDefs.multi_click.name,
+        AqaraPlugH2Cluster.cluster_id,
+        endpoint_id=2,
+        translation_key="multi_click_socket_2",
+        fallback_name="Socket 2 multi-click mode",
+    )
+    .switch(
+        AqaraPlugH2Cluster.AttributeDefs.power_outage_memory.name,
+        AqaraPlugH2Cluster.cluster_id,
+        translation_key="power_outage_memory",
+        fallback_name="Power outage memory",
+    )
+    .switch(
+        AqaraPlugH2Cluster.AttributeDefs.led_indicator.name,
+        AqaraPlugH2Cluster.cluster_id,
+        translation_key="led_indicator",
+        fallback_name="LED indicator",
+    )
+    .switch(
+        AqaraPlugH2Cluster.AttributeDefs.flip_indicator_light.name,
+        AqaraPlugH2Cluster.cluster_id,
+        translation_key="flip_indicator_light",
+        fallback_name="Flip indicator light",
+    )
+    .number(
+        AqaraPlugH2Cluster.AttributeDefs.overload_protection.name,
+        AqaraPlugH2Cluster.cluster_id,
+        min_value=OVERLOAD_PROTECTION_MIN_WATTS,
+        max_value=OVERLOAD_PROTECTION_MAX_WATTS,
+        step=1,
+        unit=UnitOfPower.WATT,
+        device_class=NumberDeviceClass.POWER,
+        entity_type=EntityType.CONFIG,
+        translation_key="overload_protection",
+        fallback_name="Overload protection",
+    )
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_1_SINGLE},
+            (DOUBLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_DOUBLE},
+            (LONG_PRESS, BUTTON_1): {COMMAND: COMMAND_1_HOLD},
+            (LONG_RELEASE, BUTTON_1): {COMMAND: COMMAND_1_RELEASE},
+            (SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_2_SINGLE},
+            (DOUBLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_DOUBLE},
+            (LONG_PRESS, BUTTON_2): {COMMAND: COMMAND_2_HOLD},
+            (LONG_RELEASE, BUTTON_2): {COMMAND: COMMAND_2_RELEASE},
+        }
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Add a few more features for Aqara H2 Sockets (UK): child lock, flip indicator lock, overload protection, multi-click mode.



## Device diagnostics
[zha-01KH2F3WHYWQ2N2RRWKVR1FH24-Aqara lumi.plug.aeu002-e02bc100bb5215e7fc95f6798f0a93cc.json](https://github.com/user-attachments/files/28675055/zha-01KH2F3WHYWQ2N2RRWKVR1FH24-Aqara.lumi.plug.aeu002-e02bc100bb5215e7fc95f6798f0a93cc.json)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
