### PR TITLE
Run mypy against zigpy types in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: uv run --frozen mypy
+        entry: mypy
         language: system
         types_or: [python, pyi]
         require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,10 +11,15 @@ repos:
         additional_dependencies: [tomli]
         args: ["--toml", "pyproject.toml"]
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0 # Keep this in sync with pyproject.toml
+  - repo: local
     hooks:
       - id: mypy
+        name: mypy
+        entry: uv run --frozen mypy
+        language: system
+        types_or: [python, pyi]
+        require_serial: true
+        files: ^zhaquirks/
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.17 # Keep this in sync with pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
     "codespell>=2.3.0",
     "colorlog",
     "coveralls",
-    "mypy==2.1.0",   # Keep this in sync with .pre-commit-config.yaml
+    "mypy==2.1.0",
     "pre-commit",
     "pylint",
     "pytest>=7.1.3",

--- a/zhaquirks/sinope/light.py
+++ b/zhaquirks/sinope/light.py
@@ -229,7 +229,8 @@ class SinopeTechnologiesManufacturerCluster(CustomCluster):
             case self.Action.Long_on:
                 return COMMAND_M_LONG_RELEASE, TURN_ON
             case _:
-                self.debug("SINOPE unhandled action: %s", action)
+                # reachable: a zigpy enum can hold an undefined value reported by a device
+                self.debug("SINOPE unhandled action: %s", action)  # type: ignore[unreachable]
                 return None, None
 
 

--- a/zhaquirks/ubisys/__init__.py
+++ b/zhaquirks/ubisys/__init__.py
@@ -98,7 +98,8 @@ def build_onoff_actions(
             bytes([input_index, 0x0D, source_ep, 0x06, 0x00, 0x01]),
             bytes([input_index, 0x03, source_ep, 0x06, 0x00, 0x00]),
         ]
-    return []
+    # reachable: a zigpy enum can hold an undefined value reported by a device
+    return []  # type: ignore[unreachable]
 
 
 class UbisysInputConfigCluster(LocalDataCluster):


### PR DESCRIPTION
## Summary

The mypy pre-commit hook used `mirrors-mypy`, which runs in pre-commit's **isolated** environment **without `zigpy` installed**. With `ignore_missing_imports = true`, every `zigpy` import resolved to `Any`, so mypy reported "Success" while real type errors against zigpy types went completely unseen — the check was effectively a no-op (a full run with zigpy present surfaces dozens of errors).

This switches mypy to a `repo: local` hook that runs `uv run --frozen mypy`, using the project's **locked** zigpy + mypy from the venv — the same pattern the [`zha`](https://github.com/zigpy/zha) project uses (it runs mypy/ruff/codespell via `uv run --frozen`). mypy now type-checks quirks against real zigpy types.

```yaml
  - repo: local
    hooks:
      - id: mypy
        name: mypy
        entry: uv run --frozen mypy
        language: system
        types_or: [python, pyi]
        require_serial: true
        files: ^zhaquirks/
```

This is the keystone of the recent mypy cleanup series (#5102, #5103, #5104, #5101) — those fixed the real errors that surface once zigpy is visible, so this hook flip lands green.

## Details

- **CI compatibility**: `pre-commit.ci` has `skip: [mypy]`, so it never runs this hook (it has no project venv) — unaffected. The `shared-ci` GitHub Actions job runs `pre-commit run --all-files` inside the `uv`-synced venv, so `uv run --frozen mypy` resolves zigpy + mypy. (Same as `zha`, which uses the same `zigpy/workflows` shared CI.)
- **Two `# type: ignore[unreachable]`** added (`ubisys.build_onoff_actions`, `sinope._get_command_from_action`): mypy now proves these defensive enum fallbacks unreachable, but zigpy `enum8`s can hold *undefined* values reported by a device, so the branches are genuinely reachable — mypy just models the enums as closed. (These ignores are only valid once zigpy is present, which is why they ship here and not earlier.)
- **Scope**: `files: ^zhaquirks/` (matches zha's `^zha/`). Test code isn't mypy-checked — the previous hook nominally ran on it but found nothing useful without zigpy; checking tests against zigpy is a separate, larger effort.
- Drops the now-obsolete `# Keep this in sync with .pre-commit-config.yaml` comment on the mypy pin — there's no longer a hook rev; mypy's version is single-sourced from `uv.lock`/`pyproject.toml`.

## Test plan

- `uv run mypy zhaquirks/` (venv has zigpy): **Success, 0 errors in 439 files**.
- `pre-commit run mypy --all-files`: **Passed** (exercises the new local hook end-to-end).
- `ruff check` / `ruff format`: clean.
- `pytest tests/test_ubisys.py tests/test_sinope.py`: 74 passed.