### PR TITLE
Add dedicated SONOFF S60ZBTPG smart plug quirk with overload protection

### DIFF
--- a/tests/test_sonoff_s60zbtpg.py
+++ b/tests/test_sonoff_s60zbtpg.py
@@ -1,0 +1,173 @@
+"""Tests for the SONOFF S60ZBTPG quirk."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from zigpy.zcl import foundation
+
+import zhaquirks
+from zhaquirks.sonoff import s60zbtpg
+
+zhaquirks.setup()
+
+
+@pytest.fixture
+def sonoff_cluster():
+    """Create a cluster instance without a full zigpy device graph."""
+    cluster = object.__new__(s60zbtpg.SonoffCustomCluster)
+    return cluster
+
+
+def _status_record():
+    """Return a successful write status record payload."""
+    return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+
+
+@pytest.mark.parametrize(
+    ("attribute_key", "expected"),
+    [
+        pytest.param(
+            s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_current_max_overload,
+            True,
+            id="attribute_def",
+        ),
+        pytest.param(
+            s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_current_max_overload.id,
+            True,
+            id="attribute_id",
+        ),
+        pytest.param(
+            s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_current_max_overload.name,
+            True,
+            id="attribute_name",
+        ),
+        pytest.param("unknown", False, id="unknown_attribute"),
+    ],
+)
+def test_has_attribute_supports_multiple_attribute_key_types(
+    sonoff_cluster, attribute_key, expected
+):
+    """Attribute lookup accepts attribute definitions, ids, and names."""
+    attr_def = s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_current_max_overload
+
+    assert sonoff_cluster._has_attribute({attribute_key: 16000}, attr_def) is expected
+
+
+@pytest.mark.asyncio
+async def test_bind_enables_current_and_power_protection(sonoff_cluster):
+    """Bind writes the non-user exposed enable flags."""
+    with (
+        patch.object(
+            s60zbtpg.CustomCluster,
+            "bind",
+            AsyncMock(return_value="bind_result"),
+        ) as super_bind,
+        patch.object(
+            sonoff_cluster,
+            "write_attributes",
+            AsyncMock(return_value=_status_record()),
+        ) as write_attributes,
+    ):
+        result = await sonoff_cluster.bind()
+
+    assert result == "bind_result"
+    super_bind.assert_awaited_once()
+    write_attributes.assert_awaited_once_with(
+        s60zbtpg.SonoffCustomCluster.enable_config
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_current_threshold_enables_current_protection_first(sonoff_cluster):
+    """Writing the current threshold auto-enables its protection flag first."""
+    attributes = {
+        s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_current_max_overload.name: 16000
+    }
+
+    with patch.object(
+        s60zbtpg.CustomCluster,
+        "write_attributes",
+        AsyncMock(side_effect=[_status_record(), _status_record()]),
+    ) as super_write:
+        await sonoff_cluster.write_attributes(attributes)
+
+    assert super_write.await_count == 2
+    first_call = super_write.await_args_list[0]
+    second_call = super_write.await_args_list[1]
+
+    assert (
+        first_call.args[0][
+            s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_current_max_overload_enable.id
+        ]
+        == 0x01
+    )
+    assert second_call.args[0] == attributes
+
+
+@pytest.mark.asyncio
+async def test_write_power_threshold_enables_power_protection_first(sonoff_cluster):
+    """Writing the power threshold auto-enables its protection flag first."""
+    attributes = {
+        s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_power_max_overload.name: 2500000
+    }
+
+    with patch.object(
+        s60zbtpg.CustomCluster,
+        "write_attributes",
+        AsyncMock(side_effect=[_status_record(), _status_record()]),
+    ) as super_write:
+        await sonoff_cluster.write_attributes(attributes)
+
+    assert super_write.await_count == 2
+    first_call = super_write.await_args_list[0]
+    second_call = super_write.await_args_list[1]
+
+    assert (
+        first_call.args[0][
+            s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_power_max_overload_enable.id
+        ]
+        == 0x01
+    )
+    assert second_call.args[0] == attributes
+
+
+@pytest.mark.asyncio
+async def test_write_both_thresholds_enable_both_protections_first(sonoff_cluster):
+    """Writing current and power thresholds enables both protection flags first."""
+    attributes = {
+        s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_current_max_overload.id: 16000,
+        s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_power_max_overload.id: 2500000,
+    }
+
+    with patch.object(
+        s60zbtpg.CustomCluster,
+        "write_attributes",
+        AsyncMock(side_effect=[_status_record(), _status_record()]),
+    ) as super_write:
+        await sonoff_cluster.write_attributes(attributes)
+
+    assert super_write.await_count == 2
+    assert super_write.await_args_list[0].args[0] == {
+        s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_current_max_overload_enable.id: 0x01,
+        s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_power_max_overload_enable.id: 0x01,
+    }
+    assert super_write.await_args_list[1].args[0] == attributes
+
+
+@pytest.mark.asyncio
+async def test_write_voltage_threshold_does_not_force_enable_voltage_protection(
+    sonoff_cluster,
+):
+    """Writing the voltage threshold keeps voltage enable as a separate control."""
+    attributes = {
+        s60zbtpg.SonoffCustomCluster.AttributeDefs.ac_voltage_max_overload.name: 230000
+    }
+
+    with patch.object(
+        s60zbtpg.CustomCluster,
+        "write_attributes",
+        AsyncMock(return_value=_status_record()),
+    ) as super_write:
+        await sonoff_cluster.write_attributes(attributes)
+
+    super_write.assert_awaited_once_with(attributes)

--- a/zhaquirks/sonoff/s60zbtpf.py
+++ b/zhaquirks/sonoff/s60zbtpf.py
@@ -67,7 +67,6 @@ class SonoffS60ElectricalMeasurement(CustomCluster, ElectricalMeasurement):
 
 (
     QuirkBuilder("SONOFF", "S60ZBTPF")
-    .applies_to("SONOFF", "S60ZBTPG")
     .replaces(SonoffS60OnOff)
     .replaces(SonoffS60ElectricalMeasurement)
     # firmware v2.0.2 reports instantaneous_demand as supported, always with value 0

--- a/zhaquirks/sonoff/s60zbtpg.py
+++ b/zhaquirks/sonoff/s60zbtpg.py
@@ -1,0 +1,211 @@
+"""SONOFF S60ZBTPG smart socket overload protection quirk."""
+
+from typing import Any, Final
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import (
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfPower,
+)
+from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+import zigpy.types as t
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef, ZCLCommandDef
+
+
+class SonoffCustomCluster(CustomCluster):
+    """Custom Sonoff cluster."""
+
+    cluster_id = 0xFC11
+    enable_config = {0x700C: 0x01, 0x7010: 0x01}
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        network_led = ZCLAttributeDef(
+            id=0x0001,
+            type=t.Bool,
+            manufacturer_code=None,
+        )
+
+        fault_code = ZCLAttributeDef(
+            id=0x0010,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+        outlet_control_protect_setting = ZCLAttributeDef(
+            id=0x7007,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+        ac_current_max_overload_enable = ZCLAttributeDef(
+            id=0x700C,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+
+        ac_current_max_overload = ZCLAttributeDef(
+            id=0x700D,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+        ac_voltage_max_overload_enable = ZCLAttributeDef(
+            id=0x700E,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+
+        ac_voltage_max_overload = ZCLAttributeDef(
+            id=0x700F,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+        ac_power_max_overload_enable = ZCLAttributeDef(
+            id=0x7010,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+
+        ac_power_max_overload = ZCLAttributeDef(
+            id=0x7011,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+    async def bind(self):
+        """Bind cluster and force-enable non-user exposed protections."""
+        result = await super().bind()
+        await self.write_attributes(self.enable_config)
+        return result
+
+    @staticmethod
+    def _has_attribute(
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        attr_def: foundation.ZCLAttributeDef,
+    ) -> bool:
+        """Return True when an attribute write payload contains attr_def."""
+        return (
+            attr_def in attributes
+            or attr_def.id in attributes
+            or attr_def.name in attributes
+        )
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | foundation.ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
+        """Force-enable overload protection before writing protected thresholds."""
+        result = []
+
+        enable_writes: dict[int, int] = {}
+        if self._has_attribute(attributes, self.AttributeDefs.ac_current_max_overload):
+            enable_writes[self.AttributeDefs.ac_current_max_overload_enable.id] = 0x01
+        if self._has_attribute(attributes, self.AttributeDefs.ac_power_max_overload):
+            enable_writes[self.AttributeDefs.ac_power_max_overload_enable.id] = 0x01
+
+        if enable_writes:
+            result += await super().write_attributes(enable_writes, **kwargs)
+
+        result += await super().write_attributes(attributes, **kwargs)
+        return result
+
+    class ServerCommandDefs(CustomCluster.ServerCommandDefs):
+        """Sonoff manufacturer specific server commands."""
+
+        clear_energy_consumption: Final = ZCLCommandDef(
+            id=0x0C,
+            schema={
+                "deviceType": t.uint8_t,
+                "deviceLength": t.uint8_t,
+                "EventType": t.uint8_t,
+            },
+            is_manufacturer_specific=True,
+        )
+
+
+(
+    QuirkBuilder("SONOFF", "S60ZBTPG")
+    .replaces(SonoffCustomCluster)
+    .binary_sensor(
+        SonoffCustomCluster.AttributeDefs.fault_code.name,
+        SonoffCustomCluster.cluster_id,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        attribute_converter=lambda x: x == 0x3020004,
+        unique_id_suffix="threshold_protection",
+        translation_key="threshold_protection",
+        fallback_name="Threshold protection",
+    )
+    .switch(
+        SonoffCustomCluster.AttributeDefs.outlet_control_protect_setting.name,
+        SonoffCustomCluster.cluster_id,
+        off_value=0,
+        on_value=1,
+        translation_key="outlet_control_protect_setting",
+        fallback_name="Outlet control protect setting",
+    )
+    .switch(
+        SonoffCustomCluster.AttributeDefs.network_led.name,
+        SonoffCustomCluster.cluster_id,
+        endpoint_id=1,
+        translation_key="network_led",
+        fallback_name="Network LED",
+    )
+    .number(
+        SonoffCustomCluster.AttributeDefs.ac_current_max_overload.name,
+        SonoffCustomCluster.cluster_id,
+        cluster_type=ClusterType.Server,
+        min_value=0.1,
+        max_value=14,
+        step=0.1,
+        unit=UnitOfElectricCurrent.AMPERE,
+        mode="box",
+        multiplier=0.001,
+        translation_key="ac_current_max_overload",
+        fallback_name="AC current max overload",
+    )
+    .switch(
+        SonoffCustomCluster.AttributeDefs.ac_voltage_max_overload_enable.name,
+        SonoffCustomCluster.cluster_id,
+        endpoint_id=1,
+        force_inverted=False,  # Optional: invert on/off
+        off_value=0,  # Optional: value written when turning off (default 0)
+        on_value=1,  # Optional: value written when turning on (default 1)
+        translation_key="ac_voltage_max_overload_enable",
+        fallback_name="AC voltage max overload enable",
+    )
+    .number(
+        SonoffCustomCluster.AttributeDefs.ac_voltage_max_overload.name,
+        SonoffCustomCluster.cluster_id,
+        cluster_type=ClusterType.Server,
+        min_value=165,
+        max_value=277,
+        step=1.0,
+        unit=UnitOfElectricPotential.VOLT,
+        mode="box",
+        multiplier=0.001,
+        device_class=NumberDeviceClass.VOLTAGE,
+        translation_key="ac_voltage_max_overload",
+        fallback_name="AC voltage max overload",
+    )
+    .number(
+        SonoffCustomCluster.AttributeDefs.ac_power_max_overload.name,
+        SonoffCustomCluster.cluster_id,
+        cluster_type=ClusterType.Server,
+        min_value=0.1,
+        max_value=3250.0,
+        step=0.1,
+        unit=UnitOfPower.WATT,
+        mode="box",
+        multiplier=0.001,
+        device_class=NumberDeviceClass.POWER,
+        translation_key="ac_power_max_overload",
+        fallback_name="AC power max overload",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Add support for the SONOFF S60ZBTPG smart plug.

This change:
- adds a manufacturer-specific custom cluster and v2 quirk for the SONOFF S60ZBTPG
- exposes the device protection settings and related entities in Home Assistant
- enables the current and power overload protection flags during cluster bind
- ensures the corresponding protection flag is enabled before writing current or power overload thresholds
- adds unit tests covering bind-time protection enabling and overload threshold write behavior

## Additional information

This PR adds support for SONOFF S60ZBTPG overload protection settings and related entities.



## Device diagnostics
[zha-01KT9C8071FPR4546EM80J2W7M-SONOFF S60ZBTPG-1d9748130052dae800c2d0b21a25d6b4.json](https://github.com/user-attachments/files/28703954/zha-01KT9C8071FPR4546EM80J2W7M-SONOFF.S60ZBTPG-1d9748130052dae800c2d0b21a25d6b4.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached