### PR TITLE
Add Tuya TS0601 radiator thermostat _TZE200_a4bpgplm (GTZ06 / AVATTO TRV07)

### DIFF
--- a/tests/test_tuya_thermostat_a4bpgplm.py
+++ b/tests/test_tuya_thermostat_a4bpgplm.py
@@ -1,0 +1,154 @@
+"""Tests for Tuya TS0601 radiator thermostat _TZE200_a4bpgplm quirk."""
+
+from unittest import mock
+
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.hvac import RunningState, Thermostat
+
+from tests.common import ClusterListener, wait_for_zigpy_tasks
+import zhaquirks
+from zhaquirks.tuya.mcu import TuyaMCUCluster
+
+zhaquirks.setup()
+
+# Incoming Tuya "get data" frames -> (expected thermostat attribute, expected value).
+# Frame layout: <fc><tsn><cmd=0x02><status><seq><dp><type><len(2)><value>.
+TUYA_READ_PLAN = (
+    # DP1 system_mode/preset enum: 0=auto, 1=manual, 2=off, 3=on(valve open)
+    (
+        b"\t\xc2\x02\x00q\x01\x04\x00\x01\x00",
+        Thermostat.AttributeDefs.system_mode,
+        Thermostat.SystemMode.Auto,
+    ),
+    (
+        b"\t\xc2\x02\x00q\x01\x04\x00\x01\x01",
+        Thermostat.AttributeDefs.system_mode,
+        Thermostat.SystemMode.Heat,
+    ),
+    (
+        b"\t\xc2\x02\x00q\x01\x04\x00\x01\x02",
+        Thermostat.AttributeDefs.system_mode,
+        Thermostat.SystemMode.Off,
+    ),
+    (
+        b"\t\xc2\x02\x00q\x01\x04\x00\x01\x03",
+        Thermostat.AttributeDefs.system_mode,
+        Thermostat.SystemMode.Heat,
+    ),
+    # DP2 setpoint: Tuya degC*10 -> ZCL degC*100 (21.0 -> 2100)
+    (
+        b"\t\xc2\x02\x00q\x02\x02\x00\x04\x00\x00\x00\xd2",
+        Thermostat.AttributeDefs.occupied_heating_setpoint,
+        2100,
+    ),
+    # DP3 local temperature: 21.5 -> 2150
+    (
+        b"\t\xc2\x02\x00q\x03\x02\x00\x04\x00\x00\x00\xd7",
+        Thermostat.AttributeDefs.local_temperature,
+        2150,
+    ),
+    # DP6 running state: 1 -> heating, 0 -> idle
+    (
+        b"\t\xc2\x02\x00q\x06\x04\x00\x01\x01",
+        Thermostat.AttributeDefs.running_state,
+        RunningState.Heat_State_On,
+    ),
+    (
+        b"\t\xc2\x02\x00q\x06\x04\x00\x01\x00",
+        Thermostat.AttributeDefs.running_state,
+        RunningState.Idle,
+    ),
+)
+
+# Outgoing frame for occupied_heating_setpoint=2500 (DP2 = 2500 // 10 = 250 = 0xFA).
+SETPOINT_WRITE_FRAME = b"\x01\x01\x00\x00\x01\x02\x02\x00\x04\x00\x00\x00\xfa"
+
+
+async def test_a4bpgplm_read(zigpy_device_from_v2_quirk):
+    """Incoming datapoints update the thermostat cluster attributes."""
+    quirked = zigpy_device_from_v2_quirk("_TZE200_a4bpgplm", "TS0601")
+    ep = quirked.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+    assert isinstance(ep.thermostat, Thermostat)
+
+    # Heating-only radiator valve, 5-35 degC range advertised to HA.
+    assert (
+        ep.thermostat.get(Thermostat.AttributeDefs.ctrl_sequence_of_oper.id)
+        == Thermostat.ControlSequenceOfOperation.Heating_Only
+    )
+    assert (
+        ep.thermostat.get(Thermostat.AttributeDefs.abs_min_heat_setpoint_limit.id)
+        == 500
+    )
+    assert (
+        ep.thermostat.get(Thermostat.AttributeDefs.abs_max_heat_setpoint_limit.id)
+        == 3500
+    )
+
+    for msg, attr, value in TUYA_READ_PLAN:
+        listener = ClusterListener(ep.thermostat)
+        hdr, data = ep.tuya_manufacturer.deserialize(msg)
+        status = ep.tuya_manufacturer.handle_get_data(data.data)
+        assert status == foundation.Status.SUCCESS
+
+        assert len(listener.attribute_updates) == 1
+        assert listener.attribute_updates[0][0] == attr.id
+        assert listener.attribute_updates[0][1] == value
+        assert ep.thermostat.get(attr.id) == value
+
+
+async def test_a4bpgplm_write_setpoint(zigpy_device_from_v2_quirk):
+    """Writing the setpoint is scaled back to Tuya degC*10 and sent on DP2."""
+    quirked = zigpy_device_from_v2_quirk("_TZE200_a4bpgplm", "TS0601")
+    ep = quirked.endpoints[1]
+
+    async def async_success(*args, **kwargs):
+        return foundation.Status.SUCCESS
+
+    with mock.patch.object(
+        ep.tuya_manufacturer.endpoint, "request", side_effect=async_success
+    ) as m1:
+        (status,) = await ep.thermostat.write_attributes(
+            {"occupied_heating_setpoint": 2500}
+        )
+        await wait_for_zigpy_tasks()
+        assert status[0].status == foundation.Status.SUCCESS
+
+        kwargs = m1.call_args.kwargs
+        assert kwargs["cluster"] == 0xEF00
+        assert kwargs["command_id"] == 0
+        assert kwargs["data"] == SETPOINT_WRITE_FRAME
+
+
+async def test_a4bpgplm_write_system_mode(zigpy_device_from_v2_quirk):
+    """system_mode writes DP1 as an ENUM datapoint (type 0x04).
+
+    Regression guard: a plain int would be sent as a 4-byte VALUE (type 0x02)
+    and the device silently ignores it (e.g. Off would never close the valve).
+    DP1 payload tail is <dp=01><type=04><len=0001><value>: off=2, heat(manual)=1, auto=0.
+    """
+    quirked = zigpy_device_from_v2_quirk("_TZE200_a4bpgplm", "TS0601")
+    ep = quirked.endpoints[1]
+
+    async def async_success(*args, **kwargs):
+        return foundation.Status.SUCCESS
+
+    cases = (
+        (Thermostat.SystemMode.Off, 0x02),
+        (Thermostat.SystemMode.Heat, 0x01),
+        (Thermostat.SystemMode.Auto, 0x00),
+    )
+    for mode, dp_value in cases:
+        with mock.patch.object(
+            ep.tuya_manufacturer.endpoint, "request", side_effect=async_success
+        ) as m1:
+            await ep.thermostat.write_attributes({"system_mode": mode})
+            await wait_for_zigpy_tasks()
+
+            kwargs = m1.call_args.kwargs
+            assert kwargs["cluster"] == 0xEF00
+            assert kwargs["command_id"] == 0
+            # <dp=1><type=0x04 enum><len=0x0001><value>
+            assert kwargs["data"].endswith(bytes([0x01, 0x04, 0x00, 0x01, dp_value]))

