### PR TITLE
Remove duplicate `BatterySize.AA` key in Tuya `BATTERY_VOLTAGES`

### DIFF
--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -58,7 +58,6 @@ BATTERY_VOLTAGES = {
     BatterySize.AAA: 15,
     BatterySize.C: 15,
     BatterySize.D: 15,
-    BatterySize.AA: 15,
     BatterySize.CR2: 30,
     BatterySize.CR123A: 30,
     BatterySize.CR2450: 30,


### PR DESCRIPTION
## Summary

`BATTERY_VOLTAGES` in `zhaquirks/tuya/builder/__init__.py` listed `BatterySize.AA: 15` twice (once in the 1.5 V group with the other AA/AAA/C/D entries, and again redundantly just before `CR2`). The `BatterySize` enum has 13 members and all 13 are already covered exactly once, so the second `AA` entry is purely redundant — there's no missing size it was meant to represent.

Removed the duplicate. No runtime effect (a dict literal keeps the last value for a repeated key, and both were identical).

Spotted while working on the TuyaQuirkBuilder annotation fixes (#5099); kept separate as it's an unrelated change. Not caught by ruff/pyflakes because the keys are attribute accesses (`BatterySize.AA`), not literals, so the repeated-key lint rule doesn't apply.

## Test plan

- Verified all 13 `BatterySize` members remain present exactly once.
- `ruff check` / `ruff format` clean.
- `pytest -k "battery or tuya_builder"` — 97 passed.