### PR TITLE
Add Aqara W500 floor heating thermostat (lumi.airrtc.aeu001)

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -9,6 +9,7 @@ from unittest import mock
 import pytest
 import zigpy.device
 from zigpy.profiles import zha
+from zigpy.quirks.v2.homeassistant import EntityType
 import zigpy.types as t
 from zigpy.zcl import (
     AttributeReportedEvent,
@@ -111,6 +112,7 @@ import zhaquirks.xiaomi.aqara.roller_curtain_e1
 import zhaquirks.xiaomi.aqara.sensor_ht_agl02
 import zhaquirks.xiaomi.aqara.smoke
 import zhaquirks.xiaomi.aqara.switch_t1
+from zhaquirks.xiaomi.aqara.thermostat_aeu001 import AqaraThermostatW500Cluster
 from zhaquirks.xiaomi.aqara.thermostat_agl001 import ScheduleEvent, ScheduleSettings
 import zhaquirks.xiaomi.aqara.weather
 import zhaquirks.xiaomi.mija.motion
@@ -2729,3 +2731,49 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
     temp = device.endpoints[1].device_temperature
     temp._update_attribute(DeviceTemperature.AttributeDefs.current_temperature.id, 25)
     assert temp.get("current_temperature") == 2500
+
+
+def test_aqara_w500_thermostat(zigpy_device_from_v2_quirk):
+    """Test the Aqara W500 floor heating thermostat quirk."""
+    device = zigpy_device_from_v2_quirk("Aqara", "lumi.airrtc.aeu001")
+
+    opple_cluster = device.endpoints[1].opple_cluster
+    assert isinstance(opple_cluster, AqaraThermostatW500Cluster)
+
+    attrs = AqaraThermostatW500Cluster.AttributeDefs
+    for name, attr_id in (
+        ("preset", 0x0311),
+        ("state", 0x0310),
+        ("sensor_source", 0x0280),
+        ("ntc_sensor_type", 0x0315),
+        ("window_detection", 0x0273),
+        ("child_lock", 0x0277),
+        ("hysteresis", 0x030C),
+    ):
+        assert getattr(attrs, name).id == attr_id
+
+    entities = {
+        entity.translation_key: entity
+        for entity in device.exposes_metadata[
+            (1, AqaraThermostatW500Cluster.cluster_id, ClusterType.Server)
+        ]
+    }
+    assert set(entities) == {
+        "preset",
+        "thermostat_state",
+        "temperature_sensor_source",
+        "ntc_sensor_type",
+        "window_detection",
+        "child_lock",
+        "hysteresis",
+    }
+
+    assert entities["thermostat_state"].fallback_name == "State"
+    assert entities["thermostat_state"].entity_type == EntityType.DIAGNOSTIC
+    assert entities["window_detection"].fallback_name == "Open window detection"
+
+    hysteresis = entities["hysteresis"]
+    assert hysteresis.min == 0
+    assert hysteresis.max == 3
+    assert hysteresis.step == 0.5
+    assert hysteresis.multiplier == 0.1

--- a/zhaquirks/xiaomi/aqara/thermostat_aeu001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_aeu001.py
@@ -1,0 +1,167 @@
+"""Aqara W500 floor heating thermostat (lumi.airrtc.aeu001 / UT-A01E)."""
+
+from __future__ import annotations
+
+from zigpy import types as t
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import EntityType, UnitOfTemperature
+from zigpy.zcl.foundation import BaseAttributeDefs, DataTypeId, ZCLAttributeDef
+
+from zhaquirks.xiaomi import LUMI, XiaomiAqaraE1Cluster
+
+XIAOMI_MFG_CODE = 0x115F
+
+
+class AqaraThermostatPreset(t.enum8):
+    """Preset attribute values."""
+
+    Home = 0x01
+    Away = 0x02
+    Sleep = 0x03
+    Vacation = 0x05
+    Evening = 0x06
+    Manual = 0x08
+
+
+class AqaraThermostatState(t.enum8):
+    """Heating state attribute values."""
+
+    Working = 0x00
+    Idle = 0x02
+
+
+class AqaraSensorSource(t.enum8):
+    """Temperature sensor source attribute values."""
+
+    Internal = 0x00
+    External = 0x01
+    NTC = 0x02
+
+
+class AqaraNTCType(t.enum32):
+    """External NTC sensor resistance attribute values."""
+
+    NTC_10k = 10
+    NTC_50k = 50
+    NTC_100k = 100
+    Unknown = 10000
+
+
+class AqaraThermostatW500Cluster(XiaomiAqaraE1Cluster):
+    """Aqara manufacturer cluster for the W500 floor heating thermostat."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Manufacturer specific attributes."""
+
+        sensor_source = ZCLAttributeDef(
+            id=0x0280,
+            type=AqaraSensorSource,
+            zcl_type=DataTypeId.uint8,
+            access="rwp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+        window_detection = ZCLAttributeDef(
+            id=0x0273,
+            type=t.Bool,
+            access="rwp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+        child_lock = ZCLAttributeDef(
+            id=0x0277,
+            type=t.Bool,
+            access="rwp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+        hysteresis = ZCLAttributeDef(
+            id=0x030C,
+            type=t.uint8_t,
+            access="rwp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+        state = ZCLAttributeDef(
+            id=0x0310,
+            type=AqaraThermostatState,
+            zcl_type=DataTypeId.uint8,
+            access="rp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+        preset = ZCLAttributeDef(
+            id=0x0311,
+            type=AqaraThermostatPreset,
+            zcl_type=DataTypeId.uint8,
+            access="rwp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+        ntc_sensor_type = ZCLAttributeDef(
+            id=0x0315,
+            type=AqaraNTCType,
+            zcl_type=DataTypeId.uint32,
+            access="rwp",
+            manufacturer_code=XIAOMI_MFG_CODE,
+        )
+
+
+(
+    QuirkBuilder(LUMI, "lumi.airrtc.aeu001")
+    .applies_to("Aqara", "lumi.airrtc.aeu001")
+    .replaces(AqaraThermostatW500Cluster)
+    .enum(
+        AqaraThermostatW500Cluster.AttributeDefs.preset.name,
+        AqaraThermostatPreset,
+        AqaraThermostatW500Cluster.cluster_id,
+        translation_key="preset",
+        fallback_name="Preset",
+    )
+    .enum(
+        AqaraThermostatW500Cluster.AttributeDefs.state.name,
+        AqaraThermostatState,
+        AqaraThermostatW500Cluster.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="thermostat_state",
+        fallback_name="State",
+    )
+    .enum(
+        AqaraThermostatW500Cluster.AttributeDefs.sensor_source.name,
+        AqaraSensorSource,
+        AqaraThermostatW500Cluster.cluster_id,
+        translation_key="temperature_sensor_source",
+        fallback_name="Temperature sensor source",
+    )
+    .enum(
+        AqaraThermostatW500Cluster.AttributeDefs.ntc_sensor_type.name,
+        AqaraNTCType,
+        AqaraThermostatW500Cluster.cluster_id,
+        translation_key="ntc_sensor_type",
+        fallback_name="NTC sensor type",
+    )
+    .switch(
+        AqaraThermostatW500Cluster.AttributeDefs.window_detection.name,
+        AqaraThermostatW500Cluster.cluster_id,
+        translation_key="window_detection",
+        fallback_name="Open window detection",
+    )
+    .switch(
+        AqaraThermostatW500Cluster.AttributeDefs.child_lock.name,
+        AqaraThermostatW500Cluster.cluster_id,
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    .number(
+        AqaraThermostatW500Cluster.AttributeDefs.hysteresis.name,
+        AqaraThermostatW500Cluster.cluster_id,
+        min_value=0,
+        max_value=3,
+        step=0.5,
+        multiplier=0.1,
+        unit=UnitOfTemperature.CELSIUS,
+        translation_key="hysteresis",
+        fallback_name="Hysteresis",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
Extend available settings for Aqara W500 thermostat: Child lock, NTC sensor type, Preset, Temperature Sensor Source, Window detection


## Device diagnostics

[zha-01KH2F3WHYWQ2N2RRWKVR1FH24-Aqara lumi.airrtc.aeu001-bf4c2759bbc2e53c9373634f9b074f0f(1).json](https://github.com/user-attachments/files/28675075/zha-01KH2F3WHYWQ2N2RRWKVR1FH24-Aqara.lumi.airrtc.aeu001-bf4c2759bbc2e53c9373634f9b074f0f.1.json)

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
