### PR TITLE
Add Giex GX04 soil sensor `_TZE2841000000_nhgdf6qr` variant

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -271,6 +271,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     TuyaQuirkBuilder("_TZE284_aao3yzhs", "TS0601")
     .applies_to("_TZE284_sgabhwa6", "TS0601")
     .applies_to("_TZE284_nhgdf6qr", "TS0601")  # Giex GX04
+    .applies_to("_TZE2841000000_nhgdf6qr", "TS0601")  # Giex GX04, corrupted manufacturer ID
     .applies_to("_TZE284_ap9owrsa", "TS0601")  # Novadigital SG-ZB
     .applies_to("_TZE284_awepdiwi", "TS0601")  # Solar powered
     .applies_to("_TZE284_33bwcga2", "TS0601")  # iHseno

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -271,7 +271,9 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     TuyaQuirkBuilder("_TZE284_aao3yzhs", "TS0601")
     .applies_to("_TZE284_sgabhwa6", "TS0601")
     .applies_to("_TZE284_nhgdf6qr", "TS0601")  # Giex GX04
-    .applies_to("_TZE2841000000_nhgdf6qr", "TS0601")  # Giex GX04, corrupted manufacturer ID
+    .applies_to(
+        "_TZE2841000000_nhgdf6qr", "TS0601"
+    )  # Giex GX04, corrupted manufacturer ID
     .applies_to("_TZE284_ap9owrsa", "TS0601")  # Novadigital SG-ZB
     .applies_to("_TZE284_awepdiwi", "TS0601")  # Solar powered
     .applies_to("_TZE284_33bwcga2", "TS0601")  # iHseno


### PR DESCRIPTION
## Proposed change

Add the corrupted manufacturer ID `_TZE2841000000_nhgdf6qr` to the existing TS0601 soil sensor quirk (the `_TZE284_aao3yzhs` group in `tuya_sensor.py`).

Some Giex GX04 soil sensor units ship announcing themselves as `_TZE2841000000_nhgdf6qr` instead of `_TZE284_nhgdf6qr` (already supported by this quirk). This is a known Tuya factory firmware error that appended `1000000` to the manufacturer prefix on a recent production batch, breaking signature matching. Without a matching quirk, ZHA only exposes battery + identify — no soil moisture or temperature entities.

Zigbee2MQTT has already merged the exact same corrupted ID (Koenkk/zigbee-herdsman-converters#12455), plus other `_TZE2841000000_*` variants from the same batch (Koenkk/zigbee-herdsman-converters#12368, Koenkk/zigbee-herdsman-converters#12461).

## Additional information

Verified on real hardware: HA 2026.6.1, ZHA with Connect ZBT-1 coordinator. Deployed this exact signature as a custom quirk (`custom_quirks_path`) — the quirk applies (`quirk_applied: True`) and soil moisture (dp 3), temperature (dp 5) and battery (dp 15) entities are created using the existing GX04 datapoint mapping, matching the behavior of my two `_TZE284_aao3yzhs` units on the same network.

## Device diagnostics

Note: diagnostics were taken with the proposed signature deployed as a custom quirk, hence `quirk_applied: true`. The signature is identical to the supported `_TZE284_nhgdf6qr` except for the manufacturer string.

<details><summary>diagnostics for _TZE2841000000_nhgdf6qr TS0601</summary>

```json
{
  "home_assistant": {
    "arch": "aarch64",
    "dev": false,
    "docker": true,
    "hassio": true,
    "installation_type": "Home Assistant OS",
    "os_name": "Linux",
    "os_version": "6.12.75-haos-raspi",
    "python_version": "3.14.5",
    "timezone": "Europe/Madrid",
    "version": "2026.6.1",
    "virtualenv": false,
    "container_arch": "aarch64",
    "supervisor": "2026.06.2",
    "host_os": "Home Assistant OS 17.3",
    "docker_version": "29.3.1",
    "chassis": "embedded",
    "run_as_root": true
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==1.4.1"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.00039041810669004917
    },
    "01KTDY0X4DHTVD3ETX85QHTXX9": {
      "wait_import_platforms": -0.20493454788811505,
      "config_entry_setup": 21.23188482807018
    }
  },
  "data": {
    "version": 2,
    "ieee": "**REDACTED**",
    "nwk": "0x1226",
    "manufacturer": "_TZE2841000000_nhgdf6qr",
    "model": "TS0601",
    "friendly_manufacturer": "_TZE2841000000_nhgdf6qr",
    "friendly_model": "TS0601",
    "name": "_TZE2841000000_nhgdf6qr TS0601",
    "quirk_applied": true,
    "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
    "exposes_features": [],
    "manufacturer_code": 4417,
    "power_source": "Battery or Unknown",
    "lqi": 92,
    "rssi": -88,
    "last_seen": "2026-07-02T17:06:46.422519+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4417,
      "maximum_buffer_size": 74,
      "maximum_incoming_transfer_size": 80,
      "server_mask": 10752,
      "maximum_outgoing_transfer_size": 80,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "SMART_PLUG",
          "id": 81
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "_TZE2841000000_nhgdf6qr"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "TS0601"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "value": 2
              },
              {
                "id": "0x0034",
                "name": "battery_rated_voltage",
                "zcl_type": "uint8",
                "value": 15
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "value": 3
              }
            ]
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x0005",
            "endpoint_attribute": "scenes",
            "attributes": []
          },
          {
            "cluster_id": "0x0402",
            "endpoint_attribute": "temperature",
            "attributes": []
          },
          {
            "cluster_id": "0x0408",
            "endpoint_attribute": "soil_moisture",
            "attributes": []
          },
          {
            "cluster_id": "0xe000",
            "endpoint_attribute": null,
            "attributes": []
          },
          {
            "cluster_id": "0xed00",
            "endpoint_attribute": null,
            "attributes": []
          },
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": "tuya_manufacturer",
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 105
              }
            ]
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "_TZE2841000000_nhgdf6qr",
      "model": "TS0601",
      "node_desc": {
        "logical_type": 2,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 128,
        "manufacturer_code": 4417,
        "maximum_buffer_size": 74,
        "maximum_incoming_transfer_size": 80,
        "server_mask": 10752,
        "maximum_outgoing_transfer_size": 80,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0051",
          "input_clusters": [
            "0x0000",
            "0xe000",
            "0xed00",
            "0x0001",
            "0x0004",
            "0x0005",
            "0x0003",
            "0xef00"
          ],
          "output_clusters": [
            "0x000a",
            "0x0019"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "button": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "button",
            "class_name": "IdentifyButton",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "identify",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "command": "identify",
            "args": [
              5
            ],
            "kwargs": {}
          },
          "state": {
            "class_name": "IdentifyButton",
            "available": true
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 92
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -88
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Battery",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "battery",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": 0,
            "unit": "%"
          },
          "state": {
            "class_name": "Battery",
            "available": true,
            "state": null,
            "battery_size": "AA",
            "battery_quantity": 2
          },
          "extra_state_attributes": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ]
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Temperature",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "temperature",
            "state_class": "measurement",
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "\u00b0C"
          },
          "state": {
            "class_name": "Temperature",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "SoilMoisture",
            "translation_key": "soil_moisture",
            "translation_placeholders": null,
            "device_class": "moisture",
            "state_class": "measurement",
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "%"
          },
          "state": {
            "class_name": "SoilMoisture",
            "available": true,
            "state": null
          }
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x00000069",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
