### PR TITLE
Fix invalid `dst_addressing` type annotations in cluster request handlers

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -175,8 +175,7 @@ class EventableCluster(CustomCluster):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: None
-        | (t.Addressing.Group | t.Addressing.IEEE | t.Addressing.NWK) = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Send cluster requests as events."""
         if (
@@ -333,8 +332,7 @@ class MotionWithReset(_Motion):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: None
-        | (t.Addressing.Group | t.Addressing.IEEE | t.Addressing.NWK) = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Handle the cluster command."""
         # check if the command is for a zone status change of ZoneStatus.Alarm_1 or ZoneStatus.Alarm_2

--- a/zhaquirks/adeo/color_controller.py
+++ b/zhaquirks/adeo/color_controller.py
@@ -1,6 +1,6 @@
 """Device handler for ADEO Lexman LXEK-5 (HR-C99C-Z-C045) & ZBEK-26 (HR-C99C-Z-C045-B) color controllers."""
 
-from typing import Any, Union
+from typing import Any
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
@@ -84,8 +84,7 @@ class AdeoManufacturerCluster(EventableCluster):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Handle the cluster command."""
         if hdr.command_id == 0x0000:

--- a/zhaquirks/bosch/rbsh_trv0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_trv0_zb_eu.py
@@ -1,6 +1,6 @@
 """Device handler for Bosch RBSH-TRV0-ZB-EU thermostat."""
 
-from typing import Any, Final, Union
+from typing import Any, Final
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder, ReportingConfig
@@ -376,8 +376,7 @@ class BoschThermostatCluster(CustomCluster, Thermostat):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """system_mode special handling.
 

--- a/zhaquirks/candeo/scene_switch_remote_5_button_rotary.py
+++ b/zhaquirks/candeo/scene_switch_remote_5_button_rotary.py
@@ -1,6 +1,6 @@
 """Candeo c-zb-sr5br 5-button remote with rotating dial."""
 
-from typing import Final, Union
+from typing import Final
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
@@ -122,8 +122,7 @@ class CandeoSceneSwitchRemoteCluster(CustomCluster):
         hdr: foundation.ZCLHeader,
         args: CandeoSceneSwitchRemoteClusterCommand,
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Overwrite handle_cluster_request to custom process this cluster."""
         if not hdr.frame_control.disable_default_response:

--- a/zhaquirks/develco/emi_han.py
+++ b/zhaquirks/develco/emi_han.py
@@ -20,10 +20,7 @@ class FrientMetering(CustomCluster, Metering):
         hdr: foundation.ZCLHeader,
         args: list,
         *,
-        dst_addressing: t.Addressing.Group
-        | t.Addressing.IEEE
-        | t.Addressing.NWK
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ) -> None:
         """Filter out incorrect divisor attribute reports from device."""
         if hdr.command_id == foundation.GeneralCommand.Report_Attributes:

--- a/zhaquirks/ikea/opencloseremote.py
+++ b/zhaquirks/ikea/opencloseremote.py
@@ -1,6 +1,6 @@
 """Device handler for IKEA of Sweden TRADFRI remote control."""
 
-from typing import Any, Union
+from typing import Any
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -57,8 +57,7 @@ class IkeaWindowCovering(CustomCluster, WindowCovering):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ) -> None:
         """Handle cluster specific commands.
 

--- a/zhaquirks/inovelli/__init__.py
+++ b/zhaquirks/inovelli/__init__.py
@@ -1,7 +1,7 @@
 """Module for Inovelli quirks implementations."""
 
 import logging
-from typing import Any, Union
+from typing import Any
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
@@ -232,8 +232,7 @@ class InovelliCluster(CustomCluster):
         hdr: ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Handle a cluster request."""
         _LOGGER.debug(

--- a/zhaquirks/konke/__init__.py
+++ b/zhaquirks/konke/__init__.py
@@ -1,6 +1,6 @@
 """Konke sensors."""
 
-from typing import Any, Final, Union
+from typing import Any, Final
 
 import zigpy.types as t
 from zigpy.zcl.clusters.general import OnOff
@@ -64,8 +64,7 @@ class KonkeOnOffCluster(CustomCluster):
         header: zigpy.zcl.foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Handle the cluster command."""
         self.info(

--- a/zhaquirks/philips/__init__.py
+++ b/zhaquirks/philips/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 import itertools
 import logging
 import time
-from typing import Any, Final, Union
+from typing import Any, Final
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
@@ -190,8 +190,7 @@ class PhilipsRemoteCluster(CustomCluster):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Handle the cluster command."""
         _LOGGER.debug(

--- a/zhaquirks/samjin/__init__.py
+++ b/zhaquirks/samjin/__init__.py
@@ -1,9 +1,9 @@
 """Module for Samjin quirks implementations."""
 
-from typing import Any, Union
+from typing import Any
 
 from zigpy.quirks import CustomCluster
-from zigpy.types import Addressing
+import zigpy.types as t
 from zigpy.zcl import foundation
 import zigpy.zcl.clusters.security
 
@@ -25,8 +25,7 @@ class SamjinIASCluster(CustomCluster, zigpy.zcl.clusters.security.IasZone):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[Addressing.Group, Addressing.IEEE, Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Handle a cluster command received on this cluster."""
         if hdr.command_id == 0:

--- a/zhaquirks/sengled/e1e_g7f.py
+++ b/zhaquirks/sengled/e1e_g7f.py
@@ -1,6 +1,6 @@
 """Sengled E1E-G7F device."""
 
-from typing import Any, Union
+from typing import Any
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -89,8 +89,7 @@ class SengledE1EG7FManufacturerSpecificCluster(CustomCluster):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Handle cluster request."""
 

--- a/zhaquirks/siglis/zigfred.py
+++ b/zhaquirks/siglis/zigfred.py
@@ -1,7 +1,7 @@
 """zigfred device handler."""
 
 import logging
-from typing import Any, Union
+from typing import Any
 
 from zigpy.profiles import zgp, zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -105,8 +105,7 @@ class ZigfredCluster(CustomCluster):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ) -> None:
         """Handle cluster specific commands."""
         if hdr.command_id == ZIGFRED_CLUSTER_COMMAND_BUTTON_EVENT:

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -5,7 +5,7 @@ DM2550ZB-G2.
 """
 
 import logging
-from typing import Any, Final, Union
+from typing import Any, Final
 
 import zigpy.profiles.zha as zha_p
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -163,8 +163,7 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Handle the cluster command."""
         self.debug(

--- a/zhaquirks/terncy/__init__.py
+++ b/zhaquirks/terncy/__init__.py
@@ -2,7 +2,7 @@
 
 from collections import deque
 import math
-from typing import Any, Union
+from typing import Any
 
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
@@ -152,8 +152,7 @@ class TerncyRawCluster(CustomCluster):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Handle a cluster command received on this cluster."""
         if hdr.command_id == 0:  # click event

--- a/zhaquirks/tuya/ts0210.py
+++ b/zhaquirks/tuya/ts0210.py
@@ -1,7 +1,5 @@
 """TS0210 vibration sensor."""
 
-from typing import Union
-
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 import zigpy.types as t
@@ -36,8 +34,7 @@ class VibrationCluster(LocalDataCluster, MotionOnEvent, IasZone):
         hdr: foundation.ZCLHeader,
         args: tuple[TuyaCommand],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ) -> None:
         """Handle cluster request."""
         self.endpoint.device.motion_bus.listener_event(MOTION_EVENT)

--- a/zhaquirks/tuya/ts0211.py
+++ b/zhaquirks/tuya/ts0211.py
@@ -1,7 +1,5 @@
 """Tuya Doorbell."""
 
-from typing import Union
-
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 import zigpy.types as t
@@ -31,8 +29,7 @@ class IasZoneDoorbellCluster(CustomCluster, IasZone):
         hdr: foundation.ZCLHeader,
         args: tuple[IasZone.ZoneStatus],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ) -> None:
         """Handle cluster request."""
         # args looks like [<ZoneStatus.Alarm_1: 1>, <bitmap8.0: 0>, 0, 0]

--- a/zhaquirks/tuya/ts1201.py
+++ b/zhaquirks/tuya/ts1201.py
@@ -257,8 +257,7 @@ class ZosungIRTransmit(CustomCluster):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Handle a cluster request."""
 

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -1,7 +1,7 @@
 """Device handler for WAXMAN leakSMART."""
 
 # pylint: disable=W0102
-from typing import Any, Union
+from typing import Any
 
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -89,8 +89,7 @@ class WAXMANApplianceEventAlerts(CustomCluster, ApplianceEventAlerts):
         hdr: foundation.ZCLHeader,
         args: list[Any],
         *,
-        dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK]
-        | None = None,
+        dst_addressing: t.AddrMode | None = None,
     ):
         """Handle a cluster command received on this cluster."""
         if hdr.command_id == WAXMAN_CMDID:


### PR DESCRIPTION
## Summary

Many `handle_cluster_request` / `handle_cluster_general_request` overrides annotate `dst_addressing` using zigpy enum **members** as types:

```python
dst_addressing: Union[t.Addressing.Group, t.Addressing.IEEE, t.Addressing.NWK] | None = None
```

`t.Addressing.Group` etc. are enum members, not types, so mypy flags each as `[valid-type]`. zigpy's own signature uses `dst_addressing: t.AddrMode | None = None` — this aligns all 18 overrides to that canonical form and drops the now-unused `Union` / `Addressing` imports.

**Annotation-only — no runtime behavior change.** Clears **57** `[valid-type]` errors (the dominant masked issue when mypy runs with zigpy available).

## Context — part 1 of enabling real mypy type-checking

This is the first step toward fixing the original finding that **CI's mypy hook can't see zigpy's types** (it runs in an isolated env without zigpy), so it reports "Success" while a real run surfaces dozens of errors. The plan:

1. **(this PR)** Fix the `dst_addressing` `valid-type` pattern — 57 of the ~62 errors.
2. Fix the remaining handful surfaced with zigpy: one other `valid-type` (`IasZone.ZoneStatus` used as a type in `ts0211`), 3 `unreachable`, 1 `operator`.
3. Flip the mypy pre-commit hook to install zigpy (`additional_dependencies: [zigpy]`) so CI actually type-checks against zigpy going forward.

## Test plan

- `mypy 2.1.0` **with zigpy**: the 57 `dst_addressing` `[valid-type]` errors are gone.
- `mypy 2.1.0` default CI config (no zigpy): clean.
- `ruff check` / `ruff format`: clean.
- `pytest`: 4769 passed, 2 xfailed.