### PR TITLE
Add overload protection settings for Sonoff S60ZBTPF

### DIFF
--- a/tests/test_sonoff_s60zbtpf.py
+++ b/tests/test_sonoff_s60zbtpf.py
@@ -1,53 +1,173 @@
-"""Tests for the SONOFF S60ZBTPF device."""
+"""Tests for the SONOFF S60ZBTPF quirk."""
 
+from unittest.mock import AsyncMock, patch
+
+import pytest
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import OnOff
-from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 
-import zhaquirks.sonoff.s60zbtpf
+import zhaquirks
+from zhaquirks.sonoff import s60zbtpf
 
 zhaquirks.setup()
 
-POWER_ID = ElectricalMeasurement.AttributeDefs.active_power.id
-CURRENT_ID = ElectricalMeasurement.AttributeDefs.rms_current.id
-VOLTAGE_ID = ElectricalMeasurement.AttributeDefs.rms_voltage.id
-ON_OFF_ID = OnOff.AttributeDefs.on_off.id
+
+@pytest.fixture
+def sonoff_cluster():
+    """Create a cluster instance without a full zigpy device graph."""
+    cluster = object.__new__(s60zbtpf.SonoffCustomCluster)
+    return cluster
 
 
-async def test_sonoff_plug_power_fix(zigpy_device_from_v2_quirk):
-    """Test Sonoff plug power measurement overrides."""
-    device = zigpy_device_from_v2_quirk("SONOFF", "S60ZBTPF")
+def _status_record():
+    """Return a successful write status record payload."""
+    return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
-    electrical_cluster = device.endpoints[1].electrical_measurement
-    on_off_cluster = device.endpoints[1].on_off
 
-    electrical_cluster.update_attribute(POWER_ID, 300)
-    electrical_cluster.update_attribute(CURRENT_ID, 13)
-    electrical_cluster.update_attribute(VOLTAGE_ID, 263)
-    assert electrical_cluster.get(POWER_ID) == 300
-    assert electrical_cluster.get(CURRENT_ID) == 13
-    assert electrical_cluster.get(VOLTAGE_ID) == 263
+@pytest.mark.parametrize(
+    ("attribute_key", "expected"),
+    [
+        pytest.param(
+            s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_current_max_overload,
+            True,
+            id="attribute_def",
+        ),
+        pytest.param(
+            s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_current_max_overload.id,
+            True,
+            id="attribute_id",
+        ),
+        pytest.param(
+            s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_current_max_overload.name,
+            True,
+            id="attribute_name",
+        ),
+        pytest.param("unknown", False, id="unknown_attribute"),
+    ],
+)
+def test_has_attribute_supports_multiple_attribute_key_types(
+    sonoff_cluster, attribute_key, expected
+):
+    """Attribute lookup accepts attribute definitions, ids, and names."""
+    attr_def = s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_current_max_overload
 
-    on_off_cluster.update_attribute(ON_OFF_ID, False)
-    assert electrical_cluster.get(POWER_ID) == 0
-    assert electrical_cluster.get(CURRENT_ID) == 0
-    assert electrical_cluster.get(VOLTAGE_ID) == foundation.DataType.uint16.non_value
+    assert sonoff_cluster._has_attribute({attribute_key: 16000}, attr_def) is expected
 
-    electrical_cluster.update_attribute(POWER_ID, 300)
-    electrical_cluster.update_attribute(CURRENT_ID, 13)
-    electrical_cluster.update_attribute(VOLTAGE_ID, 263)
-    assert electrical_cluster.get(POWER_ID) == 0
-    assert electrical_cluster.get(CURRENT_ID) == 0
-    assert electrical_cluster.get(VOLTAGE_ID) == foundation.DataType.uint16.non_value
 
-    on_off_cluster.update_attribute(ON_OFF_ID, True)
-    assert electrical_cluster.get(POWER_ID) == 0
-    assert electrical_cluster.get(CURRENT_ID) == 0
-    assert electrical_cluster.get(VOLTAGE_ID) == foundation.DataType.uint16.non_value
+@pytest.mark.asyncio
+async def test_bind_enables_current_and_power_protection(sonoff_cluster):
+    """Bind writes the non-user exposed enable flags."""
+    with (
+        patch.object(
+            s60zbtpf.CustomCluster,
+            "bind",
+            AsyncMock(return_value="bind_result"),
+        ) as super_bind,
+        patch.object(
+            sonoff_cluster,
+            "write_attributes",
+            AsyncMock(return_value=_status_record()),
+        ) as write_attributes,
+    ):
+        result = await sonoff_cluster.bind()
 
-    electrical_cluster.update_attribute(POWER_ID, 300)
-    electrical_cluster.update_attribute(CURRENT_ID, 13)
-    electrical_cluster.update_attribute(VOLTAGE_ID, 263)
-    assert electrical_cluster.get(POWER_ID) == 300
-    assert electrical_cluster.get(CURRENT_ID) == 13
-    assert electrical_cluster.get(VOLTAGE_ID) == 263
+    assert result == "bind_result"
+    super_bind.assert_awaited_once()
+    write_attributes.assert_awaited_once_with(
+        s60zbtpf.SonoffCustomCluster.enable_config
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_current_threshold_enables_current_protection_first(sonoff_cluster):
+    """Writing the current threshold auto-enables its protection flag first."""
+    attributes = {
+        s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_current_max_overload.name: 16000
+    }
+
+    with patch.object(
+        s60zbtpf.CustomCluster,
+        "write_attributes",
+        AsyncMock(side_effect=[_status_record(), _status_record()]),
+    ) as super_write:
+        await sonoff_cluster.write_attributes(attributes)
+
+    assert super_write.await_count == 2
+    first_call = super_write.await_args_list[0]
+    second_call = super_write.await_args_list[1]
+
+    assert (
+        first_call.args[0][
+            s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_current_max_overload_enable.id
+        ]
+        == 0x01
+    )
+    assert second_call.args[0] == attributes
+
+
+@pytest.mark.asyncio
+async def test_write_power_threshold_enables_power_protection_first(sonoff_cluster):
+    """Writing the power threshold auto-enables its protection flag first."""
+    attributes = {
+        s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_power_max_overload.name: 2500000
+    }
+
+    with patch.object(
+        s60zbtpf.CustomCluster,
+        "write_attributes",
+        AsyncMock(side_effect=[_status_record(), _status_record()]),
+    ) as super_write:
+        await sonoff_cluster.write_attributes(attributes)
+
+    assert super_write.await_count == 2
+    first_call = super_write.await_args_list[0]
+    second_call = super_write.await_args_list[1]
+
+    assert (
+        first_call.args[0][
+            s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_power_max_overload_enable.id
+        ]
+        == 0x01
+    )
+    assert second_call.args[0] == attributes
+
+
+@pytest.mark.asyncio
+async def test_write_both_thresholds_enable_both_protections_first(sonoff_cluster):
+    """Writing current and power thresholds enables both protection flags first."""
+    attributes = {
+        s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_current_max_overload.id: 16000,
+        s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_power_max_overload.id: 2500000,
+    }
+
+    with patch.object(
+        s60zbtpf.CustomCluster,
+        "write_attributes",
+        AsyncMock(side_effect=[_status_record(), _status_record()]),
+    ) as super_write:
+        await sonoff_cluster.write_attributes(attributes)
+
+    assert super_write.await_count == 2
+    assert super_write.await_args_list[0].args[0] == {
+        s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_current_max_overload_enable.id: 0x01,
+        s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_power_max_overload_enable.id: 0x01,
+    }
+    assert super_write.await_args_list[1].args[0] == attributes
+
+
+@pytest.mark.asyncio
+async def test_write_voltage_threshold_does_not_force_enable_voltage_protection(
+    sonoff_cluster,
+):
+    """Writing the voltage threshold keeps voltage enable as a separate control."""
+    attributes = {
+        s60zbtpf.SonoffCustomCluster.AttributeDefs.ac_voltage_max_overload.name: 230000
+    }
+
+    with patch.object(
+        s60zbtpf.CustomCluster,
+        "write_attributes",
+        AsyncMock(return_value=_status_record()),
+    ) as super_write:
+        await sonoff_cluster.write_attributes(attributes)
+
+    super_write.assert_awaited_once_with(attributes)

--- a/zhaquirks/sonoff/s60zbtpf.py
+++ b/zhaquirks/sonoff/s60zbtpf.py
@@ -1,4 +1,4 @@
-"""SONOFF S60ZBTPF - Smart socket quirk for overload protection settings."""
+"""SONOFF S60ZBTPF smart socket overload protection quirk."""
 
 from typing import Any, Final
 
@@ -36,7 +36,7 @@ class SonoffCustomCluster(CustomCluster):
             type=t.uint32_t,
             manufacturer_code=None,
         )
