### PR TITLE
Add support for SONOFF MINI-ZBDIM

### DIFF
--- a/tests/test_sonoff_mini_zbdim.py
+++ b/tests/test_sonoff_mini_zbdim.py
@@ -3,6 +3,7 @@
 import importlib
 from unittest import mock
 
+import zigpy.types as t
 from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import LevelControl
 
@@ -72,7 +73,7 @@ async def test_sonoff_mini_zbdim_write_attributes_maps_virtual_actions(
             written_attrs[1].attrid
             == SonoffCluster.AttributeDefs.delayed_power_on_state.id
         )
-        assert written_attrs[1].value.value is True
+        assert written_attrs[1].value.value == t.Bool.true
 
 
 async def test_sonoff_mini_zbdim_apply_custom_configuration_reads_backed_attributes(

--- a/tests/test_sonoff_mini_zbdim.py
+++ b/tests/test_sonoff_mini_zbdim.py
@@ -1,0 +1,141 @@
+"""Tests for Sonoff MINI-ZBDIM quirks."""
+
+import importlib
+from unittest import mock
+
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.general import LevelControl
+
+from tests.common import ClusterListener
+import zhaquirks
+
+mini_zbdim = importlib.import_module("zhaquirks.sonoff.mini-zbdim")
+SonoffCluster = mini_zbdim.SonoffCluster
+SonoffLevelControl = mini_zbdim.SonoffLevelControl
+
+zhaquirks.setup()
+
+
+async def test_sonoff_mini_zbdim_write_attributes_maps_virtual_actions(
+    zigpy_device_from_v2_quirk,
+):
+    """Virtual calibration action attributes should map to the real device attribute."""
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZBDIM",
+        cluster_ids={
+            1: {
+                SonoffCluster.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    sonoff_cluster = device.endpoints[1].sonoff_cluster
+    write_response = [
+        [foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]
+    ]
+
+    with mock.patch.object(
+        sonoff_cluster,
+        "write_attributes_raw",
+        mock.AsyncMock(return_value=write_response),
+    ) as mock_write:
+        start_value = bytes([0x01, 0x01, 0x01]).decode("latin-1")
+        await sonoff_cluster.write_attributes(
+            {SonoffCluster.AttributeDefs.set_calibration_action_start.name: start_value}
+        )
+
+        written_attrs = mock_write.call_args[0][0]
+        assert len(written_attrs) == 1
+        assert (
+            written_attrs[0].attrid
+            == SonoffCluster.AttributeDefs.set_calibration_action.id
+        )
+        assert written_attrs[0].value.value == start_value
+
+        stop_value = bytes([0x01, 0x01, 0x02]).decode("latin-1")
+        await sonoff_cluster.write_attributes(
+            {
+                SonoffCluster.AttributeDefs.set_calibration_action_stop.name: stop_value,
+                SonoffCluster.AttributeDefs.delayed_power_on_state.name: True,
+            }
+        )
+
+        written_attrs = mock_write.call_args[0][0]
+        assert len(written_attrs) == 2
+        assert (
+            written_attrs[0].attrid
+            == SonoffCluster.AttributeDefs.set_calibration_action.id
+        )
+        assert written_attrs[0].value.value == stop_value
+        assert (
+            written_attrs[1].attrid
+            == SonoffCluster.AttributeDefs.delayed_power_on_state.id
+        )
+        assert written_attrs[1].value.value is True
+
+
+async def test_sonoff_mini_zbdim_apply_custom_configuration_reads_backed_attributes(
+    zigpy_device_from_v2_quirk,
+):
+    """Pairing configuration should read the attributes behind exposed entities."""
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZBDIM",
+        cluster_ids={
+            1: {
+                SonoffCluster.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    sonoff_cluster = device.endpoints[1].sonoff_cluster
+
+    with mock.patch.object(
+        sonoff_cluster,
+        "read_attributes",
+        mock.AsyncMock(),
+    ) as mock_read:
+        await sonoff_cluster.apply_custom_configuration()
+
+    mock_read.assert_awaited_once_with(
+        [
+            SonoffCluster.AttributeDefs.delayed_power_on_state.id,
+            SonoffCluster.AttributeDefs.delayed_power_on_time.id,
+            SonoffCluster.AttributeDefs.external_trigger_mode.id,
+            SonoffCluster.AttributeDefs.calibration_status.id,
+            SonoffCluster.AttributeDefs.calibration_progress.id,
+            SonoffCluster.AttributeDefs.transition_time.id,
+            SonoffCluster.AttributeDefs.min_brightness_threshold.id,
+            SonoffCluster.AttributeDefs.dimming_light_rate.id,
+            SonoffCluster.AttributeDefs.max_brightness_threshold.id,
+            SonoffCluster.AttributeDefs.level_for_calibration.id,
+        ]
+    )
+
+
+async def test_sonoff_mini_zbdim_level_control_clamps_minimum_level(
+    zigpy_device_from_v2_quirk,
+):
+    """Current level values below the device minimum should be clamped to 2."""
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZBDIM",
+        cluster_ids={
+            1: {
+                LevelControl.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    level_cluster = device.endpoints[1].level
+    listener = ClusterListener(level_cluster)
+    current_level_id = SonoffLevelControl.AttributeDefs.current_level.id
+
+    level_cluster.update_attribute(current_level_id, 1)
+    assert listener.attribute_updates[-1] == (current_level_id, 2)
+    assert level_cluster.get(current_level_id) == 2
+
+    level_cluster.update_attribute(current_level_id, 3)
+    assert listener.attribute_updates[-1] == (current_level_id, 3)
+    assert level_cluster.get(current_level_id) == 3

--- a/zhaquirks/sonoff/mini-zbdim.py
+++ b/zhaquirks/sonoff/mini-zbdim.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+import zigpy.types as t
 from zigpy import types
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import (
@@ -19,11 +20,10 @@ from zigpy.quirks.v2.homeassistant import (
     UnitOfPower,
     UnitOfTime,
 )
-import zigpy.types as t
 from zigpy.zcl.clusters.general import LevelControl
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeAccess, ZCLAttributeDef
 
-ACTION_ID_MAPPING = [0xFFD1, 0xFFD2, 0xFFD3]
+ACTION_ATTRIBUTE_IDS = (0xFFD1, 0xFFD2, 0xFFD3)
 
 
 class SonoffCluster(CustomCluster):
@@ -127,10 +127,10 @@ class SonoffCluster(CustomCluster):
         """Map virtual calibration action attributes to the real device attribute."""
         remapped_attributes = {}
         for attr, value in attributes.items():
-            if self.find_attribute(attr).id in ACTION_ID_MAPPING:
-                remapped_attributes[self.AttributeDefs.set_calibration_action.name] = (
-                    value
-                )
+            if self.find_attribute(attr).id in ACTION_ATTRIBUTE_IDS:
+                remapped_attributes[
+                    self.AttributeDefs.set_calibration_action.name
+                ] = value
             else:
                 remapped_attributes[attr] = value
 
@@ -183,14 +183,6 @@ class DimmingLightRate(types.enum8):
     X3 = 3
     X4 = 4
     X5 = 5
-
-
-# class SetCalibrationAction(Enum):
-#     """Set calibration action attribute values."""
-
-#     Start = bytes([0x01,0x01,0x01]).decode("latin-1"),
-#     Stop = bytes([0x01,0x01,0x02]).decode("latin-1"),
-#     Clear = bytes([0x01,0x01,0x03]).decode("latin-1"),
 
 
 class CalibrationStatus(types.enum8):

--- a/zhaquirks/sonoff/mini-zbdim.py
+++ b/zhaquirks/sonoff/mini-zbdim.py
@@ -5,12 +5,13 @@ from typing import Any
 from zigpy import types
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import (
+    EntityPlatform,
+    EntityType,
     NumberDeviceClass,
     QuirkBuilder,
     SensorDeviceClass,
     SensorStateClass,
 )
-from zigpy.quirks.v2 import EntityPlatform, EntityType, QuirkBuilder
 from zigpy.quirks.v2.homeassistant import (
     PERCENTAGE,
     UnitOfElectricCurrent,
@@ -127,7 +128,9 @@ class SonoffCluster(CustomCluster):
         remapped_attributes = {}
         for attr, value in attributes.items():
             if self.find_attribute(attr).id in ACTION_ID_MAPPING:
-                remapped_attributes[self.AttributeDefs.set_calibration_action.name] = value
+                remapped_attributes[self.AttributeDefs.set_calibration_action.name] = (
+                    value
+                )
             else:
                 remapped_attributes[attr] = value
 

--- a/zhaquirks/sonoff/mini-zbdim.py
+++ b/zhaquirks/sonoff/mini-zbdim.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-import zigpy.types as t
 from zigpy import types
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import (
@@ -20,6 +19,7 @@ from zigpy.quirks.v2.homeassistant import (
     UnitOfPower,
     UnitOfTime,
 )
+import zigpy.types as t
 from zigpy.zcl.clusters.general import LevelControl
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeAccess, ZCLAttributeDef
 
@@ -128,9 +128,9 @@ class SonoffCluster(CustomCluster):
         remapped_attributes = {}
         for attr, value in attributes.items():
             if self.find_attribute(attr).id in ACTION_ATTRIBUTE_IDS:
-                remapped_attributes[
-                    self.AttributeDefs.set_calibration_action.name
-                ] = value
+                remapped_attributes[self.AttributeDefs.set_calibration_action.name] = (
+                    value
+                )
             else:
                 remapped_attributes[attr] = value
 

--- a/zhaquirks/sonoff/mini-zbdim.py
+++ b/zhaquirks/sonoff/mini-zbdim.py
@@ -1,0 +1,357 @@
+"""Sonoff MINI-ZBDIM - Zigbee Dimmer Switch."""
+
+from typing import Any
+
+from zigpy import types
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import (
+    NumberDeviceClass,
+    QuirkBuilder,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from zigpy.quirks.v2 import EntityPlatform, EntityType, QuirkBuilder
+from zigpy.quirks.v2.homeassistant import (
+    PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfPower,
+    UnitOfTime,
+)
+import zigpy.types as t
+from zigpy.zcl.clusters.general import LevelControl
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeAccess, ZCLAttributeDef
+
+ACTION_ID_MAPPING = [0xFFD1, 0xFFD2, 0xFFD3]
+
+
+class SonoffCluster(CustomCluster):
+    """Custom Sonoff cluster."""
+
+    cluster_id = 0xFC11
+    ep_attribute = "sonoff_cluster"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        delayed_power_on_state = ZCLAttributeDef(
+            id=0x0014,
+            type=t.Bool,
+            manufacturer_code=None,
+        )
+        delayed_power_on_time = ZCLAttributeDef(
+            id=0x0015,
+            type=t.uint16_t,
+            manufacturer_code=None,
+        )
+        external_trigger_mode = ZCLAttributeDef(
+            id=0x0016,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+        set_calibration_action = ZCLAttributeDef(
+            id=0x001D,
+            type=t.CharacterString,
+            manufacturer_code=None,
+        )
+        set_calibration_action_start = ZCLAttributeDef(
+            id=0xFFD1,
+            type=t.CharacterString,
+            manufacturer_code=None,
+        )
+        set_calibration_action_stop = ZCLAttributeDef(
+            id=0xFFD2,
+            type=t.CharacterString,
+            manufacturer_code=None,
+        )
+        calibration_status = ZCLAttributeDef(
+            id=0x001E,
+            type=t.uint8_t,
+            access=(ZCLAttributeAccess.Read | ZCLAttributeAccess.Report),
+            manufacturer_code=None,
+        )
+        calibration_progress = ZCLAttributeDef(
+            id=0x0020,
+            type=t.uint8_t,
+            access=(ZCLAttributeAccess.Read | ZCLAttributeAccess.Report),
+            manufacturer_code=None,
+        )
+        transition_time = ZCLAttributeDef(
+            id=0x001F,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+        min_brightness_threshold = ZCLAttributeDef(
+            id=0x4001,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+        dimming_light_rate = ZCLAttributeDef(
+            id=0x4003,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+        accurrent_current_value = ZCLAttributeDef(
+            id=0x7004,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+        accurrent_voltage_value = ZCLAttributeDef(
+            id=0x7005,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+        accurrent_power_value = ZCLAttributeDef(
+            id=0x7006,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+        max_brightness_threshold = ZCLAttributeDef(
+            id=0x4002,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+        level_for_calibration = ZCLAttributeDef(
+            id=0x4006,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | ZCLAttributeDef, Any],
+        manufacturer: int | None = None,
+        **kwargs,
+    ):
+        """Map virtual calibration action attributes to the real device attribute."""
+        remapped_attributes = {}
+        for attr, value in attributes.items():
+            if self.find_attribute(attr).id in ACTION_ID_MAPPING:
+                remapped_attributes[self.AttributeDefs.set_calibration_action.name] = value
+            else:
+                remapped_attributes[attr] = value
+
+        return await super().write_attributes(
+            remapped_attributes, manufacturer=manufacturer, **kwargs
+        )
+
+    async def apply_custom_configuration(self, *args, **kwargs):
+        """Read entity-backed attributes during pairing."""
+        await self.read_attributes(
+            [
+                self.AttributeDefs.delayed_power_on_state.id,
+                self.AttributeDefs.delayed_power_on_time.id,
+                self.AttributeDefs.external_trigger_mode.id,
+                self.AttributeDefs.calibration_status.id,
+                self.AttributeDefs.calibration_progress.id,
+                self.AttributeDefs.transition_time.id,
+                self.AttributeDefs.min_brightness_threshold.id,
+                self.AttributeDefs.dimming_light_rate.id,
+                self.AttributeDefs.max_brightness_threshold.id,
+                self.AttributeDefs.level_for_calibration.id,
+            ]
+        )
+
+
+class SonoffLevelControl(CustomCluster, LevelControl):
+    """Override level control cluster."""
+
+    def _update_attribute(self, attrid: int | t.uint16_t, value: Any) -> None:
+        """Convert the current level attribute."""
+        if attrid == self.AttributeDefs.current_level.id and value <= 2:
+            value = 2
+        super()._update_attribute(attrid, value)
+
+
+class ExternalTriggerMode(types.enum8):
+    """External trigger mode attribute values."""
+
+    Edge = 0x00
+    Pulse = 0x01
+    Double_pulse = 0x03
+    Triple_pulse = 0x04
+
+
+class DimmingLightRate(types.enum8):
+    """Dimming light rate attribute values."""
+
+    X1 = 1
+    X2 = 2
+    X3 = 3
+    X4 = 4
+    X5 = 5
+
+
+# class SetCalibrationAction(Enum):
+#     """Set calibration action attribute values."""
+
+#     Start = bytes([0x01,0x01,0x01]).decode("latin-1"),
+#     Stop = bytes([0x01,0x01,0x02]).decode("latin-1"),
+#     Clear = bytes([0x01,0x01,0x03]).decode("latin-1"),
+
+
+class CalibrationStatus(types.enum8):
+    """Calibration status attribute values."""
+
+    UnCalibrate = 0x00
+    Calibrating = 0x01
+    CalibrationFailed = 0x02
+    Calibrated = 0x03
+
+
+(
+    QuirkBuilder("SONOFF", "MINI-ZBDIM")
+    .replaces(SonoffCluster)
+    .replaces(SonoffLevelControl)
+    .removes(cluster_id=0x0B04)
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.accurrent_current_value.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricCurrent.AMPERE,
+        translation_key="accurrent_current_value",
+        fallback_name="Current",
+        divisor=1000,
+        suggested_display_precision=2,
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.accurrent_voltage_value.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricPotential.VOLT,
+        divisor=1000,
+        translation_key="accurrent_voltage_value",
+        fallback_name="Voltage",
+        suggested_display_precision=2,
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.accurrent_power_value.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfPower.WATT,
+        divisor=1000,
+        translation_key="accurrent_power_value",
+        fallback_name="Power",
+        suggested_display_precision=2,
+    )
+    .switch(
+        SonoffCluster.AttributeDefs.delayed_power_on_state.name,
+        SonoffCluster.cluster_id,
+        off_value=0,
+        on_value=1,
+        translation_key="delayed_power_on_state",
+        fallback_name="Delayed power on state",
+    )
+    .number(
+        SonoffCluster.AttributeDefs.delayed_power_on_time.name,
+        SonoffCluster.cluster_id,
+        min_value=0.5,
+        max_value=3599.5,
+        step=0.5,
+        device_class=NumberDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        multiplier=0.5,
+        translation_key="delayed_power_on_time",
+        fallback_name="Delayed power on time",
+    )
+    .write_attr_button(
+        SonoffCluster.AttributeDefs.set_calibration_action_stop.name,
+        bytes([0x01, 0x01, 0x02]).decode("latin-1"),
+        SonoffCluster.cluster_id,
+        translation_key="stop_calibrate",
+        fallback_name="Stop calibrate",
+    )
+    .write_attr_button(
+        SonoffCluster.AttributeDefs.set_calibration_action_start.name,
+        bytes([0x01, 0x01, 0x01]).decode("latin-1"),
+        SonoffCluster.cluster_id,
+        translation_key="start_calibrate",
+        fallback_name="Start calibrate",
+    )
+    # .enum(
+    #     SonoffCluster.AttributeDefs.set_calibration_action.name,
+    #     SetCalibrationAction,
+    #     SonoffCluster.cluster_id,
+    #     translation_key="set_calibration_action",
+    #     fallback_name="Set calibration action",
+    # )
+    .enum(
+        SonoffCluster.AttributeDefs.calibration_status.name,
+        CalibrationStatus,
+        SonoffCluster.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        entity_platform=EntityPlatform.SENSOR,
+        translation_key="calibration_status",
+        fallback_name="Calibration status",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.calibration_progress.name,
+        cluster_id=SonoffCluster.cluster_id,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=PERCENTAGE,
+        translation_key="calibration_progress",
+        fallback_name="Calibration progress",
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.external_trigger_mode.name,
+        ExternalTriggerMode,
+        SonoffCluster.cluster_id,
+        translation_key="external_trigger_mode",
+        fallback_name="External trigger mode",
+    )
+    .number(
+        SonoffCluster.AttributeDefs.min_brightness_threshold.name,
+        SonoffCluster.cluster_id,
+        min_value=1,
+        max_value=99,
+        step=1,
+        unit=PERCENTAGE,
+        multiplier=2.55,
+        translation_key="min_brightness_threshold",
+        fallback_name="Min brightness threshold",
+    )
+    .number(
+        SonoffCluster.AttributeDefs.transition_time.name,
+        SonoffCluster.cluster_id,
+        min_value=0,
+        max_value=5,
+        step=0.1,
+        unit="s",
+        multiplier=0.1,
+        translation_key="transition_time",
+        fallback_name="Transition time",
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.dimming_light_rate.name,
+        DimmingLightRate,
+        SonoffCluster.cluster_id,
+        translation_key="dimming_light_rate",
+        fallback_name="Dimming light rate",
+    )
+    .number(
+        SonoffCluster.AttributeDefs.max_brightness_threshold.name,
+        SonoffCluster.cluster_id,
+        min_value=2,
+        max_value=100,
+        step=1,
+        unit=PERCENTAGE,
+        multiplier=2.55,
+        translation_key="max_brightness_threshold",
+        fallback_name="Max brightness threshold",
+    )
+    .number(
+        SonoffCluster.AttributeDefs.level_for_calibration.name,
+        SonoffCluster.cluster_id,
+        min_value=1,
+        max_value=100,
+        step=1,
+        unit=PERCENTAGE,
+        multiplier=2.55,
+        translation_key="level_for_calibration",
+        fallback_name="Level For Calibration",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
Update MINI-ZBDIM's device quirks script.


## Additional information
Non-breaking change.
﻿
Tested on a physical SONOFF MINI-ZBDIM device.

## Device diagnostics

[zha-01KX087N74KN47KDWMPDVN0BS0-SONOFF MINI-ZBDIM-9877f8bd6bb3e261e5554efe56619869.json](https://github.com/user-attachments/files/29882020/zha-01KX087N74KN47KDWMPDVN0BS0-SONOFF.MINI-ZBDIM-9877f8bd6bb3e261e5554efe56619869.json)


## Checklist
- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
