### PR TITLE
Fix incorrect type annotations in `TuyaData` and `TS0211`

### DIFF
--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -158,7 +158,7 @@ class TuyaData:
 
     def __init__(
         self,
-        value: Any = None,
+        value: object | None = None,
         function: t.uint8_t = t.uint8_t(0),
         raw: bytes | None = None,
     ):

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -158,7 +158,7 @@ class TuyaData:
 
     def __init__(
         self,
-        value: TuyaDPType | None = None,
+        value: Any = None,
         function: t.uint8_t = t.uint8_t(0),
         raw: bytes | None = None,
     ):

--- a/zhaquirks/tuya/ts0211.py
+++ b/zhaquirks/tuya/ts0211.py
@@ -1,5 +1,7 @@
 """Tuya Doorbell."""
 
+from typing import Any
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 import zigpy.types as t
@@ -27,7 +29,7 @@ class IasZoneDoorbellCluster(CustomCluster, IasZone):
     def handle_cluster_request(
         self,
         hdr: foundation.ZCLHeader,
-        args: tuple[IasZone.ZoneStatus],
+        args: list[Any],
         *,
         dst_addressing: t.AddrMode | None = None,
     ) -> None:


### PR DESCRIPTION
## Summary

Two incorrect type annotations surfaced by mypy (with zigpy available), both annotation-only / no runtime change:

- **`tuya/ts0211.py`** — `IasZoneDoorbellCluster.handle_cluster_request` annotated `args: tuple[IasZone.ZoneStatus]`. `IasZone.ZoneStatus` is an enum member (not a type → `[valid-type]`), and the container is wrong — `args` is a list of multiple values (`[<ZoneStatus.Alarm_1>, <bitmap8>, 0, 0]`, per the existing comment). Changed to `args: list[Any]`, matching the canonical zigpy handler signature. (Also resolves the Copilot thread on #5102.)
- **`tuya/__init__.py`** — `TuyaData.__init__` annotated `value: TuyaDPType | None`, but `value` is the raw zigpy value being converted to a payload — `dp_type` is *derived* from it via the `isinstance` chain. Because `TuyaDPType` is an enum, mypy proved the `isinstance(value, int)` branch dead (`[unreachable]`). Annotated as `object | None` — open enough for the intentional `else → RAW` fallback, while still keeping mypy's type-checking on the parameter (`Any` would disable it; a precise union would make the RAW fallback unreachable).

Part of the effort to let CI's mypy hook type-check against zigpy (follow-up to #5102).

## Test plan

- `mypy 2.1.0` with zigpy: both errors gone.
- `mypy 2.1.0` default CI config: clean.
- `ruff check` / `ruff format`: clean.
- `pytest tests/test_tuya.py`: 62 passed.