### PR TITLE
Fix `FrameType` annotations in `TuyaQuirkBuilder.__init__`

### DIFF
--- a/zhaquirks/tuya/builder/__init__.py
+++ b/zhaquirks/tuya/builder/__init__.py
@@ -5,7 +5,6 @@ from enum import Enum
 import inspect
 import math
 import pathlib
-from types import FrameType
 from typing import Any, Self
 
 from zigpy.profiles import zha
@@ -207,8 +206,10 @@ class TuyaQuirkBuilder(QuirkBuilder):
         self.new_attributes: set[foundation.ZCLAttributeDef] = set()
         # quirk_file will point to the init call above if called from this QuirkBuilder,
         # so we need to re-set it correctly
-        current_frame: FrameType = inspect.currentframe()
-        caller: FrameType = current_frame.f_back
+        current_frame = inspect.currentframe()
+        assert current_frame is not None
+        caller = current_frame.f_back
+        assert caller is not None
         self.quirk_file = pathlib.Path(caller.f_code.co_filename)
         self.quirk_file_line = caller.f_lineno
 


### PR DESCRIPTION
> [!NOTE]
> Draft — one of the two remaining annotation issues flagged while reviewing the TuyaQuirkBuilder type-annotation work (#5099). The other (`battery_type`) turned out to be a false positive — see below.

## Summary

In `TuyaQuirkBuilder.__init__`, the caller-frame lookup annotated the locals as non-optional `FrameType`:

```python
current_frame: FrameType = inspect.currentframe()   # actually FrameType | None
caller: FrameType = current_frame.f_back             # actually FrameType | None
```

Both `inspect.currentframe()` and `frame.f_back` return `FrameType | None`. Replaced the incorrect annotations with assertion-based narrowing (CPython always provides these frames in this context), and dropped the now-unused `FrameType` import.

**Behavior-preserving** — the asserts only fire in the (impossible here) case where a frame is `None`, which the previous code would have hit as an `AttributeError` anyway.

Note: the base `zigpy` `QuirkBuilder.__init__` has the identical pattern; this only fixes the local Tuya copy.

## On the other deferred item (`battery_type`)

`battery_type: BatterySize | None = BatterySize.AA` is **not** fixed here — it's a false positive. The "default has type int" error only appears when mypy runs **without** zigpy installed (as CI currently does), where `t.enum8` resolves to `Any` and `BatterySize.AA` looks like a plain `int`. With zigpy present the annotation type-checks fine, so it's correct as-is. It's really another symptom of the pre-commit mypy hook not having zigpy available, not an annotation bug.

## Why this isn't CI-guarded

`assignment` is in the global `disable_error_code` list, so CI doesn't see this. Verified with `mypy 2.1.0 --enable-error-code assignment`: lines 210-211 clear.

## Test plan

- `mypy 2.1.0` default config — clean.
- `mypy 2.1.0 --enable-error-code assignment` — frame lines no longer error.
- `ruff check` / `ruff format` — clean.
- `pytest -k tuya` — 1160 passed.