### PR TITLE
Add ZHA quirk for HOBEIAN ZG-204ZK presence sensor

### DIFF
--- a/tests/test_tuya_motion.py
+++ b/tests/test_tuya_motion.py
@@ -69,6 +69,9 @@ zhaquirks.setup()
         ("_TZE200_2aaelwxk", "TS0601", ZCL_TUYA_MOTION),
         ("_TZE200_kb5noeto", "TS0601", ZCL_TUYA_MOTION),
         ("_TZE204_ex3rcdha", "TS0601", ZCL_TUYA_MOTION_V8),
+        ("_TZE200_ka8l86iu", "TS0601", ZCL_TUYA_MOTION),
+        ("_TZE200_zbfmvj13", "TS0601", ZCL_TUYA_MOTION),
+        ("HOBEIAN", "ZG-204ZK", ZCL_TUYA_MOTION),
     ],
 )
 async def test_tuya_motion_quirk_occ(zigpy_device_from_v2_quirk, model, manuf, occ_msg):

--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -9,7 +9,6 @@ from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import MotionWithReset
-from zhaquirks.const import BatterySize
 from zhaquirks.builder import (
     LIGHT_LUX,
     BinarySensorDeviceClass,
@@ -20,6 +19,7 @@ from zhaquirks.builder import (
     UnitOfLength,
     UnitOfTime,
 )
+from zhaquirks.const import BatterySize
 from zhaquirks.tuya import TuyaLocalCluster, TuyaPowerConfigurationCluster2AAA
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 

--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -4,10 +4,12 @@ import asyncio
 from typing import Any
 
 import zigpy.types as t
+from zigpy.zcl.clusters.general import PowerConfiguration
 from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
 
 from zhaquirks import MotionWithReset
+from zhaquirks.const import BatterySize
 from zhaquirks.builder import (
     LIGHT_LUX,
     BinarySensorDeviceClass,
@@ -1526,6 +1528,87 @@ base_tuya_motion = (
         step=1,
         translation_key="motion_detection_sensitivity",
         fallback_name="Motion detection sensitivity",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+# Tuya 24Ghz human presence sensor, ZG-204ZK
+(
+    TuyaQuirkBuilder("_TZE200_ka8l86iu", "TS0601")
+    .applies_to("_TZE200_zbfmvj13", "TS0601")
+    .applies_to("HOBEIAN", "ZG-204ZK")
+    .removes(IasZone.cluster_id)
+    .removes(PowerConfiguration.cluster_id)
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=TuyaOccupancySensing.ep_attribute,
+        attribute_name=OccupancySensing.AttributeDefs.occupancy.name,
+        converter=lambda x: x == 1,
+    )
+    .adds(TuyaOccupancySensing)
+    .tuya_number(
+        dp_id=102,
+        attribute_name="fading_time",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        min_value=10,
+        max_value=28800,
+        step=1,
+        translation_key="fading_time",
+        fallback_name="Fading time",
+    )
+    .tuya_number(
+        dp_id=4,
+        attribute_name="detection_distance",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.DISTANCE,
+        unit=UnitOfLength.METERS,
+        min_value=0,
+        max_value=5,
+        step=0.01,
+        multiplier=0.01,
+        translation_key="detection_distance",
+        fallback_name="Detection distance",
+    )
+    .tuya_number(
+        dp_id=2,
+        attribute_name="static_detection_sensitivity",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=10,
+        step=1,
+        translation_key="static_detection_sensitivity",
+        fallback_name="Static detection sensitivity",
+    )
+    .tuya_number(
+        dp_id=123,
+        attribute_name="motion_detection_sensitivity",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=10,
+        step=1,
+        translation_key="motion_detection_sensitivity",
+        fallback_name="Motion detection sensitivity",
+    )
+    .tuya_switch(
+        dp_id=107,
+        attribute_name="indicator",
+        translation_key="indicator",
+        fallback_name="LED indicator",
+    )
+    .tuya_switch(
+        dp_id=122,
+        attribute_name="anti_interference",
+        translation_key="anti_interference",
+        fallback_name="Anti interference",
+    )
+    .tuya_battery(
+        dp_id=121,
+        battery_type=BatterySize.CR2450,
+        battery_qty=1,
     )
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
## Summary
- Add a ZHA quirk for the HOBEIAN ZG-204ZK 24 GHz human presence sensor
- Map Tuya datapoints for presence, battery, fading time, detection distance, static/motion sensitivity, LED indicator, and anti-interference (matching Zigbee2MQTT)
- Remove native IAS Zone and PowerConfiguration clusters so occupancy and Tuya battery reporting work correctly on this device signature

## Test plan
- [x] `pytest tests/test_tuya_motion.py::test_tuya_motion_quirk_occ` for `HOBEIAN/ZG-204ZK` and both known Tuya fingerprints (`_TZE200_ka8l86iu`, `_TZE200_zbfmvj13`)
- [x] Verified on a real ZG-204ZK in Home Assistant via custom quirk before upstreaming

Fixes #4837