--- a/zhaquirks/tuya/ts0601_thermostat_a4bpgplm.py
+++ b/zhaquirks/tuya/ts0601_thermostat_a4bpgplm.py
@@ -1,0 +1,252 @@
+"""ZHA custom quirk for Tuya TS0601 radiator thermostat.
+
+Manufacturer: _TZE200_a4bpgplm (and siblings), model TS0601.
+z2m model: TS0601_thermostat_1 ("Thermostatic radiator valve").
+whiteLabel: id3 GTZ06, AVATTO TRV07.
+
+Datapoint map taken from zigbee-herdsman-converters devices/tuya.ts.
+DP1 semantics (thermostatSystemModeAndPreset), raw value:
+    0 = auto (schedule), 1 = manual, 2 = off, 3 = on (valve forced open).
+Temperatures on the Tuya side are degC*10; the ZCL Thermostat cluster
+expects degC*100, hence the *10 / //10 converters.
+"""
+
+import zigpy.types as t
+from zigpy.zcl.clusters.hvac import RunningState, Thermostat
+
+from zhaquirks.builder import (
+    BinarySensorDeviceClass,
+    EntityType,
+    SensorStateClass,
+    UnitOfTemperature,
+)
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.mcu import TuyaAttributesCluster
+
+
+class ThermostatTRV(Thermostat, TuyaAttributesCluster):
+    """Heating-only radiator thermostat, 5-35 degC setpoint range."""
+
+    _CONSTANT_ATTRIBUTES = {
+        Thermostat.AttributeDefs.abs_min_heat_setpoint_limit.id: 500,
+        Thermostat.AttributeDefs.abs_max_heat_setpoint_limit.id: 3500,
+        Thermostat.AttributeDefs.min_heat_setpoint_limit.id: 500,
+        Thermostat.AttributeDefs.max_heat_setpoint_limit.id: 3500,
+        Thermostat.AttributeDefs.ctrl_sequence_of_oper.id: (
+            Thermostat.ControlSequenceOfOperation.Heating_Only
+        ),
+    }
+
+    def __init__(self, *args, **kwargs):
+        """Mark standard thermostat attributes the device never reports."""
+        super().__init__(*args, **kwargs)
+        for attr in (
+            Thermostat.AttributeDefs.pi_heating_demand.id,
+            Thermostat.AttributeDefs.setpoint_change_source.id,
+            Thermostat.AttributeDefs.setpoint_change_source_timestamp.id,
+            Thermostat.AttributeDefs.setpoint_change_amount.id,
+        ):
+            self.add_unsupported_attribute(attr)
+
+
+class ScreenOrientation(t.enum8):
+    """DP116 screen orientation."""
+
+    up = 0
+    down = 2
+
+
+class DisplayBrightness(t.enum8):
+    """DP152 display brightness."""
+
+    high = 0
+    middle = 1
+    low = 2
+
+
+class HysteresisMode(t.enum8):
+    """DP153 hysteresis mode."""
+
+    comfort = 0
+    eco = 1
+
+
+class TuyaSystemMode(t.enum8):
+    """Raw DP1 values (Tuya enum): combined system_mode/preset."""
+
+    auto = 0  # schedule
+    manual = 1  # follow setpoint
+    off = 2  # valve closed
+    on = 3  # valve forced open
+
+
+# DP1 (Tuya) <-> ZCL Thermostat.SystemMode.
+# The write value MUST be a t.enum8 member so the Tuya MCU serializes it as an
+# ENUM datapoint (type 0x04); a plain int would be sent as a 4-byte VALUE and
+# the device silently ignores the mode change (e.g. Off would not close).
+_TUYA_TO_SYSMODE = {
+    TuyaSystemMode.auto: Thermostat.SystemMode.Auto,
+    TuyaSystemMode.manual: Thermostat.SystemMode.Heat,
+    TuyaSystemMode.off: Thermostat.SystemMode.Off,
+    TuyaSystemMode.on: Thermostat.SystemMode.Heat,
+}
+_SYSMODE_TO_TUYA = {
+    Thermostat.SystemMode.Auto: TuyaSystemMode.auto,
+    Thermostat.SystemMode.Heat: TuyaSystemMode.manual,
+    Thermostat.SystemMode.Off: TuyaSystemMode.off,
+}
+
+
+(
+    TuyaQuirkBuilder("_TZE200_a4bpgplm", "TS0601")
+    .applies_to("_TZE200_dv8abrrz", "TS0601")
+    .applies_to("_TZE200_z1tyspqw", "TS0601")
+    .applies_to("_TZE200_bvrlmajk", "TS0601")
+    # ----- climate (Thermostat cluster) -----
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=ThermostatTRV.ep_attribute,
+        attribute_name=ThermostatTRV.AttributeDefs.system_mode.name,
+        converter=lambda x: _TUYA_TO_SYSMODE.get(x, Thermostat.SystemMode.Heat),
+        dp_converter=lambda x: _SYSMODE_TO_TUYA.get(x, TuyaSystemMode.manual),
+    )
+    .tuya_dp(
+        dp_id=2,
+        ep_attribute=ThermostatTRV.ep_attribute,
+        attribute_name=ThermostatTRV.AttributeDefs.occupied_heating_setpoint.name,
+        converter=lambda x: x * 10,
+        dp_converter=lambda x: x // 10,
+    )
+    .tuya_dp(
+        dp_id=3,
+        ep_attribute=ThermostatTRV.ep_attribute,
+        attribute_name=ThermostatTRV.AttributeDefs.local_temperature.name,
+        converter=lambda x: x * 10,
+    )
+    .tuya_dp(
+        dp_id=6,
+        ep_attribute=ThermostatTRV.ep_attribute,
+        attribute_name=ThermostatTRV.AttributeDefs.running_state.name,
+        converter=lambda x: RunningState.Heat_State_On if x else RunningState.Idle,
+    )
+    # ----- switches -----
+    .tuya_switch(
+        dp_id=4,
+        attribute_name="boost_heating",
+        translation_key="boost_heating",
+        fallback_name="Boost heating",
+    )
+    .tuya_switch(
+        dp_id=8,
+        attribute_name="window_detection",
+        translation_key="window_detection",
+        fallback_name="Open window detection",
+    )
+    .tuya_switch(
+        dp_id=12,
+        attribute_name="child_lock",
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    # ----- numbers -----
+    .tuya_number(
+        dp_id=5,
+        type=t.uint16_t,
+        attribute_name="boost_time",
+        min_value=0,
+        max_value=1000,
+        step=1,
+        unit="min",
+        translation_key="boost_time",
+        fallback_name="Boost time",
+    )
+    .tuya_number(
+        dp_id=15,
+        type=t.uint16_t,
+        attribute_name="min_temperature",
+        min_value=1,
+        max_value=15,
+        step=0.5,
+        multiplier=0.1,
+        unit=UnitOfTemperature.CELSIUS,
+        translation_key="min_temperature",
+        fallback_name="Min temperature",
+    )
+    .tuya_number(
+        dp_id=16,
+        type=t.uint16_t,
+        attribute_name="max_temperature",
+        min_value=15,
+        max_value=35,
+        step=0.5,
+        multiplier=0.1,
+        unit=UnitOfTemperature.CELSIUS,
+        translation_key="max_temperature",
+        fallback_name="Max temperature",
+    )
+    .tuya_number(
+        dp_id=154,
+        type=t.uint16_t,
+        attribute_name="switch_deviation_eco",
+        min_value=0.5,
+        max_value=5.0,
+        step=0.1,
+        multiplier=0.1,
+        unit=UnitOfTemperature.CELSIUS,
+        translation_key="switch_deviation_eco",
+        fallback_name="Eco switch deviation",
+    )
+    # ----- sensors -----
+    .tuya_sensor(
+        dp_id=102,
+        type=t.uint16_t,
+        attribute_name="valve_position",
+        divisor=10,
+        unit="%",
+        entity_type=EntityType.DIAGNOSTIC,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="valve_position",
+        fallback_name="Valve position",
+    )
+    .tuya_battery(dp_id=13)
+    # ----- binary sensors -----
+    .tuya_binary_sensor(
+        dp_id=7,
+        attribute_name="window_open",
+        device_class=BinarySensorDeviceClass.WINDOW,
+        translation_key="window_open",
+        fallback_name="Window open",
+    )
+    .tuya_binary_sensor(
+        dp_id=14,
+        attribute_name="error_state",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        translation_key="error_state",
+        fallback_name="Error",
+    )
+    # ----- selects (enums) -----
+    .tuya_enum(
+        dp_id=116,
+        attribute_name="screen_orientation",
+        enum_class=ScreenOrientation,
+        translation_key="screen_orientation",
+        fallback_name="Screen orientation",
+    )
+    .tuya_enum(
+        dp_id=152,
+        attribute_name="display_brightness",
+        enum_class=DisplayBrightness,
+        translation_key="display_brightness",
+        fallback_name="Display brightness",
+    )
+    .tuya_enum(
+        dp_id=153,
+        attribute_name="hysteresis_mode",
+        enum_class=HysteresisMode,
+        translation_key="hysteresis_mode",
+        fallback_name="Hysteresis mode",
+    )
+    .adds(ThermostatTRV)
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
## Description

Adds a v2 `TuyaQuirkBuilder` quirk for the Tuya **TS0601 thermostatic radiator valve** reported as `_TZE200_a4bpgplm` (and siblings `_TZE200_dv8abrrz`, `_TZE200_z1tyspqw`, `_TZE200_bvrlmajk`).

In zigbee-herdsman-converters this is model `TS0601_thermostat_1` — white labels **id3 GTZ06** and **AVATTO TRV07**. It was not handled by ZHA (datapoints not decoded, no climate entity).

### Entities
- **climate** (heating-only, 5–35 °C): system mode (DP1), setpoint (DP2), local temperature (DP3), running state (DP6)
- **switch**: boost heating (DP4), open-window detection (DP8), child lock (DP12)
- **number**: boost time (DP5), min/max temperature (DP15/16), eco switch deviation (DP154)
- **sensor**: valve position (DP102), battery (DP13)
- **binary_sensor**: window (DP7), error (DP14)
- **select**: screen orientation (DP116), display brightness (DP152), hysteresis mode (DP153)

Standard ZCL thermostat attributes the device never reports (`pi_heating_demand`, `setpoint_change_source`, `setpoint_change_source_timestamp`, `setpoint_change_amount`) are marked unsupported so they don't surface as `Unknown` entities, mirroring `TuyaThermostatV2`.

Datapoint map taken from zigbee-herdsman-converters (`devices/tuya.ts`).

## Testing
- Added `tests/test_tuya_thermostat_a4bpgplm.py` covering datapoint reads (mode/setpoint/local temp/running state) and setpoint writes.
- `pytest tests/test_quirks.py` and the tuya suites pass; `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpXvQmgReJBBVwtmyuM99b