### PR TITLE
Add Tuya/Moes roller shade motor `_TZE204_xtrnjaoz` (TS0601) support

### DIFF
--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -10,7 +10,7 @@ import zhaquirks
 from zhaquirks.device import CustomZigpyDevice
 from zhaquirks.tuya import TuyaCommand, TuyaData, TuyaDatapointData
 from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaWindowCovering
-from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601
+from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601, TuyaMoesCover0601MCU
 
 zhaquirks.setup()
 
@@ -32,6 +32,158 @@ def test_ts601_moes_signature(assert_signature_matches_quirk):
         "class": "zigpy.device.Device",
     }
     assert_signature_matches_quirk(TuyaMoesCover0601, signature)
+
+
+def test_ts0601_xtrnjaoz_signature(assert_signature_matches_quirk):
+    """Test _TZE204_xtrnjaoz cover signature is matched to its quirk."""
+    signature = {
+        "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4417, maximum_buffer_size=66, maximum_incoming_transfer_size=66, server_mask=10752, maximum_outgoing_transfer_size=66, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
+        "endpoints": {
+            "1": {
+                "profile_id": 0x0104,
+                "device_type": "0x0051",
+                "in_clusters": ["0x0004", "0x0005", "0xef00", "0x0000"],
+                "out_clusters": ["0x0019", "0x000a"],
+            },
+            "242": {
+                "profile_id": 0xA1E0,
+                "device_type": "0x0061",
+                "in_clusters": [],
+                "out_clusters": ["0x0021"],
+            },
+        },
+        "manufacturer": "_TZE204_xtrnjaoz",
+        "model": "TS0601",
+        "class": "zigpy.device.Device",
+    }
+    assert_signature_matches_quirk(TuyaMoesCover0601MCU, signature)
+
+
+async def test_ts0601_xtrnjaoz_open_command(zigpy_device_from_quirk):
+    """Test that the open command sends device value 0 for this device."""
+
+    quirked = zigpy_device_from_quirk(TuyaMoesCover0601MCU)
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.up_open.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x01" in call_data  # DP ID 1 (curtain_switch)
+        assert call_data[-1:] == b"\x00"  # device value = 0 (Open)
+
+
+async def test_ts0601_xtrnjaoz_close_command(zigpy_device_from_quirk):
+    """Test that the close command sends device value 2 for this device."""
+
+    quirked = zigpy_device_from_quirk(TuyaMoesCover0601MCU)
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.down_close.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x01" in call_data  # DP ID 1 (curtain_switch)
+        assert call_data[-1:] == b"\x02"  # device value = 2 (Close)
+
+
+async def test_ts0601_xtrnjaoz_stop_command(zigpy_device_from_quirk):
+    """Test that the stop command sends device value 1 for this device."""
+
+    quirked = zigpy_device_from_quirk(TuyaMoesCover0601MCU)
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.stop.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x01" in call_data  # DP ID 1 (curtain_switch)
+        assert call_data[-1:] == b"\x01"  # device value = 1 (Stop)
+
+
+async def test_ts0601_xtrnjaoz_unsupported_command(zigpy_device_from_quirk):
+    """Test that an unsupported command_id returns UNSUP_CLUSTER_COMMAND."""
+
+    quirked = zigpy_device_from_quirk(TuyaMoesCover0601MCU)
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+
+    response = await cover_cluster.command(0xFF)
+
+    assert response.status == foundation.Status.UNSUP_CLUSTER_COMMAND
+
+
+async def test_ts0601_xtrnjaoz_go_to_lift_percentage(zigpy_device_from_quirk):
+    """Test that go_to_lift_percentage forwards the raw percentage (no inversion)."""
+
+    quirked = zigpy_device_from_quirk(TuyaMoesCover0601MCU)
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(
+            WindowCovering.ServerCommandDefs.go_to_lift_percentage.id, 42
+        )
+        await wait_for_zigpy_tasks()
+
+        assert req_mock.call_count >= 1
+        found_value = False
+        for call in req_mock.call_args_list:
+            call_data = call[1]["data"]
+            if call_data[-1:] == b"\x2a":  # 42 decimal
+                found_value = True
+        assert found_value
+
+
+async def test_ts0601_xtrnjaoz_position_report(zigpy_device_from_quirk):
+    """Test that an incoming DP8 position report updates the ZCL attribute directly (no inversion)."""
+
+    quirked = zigpy_device_from_quirk(TuyaMoesCover0601MCU)
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[TuyaDatapointData(8, TuyaData(42))],
+        )
+    )
+
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 42
+    )
 
 
 async def test_zemismart_zm16b_quirk(zigpy_device_from_v2_quirk):

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -2,7 +2,18 @@
 
 from zigpy.profiles import zha
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import (
+    Basic,
+    GreenPowerProxy,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    Scenes,
+    Time,
+)
 
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -14,12 +25,16 @@ from zhaquirks.const import (
 )
 from zhaquirks.tuya import (
     TUYA_CLUSTER_ID,
+    TUYA_MCU_COMMAND,
+    NoManufacturerCluster,
+    TuyaLocalCluster,
     TuyaManufacturerWindowCover,
     TuyaManufCluster,
     TuyaWindowCover,
     TuyaWindowCoverControl,
 )
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaClusterData, TuyaMCUCluster
 
 
 class TuyaZemismartSmartCover0601(TuyaWindowCover):
@@ -705,3 +720,160 @@ class BorderSetting(t.enum8):
     .skip_configuration()
     .add_to_registry()
 )
+
+# Maps ZCL WindowCovering server commands (up_open/down_close/stop) to this
+# device's "curtain_switch" Tuya datapoint values (standard TuyaCoverControl
+# order, confirmed against zigbee-herdsman-converters' moes.ts).
+TUYA2ZB_COMMANDS_MOES_0601 = {
+    WindowCovering.ServerCommandDefs.up_open.id: 0x00,
+    WindowCovering.ServerCommandDefs.down_close.id: 0x02,
+    WindowCovering.ServerCommandDefs.stop.id: 0x01,
+}
+
+
+class TuyaMoesWindowCovering0601MCU(
+    NoManufacturerCluster, WindowCovering, TuyaLocalCluster
+):
+    """Tuya MCU WindowCovering cluster for the Moes GM25TEQ-TYZ-2/25 roller motor."""
+
+    attributes = WindowCovering.attributes.copy()
+    attributes.update(
+        {
+            0xF000: ("curtain_switch", t.enum8, True),  # 0: open, 1: stop, 2: close
+        }
+    )
+
+    async def command(
+        self,
+        command_id: foundation.GeneralCommand | int | t.uint8_t,
+        *args,
+        manufacturer: int | t.uint16_t | None = None,
+        expect_reply: bool = True,
+        tsn: int | t.uint8_t | None = None,
+    ):
+        """Override the default Cluster command."""
+
+        self.debug(
+            "Sending Tuya Cluster Command. Cluster Command is %x, Arguments are %s",
+            command_id,
+            args,
+        )
+
+        if command_id in TUYA2ZB_COMMANDS_MOES_0601:
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_name=self.ep_attribute,
+                cluster_attr="curtain_switch",
+                attr_value=t.enum8(TUYA2ZB_COMMANDS_MOES_0601[command_id]),
+                expect_reply=expect_reply,
+                manufacturer=manufacturer,
+            )
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cluster_data,
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        if command_id == WindowCovering.ServerCommandDefs.go_to_lift_percentage.id:
+            lift_value = args[0]
+
+            cluster_data = TuyaClusterData(
+                endpoint_id=self.endpoint.endpoint_id,
+                cluster_name=self.ep_attribute,
+                cluster_attr="current_position_lift_percentage",
+                attr_value=lift_value,
+                expect_reply=expect_reply,
+                manufacturer=manufacturer,
+            )
+            self.endpoint.device.command_bus.listener_event(
+                TUYA_MCU_COMMAND,
+                cluster_data,
+            )
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
+
+        self.warning("Unsupported command_id: %s", command_id)
+        return foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(command_id=command_id, status=foundation.Status.UNSUP_CLUSTER_COMMAND)
+
+
+class TuyaMoesCoverManufCluster0601MCU(TuyaMCUCluster):
+    """Tuya MCU cluster with the Moes GM25TEQ-TYZ-2/25 roller motor's datapoints."""
+
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
+        1: DPToAttributeMapping(
+            TuyaMoesWindowCovering0601MCU.ep_attribute,
+            "curtain_switch",
+        ),
+        # DP9: set target position (outbound)
+        9: DPToAttributeMapping(
+            TuyaMoesWindowCovering0601MCU.ep_attribute,
+            "current_position_lift_percentage",
+        ),
+        # DP8: current position report (inbound)
+        8: DPToAttributeMapping(
+            TuyaMoesWindowCovering0601MCU.ep_attribute,
+            "current_position_lift_percentage",
+        ),
+    }
+
+    data_point_handlers = {
+        1: "_dp_2_attr_update",
+        8: "_dp_2_attr_update",
+        9: "_dp_2_attr_update",
+    }
+
+
+class TuyaMoesCover0601MCU(TuyaWindowCover):
+    """Tuya Moes GM25TEQ-TYZ-2/25 roller shade blinds motor for 38mm tube."""
+
+    signature = {
+        MODELS_INFO: [
+            ("_TZE204_xtrnjaoz", "TS0601"),
+        ],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaMoesCoverManufCluster0601MCU.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaMoesCoverManufCluster0601MCU,
+                    TuyaMoesWindowCovering0601MCU,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                PROFILE_ID: 41440,
+                DEVICE_TYPE: 97,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        }
+    }


