### PR TITLE
Add Tongou TO-Q-SA1 single-phase power meter

### DIFF
--- a/zhaquirks/tuya/ts0601_power.py
+++ b/zhaquirks/tuya/ts0601_power.py
@@ -25,7 +25,7 @@ from zhaquirks.tuya.mcu import DPToAttributeMapping
 # Enum used by 1-phase Tongou TO-Q-SA1 Power Meter: TOSA1-01WXJAT1A, _TZE284_pglpvdar, TS0601
 class OnlineState(t.enum8):
     """Online status reported by Tuya Power Meter."""
-    
+
     Online = 0
     Offline = 1
 
@@ -33,7 +33,7 @@ class OnlineState(t.enum8):
 # Enum used by 1-phase Tongou TO-Q-SA1 Power Meter: TOSA1-01WXJAT1A, _TZE284_pglpvdar, TS0601
 class AlertEvent(t.enum8):
     """Protection and status events reported by Tuya Power Meter."""
-    
+
     Normal = 0
 
     Over_Current_Trip = 1

--- a/zhaquirks/tuya/ts0601_power.py
+++ b/zhaquirks/tuya/ts0601_power.py
@@ -687,8 +687,8 @@ class TuyaElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     )
     .tuya_switch(
         dp_id=34,
-        attribute_name="factory_reset",
-        translation_key="factory_reset",
+        attribute_name="clear_forward_energy",
+        translation_key="clear_forward_energy",
         fallback_name="Clear forward electricity",
     )
     .tuya_switch(

--- a/zhaquirks/tuya/ts0601_power.py
+++ b/zhaquirks/tuya/ts0601_power.py
@@ -25,6 +25,7 @@ from zhaquirks.tuya.mcu import DPToAttributeMapping
 # Enum used by 1-phase Tongou TO-Q-SA1 Power Meter: TOSA1-01WXJAT1A, _TZE284_pglpvdar, TS0601
 class OnlineState(t.enum8):
     """Online status reported by Tuya Power Meter."""
+    
     Online = 0
     Offline = 1
 
@@ -32,6 +33,7 @@ class OnlineState(t.enum8):
 # Enum used by 1-phase Tongou TO-Q-SA1 Power Meter: TOSA1-01WXJAT1A, _TZE284_pglpvdar, TS0601
 class AlertEvent(t.enum8):
     """Protection and status events reported by Tuya Power Meter."""
+    
     Normal = 0
 
     Over_Current_Trip = 1

--- a/zhaquirks/tuya/ts0601_power.py
+++ b/zhaquirks/tuya/ts0601_power.py
@@ -24,12 +24,14 @@ from zhaquirks.tuya.mcu import DPToAttributeMapping
 
 # Enum used by 1-phase Tongou TO-Q-SA1 Power Meter: TOSA1-01WXJAT1A, _TZE284_pglpvdar, TS0601
 class OnlineState(t.enum8):
+    """Online status reported by Tuya Power Meter."""
     Online = 0
     Offline = 1
 
 
 # Enum used by 1-phase Tongou TO-Q-SA1 Power Meter: TOSA1-01WXJAT1A, _TZE284_pglpvdar, TS0601
 class AlertEvent(t.enum8):
+    """Protection and status events reported by Tuya Power Meter."""
     Normal = 0
 
     Over_Current_Trip = 1

--- a/zhaquirks/tuya/ts0601_power.py
+++ b/zhaquirks/tuya/ts0601_power.py
@@ -10,13 +10,57 @@ from zhaquirks.builder import (
     SensorDeviceClass,
     SensorStateClass,
     UnitOfElectricCurrent,
+    UnitOfElectricPotential,
     UnitOfEnergy,
+    UnitOfFrequency,
     UnitOfPower,
+    UnitOfTemperature,
     UnitOfTime,
 )
 from zhaquirks.tuya import TuyaLocalCluster
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zhaquirks.tuya.mcu import DPToAttributeMapping
+
+# Enum used by 1-phase Tongou TO-Q-SA1 Power Meter: TOSA1-01WXJAT1A, _TZE284_pglpvdar, TS0601
+class OnlineState(t.enum8):
+    Online = 0
+    Offline = 1
+
+# Enum used by 1-phase Tongou TO-Q-SA1 Power Meter: TOSA1-01WXJAT1A, _TZE284_pglpvdar, TS0601
+class AlertEvent(t.enum8):
+    Normal = 0
+
+    Over_Current_Trip = 1
+    Over_Power_Trip = 2
+    High_Temp_Trip = 3
+    Over_Voltage_Trip = 4
+    Under_Voltage_Trip = 5
+
+    Over_Current_Alarm = 6
+    Over_Power_Alarm = 7
+    High_Temp_Alarm = 8
+    Over_Voltage_Alarm = 9
+    Under_Voltage_Alarm = 10
+
+    Remote_ON = 11
+    Remote_OFF = 12
+
+    Manual_ON = 13
+    Manual_OFF = 14
+
+    Leakage_Trip = 15
+    Leakage_Alarm = 16
+
+    Restore_Default = 17
+    Automatic_Closing = 18
+
+    Electricity_Shortage = 19
+    Electricity_Shortage_Alarm = 20
+
+    Timing_Switch_ON = 21
+    Timing_Switch_OFF = 22
+
+    Electricity_Reset = 23
 
 
 def dp_to_power(data: bytes) -> int:
@@ -48,7 +92,7 @@ def multi_dp_to_voltage(data: bytes) -> int:
     return data[1] | (data[0] << 8)
 
 
-class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
+class TuyaElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     """Tuya Electrical Measurement cluster."""
 
     _CONSTANT_ATTRIBUTES = {
@@ -71,7 +115,7 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     )
     .tuya_dp(
         dp_id=132,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="ac_frequency",
     )
     # Energy
@@ -142,17 +186,17 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
         dp_id=6,
         attribute_mapping=[
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="active_power",
                 converter=multi_dp_to_power,
             ),
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="rms_voltage",
                 converter=multi_dp_to_voltage,
             ),
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="rms_current",
                 converter=multi_dp_to_current,
             ),
@@ -162,17 +206,17 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
         dp_id=7,
         attribute_mapping=[
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="active_power_ph_b",
                 converter=multi_dp_to_power,
             ),
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="rms_voltage_ph_b",
                 converter=multi_dp_to_voltage,
             ),
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="rms_current_ph_b",
                 converter=multi_dp_to_current,
             ),
@@ -182,17 +226,17 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
         dp_id=8,
         attribute_mapping=[
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="active_power_ph_c",
                 converter=multi_dp_to_power,
             ),
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="rms_voltage_ph_c",
                 converter=multi_dp_to_voltage,
             ),
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="rms_current_ph_c",
                 converter=multi_dp_to_current,
             ),
@@ -200,20 +244,20 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     )
     .tuya_dp(
         dp_id=102,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="power_factor",
     )
     .tuya_dp(
         dp_id=112,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="power_factor_ph_b",
     )
     .tuya_dp(
         dp_id=122,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="power_factor_ph_c",
     )
-    .adds(Tuya3PhaseElectricalMeasurement)
+    .adds(TuyaElectricalMeasurement)
     .removes(LevelControl.cluster_id)
     .removes(OnOff.cluster_id)
     .skip_configuration()
@@ -248,12 +292,12 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     )
     .tuya_dp(
         dp_id=29,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="total_active_power",
     )
     .tuya_dp(
         dp_id=32,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="ac_frequency",
         converter=lambda x: x / 100,
     )
@@ -283,22 +327,22 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     # Phase A
     .tuya_dp(
         dp_id=103,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="rms_voltage",
     )
     .tuya_dp(
         dp_id=104,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="rms_current",
     )
     .tuya_dp(
         dp_id=105,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="active_power",
     )
     .tuya_dp(
         dp_id=108,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="power_factor",
     )
     .tuya_sensor(
@@ -326,22 +370,22 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     # Phase B
     .tuya_dp(
         dp_id=112,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="rms_voltage_ph_b",
     )
     .tuya_dp(
         dp_id=113,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="rms_current_ph_b",
     )
     .tuya_dp(
         dp_id=114,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="active_power_ph_b",
     )
     .tuya_dp(
         dp_id=117,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="power_factor_ph_b",
     )
     .tuya_sensor(
@@ -369,22 +413,22 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     # Phase C
     .tuya_dp(
         dp_id=121,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="rms_voltage_ph_c",
     )
     .tuya_dp(
         dp_id=122,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="rms_current_ph_c",
     )
     .tuya_dp(
         dp_id=123,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="active_power_ph_c",
     )
     .tuya_dp(
         dp_id=126,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="power_factor_ph_c",
     )
     .tuya_sensor(
@@ -409,7 +453,7 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
         translation_key="energy_produced_ph_c",
         fallback_name="Energy produced phase C",
     )
-    .adds(Tuya3PhaseElectricalMeasurement)
+    .adds(TuyaElectricalMeasurement)
     .skip_configuration()
     .add_to_registry()
 )
@@ -441,29 +485,29 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     # ElectricalMeasurement
     .tuya_dp(
         dp_id=29,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="total_active_power",
     )
     .tuya_dp(
         dp_id=30,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="total_reactive_power",
     )
     .tuya_dp_multi(
         dp_id=6,
         attribute_mapping=[
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="active_power",
                 converter=multi_dp_to_power,
             ),
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="rms_voltage",
                 converter=multi_dp_to_voltage,
             ),
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="rms_current",
                 converter=multi_dp_to_current,
             ),
@@ -473,17 +517,17 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
         dp_id=7,
         attribute_mapping=[
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="active_power_ph_b",
                 converter=multi_dp_to_power,
             ),
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="rms_voltage_ph_b",
                 converter=multi_dp_to_voltage,
             ),
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="rms_current_ph_b",
                 converter=multi_dp_to_current,
             ),
@@ -493,17 +537,17 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
         dp_id=8,
         attribute_mapping=[
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="active_power_ph_c",
                 converter=multi_dp_to_power,
             ),
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="rms_voltage_ph_c",
                 converter=multi_dp_to_voltage,
             ),
             DPToAttributeMapping(
-                ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
                 attribute_name="rms_current_ph_c",
                 converter=multi_dp_to_current,
             ),
@@ -511,10 +555,125 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     )
     .tuya_dp(
         dp_id=50,
-        ep_attribute=Tuya3PhaseElectricalMeasurement.ep_attribute,
+        ep_attribute=TuyaElectricalMeasurement.ep_attribute,
         attribute_name="power_factor",
     )
