### PR TITLE
Add Tuya curtain motor `_TZE204_qbhze54q` (NTY N99-3E)

### DIFF
--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -2,6 +2,7 @@
 
 from unittest import mock
 
+import pytest
 from zigpy.quirks.v2 import CustomDeviceV2
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
@@ -223,3 +224,121 @@ async def test_zemismart_zm16b_battery_report(zigpy_device_from_v2_quirk):
     # Battery percentage should be scaled by 2 (default tuya_battery scale)
     power_cluster = ep.power
     assert power_cluster.get("battery_percentage_remaining") == 170
+
+
+async def test_nty_n99_3e_quirk(zigpy_device_from_v2_quirk):
+    """Test NTY N99-3E curtain motor v2 quirk."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_qbhze54q", "TS0601")
+    assert isinstance(quirked, CustomDeviceV2)
+
+    ep = quirked.endpoints[1]
+
+    # Verify clusters are present
+    cover_cluster = ep.window_covering
+    assert cover_cluster is not None
+    assert isinstance(cover_cluster, TuyaWindowCovering)
+
+    tuya_cluster = ep.tuya_manufacturer
+    assert tuya_cluster is not None
+    assert isinstance(tuya_cluster, TuyaMCUCluster)
+
+
+@pytest.mark.parametrize(
+    ("command_id", "expected_dp_value"),
+    [
+        # Standard control enum: open=0, stop=1, close=2
+        (WindowCovering.ServerCommandDefs.up_open.id, b"\x00"),
+        (WindowCovering.ServerCommandDefs.down_close.id, b"\x02"),
+        (WindowCovering.ServerCommandDefs.stop.id, b"\x01"),
+    ],
+)
+async def test_nty_n99_3e_control_commands(
+    zigpy_device_from_v2_quirk, command_id, expected_dp_value
+):
+    """Test that control commands send the correct DP values."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_qbhze54q", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(command_id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x01" in call_data  # DP ID 1 (control)
+        assert call_data[-1:] == expected_dp_value
+
+
+async def test_nty_n99_3e_position_report(zigpy_device_from_v2_quirk):
+    """Test that incoming position DP reports update the cover position."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_qbhze54q", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    cover_listener = ClusterListener(cover_cluster)
+
+    tuya_cluster = ep.tuya_manufacturer
+
+    # This unit reports position already in the ZCL convention (invert=False),
+    # so a DP 3 report of 75 maps straight to ZCL 75%.
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[TuyaDatapointData(3, TuyaData(75))],
+        )
+    )
+
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 75
+    )
+
+    # Verify attribute update event was fired
+    assert len(cover_listener.attribute_updates) == 1
+    assert (
+        cover_listener.attribute_updates[0][0]
+        == WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+    assert cover_listener.attribute_updates[0][1] == 75
+
+
+async def test_nty_n99_3e_go_to_lift_percentage(zigpy_device_from_v2_quirk):
+    """Test that go_to_lift_percentage sends the position without inversion."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_qbhze54q", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        # Send ZCL go_to_lift_percentage with 25%
+        await cover_cluster.command(
+            WindowCovering.ServerCommandDefs.go_to_lift_percentage.id, 25
+        )
+        await wait_for_zigpy_tasks()
+
+        # Should send the value as-is (invert=False)
+        # Multiple calls expected (DP 2 and DP 3 both mapped)
+        assert req_mock.call_count >= 1
+        # Check that at least one call has the correct position value
+        found_correct_position = False
+        for call in req_mock.call_args_list:
+            call_data = call[1]["data"]
+            # DP 2 (position control) with value 25 (0x19)
+            if b"\x02" in call_data and b"\x00\x00\x00\x19" in call_data:
+                found_correct_position = True
+        assert found_correct_position, "Expected DP 2 with value 25 in sent data"

--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -16,6 +16,17 @@ from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601
 zhaquirks.setup()
 
 
+def _sent_datapoints(call_data):
+    """Parse the datapoints out of a serialized Tuya MCU request frame.
+
+    Strips the ZCL header and decodes the TuyaCommand payload so tests can
+    assert on (dp, value) tuples instead of brittle raw-byte substrings.
+    """
+    _hdr, rest = foundation.ZCLHeader.deserialize(call_data)
+    tuya_cmd, _ = TuyaCommand.deserialize(rest)
+    return {dp.dp: int(dp.data.payload) for dp in tuya_cmd.datapoints}
+
+
 def test_ts601_moes_signature(assert_signature_matches_quirk):
     """Test TS0121 cover signature is matched to its quirk."""
     signature = {
@@ -248,9 +259,9 @@ async def test_nty_n99_3e_quirk(zigpy_device_from_v2_quirk):
     ("command_id", "expected_dp_value"),
     [
         # Standard control enum: open=0, stop=1, close=2
-        (WindowCovering.ServerCommandDefs.up_open.id, b"\x00"),
-        (WindowCovering.ServerCommandDefs.down_close.id, b"\x02"),
-        (WindowCovering.ServerCommandDefs.stop.id, b"\x01"),
+        (WindowCovering.ServerCommandDefs.up_open.id, 0),
+        (WindowCovering.ServerCommandDefs.down_close.id, 2),
+        (WindowCovering.ServerCommandDefs.stop.id, 1),
     ],
 )
 async def test_nty_n99_3e_control_commands(
@@ -271,9 +282,9 @@ async def test_nty_n99_3e_control_commands(
         await wait_for_zigpy_tasks()
 
         req_mock.assert_called_once()
-        call_data = req_mock.call_args[1]["data"]
-        assert b"\x01" in call_data  # DP ID 1 (control)
-        assert call_data[-1:] == expected_dp_value
+        datapoints = _sent_datapoints(req_mock.call_args[1]["data"])
+        # Control is DP 1
+        assert datapoints == {1: expected_dp_value}
 
 
 async def test_nty_n99_3e_position_report(zigpy_device_from_v2_quirk):
@@ -331,14 +342,9 @@ async def test_nty_n99_3e_go_to_lift_percentage(zigpy_device_from_v2_quirk):
         )
         await wait_for_zigpy_tasks()
 
-        # Should send the value as-is (invert=False)
-        # Multiple calls expected (DP 2 and DP 3 both mapped)
+        # Should send the value as-is (invert=False) to the position control DP 2
         assert req_mock.call_count >= 1
-        # Check that at least one call has the correct position value
-        found_correct_position = False
+        sent = {}
         for call in req_mock.call_args_list:
-            call_data = call[1]["data"]
-            # DP 2 (position control) with value 25 (0x19)
-            if b"\x02" in call_data and b"\x00\x00\x00\x19" in call_data:
-                found_correct_position = True
-        assert found_correct_position, "Expected DP 2 with value 25 in sent data"
+            sent.update(_sent_datapoints(call[1]["data"]))
+        assert sent.get(2) == 25, f"Expected DP 2 with value 25, got {sent}"

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -705,3 +705,27 @@ class BorderSetting(t.enum8):
     .skip_configuration()
     .add_to_registry()
 )
+
+
+(
+    # NTY N99-3E curtain motor.
+    # Control DP uses the standard order (0=open, 1=stop, 2=close), and this
+    # unit reports position already in the ZCL convention (0=closed, 100=open),
+    # so position values must not be inverted (invert=False).
+    TuyaQuirkBuilder("_TZE204_qbhze54q", "TS0601")
+    .tuya_cover(
+        control_dp=1,
+        position_state_dp=3,
+        position_control_dp=2,
+        invert=False,
+    )
+    .tuya_enum(
+        dp_id=5,
+        attribute_name="motor_direction",
+        enum_class=MotorDirection,
+        translation_key="motor_direction",
+        fallback_name="Motor direction",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -709,9 +709,9 @@ class BorderSetting(t.enum8):
 
 (
     # NTY N99-3E curtain motor.
-    # Control DP uses the standard order (0=open, 1=stop, 2=close), and this
-    # unit reports position already in the ZCL convention (0=closed, 100=open),
-    # so position values must not be inverted (invert=False).
+    # Control DP uses the standard order (0=open, 1=stop, 2=close). This unit
+    # already reports and accepts position using the ZCL lift-percentage
+    # convention (0=open, 100=closed), so it must not be inverted (invert=False).
     TuyaQuirkBuilder("_TZE204_qbhze54q", "TS0601")
     .tuya_cover(
         control_dp=1,


### PR DESCRIPTION
## Proposed change

Adds support for the Tuya TS0601 `_TZE204_qbhze54q` curtain motor (sold as NTY N99-3E, a center-opening curtain motor). This signature is currently unsupported — pairing it with ZHA only creates the diagnostic LQI/RSSI/firmware entities.

The motor uses the standard Tuya curtain datapoints:
- DP 1 — control (`0=open, 1=stop, 2=close`)
- DP 2 — position target (0–100)
- DP 3 — position state (0–100), already reported in the ZCL convention (`0=closed, 100=open`)
- DP 5 — motor direction (`0=forward, 1=back`)

Because this unit reports position already in the ZCL convention, the position mapping uses `invert=False`. A `motor_direction` select (DP 5) is exposed so the running direction can be flipped from HA.

All DP mappings and directions were confirmed by testing on the physical device (HA 2026.6.2): open, close, stop, go-to-position and position reporting all match the curtain's physical state.

## Additional information

Device signature (from ZHA diagnostics):

```json
{
  "manufacturer": "_TZE204_qbhze54q",
  "model": "TS0601",
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0051",
      "input_clusters": ["0x0000", "0x0004", "0x0005", "0xef00"],
      "output_clusters": ["0x0019", "0x000a"]
    },
    "242": {
      "profile_id": "0xa1e0",
      "device_type": "0x0061",
      "input_clusters": [],
      "output_clusters": ["0x0021"]
    }
  }
}
```

## Device diagnostics

[zha-01K7ZK2NNM150FF8WT0EWBH666-_TZE204_qbhze54q TS0601-a72645334af00ead01267ff0b1667ff9.json](https://github.com/user-attachments/files/28906888/zha-01K7ZK2NNM150FF8WT0EWBH666-_TZE204_qbhze54q.TS0601-a72645334af00ead01267ff0b1667ff9.1.json)

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
