### PR TITLE
Fix NLRFGPNY siren battery and firmware setup

### DIFF
--- a/tests/test_tuya_siren.py
+++ b/tests/test_tuya_siren.py
@@ -69,14 +69,14 @@ async def test_nlrfgpny_siren_status_reports(zigpy_device_from_v2_quirk):
 
     tuya_cluster.handle_get_data(
         TuyaCommand(
-                status=0,
-                tsn=3,
-                datapoints=[
-                    TuyaDatapointData(6, TuyaData(True)),
-                    TuyaDatapointData(102, TuyaData(TuyaSirenState.Sound_and_light)),
-                ],
-            )
+            status=0,
+            tsn=3,
+            datapoints=[
+                TuyaDatapointData(6, TuyaData(True)),
+                TuyaDatapointData(102, TuyaData(TuyaSirenState.Sound_and_light)),
+            ],
         )
+    )
 
     assert tuya_cluster.get("charge_state") is t.Bool.true
     assert tuya_cluster.get("alarm_mode") == TuyaSirenState.Sound_and_light

--- a/tests/test_tuya_siren.py
+++ b/tests/test_tuya_siren.py
@@ -10,7 +10,7 @@ from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
 from zhaquirks.const import OFF, ON
 from zhaquirks.tuya import TUYA_QUERY_DATA, TuyaCommand, TuyaData, TuyaDatapointData
-from zhaquirks.tuya.tuya_siren import TuyaSirenState
+from zhaquirks.tuya.tuya_siren import NlrfgpnySiren, TuyaSirenState
 
 zhaquirks.setup()
 
@@ -19,16 +19,18 @@ ZCL_TUYA_SIREN_TEMPERATURE = b"\tp\x02\x00\x02i\x02\x00\x04\x00\x00\x00\xb3"
 ZCL_TUYA_SIREN_HUMIDITY = b"\tp\x02\x00\x02j\x02\x00\x04\x00\x00\x00U"
 ZCL_TUYA_SIREN_ON = b"\t\t\x02\x00\x04h\x01\x00\x01\x01"
 ZCL_TUYA_SIREN_OFF = b"\t\t\x02\x00\x04h\x01\x00\x01\x00"
+NLRFGPNY_MANUFACTURER = "_TZE284_nlrfgpny"
 
 
 async def test_nlrfgpny_siren_apply_custom_configuration(zigpy_device_from_v2_quirk):
     """Test NLRFGPNY siren reads battery and installed firmware during configuration."""
 
     siren_dev = zigpy_device_from_v2_quirk(
-        "_TZE284_nlrfgpny",
+        NLRFGPNY_MANUFACTURER,
         "TS0601",
         cluster_ids={1: {Ota.cluster_id: ClusterType.Client}},
     )
+    assert isinstance(siren_dev, NlrfgpnySiren)
 
     with mock.patch("zigpy.zcl.Cluster.request", mock.AsyncMock()) as request_mock:
         request_mock.return_value = (foundation.Status.SUCCESS, "done")
