### PR TITLE
Improve Aqara Cube T1 Pro Support

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -2729,3 +2729,119 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
     temp = device.endpoints[1].device_temperature
     temp._update_attribute(DeviceTemperature.AttributeDefs.current_temperature.id, 25)
     assert temp.get("current_temperature") == 2500
+
+
+@pytest.mark.parametrize(
+    "quirk",
+    (
+        zhaquirks.xiaomi.aqara.cube_aqgl01.CubeAQGL01,
+        zhaquirks.xiaomi.aqara.cube_aqgl01.CubeCAGL02,
+    ),
+)
+async def test_cube_hold(zigpy_device_from_quirk, quirk):
+    """Test cube hold movement event."""
+    device = zigpy_device_from_quirk(quirk)
+    mi_cluster = device.endpoints[2].multistate_input
+    zha_listener = mock.MagicMock()
+    mi_cluster.add_listener(zha_listener)
+
+    mi_cluster.update_attribute(
+        zhaquirks.xiaomi.aqara.cube_aqgl01.STATUS_TYPE_ATTR,
+        zhaquirks.xiaomi.aqara.cube_aqgl01.HOLD_VALUE,
+    )
+
+    assert zha_listener.zha_send_event.mock_calls == [
+        mock.call(
+            zhaquirks.xiaomi.aqara.cube_aqgl01.HOLD,
+            {VALUE: zhaquirks.xiaomi.aqara.cube_aqgl01.HOLD_VALUE},
+        )
+    ]
+
+
+async def test_cube_t1_moved_after_inactivity(zigpy_device_from_quirk):
+    """Test Aqara T1 cube 1 minute inactivity movement event."""
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.cube_aqgl01.CubeCAGL02)
+    mi_cluster = device.endpoints[2].multistate_input
+    zha_listener = mock.MagicMock()
+    mi_cluster.add_listener(zha_listener)
+
+    mi_cluster.update_attribute(
+        zhaquirks.xiaomi.aqara.cube_aqgl01.STATUS_TYPE_ATTR,
+        zhaquirks.xiaomi.aqara.cube_aqgl01.INACTIVITY_VALUE,
+    )
+
+    assert zha_listener.zha_send_event.mock_calls == [
+        mock.call(
+            zhaquirks.xiaomi.aqara.cube_aqgl01.INACTIVITY,
+            {VALUE: zhaquirks.xiaomi.aqara.cube_aqgl01.INACTIVITY_VALUE},
+        )
+    ]
+
+
+async def test_cube_aqgl01_inactivity_value_not_moved_after_inactivity(
+    zigpy_device_from_quirk,
+):
+    """Test the older cube does not treat raw value 2 as 1 minute inactivity movement.
+
+    Unlike the Aqara T1 cube, raw value 2 means "wakeup" on the older cube, so
+    it is not present in its movement type mapping and no event should fire.
+    """
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.cube_aqgl01.CubeAQGL01)
+    mi_cluster = device.endpoints[2].multistate_input
+    zha_listener = mock.MagicMock()
+    mi_cluster.add_listener(zha_listener)
+
+    mi_cluster.update_attribute(
+        zhaquirks.xiaomi.aqara.cube_aqgl01.STATUS_TYPE_ATTR,
+        zhaquirks.xiaomi.aqara.cube_aqgl01.INACTIVITY_VALUE,
+    )
+
+    assert zha_listener.zha_send_event.mock_calls == []
+
+
+async def test_cube_t1_side_up(zigpy_device_from_quirk):
+    """Test Aqara T1 cube side_up event."""
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.cube_aqgl01.CubeCAGL02)
+    manufacturer_cluster = device.endpoints[2].opple_cluster
+    zha_listener = mock.MagicMock()
+    manufacturer_cluster.add_listener(zha_listener)
+
+    manufacturer_cluster.update_attribute(
+        zhaquirks.xiaomi.aqara.cube_aqgl01.CubeT1ManufacturerCluster.AttributeDefs.side_up.id,
+        3,
+    )
+
+    assert zha_listener.zha_send_event.mock_calls == [
+        mock.call(
+            zhaquirks.xiaomi.aqara.cube_aqgl01.SIDE_UP,
+            {zhaquirks.xiaomi.aqara.cube_aqgl01.ACTIVATED_FACE: 4},
+        )
+    ]
+
+
+async def test_cube_t1_manufacturer_cluster_battery_voltage(zigpy_device_from_quirk):
+    """Test Aqara T1 cube battery voltage reporting on the manufacturer cluster."""
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.cube_aqgl01.CubeCAGL02)
+    power_cluster = device.endpoints[1].power
+    manufacturer_cluster = device.endpoints[1].opple_cluster
+
+    manufacturer_cluster.update_attribute(
+        zhaquirks.xiaomi.aqara.cube_aqgl01.CubeT1ManufacturerCluster.AttributeDefs.battery_voltage_mv.id,
+        2950,
+    )
+
+    assert power_cluster["battery_voltage"] == 29.5
+
+
+async def test_cube_t1_manufacturer_cluster_battery_voltage_no_power_endpoint(
+    zigpy_device_from_quirk,
+):
+    """Test the manufacturer cluster ignores battery voltage on an endpoint without a power cluster."""
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.cube_aqgl01.CubeCAGL02)
+    manufacturer_cluster = device.endpoints[2].opple_cluster
+
+    # Should not raise, since endpoint 2 has no "power" cluster.
+    manufacturer_cluster.update_attribute(
+        zhaquirks.xiaomi.aqara.cube_aqgl01.CubeT1ManufacturerCluster.AttributeDefs.battery_voltage_mv.id,
+        2950,
+    )

