### PR TITLE
Make Tuya valve `_TZE200_81isopgh` countdown timer writable and add sibling IDs

### DIFF
--- a/tests/test_tuya_valve.py
+++ b/tests/test_tuya_valve.py
@@ -10,6 +10,7 @@ from zigpy.zcl import foundation
 
 from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
+from zhaquirks.builder import UnitOfTime
 from zhaquirks.builder.metadata import EntityMetadata
 import zhaquirks.tuya
 from zhaquirks.tuya.mcu import TuyaMCUCluster
@@ -227,6 +228,57 @@ async def test_giex_03_quirk(zigpy_device_from_v2_quirk, model, manuf):
             cluster=61184,
             sequence=1,
             data=b"\x01\x01\x00\x00\x01\x19\x02\x00\x04\x00\x00\x00\x0a",
+            command_id=0,
+            timeout=5,
+            expect_reply=False,
+            use_ieee=False,
+            ask_for_ack=None,
+            priority=None,
+            retries=None,
+            retry_delay=None,
+        )
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
+
+
+@pytest.mark.parametrize(
+    "model,manuf",
+    [
+        ("_TZE200_81isopgh", "TS0601"),
+        ("_TZE200_1n2zev06", "TS0601"),
+        ("_TZE204_qtnjuoae", "TS0601"),
+        ("_TZE200_akjefhj5", "TS0601"),
+    ],
+)
+async def test_saswell_81isopgh_writable_timer(zigpy_device_from_v2_quirk, model, manuf):
+    """DP 11 is exposed as a writable number (minutes) for the Saswell valve family."""
+    quirked = zigpy_device_from_v2_quirk(model, manuf)
+    entry = DEVICE_REGISTRY.match_entry(quirked)
+    metadata_by_suffix = {
+        md.resolved_unique_id_suffix: md
+        for md in entry.zha_device_factory.quirk_definition.entity_metadata
+    }
+    number_md: EntityMetadata = metadata_by_suffix["time_left"]
+    assert number_md.min == 1
+    assert number_md.max == 1440
+    assert number_md.unit == UnitOfTime.MINUTES
+
+
+async def test_saswell_81isopgh_write_timer(zigpy_device_from_v2_quirk):
+    """Writing the DP-11 number sends the correct Tuya frame (raw seconds)."""
+    quirked = zigpy_device_from_v2_quirk("_TZE200_81isopgh", "TS0601")
+    tuya_cluster = quirked.endpoints[1].tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as m1:
+        (status,) = await tuya_cluster.write_attributes({"time_left": 1800})
+        await wait_for_zigpy_tasks()
+        m1.assert_called_with(
+            cluster=61184,
+            sequence=1,
+            data=b"\x01\x01\x00\x00\x01\x0b\x02\x00\x04\x00\x00\x07\x08",
             command_id=0,
             timeout=5,
             expect_reply=False,

--- a/tests/test_tuya_valve.py
+++ b/tests/test_tuya_valve.py
@@ -251,7 +251,9 @@ async def test_giex_03_quirk(zigpy_device_from_v2_quirk, model, manuf):
         ("_TZE200_akjefhj5", "TS0601"),
     ],
 )
-async def test_saswell_81isopgh_writable_timer(zigpy_device_from_v2_quirk, model, manuf):
+async def test_saswell_81isopgh_writable_timer(
+    zigpy_device_from_v2_quirk, model, manuf
+):
     """DP 11 is exposed as a writable number (minutes) for the Saswell valve family."""
     quirked = zigpy_device_from_v2_quirk(model, manuf)
     entry = DEVICE_REGISTRY.match_entry(quirked)