-        outlet_Control_Protect_Setting = ZCLAttributeDef(
+        outlet_control_protect_setting = ZCLAttributeDef(
             id=0x7007,
             type=t.uint8_t,
             manufacturer_code=None,
@@ -142,11 +142,11 @@ class SonoffCustomCluster(CustomCluster):
         fallback_name="Threshold protection",
     )
     .switch(
-        SonoffCustomCluster.AttributeDefs.outlet_Control_Protect_Setting.name,
+        SonoffCustomCluster.AttributeDefs.outlet_control_protect_setting.name,
         SonoffCustomCluster.cluster_id,
         off_value=0,
         on_value=1,
-        translation_key="outlet_Control_Protect_Setting",
+        translation_key="outlet_control_protect_setting",
         fallback_name="Outlet control protect setting",
     )
     .switch(

--- a/zhaquirks/sonoff/s60zbtpf.py
+++ b/zhaquirks/sonoff/s60zbtpf.py
@@ -1,4 +1,4 @@
-"""SONOFF S60ZB - Smart Socket with power measurement fix."""
+"""SONOFF S60ZBTPF - Smart socket quirk for overload protection settings."""
 
 from typing import Any, Final
 

--- a/zhaquirks/sonoff/s60zbtpf.py
+++ b/zhaquirks/sonoff/s60zbtpf.py
@@ -1,80 +1,211 @@
-"""SONOFF S60ZBTPF - Smart Socket with power measurement fix.
+"""SONOFF S60ZB - Smart Socket with power measurement fix."""
 
-This device has a quirk where it continues to report active power consumption
-even when the socket is turned off. This quirk fixes that by, when the
-`on_off` state becomes False, setting `active_power` and `rms_current` to 0
-and `rms_voltage` to `uint16.non_value`, and by blocking subsequent updates
-to these three attributes while the socket remains off.
-"""
-
-from typing import Any
+from typing import Any, Final
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import (
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfPower,
+)
+from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import OnOff
-from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
-from zigpy.zcl.clusters.smartenergy import Metering
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef, ZCLCommandDef
 
 
-class SonoffS60OnOff(CustomCluster, OnOff):
-    """Custom OnOff cluster that resets power readings when the socket is turned off."""
+class SonoffCustomCluster(CustomCluster):
+    """Custom Sonoff cluster."""
 
-    def _update_attribute(
-        self, attrid: int | t.uint16_t | foundation.ZCLAttributeDef, value: Any
-    ) -> None:
-        """Reset attributes to zero when the socket is turned off."""
-        if (
-            self.find_attribute(attrid) == OnOff.AttributeDefs.on_off
-            and value == t.Bool.false
-        ):
-            self.endpoint.electrical_measurement.update_attribute(
-                ElectricalMeasurement.AttributeDefs.active_power.id, 0
-            )
-            self.endpoint.electrical_measurement.update_attribute(
-                ElectricalMeasurement.AttributeDefs.rms_current.id, 0
-            )
-            self.endpoint.electrical_measurement.update_attribute(
-                ElectricalMeasurement.AttributeDefs.rms_voltage.id,
-                foundation.DataType.uint16.non_value,
-            )
+    cluster_id = 0xFC11
+    enable_config = {0x700C: 0x01, 0x7010: 0x01}
 
-        super()._update_attribute(attrid, value)
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
 
+        network_led = ZCLAttributeDef(
+            id=0x0001,
+            type=t.Bool,
+            manufacturer_code=None,
+        )
 
-class SonoffS60ElectricalMeasurement(CustomCluster, ElectricalMeasurement):
-    """Custom ElectricalMeasurement cluster that prevents power updates when the socket is turned off."""
+        fault_code = ZCLAttributeDef(
+            id=0x0010,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+        outlet_Control_Protect_Setting = ZCLAttributeDef(
+            id=0x7007,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+        ac_current_max_overload_enable = ZCLAttributeDef(
+            id=0x700C,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
 
-    def _update_attribute(
-        self, attrid: int | t.uint16_t | foundation.ZCLAttributeDef, value: Any
-    ) -> None:
-        """Prevent updates when the socket is turned off."""
-        if (
-            self.endpoint.on_off.get(OnOff.AttributeDefs.on_off.id) == t.Bool.false
-            # we should always get the ID here, but just in case, check for def too
-            and self.find_attribute(attrid)
-            in (
-                ElectricalMeasurement.AttributeDefs.active_power,
-                ElectricalMeasurement.AttributeDefs.rms_current,
-                ElectricalMeasurement.AttributeDefs.rms_voltage,
-            )
-        ):
-            return
+        ac_current_max_overload = ZCLAttributeDef(
+            id=0x700D,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
 
-        super()._update_attribute(attrid, value)
+        ac_voltage_max_overload_enable = ZCLAttributeDef(
+            id=0x700E,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+
+        ac_voltage_max_overload = ZCLAttributeDef(
+            id=0x700F,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+        ac_power_max_overload_enable = ZCLAttributeDef(
+            id=0x7010,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+
+        ac_power_max_overload = ZCLAttributeDef(
+            id=0x7011,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+    async def bind(self):
+        """Bind cluster and force-enable non-user exposed protections."""
+        result = await super().bind()
+        await self.write_attributes(self.enable_config)
+        return result
+
+    @staticmethod
+    def _has_attribute(
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        attr_def: foundation.ZCLAttributeDef,
+    ) -> bool:
+        """Return True when an attribute write payload contains attr_def."""
+        return (
+            attr_def in attributes
+            or attr_def.id in attributes
+            or attr_def.name in attributes
+        )
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
+        """Force-enable overload protection before writing protected thresholds."""
+        result = []
+
+        enable_writes: dict[int, int] = {}
+        if self._has_attribute(attributes, self.AttributeDefs.ac_current_max_overload):
+            enable_writes[self.AttributeDefs.ac_current_max_overload_enable.id] = 0x01
+        if self._has_attribute(attributes, self.AttributeDefs.ac_power_max_overload):
+            enable_writes[self.AttributeDefs.ac_power_max_overload_enable.id] = 0x01
+
+        if enable_writes:
+            result += await super().write_attributes(enable_writes, **kwargs)
+
+        result += await super().write_attributes(attributes, **kwargs)
+        return result
+
+    class ServerCommandDefs(CustomCluster.ServerCommandDefs):
+        """Sonoff manufacturer specific server commands."""
+
+        clear_energy_consumption: Final = ZCLCommandDef(
+            id=0x0C,
+            schema={
+                "deviceType": t.uint8_t,
+                "deviceLength": t.uint8_t,
+                "EventType": t.uint8_t,
+            },
+            is_manufacturer_specific=True,
+        )
 
 
 (
     QuirkBuilder("SONOFF", "S60ZBTPF")
-    .applies_to("SONOFF", "S60ZBTPG")
-    .replaces(SonoffS60OnOff)
-    .replaces(SonoffS60ElectricalMeasurement)
-    # firmware v2.0.2 reports instantaneous_demand as supported, always with value 0
-    .prevent_default_entity_creation(
+    .replaces(SonoffCustomCluster)
+    .binary_sensor(
+        SonoffCustomCluster.AttributeDefs.fault_code.name,
+        SonoffCustomCluster.cluster_id,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        attribute_converter=lambda x: x == 0x3020004,
+        unique_id_suffix="threshold_protection",
+        translation_key="threshold_protection",
+        fallback_name="Threshold protection",
+    )
+    .switch(
+        SonoffCustomCluster.AttributeDefs.outlet_Control_Protect_Setting.name,
+        SonoffCustomCluster.cluster_id,
+        off_value=0,
+        on_value=1,
+        translation_key="outlet_Control_Protect_Setting",
+        fallback_name="Outlet control protect setting",
+    )
+    .switch(
+        SonoffCustomCluster.AttributeDefs.network_led.name,
+        SonoffCustomCluster.cluster_id,
         endpoint_id=1,
-        cluster_id=Metering.cluster_id,
-        unique_id_suffix="1-1794",  # no actual suffix for this
+        translation_key="network_led",
+        fallback_name="Network LED",
+    )
+    .number(
+        SonoffCustomCluster.AttributeDefs.ac_current_max_overload.name,
+        SonoffCustomCluster.cluster_id,
+        cluster_type=ClusterType.Server,
+        min_value=0.1,
+        max_value=17.0,
+        step=0.1,
+        unit=UnitOfElectricCurrent.AMPERE,
+        mode="box",
+        multiplier=0.001,
+        translation_key="ac_current_max_overload",
+        fallback_name="AC current max overload",
+    )
+    .switch(
+        SonoffCustomCluster.AttributeDefs.ac_voltage_max_overload_enable.name,
+        SonoffCustomCluster.cluster_id,
+        endpoint_id=1,
+        force_inverted=False,  # Optional: invert on/off
+        off_value=0,  # Optional: value written when turning off (default 0)
+        on_value=1,  # Optional: value written when turning on (default 1)
+        translation_key="ac_voltage_max_overload_enable",
+        fallback_name="AC voltage max overload enable",
+    )
+    .number(
+        SonoffCustomCluster.AttributeDefs.ac_voltage_max_overload.name,
+        SonoffCustomCluster.cluster_id,
+        cluster_type=ClusterType.Server,
+        min_value=165,
+        max_value=277,
+        step=1.0,
+        unit=UnitOfElectricPotential.VOLT,
+        mode="box",
+        multiplier=0.001,
+        device_class=NumberDeviceClass.VOLTAGE,
+        translation_key="ac_voltage_max_overload",
+        fallback_name="AC voltage max overload",
+    )
+    .number(
+        SonoffCustomCluster.AttributeDefs.ac_power_max_overload.name,
+        SonoffCustomCluster.cluster_id,
+        cluster_type=ClusterType.Server,
+        min_value=0.1,
+        max_value=4000.0,
+        step=0.1,
+        unit=UnitOfPower.WATT,
+        mode="box",
+        multiplier=0.001,
+        device_class=NumberDeviceClass.POWER,
+        translation_key="ac_power_max_overload",
+        fallback_name="AC power max overload",
     )
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change

Add a new quirk implementation for the SONOFF S60ZBTPF smart plug.

This change:
- adds a manufacturer-specific custom cluster and v2 quirk for the SONOFF S60ZBTPF
- exposes the device protection settings and related entities in Home Assistant
- enables the current and power overload protection flags during cluster bind
- ensures the corresponding protection flag is enabled before writing current or power overload thresholds

## Additional information

This PR adds support for SONOFF S60ZBTPF and fixes a bug where the socket still reported power consumption after it was turned off.

No breaking changes are expected.

## D
[zha-01KT9C8071FPR4546EM80J2W7M-SONOFF S60ZBTPF-06d297fe6785b2586e39df539a79c944.json](https://github.com/user-attachments/files/28702221/zha-01KT9C8071FPR4546EM80J2W7M-SONOFF.S60ZBTPF-06d297fe6785b2586e39df539a79c944.json)
evice diagnostics


## Checklist

- [x] The changes are tested and work correctly
- [] pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached