### PR TITLE
Add MOES ZS-D1 dimmer

### DIFF
--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -3,12 +3,53 @@
 from unittest import mock
 
 import pytest
+from zigpy.profiles import zha
 from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import LevelControl, OnOff
 
 from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
+from zhaquirks.tuya.mcu import TuyaClusterData, TuyaLevelControl, TuyaMCUCluster
 
 zhaquirks.setup()
+
+
+@pytest.mark.parametrize("manufacturer", ("_TZE200_a1ovdobn", "_TZE284_a1ovdobn"))
+async def test_moes_zs_d1(zigpy_device_from_v2_quirk, manufacturer):
+    """Test the MOES ZS-D1 dimmer."""
+
+    dimmer = zigpy_device_from_v2_quirk(manufacturer, "TS0601")
+    endpoint = dimmer.endpoints[1]
+
+    assert endpoint.device_type == zha.DeviceType.DIMMABLE_LIGHT
+    assert isinstance(endpoint.tuya_manufacturer, TuyaMCUCluster)
+    assert isinstance(endpoint.on_off, OnOff)
+    assert isinstance(endpoint.level, TuyaLevelControl)
+
+    tuya_cluster = endpoint.tuya_manufacturer
+
+    hdr, data = tuya_cluster.deserialize(
+        b"\x09\x01\x02\x00\x01\x02\x02\x00\x04\x00\x00\x03\x20"
+    )
+    assert tuya_cluster.handle_get_data(data.data) == foundation.Status.SUCCESS
+    assert endpoint.level.get(LevelControl.AttributeDefs.current_level.name) == 204
+
+    hdr, data = tuya_cluster.deserialize(b"\x09\x02\x02\x00\x02\x01\x01\x00\x01\x01")
+    assert tuya_cluster.handle_get_data(data.data) == foundation.Status.SUCCESS
+    assert endpoint.on_off.get(OnOff.AttributeDefs.on_off.name) == 1
+
+    commands = tuya_cluster.from_cluster_data(
+        TuyaClusterData(
+            endpoint_id=1,
+            cluster_name=TuyaLevelControl.ep_attribute,
+            cluster_attr=LevelControl.AttributeDefs.current_level.name,
+            attr_value=204,
+            expect_reply=True,
+        )
+    )
+    assert len(commands) == 1
+    assert commands[0].datapoints[0].dp == 2
+    assert commands[0].datapoints[0].data.payload == 800
 
 
 @pytest.mark.parametrize(

--- a/zhaquirks/tuya/ts0601_dimmer.py
+++ b/zhaquirks/tuya/ts0601_dimmer.py
@@ -1,7 +1,15 @@
 """Tuya based touch switch."""
 
 from zigpy.profiles import zgp, zha
-from zigpy.zcl.clusters.general import Basic, GreenPowerProxy, Groups, Ota, Scenes, Time
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    LevelControl,
+    Ota,
+    Scenes,
+    Time,
+)
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -12,8 +20,10 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya import TUYA_CLUSTER_ED00_ID, NoManufacturerCluster, TuyaDimmerSwitch
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zhaquirks.tuya.mcu import (
     TuyaInWallLevelControl,
+    TuyaLevelControl,
     TuyaLevelControlManufCluster,
     TuyaOnOff,
     TuyaOnOffNM,
@@ -418,3 +428,20 @@ class TuyaTripleSwitchDimmerGP(TuyaDimmerSwitch):
             },
         }
     }
+
+
+(
+    TuyaQuirkBuilder("_TZE200_a1ovdobn", "TS0601")  # MOES ZS-D1
+    .applies_to("_TZE284_a1ovdobn", "TS0601")
+    .tuya_onoff(dp_id=1, onoff_cfg=TuyaOnOff)
+    .tuya_dp(
+        dp_id=2,
+        ep_attribute=TuyaLevelControl.ep_attribute,
+        attribute_name=LevelControl.AttributeDefs.current_level.name,
+        converter=lambda value: (value * 255) // 1000,
+        dp_converter=lambda value: (value * 1000) // 255,
+    )
+    .adds(TuyaLevelControl)
+    .replaces_endpoint(1, device_type=zha.DeviceType.DIMMABLE_LIGHT)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Add support for the MOES ZS-D1 single-gang TS0601 dimmer.

The quirk supports the `_TZE200_a1ovdobn` and `_TZE284_a1ovdobn`
manufacturer variants. It maps:

- DP 1 to on/off
- DP 2 to brightness, scaled between Tuya's 0-1000 range and ZCL's 0-255 range

Endpoint 1 is exposed as a dimmable light.

## Additional information

The datapoint mapping and alternate fingerprint are also documented by the
Zigbee2MQTT MOES ZS-D1 converter:

https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/moes.ts

The quirk was tested with `_TZE200_a1ovdobn` on Home Assistant 2026.6.1.
On/off control, brightness control, and state reporting work correctly.

## Device diagnostics

Attach:
`zha-01J4Z3RREVW72X6PQARVAE2PNZ-_TZE200_a1ovdobn TS0601-d45f99d77eccc8228f45895ff02f5a80.json`

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
[zha-01J4Z3RREVW72X6PQARVAE2PNZ-_TZE200_a1ovdobn TS0601-d45f99d77eccc8228f45895ff02f5a80.json](https://github.com/user-attachments/files/28784990/zha-01J4Z3RREVW72X6PQARVAE2PNZ-_TZE200_a1ovdobn.TS0601-d45f99d77eccc8228f45895ff02f5a80.json)
