### PR TITLE
Add Aqara Climate Sensor W100 (lumi.sensor_ht.agl001)

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -45,6 +45,7 @@ from tests.common import ZCL_OCC_ATTR_RPT_OCC, ClusterListener
 import zhaquirks
 from zhaquirks.const import (
     ATTR_ID,
+    BUTTON,
     BUTTON_1,
     BUTTON_2,
     DEVICE_TYPE,
@@ -70,7 +71,11 @@ from zhaquirks.xiaomi import (
     XIAOMI_AQARA_ATTRIBUTE_E1,
     XIAOMI_NODE_DESC,
     BasicCluster,
+    RelativeHumidityCluster,
+    TemperatureMeasurementCluster,
+    XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
+    XiaomiPowerConfiguration,
     XiaomiQuickInitDevice,
     handle_quick_init,
 )
@@ -105,9 +110,11 @@ import zhaquirks.xiaomi.aqara.motion_agl02
 import zhaquirks.xiaomi.aqara.motion_agl04
 import zhaquirks.xiaomi.aqara.motion_aq2
 import zhaquirks.xiaomi.aqara.motion_aq2b
+from zhaquirks.xiaomi.aqara.opple_remote import STATUS_TYPE_ATTR, MultistateInputCluster
 import zhaquirks.xiaomi.aqara.plug
 import zhaquirks.xiaomi.aqara.plug_eu
 import zhaquirks.xiaomi.aqara.roller_curtain_e1
+import zhaquirks.xiaomi.aqara.sensor_ht_agl001
 import zhaquirks.xiaomi.aqara.sensor_ht_agl02
 import zhaquirks.xiaomi.aqara.smoke
 import zhaquirks.xiaomi.aqara.switch_t1
@@ -2729,3 +2736,78 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
     temp = device.endpoints[1].device_temperature
     temp._update_attribute(DeviceTemperature.AttributeDefs.current_temperature.id, 25)
     assert temp.get("current_temperature") == 2500
+
+
+def test_w100_signature_and_clusters(zigpy_device_from_v2_quirk):
+    """W100 quirk matches and swaps in its custom clusters on all endpoints."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.sensor_ht.agl001", endpoint_ids=[1, 2, 3]
+    )
+
+    ep1 = device.endpoints[1]
+    assert isinstance(ep1.temperature, TemperatureMeasurementCluster)
+    assert isinstance(ep1.humidity, RelativeHumidityCluster)
+    assert isinstance(ep1.power, XiaomiPowerConfiguration)
+    assert isinstance(ep1.opple_cluster, XiaomiAqaraE1Cluster)
+
+    # the three buttons live on endpoints 1/2/3
+    for ep_id in (1, 2, 3):
+        assert isinstance(
+            device.endpoints[ep_id].multistate_input, MultistateInputCluster
+        )
+
+
+@pytest.mark.parametrize(
+    "endpoint, value, expected_action, expected_press",
+    [
+        (1, 1, "1_single", "single"),
+        (2, 2, "2_double", "double"),
+        (3, 0, "3_hold", "hold"),
+        (1, 255, "1_release", "release"),
+    ],
+)
+def test_w100_button_events(
+    zigpy_device_from_v2_quirk, endpoint, value, expected_action, expected_press
+):
+    """A button press on any endpoint fires the expected zha_send_event."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.sensor_ht.agl001", endpoint_ids=[1, 2, 3]
+    )
+    mi_cluster = device.endpoints[endpoint].multistate_input
+    zha_listener = mock.MagicMock()
+    mi_cluster.add_listener(zha_listener)
+
+    mi_cluster.update_attribute(STATUS_TYPE_ATTR, value)
+
+    assert zha_listener.zha_send_event.mock_calls == [
+        mock.call(
+            expected_action,
+            {
+                BUTTON: endpoint,
+                PRESS_TYPE: expected_press,
+                ATTR_ID: STATUS_TYPE_ATTR,
+                VALUE: value,
+            },
+        )
+    ]
+
+
+def test_w100_battery_from_heartbeat(zigpy_device_from_v2_quirk):
+    """The 0xFCC0 heartbeat feeds battery voltage/percentage into the power cluster."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.sensor_ht.agl001", endpoint_ids=[1, 2, 3]
+    )
+    opple_cluster = device.endpoints[1].opple_cluster
+    power_cluster = device.endpoints[1].power
+    power_listener = ClusterListener(power_cluster)
+
+    voltage_id = PowerConfiguration.AttributeDefs.battery_voltage.id
+    percent_id = PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
+
+    # heartbeat carrying 3000 mV battery voltage (key 1)
+    opple_cluster.update_attribute(
+        XIAOMI_AQARA_ATTRIBUTE_E1, create_aqara_attr_report({1: 3000})
+    )
+
+    assert (voltage_id, 30.0) in power_listener.attribute_updates
+    assert any(attr_id == percent_id for attr_id, _ in power_listener.attribute_updates)

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2793,7 +2793,7 @@ def test_w100_button_events(
 
 
 def test_w100_battery_from_heartbeat(zigpy_device_from_v2_quirk):
-    """The 0xFCC0 heartbeat feeds battery voltage/percentage into the power cluster."""
+    """The 0xFCC0 heartbeat tag 102 feeds battery percent into the power cluster."""
     device = zigpy_device_from_v2_quirk(
         "Aqara", "lumi.sensor_ht.agl001", endpoint_ids=[1, 2, 3]
     )
@@ -2801,13 +2801,11 @@ def test_w100_battery_from_heartbeat(zigpy_device_from_v2_quirk):
     power_cluster = device.endpoints[1].power
     power_listener = ClusterListener(power_cluster)
 
-    voltage_id = PowerConfiguration.AttributeDefs.battery_voltage.id
     percent_id = PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
 
-    # heartbeat carrying 3000 mV battery voltage (key 1)
-    opple_cluster.update_attribute(
-        XIAOMI_AQARA_ATTRIBUTE_E1, create_aqara_attr_report({1: 3000})
-    )
+    # heartbeat carrying 87 % battery percent in tag 102 (uint8, as on the device —
+    # the W100 sends no tag-1 voltage)
+    report = bytes([102]) + foundation.TypeValue(0x20, t.uint8_t(87)).serialize()
+    opple_cluster.update_attribute(XIAOMI_AQARA_ATTRIBUTE_E1, report)
 
-    assert (voltage_id, 30.0) in power_listener.attribute_updates
-    assert any(attr_id == percent_id for attr_id, _ in power_listener.attribute_updates)
+    assert (percent_id, 87 * 2) in power_listener.attribute_updates

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2845,3 +2845,30 @@ async def test_w100_ignores_zcl_battery_reports(zigpy_device_from_v2_quirk):
     )
 
     assert power_listener.attribute_updates == []
+
+    # other general commands still reach the base handler: a device-initiated
+    # read gets a Read_Attributes_rsp task
+    hdr = foundation.ZCLHeader.general(
+        2,
+        foundation.GeneralCommand.Read_Attributes,
+        direction=foundation.Direction.Server_to_Client,
+    ).serialize()
+    cmd = (
+        foundation.GENERAL_COMMANDS[foundation.GeneralCommand.Read_Attributes]
+        .schema([percent_id])
+        .serialize()
+    )
+
+    with mock.patch.object(power_cluster, "create_catching_task") as task_mock:
+        device.packet_received(
+            t.ZigbeePacket(
+                profile_id=260,
+                cluster_id=power_cluster.cluster_id,
+                src_ep=1,
+                dst_ep=1,
+                data=t.SerializableBytes(hdr + cmd),
+            )
+        )
+
+    assert len(task_mock.mock_calls) == 1
+    task_mock.call_args.args[0].close()  # discard the un-awaited response coroutine

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2809,3 +2809,39 @@ def test_w100_battery_from_heartbeat(zigpy_device_from_v2_quirk):
     opple_cluster.update_attribute(XIAOMI_AQARA_ATTRIBUTE_E1, report)
 
     assert (percent_id, 87 * 2) in power_listener.attribute_updates
+
+
+async def test_w100_ignores_zcl_battery_reports(zigpy_device_from_v2_quirk):
+    """ZCL battery reports (always 0 on the W100) don't overwrite the heartbeat value."""
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.sensor_ht.agl001", endpoint_ids=[1, 2, 3]
+    )
+    power_cluster = device.endpoints[1].power
+    power_listener = ClusterListener(power_cluster)
+
+    percent_id = PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
+    attr = foundation.Attribute(
+        attrid=percent_id, value=foundation.TypeValue(0x20, t.uint8_t(0))
+    )
+    hdr = foundation.ZCLHeader.general(
+        1,
+        foundation.GeneralCommand.Report_Attributes,
+        direction=foundation.Direction.Server_to_Client,
+    ).serialize()
+    cmd = (
+        foundation.GENERAL_COMMANDS[foundation.GeneralCommand.Report_Attributes]
+        .schema([attr])
+        .serialize()
+    )
+
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=power_cluster.cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(hdr + cmd),
+        )
+    )
+
+    assert power_listener.attribute_updates == []

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -430,6 +430,10 @@ class XiaomiCluster(CustomCluster):
             attribute_names.update({11: ILLUMINANCE_MEASUREMENT})
         elif self.endpoint.device.model == "lumi.curtain.acn002":
             attribute_names.update({101: BATTERY_PERCENTAGE_REMAINING_ATTRIBUTE})
