### PR TITLE
Add Tuya TS110E 2 gang dimmer (_TZ3210_pagajpog)

### DIFF
--- a/zhaquirks/tuya/ts110e.py
+++ b/zhaquirks/tuya/ts110e.py
@@ -9,12 +9,14 @@ from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
     Groups,
+    Identify,
     LevelControl,
     OnOff,
     Ota,
     Scenes,
     Time,
 )
+from zigpy.zcl.clusters.lightlink import LightLink
 from zigpy.zcl.foundation import ZCLAttributeDef
 
 from zhaquirks.const import (
@@ -187,6 +189,93 @@ class DimmerSwitchWithNeutral1Gang(TuyaDimmerSwitch):
                     TuyaZBExternalSwitchTypeCluster,
                 ],
                 OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+
+class DimmerSwitchWithNeutral2Gang(TuyaDimmerSwitch):
+    """Tuya Dimmer Switch Module With Neutral 2 Gang."""
+
+    signature = {
+        MODELS_INFO: [("_TZ3210_pagajpog", "TS110E")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=257
+            # input_clusters=[5, 4, 6, 8, 57345, 4096, 3, 0]
+            # output_clusters=[25, 10]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            # <SimpleDescriptor endpoint=2 profile=260 device_type=257
+            # input_clusters=[5, 4, 6, 8, 57345]
+            # output_clusters=[]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+                # input_clusters=[]
+                # output_clusters=[33]
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    F000LevelControlCluster,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMABLE_LIGHT,
+                INPUT_CLUSTERS: [
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    F000LevelControlCluster,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [],
             },
             242: {
                 PROFILE_ID: zgp.PROFILE_ID,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Add quirk for _TZ3210_pagajpog.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

This is used by the model QS-Zigbee-D06-TRIAC-2C from OEM Aihomestyle, which we sell as [Ledtastic ZIGBEE-SWITCH-D06-TRIAC-2C](https://www.wbnet.eu/en/switches/zigbee-switches/zigbee-switch-d06-triac-2c-dual-smart-dimmer-zigbee-30). It is a Tuya-based 2 gang Zigbee dimmer.


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->

[zha-01KTPQ2M2B65MHZCRGHRS9RRJS-_TZ3210_pagajpog TS110E-a0bdce7781618201c023df00d26e0a22.json](https://github.com/user-attachments/files/28765752/zha-01KTPQ2M2B65MHZCRGHRS9RRJS-_TZ3210_pagajpog.TS110E-a0bdce7781618201c023df00d26e0a22.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached



Closes #4366
