### PR TITLE
Add APIs for groups, binding, reporting, and writing attributes

### DIFF
--- a/tests/test_quirks_v2_builder.py
+++ b/tests/test_quirks_v2_builder.py
@@ -27,7 +27,11 @@ from zigpy.zdo.types import LogicalType, NodeDescriptor
 
 from zhaquirks.builder import QuirkBuilder
 from zhaquirks.builder.device import QuirkV2Device
-from zhaquirks.builder.metadata import QuirkDefinition, recursive_freeze
+from zhaquirks.builder.metadata import (
+    QuirkDefinition,
+    ReportingConfig,
+    recursive_freeze,
+)
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.const import COMMAND, COMMAND_ON, SHORT_PRESS, TURN_ON
 from zhaquirks.device import CustomZigpyDevice
@@ -428,6 +432,44 @@ async def test_quirks_v2_no_multicast_groups(device_mock):
     quirked = registry.resolve(device_mock)
     entry = registry.match_entry(quirked)
     assert entry.zha_device_factory.quirk_definition.multicast_groups == ()
+
+
+async def test_quirks_v2_cluster_configs_coalesce(device_mock):
+    """Test bind/reporting/writes for one cluster coalesce into a single record."""
+    registry = DeviceRegistry()
+
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model)
+        .binds_cluster(OnOff.cluster_id)
+        .writes_attributes(
+            endpoint_id=1,
+            cluster_id=OnOff.cluster_id,
+            attributes={OnOff.AttributeDefs.start_up_on_off: 0x01},
+        )
+        .configures_reporting(
+            PowerConfiguration.cluster_id,
+            PowerConfiguration.AttributeDefs.battery_percentage_remaining.name,
+            reporting_config=ReportingConfig(
+                min_interval=30, max_interval=900, reportable_change=1
+            ),
+        )
+        .add_to_registry(registry)
+    )
+
+    quirked = registry.resolve(device_mock)
+    entry = registry.match_entry(quirked)
+    configs = entry.zha_device_factory.quirk_definition.cluster_configs
+    by_key = {(c.cluster_id, c.cluster_type): c for c in configs}
+
+    # OnOff bind + write collapse into one record for the (cluster, type)
+    assert len(configs) == 2
+    on_off = by_key[(OnOff.cluster_id, ClusterType.Server)]
+    assert on_off.bind is True
+    assert on_off.attribute_writes == {OnOff.AttributeDefs.start_up_on_off: 0x01}
+
+    power = by_key[(PowerConfiguration.cluster_id, ClusterType.Server)]
+    assert power.bind is True
+    assert len(power.attributes) == 1
 
 
 async def test_quirks_v2_subscribes_to_multicast_group_on_configure():

--- a/tests/test_quirks_v2_builder.py
+++ b/tests/test_quirks_v2_builder.py
@@ -2,7 +2,7 @@
 
 import logging
 from typing import Any
-from unittest.mock import AsyncMock, sentinel
+from unittest.mock import AsyncMock, MagicMock, call, patch, sentinel
 
 from frozendict import frozendict
 import pytest
@@ -26,7 +26,8 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zdo.types import LogicalType, NodeDescriptor
 
 from zhaquirks.builder import QuirkBuilder
-from zhaquirks.builder.metadata import recursive_freeze
+from zhaquirks.builder.device import QuirkV2Device
+from zhaquirks.builder.metadata import QuirkDefinition, recursive_freeze
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.const import COMMAND, COMMAND_ON, SHORT_PRESS, TURN_ON
 from zhaquirks.device import CustomZigpyDevice
@@ -393,6 +394,62 @@ async def test_quirks_v2_skip_configuration(device_mock):
     # definition rather than on the resolved zigpy device.
     entry = registry.match_entry(quirked)
     assert entry.zha_device_factory.quirk_definition.skip_configuration is True
+
+
+async def test_quirks_v2_subscribes_to_multicast_group(device_mock):
+    """Test a quirk's declared multicast groups land on the quirk definition."""
+    registry = DeviceRegistry()
+
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model)
+        .subscribes_to_multicast_group(0x549A)
+        .subscribes_to_multicast_group(0x1234)
+        .add_to_registry(registry)
+    )
+
+    quirked = registry.resolve(device_mock)
+    entry = registry.match_entry(quirked)
+    assert entry.zha_device_factory.quirk_definition.multicast_groups == (
+        0x549A,
+        0x1234,
+    )
+
+
+async def test_quirks_v2_no_multicast_groups(device_mock):
+    """Test a quirk that declares no multicast groups has an empty tuple."""
+    registry = DeviceRegistry()
+
+    (
+        QuirkBuilder(device_mock.manufacturer, device_mock.model)
+        .adds(OnOff.cluster_id)
+        .add_to_registry(registry)
+    )
+
+    quirked = registry.resolve(device_mock)
+    entry = registry.match_entry(quirked)
+    assert entry.zha_device_factory.quirk_definition.multicast_groups == ()
+
+
+async def test_quirks_v2_subscribes_to_multicast_group_on_configure():
+    """Test `async_configure` subscribes the coordinator to the declared groups."""
+    definition = QuirkDefinition(multicast_groups=(0x549A, 0x549B))
+
+    # Build a bare QuirkV2Device without ZHA's heavy `Device.__init__`; only the
+    # quirk definition and gateway are needed to exercise the override.
+    device = object.__new__(QuirkV2Device)
+    device._quirk_definition = definition
+
+    app = MagicMock()
+    app.subscribe_to_multicast_group = AsyncMock()
+    device._gateway = MagicMock(application_controller=app)
+
+    with patch(
+        "zhaquirks.builder.device.Device.async_configure", AsyncMock()
+    ) as super_configure:
+        await device.async_configure()
+
+    assert super_configure.mock_calls == [call()]
+    assert app.subscribe_to_multicast_group.mock_calls == [call(0x549A), call(0x549B)]
 
 
 async def test_quirks_v2_device_automation_triggers_on_zigpy_device(device_mock):

--- a/zhaquirks/builder/builder.py
+++ b/zhaquirks/builder/builder.py
@@ -364,6 +364,7 @@ class QuirkBuilder:
         self.device_automation_triggers_metadata: dict[
             tuple[str, str], dict[str, str]
         ] = {}
+        self.multicast_groups: list[int] = []
 
         current_frame: FrameType = inspect.currentframe()
         caller: FrameType = current_frame.f_back
@@ -954,6 +955,11 @@ class QuirkBuilder:
         self.device_automation_triggers_metadata.update(device_automation_triggers)
         return self
 
+    def subscribes_to_multicast_group(self, group_id: int) -> Self:
+        """Register a group ID the coordinator must subscribe to."""
+        self.multicast_groups.append(group_id)
+        return self
+
     def friendly_name(self, *, model: str, manufacturer: str) -> Self:
         """Rename the device."""
         self.friendly_name_metadata = FriendlyNameMetadata(
@@ -1092,6 +1098,7 @@ class QuirkBuilder:
             entity_metadata=tuple(self.entity_metadata),
             device_automation_triggers=self.device_automation_triggers_metadata,
             skip_configuration=self.skip_device_configuration,
+            multicast_groups=tuple(self.multicast_groups),
         )
 
         # Shared QuirkV2Device (or custom subclass) bound to this definition; no subclass minted.

