### PR TITLE
Add overridable `reset_after` property to motion reset cluster

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1673,6 +1673,31 @@ async def test_xiaomi_p1_t1_motion_sensor(
 
 
 @pytest.mark.parametrize(
+    "quirk, default_reset_s",
+    (
+        (zhaquirks.xiaomi.aqara.motion_ac02.LumiMotionAC02, 30),
+        (zhaquirks.xiaomi.aqara.motion_agl04.LumiLumiMotionAgl04, 60),
+    ),
+)
+async def test_aqara_motion_reset_after_detection_interval(
+    zigpy_device_from_quirk, quirk, default_reset_s
+):
+    """Test that the motion reset interval follows `detection_interval`."""
+    device = zigpy_device_from_quirk(quirk)
+
+    motion_cluster = device.endpoints[1].ias_zone
+    opple_cluster = device.endpoints[1].opple_cluster
+
+    # without a cached detection_interval, fall back to the static reset_s
+    assert opple_cluster.get("detection_interval") is None
+    assert motion_cluster.reset_after == default_reset_s
+
+    # once detection_interval is known, reset_after follows it
+    opple_cluster.update_attribute(0x0102, 90)
+    assert motion_cluster.reset_after == 90
+
+
+@pytest.mark.parametrize(
     "quirk, cluster_name, raw_report, expected_results",
     (
         (

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1683,17 +1683,18 @@ async def test_aqara_motion_reset_after_detection_interval(
     zigpy_device_from_quirk, quirk, default_reset_s
 ):
     """Test that the motion reset interval follows `detection_interval`."""
+    detection_interval = zhaquirks.xiaomi.aqara.motion_ac02.DETECTION_INTERVAL
     device = zigpy_device_from_quirk(quirk)
 
     motion_cluster = device.endpoints[1].ias_zone
     opple_cluster = device.endpoints[1].opple_cluster
 
     # without a cached detection_interval, fall back to the static reset_s
-    assert opple_cluster.get("detection_interval") is None
+    assert opple_cluster.get(detection_interval) is None
     assert motion_cluster.reset_after == default_reset_s
 
     # once detection_interval is known, reset_after follows it
-    opple_cluster.update_attribute(0x0102, 90)
+    opple_cluster.update_attribute(detection_interval, 90)
     assert motion_cluster.reset_after == 90
 
 

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -312,6 +312,16 @@ class _Motion(CustomCluster, IasZone):
         self._loop = asyncio.get_running_loop()
         self._timer_handle = None
 
+    @property
+    def reset_after(self) -> int:
+        """Return the number of seconds after which to reset the motion state.
+
+        Defaults to the static ``reset_s``. Subclasses can override this to
+        derive the value from a device attribute, so the freshest value is
+        always used (and is computed lazily, only when needed).
+        """
+        return self.reset_s
+
     def _turn_off(self):
         self._timer_handle = None
         self.debug("%s - Resetting motion sensor", self.endpoint.device.ieee)
@@ -341,7 +351,7 @@ class MotionWithReset(_Motion):
         if hdr.command_id == ZONE_STATUS_CHANGE_COMMAND and args[0] & 3:
             if self._timer_handle:
                 self._timer_handle.cancel()
-            self._timer_handle = self._loop.call_later(self.reset_s, self._turn_off)
+            self._timer_handle = self._loop.call_later(self.reset_after, self._turn_off)
             if self.send_occupancy_event:
                 self.endpoint.device.occupancy_bus.listener_event(OCCUPANCY_EVENT)
 
@@ -367,7 +377,7 @@ class MotionOnEvent(_Motion):
         if self._timer_handle:
             self._timer_handle.cancel()
 
-        self._timer_handle = self._loop.call_later(self.reset_s, self._turn_off)
+        self._timer_handle = self._loop.call_later(self.reset_after, self._turn_off)
 
 
 class _Occupancy(CustomCluster, OccupancySensing):

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -314,12 +314,7 @@ class _Motion(CustomCluster, IasZone):
 
     @property
     def reset_after(self) -> int:
-        """Return the number of seconds after which to reset the motion state.
-
-        Defaults to the static ``reset_s``. Subclasses can override this to
-        derive the value from a device attribute, so the freshest value is
-        always used (and is computed lazily, only when needed).
-        """
+        """Seconds before resetting motion; override to derive from an attribute."""
         return self.reset_s
 
     def _turn_off(self):

--- a/zhaquirks/xiaomi/aqara/motion_ac02.py
+++ b/zhaquirks/xiaomi/aqara/motion_ac02.py
@@ -72,7 +72,7 @@ class LocalMotionCluster(MotionCluster):
     @property
     def reset_after(self) -> int:
         """Use the device's `detection_interval` if known, else `reset_s`."""
-        interval = self.endpoint.opple_cluster.get("detection_interval")
+        interval = self.endpoint.opple_cluster.get(DETECTION_INTERVAL)
         if interval is None:
             return self.reset_s
         return int(interval)

--- a/zhaquirks/xiaomi/aqara/motion_ac02.py
+++ b/zhaquirks/xiaomi/aqara/motion_ac02.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-import logging
-from typing import Any
-
 from zigpy import types
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
-from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 
 from zhaquirks import Bus, LocalDataCluster
@@ -33,7 +29,6 @@ MOTION_ATTRIBUTE = 274
 DETECTION_INTERVAL = 0x0102
 MOTION_SENSITIVITY = 0x010C
 TRIGGER_INDICATOR = 0x0152
-_LOGGER = logging.getLogger(__name__)
 
 
 class OppleCluster(XiaomiMotionManufacturerCluster):
@@ -48,21 +43,6 @@ class OppleCluster(XiaomiMotionManufacturerCluster):
         MOTION_SENSITIVITY: ("motion_sensitivity", types.uint8_t, True),
         TRIGGER_INDICATOR: ("trigger_indicator", types.uint8_t, True),
     }
-
-    async def write_attributes(
-        self,
-        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
-        **kwargs,
-    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
-        """Write attributes to device with internal 'attributes' validation."""
-        result = await super().write_attributes(attributes, **kwargs)
-        interval = attributes.get(
-            "detection_interval", attributes.get(DETECTION_INTERVAL)
-        )
-        _LOGGER.debug("detection interval: %s", interval)
-        if interval is not None:
-            self.endpoint.ias_zone.reset_s = int(interval)
-        return result
 
 
 class IlluminanceMeasurementClusterP1(LocalIlluminanceMeasurementCluster):
@@ -88,6 +68,14 @@ class LocalMotionCluster(MotionCluster):
     """Local motion cluster."""
 
     reset_s: int = 30
+
+    @property
+    def reset_after(self) -> int:
+        """Reset motion using the device's `detection_interval`, if known."""
+        interval = self.endpoint.opple_cluster.get("detection_interval")
+        if interval is None:
+            return self.reset_s
+        return int(interval)
 
 
 class LumiMotionAC02(CustomDevice):

--- a/zhaquirks/xiaomi/aqara/motion_ac02.py
+++ b/zhaquirks/xiaomi/aqara/motion_ac02.py
@@ -71,7 +71,7 @@ class LocalMotionCluster(MotionCluster):
 
     @property
     def reset_after(self) -> int:
-        """Reset motion using the device's `detection_interval`, if known."""
+        """Use the device's `detection_interval` if known, else `reset_s`."""
         interval = self.endpoint.opple_cluster.get("detection_interval")
         if interval is None:
             return self.reset_s

--- a/zhaquirks/xiaomi/aqara/motion_agl04.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl04.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from zigpy import types
 from zigpy.profiles import zha
-from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.measurement import OccupancySensing
 
@@ -41,26 +38,19 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         MOTION_SENSITIVITY: ("motion_sensitivity", types.uint8_t, True),
     }
 
-    async def write_attributes(
-        self,
-        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
-        **kwargs,
-    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
-        """Write attributes to device with internal 'attributes' validation."""
-        result = await super().write_attributes(attributes, **kwargs)
-        interval = attributes.get(
-            "detection_interval", attributes.get(DETECTION_INTERVAL)
-        )
-        self.endpoint.device.debug("occupancy reset interval: %s", interval)
-        if interval is not None:
-            self.endpoint.ias_zone.reset_s = int(interval)
-        return result
-
 
 class LocalMotionCluster(MotionCluster):
     """Local motion cluster."""
 
     reset_s: int = 60
+
+    @property
+    def reset_after(self) -> int:
+        """Reset motion using the device's `detection_interval`, if known."""
+        interval = self.endpoint.opple_cluster.get("detection_interval")
+        if interval is None:
+            return self.reset_s
+        return int(interval)
 
 
 class LumiLumiMotionAgl04(XiaomiCustomDevice):

--- a/zhaquirks/xiaomi/aqara/motion_agl04.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl04.py
@@ -47,7 +47,7 @@ class LocalMotionCluster(MotionCluster):
     @property
     def reset_after(self) -> int:
         """Use the device's `detection_interval` if known, else `reset_s`."""
-        interval = self.endpoint.opple_cluster.get("detection_interval")
+        interval = self.endpoint.opple_cluster.get(DETECTION_INTERVAL)
         if interval is None:
             return self.reset_s
         return int(interval)

--- a/zhaquirks/xiaomi/aqara/motion_agl04.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl04.py
@@ -46,7 +46,7 @@ class LocalMotionCluster(MotionCluster):
 
     @property
     def reset_after(self) -> int:
-        """Reset motion using the device's `detection_interval`, if known."""
+        """Use the device's `detection_interval` if known, else `reset_s`."""
         interval = self.endpoint.opple_cluster.get("detection_interval")
         if interval is None:
             return self.reset_s


### PR DESCRIPTION
## Proposed change

This changes two Aqara motion sensor quirks, which have a configurable number entity in ZHA for setting their motion timeout, to not depend on special ZHA logic to set the `reset_s` attribute in the cluster classes, so zha-quirks knows when to reset the timer.

Instead, `reset_after` is now a property that subclasses can override to derive the reset interval from a device attribute. Then, the attribute cache is only accessed when it's needed, not at startup, like with the ZHA approach. Otherwise, `reset_s` remains as a static attribute for all other quirks that use this, or as the default when nothing is in the attribute cache.


## Additional information

Implements the changes suggested in (and kinda requires the PR):
- https://github.com/zigpy/zha/pull/782#discussion_r3344900453

Couple of side notes:
- We should make sure that the attribute is read when pairing by ZHA (or automatically done when moved to quirks v2)
- We should likely also make sure that the static/default `reset_s` matches what the sensor has as the default (30s?).
- This should also be tested with a real device.
- We should really migrate the [last 7 remaining quirks](https://github.com/search?q=repo%3Azigpy%2Fzha-device-handlers%20%22%20attributes%20%3D%20%7B%22&type=code) that still use the old attribute definitions. (I thought we already did this? 😅)
- We should add proper test coverage for this "auto-reset motion cluster". I don't think we have any, as this was added years ago.


## Device diagnostics

TODO (maybe)


## Checklist

- [ ] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
