### PR TITLE
Add quirks v2 builder cluster binding + reporting without entity

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,6 +109,42 @@ Example: Change device type so HA creates correct entity (ZHA profile used by de
 .replaces_endpoint(1, device_type=zha.DeviceType.DIMMABLE_LIGHT)
 ```
 
+**Cluster Binding & Reporting (without an entity):**
+
+Normally a cluster is bound and an attribute's reporting is configured as a side
+effect of creating an entity for that attribute (via the entity method's
+`reporting_config=`). When no entity is wanted, these methods set up binding
+and/or reporting directly:
+
+- `.binds(cluster_id, cluster_type=ClusterType.Server, endpoint_id=1)` - Bind a
+  cluster to the coordinator without exposing an entity. Use for clusters that
+  must be bound so the device sends unsolicited reports/commands.
+- `.configures_reporting(cluster_id, attribute_name, reporting_config, cluster_type=ClusterType.Server, endpoint_id=1, bind=True, read_on_startup=False)` -
+  Configure attribute reporting for an attribute that has no associated entity.
+  Binds the cluster by default (reporting requires a binding); pass `bind=False`
+  to skip binding, or `read_on_startup=True` to also read the attribute once at
+  configuration time.
+
+```python
+from zhaquirks.builder import QuirkBuilder, ReportingConfig
+
+(
+    QuirkBuilder("Shelly", "Mini1PM")
+    # Bind the manufacturer RPC cluster and report its rx_ctl attribute so
+    # input-status notifications arrive without polling - no entity created.
+    .configures_reporting(
+        0xFC01,
+        "rx_ctl",
+        ReportingConfig(min_interval=0, max_interval=900, reportable_change=1),
+    )
+    .add_to_registry()
+)
+```
+
+These are realized as config-only virtual entities that ZHA's cluster-config
+aggregation consumes; they never appear as Home Assistant entities and respect
+`.skip_configuration()`.
+
 **Entity Creation (Home Assistant):**
 All entity methods require `fallback_name`. Common parameters:
 - `attribute_name`: ZCL attribute to expose

--- a/tests/test_quirks_v2_builder.py
+++ b/tests/test_quirks_v2_builder.py
@@ -26,7 +26,12 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zdo.types import LogicalType, NodeDescriptor
 
 from zhaquirks.builder import QuirkBuilder
-from zhaquirks.builder.metadata import recursive_freeze
+from zhaquirks.builder.metadata import (
+    AttributeReportingConfigMetadata,
+    ClusterConfigMetadata,
+    ReportingConfig,
+    recursive_freeze,
+)
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.device import CustomZigpyDevice
 from zhaquirks.legacy import signature_matches
@@ -392,6 +397,94 @@ async def test_quirks_v2_skip_configuration(device_mock):
     # definition rather than on the resolved zigpy device.
     entry = registry.match_entry(quirked)
     assert entry.zha_device_factory.quirk_definition.skip_configuration is True
+
+
+async def test_quirks_v2_binds(device_mock):
+    """Test adding a quirk that binds a cluster without exposing an entity."""
+    registry = DeviceRegistry()
+
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model)
+        .binds(OnOff.cluster_id, cluster_type=ClusterType.Client)
+        .add_to_registry(registry)
+    )
+
+    quirked = registry.resolve(device_mock)
+    assert isinstance(quirked, CustomZigpyDevice)
+
+    entry = registry.match_entry(quirked)
+    cluster_configs = entry.zha_device_factory.quirk_definition.cluster_configs
+    assert cluster_configs == (
+        ClusterConfigMetadata(
+            cluster_id=OnOff.cluster_id,
+            endpoint_id=1,
+            cluster_type=ClusterType.Client,
+            bind=True,
+            attributes=(),
+        ),
+    )
+
+
+async def test_quirks_v2_configures_reporting(device_mock):
+    """Test adding a quirk that configures reporting without exposing an entity."""
+    registry = DeviceRegistry()
+
+    reporting = ReportingConfig(min_interval=0, max_interval=900, reportable_change=1)
+
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model)
+        .configures_reporting(
+            OnOff.cluster_id,
+            OnOff.AttributeDefs.on_off.name,
+            reporting,
+        )
+        .add_to_registry(registry)
+    )
+
+    quirked = registry.resolve(device_mock)
+    assert isinstance(quirked, CustomZigpyDevice)
+
+    entry = registry.match_entry(quirked)
+    cluster_configs = entry.zha_device_factory.quirk_definition.cluster_configs
+    assert cluster_configs == (
+        ClusterConfigMetadata(
+            cluster_id=OnOff.cluster_id,
+            endpoint_id=1,
+            cluster_type=ClusterType.Server,
+            bind=True,
+            attributes=(
+                AttributeReportingConfigMetadata(
+                    attribute_name=OnOff.AttributeDefs.on_off.name,
+                    reporting_config=reporting,
+                    read_on_startup=False,
+                ),
+            ),
+        ),
+    )
+
+
+async def test_quirks_v2_configures_reporting_no_bind(device_mock):
+    """Test configuring reporting while skipping the implicit cluster bind."""
+    registry = DeviceRegistry()
+
+    reporting = ReportingConfig(min_interval=1, max_interval=60, reportable_change=1)
+
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model)
+        .configures_reporting(
+            OnOff.cluster_id,
+            OnOff.AttributeDefs.on_off.name,
+            reporting,
+            bind=False,
+            read_on_startup=True,
+        )
+        .add_to_registry(registry)
+    )
+
+    entry = registry.match_entry(registry.resolve(device_mock))
+    (cluster_config,) = entry.zha_device_factory.quirk_definition.cluster_configs
+    assert cluster_config.bind is False
+    assert cluster_config.attributes[0].read_on_startup is True
 
 
 async def test_quirks_v2_removes(device_mock):

--- a/zhaquirks/builder/builder.py
+++ b/zhaquirks/builder/builder.py
@@ -47,8 +47,10 @@ from zigpy.zdo.types import NodeDescriptor
 
 from zhaquirks.builder.device import QuirkV2Device, QuirkV2Factory
 from zhaquirks.builder.metadata import (
+    AttributeReportingConfigMetadata,
     BinarySensorMetadata,
     ChangedEntityMetadata,
+    ClusterConfigMetadata,
     DeviceAlertLevel,
     DeviceAlertMetadata,
     EntityMetadata,
@@ -348,6 +350,7 @@ class QuirkBuilder:
         self.replaces_ops: list[ReplaceCluster] = []
         self.replace_occurrences_ops: list[ReplaceClusterOccurrences] = []
         self.entity_metadata: list[EntityMetadata] = []
+        self.cluster_config_metadata: list[ClusterConfigMetadata] = []
         self.device_automation_triggers_metadata: dict[
             tuple[str, str], dict[str, str]
         ] = {}
@@ -934,6 +937,66 @@ class QuirkBuilder:
         )
         return self
 
+    def binds(
+        self,
+        cluster_id: int,
+        cluster_type: ClusterType = ClusterType.Server,
+        endpoint_id: int = 1,
+    ) -> Self:
+        """Bind a cluster to the coordinator without exposing an entity.
+
+        Use this for clusters that must be bound so the device sends unsolicited
+        reports or commands, but where no Home Assistant entity is created from
+        the cluster. To also configure attribute reporting use
+        `configures_reporting` instead (it binds the cluster as well).
+        """
+        self.cluster_config_metadata.append(
+            ClusterConfigMetadata(
+                cluster_id=cluster_id,
+                endpoint_id=endpoint_id,
+                cluster_type=cluster_type,
+                bind=True,
+            )
+        )
+        return self
+
+    def configures_reporting(
+        self,
+        cluster_id: int,
+        attribute_name: str,
+        reporting_config: ReportingConfig,
+        cluster_type: ClusterType = ClusterType.Server,
+        endpoint_id: int = 1,
+        bind: bool = True,
+        read_on_startup: bool = False,
+    ) -> Self:
+        """Set up attribute reporting for a cluster without exposing an entity.
+
+        The entity-less counterpart of the `reporting_config` accepted by the
+        entity methods: it configures reporting for an attribute that has no
+        associated Home Assistant entity. The cluster is bound by default
+        (reporting requires a binding); pass ``bind=False`` to skip binding,
+        e.g. when another quirk feature already binds the cluster. Set
+        ``read_on_startup`` to also read the attribute once when the device is
+        configured.
+        """
+        self.cluster_config_metadata.append(
+            ClusterConfigMetadata(
+                cluster_id=cluster_id,
+                endpoint_id=endpoint_id,
+                cluster_type=cluster_type,
+                bind=bind,
+                attributes=(
+                    AttributeReportingConfigMetadata(
+                        attribute_name=attribute_name,
+                        reporting_config=reporting_config,
+                        read_on_startup=read_on_startup,
+                    ),
+                ),
+            )
+        )
+        return self
+
     def device_automation_triggers(
         self, device_automation_triggers: dict[tuple[str, str], dict[str, str]]
     ) -> Self:
@@ -1077,6 +1140,7 @@ class QuirkBuilder:
             disabled_default_entities=tuple(self.disabled_default_entities),
             changed_entity_metadata=tuple(self.changed_entity_metadata),
             entity_metadata=tuple(self.entity_metadata),
+            cluster_configs=tuple(self.cluster_config_metadata),
             device_automation_triggers=self.device_automation_triggers_metadata,
             skip_configuration=self.skip_device_configuration,
         )

--- a/zhaquirks/builder/discovery.py
+++ b/zhaquirks/builder/discovery.py
@@ -25,10 +25,12 @@ from zha.application.platforms import (
     sensor,
     switch,
 )
+from zha.application.platforms.virtual import VirtualEntity
 from zigpy.zcl import ClusterType, ReportingConfig
 
 from zhaquirks.builder.metadata import (
     BinarySensorMetadata,
+    ClusterConfigMetadata,
     EntityMetadata,
     NumberMetadata,
     SwitchMetadata,
@@ -42,6 +44,17 @@ if TYPE_CHECKING:
     from zha.zigbee.device import Device
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class QuirkClusterConfigEntity(VirtualEntity):
+    """Entity-less carrier for quirk-declared cluster bind/reporting config.
+
+    Yielded by quirk v2 discovery so ZHA's cluster-config aggregation binds the
+    cluster and/or configures attribute reporting. As a virtual entity it is
+    never registered as a Home Assistant entity; it exists purely to drive that
+    cluster-level setup work.
+    """
+
 
 QUIRKS_ENTITY_META_TO_ENTITY_CLASS: dict[
     tuple[Platform, type], type[PlatformEntity]
@@ -127,16 +140,126 @@ def _platform_kwargs(entity_metadata: EntityMetadata) -> dict[str, Any]:
     return {}
 
 
+def _discover_cluster_config_entities(
+    device: Device, cluster_configs: tuple[ClusterConfigMetadata, ...]
+) -> Iterator[PlatformEntity]:
+    """Yield config-only virtual entities for entity-less cluster configs.
+
+    Each `ClusterConfigMetadata` becomes a `QuirkClusterConfigEntity` carrying a
+    per-instance `_server_cluster_config`/`_client_cluster_config`. ZHA's
+    cluster-config aggregation then binds the cluster and/or configures
+    attribute reporting, without surfacing a Home Assistant entity.
+    """
+    for cluster_config in cluster_configs:
+        endpoint_id = cluster_config.endpoint_id
+        cluster_id = cluster_config.cluster_id
+        cluster_type = cluster_config.cluster_type
+
+        if endpoint_id not in device.endpoints:
+            _LOGGER.warning(
+                "Device: %s-%s does not have an endpoint with id: %s - unable to "
+                "apply cluster config: %s",
+                str(device.ieee),
+                device.name,
+                endpoint_id,
+                cluster_config,
+            )
+            continue
+
+        endpoint = device.endpoints[endpoint_id]
+        cluster = (
+            endpoint.zigpy_endpoint.in_clusters.get(cluster_id)
+            if cluster_type is ClusterType.Server
+            else endpoint.zigpy_endpoint.out_clusters.get(cluster_id)
+        )
+
+        if cluster is None:
+            _LOGGER.warning(
+                "Device: %s-%s does not have a cluster with id: %s - "
+                "unable to apply cluster config: %s",
+                str(device.ieee),
+                device.name,
+                cluster_id,
+                cluster_config,
+            )
+            continue
+
+        # Keep attribute names as strings - quirks can reference manufacturer
+        # specific attributes that aren't part of the cluster's schema; the
+        # cluster_config aggregation/configure flow handles both name and
+        # ZCLAttributeDef.
+        attributes = {
+            attr.attribute_name: AttrConfig(
+                read_on_startup=attr.read_on_startup,
+                reporting=(
+                    ReportingConfig(
+                        min_interval=attr.reporting_config.min_interval,
+                        max_interval=attr.reporting_config.max_interval,
+                        reportable_change=attr.reporting_config.reportable_change,
+                    )
+                    if attr.reporting_config is not None
+                    else None
+                ),
+            )
+            for attr in cluster_config.attributes
+        }
+        config = {
+            cluster.cluster_id: ClusterConfig(
+                bind=cluster_config.bind,
+                attributes=attributes,
+            )
+        }
+
+        # A config-only virtual entity needs a unique_id distinct from every
+        # other entity on the same endpoint. The endpoint is already part of the
+        # base unique_id, so discriminate by cluster id plus either the
+        # configured attribute names or "bind".
+        if cluster_config.unique_id_suffix is not None:
+            suffix = cluster_config.unique_id_suffix
+        else:
+            discriminator = (
+                "-".join(attr.attribute_name for attr in cluster_config.attributes)
+                if cluster_config.attributes
+                else "bind"
+            )
+            suffix = f"cluster_config-{cluster_id:#06x}-{discriminator}"
+
+        entity = QuirkClusterConfigEntity(
+            endpoint=endpoint,
+            device=device,
+            cluster=cluster,
+            from_quirk=True,
+            unique_id_suffix=suffix,
+        )
+        if cluster_type is ClusterType.Server:
+            entity._server_cluster_config = config
+        else:
+            entity._client_cluster_config = config
+
+        yield entity
+
+        _LOGGER.debug(
+            "cluster config -> '%s' using cluster 0x%04x on endpoint %s",
+            QuirkClusterConfigEntity.__name__,
+            cluster.cluster_id,
+            endpoint_id,
+        )
+
+
 def discover_quirks_v2_entities(device: Device) -> Iterator[PlatformEntity]:
     """Discover entities exposed by a device's quirks v2 metadata."""
     quirk_metadata = device.quirk_metadata
-    if quirk_metadata is None or not quirk_metadata.entity_metadata:
+    if quirk_metadata is None or (
+        not quirk_metadata.entity_metadata and not quirk_metadata.cluster_configs
+    ):
         _LOGGER.debug(
             "Device: %s-%s does not expose any quirks v2 entities",
             str(device.ieee),
             device.name,
         )
         return
+
+    yield from _discover_cluster_config_entities(device, quirk_metadata.cluster_configs)
 
     for entity_metadata in quirk_metadata.entity_metadata:
         endpoint_id = entity_metadata.endpoint_id

--- a/zhaquirks/builder/metadata.py
+++ b/zhaquirks/builder/metadata.py
@@ -37,6 +37,41 @@ class ReportingConfig:
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)
+class AttributeReportingConfigMetadata:
+    """Reporting / read-on-startup config for a single attribute, without an entity.
+
+    The entity-less counterpart of an entity's `reporting_config`: it lets a
+    quirk request attribute reporting (and/or a fresh read at startup) for an
+    attribute that has no associated Home Assistant entity.
+    """
+
+    attribute_name: str = attrs.field()
+    reporting_config: ReportingConfig | None = attrs.field(default=None)
+    read_on_startup: bool = attrs.field(default=False)
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
+class ClusterConfigMetadata:
+    """Entity-less cluster configuration: bind a cluster and/or set up reporting.
+
+    Mirrors ZHA's per-cluster `ClusterConfig`/`AttrConfig`, but is expressed
+    declaratively in quirk metadata. It is realized as a config-only virtual
+    entity that ZHA's cluster-config aggregation picks up to bind the cluster
+    and configure attribute reporting, without the cluster ever being surfaced
+    as a Home Assistant entity.
+    """
+
+    cluster_id: int = attrs.field()
+    endpoint_id: int = attrs.field(default=1)
+    cluster_type: ClusterType = attrs.field(default=ClusterType.Server)
+    bind: bool = attrs.field(default=False)
+    attributes: tuple[AttributeReportingConfigMetadata, ...] = attrs.field(
+        factory=tuple
+    )
+    unique_id_suffix: str | None = attrs.field(default=None)
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
 class EntityMetadata:
     """Metadata for an exposed entity."""
 
@@ -253,6 +288,7 @@ class QuirkDefinition:
         factory=tuple
     )
     entity_metadata: tuple[EntityMetadata, ...] = attrs.field(factory=tuple)
+    cluster_configs: tuple[ClusterConfigMetadata, ...] = attrs.field(factory=tuple)
     device_automation_triggers: frozendict[tuple[str, str], frozendict[str, str]] = (
         attrs.field(factory=frozendict, converter=recursive_freeze)
     )


### PR DESCRIPTION
DRAFT.

### Thoughts

I'm not sure if we exclusively want this on a quirks v2 level, or perhaps also have a wrapper to add more parameters to a `ZCLAttributeDef`, like reporting configuration and "read on startup", so custom attributes aren't defined in a completely different way compared to their reporting config? Not sure... (e.g. to avoid duplication or mistakes when quirks reuse the same custom clusters but forget to also copy the reporting config)

I guess either way, we still wants a fully quirks v2 way to do this..?

## Proposed change

This adds a `configures_reporting` + `binds` method to the quirks v2 builder, so v2 quirks can also configure reporting and binding without an associated quirks v2 entity. This is done by having ZHA discover a virtual entity with the expected `ClusterConfig` set.

<details>
<summary>Implementation details</summary>

### New builder methods

Both live on `QuirkBuilder` and return `self`, so they chain like the other builder methods:

```python
.binds(cluster_id, cluster_type=ClusterType.Server, endpoint_id=1)

.configures_reporting(
    cluster_id,
    attribute_name,
    reporting_config,                       # builder.ReportingConfig
    cluster_type=ClusterType.Server,
    endpoint_id=1,
    bind=True,                              # reporting requires a binding
    read_on_startup=False,
)
```

- `binds(...)` binds a cluster to the coordinator without exposing an entity — for clusters that must be bound so the device sends unsolicited reports/commands.
- `configures_reporting(...)` is the entity-less counterpart of the `reporting_config=` accepted by the entity methods. It binds the cluster by default (pass `bind=False` to skip, e.g. when another feature already binds it) and can optionally read the attribute once at configuration time via `read_on_startup=True`.

Example (the same Shelly RPC cluster as the ZHA PR below):

```python
(
    QuirkBuilder("Shelly", "Mini1PM")
    .configures_reporting(
        0xFC01,
        "rx_ctl",
        ReportingConfig(min_interval=0, max_interval=900, reportable_change=1),
    )
    .add_to_registry()
)
```

### How it works

- New metadata `ClusterConfigMetadata` + `AttributeReportingConfigMetadata` (`zhaquirks/builder/metadata.py`), accumulated by the builder and carried on `QuirkDefinition.cluster_configs`.
- `zhaquirks/builder/discovery.py` yields a config-only `QuirkClusterConfigEntity(VirtualEntity)` per cluster config, with a per-instance `_server_cluster_config` / `_client_cluster_config`. This reuses ZHA's existing cluster-config flow: `aggregate_cluster_configs` / `configure_cluster_configs` then bind the cluster and configure reporting. No new ZHA-side machinery is required.
- Being a `VirtualEntity`, it is never registered as a Home Assistant entity, and it respects `.skip_configuration()`.
- The generated `unique_id` suffix is `cluster_config-{cluster_id:#06x}-{attribute names|"bind"}`, so multiple configs on the same endpoint don't collide.

### Tests

Tests are metadata-level in `tests/test_quirks_v2_builder.py` (assert the builder produces the expected `cluster_configs` on the `QuirkDefinition`). The full quirk-validation suites still pass. End-to-end binding/reporting behavior is exercised on the ZHA side in `tests/test_discover.py`; this repo has no ZHA-`Device` discovery scaffolding, so integration coverage lives there.

</details>


## Additional information

This may be an alternative to the following ZHA PR:
- https://github.com/zigpy/zha/pull/800

Also somewhat related is the relevant quirks PR (for that ZHA PR):
- https://github.com/zigpy/zha-device-handlers/pull/5106

## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
