### PR TITLE
Fix mypy 2.1.0 unreachable false positive in Danfoss test

### DIFF
--- a/tests/test_danfoss.py
+++ b/tests/test_danfoss.py
@@ -1,5 +1,6 @@
 """Tests the Danfoss quirk (all tests were written for the Popp eT093WRO)."""
 
+from typing import cast
 from unittest import mock
 
 from zigpy.quirks import CustomCluster
@@ -189,7 +190,10 @@ async def test_customized_standardcluster(zigpy_device_from_quirk):
         await danfoss_thermostat_cluster._configure_reporting([one, two])
         assert reports == [two]
 
-    reports = None
+    # typed wide so mypy doesn't narrow to None (the mocked _read_attributes
+    # side effect reassigns this to a list), which would flag the assert below
+    # as comparing an always-None value and mark later code unreachable
+    reports = cast(list | None, None)
 
     def mock_read_attributes(attrs, *args, **kwargs):
         nonlocal reports


### PR DESCRIPTION
## Summary

mypy 2.1.0 flags `tests/test_danfoss.py`:

```
tests/test_danfoss.py:213: error: Statement is unreachable  [unreachable]
```

In `test_customized_standardcluster`, `reports` is reset to `None` and then reassigned to a list inside a mocked `_read_attributes` side effect. mypy can't see the mock mutate it, so with `strict_equality` + `warn_unreachable` it narrows `reports` to `None`, treats the following `assert reports == [656]` (a concrete `list[int]`) as statically always-false, and marks the rest of the function unreachable.

This is the second failure blocking the "Auto-update pre-commit hooks" PR (#3849, which bumps mypy to v2.1.0).

## Fix

Type the reset expression as `list | None` via `cast` so mypy keeps the union instead of narrowing to `None`. It's a runtime no-op (`cast` returns its argument unchanged), so test behavior is identical.

A `# type: ignore[unreachable]` was rejected as an alternative: the currently pinned mypy 1.14.1 doesn't see line 213 as unreachable, so with `warn_unused_ignores = true` the ignore would itself error on `dev`.

## Test plan

Verified clean under:
- mypy 2.1.0 (the new pin) — both with and without `zigpy` installed
- mypy 1.14.1 (current pin) — no `warn_unused_ignores` regression
- `ruff 0.9.4 check`/`format`
- `pytest tests/test_danfoss.py::test_customized_standardcluster` passes