### PR TITLE
Add Tuya soil sensor `_TZE2841000000_tgrzpqf4` variant

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -275,6 +275,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE284_awepdiwi", "TS0601")  # Solar powered
     .applies_to("_TZE284_33bwcga2", "TS0601")  # iHseno
     .applies_to("_TZE284_tgrzpqf4", "TS0601")
+    .applies_to("_TZE2841000000_tgrzpqf4", "TS0601")
     .tuya_temperature(dp_id=5, scale=10)
     .tuya_battery(dp_id=15)
     .tuya_soil_moisture(dp_id=3)


### PR DESCRIPTION
I bought one of this sensors from amazon, it came with a different signature. I successfully got it working by tuning this signature.

## Proposed change
I bought one of this sensors from amazon, it came with a different signature. I successfully got it working by tuning this signature.

## Device diagnostics
[zha-7d28d956c5dbcbb427d4f18bdcd32a48-_TZE2841000000_tgrzpqf4 TS0601-9d89a0b629345387fca90f9b0e66fdb2 (1).json](https://github.com/user-attachments/files/29609932/zha-7d28d956c5dbcbb427d4f18bdcd32a48-_TZE2841000000_tgrzpqf4.TS0601-9d89a0b629345387fca90f9b0e66fdb2.1.json)
Diagnostics were generated after I manually applied my fix on my hass instance.

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works (I don't think it's necessary)
- [x] Device diagnostics data has been attached
