### PR TITLE
Remove old ruff rule S320

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,6 @@ select = [
     "S317",    # suspicious-xml-sax-usage
     "S318",    # suspicious-xml-mini-dom-usage
     "S319",    # suspicious-xml-pull-dom-usage
-    "S320",    # suspicious-xmle-tree-usage
     "S601",    # paramiko-call
     "S602",    # subprocess-popen-with-shell-equals-true
     "S604",    # call-with-shell-equals-true


### PR DESCRIPTION
## Summary

`S320` (`suspicious-xmle-tree-usage`) was **removed** in ruff 0.15, so any ruff ≥ 0.15 aborts before linting:

```
ruff failed
  Cause: Rule `S320` was removed and cannot be selected.
```

This is the first of the failures blocking the "Auto-update pre-commit hooks" PR (#3849, which bumps ruff to v0.15.17). Removing the rule from `select` is safe on the currently pinned ruff 0.9.4 (it just stops selecting that rule) and unblocks the config load on 0.15.x.

## Scope

Config-only change to unblock the ruff upgrade. It intentionally does **not** include:
- The ruff version bumps in `.pre-commit-config.yaml` / `pyproject.toml` — those belong in #3849.
- The ~40 new lint findings that ruff 0.15.17 surfaces once the config loads (mostly `--fix`-able); those are a consequence of the version bump and should be handled there.
- The non-fatal `TRY302` → `TRY203` rename deprecation (tidy-up for #3849).

## Test plan

- `ruff 0.9.4 check` (current pin): `All checks passed!`
- `ruff 0.15.17 check`: config now loads (no longer fatals on `S320`).