### PR TITLE
Add Tuya curtain motor `_TZE204_qbhze54q` (NTY N99-3E)

### DIFF
--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -2,6 +2,7 @@
 
 from unittest import mock
 
+import pytest
 from zigpy.quirks.v2 import CustomDeviceV2
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
@@ -10,7 +11,10 @@ from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
 from zhaquirks.tuya import TuyaCommand, TuyaData, TuyaDatapointData
 from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaWindowCovering
-from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601
+from zhaquirks.tuya.ts0601_cover import (
+    TuyaMoesCover0601,
+    TuyaWindowCoveringInvertedControl,
+)
 
 zhaquirks.setup()
 
@@ -223,3 +227,122 @@ async def test_zemismart_zm16b_battery_report(zigpy_device_from_v2_quirk):
     # Battery percentage should be scaled by 2 (default tuya_battery scale)
     power_cluster = ep.power
     assert power_cluster.get("battery_percentage_remaining") == 170
+
+
+async def test_nty_n99_3e_quirk(zigpy_device_from_v2_quirk):
+    """Test NTY N99-3E curtain motor v2 quirk."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_qbhze54q", "TS0601")
+    assert isinstance(quirked, CustomDeviceV2)
+
+    ep = quirked.endpoints[1]
+
+    # Verify clusters are present
+    cover_cluster = ep.window_covering
+    assert cover_cluster is not None
+    assert isinstance(cover_cluster, TuyaWindowCoveringInvertedControl)
+
+    tuya_cluster = ep.tuya_manufacturer
+    assert tuya_cluster is not None
+    assert isinstance(tuya_cluster, TuyaMCUCluster)
+
+
+@pytest.mark.parametrize(
+    ("command_id", "expected_dp_value"),
+    [
+        # This motor uses an inverted control enum (0=close, 1=stop, 2=open),
+        # so up_open/down_close must send the swapped values
+        (WindowCovering.ServerCommandDefs.up_open.id, b"\x02"),
+        (WindowCovering.ServerCommandDefs.down_close.id, b"\x00"),
+        (WindowCovering.ServerCommandDefs.stop.id, b"\x01"),
+    ],
+)
+async def test_nty_n99_3e_control_commands(
+    zigpy_device_from_v2_quirk, command_id, expected_dp_value
+):
+    """Test that control commands send the inverted DP values."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_qbhze54q", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(command_id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x01" in call_data  # DP ID 1 (control)
+        assert call_data[-1:] == expected_dp_value
+
+
+async def test_nty_n99_3e_position_report(zigpy_device_from_v2_quirk):
+    """Test that incoming position DP reports update the cover position."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_qbhze54q", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    cover_listener = ClusterListener(cover_cluster)
+
+    tuya_cluster = ep.tuya_manufacturer
+
+    # Simulate device reporting position 75 (75% open) via DP 3
+    # Should convert to ZCL 25% (0%=open, 100%=closed)
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[TuyaDatapointData(3, TuyaData(75))],
+        )
+    )
+
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 25
+    )
+
+    # Verify attribute update event was fired
+    assert len(cover_listener.attribute_updates) == 1
+    assert (
+        cover_listener.attribute_updates[0][0]
+        == WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+    assert cover_listener.attribute_updates[0][1] == 25
+
+
+async def test_nty_n99_3e_go_to_lift_percentage(zigpy_device_from_v2_quirk):
+    """Test that go_to_lift_percentage sends correct inverted position."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_qbhze54q", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        # Send ZCL go_to_lift_percentage with 25% (25% closed = 75% open)
+        await cover_cluster.command(
+            WindowCovering.ServerCommandDefs.go_to_lift_percentage.id, 25
+        )
+        await wait_for_zigpy_tasks()
+
+        # Should send inverted value (100 - 25 = 75) to device
+        # Multiple calls expected (DP 2 and DP 3 both mapped)
+        assert req_mock.call_count >= 1
+        # Check that at least one call has the correct position value
+        found_correct_position = False
+        for call in req_mock.call_args_list:
+            call_data = call[1]["data"]
+            # DP 2 (position control) with value 75
+            if b"\x02" in call_data and b"\x00\x00\x00\x4b" in call_data:
+                found_correct_position = True
+        assert found_correct_position, "Expected DP 2 with value 75 in sent data"

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -1,7 +1,11 @@
 """Tuya based cover and blinds."""
 
+from typing import Any
+
 from zigpy.profiles import zha
 import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
 
 from zhaquirks.const import (
@@ -20,6 +24,7 @@ from zhaquirks.tuya import (
     TuyaWindowCoverControl,
 )
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.mcu import TuyaWindowCovering
 
 
 class TuyaZemismartSmartCover0601(TuyaWindowCover):
@@ -701,6 +706,65 @@ class BorderSetting(t.enum8):
         unique_id_suffix="border_remove_all",
         translation_key="delete_all_limits",
         fallback_name="Delete all limits",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+class TuyaWindowCoveringInvertedControl(TuyaWindowCovering):
+    """WindowCovering cluster for motors with an inverted control DP enum.
+
+    Some curtain motors interpret the control DP values inverted from the
+    zhaquirks default: 0=close, 1=stop, 2=open instead of 0=open, 1=stop,
+    2=close, while still reporting positions with the regular convention.
+    Swapping open/close makes the motor move in the requested direction.
+    """
+
+    _COMMAND_SWAP = {
+        WindowCovering.ServerCommandDefs.up_open.id: (
+            WindowCovering.ServerCommandDefs.down_close.id
+        ),
+        WindowCovering.ServerCommandDefs.down_close.id: (
+            WindowCovering.ServerCommandDefs.up_open.id
+        ),
+    }
+
+    async def command(
+        self,
+        command_id: foundation.GeneralCommand | int | t.uint8_t,
+        *args,
+        manufacturer: int | t.uint16_t | None = None,
+        expect_reply: bool = True,
+        tsn: int | t.uint8_t | None = None,
+        **kwargs: Any,
+    ):
+        """Swap open/close before passing the command to the default handler."""
+        return await super().command(
+            self._COMMAND_SWAP.get(command_id, command_id),
+            *args,
+            manufacturer=manufacturer,
+            expect_reply=expect_reply,
+            tsn=tsn,
+            **kwargs,
+        )
+
+
+(
+    # NTY N99-3E curtain motor
+    TuyaQuirkBuilder("_TZE204_qbhze54q", "TS0601")
+    .tuya_cover(
+        control_dp=1,
+        position_state_dp=3,
+        position_control_dp=2,
+        cover_cfg=TuyaWindowCoveringInvertedControl,
+    )
+    .tuya_enum(
+        dp_id=5,
+        attribute_name="motor_direction",
+        enum_class=MotorDirection,
+        translation_key="motor_direction",
+        fallback_name="Motor direction",
     )
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
## Proposed change

Adds support for the Tuya TS0601 `_TZE204_qbhze54q` curtain motor (sold as NTY N99-3E, a center-opening curtain motor). This signature is currently unsupported — pairing it with ZHA only creates the diagnostic LQI/RSSI/firmware entities.

The motor uses the standard Tuya curtain datapoints (DP 1 = control, DP 2 = position target, DP 3 = position state, DP 5 = motor direction), but it interprets the control enum **inverted** with respect to the zhaquirks default: `0=close, 1=stop, 2=open` (the default `TuyaCoverControl` sends `0=open, 1=stop, 2=close`). Position reports use the regular convention, so only the open/close commands need swapping.

This PR:
- Adds `TuyaWindowCoveringInvertedControl`, a `TuyaWindowCovering` subclass that swaps `up_open`/`down_close` before delegating to the default handler. This is the first v2 cover quirk needing inverted control values — if you'd rather have this as a generic option on `TuyaQuirkBuilder.tuya_cover()`, happy to rework it.
- Registers a v2 quirk for `_TZE204_qbhze54q` using that cluster.

All DP mappings were confirmed by testing on the physical device (HA 2026.6.2): position reporting, go-to-position, and open/stop/close all work correctly with this quirk. Without the command swap, open/close move the motor in the opposite direction.

## Additional information

Device signature (from ZHA diagnostics):

```json
{
  "manufacturer": "_TZE204_qbhze54q",
  "model": "TS0601",
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0051",
      "input_clusters": ["0x0000", "0x0004", "0x0005", "0xef00"],
      "output_clusters": ["0x0019", "0x000a"]
    },
    "242": {
      "profile_id": "0xa1e0",
      "device_type": "0x0061",
      "input_clusters": [],
      "output_clusters": ["0x0021"]
    }
  }
}
```

## Device diagnostics

[zha-01K7ZK2NNM150FF8WT0EWBH666-_TZE204_qbhze54q TS0601-a72645334af00ead01267ff0b1667ff9.json](https://github.com/user-attachments/files/28906486/zha-01K7ZK2NNM150FF8WT0EWBH666-_TZE204_qbhze54q.TS0601-a72645334af00ead01267ff0b1667ff9.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