--- a/tests/test_tuya_valve.py
+++ b/tests/test_tuya_valve.py
@@ -280,6 +280,7 @@ async def test_saswell_81isopgh_write_timer(zigpy_device_from_v2_quirk):
         m1.assert_called_with(
             cluster=61184,
             sequence=1,
+            # DP 11 (0x0b), uint32, value=1800 s = 30 min
             data=b"\x01\x01\x00\x00\x01\x0b\x02\x00\x04\x00\x00\x07\x08",
             command_id=0,
             timeout=5,

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -62,7 +62,9 @@ class TuyaValveStatus(t.enum8):
 (
     TuyaQuirkBuilder("_TZE200_81isopgh", "TS0601")
     .applies_to("_TZE200_1n2zev06", "TS0601")
-    .applies_to("_TZE204_qtnjuoae", "TS0601")  # SASWELL SAS980SWT-7-Z01, reported same (issue #3287)
+    .applies_to(
+        "_TZE204_qtnjuoae", "TS0601"
+    )  # SASWELL SAS980SWT-7-Z01, reported same (issue #3287)
     .applies_to("_TZE200_akjefhj5", "TS0601")  # reported same (discussion #1660)
     .tuya_onoff(dp_id=1)
     .tuya_metering(

--- a/zhaquirks/tuya/tuya_valve.py
+++ b/zhaquirks/tuya/tuya_valve.py
@@ -62,6 +62,8 @@ class TuyaValveStatus(t.enum8):
 (
     TuyaQuirkBuilder("_TZE200_81isopgh", "TS0601")
     .applies_to("_TZE200_1n2zev06", "TS0601")
+    .applies_to("_TZE204_qtnjuoae", "TS0601")  # SASWELL SAS980SWT-7-Z01, reported same (issue #3287)
+    .applies_to("_TZE200_akjefhj5", "TS0601")  # reported same (discussion #1660)
     .tuya_onoff(dp_id=1)
     .tuya_metering(
         dp_id=5, scale=0.0295735
@@ -80,14 +82,16 @@ class TuyaValveStatus(t.enum8):
         fallback_name="Weather delay",
         initially_disabled=True,
     )
-    .tuya_sensor(
+    # DP 11 raw value is in seconds; expose as a writable countdown in minutes.
+    .tuya_number(
         dp_id=11,
         attribute_name="time_left",
         type=t.uint32_t,
-        converter=lambda x: x / 60,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.DURATION,
-        unit=UnitOfTime.SECONDS,
+        min_value=1,
+        max_value=1440,
+        step=1,
+        multiplier=1 / 60,
+        unit=UnitOfTime.MINUTES,
         translation_key="time_left",
         fallback_name="Time left",
     )


### PR DESCRIPTION
## Summary

The Saswell/Tuya `_TZE200_81isopgh` irrigation valve exposed its countdown timer (DP 11) as a **read-only sensor**, so the run duration couldn't be set from Home Assistant. This PR:

1. **Promotes DP 11 to a writable `number`** (minutes), mirroring the existing `_TZE200_2wg5qrjy` block in the same file (`type=t.uint32_t`, `multiplier=1 / 60`, `unit=UnitOfTime.MINUTES`, `min_value=1`, `max_value=1440`).
2. **Fixes a DP-11 unit bug:** the old mapping used `converter=lambda x: x / 60` (raw seconds → minutes) but labelled the result `UnitOfTime.SECONDS` — self-contradictory. It's now consistent: `multiplier=1 / 60` with `unit=UnitOfTime.MINUTES`.
3. **Adds two reported-equivalent sibling manufacturer IDs:** `_TZE204_qtnjuoae` (#3287) and `_TZE200_akjefhj5` (#1660).

DP 12 (`timer_state`), DP 15 (`last_valve_open_duration`), and the raw DP 6 / DP 102 attributes are unchanged.

## Hardware validation

I own and tested the physical device. A dedicated bench `_TZE200_81isopgh` unit (not plumbed to water) was used so no in-service unit was disturbed.

- **Entity path (the change itself):** with a local quirk identical to this PR's entity definition, setting the **`number` entity** to 2 minutes opened the valve and it auto-closed after ~2 minutes, confirming the `number → multiplier(1/60) → DP 11 (seconds)` path drives the device end-to-end.
- DP 11 is a **dual-purpose register** (writing sets the duration; it counts down live during the run) — same behaviour as the upstream `_TZE200_2wg5qrjy`. No separate setpoint datapoint exists.

## Device signature

```json
{
  "manufacturer": "_TZE200_81isopgh",
  "model": "TS0601",
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0051",
      "input_clusters": ["0x0000", "0x0004", "0x0005", "0xef00"],
      "output_clusters": ["0x0019", "0x000a"]
    }
  }
}
```

Full device diagnostics JSON available here: [test_valve_diagnostics.json](https://github.com/user-attachments/files/29386926/test_valve_diagnostics.json)

## ⚠️ Breaking change

DP 11 moves from the `sensor` platform to the `number` platform. For existing users of this device, `sensor.<name>_time_left` is replaced by `number.<name>_time_left`. The `attribute_name` (`"time_left"`) is intentionally kept to avoid any additional `unique_id` churn beyond the unavoidable platform change.

## Note on the sibling IDs

Only `_TZE200_81isopgh` was hardware-validated (it is the unit I own). `_TZE204_qtnjuoae` (#3287) and `_TZE200_akjefhj5` (#1660) are added on the strength of community reports that they are the same device — **not personally tested**. Happy to drop them if you'd prefer hardware-confirmed additions only.

## Tests

`tests/test_tuya_valve.py`:
- `test_saswell_81isopgh_writable_timer` — parametrized across all four manufacturer IDs; asserts the `time_left` entity is a number with `min=1`, `max=1440`, `unit=minutes`.
- `test_saswell_81isopgh_write_timer` — byte-exact frame assertion that writing the DP-11 attribute emits the correct Tuya frame (DP 11, uint32, 1800 s).

`pre-commit run --all-files` (ruff, ruff-format, mypy, codespell) passes; the full `tests/test_tuya_valve.py` suite passes (19 tests).

Relates to #3143 (`_TZE200_81isopgh` "missing values", closed stale — the writable timer was never raised there).