--- a/zhaquirks/xiaomi/aqara/cube_aqgl01.py
+++ b/zhaquirks/xiaomi/aqara/cube_aqgl01.py
@@ -420,7 +420,7 @@ class CubeAQGL01(XiaomiCustomDevice):
     }
 
 
-class CubeCAGL02FPO(XiaomiCustomDevice):
+class CubeCAGL02(XiaomiCustomDevice):
     """Aqara T1 magic cube device."""
 
     def __init__(self, *args, **kwargs):

--- a/zhaquirks/xiaomi/aqara/cube_aqgl01.py
+++ b/zhaquirks/xiaomi/aqara/cube_aqgl01.py
@@ -1,5 +1,8 @@
 """Xiaomi aqara magic cube device."""
 
+from typing import Final
+
+from zigpy import types as t
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import (
     AnalogInput,
@@ -11,6 +14,7 @@ from zigpy.zcl.clusters.general import (
     PowerConfiguration,
     Scenes,
 )
+from zigpy.zcl.foundation import ZCLAttributeDef
 
 from zhaquirks import CustomCluster
 from zhaquirks.const import (
@@ -33,6 +37,7 @@ from zhaquirks.xiaomi import (
     LUMI,
     BasicCluster,
     DeviceTemperatureCluster,
+    XiaomiAqaraE1Cluster,
     XiaomiCustomDevice,
     XiaomiPowerConfiguration,
 )
@@ -183,6 +188,36 @@ class MultistateInputCluster(CustomCluster, MultistateInput):
 
             # show something in the sensor in HA
             super()._update_attribute(0, action)
+
+
+class CubeT1PowerConfiguration(XiaomiPowerConfiguration):
+    """Power configuration cluster matching the Aqara T1 cube's battery voltage range."""
+
+    MIN_VOLTS_MV = 2850
+    MAX_VOLTS_MV = 3000
+
+
+class CubeT1ManufacturerCluster(XiaomiAqaraE1Cluster):
+    """Aqara manufacturer specific cluster for the T1 cube.
+
+    The T1 cube reports its battery voltage as an individual attribute on
+    this cluster instead of using the legacy Xiaomi attribute blob on the
+    Basic cluster, so it is not picked up by XiaomiPowerConfiguration on its
+    own. This cluster is not present in the device's signature, but the
+    device communicates on it regardless.
+    """
+
+    class AttributeDefs(XiaomiAqaraE1Cluster.AttributeDefs):
+        """Attribute definitions."""
+
+        battery_voltage_mv: Final = ZCLAttributeDef(
+            id=0x0001, type=t.uint16_t, is_manufacturer_specific=True
+        )
+
+    def _update_attribute(self, attrid, value):
+        if attrid == self.AttributeDefs.battery_voltage_mv.id:
+            self.endpoint.power.battery_reported(value)
+        super()._update_attribute(attrid, value)
 
 
 class AnalogInputCluster(CustomCluster, AnalogInput):
@@ -349,7 +384,7 @@ class CubeAQGL01(XiaomiCustomDevice):
     }
 
 
-class CubeCAGL02(XiaomiCustomDevice):
+class CubeCAGL02FPO(XiaomiCustomDevice):
     """Aqara T1 magic cube device."""
 
     def __init__(self, *args, **kwargs):
@@ -413,10 +448,11 @@ class CubeCAGL02(XiaomiCustomDevice):
                 DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,
                 INPUT_CLUSTERS: [
                     BasicCluster,
-                    XiaomiPowerConfiguration,
+                    CubeT1PowerConfiguration,
                     Identify.cluster_id,
                     Ota.cluster_id,
                     MultistateInput.cluster_id,
+                    CubeT1ManufacturerCluster,
                 ],
                 OUTPUT_CLUSTERS: [
                     BasicCluster.cluster_id,

--- a/zhaquirks/xiaomi/aqara/cube_aqgl01.py
+++ b/zhaquirks/xiaomi/aqara/cube_aqgl01.py
@@ -252,9 +252,7 @@ class CubeT1ManufacturerCluster(XiaomiAqaraE1Cluster):
             if hasattr(self.endpoint, "power"):
                 self.endpoint.power.battery_reported(value)
         elif attrid == self.AttributeDefs.side_up.id:
-            self.listener_event(
-                ZHA_SEND_EVENT, SIDE_UP, {ACTIVATED_FACE: value + 1}
-            )
+            self.listener_event(ZHA_SEND_EVENT, SIDE_UP, {ACTIVATED_FACE: value + 1})
         super()._update_attribute(attrid, value)
 
 

--- a/zhaquirks/xiaomi/aqara/cube_aqgl01.py
+++ b/zhaquirks/xiaomi/aqara/cube_aqgl01.py
@@ -80,6 +80,8 @@ ROTATE_RIGHT = "rotate_right"
 ROTATED = "device_rotated"
 SHAKE = "shake"
 SHAKE_VALUE = 0
+SIDE_UP = "side_up"
+SIDE_UPPED = "device_side_up"
 SLID = "device_slid"
 SLIDE = "slide"
 
@@ -200,11 +202,11 @@ class CubeT1PowerConfiguration(XiaomiPowerConfiguration):
 class CubeT1ManufacturerCluster(XiaomiAqaraE1Cluster):
     """Aqara manufacturer specific cluster for the T1 cube.
 
-    The T1 cube reports its battery voltage as an individual attribute on
-    this cluster instead of using the legacy Xiaomi attribute blob on the
-    Basic cluster, so it is not picked up by XiaomiPowerConfiguration on its
-    own. This cluster is not present in the device's signature, but the
-    device communicates on it regardless.
+    The T1 cube reports manufacturer specific attributes as individual
+    attributes on this cluster instead of using the legacy Xiaomi attribute
+    blob on the Basic cluster. This cluster is not present in the device's
+    signature, but the device communicates on it regardless, from both
+    endpoint 1 (e.g. battery voltage) and endpoint 2 (e.g. side_up).
     """
 
     class AttributeDefs(XiaomiAqaraE1Cluster.AttributeDefs):
@@ -214,9 +216,20 @@ class CubeT1ManufacturerCluster(XiaomiAqaraE1Cluster):
             id=0x0001, type=t.uint16_t, is_manufacturer_specific=True
         )
 
+        # Reported only in scene_mode, when the cube is picked up, rotated to
+        # a new face, and set back down without being flipped or dropped.
+        side_up: Final = ZCLAttributeDef(
+            id=0x0149, type=t.uint8_t, is_manufacturer_specific=True
+        )
+
     def _update_attribute(self, attrid, value):
         if attrid == self.AttributeDefs.battery_voltage_mv.id:
-            self.endpoint.power.battery_reported(value)
+            if hasattr(self.endpoint, "power"):
+                self.endpoint.power.battery_reported(value)
+        elif attrid == self.AttributeDefs.side_up.id:
+            self.listener_event(
+                ZHA_SEND_EVENT, SIDE_UP, {ACTIVATED_FACE: value + 1}
+            )
         super()._update_attribute(attrid, value)
 
 
@@ -462,7 +475,7 @@ class CubeCAGL02FPO(XiaomiCustomDevice):
             },
             2: {
                 DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,
-                INPUT_CLUSTERS: [MultistateInputCluster],
+                INPUT_CLUSTERS: [MultistateInputCluster, CubeT1ManufacturerCluster],
                 OUTPUT_CLUSTERS: [
                     MultistateInput.cluster_id,
                 ],
@@ -477,4 +490,13 @@ class CubeCAGL02FPO(XiaomiCustomDevice):
         },
     }
 
