### PR TITLE
Add Tuya TS0601 _TZE204_guvc7pdy curtain motor (Moes)

### DIFF
--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -223,3 +223,166 @@ async def test_zemismart_zm16b_battery_report(zigpy_device_from_v2_quirk):
     # Battery percentage should be scaled by 2 (default tuya_battery scale)
     power_cluster = ep.power
     assert power_cluster.get("battery_percentage_remaining") == 170
+
+
+async def test_moes_guvc7pdy_quirk(zigpy_device_from_v2_quirk):
+    """Test Moes _TZE204_guvc7pdy curtain motor v2 quirk."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_guvc7pdy", "TS0601")
+    assert isinstance(quirked, CustomZigpyDevice)
+
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    assert cover_cluster is not None
+    assert isinstance(cover_cluster, TuyaWindowCovering)
+
+    tuya_cluster = ep.tuya_manufacturer
+    assert tuya_cluster is not None
+    assert isinstance(tuya_cluster, TuyaMCUCluster)
+
+
+async def test_moes_guvc7pdy_position_report(zigpy_device_from_v2_quirk):
+    """Test that incoming position DP reports update the cover position."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_guvc7pdy", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    cover_listener = ClusterListener(cover_cluster)
+
+    tuya_cluster = ep.tuya_manufacturer
+
+    # Device reports position 25 via DP 3; this motor reports in ZCL
+    # orientation already (0=open, 100=closed), so no inversion
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[TuyaDatapointData(3, TuyaData(25))],
+        )
+    )
+
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 25
+    )
+
+    assert len(cover_listener.attribute_updates) == 1
+    assert (
+        cover_listener.attribute_updates[0][0]
+        == WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+    assert cover_listener.attribute_updates[0][1] == 25
+
+    # DP 2 (target position echo) also updates the position attribute
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=2,
+            datapoints=[TuyaDatapointData(2, TuyaData(100))],
+        )
+    )
+
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 100
+    )
+
+
+async def test_moes_guvc7pdy_open_command(zigpy_device_from_v2_quirk):
+    """Test that the open command sends this motor's reversed DP value."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_guvc7pdy", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.up_open.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        # DP 1 with value 2 (this motor: 2=open, reversed from TuyaCoverControl)
+        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[-1:] == b"\x02"  # Value = open (2)
+
+
+async def test_moes_guvc7pdy_close_command(zigpy_device_from_v2_quirk):
+    """Test that the close command sends this motor's reversed DP value."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_guvc7pdy", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.down_close.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        # DP 1 with value 0 (this motor: 0=close, reversed from TuyaCoverControl)
+        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[-1:] == b"\x00"  # Value = close (0)
+
+
+async def test_moes_guvc7pdy_stop_command(zigpy_device_from_v2_quirk):
+    """Test that the stop command sends the correct DP value."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_guvc7pdy", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.stop.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        # DP 1 with value 1 (stop is the same in both orientations)
+        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[-1:] == b"\x01"  # Value = stop (1)
+
+
+async def test_moes_guvc7pdy_go_to_lift_percentage(zigpy_device_from_v2_quirk):
+    """Test that go_to_lift_percentage sends the position uninverted."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE204_guvc7pdy", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(
+            WindowCovering.ServerCommandDefs.go_to_lift_percentage.id, 25
+        )
+        await wait_for_zigpy_tasks()
+
+        # Multiple calls possible (DP 2 and DP 3 both mapped to the attribute)
+        assert req_mock.call_count >= 1
+        found_correct_position = False
+        for call in req_mock.call_args_list:
+            call_data = call[1]["data"]
+            # DP 2 (position control) with value 25, no inversion
+            if b"\x02" in call_data and b"\x00\x00\x00\x19" in call_data:
+                found_correct_position = True
+        assert found_correct_position, "Expected DP 2 with value 25 in sent data"

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 import zigpy.types as t
+from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
 
 from zhaquirks.const import (
@@ -20,6 +21,7 @@ from zhaquirks.tuya import (
     TuyaWindowCoverControl,
 )
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.mcu import TuyaCoverControl, TuyaWindowCovering
 
 
 class TuyaZemismartSmartCover0601(TuyaWindowCover):
@@ -702,6 +704,38 @@ class BorderSetting(t.enum8):
         translation_key="delete_all_limits",
         fallback_name="Delete all limits",
     )
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+(
+    # Moes curtain motor. Cannot use tuya_cover() because this motor's control
+    # DP enum is reversed relative to TuyaCoverControl: the device uses
+    # 0=close, 1=stop, 2=open, so both directions are mapped with converters.
+    TuyaQuirkBuilder("_TZE204_guvc7pdy", "TS0601")
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=TuyaWindowCovering.ep_attribute,
+        attribute_name=TuyaWindowCovering.AttributeDefs.tuya_cover_command.name,
+        converter=lambda x: TuyaCoverControl(2 - x),
+        dp_converter=lambda x: TuyaCoverControl(2 - int(x)),
+    )
+    # DP 2 sets the target position, DP 3 reports the current position while
+    # moving. Both are 0-100 in ZCL orientation already (0=open, 100=closed),
+    # so no inversion.
+    .tuya_dp(
+        dp_id=2,
+        ep_attribute=TuyaWindowCovering.ep_attribute,
+        attribute_name=WindowCovering.AttributeDefs.current_position_lift_percentage.name,
+    )
+    .tuya_dp(
+        dp_id=3,
+        ep_attribute=TuyaWindowCovering.ep_attribute,
+        attribute_name=WindowCovering.AttributeDefs.current_position_lift_percentage.name,
+    )
+    .adds(TuyaWindowCovering)
+    .replaces_endpoint(1, device_type=zha.DeviceType.WINDOW_COVERING_DEVICE)
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -709,6 +709,17 @@ class BorderSetting(t.enum8):
 )
 
 
