### PR TITLE
Fix `TuyaQuirkBuilder` parameter type annotations

### DIFF
--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -216,7 +216,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def _tuya_battery(
         self,
         dp_id: int,
-        power_cfg: PowerConfiguration,
+        power_cfg: type[PowerConfiguration],
         scale: float,
         endpoint_id: int = 1,
     ) -> Self:
@@ -234,7 +234,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_battery(
         self,
         dp_id: int,
-        power_cfg: PowerConfiguration | None = None,
+        power_cfg: type[PowerConfiguration] | None = None,
         battery_type: BatterySize | None = BatterySize.AA,
         battery_qty: int | None = 2,
         battery_voltage: int | None = None,
@@ -399,7 +399,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_ias(
         self,
         dp_id: int,
-        ias_cfg: TuyaLocalCluster,
+        ias_cfg: type[TuyaLocalCluster],
         converter: Callable[[Any], Any] | None = None,
         endpoint_id: int = 1,
     ) -> Self:

--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -270,7 +270,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_illuminance(
         self,
         dp_id: int,
-        illuminance_cfg: TuyaLocalCluster = TuyaIlluminance,
+        illuminance_cfg: type[TuyaLocalCluster] = TuyaIlluminance,
         converter: Callable[[Any], Any] | None = (
             lambda x: 10000 * math.log10(x) + 1 if x != 0 else 0
         ),
@@ -300,7 +300,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_co2(
         self,
         dp_id: int,
-        co2_cfg: TuyaLocalCluster = TuyaCO2Concentration,
+        co2_cfg: type[TuyaLocalCluster] = TuyaCO2Concentration,
         scale: float = 1e-6,
         endpoint_id: int = 1,
     ) -> Self:
@@ -318,7 +318,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_electrical_conductivity(
         self,
         dp_id: int,
-        ec_cfg: TuyaLocalCluster = TuyaElectricalConductivity,
+        ec_cfg: type[TuyaLocalCluster] = TuyaElectricalConductivity,
         scale: float = 1,
         endpoint_id: int = 1,
     ) -> Self:
@@ -336,9 +336,9 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_formaldehyde(
         self,
         dp_id: int,
-        form_cfg: TuyaLocalCluster = TuyaFormaldehydeConcentration,
+        form_cfg: type[TuyaLocalCluster] = TuyaFormaldehydeConcentration,
         # Convert from µg/m3 to ppm, note, ZHA will scale by 1e6
-        converter: float = lambda x: (
+        converter: Callable[[Any], Any] | None = lambda x: (
             round(
                 ((MOL_VOL_AIR_NTP * x) / TuyaFormaldehydeConcentration.MOLECULAR_MASS),
                 2,
@@ -361,7 +361,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_pm25(
         self,
         dp_id: int,
-        pm25_cfg: TuyaLocalCluster = TuyaPM25Concentration,
+        pm25_cfg: type[TuyaLocalCluster] = TuyaPM25Concentration,
         scale: float = 1,
         endpoint_id: int = 1,
     ) -> Self:
@@ -417,7 +417,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_metering(
         self,
         dp_id: int,
-        metering_cfg: TuyaLocalCluster = TuyaValveWaterConsumedNoInstDemand,
+        metering_cfg: type[TuyaLocalCluster] = TuyaValveWaterConsumedNoInstDemand,
         scale: float = 1,
         endpoint_id: int = 1,
     ) -> Self:
@@ -435,7 +435,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_onoff(
         self,
         dp_id: int,
-        onoff_cfg: TuyaLocalCluster = TuyaOnOffNM,
+        onoff_cfg: type[TuyaLocalCluster] = TuyaOnOffNM,
         endpoint_id: int = 1,
     ) -> Self:
         """Add a Tuya OnOff Configuration."""
@@ -454,7 +454,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
         position_state_dp: int,
         position_control_dp: int,
         invert: bool = True,
-        cover_cfg: TuyaLocalCluster = TuyaWindowCovering,
+        cover_cfg: type[TuyaLocalCluster] = TuyaWindowCovering,
     ) -> Self:
         """Add a Tuya WindowCovering Configuration.
 
@@ -494,7 +494,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_humidity(
         self,
         dp_id: int,
-        rh_cfg: TuyaLocalCluster = TuyaRelativeHumidity,
+        rh_cfg: type[TuyaLocalCluster] = TuyaRelativeHumidity,
         scale: float = 100,
         endpoint_id: int = 1,
     ) -> Self:
@@ -512,7 +512,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_soil_moisture(
         self,
         dp_id: int,
-        soil_cfg: TuyaLocalCluster = TuyaSoilMoisture,
+        soil_cfg: type[TuyaLocalCluster] = TuyaSoilMoisture,
         scale: float = 100,
         endpoint_id: int = 1,
     ) -> Self:
@@ -530,7 +530,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_temperature(
         self,
         dp_id: int,
-        temp_cfg: TuyaLocalCluster = TuyaTemperatureMeasurement,
+        temp_cfg: type[TuyaLocalCluster] = TuyaTemperatureMeasurement,
         scale: float = 100,
         endpoint_id: int = 1,
     ) -> Self:
@@ -558,7 +558,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
     def tuya_voc(
         self,
         dp_id: int,
-        voc_cfg: TuyaLocalCluster = TuyaAirQualityVOC,
+        voc_cfg: type[TuyaLocalCluster] = TuyaAirQualityVOC,
         scale: float = 1e-6,
         endpoint_id: int = 1,
     ) -> Self:
@@ -928,7 +928,7 @@ class TuyaQuirkBuilder(QuirkBuilder):
 
     def add_to_registry(
         self,
-        replacement_cluster: TuyaMCUCluster = TuyaMCUCluster,
+        replacement_cluster: type[TuyaMCUCluster] = TuyaMCUCluster,
         force_add_cluster: bool = False,
         mcu_write_command: foundation.GeneralCommand | int | t.uint8_t = TUYA_SET_DATA,
     ) -> QuirksV2RegistryEntry:


### PR DESCRIPTION
## Summary

Follow-up to the pre-commit hook autoupdate (#3849), where a Copilot review noticed that `tuya_formaldehyde`'s `converter` parameter is annotated `float` despite taking a callable. Investigating that surfaced a whole cluster of the same class of bug in `TuyaQuirkBuilder`: methods annotate a cluster-**class** parameter as the **instance** type while passing/using the class.

This corrects all of them in `zhaquirks/tuya/builder/__init__.py` (17 annotations):

- 12 `*_cfg: TuyaLocalCluster = <ClusterClass>` → `type[TuyaLocalCluster]` (illuminance, co2, ec, form, pm25, metering, onoff, cover, rh, soil, temp, voc) — used as classes (`cfg.ep_attribute`, passed to `.adds()`).
- `replacement_cluster: TuyaMCUCluster` → `type[TuyaMCUCluster]`.
- `power_cfg` in `_tuya_battery` and `tuya_battery` → `type[PowerConfiguration]` (`| None` where defaulted).
- `ias_cfg: TuyaLocalCluster` in `tuya_ias` → `type[TuyaLocalCluster]`.
- `converter: float` → `Callable[[Any], Any] | None`, matching the other converter methods in the file.

**Annotation-only — no runtime behavior change.**

## Why these weren't caught

These are all suppressed by the global `disable_error_code` list in `pyproject.toml`, so mypy never reports them: the default-value mismatches surface under `assignment` and the call-site mismatches under `arg-type` — both disabled.

Verified by re-enabling each code:
- `--enable-error-code assignment`: the 14 default-value lines clear.
- `--enable-error-code arg-type`: the 4 `ias_cfg`/`power_cfg` call-site errors clear.

Two unrelated pre-existing issues are deliberately left out (they need more than an annotation tweak): the `inspect.currentframe()` `FrameType | None` locals (211-212) and `battery_type` (238).

## Test plan

- `mypy 2.1.0` (default repo config) — clean.
- `mypy 2.1.0 --enable-error-code assignment` / `--enable-error-code arg-type` — target lines no longer error.
- `ruff check` / `ruff format` — clean.
- `pytest -k tuya` — 1160 passed.