### PR TITLE
Add SONOFF SNZB-04PR2 tamper quirk

### DIFF
--- a/tests/test_sonoff.py
+++ b/tests/test_sonoff.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+import zigpy.types as t
 from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import OnOff
 
@@ -17,6 +18,46 @@ from zhaquirks.sonoff.zbm5 import (
 )
 
 zhaquirks.setup()
+
+
+@pytest.mark.parametrize("tamper_state", (0, 1))
+async def test_snzb04pr2_tamper_report_updates_attribute_cache(
+    zigpy_device_from_v2_quirk, tamper_state
+):
+    """Standard ZCL tamper reports update the PR2 tamper attribute."""
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="SNZB-04PR2",
+        cluster_ids={1: {0xFC11: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].sonoff_contact_cluster
+    listener = ClusterListener(cluster)
+
+    attribute = foundation.Attribute(
+        attrid=cluster.AttributeDefs.tamper.id,
+        value=foundation.TypeValue(type=t.uint8_t(0x20), value=t.uint8_t(tamper_state)),
+    )
+    header = foundation.ZCLHeader.general(
+        tsn=1,
+        command_id=foundation.GeneralCommand.Report_Attributes,
+    )
+    report = foundation.GENERAL_COMMANDS[
+        foundation.GeneralCommand.Report_Attributes
+    ].schema([attribute])
+
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=0x0104,
+            cluster_id=cluster.cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(header.serialize() + report.serialize()),
+        )
+    )
+
+    assert listener.attribute_updates == [
+        (cluster.AttributeDefs.tamper.id, tamper_state)
+    ]
 
 
 @pytest.mark.parametrize(

--- a/zhaquirks/sonoff/snzb04pr2.py
+++ b/zhaquirks/sonoff/snzb04pr2.py
@@ -1,0 +1,71 @@
+"""Sonoff SNZB-04PR2 device."""
+
+from zigpy import types
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import (
+    BinarySensorDeviceClass,
+    EntityType,
+    QuirkBuilder,
+    ReportingConfig,
+)
+from zigpy.zcl.clusters.general import OnOff
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+
+class SonoffContactCluster(CustomCluster):
+    """Sonoff manufacturer specific cluster for contact sensor."""
+
+    cluster_id = 64529  # 0xfc11
+    name = "Sonoff contact cluster"
+    ep_attribute = "sonoff_contact_cluster"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        # tamper = ZCLAttributeDef(
+        #     id=0x2000,
+        #     type=types.Bool,
+        #     is_manufacturer_specific=True,
+        # )
+
+        tamper = ZCLAttributeDef(
+            id=0x2000,
+            type=types.uint8_t,
+            access="rp",
+        )
+
+    def handle_cluster_general_request(self, hdr, args, *extra, **kwargs):
+        super().handle_cluster_general_request(hdr, args, *extra, **kwargs)
+
+        if hdr.command_id != 0x0A:  # Report Attributes
+            return
+
+        for attr in args.attribute_reports:
+            if attr.attrid == self.AttributeDefs.tamper.id:
+                self._update_attribute(attr.attrid, int(attr.value.value))
+
+
+(
+    #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
+    #  device_version=0
+    #  input_clusters=[0, 1, 3, 32, 1280, 64529, 64567]
+    #  output_clusters=[3, 6, 25]>
+    # QuirkBuilder("eWeLink", "SNZB-04PR2")
+    QuirkBuilder("SONOFF", "SNZB-04PR2")
+    .prevent_default_entity_creation(endpoint_id=1, cluster_id=OnOff.cluster_id)
+    .replaces(SonoffContactCluster, endpoint_id=1)
+    .binary_sensor(
+        "tamper",
+        SonoffContactCluster.cluster_id,
+        endpoint_id=1,
+        reporting_config=ReportingConfig(
+            min_interval=0,
+            max_interval=900,
+            reportable_change=1,
+        ),
+        device_class=BinarySensorDeviceClass.TAMPER,
+        entity_type=EntityType.DIAGNOSTIC,
+        fallback_name="Tamper",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/sonoff/snzb04pr2.py
+++ b/zhaquirks/sonoff/snzb04pr2.py
@@ -1,5 +1,32 @@
 """Sonoff SNZB-04PR2 device."""
 
+# Changes compared with the SONOFF-provided ZHA quirk:
+#
+# SONOFF's original quirk defined the tamper attribute on cluster 0xFC11,
+# attribute 0x2000, as a manufacturer-specific Bool:
+#
+#   type=types.Bool
+#   is_manufacturer_specific=True
+#
+# Device logs show that the SNZB-04PR2 actually reports this attribute as a
+# normal ZCL Report Attributes frame on the manufacturer-specific cluster:
+#
+#   cluster_id=0xFC11
+#   attribute_id=0x2000
+#   type=uint8_t
+#   manufacturer_code=None
+#   value=0/1
+#
+# Therefore this quirk changes the attribute definition to types.uint8_t and
+# removes is_manufacturer_specific=True. The cluster remains manufacturer-
+# specific, but the attribute report itself is not manufacturer-coded.
+#
+# Additionally, live tamper reports were received and decoded by ZHA but did not
+# reliably update the binary sensor state. handle_cluster_general_request()
+# catches Report Attributes command 0x0A for attribute 0x2000 and updates the
+# attribute cache with the actual reported 0/1 value, so live tamper changes
+# update immediately without double-processing the report.
+
 from zigpy import types
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import (
@@ -22,6 +49,8 @@ class SonoffContactCluster(CustomCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
 
+        # SONOFF-provided version:
+        #
         # tamper = ZCLAttributeDef(
         #     id=0x2000,
         #     type=types.Bool,
@@ -35,15 +64,15 @@ class SonoffContactCluster(CustomCluster):
         )
 
     def handle_cluster_general_request(self, hdr, args, *extra, **kwargs):
+        """Handle reported tamper attribute updates."""
+        if hdr.command_id == 0x0A:  # Report Attributes
+            for attr in getattr(args, "attribute_reports", []):
+                if attr.attrid == self.AttributeDefs.tamper.id:
+                    self._update_attribute(attr.attrid, int(attr.value.value))
+                    return
+
         super().handle_cluster_general_request(hdr, args, *extra, **kwargs)
-
-        if hdr.command_id != 0x0A:  # Report Attributes
-            return
-
-        for attr in args.attribute_reports:
-            if attr.attrid == self.AttributeDefs.tamper.id:
-                self._update_attribute(attr.attrid, int(attr.value.value))
-
+        
 
 (
     #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026

--- a/zhaquirks/sonoff/snzb04pr2.py
+++ b/zhaquirks/sonoff/snzb04pr2.py
@@ -72,7 +72,7 @@ class SonoffContactCluster(CustomCluster):
                     return
 
         super().handle_cluster_general_request(hdr, args, *extra, **kwargs)
-        
+
 
 (
     #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026


### PR DESCRIPTION
## Proposed change

Add a dedicated ZHA quirk for the SONOFF SNZB-04PR2 contact sensor.

The SNZB-04PR2 is a different device from the existing SNZB-04P and reports tamper on Sonoff manufacturer-specific cluster `0xFC11`, attribute `0x2000`.

The official SONOFF documentation links a ZHA script from FAQ point 5: https://help.sonoff.tech/docs/SNZB-04PR2

In local testing, the SONOFF-provided script exposed the tamper entity, but live tamper changes did not reliably update the ZHA binary sensor.

Compared with the SONOFF-provided ZHA script, this PR:

- Defines tamper attribute `0x2000` on cluster `0xFC11` as `types.uint8_t` instead of `types.Bool`.
- Removes `is_manufacturer_specific=True`, because the device reports `manufacturer_code=None`.
- Keeps cluster `0xFC11` as the Sonoff manufacturer-specific cluster.
- Handles live `Report Attributes` updates for `0x2000` so the ZHA tamper binary sensor updates immediately.

Debug logs from the device show that the SNZB-04PR2 reports tamper as a normal ZCL `Report Attributes` frame on the manufacturer-specific cluster:

```text
cluster_id=0xFC11
attribute_id=0x2000
type=uint8_t
manufacturer_code=None
value=0/1
```

## Additional information

This is intentionally added as a separate SNZB-04PR2 quirk rather than modifying `snzb04p.py`, because the PR2 is a different model and uses a different tamper reporting path.

The important distinction observed in the logs is:

```text
manufacturer-specific cluster: yes
manufacturer-specific attribute report: no
```

Example live report for tamper active:

```text
[0xA89E:1:0xfc11] Received ZCL frame: '18 a4 0a 00 20 20 01'
Decoded ZCL frame header:
FrameControl<0x18>(..., is_manufacturer_specific=0, ...)
Decoded ZCL frame:
SonoffContactCluster:Report_Attributes(
  attribute_reports=[
    Attribute(attrid=0x2000, value=TypeValue(type=uint8_t, value=1))
  ]
)
Emitting event attribute_report:
attribute_name='tamper',
attribute_id=8192,
manufacturer_code=None,
raw_value=1,
value=1
```

Example live report for tamper clear:

```text
[0xA89E:1:0xfc11] Received ZCL frame: '18 a5 0a 00 20 20 00'
Decoded ZCL frame:
SonoffContactCluster:Report_Attributes(
  attribute_reports=[
    Attribute(attrid=0x2000, value=TypeValue(type=uint8_t, value=0))
  ]
)
```

Tested locally with a custom ZHA quirk on a SONOFF SNZB-04PR2:

- the tamper entity is provided by ZHA
- the tamper state is correct after ZHA startup
- live tamper changes update the binary sensor immediately
- repeated reports `0 -> 1 -> 0` are reflected correctly in Home Assistant

This PR does not require any Home Assistant Core changes.

## Device diagnostics

<details>
<summary>Redacted SONOFF SNZB-04PR2 diagnostics</summary>

```json
{
  "data": {
    "version": 2,
    "ieee": "**REDACTED**",
    "nwk": "**REDACTED**",
    "manufacturer": "SONOFF",
    "model": "SNZB-04PR2",
    "friendly_manufacturer": "SONOFF",
    "friendly_model": "SNZB-04PR2",
    "name": "SONOFF SNZB-04PR2",
    "quirk_applied": true,
    "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
    "manufacturer_code": 4742,
    "power_source": "Battery or Unknown",
    "available": true,
    "device_type": "EndDevice",
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4742,
      "maximum_buffer_size": 74,
      "maximum_incoming_transfer_size": 404,
      "server_mask": 10752,
      "maximum_outgoing_transfer_size": 404,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "IAS_ZONE",
          "id": 1026
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "SONOFF"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "SNZB-04PR2"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "zcl_type": "uint8",
                "value": 200
              },
              {
                "id": "0x0020",
                "name": "battery_voltage",
                "zcl_type": "uint8",
                "value": 32
              }
            ]
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0020",
            "endpoint_attribute": "poll_control",
            "attributes": [
              {
                "id": "0x0003",
                "name": "fast_poll_timeout",
                "zcl_type": "uint16",
                "value": 120
              }
            ]
          },
          {
            "cluster_id": "0x0500",
            "endpoint_attribute": "ias_zone",
            "attributes": [
              {
                "id": "0x0010",
                "name": "cie_addr",
                "zcl_type": "EUI64",
                "value": "**REDACTED**"
              },
              {
                "id": "0x0000",
                "name": "zone_state",
                "zcl_type": "enum8",
                "value": 1
              },
              {
                "id": "0x0002",
                "name": "zone_status",
                "zcl_type": "map16",
                "value": 0
              },
              {
                "id": "0x0001",
                "name": "zone_type",
                "zcl_type": "enum16",
                "value": 21
              }
            ]
          },
          {
            "cluster_id": "0xfc11",
            "endpoint_attribute": "sonoff_contact_cluster",
            "attributes": [
              {
                "id": "0x2000",
                "name": "tamper",
                "zcl_type": "uint8",
                "value": 0
              }
            ]
          },
          {
            "cluster_id": "0xfc57",
            "endpoint_attribute": "works_with_all_hubs",
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 4097
              }
            ],
            "last_query_cmd": {
              "manufacturer_code": 4742,
              "image_type": 2063,
              "current_file_version": 4097,
              "hardware_version": null
            }
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "SONOFF",
      "model": "SNZB-04PR2",
      "node_desc": {
        "logical_type": 2,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 128,
        "manufacturer_code": 4742,
        "maximum_buffer_size": 74,
        "maximum_incoming_transfer_size": 404,
        "server_mask": 10752,
        "maximum_outgoing_transfer_size": 404,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0402",
          "input_clusters": [
            "0x0000",
            "0x0001",
            "0x0003",
            "0x0020",
            "0x0500",
            "0xfc57",
            "0xfc11"
          ],
          "output_clusters": [
            "0x0003",
            "0x0019"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "info_object": {
            "platform": "binary_sensor",
            "class_name": "IASZone",
            "device_class": "opening",
            "entity_category": null,
            "primary": true,
            "endpoint_id": 1,
            "available": true,
            "attribute_name": "zone_status"
          },
          "state": {
            "class_name": "IASZone",
            "available": true,
            "state": false
          }
        },
        {
          "info_object": {
            "fallback_name": "Tamper",
            "platform": "binary_sensor",
            "class_name": "BinarySensor",
            "device_class": "tamper",
            "entity_category": "diagnostic",
            "primary": false,
            "endpoint_id": 1,
            "available": true,
            "attribute_name": "tamper"
          },
          "state": {
            "class_name": "BinarySensor",
            "available": true,
            "state": false
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "platform": "sensor",
            "class_name": "Battery",
            "device_class": "battery",
            "entity_category": "diagnostic",
            "endpoint_id": 1,
            "available": true,
            "unit": "%"
          },
          "state": {
            "class_name": "Battery",
            "available": true,
            "state": 100.0,
            "battery_voltage": 3.2
          }
        }
      ],
      "update": [
        {
          "info_object": {
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "device_class": "firmware",
            "entity_category": "config",
            "endpoint_id": 1,
            "available": true
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x00001001",
            "in_progress": false
          }
        }
      ]
    }
  },
  "issues": []
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works 
- [x] Device diagnostics data has been attached 