+class MoesCoverCommand(t.enum8):
+    """Moes _TZE204_guvc7pdy cover command values.
+
+    Reversed relative to TuyaCoverControl (0=open, 2=close).
+    """
+
+    Close = 0x00
+    Stop = 0x01
+    Open = 0x02
+
+
 (
     # Moes curtain motor. Cannot use tuya_cover() because this motor's control
     # DP enum is reversed relative to TuyaCoverControl: the device uses
@@ -719,7 +730,7 @@ class BorderSetting(t.enum8):
         ep_attribute=TuyaWindowCovering.ep_attribute,
         attribute_name=TuyaWindowCovering.AttributeDefs.tuya_cover_command.name,
         converter=lambda x: TuyaCoverControl(2 - x),
-        dp_converter=lambda x: TuyaCoverControl(2 - int(x)),
+        dp_converter=lambda x: MoesCoverCommand(2 - int(x)),
     )
     # DP 2 sets the target position, DP 3 reports the current position while
     # moving. Both are 0-100 in ZCL orientation already (0=open, 100=closed),


### PR DESCRIPTION
## Proposed change

Adds support for the Moes/Tuya TS0601 curtain motor `_TZE204_guvc7pdy` as a quirks v2 entry in `ts0601_cover.py`, built with `TuyaQuirkBuilder`.

This motor cannot use the standard `tuya_cover()` helper because its control DP enum is **reversed** relative to `TuyaCoverControl`: the device uses 0=close, 1=stop, 2=open (standard is 0=open, 2=close). The control DP is therefore mapped with explicit converters in both directions. Position DPs (DP 2 = target position, DP 3 = position reports) are already in ZCL orientation (0=open, 100=closed), so they are mapped without inversion.

DP mappings:

| DP | Function | Notes |
|----|----------|-------|
| 1  | open/stop/close | reversed enum: 0=close, 1=stop, 2=open |
| 2  | target position (0-100) | written on `go_to_lift_percentage`, no inversion |
| 3  | current position reports (0-100) | no inversion |

## Additional information

Verified on hardware (ZHA, Home Assistant 2026.4.1, zha-quirks 1.1.1): open/close/stop physically move the motor, `go_to_lift_percentage` works, and the motor's own position reports (DP 3) track real movement in HA. The DP mappings were previously proven by a long-running local v1 quirk for the same device.

## Device diagnostics

Diagnostics posted in a comment below (environment sections trimmed; sensitive values redacted by HA).

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached