### PR TITLE
Add multi-click mode and button press events to Aqara Dimmer Switch H2 EU

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -47,6 +47,10 @@ from zhaquirks.const import (
     ATTR_ID,
     BUTTON_1,
     BUTTON_2,
+    COMMAND_DOUBLE,
+    COMMAND_HOLD,
+    COMMAND_RELEASE,
+    COMMAND_SINGLE,
     DEVICE_TYPE,
     ENDPOINT_ID,
     ENDPOINTS,
@@ -2729,3 +2733,65 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
     temp = device.endpoints[1].device_temperature
     temp._update_attribute(DeviceTemperature.AttributeDefs.current_temperature.id, 25)
     assert temp.get("current_temperature") == 2500
+
+
+@pytest.mark.parametrize(
+    "press_value, command",
+    [
+        (0, COMMAND_HOLD),
+        (1, COMMAND_SINGLE),
+        (2, COMMAND_DOUBLE),
+        (255, COMMAND_RELEASE),
+    ],
+)
+def test_aqara_h2_dimmer_press_events(zigpy_device_from_v2_quirk, press_value, command):
+    """Test Aqara Dimmer Switch H2 EU (lumi.switch.agl011) press events."""
+    device = zigpy_device_from_v2_quirk("Aqara", "lumi.switch.agl011")
+
+    mi_cluster = device.endpoints[1].multistate_input
+    mi_listener = ClusterListener(mi_cluster)
+    zha_listener = mock.MagicMock()
+    mi_cluster.add_listener(zha_listener)
+
+    # button press report triggers the corresponding ZHA event
+    mi_cluster.update_attribute(
+        MultistateInput.AttributeDefs.present_value.id, press_value
+    )
+    assert zha_listener.zha_send_event.mock_calls == [
+        mock.call(
+            command,
+            {
+                ATTR_ID: MultistateInput.AttributeDefs.present_value.id,
+                VALUE: press_value,
+            },
+        )
+    ]
+
+    # the attribute update itself is still processed normally
+    assert mi_listener.attribute_updates == [
+        (MultistateInput.AttributeDefs.present_value.id, press_value)
+    ]
+
+
+def test_aqara_h2_dimmer_no_event_for_unknown_press_value(
+    zigpy_device_from_v2_quirk,
+):
+    """Test that unknown present_value reports do not emit press events."""
+    device = zigpy_device_from_v2_quirk("Aqara", "lumi.switch.agl011")
+
+    mi_cluster = device.endpoints[1].multistate_input
+    zha_listener = mock.MagicMock()
+    mi_cluster.add_listener(zha_listener)
+
+    mi_cluster.update_attribute(MultistateInput.AttributeDefs.present_value.id, 5)
+    mi_cluster.update_attribute(MultistateInput.AttributeDefs.state_text.id, "foo")
+    assert zha_listener.zha_send_event.mock_calls == []
+
+
+def test_aqara_h2_dimmer_multi_click_attribute(zigpy_device_from_v2_quirk):
+    """Test that the multi_click attribute is defined on the Lumi cluster."""
+    device = zigpy_device_from_v2_quirk("Aqara", "lumi.switch.agl011")
+
+    opple_cluster = device.endpoints[1].opple_cluster
+    attr = opple_cluster.find_attribute("multi_click")
+    assert attr.id == 0x0286

--- a/zhaquirks/xiaomi/aqara/switch_agl011.py
+++ b/zhaquirks/xiaomi/aqara/switch_agl011.py
@@ -2,10 +2,34 @@
 
 from zigpy import types
 from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import MultistateInput
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 from zhaquirks.builder import QuirkBuilder
+from zhaquirks.clusters import CustomCluster
+from zhaquirks.const import (
+    ATTR_ID,
+    BUTTON,
+    COMMAND,
+    COMMAND_DOUBLE,
+    COMMAND_HOLD,
+    COMMAND_RELEASE,
+    COMMAND_SINGLE,
+    DOUBLE_PRESS,
+    LONG_PRESS,
+    LONG_RELEASE,
+    SHORT_PRESS,
+    VALUE,
+    ZHA_SEND_EVENT,
+)
 from zhaquirks.xiaomi import DeviceTemperatureCluster, XiaomiAqaraE1Cluster
+
+PRESS_VALUE_TO_COMMAND = {
+    0: COMMAND_HOLD,
+    1: COMMAND_SINGLE,
+    2: COMMAND_DOUBLE,
+    255: COMMAND_RELEASE,
+}
 
 
 class ModeSwitch(types.enum16):
@@ -38,6 +62,26 @@ class PowerOnState(types.enum8):
     Inverted = 0x03
 
 
+class MultiClickMode(types.enum8):
+    """Enum for dimmer multi-click mode."""
+
+    Off = 0x01
+    On = 0x02
+
+
+class MultistateInputCluster(CustomCluster, MultistateInput):
+    """Multistate input cluster."""
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == 0x0055 and value in PRESS_VALUE_TO_COMMAND:
+            self.listener_event(
+                ZHA_SEND_EVENT,
+                PRESS_VALUE_TO_COMMAND[value],
+                {ATTR_ID: attrid, VALUE: value},
+            )
+
+
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Aqara manufacturer-specific cluster for the dimmer switch H2 EU."""
 
@@ -58,6 +102,9 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         )
         mode_switch = ZCLAttributeDef(
             id=0x0004, type=types.uint16_t, access="rw", is_manufacturer_specific=True
+        )
+        multi_click = ZCLAttributeDef(
+            id=0x0286, type=types.uint8_t, access="rw", is_manufacturer_specific=True
         )
         operation_mode = ZCLAttributeDef(
             id=0x0200, type=types.uint8_t, access="rw", is_manufacturer_specific=True
@@ -81,6 +128,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     .replaces_endpoint(1, device_type=zha.DeviceType.DIMMABLE_LIGHT)
     .adds(DeviceTemperatureCluster)
     .adds(OppleCluster)
+    .adds(MultistateInputCluster)
     .switch(
         OppleCluster.AttributeDefs.flip_indicator_light.name,
         OppleCluster.cluster_id,
@@ -92,6 +140,13 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         OppleCluster.cluster_id,
         translation_key="led_indicator",
         fallback_name="LED indicator",
+    )
+    .enum(
+        OppleCluster.AttributeDefs.multi_click.name,
+        MultiClickMode,
+        OppleCluster.cluster_id,
+        translation_key="multi_click",
+        fallback_name="Multi-click mode",
     )
     .number(
         OppleCluster.AttributeDefs.max_brightness.name,
@@ -156,6 +211,14 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         step=1,
         translation_key="sensitivity",
         fallback_name="Sensitivity",
+    )
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_SINGLE},
+            (DOUBLE_PRESS, BUTTON): {COMMAND: COMMAND_DOUBLE},
+            (LONG_PRESS, BUTTON): {COMMAND: COMMAND_HOLD},
+            (LONG_RELEASE, BUTTON): {COMMAND: COMMAND_RELEASE},
+        }
     )
     .add_to_registry()
 )


### PR DESCRIPTION
…2 EU (lumi.switch.agl011)

## Proposed change
Add support for multi click mode on Aqara Dimmer H2 EU allowing custom automations.

## Additional information
Copied from Z2MQTT and tested on my own H2 Dimmer running latest firmware(4120)

## Device diagnostics
[zha-01KR51KGAPFMXGWB2ZB520KHD1-Aqara lumi.switch.agl011-726c7dc73ae5d33d205260beec7711a2.json](https://github.com/user-attachments/files/29860381/zha-01KR51KGAPFMXGWB2ZB520KHD1-Aqara.lumi.switch.agl011-726c7dc73ae5d33d205260beec7711a2.json)

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached



Related: #5038
