### PR TITLE
Expose basic siren for Frient HESZB-120 heat alarm

### DIFF
--- a/zhaquirks/develco/heat_alarm.py
+++ b/zhaquirks/develco/heat_alarm.py
@@ -1,13 +1,36 @@
 """Frient Heat Detector."""
 
-from zhaquirks.builder import QuirkBuilder
+from zha.quirks import SIREN_BASIC
+from zigpy.zcl.clusters.general import BinaryInput
+from zigpy.zcl.clusters.security import IasWd, IasZone
 
-from . import DevelcoIasZone, DevelcoPowerConfiguration
+from zhaquirks.builder import EntityType, QuirkBuilder
+from zhaquirks.develco import DevelcoIasZone, DevelcoPowerConfiguration
 
 (
     QuirkBuilder("frient A/S", "HESZB-120")
     .applies_to("Develco Products A/S", "HESZB-120")
     .replaces(DevelcoIasZone, endpoint_id=35)
     .replaces(DevelcoPowerConfiguration, endpoint_id=35)
+    # The device only has basic siren features, so hint that to ZHA
+    .exposes_feature(SIREN_BASIC)
+    # Hide the default binary input sensor
+    .prevent_default_entity_creation(
+        endpoint_id=35,
+        cluster_id=BinaryInput.cluster_id,
+    )
+    # The IAS Zone sensor should be primary
+    .change_entity_metadata(
+        endpoint_id=35,
+        cluster_id=IasZone.cluster_id,
+        new_primary=True,
+    )
+    # Not the siren
+    .change_entity_metadata(
+        endpoint_id=35,
+        cluster_id=IasWd.cluster_id,
+        new_primary=False,
+        new_entity_category=EntityType.CONFIG,
+    )
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
Mirror the SMSZB-120 smoke alarm quirk: the HESZB-120 exposes a full advanced siren (tones/volume/duration) by default, but the device only supports basic siren features. Hint `SIREN_BASIC` to ZHA, hide the default binary input sensor, make the IAS Zone sensor primary, and demote the siren to a config entity.

With this PR, the quirk is now identical to the Frient smoke sensor and water leak sensor quirk.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
This was missed in the below PR because no diagnostics were in the ZHA database:
- https://github.com/zigpy/zha-device-handlers/pull/4854


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
See:
- https://github.com/zigpy/zha-device-handlers/pull/4460


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