--- a/zhaquirks/builder/builder.py
+++ b/zhaquirks/builder/builder.py
@@ -47,8 +47,10 @@ from zigpy.zdo.types import NodeDescriptor
 
 from zhaquirks.builder.device import QuirkV2Device, QuirkV2Factory
 from zhaquirks.builder.metadata import (
+    AttributeReportingConfigMetadata,
     BinarySensorMetadata,
     ChangedEntityMetadata,
+    ClusterConfigMetadata,
     DeviceAlertLevel,
     DeviceAlertMetadata,
     EntityMetadata,
@@ -328,6 +330,15 @@ class SetDeviceAutomationTriggers:
         return device
 
 
+@dataclass
+class ClusterConfigAccumulator:
+    """Mutable per-cluster config gathered while building, frozen into `ClusterConfigMetadata`."""
+
+    bind: bool = False
+    attributes: list[AttributeReportingConfigMetadata] = field(default_factory=list)
+    attribute_writes: dict[ZCLAttributeDef, Any] = field(default_factory=dict)
+
+
 class QuirkBuilder:
     """Builder compiling a declarative quirk into a registered `Device` subclass."""
 
@@ -365,6 +376,11 @@ class QuirkBuilder:
             tuple[str, str], dict[str, str]
         ] = {}
         self.multicast_groups: list[int] = []
+        # Keyed by (endpoint_id, cluster_id, cluster_type) so bind, reporting, and
+        # attribute writes for the same cluster coalesce into one config record.
+        self.cluster_configs: dict[
+            tuple[int, int, ClusterType], ClusterConfigAccumulator
+        ] = {}
 
         current_frame: FrameType = inspect.currentframe()
         caller: FrameType = current_frame.f_back
@@ -960,6 +976,60 @@ class QuirkBuilder:
         self.multicast_groups.append(group_id)
         return self
 
+    def _cluster_config(
+        self, endpoint_id: int, cluster_id: int, cluster_type: ClusterType
+    ) -> ClusterConfigAccumulator:
+        """Return the mutable config accumulator for one cluster, creating it."""
+        return self.cluster_configs.setdefault(
+            (endpoint_id, cluster_id, cluster_type), ClusterConfigAccumulator()
+        )
+
+    def binds_cluster(
+        self,
+        cluster_id: int,
+        cluster_type: ClusterType = ClusterType.Server,
+        endpoint_id: int = 1,
+    ) -> Self:
+        """Bind a cluster to the coordinator without exposing an entity."""
+        self._cluster_config(endpoint_id, cluster_id, cluster_type).bind = True
+        return self
+
+    def configures_reporting(
+        self,
+        cluster_id: int,
+        attribute_name: str,
+        reporting_config: ReportingConfig,
+        cluster_type: ClusterType = ClusterType.Server,
+        endpoint_id: int = 1,
+        bind: bool = True,
+        read_on_startup: bool = False,
+    ) -> Self:
+        """Set up attribute reporting for a cluster without exposing an entity."""
+        config = self._cluster_config(endpoint_id, cluster_id, cluster_type)
+        config.bind = config.bind or bind
+        config.attributes.append(
+            AttributeReportingConfigMetadata(
+                attribute_name=attribute_name,
+                reporting_config=reporting_config,
+                read_on_startup=read_on_startup,
+            )
+        )
+        return self
+
+    def writes_attributes(
+        self,
+        *,
+        endpoint_id: int,
+        cluster_id: int,
+        cluster_type: ClusterType = ClusterType.Server,
+        attributes: dict[ZCLAttributeDef, Any],
+    ) -> Self:
+        """Write attributes to a cluster once, when the device is configured."""
+        self._cluster_config(
+            endpoint_id, cluster_id, cluster_type
+        ).attribute_writes.update(attributes)
+        return self
+
     def friendly_name(self, *, model: str, manufacturer: str) -> Self:
         """Rename the device."""
         self.friendly_name_metadata = FriendlyNameMetadata(
@@ -1099,6 +1169,21 @@ class QuirkBuilder:
             device_automation_triggers=self.device_automation_triggers_metadata,
             skip_configuration=self.skip_device_configuration,
             multicast_groups=tuple(self.multicast_groups),
+            cluster_configs=tuple(
+                ClusterConfigMetadata(
+                    endpoint_id=endpoint_id,
+                    cluster_id=cluster_id,
+                    cluster_type=cluster_type,
+                    bind=config.bind,
+                    attributes=tuple(config.attributes),
+                    attribute_writes=frozendict(config.attribute_writes),
+                )
+                for (
+                    endpoint_id,
+                    cluster_id,
+                    cluster_type,
+                ), config in self.cluster_configs.items()
+            ),
         )
 
         # Shared QuirkV2Device (or custom subclass) bound to this definition; no subclass minted.

--- a/zhaquirks/builder/device.py
+++ b/zhaquirks/builder/device.py
@@ -47,6 +47,17 @@ class QuirkV2Device(Device):
         yield from super().discover_entities()
         yield from discover_quirks_v2_entities(self)
 
+    async def async_configure(self) -> None:
+        """Configure the device, then subscribe the coordinator to its groups."""
+        await super().async_configure()
+
+        app = self.gateway.application_controller
+
+        # Coordinators with old firmware still filter group commands unless manually
+        # added
+        for group_id in self._quirk_definition.multicast_groups:
+            await app.subscribe_to_multicast_group(group_id)
+
     def _quirk_exposes_features(self) -> set[str]:
         return {f.feature for f in self._quirk_definition.exposes_features}
 

--- a/zhaquirks/builder/discovery.py
+++ b/zhaquirks/builder/discovery.py
@@ -25,10 +25,12 @@ from zha.application.platforms import (
     sensor,
     switch,
 )