-    .adds(Tuya3PhaseElectricalMeasurement)
+    .adds(TuyaElectricalMeasurement)
+    .skip_configuration()
+    .add_to_registry()
+)
+
+(
+    TuyaQuirkBuilder("_TZE284_pglpvdar", "TS0601")
+    # Register DP 6 for the custom cluster to handle
+    .tuya_dp_multi(
+        dp_id=6,
+        attribute_mapping=[
+            DPToAttributeMapping(
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
+                attribute_name="rms_voltage",
+                converter=multi_dp_to_voltage,
+            ),
+            DPToAttributeMapping(
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
+                attribute_name="rms_current",
+                converter=multi_dp_to_current,
+            ),
+            DPToAttributeMapping(
+                ep_attribute=TuyaElectricalMeasurement.ep_attribute,
+                attribute_name="active_power",
+                converter=multi_dp_to_power,
+            ),
+        ],
+    )
+    
+    # Energy
+    .tuya_sensor(dp_id=1, attribute_name="energy", translation_key="total_forward_energy",
+                 type=t.uint32_t, device_class=SensorDeviceClass.ENERGY,
+                 state_class=SensorStateClass.TOTAL_INCREASING,
+                 unit=UnitOfEnergy.KILO_WATT_HOUR, divisor=100,
+                 fallback_name="Total forward energy")
+    .tuya_sensor(dp_id=125, attribute_name="forward_energy", translation_key="forward_energy",
+                 type=t.uint32_t, device_class=SensorDeviceClass.ENERGY,
+                 state_class=SensorStateClass.TOTAL_INCREASING,
+                 unit=UnitOfEnergy.KILO_WATT_HOUR, divisor=100,
+                 fallback_name="Forward electricity")
+    .tuya_sensor(dp_id=13, attribute_name="remaining_energy", translation_key="remaining_energy",
+                 type=t.uint32_t, device_class=SensorDeviceClass.ENERGY_STORAGE,
+                 state_class=SensorStateClass.MEASUREMENT,
+                 unit=UnitOfEnergy.KILO_WATT_HOUR, divisor=100,
+                 fallback_name="Remaining electricity")
+
+    # Advanced measurements
+    .tuya_sensor(dp_id=32, attribute_name="ac_frequency", type=t.uint32_t,
+                 device_class=SensorDeviceClass.FREQUENCY,
+                 state_class=SensorStateClass.MEASUREMENT,
+                 unit=UnitOfFrequency.HERTZ, divisor=100,
+                 fallback_name="Frequency", translation_key="ac_frequency")
+    .tuya_sensor(dp_id=50, attribute_name="power_factor", type=t.uint32_t,
+                 device_class=SensorDeviceClass.POWER_FACTOR,
+                 state_class=SensorStateClass.MEASUREMENT,
+                 divisor=100,
+                 fallback_name="Power factor", translation_key="power_factor")
+    .tuya_sensor(dp_id=131, attribute_name="temperature", type=t.uint32_t,
+                 device_class=SensorDeviceClass.TEMPERATURE,
+                 state_class=SensorStateClass.MEASUREMENT,
+                 unit=UnitOfTemperature.CELSIUS, divisor=10,
+                 fallback_name="CPU temperature")
+
+    # Writable / config DPs
+    .tuya_enum(dp_id=109, attribute_name="online_state", translation_key="online_state",
+               enum_class=OnlineState, fallback_name="Online state")
+    .tuya_enum(dp_id=110, attribute_name="event", translation_key="event",
+               enum_class=AlertEvent, fallback_name="Event")
+
+    .tuya_switch(dp_id=11, attribute_name="prepayment_switch", translation_key="prepayment_switch",
+                 fallback_name="Prepayment switch")
+    .tuya_switch(dp_id=12, attribute_name="clear_remaining_energy", translation_key="clear_remaining_energy",
+                 fallback_name="Clear remaining electricity")
+    .tuya_switch(dp_id=34, attribute_name="factory_reset", translation_key="factory_reset",
+                 fallback_name="Clear forward electricity")
+    .tuya_switch(dp_id=113, attribute_name="restore_default", translation_key="restore_default",
+                 fallback_name="Restore default alarms/thresholds")
+
+    .tuya_switch(dp_id=101, attribute_name="balance_alarm", translation_key="balance_alarm",
+                 fallback_name="Balance alarm")
+    .tuya_switch(dp_id=102, attribute_name="overvoltage_alarm", translation_key="overvoltage_alarm",
+                 fallback_name="Over-voltage alarm")
+    .tuya_switch(dp_id=103, attribute_name="undervoltage_alarm", translation_key="undervoltage_alarm",
+                 fallback_name="Under-voltage alarm")
+    .tuya_switch(dp_id=104, attribute_name="overcurrent_alarm", translation_key="overcurrent_alarm",
+                 fallback_name="Over-current alarm")
+    .tuya_switch(dp_id=105, attribute_name="overpower_alarm", translation_key="overpower_alarm",
+                 fallback_name="Over-power alarm")
+    .tuya_switch(dp_id=107, attribute_name="temperature_alarm", translation_key="temperature_alarm",
+                 fallback_name="Temperature alarm")
+
+    # Numeric thresholds
+    .tuya_number(dp_id=14, attribute_name="add_electricity_charge", translation_key="add_electricity_charge",
+                 type=t.uint32_t, min_value=0, max_value=500, step=1, multiplier=0.01, unit=UnitOfEnergy.KILO_WATT_HOUR,
+                 fallback_name="Add electricity charge, kWh [0..500]")
+    .tuya_number(dp_id=114, attribute_name="current_threshold", translation_key="current_threshold",
+                 type=t.uint32_t, min_value=1, max_value=50, step=1, unit=UnitOfElectricCurrent.AMPERE,
+                 fallback_name="Current threshold, A [1..50]")
+    .tuya_number(dp_id=115, attribute_name="overvoltage_threshold", translation_key="overvoltage_threshold",
+                 type=t.uint32_t, min_value=100, max_value=280, step=1, unit=UnitOfElectricPotential.VOLT,
+                 fallback_name="Over-voltage threshold, V [100..280]")
+    .tuya_number(dp_id=116, attribute_name="undervoltage_threshold", translation_key="undervoltage_threshold",
+                 type=t.uint32_t, min_value=100, max_value=280, step=1, unit=UnitOfElectricPotential.VOLT,
+                 fallback_name="Under-voltage threshold, V [100..280]")
+    .tuya_number(dp_id=118, attribute_name="temperature_threshold", translation_key="temperature_threshold",
+                 type=t.int32s, min_value=-25, max_value=100, step=1, multiplier=0.1, unit=UnitOfTemperature.CELSIUS,
+                 fallback_name="Temperature threshold, C [-25..100]")
+    # e27182: The two alerts below I was unable to make working / 11.06.2026
+    .tuya_number(dp_id=119, attribute_name="overpower_threshold", translation_key="overpower_threshold",
+                 type=t.uint32_t, min_value=5, max_value=12005, step=10, unit=UnitOfPower.WATT,
+                 fallback_name="Over-power threshold, W [5..12005]")
+    .tuya_number(dp_id=120, attribute_name="balance_threshold", translation_key="balance_threshold",
+                 type=t.uint32_t, min_value=10, max_value=500, step=1, unit=UnitOfEnergy.KILO_WATT_HOUR,
+                 fallback_name="Balance threshold, kWh [10..500]")
+
+    .adds(TuyaElectricalMeasurement)
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0601_power.py
+++ b/zhaquirks/tuya/ts0601_power.py
@@ -21,10 +21,12 @@ from zhaquirks.tuya import TuyaLocalCluster
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zhaquirks.tuya.mcu import DPToAttributeMapping
 
+
 # Enum used by 1-phase Tongou TO-Q-SA1 Power Meter: TOSA1-01WXJAT1A, _TZE284_pglpvdar, TS0601
 class OnlineState(t.enum8):
     Online = 0
     Offline = 1
+
 
 # Enum used by 1-phase Tongou TO-Q-SA1 Power Meter: TOSA1-01WXJAT1A, _TZE284_pglpvdar, TS0601
 class AlertEvent(t.enum8):
@@ -586,93 +588,228 @@ class TuyaElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
             ),
         ],
     )
-    
     # Energy
-    .tuya_sensor(dp_id=1, attribute_name="energy", translation_key="total_forward_energy",
-                 type=t.uint32_t, device_class=SensorDeviceClass.ENERGY,
-                 state_class=SensorStateClass.TOTAL_INCREASING,
-                 unit=UnitOfEnergy.KILO_WATT_HOUR, divisor=100,
-                 fallback_name="Total forward energy")
-    .tuya_sensor(dp_id=125, attribute_name="forward_energy", translation_key="forward_energy",
-                 type=t.uint32_t, device_class=SensorDeviceClass.ENERGY,
-                 state_class=SensorStateClass.TOTAL_INCREASING,
-                 unit=UnitOfEnergy.KILO_WATT_HOUR, divisor=100,
-                 fallback_name="Forward electricity")
-    .tuya_sensor(dp_id=13, attribute_name="remaining_energy", translation_key="remaining_energy",
-                 type=t.uint32_t, device_class=SensorDeviceClass.ENERGY_STORAGE,
-                 state_class=SensorStateClass.MEASUREMENT,
-                 unit=UnitOfEnergy.KILO_WATT_HOUR, divisor=100,
-                 fallback_name="Remaining electricity")
-
+    .tuya_sensor(
+        dp_id=1,
+        attribute_name="energy",
+        translation_key="total_forward_energy",
+        type=t.uint32_t,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=100,
+        fallback_name="Total forward energy",
+    )
+    .tuya_sensor(
+        dp_id=125,
+        attribute_name="forward_energy",
+        translation_key="forward_energy",
+        type=t.uint32_t,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=100,
+        fallback_name="Forward electricity",
+    )
+    .tuya_sensor(
+        dp_id=13,
+        attribute_name="remaining_energy",
+        translation_key="remaining_energy",
+        type=t.uint32_t,
+        device_class=SensorDeviceClass.ENERGY_STORAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=100,
+        fallback_name="Remaining electricity",
+    )
     # Advanced measurements