@@ -57,7 +59,7 @@ async def test_nlrfgpny_siren_apply_custom_configuration(zigpy_device_from_v2_qu
 async def test_nlrfgpny_siren_status_reports(zigpy_device_from_v2_quirk):
     """Test NLRFGPNY siren Tuya status reports update charging and alarm mode."""
 
-    siren_dev = zigpy_device_from_v2_quirk("_TZE284_nlrfgpny", "TS0601")
+    siren_dev = zigpy_device_from_v2_quirk(NLRFGPNY_MANUFACTURER, "TS0601")
     tuya_cluster = siren_dev.endpoints[1].tuya_manufacturer
     power_cluster = siren_dev.endpoints[1].power
     battery_attr = PowerConfiguration.AttributeDefs.battery_percentage_remaining
@@ -87,7 +89,7 @@ async def test_nlrfgpny_siren_optional_reads_are_non_fatal(zigpy_device_from_v2_
     """Test NLRFGPNY siren ignores optional battery and OTA read failures."""
 
     siren_dev = zigpy_device_from_v2_quirk(
-        "_TZE284_nlrfgpny",
+        NLRFGPNY_MANUFACTURER,
         "TS0601",
         cluster_ids={1: {Ota.cluster_id: ClusterType.Client}},
     )
@@ -125,7 +127,7 @@ async def test_nlrfgpny_siren_configuration_without_endpoint(
 ):
     """Test NLRFGPNY siren configuration tolerates a missing endpoint."""
 
-    siren_dev = zigpy_device_from_v2_quirk("_TZE284_nlrfgpny", "TS0601")
+    siren_dev = zigpy_device_from_v2_quirk(NLRFGPNY_MANUFACTURER, "TS0601")
     siren_dev.endpoints = {}
 
     with mock.patch(
@@ -140,7 +142,7 @@ async def test_nlrfgpny_siren_configuration_without_endpoint(
 async def test_nlrfgpny_siren_preserves_alarm_mode(zigpy_device_from_v2_quirk):
     """Test NLRFGPNY siren restores cached alarm mode if data query omits it."""
 
-    siren_dev = zigpy_device_from_v2_quirk("_TZE284_nlrfgpny", "TS0601")
+    siren_dev = zigpy_device_from_v2_quirk(NLRFGPNY_MANUFACTURER, "TS0601")
     tuya_cluster = siren_dev.endpoints[1].tuya_manufacturer
     alarm_mode_attr = tuya_cluster.attributes_by_name["alarm_mode"]
     tuya_cluster._update_attribute(alarm_mode_attr.id, TuyaSirenState.Sound_and_light)

--- a/tests/test_tuya_siren.py
+++ b/tests/test_tuya_siren.py
@@ -73,9 +73,7 @@ async def test_nlrfgpny_siren_status_reports(zigpy_device_from_v2_quirk):
             tsn=3,
             datapoints=[
                 TuyaDatapointData(6, TuyaData(True)),
-                TuyaDatapointData(
-                    102, TuyaData(TuyaSirenState.Sound_and_light)
-                ),
+                TuyaDatapointData(102, TuyaData(TuyaSirenState.Sound_and_light)),
             ],
         )
     )
@@ -90,9 +88,7 @@ async def test_nlrfgpny_siren_preserves_alarm_mode(zigpy_device_from_v2_quirk):
     siren_dev = zigpy_device_from_v2_quirk("_TZE284_nlrfgpny", "TS0601")
     tuya_cluster = siren_dev.endpoints[1].tuya_manufacturer
     alarm_mode_attr = tuya_cluster.attributes_by_name["alarm_mode"]
-    tuya_cluster._update_attribute(
-        alarm_mode_attr.id, TuyaSirenState.Sound_and_light
-    )
+    tuya_cluster._update_attribute(alarm_mode_attr.id, TuyaSirenState.Sound_and_light)
 
     async def clear_alarm_mode():
         tuya_cluster._attr_cache.remove(alarm_mode_attr)

--- a/tests/test_tuya_siren.py
+++ b/tests/test_tuya_siren.py
@@ -2,11 +2,15 @@
 
 from unittest import mock
 
-from zigpy.zcl import foundation
+import zigpy.types as t
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.general import Ota, PowerConfiguration
 
 from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
 from zhaquirks.const import OFF, ON
+from zhaquirks.tuya import TUYA_QUERY_DATA, TuyaCommand, TuyaData, TuyaDatapointData
+from zhaquirks.tuya.tuya_siren import TuyaSirenState
 
 zhaquirks.setup()
 
@@ -15,6 +19,93 @@ ZCL_TUYA_SIREN_TEMPERATURE = b"\tp\x02\x00\x02i\x02\x00\x04\x00\x00\x00\xb3"
 ZCL_TUYA_SIREN_HUMIDITY = b"\tp\x02\x00\x02j\x02\x00\x04\x00\x00\x00U"
 ZCL_TUYA_SIREN_ON = b"\t\t\x02\x00\x04h\x01\x00\x01\x01"
 ZCL_TUYA_SIREN_OFF = b"\t\t\x02\x00\x04h\x01\x00\x01\x00"
+
+
+async def test_nlrfgpny_siren_apply_custom_configuration(zigpy_device_from_v2_quirk):
+    """Test NLRFGPNY siren reads battery and installed firmware during configuration."""
+
+    siren_dev = zigpy_device_from_v2_quirk(
+        "_TZE284_nlrfgpny",
+        "TS0601",
+        cluster_ids={1: {Ota.cluster_id: ClusterType.Client}},
+    )
+
+    with mock.patch("zigpy.zcl.Cluster.request", mock.AsyncMock()) as request_mock:
+        request_mock.return_value = (foundation.Status.SUCCESS, "done")
+
+        await siren_dev.apply_custom_configuration()
+
+        assert request_mock.call_count == 4
+
+        basic_read = request_mock.mock_calls[0]
+        assert basic_read.args[1] == foundation.GeneralCommand.Read_Attributes
+        assert basic_read.args[3] == [4, 0, 1, 5, 7, 65534]
+
+        data_query = request_mock.mock_calls[1]
+        assert data_query.args[1] == TUYA_QUERY_DATA
+
+        power_read = request_mock.mock_calls[2]
+        assert power_read.args[1] == foundation.GeneralCommand.Read_Attributes
+        assert power_read.args[3] == [
+            PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
+        ]
+
+        ota_read = request_mock.mock_calls[3]
+        assert ota_read.args[1] == foundation.GeneralCommand.Read_Attributes
+        assert ota_read.args[3] == [
+            Ota.AttributeDefs.current_file_version.id,
+            Ota.AttributeDefs.current_zigbee_stack_version.id,
+            Ota.AttributeDefs.image_upgrade_status.id,
+            Ota.AttributeDefs.manufacturer_id.id,
+            Ota.AttributeDefs.image_type_id.id,
+        ]
+
+
+async def test_nlrfgpny_siren_status_reports(zigpy_device_from_v2_quirk):
+    """Test NLRFGPNY siren Tuya status reports update charging and alarm mode."""
+
+    siren_dev = zigpy_device_from_v2_quirk("_TZE284_nlrfgpny", "TS0601")
+    tuya_cluster = siren_dev.endpoints[1].tuya_manufacturer
+
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=3,
+            datapoints=[
+                TuyaDatapointData(6, TuyaData(True)),
+                TuyaDatapointData(
+                    102, TuyaData(TuyaSirenState.Sound_and_light)
+                ),
+            ],
+        )
+    )
+
+    assert tuya_cluster.get("charge_state") is t.Bool.true
+    assert tuya_cluster.get("alarm_mode") == TuyaSirenState.Sound_and_light
+
+
+async def test_nlrfgpny_siren_preserves_alarm_mode(zigpy_device_from_v2_quirk):
+    """Test NLRFGPNY siren restores cached alarm mode if data query omits it."""
+
+    siren_dev = zigpy_device_from_v2_quirk("_TZE284_nlrfgpny", "TS0601")
+    tuya_cluster = siren_dev.endpoints[1].tuya_manufacturer
+    alarm_mode_attr = tuya_cluster.attributes_by_name["alarm_mode"]
+    tuya_cluster._update_attribute(
+        alarm_mode_attr.id, TuyaSirenState.Sound_and_light
+    )
+
+    async def clear_alarm_mode():
+        tuya_cluster._attr_cache.remove(alarm_mode_attr)
+
+    with (
+        mock.patch.object(siren_dev, "spell_data_query", side_effect=clear_alarm_mode),
+        mock.patch("zigpy.zcl.Cluster.request", mock.AsyncMock()) as request_mock,
+    ):
+        request_mock.return_value = (foundation.Status.SUCCESS, "done")
+
+        await siren_dev.apply_custom_configuration()
+
+    assert tuya_cluster.get("alarm_mode") == TuyaSirenState.Sound_and_light
 
 
 async def test_siren_state_report(zigpy_device_from_v2_quirk):

