### PR TITLE
Add Tuya sensor quirk for _TZE284_hodyryli

### DIFF
--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -208,7 +208,9 @@ async def test_handle_get_data_probe_sensor(zigpy_device_from_v2_quirk, model, m
     assert ep.temperature.get("measured_value") == 2530  # 253 * 10
     assert ep.humidity.get("measured_value") == 7100  # 71 * 100
     assert ep.power.get("battery_percentage_remaining") == 100  # state 1 → 100
-    assert ep.tuya_manufacturer.get("temperature_probe") == 245  # raw value, ÷10 for display
+    assert (
+        ep.tuya_manufacturer.get("temperature_probe") == 245
+    )  # raw value, ÷10 for display
 
     # Battery state 0 maps to 0, not 50 (unlike _TZE200_upagmta9)
     bat_empty = b"\x09\xe0\x02\x0b\x33\x03\x02\x00\x04\x00\x00\x00\x00"

--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -11,6 +11,8 @@ from zhaquirks.tuya.mcu import TuyaMCUCluster
 
 # Temp DP 1, Humidity DP 2, Battery DP 3
 TUYA_TEMP01_HUM02_BAT03 = b"\x09\xe0\x02\x0b\x33\x01\x02\x00\x04\x00\x00\x00\xfd\x02\x02\x00\x04\x00\x00\x00\x47\x03\x02\x00\x04\x00\x00\x00\x01"
+# Temp DP 1, Humidity DP 2, Battery DP 3 (state=1), Probe DP 38 (raw=245 → 24.5 °C)
+TUYA_TEMP01_HUM02_BAT03_PROBE38 = b"\x09\xe0\x02\x0b\x33\x01\x02\x00\x04\x00\x00\x00\xfd\x02\x02\x00\x04\x00\x00\x00\x47\x03\x02\x00\x04\x00\x00\x00\x01\x26\x02\x00\x04\x00\x00\x00\xf5"
 # Temp DP 1, Humidity DP 2, Battery DP 4
 TUYA_TEMP01_HUM02_BAT04 = b"\x09\xe0\x02\x0b\x33\x01\x02\x00\x04\x00\x00\x00\xfd\x02\x02\x00\x04\x00\x00\x00\x47\x04\x02\x00\x04\x00\x00\x00\x01"
 TUYA_USP = b"\x09\xe0\x02\x0b\x33\x01\x02\x00\x04\x00\x00\x00\xfd\x02\x02\x00\x04\x00\x00\x00\x47\xff\x02\x00\x04\x00\x00\x00\x64"
@@ -178,3 +180,43 @@ def test_valid_attributes(zigpy_device_from_v2_quirk):
     assert {temperature_attr_id} == temperature_cluster._VALID_ATTRIBUTES
     assert {humidity_attr_id} == humidity_cluster._VALID_ATTRIBUTES
     assert {power_attr_id} == power_config_cluster._VALID_ATTRIBUTES
+
+
+@pytest.mark.parametrize(
+    "model,manuf",
+    [
+        ("_TZE284_hodyryli", "TS0601"),
+        ("_TZE284_8se38w3c", "TS0601"),
+    ],
+)
+async def test_handle_get_data_probe_sensor(zigpy_device_from_v2_quirk, model, manuf):
+    """Test temp/humidity/battery/probe sensor (hodyryli / 8se38w3c)."""
+
+    quirked = zigpy_device_from_v2_quirk(model, manuf)
+    ep = quirked.endpoints[1]
+
+    assert ep.basic is not None
+    assert isinstance(ep.basic, Basic)
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+
+    hdr, data = ep.tuya_manufacturer.deserialize(TUYA_TEMP01_HUM02_BAT03_PROBE38)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+
+    assert ep.temperature.get("measured_value") == 2530  # 253 * 10
+    assert ep.humidity.get("measured_value") == 7100  # 71 * 100
+    assert ep.power.get("battery_percentage_remaining") == 100  # state 1 → 100
+    assert ep.tuya_manufacturer.get("temperature_probe") == 245  # raw value, ÷10 for display
+
+    # Battery state 0 maps to 0, not 50 (unlike _TZE200_upagmta9)
+    bat_empty = b"\x09\xe0\x02\x0b\x33\x03\x02\x00\x04\x00\x00\x00\x00"
+    hdr, data = ep.tuya_manufacturer.deserialize(bat_empty)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    assert ep.power.get("battery_percentage_remaining") == 0
+
+    hdr, data = ep.tuya_manufacturer.deserialize(TUYA_USP)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.UNSUPPORTED_ATTRIBUTE

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -334,6 +334,33 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
 
 
 (
+    TuyaQuirkBuilder("_TZE284_hodyryli", "TS0601")  # ZY-ZTH03PRO
+    .applies_to("_TZE284_8se38w3c", "TS0601")  # TZ-ZT01_GA4
+    .tuya_temperature(dp_id=1, scale=10)
+    .tuya_humidity(dp_id=2)
+    .tuya_dp(
+        dp_id=3,
+        ep_attribute=TuyaPowerConfigurationCluster2AAA.ep_attribute,
+        attribute_name="battery_percentage_remaining",
+        converter=lambda x: {0: 0, 1: 100, 2: 200}[x],
+    )
+    .adds(TuyaPowerConfigurationCluster2AAA)
+    .tuya_sensor(
+        dp_id=38,
+        attribute_name="temperature_probe",
+        type=t.int16s,
+        divisor=10,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        unit=UnitOfTemperature.CELSIUS,
+        translation_key="temperature_probe",
+        fallback_name="Probe temperature",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+(
     TuyaQuirkBuilder("_TZE200_upagmta9", "TS0601")
     .applies_to("_TZE204_upagmta9", "TS0601")
     .applies_to("_TZE200_cirvgep4", "TS0601")


### PR DESCRIPTION
## Proposed change

Add support for "_TZE284_hodyryli", "TS0601" (and 8se38w3c which seems to have the exact same requirements) using inspiration from support for this device in https://github.com/0leg7/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts.

## Additional information

Works on my home assistant install
<img width="795" height="304" alt="image" src="https://github.com/user-attachments/assets/452c3705-fcf1-4ce9-8780-70ab2c6dba76" />



## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
