### PR TITLE
Narrow `present_value` type in Aqara E1 roller curtain handler

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -11,6 +11,7 @@ import zigpy.device
 from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.zcl import (
+    AttributeReadEvent,
     AttributeReportedEvent,
     AttributeUpdatedEvent,
     Cluster,
@@ -2470,6 +2471,25 @@ async def test_xiaomi_e1_roller_position_updates(
         WindowCovering.AttributeDefs.current_position_lift_percentage.id,
         75,
     )
+
+    # a present_value read event without a value (value=None) must be ignored:
+    # it should not raise and must not update the WindowCovering position
+    window_covering_listener.attribute_updates.clear()
+    analog_cluster.emit(
+        AttributeReadEvent.event_type,
+        AttributeReadEvent(
+            device_ieee=str(device.ieee),
+            endpoint_id=analog_cluster.endpoint.endpoint_id,
+            cluster_type=ClusterType.Server,
+            cluster_id=analog_cluster.cluster_id,
+            attribute_name=analog_attr.name,
+            attribute_id=analog_attr.id,
+            manufacturer_code=None,
+            raw_value=None,
+            value=None,
+        ),
+    )
+    assert len(window_covering_listener.attribute_updates) == 0
 
 
 @pytest.mark.parametrize("endpoint", [(1), (2)])

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -11,7 +11,6 @@ import zigpy.device
 from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.zcl import (
-    AttributeReadEvent,
     AttributeReportedEvent,
     AttributeUpdatedEvent,
     Cluster,
@@ -2471,25 +2470,6 @@ async def test_xiaomi_e1_roller_position_updates(
         WindowCovering.AttributeDefs.current_position_lift_percentage.id,
         75,
     )
-
-    # a present_value read event without a value (value=None) must be ignored:
-    # it should not raise and must not update the WindowCovering position
-    window_covering_listener.attribute_updates.clear()
-    analog_cluster.emit(
-        AttributeReadEvent.event_type,
-        AttributeReadEvent(
-            device_ieee=str(device.ieee),
-            endpoint_id=analog_cluster.endpoint.endpoint_id,
-            cluster_type=ClusterType.Server,
-            cluster_id=analog_cluster.cluster_id,
-            attribute_name=analog_attr.name,
-            attribute_id=analog_attr.id,
-            manufacturer_code=None,
-            raw_value=None,
-            value=None,
-        ),
-    )
-    assert len(window_covering_listener.attribute_updates) == 0
 
 
 @pytest.mark.parametrize("endpoint", [(1), (2)])

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -122,9 +122,7 @@ class AnalogOutputRollerE1(CustomCluster, AnalogOutput):
     ) -> None:
         """Handle attribute read/reported events."""
         if event.attribute_id == self.AttributeDefs.present_value.id:
-            # event.value is typed Any | None only because of a legacy zigpy
-            # LocalDataCluster workaround; a real device read/report always
-            # carries a value, so present_value is never None here.
+            # present_value is never None for a real device read/report
             assert event.value is not None
             self.endpoint.window_covering.update_attribute(
                 WindowCovering.AttributeDefs.current_position_lift_percentage.id,

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -122,6 +122,8 @@ class AnalogOutputRollerE1(CustomCluster, AnalogOutput):
     ) -> None:
         """Handle attribute read/reported events."""
         if event.attribute_id == self.AttributeDefs.present_value.id:
+            if event.value is None:
+                return
             self.endpoint.window_covering.update_attribute(
                 WindowCovering.AttributeDefs.current_position_lift_percentage.id,
                 t.uint8_t(100 - event.value),

--- a/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/roller_curtain_e1.py
@@ -122,8 +122,10 @@ class AnalogOutputRollerE1(CustomCluster, AnalogOutput):
     ) -> None:
         """Handle attribute read/reported events."""
         if event.attribute_id == self.AttributeDefs.present_value.id:
-            if event.value is None:
-                return
+            # event.value is typed Any | None only because of a legacy zigpy
+            # LocalDataCluster workaround; a real device read/report always
+            # carries a value, so present_value is never None here.
+            assert event.value is not None
             self.endpoint.window_covering.update_attribute(
                 WindowCovering.AttributeDefs.current_position_lift_percentage.id,
                 t.uint8_t(100 - event.value),


### PR DESCRIPTION
## Summary

`AnalogOutputRollerE1._handle_attribute_read_or_reported` computed `t.uint8_t(100 - event.value)`, which mypy flags as `[operator]: int - None` because `event.value` is typed `Any | None` (from `AttributeReadEvent.value`).

In practice `value` is **never** `None` here. zigpy's own read handling documents this:

> `# There is no way for value to actually be None when read from a real device.`

The only `None`-producing path is a legacy `LocalDataCluster` / `_VALID_ATTRIBUTES` workaround, which doesn't apply to this normal `CustomCluster` and is swallowed (`if cached_value is None: continue`) before any event is emitted. So `None` would be an invariant violation, not an expected runtime value.

Accordingly this uses `assert event.value is not None` (with an explanatory comment) rather than a defensive `if None: return`. The assert documents the invariant and narrows the type for mypy, without implying `None` is a normal case to skip.

Part of the effort to let CI's mypy hook type-check against zigpy (follow-up to #5102).

## Test plan

- `mypy 2.1.0` with zigpy: `[operator]` error gone.
- `mypy 2.1.0` default CI config (no zigpy): clean.
- `ruff check` / `ruff format`: clean.
- `pytest tests/test_xiaomi.py`: 176 passed (existing read→position / report→position coverage exercises the handler). No dedicated test for the `None` case, since it can't occur for a real device.