### PR TITLE
Add `firmware_version` to `zigpy_device_from_v2_quirk` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from zigpy.device import Device
 import zigpy.quirks
 import zigpy.types
 from zigpy.zcl import ClusterType, foundation
-from zigpy.zcl.clusters.general import Basic
+from zigpy.zcl.clusters.general import Basic, Ota
 from zigpy.zdo.types import NodeDescriptor
 
 from zhaquirks.const import (
@@ -174,6 +174,7 @@ def zigpy_device_from_v2_quirk(MockAppController, ieee_mock):
         ieee=None,
         nwk=zigpy.types.NWK(0x1234),
         apply_quirk=True,
+        firmware_version: int | None = None,
     ) -> Device:
         """Create zigpy device for v2 quirks test by manufacturer and model.
 
@@ -187,6 +188,9 @@ def zigpy_device_from_v2_quirk(MockAppController, ieee_mock):
         :param ieee: IEEE address of the device.
         :param nwk: Network address of the device.
         :param apply_quirk: Whether to apply the quirk to the device.
+        :param firmware_version: If set, add an OTA client cluster on ep 1 reporting
+            this `current_file_version`, so quirks using `firmware_version_filter`
+            can be selected. `None` leaves the device without a reported version.
         :return: Zigpy device object.
         """
         if ieee is None:
@@ -203,6 +207,11 @@ def zigpy_device_from_v2_quirk(MockAppController, ieee_mock):
             if ep_id == 1:
                 endpoint_clusters[ep_id][Basic.cluster_id] = ClusterType.Server
 
+        # firmware_version_filter reads current_file_version from an OTA client
+        # cluster, so add one on ep 1 when a firmware version is requested
+        if firmware_version is not None:
+            endpoint_clusters.setdefault(1, {})[Ota.cluster_id] = ClusterType.Client
+
         raw_device = zigpy.device.Device(MockAppController, ieee, nwk)
         raw_device.manufacturer = manufacturer
         raw_device.model = model
@@ -218,6 +227,12 @@ def zigpy_device_from_v2_quirk(MockAppController, ieee_mock):
                     ep.add_output_cluster(cluster_id)
                 else:
                     ep.add_input_cluster(cluster_id)
+
+        # seed the reported firmware version before quirk selection runs
+        if firmware_version is not None:
+            raw_device.endpoints[1].out_clusters[Ota.cluster_id].update_attribute(
+                Ota.AttributeDefs.current_file_version.id, firmware_version
+            )
 
         quirked = zigpy.quirks.get_device(raw_device)
 

--- a/tests/test_innr.py
+++ b/tests/test_innr.py
@@ -1,0 +1,59 @@
+"""Tests for Innr quirks."""
+
+import pytest
+from zigpy.zcl.clusters.smartenergy import Metering
+
+import zhaquirks
+from zhaquirks.innr import MeteringClusterInnrNew, MeteringClusterInnrOld
+
+zhaquirks.setup()
+
+# firmware version that fixed the metering divisor bug (max_version is exclusive)
+SP240_DIVISOR_FIX_FW_VERSION = 0x191B3685
+DIVISOR_ID = Metering.AttributeDefs.divisor.id
+
+
+@pytest.mark.parametrize(
+    ("firmware_version", "expected_cluster", "expected_divisor"),
+    [
+        # firmware before the fix uses the old override (divisor 100)
+        (
+            SP240_DIVISOR_FIX_FW_VERSION - 1,
+            MeteringClusterInnrOld,
+            100,
+        ),
+        # the fixed firmware and newer use the new override (divisor 1000)
+        (
+            SP240_DIVISOR_FIX_FW_VERSION,
+            MeteringClusterInnrNew,
+            1000,
+        ),
+        (
+            SP240_DIVISOR_FIX_FW_VERSION + 1,
+            MeteringClusterInnrNew,
+            1000,
+        ),
+        # a device that does not report a firmware version is treated as new
+        # (the new quirk has allow_missing=True, the old one allow_missing=False)
+        (
+            None,
+            MeteringClusterInnrNew,
+            1000,
+        ),
+    ],
+)
+def test_innr_sp240_firmware_version_metering(
+    zigpy_device_from_v2_quirk,
+    firmware_version,
+    expected_cluster,
+    expected_divisor,
+):
+    """Test the correct Innr SP 240 quirk is selected based on firmware version."""
+    device = zigpy_device_from_v2_quirk(
+        "innr", "SP 240", firmware_version=firmware_version
+    )
+
+    metering_cluster = device.endpoints[1].smartenergy_metering
+    assert isinstance(metering_cluster, expected_cluster)
+    # the constant divisor override is applied regardless of what the device reports
+    assert metering_cluster.get(DIVISOR_ID) == expected_divisor

--- a/tests/test_innr.py
+++ b/tests/test_innr.py
@@ -10,7 +10,6 @@ zhaquirks.setup()
 
 # firmware version that fixed the metering divisor bug (max_version is exclusive)
 SP240_DIVISOR_FIX_FW_VERSION = 0x191B3685
-DIVISOR_ID = Metering.AttributeDefs.divisor.id
 
 
 @pytest.mark.parametrize(
@@ -55,5 +54,6 @@ def test_innr_sp240_firmware_version_metering(
 
     metering_cluster = device.endpoints[1].smartenergy_metering
     assert isinstance(metering_cluster, expected_cluster)
+
     # the constant divisor override is applied regardless of what the device reports
-    assert metering_cluster.get(DIVISOR_ID) == expected_divisor
+    assert metering_cluster.get(Metering.AttributeDefs.divisor.id) == expected_divisor


### PR DESCRIPTION
## Proposed change
Quirks using `firmware_version_filter` read `current_file_version` from an OTA client cluster during quirk selection.
The fixture previously offered no way to set that before `get_device` runs, so firmware-version-filtered quirks could only ever hit the allow_missing path.

Add a `firmware_version` parameter that adds an OTA client cluster on endpoint 1 and seeds `current_file_version` before quirk selection, so the min_version/max_version branches can be exercised in tests.

An example test for the Innr SP 240 plug is added.

## Additional information
This may be used for the Sonoff S60 plug with pre/post v2.0.3 changes.

## Device diagnostics
N/A


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
