### PR TITLE
Add BSEED TS0726 scene switch quirks

### DIFF
--- a/tests/test_tuya_ts0726.py
+++ b/tests/test_tuya_ts0726.py
@@ -77,5 +77,27 @@ def test_bseed_ts0726_scene_events(
 
     hdr = foundation.ZCLHeader.cluster(tsn=1, command_id=0xFD)
     cluster.handle_cluster_request(hdr, [0])
+    cluster.handle_cluster_request(hdr, [0])
 
     assert listener.zha_send_event.call_args == mock.call(expected_command, [])
+    assert listener.zha_send_event.call_count == 1
+
+
+def test_bseed_ts0726_forwards_standard_on_off_requests(zigpy_device_from_v2_quirk):
+    """Test standard OnOff commands are handled normally."""
+
+    device = zigpy_device_from_v2_quirk(
+        "_TZ3002_jn2x20tg",
+        "TS0726",
+        cluster_ids={1: {OnOff.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].in_clusters[OnOff.cluster_id]
+
+    hdr = foundation.ZCLHeader.cluster(
+        tsn=2, command_id=OnOff.ServerCommandDefs.on.id
+    )
+
+    with mock.patch.object(OnOff, "handle_cluster_request", autospec=True) as handler:
+        cluster.handle_cluster_request(hdr, [])
+
+    handler.assert_called_once_with(cluster, hdr, [], dst_addressing=None)

--- a/tests/test_tuya_ts0726.py
+++ b/tests/test_tuya_ts0726.py
@@ -1,0 +1,80 @@
+"""Tests for Tuya/BSEED TS0726 scene switch quirks."""
+
+from unittest import mock
+
+import pytest
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.general import OnOff
+
+from zhaquirks.tuya import TUYA_CLUSTER_E000_ID, TUYA_CLUSTER_E001_ID
+from zhaquirks.tuya.ts0726 import BseedTS0726OnOffCluster, BseedTS0726OptionsCluster
+
+
+@pytest.mark.parametrize(
+    ("manufacturer", "endpoint_ids", "expected_endpoint_count"),
+    [
+        ("_TZ3002_jn2x20tg", [1], 1),
+        ("_TZ3002_zjuvw9zf", [1, 2], 2),
+    ],
+)
+def test_bseed_ts0726_clusters(
+    zigpy_device_from_v2_quirk, manufacturer, endpoint_ids, expected_endpoint_count
+):
+    """Test TS0726 clusters are replaced."""
+
+    cluster_ids = {
+        endpoint_id: {
+            OnOff.cluster_id: ClusterType.Server,
+            TUYA_CLUSTER_E001_ID: ClusterType.Server,
+        }
+        for endpoint_id in endpoint_ids
+    }
+    cluster_ids[1][TUYA_CLUSTER_E000_ID] = ClusterType.Server
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer,
+        "TS0726",
+        cluster_ids=cluster_ids,
+    )
+
+    for endpoint_id in range(1, expected_endpoint_count + 1):
+        assert isinstance(
+            device.endpoints[endpoint_id].in_clusters[OnOff.cluster_id],
+            BseedTS0726OnOffCluster,
+        )
+        assert isinstance(
+            device.endpoints[endpoint_id].in_clusters[TUYA_CLUSTER_E001_ID],
+            BseedTS0726OptionsCluster,
+        )
+
+
+@pytest.mark.parametrize(
+    ("manufacturer", "endpoint_id", "expected_command"),
+    [
+        ("_TZ3002_jn2x20tg", 1, "scene_1"),
+        ("_TZ3002_zjuvw9zf", 1, "scene_1"),
+        ("_TZ3002_zjuvw9zf", 2, "scene_2"),
+    ],
+)
+def test_bseed_ts0726_scene_events(
+    zigpy_device_from_v2_quirk, manufacturer, endpoint_id, expected_command
+):
+    """Test TS0726 scene mode events."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer,
+        "TS0726",
+        endpoint_ids=[1, 2],
+        cluster_ids={
+            1: {OnOff.cluster_id: ClusterType.Server},
+            2: {OnOff.cluster_id: ClusterType.Server},
+        },
+    )
+    cluster = device.endpoints[endpoint_id].in_clusters[OnOff.cluster_id]
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    hdr = foundation.ZCLHeader.cluster(tsn=1, command_id=0xFD)
+    cluster.handle_cluster_request(hdr, [0])
+
+    assert listener.zha_send_event.call_args == mock.call(expected_command, [])

--- a/tests/test_tuya_ts0726.py
+++ b/tests/test_tuya_ts0726.py
@@ -71,6 +71,7 @@ def test_bseed_ts0726_scene_events(
         },
     )
     cluster = device.endpoints[endpoint_id].in_clusters[OnOff.cluster_id]
+    cluster.send_default_rsp = mock.MagicMock()
     listener = mock.MagicMock()
     cluster.add_listener(listener)
 

--- a/tests/test_tuya_ts0726.py
+++ b/tests/test_tuya_ts0726.py
@@ -93,9 +93,7 @@ def test_bseed_ts0726_forwards_standard_on_off_requests(zigpy_device_from_v2_qui
     )
     cluster = device.endpoints[1].in_clusters[OnOff.cluster_id]
 
-    hdr = foundation.ZCLHeader.cluster(
-        tsn=2, command_id=OnOff.ServerCommandDefs.on.id
-    )
+    hdr = foundation.ZCLHeader.cluster(tsn=2, command_id=OnOff.ServerCommandDefs.on.id)
 
     with mock.patch.object(OnOff, "handle_cluster_request", autospec=True) as handler:
         cluster.handle_cluster_request(hdr, [])

--- a/zhaquirks/tuya/ts0726.py
+++ b/zhaquirks/tuya/ts0726.py
@@ -1,0 +1,244 @@
+"""Device handler for Tuya/BSEED TS0726 scene switches."""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import OnOff
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+from zhaquirks import EventableCluster
+from zhaquirks.builder import QuirkBuilder
+from zhaquirks.clusters import CustomCluster
+from zhaquirks.const import (
+    BUTTON_1,
+    BUTTON_2,
+    COMMAND,
+    ENDPOINT_ID,
+    SHORT_PRESS,
+    ZHA_SEND_EVENT,
+)
+from zhaquirks.tuya import (
+    TUYA_CLUSTER_E001_ID,
+    TuyaZBExternalSwitchTypeCluster,
+    TuyaZBE000Cluster,
+)
+
+
+class BseedBacklightMode(t.enum8):
+    """Backlight mode enum."""
+
+    Off = 0x00
+    On = 0x01
+
+
+class BseedIndicatorMode(t.enum8):
+    """Indicator mode enum."""
+
+    None_ = 0x00
+    Relay = 0x01
+    Position = 0x02
+
+
+class BseedPowerOnBehavior(t.enum8):
+    """Power-on behavior enum."""
+
+    Off = 0x00
+    On = 0x01
+    Previous = 0x02
+
+
+class BseedSwitchMode(t.enum8):
+    """Switch mode enum."""
+
+    Switch = 0x00
+    Scene = 0x01
+
+
+class BseedTS0726OnOffCluster(OnOff, EventableCluster):
+    """OnOff cluster with BSEED TS0726 attributes and scene actions."""
+
+    class AttributeDefs(OnOff.AttributeDefs):
+        """Attribute definitions."""
+
+        backlight_mode: Final = ZCLAttributeDef(id=0x5000, type=BseedBacklightMode)
+        indicator_mode: Final = ZCLAttributeDef(id=0x8001, type=BseedIndicatorMode)
+
+    class ServerCommandDefs(OnOff.ServerCommandDefs):
+        """Server command definitions."""
+
+        tuya_action_2: Final = foundation.ZCLCommandDef(
+            id=0xFC,
+            schema={"value": t.uint8_t},
+            is_manufacturer_specific=True,
+        )
+        tuya_action: Final = foundation.ZCLCommandDef(
+            id=0xFD,
+            schema={"value": t.uint8_t},
+            is_manufacturer_specific=True,
+        )
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+
+        self._last_action_tsn = None
+        super().__init__(*args, **kwargs)
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing=None,
+    ) -> None:
+        """Emit ZHA events for TS0726 scene button presses."""
+
+        if hdr.command_id not in (
+            self.ServerCommandDefs.tuya_action_2.id,
+            self.ServerCommandDefs.tuya_action.id,
+        ):
+            return super().handle_cluster_request(
+                hdr, args, dst_addressing=dst_addressing
+            )
+
+        if not hdr.frame_control.disable_default_response:
+            self.send_default_rsp(hdr, status=foundation.Status.SUCCESS)
+
+        if self._last_action_tsn == hdr.tsn:
+            return
+
+        self._last_action_tsn = hdr.tsn
+        self.listener_event(
+            ZHA_SEND_EVENT,
+            f"scene_{self.endpoint.endpoint_id}",
+            [],
+        )
+
+
+class BseedTS0726OptionsCluster(CustomCluster):
+    """Tuya cluster 0xE001 with TS0726 options."""
+
+    name = "BSEED TS0726 options"
+    cluster_id = TUYA_CLUSTER_E001_ID
+    ep_attribute = "bseed_ts0726_options"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        power_on_behavior: Final = ZCLAttributeDef(
+            id=0xD010, type=BseedPowerOnBehavior
+        )
+        switch_mode: Final = ZCLAttributeDef(id=0xD020, type=BseedSwitchMode)
+        external_switch_type: Final = (
+            TuyaZBExternalSwitchTypeCluster.AttributeDefs.external_switch_type
+        )
+
+
+(
+    QuirkBuilder("_TZ3002_jn2x20tg", "TS0726")
+    .friendly_name(model="EC-GL86ZPCS11", manufacturer="BSEED")
+    .replaces(BseedTS0726OnOffCluster)
+    .replaces(TuyaZBE000Cluster)
+    .replaces(BseedTS0726OptionsCluster)
+    .enum(
+        BseedTS0726OnOffCluster.AttributeDefs.backlight_mode.name,
+        BseedBacklightMode,
+        BseedTS0726OnOffCluster.cluster_id,
+        translation_key="backlight_mode",
+        fallback_name="Backlight mode",
+    )
+    .enum(
+        BseedTS0726OnOffCluster.AttributeDefs.indicator_mode.name,
+        BseedIndicatorMode,
+        BseedTS0726OnOffCluster.cluster_id,
+        translation_key="indicator_mode",
+        fallback_name="Indicator mode",
+    )
+    .enum(
+        BseedTS0726OptionsCluster.AttributeDefs.power_on_behavior.name,
+        BseedPowerOnBehavior,
+        BseedTS0726OptionsCluster.cluster_id,
+        translation_key="power_on_behavior",
+        fallback_name="Power-on behavior",
+    )
+    .enum(
+        BseedTS0726OptionsCluster.AttributeDefs.switch_mode.name,
+        BseedSwitchMode,
+        BseedTS0726OptionsCluster.cluster_id,
+        translation_key="switch_mode",
+        fallback_name="Switch mode",
+    )
+    .device_automation_triggers(
+        {(SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: "scene_1"}}
+    )
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder("_TZ3002_zjuvw9zf", "TS0726")
+    .friendly_name(model="EC-GL86ZPCS21", manufacturer="BSEED")
+    .replaces(BseedTS0726OnOffCluster)
+    .replaces(TuyaZBE000Cluster)
+    .replaces(BseedTS0726OptionsCluster)
+    .replaces(BseedTS0726OnOffCluster, endpoint_id=2)
+    .replaces(BseedTS0726OptionsCluster, endpoint_id=2)
+    .enum(
+        BseedTS0726OnOffCluster.AttributeDefs.backlight_mode.name,
+        BseedBacklightMode,
+        BseedTS0726OnOffCluster.cluster_id,
+        translation_key="backlight_mode",
+        fallback_name="Backlight mode",
+    )
+    .enum(
+        BseedTS0726OnOffCluster.AttributeDefs.indicator_mode.name,
+        BseedIndicatorMode,
+        BseedTS0726OnOffCluster.cluster_id,
+        translation_key="indicator_mode",
+        fallback_name="Indicator mode",
+    )
+    .enum(
+        BseedTS0726OptionsCluster.AttributeDefs.power_on_behavior.name,
+        BseedPowerOnBehavior,
+        BseedTS0726OptionsCluster.cluster_id,
+        endpoint_id=1,
+        translation_key="power_on_behavior",
+        fallback_name="Power-on behavior",
+        unique_id_suffix="power_on_behavior_l1",
+    )
+    .enum(
+        BseedTS0726OptionsCluster.AttributeDefs.power_on_behavior.name,
+        BseedPowerOnBehavior,
+        BseedTS0726OptionsCluster.cluster_id,
+        endpoint_id=2,
+        translation_key="power_on_behavior",
+        fallback_name="Power-on behavior",
+        unique_id_suffix="power_on_behavior_l2",
+    )
+    .enum(
+        BseedTS0726OptionsCluster.AttributeDefs.switch_mode.name,
+        BseedSwitchMode,
+        BseedTS0726OptionsCluster.cluster_id,
+        endpoint_id=1,
+        translation_key="switch_mode",
+        fallback_name="Switch mode",
+        unique_id_suffix="switch_mode_l1",
+    )
+    .enum(
+        BseedTS0726OptionsCluster.AttributeDefs.switch_mode.name,
+        BseedSwitchMode,
+        BseedTS0726OptionsCluster.cluster_id,
+        endpoint_id=2,
+        translation_key="switch_mode",
+        fallback_name="Switch mode",
+        unique_id_suffix="switch_mode_l2",
+    )
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: "scene_1"},
+            (SHORT_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: "scene_2"},
+        }
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0726.py
+++ b/zhaquirks/tuya/ts0726.py
@@ -22,8 +22,8 @@ from zhaquirks.const import (
 )
 from zhaquirks.tuya import (
     TUYA_CLUSTER_E001_ID,
-    TuyaZBExternalSwitchTypeCluster,
     TuyaZBE000Cluster,
+    TuyaZBExternalSwitchTypeCluster,
 )
 
 
@@ -127,9 +127,7 @@ class BseedTS0726OptionsCluster(CustomCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
 
-        power_on_behavior: Final = ZCLAttributeDef(
-            id=0xD010, type=BseedPowerOnBehavior
-        )
+        power_on_behavior: Final = ZCLAttributeDef(id=0xD010, type=BseedPowerOnBehavior)
         switch_mode: Final = ZCLAttributeDef(id=0xD020, type=BseedSwitchMode)
         external_switch_type: Final = (
             TuyaZBExternalSwitchTypeCluster.AttributeDefs.external_switch_type


### PR DESCRIPTION
## Proposed change

Add native ZHA quirk support for BSEED/Tuya TS0726 scene switches:

- BSEED EC-GL86ZPCS11, 1-gang, `_TZ3002_jn2x20tg`
- BSEED EC-GL86ZPCS21, 2-gang, `_TZ3002_zjuvw9zf`

The quirk adds:

- friendly manufacturer/model metadata
- `0x5000` backlight mode on the OnOff cluster
- `0x8001` indicator mode on the OnOff cluster
- `0xD010` power-on behavior on cluster `0xE001`
- `0xD020` switch mode on cluster `0xE001`
- scene action events: `scene_1` and `scene_2`
- config enum metadata so Home Assistant can create select entities


## Additional information
Device signatures were captured from real BSEED devices:

### EC-GL86ZPCS11

- manufacturer: `_TZ3002_jn2x20tg`
- model: `TS0726`
- endpoints: `1`, `242`
- endpoint 1 input clusters: `0x0000`, `0x0003`, `0x0004`, `0x0005`, `0x0006`, `0xE000`, `0xE001`

### EC-GL86ZPCS21

- manufacturer: `_TZ3002_zjuvw9zf`
- model: `TS0726`
- endpoints: `1`, `2`, `242`
- endpoint 1 input clusters: `0x0000`, `0x0003`, `0x0004`, `0x0005`, `0x0006`, `0xE000`, `0xE001`
- endpoint 2 input clusters: `0x0004`, `0x0005`, `0x0006`, `0xE001`

The option mappings are based on Zigbee2MQTT's TS0726 converters and verified
against the BSEED devices:

- `switch_mode`: cluster `0xE001`, attribute `0xD020`, `switch=0`, `scene=1`
- `power_on_behavior`: cluster `0xE001`, attribute `0xD010`, `off=0`, `on=1`, `previous=2`
- `backlight_mode`: OnOff cluster, attribute `0x5000`, `off=0`, `on=1`
- `indicator_mode`: OnOff cluster, attribute `0x8001`, `none=0`, `relay=1`, `position=2`


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
