### PR TITLE
Add network LED for Sonoff ZBM5 switches

### DIFF
--- a/zhaquirks/sonoff/zbm5.py
+++ b/zhaquirks/sonoff/zbm5.py
@@ -51,6 +51,11 @@ class SonoffCluster(CustomCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
 
+        network_led = ZCLAttributeDef(
+            id=0x0001,
+            type=t.Bool,
+            manufacturer_code=None,
+        )
         work_mode = ZCLAttributeDef(
             id=0x0018,
             type=SonoffWorkMode,

--- a/zhaquirks/sonoff/zbm5.py
+++ b/zhaquirks/sonoff/zbm5.py
@@ -166,6 +166,12 @@ zbm_1c_quirk = (
         fallback_name="Work mode",
     )
     .switch(
+        SonoffCluster.AttributeDefs.network_led.name,
+        SonoffCluster.cluster_id,
+        translation_key="network_led",
+        fallback_name="Network LED",
+    )
+    .switch(
         SonoffInputConfigCluster.AttributeDefs.relay_1_detached.name,
         SonoffInputConfigCluster.cluster_id,
         translation_key="detach_relay_id",


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR adds the ability to enable or disable the blue network LED for Sonoff ZBM5 switches.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
The Sonoff ZBM5 switch exposes a boolean attribute that allows enabling or disabling the network LED. If set to true, the color of one of the LEDs will be set to blue instead of orange when the switch is connected to a Zigbee network.

```
cluster_type: in
endpoint_id: 1
cluster_id: 0xfc11  # SonoffCluster
attribute: 0x0001   # Network LED
value:              # true/false
```

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-01KS5HW27AJRPQ1T943RD0NZKX-SONOFF ZBM5-3C-80_86-b5cee3e289ac95d3c1e38bef628c105b.json](https://github.com/user-attachments/files/29677722/zha-01KS5HW27AJRPQ1T943RD0NZKX-SONOFF.ZBM5-3C-80_86-b5cee3e289ac95d3c1e38bef628c105b.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