+        elif self.endpoint.device.model == "lumi.sensor_ht.agl001":
+            # The W100 heartbeat carries no tag-1 battery voltage; battery percent is
+            # in tag 102 (and its standard PowerConfiguration attribute reports 0).
+            attribute_names.update({102: BATTERY_PERCENTAGE_REMAINING_ATTRIBUTE})
         elif self.endpoint.device.model in [
             "lumi.motion.agl02",
             "lumi.motion.ac02",

--- a/zhaquirks/xiaomi/aqara/sensor_ht_agl001.py
+++ b/zhaquirks/xiaomi/aqara/sensor_ht_agl001.py
@@ -2,9 +2,11 @@
 
 Exposes the three buttons (plus/center/minus = endpoints 1/2/3) as zha_event and
 device-automation triggers via the shared Aqara ``MultistateInputCluster``, and battery
-from the 0xFCC0 heartbeat struct (``XiaomiAqaraE1Cluster`` feeding
-``XiaomiPowerConfiguration``, same wiring as the H1 remote).
-
+from the 0xFCC0 heartbeat struct. The W100 reports battery percent only in heartbeat
+tag 102 — there is no tag-1 voltage, and the standard PowerConfiguration attribute
+always reports 0 — so ``XiaomiCluster._parse_aqara_attributes`` maps tag 102 for this
+model (matching zigbee2mqtt's TH-S04D converter,
+https://github.com/Koenkk/zigbee-herdsman-converters/pull/10787).
 """
 
 from zhaquirks.builder import QuirkBuilder

--- a/zhaquirks/xiaomi/aqara/sensor_ht_agl001.py
+++ b/zhaquirks/xiaomi/aqara/sensor_ht_agl001.py
@@ -9,6 +9,8 @@ model (matching zigbee2mqtt's TH-S04D converter,
 https://github.com/Koenkk/zigbee-herdsman-converters/pull/10787).
 """
 
+from zigpy.zcl import foundation
+
 from zhaquirks.builder import QuirkBuilder
 from zhaquirks.const import COMMAND, DOUBLE_PRESS, LONG_PRESS, LONG_RELEASE, SHORT_PRESS
 from zhaquirks.xiaomi import (
@@ -39,12 +41,28 @@ CENTER_BUTTON = "center"
 MINUS_BUTTON = "minus"
 
 
+class W100PowerConfiguration(XiaomiPowerConfiguration):
+    """PowerConfiguration that drops the device's own ZCL battery reports.
+
+    The W100's battery_percentage_remaining attribute always reports 0, and a
+    reporting config from a pre-quirk join persists in the device — a 0 every
+    max-interval that overwrites the heartbeat-derived value. Battery comes solely
+    from the 0xFCC0 heartbeat via ``battery_percent_reported``.
+    """
+
+    def handle_cluster_general_request(self, hdr, args, *, dst_addressing=None):
+        """Drop attribute reports; pass everything else through."""
+        if hdr.command_id == foundation.GeneralCommand.Report_Attributes:
+            return
+        super().handle_cluster_general_request(hdr, args, dst_addressing=dst_addressing)
+
+
 (
     QuirkBuilder(AQARA, "lumi.sensor_ht.agl001")
     .friendly_name(manufacturer="Aqara", model="Climate Sensor W100")
     .replaces(TemperatureMeasurementCluster)
     .replaces(RelativeHumidityCluster)
-    .replaces(XiaomiPowerConfiguration)
+    .replaces(W100PowerConfiguration)
     .replaces(XiaomiAqaraE1Cluster)
     .replaces(MultistateInputCluster)
     .replaces(MultistateInputCluster, endpoint_id=2)

--- a/zhaquirks/xiaomi/aqara/sensor_ht_agl001.py
+++ b/zhaquirks/xiaomi/aqara/sensor_ht_agl001.py
@@ -1,0 +1,67 @@
+"""Quirk for the Aqara Climate Sensor W100 (lumi.sensor_ht.agl001).
+
+Exposes the three buttons (plus/center/minus = endpoints 1/2/3) as zha_event and
+device-automation triggers via the shared Aqara ``MultistateInputCluster``, and battery
+from the 0xFCC0 heartbeat struct (``XiaomiAqaraE1Cluster`` feeding
+``XiaomiPowerConfiguration``, same wiring as the H1 remote).
+
+"""
+
+from zhaquirks.builder import QuirkBuilder
+from zhaquirks.const import COMMAND, DOUBLE_PRESS, LONG_PRESS, LONG_RELEASE, SHORT_PRESS
+from zhaquirks.xiaomi import (
+    AQARA,
+    RelativeHumidityCluster,
+    TemperatureMeasurementCluster,
+    XiaomiAqaraE1Cluster,
+    XiaomiPowerConfiguration,
+)
+from zhaquirks.xiaomi.aqara.opple_remote import (
+    COMMAND_1_DOUBLE,
+    COMMAND_1_HOLD,
+    COMMAND_1_RELEASE,
+    COMMAND_1_SINGLE,
+    COMMAND_2_DOUBLE,
+    COMMAND_2_HOLD,
+    COMMAND_2_RELEASE,
+    COMMAND_2_SINGLE,
+    COMMAND_3_DOUBLE,
+    COMMAND_3_HOLD,
+    COMMAND_3_RELEASE,
+    COMMAND_3_SINGLE,
+    MultistateInputCluster,
+)
+
+PLUS_BUTTON = "plus"
+CENTER_BUTTON = "center"
+MINUS_BUTTON = "minus"
+
+
+(
+    QuirkBuilder(AQARA, "lumi.sensor_ht.agl001")
+    .friendly_name(manufacturer="Aqara", model="Climate Sensor W100")
+    .replaces(TemperatureMeasurementCluster)
+    .replaces(RelativeHumidityCluster)
+    .replaces(XiaomiPowerConfiguration)
+    .replaces(XiaomiAqaraE1Cluster)
+    .replaces(MultistateInputCluster)
+    .replaces(MultistateInputCluster, endpoint_id=2)
+    .replaces(MultistateInputCluster, endpoint_id=3)
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, PLUS_BUTTON): {COMMAND: COMMAND_1_SINGLE},
+            (DOUBLE_PRESS, PLUS_BUTTON): {COMMAND: COMMAND_1_DOUBLE},
+            (LONG_PRESS, PLUS_BUTTON): {COMMAND: COMMAND_1_HOLD},
+            (LONG_RELEASE, PLUS_BUTTON): {COMMAND: COMMAND_1_RELEASE},
+            (SHORT_PRESS, CENTER_BUTTON): {COMMAND: COMMAND_2_SINGLE},
+            (DOUBLE_PRESS, CENTER_BUTTON): {COMMAND: COMMAND_2_DOUBLE},
+            (LONG_PRESS, CENTER_BUTTON): {COMMAND: COMMAND_2_HOLD},
+            (LONG_RELEASE, CENTER_BUTTON): {COMMAND: COMMAND_2_RELEASE},
+            (SHORT_PRESS, MINUS_BUTTON): {COMMAND: COMMAND_3_SINGLE},
+            (DOUBLE_PRESS, MINUS_BUTTON): {COMMAND: COMMAND_3_DOUBLE},
+            (LONG_PRESS, MINUS_BUTTON): {COMMAND: COMMAND_3_HOLD},
+            (LONG_RELEASE, MINUS_BUTTON): {COMMAND: COMMAND_3_RELEASE},
+        }
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Adds a v2 quirk for the Aqara Climate Sensor W100 (`lumi.sensor_ht.agl001`):

- The three buttons (plus/center/minus on endpoints 1/2/3) are exposed as
  `zha_event`/device-automation triggers via the shared Aqara `MultistateInputCluster`.
- Battery comes from the 0xFCC0 heartbeat, which on this device carries battery percent
  in struct tag 102: there is no generic tag-1 voltage, and the standard
  PowerConfiguration attribute always reports 0. `_parse_aqara_attributes` maps the tag
  model-specifically, like `lumi.curtain.acn002`'s tag 101 — the same data location
  zigbee2mqtt uses for this device (TH-S04D; Koenkk/zigbee-herdsman-converters#10787,
  Koenkk/zigbee2mqtt#27262).

Supersedes the stale draft #4199.

## Additional information

Fixes #4094.

Tested on six devices running firmware 0.0.0_1641 (`0x00001029`): buttons fire the
expected events, and battery populates from the hourly heartbeat (the diagnostics below
show `battery_percentage_remaining` = 200, i.e. 100 %, cached from a live heartbeat).

## Device diagnostics

<details><summary>Diagnostics — firmware 0x00001029 (0.0.0_1641)</summary>

```json
{
  "home_assistant": {
    "arch": "aarch64",
    "dev": false,
    "docker": true,
    "hassio": true,
    "installation_type": "Home Assistant OS",
    "os_name": "Linux",
    "os_version": "6.18.34-haos-raspi",
    "python_version": "3.14.6",
    "timezone": "**REDACTED**",
    "version": "2026.7.0",
    "virtualenv": false,
    "container_arch": "aarch64",
    "supervisor": "2026.06.2",
    "host_os": "Home Assistant OS 18.1",
    "docker_version": "29.5.3",
    "chassis": "embedded",
    "run_as_root": true
  },
  "custom_components": "**REDACTED**",
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==2.0.0",
      "zha-quirks==2.1.0"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 7.111098966561258e-05
    },
    "**REDACTED**": {
      "wait_import_platforms": -0.015486639982555062,
      "config_entry_setup": 8.80909331300063
    }
  },
  "data": {
    "version": 2,
    "ieee": "**REDACTED**",
    "nwk": "0x0058",
    "manufacturer": "Aqara",
    "model": "lumi.sensor_ht.agl001",
    "friendly_manufacturer": "Aqara",
    "friendly_model": "Climate Sensor W100",
    "name": "Aqara Climate Sensor W100",
    "quirk_applied": true,
    "quirk_class": "sensor_ht_agl001:(Aqara / lumi.sensor_ht.agl001)",
    "exposes_features": [],
    "manufacturer_code": 4447,
    "power_source": "Battery or Unknown",
    "lqi": 104,
    "rssi": -74,
    "last_seen": "2026-07-03T20:11:25.622927+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4447,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 1036,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 1036,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "TEMPERATURE_SENSOR",
          "id": 770
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "Aqara"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "lumi.sensor_ht.agl001"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "zcl_type": "uint8",
                "value": 200
              },
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "value": 1
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "value": 255
              },
              {
                "id": "0x0020",
                "name": "battery_voltage",
                "zcl_type": "uint8",
                "unsupported": true
              }
            ]
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0012",
            "endpoint_attribute": "multistate_input",
            "attributes": []
          },
          {
            "cluster_id": "0x0402",
            "endpoint_attribute": "temperature",
            "attributes": [
              {
                "id": "0x0000",
                "name": "measured_value",
                "zcl_type": "int16",
                "value": 2156
              }
            ]
          },
          {
            "cluster_id": "0x0405",
            "endpoint_attribute": "humidity",
            "attributes": [
              {
                "id": "0x0000",
                "name": "measured_value",
                "zcl_type": "uint16",
                "value": 4762
              }
            ]
          },
          {
            "cluster_id": "0xfcc0",
            "endpoint_attribute": "opple_cluster",
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 4137
              }
            ],
            "last_query_cmd": {
              "manufacturer_code": 4447,
              "image_type": 9744,
              "current_file_version": 4137,
              "hardware_version": null
            }
          }
        ]
      },
      "2": {
        "profile_id": 260,
        "device_type": {
          "name": "ON_OFF_SWITCH",
          "id": 0
        },
        "in_clusters": [
          {
            "cluster_id": "0x0012",
            "endpoint_attribute": "multistate_input",
            "attributes": []
          }
        ],
        "out_clusters": []
      },
      "3": {
        "profile_id": 260,
        "device_type": {
          "name": "ON_OFF_SWITCH",
          "id": 0
        },
        "in_clusters": [
          {
            "cluster_id": "0x0012",
            "endpoint_attribute": "multistate_input",
            "attributes": []
          }
        ],
        "out_clusters": []
      }
    },
    "original_signature": {
      "manufacturer": "Aqara",
      "model": "lumi.sensor_ht.agl001",
      "node_desc": {
        "logical_type": 2,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 128,
        "manufacturer_code": 4447,
        "maximum_buffer_size": 82,
        "maximum_incoming_transfer_size": 1036,
        "server_mask": 11264,
        "maximum_outgoing_transfer_size": 1036,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "3": {
          "profile_id": "0x0104",
          "device_type": "0x0000",
          "input_clusters": [
            "0x0012"
          ],
          "output_clusters": []
        },
        "2": {
          "profile_id": "0x0104",
          "device_type": "0x0000",
          "input_clusters": [
            "0x0012"
          ],
          "output_clusters": []
        },
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0302",
          "input_clusters": [
            "0x0012",
            "0x0405",
            "0x0402",
            "0x0001",
            "0x0003",
            "0x0000",
            "0xfcc0"
          ],
          "output_clusters": [
            "0x0019"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "button": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "button",
            "class_name": "IdentifyButton",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "identify",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "command": "identify",
            "args": [
              5
            ],
            "kwargs": {}
          },
          "state": {
            "class_name": "IdentifyButton",
            "available": true
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 104
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -74
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Battery",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "battery",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": 0,
            "unit": "%"
          },
          "state": {
            "class_name": "Battery",
            "available": true,
            "state": 100.0,
            "battery_size": "Unknown",
            "battery_quantity": 1
          },
          "extra_state_attributes": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ]
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Temperature",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "temperature",
            "state_class": "measurement",
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "°C"
          },
          "state": {
            "class_name": "Temperature",
            "available": true,
            "state": 21.56
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Humidity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "humidity",
            "state_class": "measurement",
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "%"
          },
          "state": {
            "class_name": "Humidity",
            "available": true,
            "state": 47.62
          }
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x00001029",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": "0x00001029",
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