-    .tuya_sensor(dp_id=32, attribute_name="ac_frequency", type=t.uint32_t,
-                 device_class=SensorDeviceClass.FREQUENCY,
-                 state_class=SensorStateClass.MEASUREMENT,
-                 unit=UnitOfFrequency.HERTZ, divisor=100,
-                 fallback_name="Frequency", translation_key="ac_frequency")
-    .tuya_sensor(dp_id=50, attribute_name="power_factor", type=t.uint32_t,
-                 device_class=SensorDeviceClass.POWER_FACTOR,
-                 state_class=SensorStateClass.MEASUREMENT,
-                 divisor=100,
-                 fallback_name="Power factor", translation_key="power_factor")
-    .tuya_sensor(dp_id=131, attribute_name="temperature", type=t.uint32_t,
-                 device_class=SensorDeviceClass.TEMPERATURE,
-                 state_class=SensorStateClass.MEASUREMENT,
-                 unit=UnitOfTemperature.CELSIUS, divisor=10,
-                 fallback_name="CPU temperature")
-
+    .tuya_sensor(
+        dp_id=32,
+        attribute_name="ac_frequency",
+        type=t.uint32_t,
+        device_class=SensorDeviceClass.FREQUENCY,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfFrequency.HERTZ,
+        divisor=100,
+        fallback_name="Frequency",
+        translation_key="ac_frequency",
+    )
+    .tuya_sensor(
+        dp_id=50,
+        attribute_name="power_factor",
+        type=t.uint32_t,
+        device_class=SensorDeviceClass.POWER_FACTOR,
+        state_class=SensorStateClass.MEASUREMENT,
+        divisor=100,
+        fallback_name="Power factor",
+        translation_key="power_factor",
+    )
+    .tuya_sensor(
+        dp_id=131,
+        attribute_name="temperature",
+        type=t.uint32_t,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfTemperature.CELSIUS,
+        divisor=10,
+        fallback_name="CPU temperature",
+    )
     # Writable / config DPs
-    .tuya_enum(dp_id=109, attribute_name="online_state", translation_key="online_state",
-               enum_class=OnlineState, fallback_name="Online state")
-    .tuya_enum(dp_id=110, attribute_name="event", translation_key="event",
-               enum_class=AlertEvent, fallback_name="Event")
-
-    .tuya_switch(dp_id=11, attribute_name="prepayment_switch", translation_key="prepayment_switch",
-                 fallback_name="Prepayment switch")
-    .tuya_switch(dp_id=12, attribute_name="clear_remaining_energy", translation_key="clear_remaining_energy",
-                 fallback_name="Clear remaining electricity")
-    .tuya_switch(dp_id=34, attribute_name="factory_reset", translation_key="factory_reset",
-                 fallback_name="Clear forward electricity")
-    .tuya_switch(dp_id=113, attribute_name="restore_default", translation_key="restore_default",
-                 fallback_name="Restore default alarms/thresholds")
-
-    .tuya_switch(dp_id=101, attribute_name="balance_alarm", translation_key="balance_alarm",
-                 fallback_name="Balance alarm")
-    .tuya_switch(dp_id=102, attribute_name="overvoltage_alarm", translation_key="overvoltage_alarm",
-                 fallback_name="Over-voltage alarm")
-    .tuya_switch(dp_id=103, attribute_name="undervoltage_alarm", translation_key="undervoltage_alarm",
-                 fallback_name="Under-voltage alarm")
-    .tuya_switch(dp_id=104, attribute_name="overcurrent_alarm", translation_key="overcurrent_alarm",
-                 fallback_name="Over-current alarm")
-    .tuya_switch(dp_id=105, attribute_name="overpower_alarm", translation_key="overpower_alarm",
-                 fallback_name="Over-power alarm")
-    .tuya_switch(dp_id=107, attribute_name="temperature_alarm", translation_key="temperature_alarm",
-                 fallback_name="Temperature alarm")
-
+    .tuya_enum(
+        dp_id=109,
+        attribute_name="online_state",
+        translation_key="online_state",
+        enum_class=OnlineState,
+        fallback_name="Online state",
+    )
+    .tuya_enum(
+        dp_id=110,
+        attribute_name="event",
+        translation_key="event",
+        enum_class=AlertEvent,
+        fallback_name="Event",
+    )
+    .tuya_switch(
+        dp_id=11,
+        attribute_name="prepayment_switch",
+        translation_key="prepayment_switch",
+        fallback_name="Prepayment switch",
+    )
+    .tuya_switch(
+        dp_id=12,
+        attribute_name="clear_remaining_energy",
+        translation_key="clear_remaining_energy",
+        fallback_name="Clear remaining electricity",
+    )
+    .tuya_switch(
+        dp_id=34,
+        attribute_name="factory_reset",
+        translation_key="factory_reset",
+        fallback_name="Clear forward electricity",
+    )
+    .tuya_switch(
+        dp_id=113,
+        attribute_name="restore_default",
+        translation_key="restore_default",
+        fallback_name="Restore default alarms/thresholds",
+    )
+    .tuya_switch(
+        dp_id=101,
+        attribute_name="balance_alarm",
+        translation_key="balance_alarm",
+        fallback_name="Balance alarm",
+    )
+    .tuya_switch(
+        dp_id=102,
+        attribute_name="overvoltage_alarm",
+        translation_key="overvoltage_alarm",
+        fallback_name="Over-voltage alarm",
+    )
+    .tuya_switch(
+        dp_id=103,
+        attribute_name="undervoltage_alarm",
+        translation_key="undervoltage_alarm",
+        fallback_name="Under-voltage alarm",
+    )
+    .tuya_switch(
+        dp_id=104,
+        attribute_name="overcurrent_alarm",
+        translation_key="overcurrent_alarm",
+        fallback_name="Over-current alarm",
+    )
+    .tuya_switch(
+        dp_id=105,
+        attribute_name="overpower_alarm",
+        translation_key="overpower_alarm",
+        fallback_name="Over-power alarm",
+    )
+    .tuya_switch(
+        dp_id=107,
+        attribute_name="temperature_alarm",
+        translation_key="temperature_alarm",
+        fallback_name="Temperature alarm",
+    )
     # Numeric thresholds