-    device_automation_triggers = CubeAQGL01.device_automation_triggers
+    device_automation_triggers = {
+        **CubeAQGL01.device_automation_triggers,
+        (SIDE_UPPED, FACE_ANY): {COMMAND: SIDE_UP},
+        (SIDE_UPPED, FACE_1): {COMMAND: SIDE_UP, ARGS: {ACTIVATED_FACE: 1}},
+        (SIDE_UPPED, FACE_2): {COMMAND: SIDE_UP, ARGS: {ACTIVATED_FACE: 2}},
+        (SIDE_UPPED, FACE_3): {COMMAND: SIDE_UP, ARGS: {ACTIVATED_FACE: 3}},
+        (SIDE_UPPED, FACE_4): {COMMAND: SIDE_UP, ARGS: {ACTIVATED_FACE: 4}},
+        (SIDE_UPPED, FACE_5): {COMMAND: SIDE_UP, ARGS: {ACTIVATED_FACE: 5}},
+        (SIDE_UPPED, FACE_6): {COMMAND: SIDE_UP, ARGS: {ACTIVATED_FACE: 6}},
+    }

--- a/zhaquirks/xiaomi/aqara/cube_aqgl01.py
+++ b/zhaquirks/xiaomi/aqara/cube_aqgl01.py
@@ -65,6 +65,8 @@ FLIPPED = "device_flipped"
 HELD = "device_held"
 HOLD = "hold"
 HOLD_VALUE = 4