### PR DESCRIPTION
## Summary

Adds ZHA quirk support for the Moes GM25TEQ-TYZ-2/25 roller shade
blinds motor (`_TZE204_xtrnjaoz`).

The DP mapping is confirmed against
[zigbee-herdsman-converters (moes.ts)](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/moes.ts):
- DP1: control (`Open=0x00, Stop=0x01, Close=0x02`, standard `TuyaCoverControl` order)
- DP9: set target lift position (0-100, no inversion needed on the ZCL side)
- DP8: current lift position report (0-100, no inversion needed on the ZCL side)

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Added unit tests covering signature matching and the
      open/close/stop/go_to_lift_percentage/position-report paths
      (`tests/test_tuya_cover.py`)
- [x] Full test suite passes (`pytest tests/`)
- [x] Verified against physical hardware: open, close, stop and
      lift-percentage slider all work correctly from Home Assistant

<details>
<summary>Device diagnostics dump</summary>

```json
{
  "home_assistant": {
    "arch": "aarch64",
    "dev": false,
    "docker": true,
    "hassio": false,
    "installation_type": "Home Assistant Container",
    "os_name": "Linux",
    "os_version": "6.12.47+rpt-rpi-2712",
    "python_version": "3.14.5",
    "timezone": "Europe/Moscow",
    "version": "2026.6.2",
    "virtualenv": false,
    "container_arch": "aarch64",
    "run_as_root": true
  },
  "custom_components": {
    "gyvertwink": {
      "documentation": "https://github.com/DmitryKolyadin/GyverTwinkHA",
      "version": "1.0.0",
      "requirements": []
    },
    "moonraker": {
      "documentation": "https://moonraker-home-assistant.readthedocs.io/en/latest/",
      "version": "1.13.1",
      "requirements": [
        "moonraker-api==2.0.6"
      ]
    },
    "yainternetometr": {
      "documentation": "https://github.com/ErilovNikita/ha-yainternetometr#readme",
      "version": "v1.1.1",
      "requirements": [
        "yaspeedtest==0.1.7"
      ]
    },
    "polaris": {
      "documentation": "https://github.com/samoswall/polaris-mqtt",
      "version": "1.0.13",
      "requirements": []
    },
    "ui_lovelace_minimalist": {
      "documentation": "https://ui-lovelace-minimalist.github.io/UI/",
      "version": "v1.5.0",
      "requirements": [
        "aiofiles>=0.8.0",
        "aiogithubapi>=22.2.4"
      ]
    },
    "yandex_pogoda": {
      "documentation": "https://github.com/yandex/pogoda-home-assistant/wiki",
      "version": "0.0.10",
      "requirements": []
    },
    "custom_icons": {
      "documentation": "https://github.com/thomasloven/hass-custom_icons",
      "version": "1.0.1",
      "requirements": []
    },
    "yandex_smart_home": {
      "documentation": "https://docs.yaha-cloud.ru/v1.1.x/",
      "version": "1.1.2",
      "requirements": []
    },
    "dreame_vacuum": {
      "documentation": "https://github.com/Tasshack/dreame-vacuum/tree/dev?tab=readme-ov-file#features",
      "version": "v2.0.0b25",
      "requirements": [
        "pillow",
        "numpy",
        "requests",
        "pycryptodome",
        "python-miio",
        "mini-racer",
        "paho-mqtt"
      ]
    },
    "localtuya": {
      "documentation": "https://github.com/rospogrigio/localtuya/",
      "version": "5.2.3",
      "requirements": []
    },
    "simpleicons": {
      "documentation": "https://github.com/vigonotion/hass-simpleicons",
      "version": "v2.4.1",
      "requirements": [
        "simplepycons==1!15.3.0"
      ]
    },
    "yandex_station": {
      "documentation": "https://github.com/AlexxIT/YandexStation",
      "version": "3.20.3",
      "requirements": []
    },
    "hacs": {
      "documentation": "https://hacs.xyz/docs/use/",
      "version": "2.0.5",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==1.4.1"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 7.481500506401062e-05
    },
    "01K7PVHA8GZCXZYGFQ5YNSGFDM": {
      "wait_import_platforms": -0.018386152980383486,
      "config_entry_setup": 5.543311810994055
    }
  },
  "data": {
    "version": 2,
    "ieee": "**REDACTED**",
    "nwk": "0x6F4E",
    "manufacturer": "_TZE204_xtrnjaoz",
    "model": "TS0601",
    "friendly_manufacturer": "_TZE204_xtrnjaoz",
    "friendly_model": "TS0601",
    "name": "_TZE204_xtrnjaoz TS0601",
    "quirk_applied": true,
    "quirk_class": "kitcher_curtain_motor.TuyaCurtainMotor_TZE204_xtrnjaoz",
    "exposes_features": [],
    "manufacturer_code": 4417,
    "power_source": "Mains",
    "lqi": 156,
    "rssi": -61,
    "last_seen": "2026-07-06T17:09:26.499900+00:00",
    "available": true,
    "device_type": "Router",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "Router",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 142,
      "manufacturer_code": 4417,
      "maximum_buffer_size": 66,
      "maximum_incoming_transfer_size": 66,
      "server_mask": 10752,
      "maximum_outgoing_transfer_size": 66,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "WINDOW_COVERING_DEVICE",
          "id": 514
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0001",
                "name": "app_version",
                "zcl_type": "uint8",
                "value": 74
              },
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "_TZE204_xtrnjaoz"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "TS0601"
              }
            ]
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x0005",
            "endpoint_attribute": "scenes",
            "attributes": []
          },
          {
            "cluster_id": "0x0102",
            "endpoint_attribute": "window_covering",
            "attributes": [
              {
                "id": "0x0007",
                "name": "config_status",
                "zcl_type": "map8",
                "unsupported": true
              },
              {
                "id": "0x0008",
                "name": "current_position_lift_percentage",
                "zcl_type": "uint8",
                "value": 50
              },
              {
                "id": "0x0009",
                "name": "current_position_tilt_percentage",
                "zcl_type": "uint8",
                "unsupported": true
              },
              {
                "id": "0xf000",
                "name": "curtain_switch",
                "zcl_type": "enum8",
                "value": 1
              },
              {
                "id": "0x0017",
                "name": "window_covering_mode",
                "zcl_type": "map8",
                "unsupported": true
              },
              {
                "id": "0x0000",
                "name": "window_covering_type",
                "zcl_type": "enum8",
                "value": 0
              }
            ]
          },
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": "tuya_manufacturer",
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 74
              }
            ],
            "last_query_cmd": {
              "manufacturer_code": 4417,
              "image_type": 54179,
              "current_file_version": 74,
              "hardware_version": null
            }
          }
        ]
      },
      "242": {
        "profile_id": 41440,
        "device_type": {
          "name": "PROXY_BASIC",
          "id": 97
        },
        "in_clusters": [],
        "out_clusters": [
          {
            "cluster_id": "0x0021",
            "endpoint_attribute": "green_power",
            "attributes": []
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "_TZE204_xtrnjaoz",
      "model": "TS0601",
      "node_desc": {
        "logical_type": 1,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 142,
        "manufacturer_code": 4417,
        "maximum_buffer_size": 66,
        "maximum_incoming_transfer_size": 66,
        "server_mask": 10752,
        "maximum_outgoing_transfer_size": 66,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0051",
          "input_clusters": [
            "0x0004",
            "0x0005",
            "0xef00",
            "0x0000"
          ],
          "output_clusters": [
            "0x0019",
            "0x000a"
          ]
        },
        "242": {
          "profile_id": "0xa1e0",
          "device_type": "0x0061",
          "input_clusters": [],
          "output_clusters": [
            "0x0021"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "cover": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "cover",
            "class_name": "Cover",
            "translation_key": "cover",
            "translation_placeholders": null,
            "device_class": "shade",
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": true,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null
          },
          "state": {
            "class_name": "Cover",
            "available": true,
            "current_position": 50,
            "current_tilt_position": null,
            "state": "open",
            "is_opening": false,
            "is_closing": false,
            "is_closed": false,
            "supported_features": 15
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 156
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -61
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "WindowCoveringTypeSensor",
            "translation_key": "window_covering_type",
            "translation_placeholders": null,
            "device_class": "enum",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "WindowCoveringTypeSensor",
            "available": true,
            "state": "Rollershade"
          }
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x0000004a",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [
      {
        "device_type": "Coordinator",
        "rx_on_when_idle": "On",
        "relationship": "Parent",
        "extended_pan_id": "**REDACTED**",
        "ieee": "**REDACTED**",
        "nwk": "0x0000",
        "permit_joining": "Unknown",
        "depth": 0,
        "lqi": 88
      },
      {
        "device_type": "Router",
        "rx_on_when_idle": "On",
        "relationship": "Parent",
        "extended_pan_id": "**REDACTED**",
        "ieee": "**REDACTED**",
        "nwk": "0xA326",
        "permit_joining": "Unknown",
        "depth": 1,
        "lqi": 54
      },
      {
        "device_type": "Router",
        "rx_on_when_idle": "On",
        "relationship": "Sibling",
        "extended_pan_id": "**REDACTED**",
        "ieee": "**REDACTED**",
        "nwk": "0x4F48",
        "permit_joining": "Unknown",
        "depth": 0,
        "lqi": 0
      },
      {
        "device_type": "Router",
        "rx_on_when_idle": "On",
        "relationship": "Sibling",
        "extended_pan_id": "**REDACTED**",
        "ieee": "**REDACTED**",
        "nwk": "0x8278",
        "permit_joining": "Unknown",
        "depth": 0,
        "lqi": 0
      }
    ],
    "routes": []
  },
  "issues": []
}
```

</details>
