### PR TITLE
Expose v2 quirk device automation triggers on zigpy device

### DIFF
--- a/tests/test_quirks_v2_builder.py
+++ b/tests/test_quirks_v2_builder.py
@@ -28,6 +28,7 @@ from zigpy.zdo.types import LogicalType, NodeDescriptor
 from zhaquirks.builder import QuirkBuilder
 from zhaquirks.builder.metadata import recursive_freeze
 from zhaquirks.clusters import CustomCluster
+from zhaquirks.const import COMMAND, COMMAND_ON, SHORT_PRESS, TURN_ON
 from zhaquirks.device import CustomZigpyDevice
 from zhaquirks.legacy import signature_matches
 
@@ -392,6 +393,40 @@ async def test_quirks_v2_skip_configuration(device_mock):
     # definition rather than on the resolved zigpy device.
     entry = registry.match_entry(quirked)
     assert entry.zha_device_factory.quirk_definition.skip_configuration is True
+
+
+async def test_quirks_v2_device_automation_triggers_on_zigpy_device(device_mock):
+    """Test quirk-defined triggers are stamped onto the resolved zigpy device."""
+    registry = DeviceRegistry()
+
+    triggers = {(SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON}}
+
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model)
+        .device_automation_triggers(triggers)
+        .add_to_registry(registry)
+    )
+
+    quirked = registry.resolve(device_mock)
+    assert isinstance(quirked, CustomZigpyDevice)
+
+    # Consumers reading only the zigpy device (e.g. HA's early device trigger
+    # cache) see the same triggers a v1 quirk exposes as a class attribute.
+    assert quirked.device_automation_triggers == triggers
+
+
+async def test_quirks_v2_no_device_automation_triggers(device_mock):
+    """Test no trigger attribute is stamped when a quirk defines none."""
+    registry = DeviceRegistry()
+
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model)
+        .adds(OnOff.cluster_id)
+        .add_to_registry(registry)
+    )
+
+    quirked = registry.resolve(device_mock)
+    assert not hasattr(quirked, "device_automation_triggers")
 
 
 async def test_quirks_v2_removes(device_mock):

--- a/zhaquirks/builder/builder.py
+++ b/zhaquirks/builder/builder.py
@@ -315,6 +315,19 @@ class SetModelInfo:
         return device
 
 
+@dataclass(frozen=True)
+class SetDeviceAutomationTriggers:
+    """Set the quirk-defined device automation triggers on a device."""
+
+    triggers: frozendict[tuple[str, str], frozendict[str, str]]
+
+    def __call__(self, device: zigpy.device.Device) -> zigpy.device.Device:
+        """Apply this operation to the given zigpy device."""
+        device.device_automation_triggers = dict(self.triggers)
+
+        return device
+
+
 class QuirkBuilder:
     """Builder compiling a declarative quirk into a registered `Device` subclass."""
 
@@ -1089,7 +1102,20 @@ class QuirkBuilder:
         # modifications, so the bare device is left intact for persistence.
         clone = ReplaceZigpyDevice(self.custom_zigpy_device_class)
 
-        zigpy_transforms = (clone, *self._compile_transformations())
+        ops = self._compile_transformations()
+
+        # Stamp the triggers onto the resolved zigpy device (matching v1 quirks,
+        # where they are a class attribute) so consumers reading only the zigpy
+        # device — e.g. HA's early device trigger cache — see them too.
+        if quirk_definition.device_automation_triggers:
+            ops = (
+                *ops,
+                SetDeviceAutomationTriggers(
+                    triggers=quirk_definition.device_automation_triggers
+                ),
+            )
+
+        zigpy_transforms = (clone, *ops)
 
         entry = QuirkRegistryEntry(
             device_match=device_match,


### PR DESCRIPTION
Note: This is a temporary change for the next HA Core patch release. We'll have a better fix with a couple ZHA and quirks changes in a bit:
- Possible future ZHA change: https://github.com/zigpy/zha/compare/zigpy-bot/drop-v1-trigger-attribute-read
- Possible future quirks change: https://github.com/zigpy/zha-device-handlers/compare/zigpy-bot/v1-entry-device-automation-triggers

## Proposed change

This sets the `device_automation_triggers` attribute on the zigpy device used for v2 quirks to fix device automation triggers for quirks v2 devices.

### AI summary

v1 quirks expose `device_automation_triggers` as a class attribute on the zigpy-level CustomDevice, but v2 (`QuirkBuilder`) quirks only carried them in the `QuirkDefinition` surfaced through the ZHA-level `QuirkV2Device` wrapper. Consumers reading only the resolved zigpy device — e.g. Home Assistant's early device trigger cache built via `get_device_automation_triggers` — therefore saw no quirk-defined triggers for v2 quirks (only `device_offline`), breaking automations referencing e.g. remote button presses while ZHA was still starting up.

Add a `SetDeviceAutomationTriggers` transform that stamps the definition's triggers onto the `CustomZigpyDevice` clone during quirk resolution, restoring v1 semantics uniformly.

## Additional information
Related HA Core PRs and issues:
- https://github.com/home-assistant/core/pull/175895 (required for this fix to work)
- https://github.com/home-assistant/core/issues/175544
- https://github.com/home-assistant/core/issues/175890

## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