-    .tuya_number(dp_id=14, attribute_name="add_electricity_charge", translation_key="add_electricity_charge",
-                 type=t.uint32_t, min_value=0, max_value=500, step=1, multiplier=0.01, unit=UnitOfEnergy.KILO_WATT_HOUR,
-                 fallback_name="Add electricity charge, kWh [0..500]")
-    .tuya_number(dp_id=114, attribute_name="current_threshold", translation_key="current_threshold",
-                 type=t.uint32_t, min_value=1, max_value=50, step=1, unit=UnitOfElectricCurrent.AMPERE,
-                 fallback_name="Current threshold, A [1..50]")
-    .tuya_number(dp_id=115, attribute_name="overvoltage_threshold", translation_key="overvoltage_threshold",
-                 type=t.uint32_t, min_value=100, max_value=280, step=1, unit=UnitOfElectricPotential.VOLT,
-                 fallback_name="Over-voltage threshold, V [100..280]")
-    .tuya_number(dp_id=116, attribute_name="undervoltage_threshold", translation_key="undervoltage_threshold",
-                 type=t.uint32_t, min_value=100, max_value=280, step=1, unit=UnitOfElectricPotential.VOLT,
-                 fallback_name="Under-voltage threshold, V [100..280]")
-    .tuya_number(dp_id=118, attribute_name="temperature_threshold", translation_key="temperature_threshold",
-                 type=t.int32s, min_value=-25, max_value=100, step=1, multiplier=0.1, unit=UnitOfTemperature.CELSIUS,
-                 fallback_name="Temperature threshold, C [-25..100]")
+    .tuya_number(
+        dp_id=14,
+        attribute_name="add_electricity_charge",
+        translation_key="add_electricity_charge",
+        type=t.uint32_t,
+        min_value=0,
+        max_value=500,
+        step=1,
+        multiplier=0.01,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        fallback_name="Add electricity charge, kWh [0..500]",
+    )
+    .tuya_number(
+        dp_id=114,
+        attribute_name="current_threshold",
+        translation_key="current_threshold",
+        type=t.uint32_t,
+        min_value=1,
+        max_value=50,
+        step=1,
+        unit=UnitOfElectricCurrent.AMPERE,
+        fallback_name="Current threshold, A [1..50]",
+    )
+    .tuya_number(
+        dp_id=115,
+        attribute_name="overvoltage_threshold",
+        translation_key="overvoltage_threshold",
+        type=t.uint32_t,
+        min_value=100,
+        max_value=280,
+        step=1,
+        unit=UnitOfElectricPotential.VOLT,
+        fallback_name="Over-voltage threshold, V [100..280]",
+    )
+    .tuya_number(
+        dp_id=116,
+        attribute_name="undervoltage_threshold",
+        translation_key="undervoltage_threshold",
+        type=t.uint32_t,
+        min_value=100,
+        max_value=280,
+        step=1,
+        unit=UnitOfElectricPotential.VOLT,
+        fallback_name="Under-voltage threshold, V [100..280]",
+    )
+    .tuya_number(
+        dp_id=118,
+        attribute_name="temperature_threshold",
+        translation_key="temperature_threshold",
+        type=t.int32s,
+        min_value=-25,
+        max_value=100,
+        step=1,
+        multiplier=0.1,
+        unit=UnitOfTemperature.CELSIUS,
+        fallback_name="Temperature threshold, C [-25..100]",
+    )
     # e27182: The two alerts below I was unable to make working / 11.06.2026
-    .tuya_number(dp_id=119, attribute_name="overpower_threshold", translation_key="overpower_threshold",
-                 type=t.uint32_t, min_value=5, max_value=12005, step=10, unit=UnitOfPower.WATT,
-                 fallback_name="Over-power threshold, W [5..12005]")
-    .tuya_number(dp_id=120, attribute_name="balance_threshold", translation_key="balance_threshold",
-                 type=t.uint32_t, min_value=10, max_value=500, step=1, unit=UnitOfEnergy.KILO_WATT_HOUR,
-                 fallback_name="Balance threshold, kWh [10..500]")
-
+    .tuya_number(
+        dp_id=119,
+        attribute_name="overpower_threshold",
+        translation_key="overpower_threshold",
+        type=t.uint32_t,
+        min_value=5,
+        max_value=12005,
+        step=10,
+        unit=UnitOfPower.WATT,
+        fallback_name="Over-power threshold, W [5..12005]",
+    )
+    .tuya_number(
+        dp_id=120,
+        attribute_name="balance_threshold",
+        translation_key="balance_threshold",
+        type=t.uint32_t,
+        min_value=10,
+        max_value=500,
+        step=1,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        fallback_name="Balance threshold, kWh [10..500]",
+    )
     .adds(TuyaElectricalMeasurement)
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
## Proposed change

- Add full support of Tongou TO-Q-SA1 Power Meter: TOSA1-01WXJAT1A, _TZE284_pglpvdar, TS0601 - with sensors, alerts, controls. Everything this device has.
- Also renamed Tuya3PhaseElectricalMeasurement to TuyaElectricalMeasurement to keep it more universal

## Additional information

Fixes #4643

See full description in the issue above.
This device also goes to sleep after 30 minutes of app inactivity. So special 'watchdog' automation script required:

```
alias: Tongou Watchdog
description: ""
triggers:
  - trigger: time_pattern
    minutes: /30
conditions: []
actions:
  - action: select.select_option
    metadata: {}
    target:
      entity_id: select.corridor_powermeter_ts0601_online_state
    data:
      option: Offline
  - delay:
      hours: 0
      minutes: 0
      seconds: 1
      milliseconds: 0
  - action: select.select_option
    metadata: {}
    target:
      entity_id: select.corridor_powermeter_ts0601_online_state
    data:
      option: Online
mode: single
```

## Device diagnostics

[zha-01KSAQVEXJ78TPZ39EV08FQXP6-_TZE284_pglpvdar TS0601-f3c69eba9af0e23b9341da7e41fad9f5.json](https://github.com/user-attachments/files/28854958/zha-01KSAQVEXJ78TPZ39EV08FQXP6-_TZE284_pglpvdar.TS0601-f3c69eba9af0e23b9341da7e41fad9f5.json)

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
