### PR TITLE
Override wrong OTA `current_file_version` for Aqara E1 thermostat

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -25,6 +25,7 @@ from zigpy.zcl.clusters.general import (
     MultistateInput,
     MultistateOutput,
     OnOff,
+    Ota,
     PowerConfiguration,
 )
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
@@ -1493,6 +1494,58 @@ async def test_xiaomi_e1_thermostat_attribute_update(zigpy_device_from_quirk, qu
     assert len(power_config_listener.attribute_updates) == 1
     assert power_config_listener.attribute_updates[0][0] == zcl_battery_percentage_id
     assert power_config_listener.attribute_updates[0][1] == 100  # ZCL is doubled
+
+
+async def test_xiaomi_e1_thermostat_ota_file_version_override(zigpy_device_from_quirk):
+    """Test the E1 thermostat's wrong OTA current_file_version is overridden.
+
+    The device reports a low, incorrect current_file_version in both the OTA attribute
+    and its query_next_image command. The real, OTA-comparable version is reported on
+    the Aqara manufacturer cluster (attribute 0x00EE), and the quirk substitutes it on
+    both paths so ZHA's update entity no longer shows a permanent "update available".
+    """
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.thermostat_agl001.AGL001)
+
+    opple_cluster = device.endpoints[1].opple_cluster
+    ota_cluster = device.endpoints[1].out_clusters[Ota.cluster_id]
+
+    current_file_version_id = Ota.AttributeDefs.current_file_version.id
+    firmware_version_id = zhaquirks.xiaomi.aqara.thermostat_agl001.FIRMWARE_VERSION
+
+    wrong_version = 0x00000019  # device reports a low/wrong value (decimal 25)
+    real_version = 0x00000407  # actual, OTA-comparable firmware version
+
+    # Until the real version is known, the wrong value passes through unchanged.
+    ota_cluster.update_attribute(current_file_version_id, wrong_version)
+    assert ota_cluster.get(current_file_version_id) == wrong_version
+
+    # The device reports its real firmware version on the Aqara cluster (0x00EE).
+    opple_cluster.update_attribute(firmware_version_id, real_version)
+
+    # Now the wrong OTA attribute value is corrected to the real version.
+    ota_cluster.update_attribute(current_file_version_id, wrong_version)
+    assert ota_cluster.get(current_file_version_id) == real_version
+
+    # The wrong version in query_next_image is corrected before zigpy caches it as
+    # last_query_cmd (which drives the "update available" decision).
+    captured_tasks = []
+    ota_cluster.create_catching_task = lambda coro, *args, **kwargs: (
+        captured_tasks.append(coro)
+    )
+    hdr = foundation.ZCLHeader.cluster(
+        tsn=1, command_id=Ota.ServerCommandDefs.query_next_image.id
+    )
+    cmd = Ota.ServerCommandDefs.query_next_image.schema(
+        field_control=Ota.QueryNextImageCommand.FieldControl(0),
+        manufacturer_code=0x115F,
+        image_type=0x0000,
+        current_file_version=wrong_version,
+    )
+    ota_cluster.handle_cluster_request(hdr, cmd)
+    await captured_tasks[0]
+
+    assert ota_cluster.last_query_cmd is not None
+    assert ota_cluster.last_query_cmd.current_file_version == real_version
 
 
 @pytest.mark.parametrize(

--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -50,6 +50,7 @@ SCHEDULE = 0x027D
 SCHEDULE_SETTINGS = 0x0276
 SENSOR = 0x027E
 BATTERY_PERCENTAGE = 0x040A
+FIRMWARE_VERSION = 0x00EE
 
 XIAOMI_CLUSTER_ID = 0xFCC0
 
@@ -419,6 +420,9 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
         battery_percentage: Final = ZCLAttributeDef(
             id=BATTERY_PERCENTAGE, type=t.uint8_t, is_manufacturer_specific=True
         )
+        firmware_version: Final = ZCLAttributeDef(
+            id=FIRMWARE_VERSION, type=t.uint32_t, is_manufacturer_specific=True
+        )
 
     def _update_attribute(self, attrid, value):
         self.debug("Updating attribute on Xiaomi cluster %s with %s", attrid, value)
@@ -430,6 +434,46 @@ class AqaraThermostatSpecificCluster(XiaomiAqaraE1Cluster):
                 ZCL_SYSTEM_MODE, XIAOMI_SYSTEM_MODE_MAP[value]
             )
         super()._update_attribute(attrid, value)
+
+
+class XiaomiE1OtaCluster(CustomCluster, Ota):
+    """OTA cluster that corrects the wrong firmware version reported by the E1 TRV.
+
+    The thermostat reports a low, incorrect ``current_file_version`` in both the OTA
+    attribute (0x0002) and its ``query_next_image`` command, so the device looks
+    permanently out of date and the update entity is stuck on "update available" even
+    right after a successful update. The real, OTA-comparable version is reported on
+    the Aqara manufacturer cluster (attribute 0x00EE); substitute it on both paths.
+
+    This mirrors the ``lumiFileVersion`` override Zigbee2MQTT applies to this model.
+    """
+
+    def _correct_file_version(self) -> int | None:
+        """Return the real firmware version from the Aqara cluster, if known."""
+        return self.endpoint.opple_cluster.get(FIRMWARE_VERSION)
+
+    def _update_attribute(self, attrid, value):
+        """Override the device's wrong ``current_file_version`` attribute value."""
+        if (
+            attrid == Ota.AttributeDefs.current_file_version.id
+            and (real_version := self._correct_file_version()) is not None
+        ):
+            value = real_version
+        super()._update_attribute(attrid, value)
+
+    def handle_cluster_request(self, hdr, args, *, dst_addressing=None):
+        """Override the wrong ``current_file_version`` in ``query_next_image``.
+
+        zigpy caches this command as ``last_query_cmd`` and uses its
+        ``current_file_version`` directly to decide whether an image is available, so
+        the value must be corrected before delegating to the base handler.
+        """
+        if (
+            hdr.command_id == self.ServerCommandDefs.query_next_image.id
+            and (real_version := self._correct_file_version()) is not None
+        ):
+            args = args.replace(current_file_version=real_version)
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
 
 
 class AGL001(XiaomiCustomDevice):
@@ -477,7 +521,7 @@ class AGL001(XiaomiCustomDevice):
                     Identify.cluster_id,
                     ThermostatCluster,
                     AqaraThermostatSpecificCluster,
-                    Ota.cluster_id,
+                    XiaomiE1OtaCluster,
                 ],
             }
         }


### PR DESCRIPTION
DRAFT.

## Proposed change

The Aqara E1 radiator thermostat (`lumi.airrtc.agl001`) reports a **low, incorrect `current_file_version`** in both the OTA cluster attribute (`0x0002`) and its `query_next_image` command. ZHA compares that value against the available images, so the update entity is stuck showing **"update available"** even immediately after a successful update.

The device does expose its real, OTA-comparable firmware version — on the Aqara manufacturer cluster (`0xFCC0`, attribute `0x00EE`). This PR caches that attribute and substitutes it for the wrong value on **both** paths ZHA consumes:

- the OTA `current_file_version` **attribute** — drives the entity's displayed installed version, and
- the `query_next_image` **command** — zigpy caches it as `last_query_cmd` and reads `last_query_cmd.current_file_version` directly to decide whether an image is available.

This mirrors the `lumiFileVersion` override that Zigbee2MQTT applies to this exact model.

Related: zigpy/zigpy-ota#54 (the OTA image submission is blocked on this).

<details>
<summary>How the override works</summary>

- Adds a `firmware_version` attribute (`0x00EE`, `uint32_t`) to `AqaraThermostatSpecificCluster`, so the real version the device reports on `0xFCC0` is parsed and cached instead of being dropped as an unknown attribute.
- Replaces the device's client OTA cluster with `XiaomiE1OtaCluster(CustomCluster, Ota)`:
  - `_update_attribute` — when the OTA `current_file_version` attribute is set, substitutes the cached `0x00EE` value.
  - `handle_cluster_request` — rewrites `current_file_version` in the incoming `query_next_image` command (via `.replace(...)`) **before** delegating to `super()`, so `last_query_cmd` — and therefore both the availability decision and the emitted `OtaImageAvailableEvent` — carry the corrected value.
- Substitution only happens once `0x00EE` is known; until then the device's raw value passes through unchanged.

</details>

<details>
<summary>Why the fix lives at this layer (and not by overriding <code>emit</code>)</summary>

The "is an update available?" decision is made in zigpy's `OTA.check_cluster_for_ota` → `get_ota_images` → `check_version(last_query_cmd.current_file_version)`, which runs **before** and feeds **into** the `OtaImageAvailableEvent` that ZHA's update entity listens for. Overriding the cluster's `emit` would be too late: by the time the event fires, `images_result` has already been computed with the wrong version, so the already-installed image is still in the upgrades list. Correcting `last_query_cmd` (via the command handler) is the lowest seam that fixes both the availability decision and the displayed installed version.

</details>

<details>
<summary>Zigbee2MQTT reference</summary>

- herdsman-converters reads the real version off the Lumi cluster: `case 0x00ee: meta.device.meta.lumiFileVersion = value` (`src/lib/lumi.ts`).
- herdsman substitutes it for exactly this model before the image comparison: `if (this.meta.lumiFileVersion && this.modelID === "lumi.airrtc.agl001" …) current = {...current, fileVersion: this.meta.lumiFileVersion}` (`src/controller/model/device.ts`).

</details>

## Additional information

<details>
<summary>Interim approach + long-term direction</summary>

This is the quirk-based override discussed in zigpy/zigpy-ota#54 — it needs zero library changes. The cleaner long-term home would be a ZHA-side hook letting a quirk declare an alternate version-source attribute for the update entity, which would also cover the two `lumi.curtain.*` models Z2M special-cases the same way. No such hook exists today.

</details>

<details>
<summary>Active-flash path note</summary>

`OTAManager._image_query_req` reads the raw wire command via `callback_for_response` (bypassing the cluster), so it still sees the low version during an active flash. This isn't a practical concern: a user-initiated install forces the update (`force=True` skips the version check), and with the proactive path fixed the entity won't offer a spurious update in the first place.

</details>

## Device diagnostics

This modifies an existing quirk (adding custom OTA-version-override logic) rather than adding a new quirk, so no new diagnostics fixture is required. The custom logic is covered by a dedicated unit test (`test_xiaomi_e1_thermostat_ota_file_version_override`).

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached — N/A (existing quirk; see above)