+INACTIVITY = "1_min_inactivity"
+INACTIVITY_VALUE = 2
 KNOCK = "knock"
 
 KNOCK_1_VALUE = 512  # aqara skyside
@@ -76,6 +78,7 @@ KNOCK_6_VALUE = 517  # aqara facing me upright
 
 KNOCKED = "device_knocked"
 LEFT = "left"
+MOVED_AFTER_INACTIVITY = "device_moved_after_inactivity"
 RELATIVE_DEGREES = "relative_degrees"
 RIGHT = "right"
 ROTATE_LEFT = "rotate_left"
@@ -168,6 +171,10 @@ extend_dict(MOVEMENT_TYPE, FLIP, range(FLIP_BEGIN, FLIP_END))
 class MultistateInputCluster(CustomCluster, MultistateInput):
     """Multistate input cluster."""
 
+    # Subclasses may override this to map additional/different raw values,
+    # since the same raw value can mean different things on different cubes.
+    MOVEMENT_TYPE = MOVEMENT_TYPE
+
     def __init__(self, *args, **kwargs):
         """Init."""
         self._current_state = {}
@@ -176,7 +183,9 @@ class MultistateInputCluster(CustomCluster, MultistateInput):
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
         if attrid == STATUS_TYPE_ATTR:
-            self._current_state[STATUS_TYPE_ATTR] = action = MOVEMENT_TYPE.get(value)
+            self._current_state[STATUS_TYPE_ATTR] = action = self.MOVEMENT_TYPE.get(
+                value
+            )
             event_args = {VALUE: value}
             if action is not None:
                 if action in (SLIDE, KNOCK):
@@ -195,6 +204,17 @@ class MultistateInputCluster(CustomCluster, MultistateInput):
 
             # show something in the sensor in HA
             super()._update_attribute(0, action)
+
+
+class CubeT1MultistateInputCluster(MultistateInputCluster):
+    """Multistate input cluster for the Aqara T1 cube.
+
+    Raw value 2 means the cube was moved after standing still for a minute,
+    unlike the older cube (CubeAQGL01), where the same raw value means
+    "wakeup" instead.
+    """
+
+    MOVEMENT_TYPE = {**MOVEMENT_TYPE, INACTIVITY_VALUE: INACTIVITY}
 
 
 class CubeT1PowerConfiguration(XiaomiPowerConfiguration):
