### PR TITLE
Add Busch-Jaeger 6737 (RM01) and 6737/01 (RB01) quirk

### DIFF
--- a/tests/test_busch_jaeger.py
+++ b/tests/test_busch_jaeger.py
@@ -1,0 +1,74 @@
+"""Tests for Busch-Jaeger ZigBee Light Link wall transmitter quirks."""
+
+import pytest
+from zha.quirks import QUIRK_REGISTRY_ENTRY_ATTR
+from zigpy.zcl import ClusterType
+from zigpy.zcl.clusters.general import LevelControl, OnOff
+
+import zhaquirks
+
+zhaquirks.setup()
+
+ROW_ENDPOINTS = {1: 0x0A, 2: 0x0B, 3: 0x0C, 4: 0x0D}
+
+
+def _rocker_clusters() -> dict:
+    """OnOff + LevelControl as output (client) clusters on each rocker endpoint."""
+    return {
+        endpoint: {
+            OnOff.cluster_id: ClusterType.Client,
+            LevelControl.cluster_id: ClusterType.Client,
+        }
+        for endpoint in ROW_ENDPOINTS.values()
+    }
+
+
+def _triggers(device) -> dict:
+    """Return the device automation triggers of the applied quirk."""
+    entry = getattr(device, QUIRK_REGISTRY_ENTRY_ATTR)
+    return entry.zha_device_factory.quirk_definition.device_automation_triggers
+
+
+@pytest.mark.parametrize("model", ["RM01", "RB01"])
+def test_quirk_applies(zigpy_device_from_v2_quirk, model):
+    """The quirk applies to both Busch-Jaeger models."""
+    device = zigpy_device_from_v2_quirk(
+        "Busch-Jaeger", model, cluster_ids=_rocker_clusters()
+    )
+    assert getattr(device, QUIRK_REGISTRY_ENTRY_ATTR, None) is not None
+
+
+@pytest.mark.parametrize("model", ["RM01", "RB01"])
+def test_device_automation_triggers(zigpy_device_from_v2_quirk, model):
+    """Every rocker row exposes on/off and dim triggers on its own endpoint."""
+    device = zigpy_device_from_v2_quirk(
+        "Busch-Jaeger", model, cluster_ids=_rocker_clusters()
+    )
+    triggers = _triggers(device)
+
+    for row, endpoint in ROW_ENDPOINTS.items():
+        assert dict(triggers[("remote_button_short_press", f"on_row_{row}")]) == {
+            "endpoint_id": endpoint,
+            "cluster_id": OnOff.cluster_id,
+            "command": "on",
+        }
+        assert dict(triggers[("remote_button_short_press", f"off_row_{row}")]) == {
+            "endpoint_id": endpoint,
+            "cluster_id": OnOff.cluster_id,
+            "command": "off",
+        }
+        assert dict(triggers[("remote_button_long_press", f"up_row_{row}")]) == {
+            "endpoint_id": endpoint,
+            "cluster_id": LevelControl.cluster_id,
+            "command": "step_with_on_off",
+        }
+        assert dict(triggers[("remote_button_long_press", f"down_row_{row}")]) == {
+            "endpoint_id": endpoint,
+            "cluster_id": LevelControl.cluster_id,
+            "command": "step",
+        }
+        assert dict(triggers[("remote_button_long_release", f"stop_row_{row}")]) == {
+            "endpoint_id": endpoint,
+            "cluster_id": LevelControl.cluster_id,
+            "command": "stop",
+        }

--- a/zhaquirks/busch_jaeger.py
+++ b/zhaquirks/busch_jaeger.py
@@ -1,0 +1,88 @@
+"""Quirks for Busch-Jaeger ZigBee Light Link wall transmitters.
+
+Covers two 4-gang rocker controllers whose rows do not expose named actions to
+ZHA out of the box:
+
+* 6737    -> model "RM01", mains-powered 4-gang control element with a built-in
+             dimmer load on endpoint 0x12.
+* 6737/01 -> model "RB01", battery-powered wall transmitter, no load.
+
+Each rocker row is its own ZLL controller endpoint (0x0a-0x0d) with OnOff and
+LevelControl output clusters. Per rocker half a short tap sends OnOff on/off and
+a hold sends LevelControl step/stop. This quirk maps those to
+``device_automation_triggers`` so the rows show up as named actions in the
+automation editor.
+
+Note: like other pure ZLL controllers, a rocker only transmits once its output
+clusters are bound to a target (e.g. the coordinator). That binding is a manual
+step the quirk cannot perform; until a row is bound it stays silent.
+"""
+
+from zhaquirks.builder import QuirkBuilder
+from zhaquirks.const import (
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_STEP,
+    COMMAND_STEP_ON_OFF,
+    COMMAND_STOP,
+    ENDPOINT_ID,
+    LONG_PRESS,
+    LONG_RELEASE,
+    SHORT_PRESS,
+)
+
+ONOFF_CLUSTER_ID = 0x0006
+LEVEL_CLUSTER_ID = 0x0008
+
+ROW_ENDPOINTS = {1: 0x0A, 2: 0x0B, 3: 0x0C, 4: 0x0D}
+
+
+def _row_triggers(row: int, endpoint: int) -> dict:
+    """Return the device automation triggers for a single rocker row."""
+    return {
+        (SHORT_PRESS, f"on_row_{row}"): {
+            ENDPOINT_ID: endpoint,
+            CLUSTER_ID: ONOFF_CLUSTER_ID,
+            COMMAND: COMMAND_ON,
+        },
+        (SHORT_PRESS, f"off_row_{row}"): {
+            ENDPOINT_ID: endpoint,
+            CLUSTER_ID: ONOFF_CLUSTER_ID,
+            COMMAND: COMMAND_OFF,
+        },
+        (LONG_PRESS, f"up_row_{row}"): {
+            ENDPOINT_ID: endpoint,
+            CLUSTER_ID: LEVEL_CLUSTER_ID,
+            COMMAND: COMMAND_STEP_ON_OFF,
+        },
+        (LONG_PRESS, f"down_row_{row}"): {
+            ENDPOINT_ID: endpoint,
+            CLUSTER_ID: LEVEL_CLUSTER_ID,
+            COMMAND: COMMAND_STEP,
+        },
+        (LONG_RELEASE, f"stop_row_{row}"): {
+            ENDPOINT_ID: endpoint,
+            CLUSTER_ID: LEVEL_CLUSTER_ID,
+            COMMAND: COMMAND_STOP,
+        },
+    }
+
+
+_TRIGGERS: dict = {}
+for _row, _ep in ROW_ENDPOINTS.items():
+    _TRIGGERS.update(_row_triggers(_row, _ep))
+
+
+(
+    QuirkBuilder("Busch-Jaeger", "RM01")
+    .device_automation_triggers(_TRIGGERS)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder("Busch-Jaeger", "RB01")
+    .device_automation_triggers(_TRIGGERS)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Summary

Adds a v2 (`QuirkBuilder`) quirk for two Busch-Jaeger ZigBee Light Link 4-gang
wall transmitters whose rocker rows expose no named actions to ZHA out of the
box:

| Device | Model | Type |
|--------|-------|------|
| 6737    | `RM01` | mains-powered 4-gang control element (built-in dimmer load on ep `0x12`) |
| 6737/01 | `RB01` | battery-powered wall transmitter, no load |

Each rocker row is its own ZLL controller endpoint (`0x0a`–`0x0d`) with OnOff and
LevelControl output clusters. The quirk maps every row to
`device_automation_triggers` so the rows show up as named actions in the
automation editor.

### Gesture → trigger mapping (per row)

| Gesture | Cluster | Command | Trigger subtype |
|---------|---------|---------|-----------------|
| short tap right | OnOff | `on` | `on_row_N` |
| short tap left  | OnOff | `off` | `off_row_N` |
| hold up   | LevelControl | `step_with_on_off` | `up_row_N` |
| hold down | LevelControl | `step` | `down_row_N` |
| release   | LevelControl | `stop` | `stop_row_N` |

### Important behavioural note

Like other pure ZLL controllers, a rocker only transmits once its output
clusters are **bound** to a target (e.g. the coordinator). That binding is a
manual step the quirk cannot perform; until a row is bound it stays silent. The
quirk's value is exposing the rows as named triggers once bound (instead of raw
`zha_event`s). This is called out in the module docstring.

### Signatures

Confirmed from live devices.

**RM01** — `manufacturer: "Busch-Jaeger"`, `model: "RM01"`, logical type router.
Rocker endpoints `0x0a`–`0x0d`: profile `0xc05e`, device type `0x0810`, output
clusters `0x0006 0x0008 0x0300` (+ `0x0003 0x0004 0x0005 0x1000`). Endpoint
`0x12` is the internal dimmer (device type `0x0100`), already exposed by ZHA as a
light and left untouched.

**RB01** — same rocker endpoints/clusters, logical type sleepy end device, no
`0x12` load endpoint.

## Testing

- `tests/test_busch_jaeger.py` added: verifies the quirk applies to both models
  and that every rocker row exposes the expected on/off + dim triggers on its
  endpoint.
- Locally: `pytest tests/test_busch_jaeger.py` (4 passed), the generic
  `tests/test_quirks.py` trigger tests pass, and `ruff check` / `ruff format` /
  `mypy` are clean.