--- a/tests/test_tuya_siren.py
+++ b/tests/test_tuya_siren.py
@@ -35,30 +35,23 @@ async def test_nlrfgpny_siren_apply_custom_configuration(zigpy_device_from_v2_qu
 
         await siren_dev.apply_custom_configuration()
 
-        assert request_mock.call_count == 4
-
-        basic_read = request_mock.mock_calls[0]
-        assert basic_read.args[1] == foundation.GeneralCommand.Read_Attributes
-        assert basic_read.args[3] == [4, 0, 1, 5, 7, 65534]
-
-        data_query = request_mock.mock_calls[1]
-        assert data_query.args[1] == TUYA_QUERY_DATA
-
-        power_read = request_mock.mock_calls[2]
-        assert power_read.args[1] == foundation.GeneralCommand.Read_Attributes
-        assert power_read.args[3] == [
-            PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
+        read_attributes_calls = [
+            call.args[3]
+            for call in request_mock.mock_calls
+            if call.args[1] == foundation.GeneralCommand.Read_Attributes
         ]
-
-        ota_read = request_mock.mock_calls[3]
-        assert ota_read.args[1] == foundation.GeneralCommand.Read_Attributes
-        assert ota_read.args[3] == [
+        assert [4, 0, 1, 5, 7, 65534] in read_attributes_calls
+        assert [
+            PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
+        ] in read_attributes_calls
+        assert [
             Ota.AttributeDefs.current_file_version.id,
             Ota.AttributeDefs.current_zigbee_stack_version.id,
             Ota.AttributeDefs.image_upgrade_status.id,
             Ota.AttributeDefs.manufacturer_id.id,
             Ota.AttributeDefs.image_type_id.id,
-        ]
+        ] in read_attributes_calls
+        assert any(call.args[1] == TUYA_QUERY_DATA for call in request_mock.mock_calls)
 
 
 async def test_nlrfgpny_siren_status_reports(zigpy_device_from_v2_quirk):
@@ -85,6 +78,9 @@ async def test_nlrfgpny_siren_status_reports(zigpy_device_from_v2_quirk):
     assert tuya_cluster.get("charge_state") is t.Bool.true
     assert tuya_cluster.get("alarm_mode") == TuyaSirenState.Sound_and_light
     assert power_cluster.get(battery_attr.id) == 200
+
+    power_cluster.update_attribute(battery_attr.id, 50)
+    assert power_cluster.get(battery_attr.id) == 50
 
 
 async def test_nlrfgpny_siren_optional_reads_are_non_fatal(zigpy_device_from_v2_quirk):
@@ -150,7 +146,7 @@ async def test_nlrfgpny_siren_preserves_alarm_mode(zigpy_device_from_v2_quirk):
     tuya_cluster._update_attribute(alarm_mode_attr.id, TuyaSirenState.Sound_and_light)
 
     async def clear_alarm_mode():
-        tuya_cluster._attr_cache.remove(alarm_mode_attr)
+        tuya_cluster._attr_cache.clear()
 
     with (
         mock.patch.object(siren_dev, "spell_data_query", side_effect=clear_alarm_mode),

--- a/tests/test_tuya_siren.py
+++ b/tests/test_tuya_siren.py
@@ -66,6 +66,8 @@ async def test_nlrfgpny_siren_status_reports(zigpy_device_from_v2_quirk):
 
     siren_dev = zigpy_device_from_v2_quirk("_TZE284_nlrfgpny", "TS0601")
     tuya_cluster = siren_dev.endpoints[1].tuya_manufacturer
+    power_cluster = siren_dev.endpoints[1].power
+    battery_attr = PowerConfiguration.AttributeDefs.battery_percentage_remaining
 
     tuya_cluster.handle_get_data(
         TuyaCommand(
@@ -73,13 +75,70 @@ async def test_nlrfgpny_siren_status_reports(zigpy_device_from_v2_quirk):
             tsn=3,
             datapoints=[
                 TuyaDatapointData(6, TuyaData(True)),
+                TuyaDatapointData(15, TuyaData(100)),
                 TuyaDatapointData(102, TuyaData(TuyaSirenState.Sound_and_light)),
             ],
         )
     )
+    power_cluster.update_attribute("unknown_attribute", 1)
 
     assert tuya_cluster.get("charge_state") is t.Bool.true
     assert tuya_cluster.get("alarm_mode") == TuyaSirenState.Sound_and_light
+    assert power_cluster.get(battery_attr.id) == 200
+
+
+async def test_nlrfgpny_siren_optional_reads_are_non_fatal(zigpy_device_from_v2_quirk):
+    """Test NLRFGPNY siren ignores optional battery and OTA read failures."""
+
+    siren_dev = zigpy_device_from_v2_quirk(
+        "_TZE284_nlrfgpny",
+        "TS0601",
+        cluster_ids={1: {Ota.cluster_id: ClusterType.Client}},
+    )
+    power_cluster = siren_dev.endpoints[1].power
+    ota_cluster = siren_dev.endpoints[1].out_clusters[Ota.cluster_id]
+
+    with (
+        mock.patch("zigpy.zcl.Cluster.request", mock.AsyncMock()) as request_mock,
+        mock.patch.object(
+            power_cluster,
+            "read_attributes",
+            mock.AsyncMock(side_effect=RuntimeError("battery read failed")),
+        ),
+        mock.patch.object(
+            ota_cluster,
+            "read_attributes",
+            mock.AsyncMock(side_effect=RuntimeError("ota read failed")),
+        ),
+        mock.patch.object(siren_dev, "debug") as debug_mock,
+    ):
+        request_mock.return_value = (foundation.Status.SUCCESS, "done")
+
+        await siren_dev.apply_custom_configuration()
+
+    debug_mock.assert_has_calls(
+        [
+            mock.call("Failed to read battery percentage: %s", mock.ANY),
+            mock.call("Failed to read OTA attributes: %s", mock.ANY),
+        ]
+    )
+
+
+async def test_nlrfgpny_siren_configuration_without_endpoint(
+    zigpy_device_from_v2_quirk,
+):
+    """Test NLRFGPNY siren configuration tolerates a missing endpoint."""
+
+    siren_dev = zigpy_device_from_v2_quirk("_TZE284_nlrfgpny", "TS0601")
+    siren_dev.endpoints = {}
+
+    with mock.patch(
+        "zigpy.quirks.v2.CustomDeviceV2.apply_custom_configuration",
+        mock.AsyncMock(),
+    ) as apply_mock:
+        await siren_dev.apply_custom_configuration()
+
+    apply_mock.assert_awaited_once()
 
 
 async def test_nlrfgpny_siren_preserves_alarm_mode(zigpy_device_from_v2_quirk):

--- a/tests/test_tuya_siren.py
+++ b/tests/test_tuya_siren.py
@@ -69,14 +69,14 @@ async def test_nlrfgpny_siren_status_reports(zigpy_device_from_v2_quirk):
 
     tuya_cluster.handle_get_data(
         TuyaCommand(
-            status=0,
-            tsn=3,
-            datapoints=[
-                TuyaDatapointData(6, TuyaData(True)),
-                TuyaDatapointData(102, TuyaData(TuyaSirenState.Sound_and_light)),
-            ],
+                status=0,
+                tsn=3,
+                datapoints=[
+                    TuyaDatapointData(6, TuyaData(True)),
+                    TuyaDatapointData(102, TuyaData(TuyaSirenState.Sound_and_light)),
+                ],
+            )
         )
-    )
 
     assert tuya_cluster.get("charge_state") is t.Bool.true
     assert tuya_cluster.get("alarm_mode") == TuyaSirenState.Sound_and_light

--- a/zhaquirks/tuya/tuya_siren.py
+++ b/zhaquirks/tuya/tuya_siren.py
@@ -1,5 +1,6 @@
 """Tuya Siren."""
 
+from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import CustomDeviceV2, EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTemperature, UnitOfTime
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
@@ -133,7 +134,7 @@ class NeoBatteryState(t.enum8):
     USB = 0x04
 
 
-class NlrfgpnySirenPowerConfiguration(PowerConfiguration):
+class NlrfgpnySirenPowerConfiguration(CustomCluster, PowerConfiguration):
     """PowerConfiguration cluster for NLRFGPNY sirens with readable battery."""
 
     _CONSTANT_ATTRIBUTES = {

--- a/zhaquirks/tuya/tuya_siren.py
+++ b/zhaquirks/tuya/tuya_siren.py
@@ -1,11 +1,13 @@
 """Tuya Siren."""
 
-from zigpy.quirks.v2 import EntityPlatform, EntityType
+from zigpy.quirks.v2 import CustomDeviceV2, EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTemperature, UnitOfTime
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 import zigpy.types as t
+from zigpy.zcl.clusters.general import Ota, PowerConfiguration
 
 from zhaquirks.const import BatterySize
+from zhaquirks.tuya import TUYA_CLUSTER_ID, BaseEnchantedDevice
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
@@ -131,6 +133,78 @@ class NeoBatteryState(t.enum8):
     USB = 0x04
 
 
+class NlrfgpnySirenPowerConfiguration(PowerConfiguration):
+    """PowerConfiguration cluster for NLRFGPNY sirens with readable battery."""
+
+    _CONSTANT_ATTRIBUTES = {
+        PowerConfiguration.AttributeDefs.battery_size.id: BatterySize.Other,
+        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 30,
+        PowerConfiguration.AttributeDefs.battery_quantity.id: 1,
+    }
+
+    def update_attribute(self, attr_name: str, value) -> None:
+        """Update attribute by name for Tuya datapoint reports."""
+        attr = self.attributes_by_name.get(attr_name)
+        if attr is not None:
+            self._update_attribute(attr.id, value)
+
+
+class NlrfgpnySiren(CustomDeviceV2, BaseEnchantedDevice):
+    """NLRFGPNY siren that reports battery and installed firmware version."""
+
+    tuya_spell_data_query = True
+
+    async def apply_custom_configuration(self, *args, **kwargs):
+        """Read attributes this device does not send in Tuya data query responses."""
+        endpoint = self.endpoints.get(1)
+        alarm_mode = None
+        alarm_mode_attr = None
+        tuya_cluster = None
+        if endpoint is not None:
+            tuya_cluster = endpoint.in_clusters.get(TUYA_CLUSTER_ID)
+            if tuya_cluster is not None:
+                alarm_mode_attr = tuya_cluster.attributes_by_name.get("alarm_mode")
+                if alarm_mode_attr is not None:
+                    alarm_mode = tuya_cluster.get(alarm_mode_attr.id)
+
+        await super().apply_custom_configuration(*args, **kwargs)
+
+        if (
+            alarm_mode is not None
+            and alarm_mode_attr is not None
+            and tuya_cluster is not None
+            and tuya_cluster.get(alarm_mode_attr.id) is None
+        ):
+            tuya_cluster._update_attribute(alarm_mode_attr.id, alarm_mode)
+
+        if endpoint is None:
+            return
+
+        power_cluster = endpoint.in_clusters.get(PowerConfiguration.cluster_id)
+        if power_cluster is not None:
+            try:
+                await power_cluster.read_attributes(
+                    [PowerConfiguration.AttributeDefs.battery_percentage_remaining.id]
+                )
+            except Exception as exc:  # noqa: BLE001
+                self.debug("Failed to read battery percentage: %s", exc)
+
+        ota_cluster = endpoint.out_clusters.get(Ota.cluster_id)
+        if ota_cluster is not None:
+            try:
+                await ota_cluster.read_attributes(
+                    [
+                        Ota.AttributeDefs.current_file_version.id,
+                        Ota.AttributeDefs.current_zigbee_stack_version.id,
+                        Ota.AttributeDefs.image_upgrade_status.id,
+                        Ota.AttributeDefs.manufacturer_id.id,
+                        Ota.AttributeDefs.image_type_id.id,
+                    ]
+                )
+            except Exception as exc:  # noqa: BLE001
+                self.debug("Failed to read OTA attributes: %s", exc)
+
+
 (
     TuyaQuirkBuilder("_TZE204_nlrfgpny", "TS0601")
     .applies_to("TZE200_nlrfgpny", "TS0601")
@@ -168,9 +242,7 @@ class NeoBatteryState(t.enum8):
         translation_key="siren_on",
         fallback_name="Siren on",
     )
-    .tuya_battery(
-        dp_id=15, battery_type=BatterySize.Other, battery_qty=1, battery_voltage=30
-    )
+    .tuya_battery(dp_id=15, power_cfg=NlrfgpnySirenPowerConfiguration)
     .tuya_binary_sensor(
         dp_id=20,
         attribute_name="tamper",
@@ -199,7 +271,7 @@ class NeoBatteryState(t.enum8):
         translation_key="alarm_mode",
         fallback_name="Alarm mode",
     )
-    .tuya_enchantment()
+    .device_class(NlrfgpnySiren)
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/tuya_siren.py
+++ b/zhaquirks/tuya/tuya_siren.py
@@ -1,10 +1,13 @@
 """Tuya Siren."""
 
+from typing import Any
+
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import CustomDeviceV2, EntityPlatform, EntityType
 from zigpy.quirks.v2.homeassistant import PERCENTAGE, UnitOfTemperature, UnitOfTime
 from zigpy.quirks.v2.homeassistant.binary_sensor import BinarySensorDeviceClass
 import zigpy.types as t
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Ota, PowerConfiguration
 
 from zhaquirks.const import BatterySize
@@ -143,11 +146,18 @@ class NlrfgpnySirenPowerConfiguration(CustomCluster, PowerConfiguration):
         PowerConfiguration.AttributeDefs.battery_quantity.id: 1,
     }
 
-    def update_attribute(self, attr_name: str, value) -> None:
-        """Update attribute by name for Tuya datapoint reports."""
-        attr = self.attributes_by_name.get(attr_name)
-        if attr is not None:
-            self._update_attribute(attr.id, value)
+    def update_attribute(
+        self, attrid: int | t.uint16_t | foundation.ZCLAttributeDef | str, value: Any
+    ) -> None:
+        """Update attribute by name for Tuya datapoints, or id for ZCL reports."""
+        if isinstance(attrid, str):
+            attr = self.attributes_by_name.get(attrid)
+            if attr is None:
+                self.debug("no such attribute: %s", attrid)
+                return
+            attrid = attr.id
+
+        super().update_attribute(attrid, value)
 
 
 class NlrfgpnySiren(CustomDeviceV2, BaseEnchantedDevice):


### PR DESCRIPTION
## Summary

- enable Tuya data query during setup for the NLRFGPNY TS0601 solar siren so DP 15 battery and DP 6 charging state are populated when the device reports them
- use a Power Configuration cluster variant that accepts Tuya battery datapoint updates while keeping the existing battery metadata
- read OTA attributes during setup so the installed firmware version is cached and exposed by ZHA
- preserve the cached alarm mode value when a Tuya data query response omits DP 102

## Notes

This does not synthesize battery values when the device does not report DP 15. Related Zigbee2MQTT reports indicate this siren may not emit battery while solar-charged/full, and may start reporting only after the battery drops below full. This also does not synthesize update availability: ZHA can expose the installed firmware version from the OTA cluster, but `latest_version` still depends on an OTA provider returning a compatible image.

## Validation

- `uv run pytest -q tests/test_tuya_siren.py`
- `uv run ruff check zhaquirks/tuya/tuya_siren.py tests/test_tuya_siren.py`
- Live checked on `_TZE284_nlrfgpny` / `TS0601`: battery and charging populate after reconfigure, installed firmware version is cached, and alarm mode can still be set after reconfigure.