+from zha.application.platforms.virtual import VirtualEntity
 from zigpy.zcl import ClusterType, ReportingConfig
 
 from zhaquirks.builder.metadata import (
     BinarySensorMetadata,
+    ClusterConfigMetadata,
     EntityMetadata,
     NumberMetadata,
     SwitchMetadata,
@@ -127,16 +129,107 @@ def _platform_kwargs(entity_metadata: EntityMetadata) -> dict[str, Any]:
     return {}
 
 
+class QuirkClusterConfigEntity(VirtualEntity):
+    """Entity-less carrier for quirk-declared cluster bind/write/reporting config."""
+
+
+def _discover_cluster_config_entities(
+    device: Device, cluster_configs: tuple[ClusterConfigMetadata, ...]
+) -> Iterator[PlatformEntity]:
+    """Yield config-only virtual entities for entity-less cluster configs."""
+    for cluster_config in cluster_configs:
+        endpoint_id = cluster_config.endpoint_id
+        cluster_id = cluster_config.cluster_id
+        cluster_type = cluster_config.cluster_type
+
+        if endpoint_id not in device.endpoints:
+            _LOGGER.warning(
+                "Device: %s-%s does not have an endpoint with id: %s - unable to "
+                "apply cluster config: %s",
+                str(device.ieee),
+                device.name,
+                endpoint_id,
+                cluster_config,
+            )
+            continue
+
+        endpoint = device.endpoints[endpoint_id]
+        cluster = (
+            endpoint.zigpy_endpoint.in_clusters.get(cluster_id)
+            if cluster_type is ClusterType.Server
+            else endpoint.zigpy_endpoint.out_clusters.get(cluster_id)
+        )
+
+        if cluster is None:
+            _LOGGER.warning(
+                "Device: %s-%s does not have a cluster with id: %s - "
+                "unable to apply cluster config: %s",
+                str(device.ieee),
+                device.name,
+                cluster_id,
+                cluster_config,
+            )
+            continue
+
+        # Attribute names stay strings - quirks can reference manufacturer
+        # specific attributes outside the cluster's schema; the aggregation and
+        # configure flow handle both names and ZCLAttributeDef objects.
+        attributes = {
+            attr.attribute_name: AttrConfig(
+                read_on_startup=attr.read_on_startup,
+                reporting=(
+                    ReportingConfig(
+                        min_interval=attr.reporting_config.min_interval,
+                        max_interval=attr.reporting_config.max_interval,
+                        reportable_change=attr.reporting_config.reportable_change,
+                    )
+                    if attr.reporting_config is not None
+                    else None
+                ),
+            )
+            for attr in cluster_config.attributes
+        }
+        config = {
+            cluster.cluster_id: ClusterConfig(
+                bind=cluster_config.bind,
+                attributes=attributes,
+                attribute_writes=dict(cluster_config.attribute_writes),
+            )
+        }
+
+        # One config record per (endpoint, cluster, type); the suffix only needs
+        # to disambiguate a server and client config on the same cluster.
+        suffix = f"cluster_config-{cluster_id:#06x}-{cluster_type.name.lower()}"
+
+        entity = QuirkClusterConfigEntity(
+            endpoint=endpoint,
+            device=device,
+            cluster=cluster,
+            from_quirk=True,
+            unique_id_suffix=suffix,
+        )
+        if cluster_type is ClusterType.Server:
+            entity._server_cluster_config = config
+        else:
+            entity._client_cluster_config = config
+
+        yield entity
+
+
 def discover_quirks_v2_entities(device: Device) -> Iterator[PlatformEntity]:
     """Discover entities exposed by a device's quirks v2 metadata."""
     quirk_metadata = device.quirk_metadata
-    if quirk_metadata is None or not quirk_metadata.entity_metadata:
+    if quirk_metadata is None or (
+        not quirk_metadata.entity_metadata and not quirk_metadata.cluster_configs
+    ):
         _LOGGER.debug(
             "Device: %s-%s does not expose any quirks v2 entities",
             str(device.ieee),
             device.name,
         )
         return
+
+    yield from _discover_cluster_config_entities(device, quirk_metadata.cluster_configs)
 
     for entity_metadata in quirk_metadata.entity_metadata:
         endpoint_id = entity_metadata.endpoint_id

--- a/zhaquirks/builder/metadata.py
+++ b/zhaquirks/builder/metadata.py
@@ -23,6 +23,7 @@ from zha.application.platforms.sensor.device_class import (
     SensorStateClass,
 )
 from zigpy.zcl import ClusterType
+from zigpy.zcl.foundation import ZCLAttributeDef
 
 # pylint: disable=too-many-instance-attributes
 
@@ -224,6 +225,35 @@ class ChangedEntityMetadata:
     new_fallback_name: str | None = attrs.field(default=None)
 
 
+@attrs.define(frozen=True, kw_only=True, repr=True)
+class AttributeReportingConfigMetadata:
+    """Reporting / read-on-startup config for a single attribute, without an entity."""
+
+    attribute_name: str = attrs.field()
+    reporting_config: ReportingConfig | None = attrs.field(default=None)
+    read_on_startup: bool = attrs.field(default=False)
+
+
+@attrs.define(frozen=True, kw_only=True, repr=True)
+class ClusterConfigMetadata:
+    """Entity-less cluster configuration: bind, write attributes, and/or set up reporting.
+
+    Realized as a config-only virtual entity that ZHA's cluster-config
+    aggregation picks up, without the cluster being surfaced as an entity.
+    """
+
+    cluster_id: int = attrs.field()
+    endpoint_id: int = attrs.field(default=1)
+    cluster_type: ClusterType = attrs.field(default=ClusterType.Server)
+    bind: bool = attrs.field(default=False)
+    attributes: tuple[AttributeReportingConfigMetadata, ...] = attrs.field(
+        factory=tuple
+    )
+    attribute_writes: frozendict[ZCLAttributeDef, Any] = attrs.field(
+        factory=frozendict, converter=frozendict
+    )
+
+
 def recursive_freeze(obj: Any) -> Any:
     """Recursively convert mutable collections to immutable ones."""
     if isinstance(obj, dict):
@@ -258,3 +288,4 @@ class QuirkDefinition:
     )
     skip_configuration: bool = attrs.field(default=False)
     multicast_groups: tuple[int, ...] = attrs.field(factory=tuple, converter=tuple)
+    cluster_configs: tuple[ClusterConfigMetadata, ...] = attrs.field(factory=tuple)

--- a/zhaquirks/builder/metadata.py
+++ b/zhaquirks/builder/metadata.py
@@ -257,3 +257,4 @@ class QuirkDefinition:
         attrs.field(factory=frozendict, converter=recursive_freeze)
     )
     skip_configuration: bool = attrs.field(default=False)
+    multicast_groups: tuple[int, ...] = attrs.field(factory=tuple, converter=tuple)

--- a/zhaquirks/ikea/bilresarotary.py
+++ b/zhaquirks/ikea/bilresarotary.py
@@ -1,4 +1,4 @@
-"""IKEA Bilresa 2 button remote control."""
+"""IKEA Bilresa rotary (scroll wheel) remote control."""
 
 from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import LevelControl, OnOff, Scenes
@@ -25,14 +25,22 @@ from zhaquirks.const import (
 from zhaquirks.ikea import IKEA, IkeaBilresaLevelControl, ScenesCluster
 
 (
-    QuirkBuilder(IKEA, "09B9")
+    QuirkBuilder(IKEA, "09BA")
     .subscribes_to_multicast_group(0x549A)
+    .subscribes_to_multicast_group(0x549B)
+    .subscribes_to_multicast_group(0x549C)
+    .subscribes_to_multicast_group(0xFF09)
     .replaces(ScenesCluster, cluster_type=ClusterType.Client)
     .replace_cluster_occurrences(IkeaBilresaLevelControl)
     .device_automation_triggers(
         {
             (SHORT_PRESS, TURN_ON): {
                 COMMAND: COMMAND_ON,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: 1,
+            },
+            (SHORT_PRESS, TURN_OFF): {
+                COMMAND: COMMAND_OFF,
                 CLUSTER_ID: OnOff.cluster_id,
                 ENDPOINT_ID: 1,
             },
@@ -45,11 +53,6 @@ from zhaquirks.ikea import IKEA, IkeaBilresaLevelControl, ScenesCluster
             (LONG_RELEASE, DIM_UP): {
                 COMMAND: "move_up_release",
                 CLUSTER_ID: LevelControl.cluster_id,
-                ENDPOINT_ID: 1,
-            },
-            (SHORT_PRESS, TURN_OFF): {
-                COMMAND: COMMAND_OFF,
-                CLUSTER_ID: OnOff.cluster_id,
                 ENDPOINT_ID: 1,
             },
             (LONG_PRESS, DIM_DOWN): {

--- a/zhaquirks/mli/tint.py
+++ b/zhaquirks/mli/tint.py
@@ -1,30 +1,12 @@
 """Tint remote."""
 
-from zigpy.profiles import zha
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Groups,
-    Identify,
-    LevelControl,
-    OnOff,
-    Ota,
-    Scenes,
-)
-from zigpy.zcl.clusters.lighting import Color
-from zigpy.zcl.clusters.lightlink import LightLink
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.general import Basic, Scenes
 
 from zhaquirks import Bus, LocalDataCluster
+from zhaquirks.builder import QuirkBuilder
 from zhaquirks.clusters import CustomCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-from zhaquirks.legacy import CustomDevice
+from zhaquirks.device import CustomZigpyDevice
 
 TINT_SCENE_ATTR = 0x4005
 
@@ -59,7 +41,7 @@ class TintRemoteBasicCluster(CustomCluster, Basic):
         self.endpoint.device.scene_bus.listener_event("change_scene", value)
 
 
-class TintRemote(CustomDevice):
+class TintRemote(CustomZigpyDevice):
     """Tint remote quirk."""
 
     def __init__(self, *args, **kwargs):
@@ -67,54 +49,12 @@ class TintRemote(CustomDevice):
         self.scene_bus = Bus()
         super().__init__(*args, **kwargs)
 
-    signature = {
-        # endpoint=1 profile=260 device_type=2048 device_version=1 input_clusters=[0, 3, 4096]
-        # output_clusters=[0, 3, 4, 5, 8, 25, 768, 4096]
-        MODELS_INFO: [("MLI", "ZBT-Remote-ALL-RGBW")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_CONTROLLER,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    LightLink.cluster_id,  # 4096
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Ota.cluster_id,  # 25
-                    Color.cluster_id,  # 768
-                    LightLink.cluster_id,  # 4096
-                ],
-            },
-        },
-    }
 
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_CONTROLLER,
-                INPUT_CLUSTERS: [
-                    TintRemoteBasicCluster,  # 0
-                    Identify.cluster_id,  # 3
-                    LightLink.cluster_id,  # 4096
-                ],
-                OUTPUT_CLUSTERS: [
-                    Basic.cluster_id,  # 0
-                    Identify.cluster_id,  # 3
-                    Groups.cluster_id,  # 4
-                    TintRemoteScenesCluster,  # 5
-                    OnOff.cluster_id,  # 6
-                    LevelControl.cluster_id,  # 8
-                    Ota.cluster_id,  # 25
-                    Color.cluster_id,  # 768
-                    LightLink.cluster_id,  # 4096
-                ],
-            },
-        },
-    }
+(
+    QuirkBuilder("MLI", "ZBT-Remote-ALL-RGBW")
+    .device_class(TintRemote)
+    .subscribes_to_multicast_group(0x4004)
+    .replaces(TintRemoteBasicCluster, endpoint_id=1)
+    .adds(TintRemoteScenesCluster, cluster_type=ClusterType.Client, endpoint_id=1)
+    .add_to_registry()
+)

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -51,6 +51,7 @@ from zhaquirks.const import (
     ZHA_SEND_EVENT,
     BatterySize,
 )
+from zhaquirks.device import CustomZigpyDevice
 from zhaquirks.legacy import (
     CustomDevice,
     get_quirk_list,
@@ -118,8 +119,8 @@ XIAOMI_NODE_DESC = NodeDescriptor(
 _LOGGER = logging.getLogger(__name__)
 
 
-class XiaomiCustomDevice(CustomDevice):
-    """Custom device representing xiaomi devices."""
+class XiaomiCustomDeviceMixin:
+    """Shared Xiaomi device behavior for both v1 and v2 quirk device bases."""
 
     def __init__(self, *args, **kwargs):
         """Init."""
@@ -149,6 +150,14 @@ class XiaomiCustomDevice(CustomDevice):
                 ),
                 packet,
             )
+
+
+class XiaomiCustomDevice(XiaomiCustomDeviceMixin, CustomDevice):
+    """Custom device representing xiaomi devices."""
+
+
+class XiaomiCustomZigpyDevice(XiaomiCustomDeviceMixin, CustomZigpyDevice):
+    """Quirks v2 zigpy device base for Xiaomi devices."""
 
 
 class XiaomiQuickInitDevice(XiaomiCustomDevice, QuickInitDevice):

--- a/zhaquirks/xiaomi/aqara/opple_remote.py
+++ b/zhaquirks/xiaomi/aqara/opple_remote.py
@@ -1,19 +1,14 @@
 """Xiaomi aqara opple remote devices."""
 
+from typing import Final
+
 from zigpy import types
 from zigpy.profiles import zha
-from zigpy.zcl.clusters.general import (
-    Basic,
-    Identify,
-    LevelControl,
-    MultistateInput,
-    OnOff,
-    PowerConfiguration,
-)
-from zigpy.zcl.clusters.lighting import Color
-from zigpy.zdo.types import NodeDescriptor
+from zigpy.zcl.clusters.general import MultistateInput
+from zigpy.zcl.foundation import ZCLAttributeDef
 
 from zhaquirks import CustomCluster
+from zhaquirks.builder import QuirkBuilder
 from zhaquirks.const import (
     ALT_DOUBLE_PRESS,
     ALT_LONG_PRESS,
@@ -33,19 +28,12 @@ from zhaquirks.const import (
     COMMAND_ON,
     COMMAND_STEP,
     COMMAND_STEP_COLOR_TEMP,
-    DEVICE_TYPE,
     DOUBLE_PRESS,
     ENDPOINT_ID,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
     LONG_PRESS,
     LONG_RELEASE,
-    MODELS_INFO,
-    NODE_DESCRIPTOR,
-    OUTPUT_CLUSTERS,
     PARAMS,
     PRESS_TYPE,
-    PROFILE_ID,
     SHORT_PRESS,
     TRIPLE_PRESS,
     VALUE,
@@ -55,7 +43,7 @@ from zhaquirks.xiaomi import (
     LUMI,
     BasicCluster,
     XiaomiAqaraE1Cluster,
-    XiaomiCustomDevice,
+    XiaomiCustomZigpyDevice,
     XiaomiPowerConfiguration,
 )
 
@@ -138,1484 +126,234 @@ class MultistateInputCluster(CustomCluster, MultistateInput):
 class OppleCluster(XiaomiAqaraE1Cluster):
     """Opple cluster."""
 
-    attributes = {
-        0x0009: ("mode", types.uint8_t, True),
-    }
-    attr_config = {0x0009: 0x01}
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self._current_state = None
-        super().__init__(*args, **kwargs)
-
-    async def bind(self):
-        """Bind cluster."""
-        result = await super().bind()
-        await self.write_attributes(self.attr_config, manufacturer=OPPLE_MFG_CODE)
-        return result
-
-
-class RemoteB286OPCN01(XiaomiCustomDevice):
-    """Aqara Opple 2 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b286opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            # <SimpleDescriptor endpoint=2 profile=260 device_type=259
-            # device_version=1
-            # input_clusters=[3]
-            # output_clusters=[6, 3]>
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            3: {},
-            4: {},
-            5: {},
-            6: {},
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            3: {},
-            4: {},
-            5: {},
-            6: {},
-        },
-    }
-
-    device_automation_triggers = {
-        (DOUBLE_PRESS, BUTTON_1): {
-            COMMAND: COMMAND_STEP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"step_mode": 1},
-        },
-        (SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1},
-        (LONG_PRESS, BUTTON_1): {
-            COMMAND: COMMAND_STEP_COLOR_TEMP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"step_mode": 1},
-        },
-        (DOUBLE_PRESS, BUTTON_2): {
-            COMMAND: COMMAND_STEP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"step_mode": 0},
-        },
-        (SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_ON, ENDPOINT_ID: 1},
-        (LONG_PRESS, BUTTON_2): {
-            COMMAND: COMMAND_STEP_COLOR_TEMP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"step_mode": 3},
-        },
-        (ALT_SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_1_SINGLE},
-        (ALT_DOUBLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_DOUBLE},
-        (TRIPLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_TRIPLE},
-        (ALT_LONG_PRESS, BUTTON_1): {COMMAND: COMMAND_1_HOLD},
-        (LONG_RELEASE, BUTTON_1): {COMMAND: COMMAND_1_RELEASE},
-        (ALT_SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_2_SINGLE},
-        (ALT_DOUBLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_DOUBLE},
-        (TRIPLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_TRIPLE},
-        (ALT_LONG_PRESS, BUTTON_2): {COMMAND: COMMAND_2_HOLD},
-        (LONG_RELEASE, BUTTON_2): {COMMAND: COMMAND_2_RELEASE},
-    }
-
-
-class RemoteB286OPCN01V2(XiaomiCustomDevice):
-    """Aqara Opple 2 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b286opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
-
-    device_automation_triggers = RemoteB286OPCN01.device_automation_triggers
-
-
-class RemoteB286OPCN01Alt(XiaomiCustomDevice):
-    """Aqara Opple 2 button remote device (after alternate mode is enabled)."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b286opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {},
-            3: {},
-            4: {},
-            5: {},
-            6: {},
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            3: {},
-            4: {},
-            5: {},
-            6: {},
-        },
-    }
-
-    device_automation_triggers = RemoteB286OPCN01.device_automation_triggers
-
-
-class RemoteB486OPCN01(XiaomiCustomDevice):
-    """Aqara Opple 4 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b486opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            # <SimpleDescriptor endpoint=2 profile=260 device_type=259
-            # device_version=1
-            # input_clusters=[3]
-            # output_clusters=[6, 3]>
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            3: {},
-            4: {},
-            5: {},
-            6: {},
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            5: {},
-            6: {},
-        },
-    }
-
-    device_automation_triggers = {
-        (SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1},
-        (SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_ON, ENDPOINT_ID: 1},
-        (SHORT_PRESS, BUTTON_3): {
-            COMMAND: COMMAND_STEP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"step_mode": 1},
-        },
-        (DOUBLE_PRESS, BUTTON_3): {
-            COMMAND: COMMAND_STEP_COLOR_TEMP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"step_mode": 1},
-        },
-        (SHORT_PRESS, BUTTON_4): {
-            COMMAND: COMMAND_STEP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"step_mode": 0},
-        },
-        (DOUBLE_PRESS, BUTTON_4): {
-            COMMAND: COMMAND_STEP_COLOR_TEMP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"step_mode": 3},
-        },
-        (ALT_SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_1_SINGLE},
-        (ALT_DOUBLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_DOUBLE},
-        (TRIPLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_TRIPLE},
-        (ALT_LONG_PRESS, BUTTON_1): {COMMAND: COMMAND_1_HOLD},
-        (LONG_RELEASE, BUTTON_1): {COMMAND: COMMAND_1_RELEASE},
-        (ALT_SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_2_SINGLE},
-        (ALT_DOUBLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_DOUBLE},
-        (TRIPLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_TRIPLE},
-        (ALT_LONG_PRESS, BUTTON_2): {COMMAND: COMMAND_2_HOLD},
-        (LONG_RELEASE, BUTTON_2): {COMMAND: COMMAND_2_RELEASE},
-        (ALT_SHORT_PRESS, BUTTON_3): {COMMAND: COMMAND_3_SINGLE},
-        (ALT_DOUBLE_PRESS, BUTTON_3): {COMMAND: COMMAND_3_DOUBLE},
-        (TRIPLE_PRESS, BUTTON_3): {COMMAND: COMMAND_3_TRIPLE},
-        (ALT_LONG_PRESS, BUTTON_3): {COMMAND: COMMAND_3_HOLD},
-        (LONG_RELEASE, BUTTON_3): {COMMAND: COMMAND_3_RELEASE},
-        (ALT_SHORT_PRESS, BUTTON_4): {COMMAND: COMMAND_4_SINGLE},
-        (ALT_DOUBLE_PRESS, BUTTON_4): {COMMAND: COMMAND_4_DOUBLE},
-        (TRIPLE_PRESS, BUTTON_4): {COMMAND: COMMAND_4_TRIPLE},
-        (ALT_LONG_PRESS, BUTTON_4): {COMMAND: COMMAND_4_HOLD},
-        (LONG_RELEASE, BUTTON_4): {COMMAND: COMMAND_4_RELEASE},
-    }
-
-
-class RemoteB686OPCN01(XiaomiCustomDevice):
-    """Aqara Opple 6 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b686opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            # <SimpleDescriptor endpoint=2 profile=260 device_type=259
-            # device_version=1
-            # input_clusters=[3]
-            # output_clusters=[6, 3]>
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            3: {},
-            4: {},
-            5: {},
-            6: {},
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
-
-    device_automation_triggers = {
-        (SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1},
-        (SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_ON, ENDPOINT_ID: 1},
-        (SHORT_PRESS, BUTTON_3): {
-            COMMAND: COMMAND_STEP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"step_mode": 1},
-        },
-        (LONG_PRESS, BUTTON_3): {
-            COMMAND: COMMAND_MOVE,
-            ENDPOINT_ID: 1,
-            PARAMS: {"move_mode": 1},
-        },
-        (SHORT_PRESS, BUTTON_4): {
-            COMMAND: COMMAND_STEP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"step_mode": 0},
-        },
-        (LONG_PRESS, BUTTON_4): {
-            COMMAND: COMMAND_MOVE,
-            ENDPOINT_ID: 1,
-            PARAMS: {"move_mode": 0},
-        },
-        (SHORT_PRESS, BUTTON_5): {
-            COMMAND: COMMAND_STEP_COLOR_TEMP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"step_mode": 1},
-        },
-        (LONG_PRESS, BUTTON_5): {
-            COMMAND: COMMAND_MOVE_COLOR_TEMP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"move_mode": 1},
-        },
-        (SHORT_PRESS, BUTTON_6): {
-            COMMAND: COMMAND_STEP_COLOR_TEMP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"step_mode": 3},
-        },
-        (LONG_PRESS, BUTTON_6): {
-            COMMAND: COMMAND_MOVE_COLOR_TEMP,
-            ENDPOINT_ID: 1,
-            PARAMS: {"move_mode": 3},
-        },
-        (ALT_SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_1_SINGLE},
-        (ALT_DOUBLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_DOUBLE},
-        (TRIPLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_TRIPLE},
-        (ALT_LONG_PRESS, BUTTON_1): {COMMAND: COMMAND_1_HOLD},
-        (LONG_RELEASE, BUTTON_1): {COMMAND: COMMAND_1_RELEASE},
-        (ALT_SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_2_SINGLE},
-        (ALT_DOUBLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_DOUBLE},
-        (TRIPLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_TRIPLE},
-        (ALT_LONG_PRESS, BUTTON_2): {COMMAND: COMMAND_2_HOLD},
-        (LONG_RELEASE, BUTTON_2): {COMMAND: COMMAND_2_RELEASE},
-        (ALT_SHORT_PRESS, BUTTON_3): {COMMAND: COMMAND_3_SINGLE},
-        (ALT_DOUBLE_PRESS, BUTTON_3): {COMMAND: COMMAND_3_DOUBLE},
-        (TRIPLE_PRESS, BUTTON_3): {COMMAND: COMMAND_3_TRIPLE},
-        (ALT_LONG_PRESS, BUTTON_3): {COMMAND: COMMAND_3_HOLD},
-        (LONG_RELEASE, BUTTON_3): {COMMAND: COMMAND_3_RELEASE},
-        (ALT_SHORT_PRESS, BUTTON_4): {COMMAND: COMMAND_4_SINGLE},
-        (ALT_DOUBLE_PRESS, BUTTON_4): {COMMAND: COMMAND_4_DOUBLE},
-        (TRIPLE_PRESS, BUTTON_4): {COMMAND: COMMAND_4_TRIPLE},
-        (ALT_LONG_PRESS, BUTTON_4): {COMMAND: COMMAND_4_HOLD},
-        (LONG_RELEASE, BUTTON_4): {COMMAND: COMMAND_4_RELEASE},
-        (ALT_SHORT_PRESS, BUTTON_5): {COMMAND: COMMAND_5_SINGLE},
-        (ALT_DOUBLE_PRESS, BUTTON_5): {COMMAND: COMMAND_5_DOUBLE},
-        (TRIPLE_PRESS, BUTTON_5): {COMMAND: COMMAND_5_TRIPLE},
-        (ALT_LONG_PRESS, BUTTON_5): {COMMAND: COMMAND_5_HOLD},
-        (LONG_RELEASE, BUTTON_5): {COMMAND: COMMAND_5_RELEASE},
-        (ALT_SHORT_PRESS, BUTTON_6): {COMMAND: COMMAND_6_SINGLE},
-        (ALT_DOUBLE_PRESS, BUTTON_6): {COMMAND: COMMAND_6_DOUBLE},
-        (TRIPLE_PRESS, BUTTON_6): {COMMAND: COMMAND_6_TRIPLE},
-        (ALT_LONG_PRESS, BUTTON_6): {COMMAND: COMMAND_6_HOLD},
-        (LONG_RELEASE, BUTTON_6): {COMMAND: COMMAND_6_RELEASE},
-    }
-
-
-class RemoteB286OPCN01V3(XiaomiCustomDevice):
-    """Aqara Opple 2 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b286opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            # <SimpleDescriptor endpoint=2 profile=260 device_type=259
-            # device_version=1
-            # input_clusters=[3]
-            # output_clusters=[6, 3]>
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            }
-        },
-    }
-
-    device_automation_triggers = RemoteB286OPCN01.device_automation_triggers
-
-
-class RemoteB286OPCN01V4(XiaomiCustomDevice):
-    """Aqara Opple 2 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b286opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id, Identify.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id, Identify.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-        },
-    }
-
-    device_automation_triggers = RemoteB286OPCN01.device_automation_triggers
-
-
-class RemoteB486OPCN01V2(XiaomiCustomDevice):
-    """Aqara Opple 4 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b486opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
-
-    device_automation_triggers = RemoteB486OPCN01.device_automation_triggers
-
-
-class RemoteB486OPCN01V3(XiaomiCustomDevice):
-    """Aqara Opple 4 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b486opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {},
-            3: {},
-            4: {},
-            5: {},
-            6: {},
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            5: {},
-            6: {},
-        },
-    }
-
-    device_automation_triggers = RemoteB486OPCN01.device_automation_triggers
-
-
-class RemoteB486OPCN01V4(XiaomiCustomDevice):
-    """Aqara Opple 4 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b486opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            # <SimpleDescriptor endpoint=2 profile=260 device_type=259
-            # device_version=1
-            # input_clusters=[3]
-            # output_clusters=[6, 3]>
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            # <SimpleDescriptor endpoint=2 profile=260 device_type=259
-            # device_version=1
-            # input_clusters=[3, 18]
-            # output_clusters=[6]>
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInput.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInput.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInput.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInput.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
-
-    device_automation_triggers = RemoteB486OPCN01.device_automation_triggers
-
-
-class RemoteB686OPCN01V2(XiaomiCustomDevice):
-    """Aqara Opple 6 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b686opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            }
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
-                OUTPUT_CLUSTERS: [Identify.cluster_id, OnOff.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
-
-    device_automation_triggers = RemoteB686OPCN01.device_automation_triggers
-
-
-class RemoteB686OPCN01V3(XiaomiCustomDevice):
-    """Aqara Opple 6 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b686opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id, Identify.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id, Identify.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-        },
-    }
-
-    device_automation_triggers = RemoteB686OPCN01.device_automation_triggers
-
-
-class RemoteB686OPCN01V4(XiaomiCustomDevice):
-    """Aqara Opple 6 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b686opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id, Identify.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [
-                    MultistateInputCluster.cluster_id,
-                    Identify.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            5: {},
-            6: {},
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id, Identify.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-        },
-    }
-
-    device_automation_triggers = RemoteB686OPCN01.device_automation_triggers
-
-
-class RemoteB686OPCN01V5(XiaomiCustomDevice):
-    """Aqara Opple 6 button remote device."""
-
-    signature = {
-        # <SimpleDescriptor endpoint=1 profile=260 device_type=261
-        # device_version=1
-        # input_clusters=[0, 3, 1]
-        # output_clusters=[3, 6, 8, 768]>
-        MODELS_INFO: [(LUMI, "lumi.remote.b686opcn01")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    PowerConfiguration.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {},
-            3: {},
-            4: {},
-            5: {},
-            6: {},
-        },
-    }
-
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    Identify.cluster_id,
-                    XiaomiPowerConfiguration,
-                    OppleCluster,
-                    MultistateInputCluster,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    OnOff.cluster_id,
-                    LevelControl.cluster_id,
-                    Color.cluster_id,
-                ],
-            },
-            2: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id, Identify.cluster_id],
-            },
-            3: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            4: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            5: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-            6: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-                INPUT_CLUSTERS: [MultistateInputCluster, Identify.cluster_id],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
-            },
-        },
-    }
-
-    device_automation_triggers = RemoteB686OPCN01.device_automation_triggers
+    class AttributeDefs(XiaomiAqaraE1Cluster.AttributeDefs):
+        """Attribute definitions."""
+
+        mode: Final = ZCLAttributeDef(
+            id=0x0009, type=types.uint8_t, manufacturer_code=OPPLE_MFG_CODE
+        )
+
+
+B286_TRIGGERS = {
+    (DOUBLE_PRESS, BUTTON_1): {
+        COMMAND: COMMAND_STEP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 1},
+    },
+    (SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1},
+    (LONG_PRESS, BUTTON_1): {
+        COMMAND: COMMAND_STEP_COLOR_TEMP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 1},
+    },
+    (DOUBLE_PRESS, BUTTON_2): {
+        COMMAND: COMMAND_STEP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 0},
+    },
+    (SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_ON, ENDPOINT_ID: 1},
+    (LONG_PRESS, BUTTON_2): {
+        COMMAND: COMMAND_STEP_COLOR_TEMP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 3},
+    },
+    (ALT_SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_1_SINGLE},
+    (ALT_DOUBLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_DOUBLE},
+    (TRIPLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_TRIPLE},
+    (ALT_LONG_PRESS, BUTTON_1): {COMMAND: COMMAND_1_HOLD},
+    (LONG_RELEASE, BUTTON_1): {COMMAND: COMMAND_1_RELEASE},
+    (ALT_SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_2_SINGLE},
+    (ALT_DOUBLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_DOUBLE},
+    (TRIPLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_TRIPLE},
+    (ALT_LONG_PRESS, BUTTON_2): {COMMAND: COMMAND_2_HOLD},
+    (LONG_RELEASE, BUTTON_2): {COMMAND: COMMAND_2_RELEASE},
+}
+
+B486_TRIGGERS = {
+    (SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1},
+    (SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_ON, ENDPOINT_ID: 1},
+    (SHORT_PRESS, BUTTON_3): {
+        COMMAND: COMMAND_STEP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 1},
+    },
+    (DOUBLE_PRESS, BUTTON_3): {
+        COMMAND: COMMAND_STEP_COLOR_TEMP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 1},
+    },
+    (SHORT_PRESS, BUTTON_4): {
+        COMMAND: COMMAND_STEP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 0},
+    },
+    (DOUBLE_PRESS, BUTTON_4): {
+        COMMAND: COMMAND_STEP_COLOR_TEMP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 3},
+    },
+    (ALT_SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_1_SINGLE},
+    (ALT_DOUBLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_DOUBLE},
+    (TRIPLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_TRIPLE},
+    (ALT_LONG_PRESS, BUTTON_1): {COMMAND: COMMAND_1_HOLD},
+    (LONG_RELEASE, BUTTON_1): {COMMAND: COMMAND_1_RELEASE},
+    (ALT_SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_2_SINGLE},
+    (ALT_DOUBLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_DOUBLE},
+    (TRIPLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_TRIPLE},
+    (ALT_LONG_PRESS, BUTTON_2): {COMMAND: COMMAND_2_HOLD},
+    (LONG_RELEASE, BUTTON_2): {COMMAND: COMMAND_2_RELEASE},
+    (ALT_SHORT_PRESS, BUTTON_3): {COMMAND: COMMAND_3_SINGLE},
+    (ALT_DOUBLE_PRESS, BUTTON_3): {COMMAND: COMMAND_3_DOUBLE},
+    (TRIPLE_PRESS, BUTTON_3): {COMMAND: COMMAND_3_TRIPLE},
+    (ALT_LONG_PRESS, BUTTON_3): {COMMAND: COMMAND_3_HOLD},
+    (LONG_RELEASE, BUTTON_3): {COMMAND: COMMAND_3_RELEASE},
+    (ALT_SHORT_PRESS, BUTTON_4): {COMMAND: COMMAND_4_SINGLE},
+    (ALT_DOUBLE_PRESS, BUTTON_4): {COMMAND: COMMAND_4_DOUBLE},
+    (TRIPLE_PRESS, BUTTON_4): {COMMAND: COMMAND_4_TRIPLE},
+    (ALT_LONG_PRESS, BUTTON_4): {COMMAND: COMMAND_4_HOLD},
+    (LONG_RELEASE, BUTTON_4): {COMMAND: COMMAND_4_RELEASE},
+}
+
+B686_TRIGGERS = {
+    (SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_OFF, ENDPOINT_ID: 1},
+    (SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_ON, ENDPOINT_ID: 1},
+    (SHORT_PRESS, BUTTON_3): {
+        COMMAND: COMMAND_STEP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 1},
+    },
+    (LONG_PRESS, BUTTON_3): {
+        COMMAND: COMMAND_MOVE,
+        ENDPOINT_ID: 1,
+        PARAMS: {"move_mode": 1},
+    },
+    (SHORT_PRESS, BUTTON_4): {
+        COMMAND: COMMAND_STEP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 0},
+    },
+    (LONG_PRESS, BUTTON_4): {
+        COMMAND: COMMAND_MOVE,
+        ENDPOINT_ID: 1,
+        PARAMS: {"move_mode": 0},
+    },
+    (SHORT_PRESS, BUTTON_5): {
+        COMMAND: COMMAND_STEP_COLOR_TEMP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 1},
+    },
+    (LONG_PRESS, BUTTON_5): {
+        COMMAND: COMMAND_MOVE_COLOR_TEMP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"move_mode": 1},
+    },
+    (SHORT_PRESS, BUTTON_6): {
+        COMMAND: COMMAND_STEP_COLOR_TEMP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"step_mode": 3},
+    },
+    (LONG_PRESS, BUTTON_6): {
+        COMMAND: COMMAND_MOVE_COLOR_TEMP,
+        ENDPOINT_ID: 1,
+        PARAMS: {"move_mode": 3},
+    },
+    (ALT_SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_1_SINGLE},
+    (ALT_DOUBLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_DOUBLE},
+    (TRIPLE_PRESS, BUTTON_1): {COMMAND: COMMAND_1_TRIPLE},
+    (ALT_LONG_PRESS, BUTTON_1): {COMMAND: COMMAND_1_HOLD},
+    (LONG_RELEASE, BUTTON_1): {COMMAND: COMMAND_1_RELEASE},
+    (ALT_SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_2_SINGLE},
+    (ALT_DOUBLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_DOUBLE},
+    (TRIPLE_PRESS, BUTTON_2): {COMMAND: COMMAND_2_TRIPLE},
+    (ALT_LONG_PRESS, BUTTON_2): {COMMAND: COMMAND_2_HOLD},
+    (LONG_RELEASE, BUTTON_2): {COMMAND: COMMAND_2_RELEASE},
+    (ALT_SHORT_PRESS, BUTTON_3): {COMMAND: COMMAND_3_SINGLE},
+    (ALT_DOUBLE_PRESS, BUTTON_3): {COMMAND: COMMAND_3_DOUBLE},
+    (TRIPLE_PRESS, BUTTON_3): {COMMAND: COMMAND_3_TRIPLE},
+    (ALT_LONG_PRESS, BUTTON_3): {COMMAND: COMMAND_3_HOLD},
+    (LONG_RELEASE, BUTTON_3): {COMMAND: COMMAND_3_RELEASE},
+    (ALT_SHORT_PRESS, BUTTON_4): {COMMAND: COMMAND_4_SINGLE},
+    (ALT_DOUBLE_PRESS, BUTTON_4): {COMMAND: COMMAND_4_DOUBLE},
+    (TRIPLE_PRESS, BUTTON_4): {COMMAND: COMMAND_4_TRIPLE},
+    (ALT_LONG_PRESS, BUTTON_4): {COMMAND: COMMAND_4_HOLD},
+    (LONG_RELEASE, BUTTON_4): {COMMAND: COMMAND_4_RELEASE},
+    (ALT_SHORT_PRESS, BUTTON_5): {COMMAND: COMMAND_5_SINGLE},
+    (ALT_DOUBLE_PRESS, BUTTON_5): {COMMAND: COMMAND_5_DOUBLE},
+    (TRIPLE_PRESS, BUTTON_5): {COMMAND: COMMAND_5_TRIPLE},
+    (ALT_LONG_PRESS, BUTTON_5): {COMMAND: COMMAND_5_HOLD},
+    (LONG_RELEASE, BUTTON_5): {COMMAND: COMMAND_5_RELEASE},
+    (ALT_SHORT_PRESS, BUTTON_6): {COMMAND: COMMAND_6_SINGLE},
+    (ALT_DOUBLE_PRESS, BUTTON_6): {COMMAND: COMMAND_6_DOUBLE},
+    (TRIPLE_PRESS, BUTTON_6): {COMMAND: COMMAND_6_TRIPLE},
+    (ALT_LONG_PRESS, BUTTON_6): {COMMAND: COMMAND_6_HOLD},
+    (LONG_RELEASE, BUTTON_6): {COMMAND: COMMAND_6_RELEASE},
+}
+
+
+# Each button reports its presses on its own endpoint. Firmwares expose
+# different endpoint counts; `adds` skips any endpoint that isn't present.
+(
+    QuirkBuilder(LUMI, "lumi.remote.b286opcn01")
+    .zigpy_device_class(XiaomiCustomZigpyDevice)
+    .replaces(BasicCluster, endpoint_id=1)
+    .replaces(XiaomiPowerConfiguration, endpoint_id=1)
+    .adds(OppleCluster, endpoint_id=1)
+    .writes_attributes(
+        endpoint_id=1,
+        cluster_id=OppleCluster.cluster_id,
+        attributes={OppleCluster.AttributeDefs.mode: 0x01},
+    )
+    .adds_endpoint(endpoint_id=2, device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH)
+    .adds(MultistateInputCluster, endpoint_id=1)
+    .adds(MultistateInputCluster, endpoint_id=2)
+    .device_automation_triggers(B286_TRIGGERS)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder(LUMI, "lumi.remote.b486opcn01")
+    .zigpy_device_class(XiaomiCustomZigpyDevice)
+    .replaces(BasicCluster, endpoint_id=1)
+    .replaces(XiaomiPowerConfiguration, endpoint_id=1)
+    .adds(OppleCluster, endpoint_id=1)
+    .writes_attributes(
+        endpoint_id=1,
+        cluster_id=OppleCluster.cluster_id,
+        attributes={OppleCluster.AttributeDefs.mode: 0x01},
+    )
+    .adds_endpoint(endpoint_id=2, device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH)
+    .adds_endpoint(endpoint_id=3, device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH)
+    .adds_endpoint(endpoint_id=4, device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH)
+    .adds(MultistateInputCluster, endpoint_id=1)
+    .adds(MultistateInputCluster, endpoint_id=2)
+    .adds(MultistateInputCluster, endpoint_id=3)
+    .adds(MultistateInputCluster, endpoint_id=4)
+    .device_automation_triggers(B486_TRIGGERS)
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder(LUMI, "lumi.remote.b686opcn01")
+    .zigpy_device_class(XiaomiCustomZigpyDevice)
+    .replaces(BasicCluster, endpoint_id=1)
+    .replaces(XiaomiPowerConfiguration, endpoint_id=1)
+    .adds(OppleCluster, endpoint_id=1)
+    .writes_attributes(
+        endpoint_id=1,
+        cluster_id=OppleCluster.cluster_id,
+        attributes={OppleCluster.AttributeDefs.mode: 0x01},
+    )
+    .adds_endpoint(endpoint_id=2, device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH)
+    .adds_endpoint(endpoint_id=3, device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH)
+    .adds_endpoint(endpoint_id=4, device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH)
+    .adds_endpoint(endpoint_id=5, device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH)
+    .adds_endpoint(endpoint_id=6, device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH)
+    .adds(MultistateInputCluster, endpoint_id=1)
+    .adds(MultistateInputCluster, endpoint_id=2)
+    .adds(MultistateInputCluster, endpoint_id=3)
+    .adds(MultistateInputCluster, endpoint_id=4)
+    .adds(MultistateInputCluster, endpoint_id=5)
+    .adds(MultistateInputCluster, endpoint_id=6)
+    .device_automation_triggers(B686_TRIGGERS)
+    .add_to_registry()
+)

--- a/zhaquirks/xiaomi/aqara/opple_switch.py
+++ b/zhaquirks/xiaomi/aqara/opple_switch.py
@@ -121,6 +121,12 @@ class OppleSwitchCluster(OppleCluster):
             id=0x0203, type=t.Bool, is_manufacturer_specific=True
         )
 
+    async def bind(self):
+        """Bind cluster and enable multi-press reporting mode."""
+        result = await super().bind()
+        await self.write_attributes({OppleCluster.AttributeDefs.mode: 0x01})
+        return result
+
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
         if attrid == 0x00FC:


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
This PR adds a few new quirks v2 APIs (zigpy and ZHA PRs will be linked later):
- `subscribes_to_multicast_group`: Fixes https://github.com/zigpy/bellows/issues/708 by adding the coordinator to the required groups, provided by a quirk. I've added a few default implementations (there aren't many devices that need this)
- `binds_cluster`: binds to a cluster. This replaces the current manufacturer-specific binding done in ZHA.
- `configures_reporting`: similar to `.sensor(..., reporting_config=...)` but without requiring an entity to be created.
- `writes_attributes`: writes an attribute during initialization. This replaces a few `binds()` overrides and further reduces the amount of Python runtime code.

`writes_attributes` allowed the Opple remote quirk to be rewritten from V1 to V2.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