@@ -480,7 +500,10 @@ class CubeCAGL02FPO(XiaomiCustomDevice):
             },
             2: {
                 DEVICE_TYPE: XIAOMI_SENSORS_REPLACEMENT,
-                INPUT_CLUSTERS: [MultistateInputCluster, CubeT1ManufacturerCluster],
+                INPUT_CLUSTERS: [
+                    CubeT1MultistateInputCluster,
+                    CubeT1ManufacturerCluster,
+                ],
                 OUTPUT_CLUSTERS: [
                     MultistateInput.cluster_id,
                 ],
@@ -498,6 +521,7 @@ class CubeCAGL02FPO(XiaomiCustomDevice):
     device_automation_triggers = {
         **CubeAQGL01.device_automation_triggers,
         (HELD, TURN_ON): {COMMAND: HOLD},
+        (MOVED_AFTER_INACTIVITY, TURN_ON): {COMMAND: INACTIVITY},
         (SIDE_UPPED, FACE_ANY): {COMMAND: SIDE_UP},
         (SIDE_UPPED, FACE_1): {COMMAND: SIDE_UP, ARGS: {ACTIVATED_FACE: 1}},
         (SIDE_UPPED, FACE_2): {COMMAND: SIDE_UP, ARGS: {ACTIVATED_FACE: 2}},

--- a/zhaquirks/xiaomi/aqara/cube_aqgl01.py
+++ b/zhaquirks/xiaomi/aqara/cube_aqgl01.py
@@ -62,6 +62,9 @@ FLIP_BEGIN = 50
 FLIP_DEGREES = "flip_degrees"
 FLIP_END = 180
 FLIPPED = "device_flipped"
+HELD = "device_held"
+HOLD = "hold"
+HOLD_VALUE = 4
 KNOCK = "knock"
 
 KNOCK_1_VALUE = 512  # aqara skyside
@@ -103,6 +106,7 @@ XIAOMI_SENSORS_REPLACEMENT = 0x6F01
 
 MOVEMENT_TYPE = {
     SHAKE_VALUE: SHAKE,
+    HOLD_VALUE: HOLD,
     DROP_VALUE: DROP,
     SLIDE_1_VALUE: SLIDE,
     SLIDE_2_VALUE: SLIDE,
@@ -120,6 +124,7 @@ MOVEMENT_TYPE = {
 
 MOVEMENT_TYPE_DESCRIPTION = {
     SHAKE_VALUE: SHAKE,
+    HOLD_VALUE: HOLD,
     DROP_VALUE: DROP,
     SLIDE_1_VALUE: "aqara logo on top",
     SLIDE_2_VALUE: "aqara logo facing user rotated 90 degrees right",
@@ -492,6 +497,7 @@ class CubeCAGL02FPO(XiaomiCustomDevice):
 
     device_automation_triggers = {
         **CubeAQGL01.device_automation_triggers,
+        (HELD, TURN_ON): {COMMAND: HOLD},
         (SIDE_UPPED, FACE_ANY): {COMMAND: SIDE_UP},
         (SIDE_UPPED, FACE_1): {COMMAND: SIDE_UP, ARGS: {ACTIVATED_FACE: 1}},
         (SIDE_UPPED, FACE_2): {COMMAND: SIDE_UP, ARGS: {ACTIVATED_FACE: 2}},


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

This device is currently only partially supported, this PR improves support.

Diagnostic:

| **What** | **Before** | **After** |
|-|-|-|
| **Battery** | Reports as "Unknown" | Reports as % (press reset button to force it to update immediately) |

Events:

| **Event** | **Modes** | **Before** | **After** |
|-|-|-|-|
| **flip90** | Action | OK | OK |
| **flip180** | Action | OK | OK |
| **rotate** | Scene / Action | OK | OK |
| **push** | Action | OK | OK |
| **tap** | Action | OK | OK |
| **shake** | Scene / Action | OK | OK |
| **move after 1m inactivitiy** | Scene / Action | Missing | Added |
| **flip** | Scene | Missing | Added |
| **pick up and hold** | Scene | Missing | Added |

Tip: to switch between modes, open cover, and press reset button 5 times.

For reference, here's the [device manual](https://cdn.shopify.com/s/files/1/0710/9220/7830/files/Cube-T1-Pro_User-Manual.pdf?v=1723627631) that documents what events should be supported for each mode. Manual says rotate and move after 1m inactivitiy shouldn't work with scene mode, but... they do Oo. 

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

This PR is additive: previously working events should be the same.

I've tested all cases from tables above, things are working fine.

This [Blueprint](https://gist.github.com/fornellas/7e7205200cca9a77c1f1ab9a024037d3)  exposes all possible events and make it easy to configure them.

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->

[zha-01KRPWMR1TP0WS2AFPH3384TTX-LUMI lumi.remote.cagl02-b84b94f43dac055b96f6982b7d2d8b83 (1).json](https://github.com/user-attachments/files/29940293/zha-01KRPWMR1TP0WS2AFPH3384TTX-LUMI.lumi.remote.cagl02-b84b94f43dac055b96f6982b7d2d8b83.1.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
