### PR TITLE
Add support for SONOFF MINI-ZB1GSP

### DIFF
--- a/tests/test_sonoff_minizb1gsp.py
+++ b/tests/test_sonoff_minizb1gsp.py
@@ -1,5 +1,7 @@
 """Tests for Sonoff MINI-ZB1GSP quirks."""
 
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -7,18 +9,27 @@ from zigpy.zcl import ClusterType, foundation
 
 from tests.common import ClusterListener
 import zhaquirks
-from zhaquirks.sonoff.minizb1gsp import (
-    FAST_SCENE_PACKET_MODIFY,
-    FAST_SCENE_PACKET_REPORT,
-    FastSceneProtection,
-    FastSceneState,
-    SonoffCluster,
-    SonoffFastSceneConfigCluster,
-    decode_fast_scene_payload,
-    encode_fast_scene_payload,
-    fast_scene_array_from_payload,
-    fast_scene_payload_from_array,
+
+_MINI_ZB1GSP_PATH = (
+    Path(__file__).resolve().parents[1] / "zhaquirks" / "sonoff" / "mini-zb1gsp.py"
 )
+_MINI_ZB1GSP_SPEC = spec_from_file_location(
+    "zhaquirks.sonoff.mini_zb1gsp_test_module", _MINI_ZB1GSP_PATH
+)
+assert _MINI_ZB1GSP_SPEC is not None and _MINI_ZB1GSP_SPEC.loader is not None
+mini_zb1gsp = module_from_spec(_MINI_ZB1GSP_SPEC)
+_MINI_ZB1GSP_SPEC.loader.exec_module(mini_zb1gsp)
+
+FAST_SCENE_PACKET_MODIFY = mini_zb1gsp.FAST_SCENE_PACKET_MODIFY
+FAST_SCENE_PACKET_REPORT = mini_zb1gsp.FAST_SCENE_PACKET_REPORT
+FastSceneProtection = mini_zb1gsp.FastSceneProtection
+FastSceneState = mini_zb1gsp.FastSceneState
+SonoffCluster = mini_zb1gsp.SonoffCluster
+SonoffFastSceneConfigCluster = mini_zb1gsp.SonoffFastSceneConfigCluster
+decode_fast_scene_payload = mini_zb1gsp.decode_fast_scene_payload
+encode_fast_scene_payload = mini_zb1gsp.encode_fast_scene_payload
+fast_scene_array_from_payload = mini_zb1gsp.fast_scene_array_from_payload
+fast_scene_payload_from_array = mini_zb1gsp.fast_scene_payload_from_array
 
 zhaquirks.setup()
 
@@ -135,7 +146,9 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
         cluster.get(cluster.AttributeDefs.protection_only_ext_mode_restore.id) is True
     )
     assert cluster.get(cluster.AttributeDefs.protection_over_voltage_mv.id) == 250000
-    assert cluster.get(cluster.AttributeDefs.protection_over_voltage_enabled.id) is True
+    assert (
+        cluster.get(cluster.AttributeDefs.protection_over_voltage_enabled.id) is True
+    )
     assert cluster.get(cluster.AttributeDefs.protection_under_voltage_mv.id) == 180000
     assert (
         cluster.get(cluster.AttributeDefs.protection_under_voltage_enabled.id) is True
@@ -147,26 +160,8 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
 @pytest.mark.parametrize(
     ("result", "expected"),
     [
-        (
-            [
-                [
-                    foundation.WriteAttributesStatusRecord(
-                        status=foundation.Status.SUCCESS
-                    )
-                ]
-            ],
-            True,
-        ),
-        (
-            [
-                [
-                    foundation.WriteAttributesStatusRecord(
-                        status=foundation.Status.FAILURE
-                    )
-                ]
-            ],
-            False,
-        ),
+        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]], True),
+        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.FAILURE)]], False),
         ([], False),
         (None, False),
     ],
@@ -211,9 +206,7 @@ async def test_sonoff_minizb1gsp_fast_scene_propagation(zigpy_device_from_v2_qui
         == 567890
     )
     assert (
-        local_cluster.get(
-            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
-        )
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
         is True
     )
     assert (
@@ -336,9 +329,7 @@ async def test_sonoff_minizb1gsp_fast_scene_write_attributes_logic(
         == 1600
     )
     assert (
-        local_cluster.get(
-            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
-        )
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
         is False
     )
     assert local_cluster.get(local_cluster.AttributeDefs.protection_notify.id) is False

--- a/tests/test_sonoff_minizb1gsp.py
+++ b/tests/test_sonoff_minizb1gsp.py
@@ -129,57 +129,31 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
     """Decoded fast scene state is exposed as local attributes."""
 
     cluster = object.__new__(SonoffFastSceneConfigCluster)
-    cluster._attr_cache = {}
-    cluster._fast_scene_state = FastSceneState()
+    object.__setattr__(cluster, "_fast_scene_state", FastSceneState())
+    object.__setattr__(cluster, "_update_attribute", mock.MagicMock())
 
     state = _sample_fast_scene_state()
     cluster.update_fast_scene_state(state)
 
     assert cluster._fast_scene_state == state
-    assert (
-        cluster.get(cluster.AttributeDefs.protection_over_current_ma.id)
-        == state.protection.over_current_ma
-    )
-    assert (
-        cluster.get(cluster.AttributeDefs.protection_over_load_mw.id)
-        == state.protection.over_load_mw
-    )
-    assert (
-        cluster.get(cluster.AttributeDefs.protection_only_ext_mode_restore.id) is True
-    )
-    assert cluster.get(cluster.AttributeDefs.protection_over_voltage_mv.id) == 250000
-    assert cluster.get(cluster.AttributeDefs.protection_over_voltage_enabled.id) is True
-    assert cluster.get(cluster.AttributeDefs.protection_under_voltage_mv.id) == 180000
-    assert (
-        cluster.get(cluster.AttributeDefs.protection_under_voltage_enabled.id) is True
-    )
-    assert cluster.get(cluster.AttributeDefs.protection_auto_recover.id) is True
-    assert cluster.get(cluster.AttributeDefs.protection_notify.id) is True
+    assert cluster._update_attribute.call_args_list == [
+        mock.call(cluster.AttributeDefs.protection_over_current_ma.id, 1234),
+        mock.call(cluster.AttributeDefs.protection_over_load_mw.id, 567890),
+        mock.call(cluster.AttributeDefs.protection_only_ext_mode_restore.id, True),
+        mock.call(cluster.AttributeDefs.protection_over_voltage_mv.id, 250000),
+        mock.call(cluster.AttributeDefs.protection_over_voltage_enabled.id, True),
+        mock.call(cluster.AttributeDefs.protection_under_voltage_mv.id, 180000),
+        mock.call(cluster.AttributeDefs.protection_under_voltage_enabled.id, True),
+        mock.call(cluster.AttributeDefs.protection_auto_recover.id, True),
+        mock.call(cluster.AttributeDefs.protection_notify.id, True),
+    ]
 
 
 @pytest.mark.parametrize(
     ("result", "expected"),
     [
-        (
-            [
-                [
-                    foundation.WriteAttributesStatusRecord(
-                        status=foundation.Status.SUCCESS
-                    )
-                ]
-            ],
-            True,
-        ),
-        (
-            [
-                [
-                    foundation.WriteAttributesStatusRecord(
-                        status=foundation.Status.FAILURE
-                    )
-                ]
-            ],
-            False,
-        ),
+        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]], True),
+        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.FAILURE)]], False),
         ([], False),
         (None, False),
     ],
@@ -224,9 +198,7 @@ async def test_sonoff_minizb1gsp_fast_scene_propagation(zigpy_device_from_v2_qui
         == 567890
     )
     assert (
-        local_cluster.get(
-            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
-        )
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
         is True
     )
     assert (
@@ -349,9 +321,7 @@ async def test_sonoff_minizb1gsp_fast_scene_write_attributes_logic(
         == 1600
     )
     assert (
-        local_cluster.get(
-            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
-        )
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
         is False
     )
     assert local_cluster.get(local_cluster.AttributeDefs.protection_notify.id) is False

--- a/tests/test_sonoff_minizb1gsp.py
+++ b/tests/test_sonoff_minizb1gsp.py
@@ -2,6 +2,7 @@
 
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+import sys
 from unittest import mock
 
 import pytest
@@ -18,6 +19,7 @@ _MINI_ZB1GSP_SPEC = spec_from_file_location(
 )
 assert _MINI_ZB1GSP_SPEC is not None and _MINI_ZB1GSP_SPEC.loader is not None
 mini_zb1gsp = module_from_spec(_MINI_ZB1GSP_SPEC)
+sys.modules[_MINI_ZB1GSP_SPEC.name] = mini_zb1gsp
 _MINI_ZB1GSP_SPEC.loader.exec_module(mini_zb1gsp)
 
 FAST_SCENE_PACKET_MODIFY = mini_zb1gsp.FAST_SCENE_PACKET_MODIFY
@@ -34,7 +36,7 @@ fast_scene_payload_from_array = mini_zb1gsp.fast_scene_payload_from_array
 zhaquirks.setup()
 
 
-def _sample_fast_scene_state() -> FastSceneState:
+def _sample_fast_scene_state():
     """Return a representative fast scene configuration."""
 
     return FastSceneState(
@@ -146,7 +148,9 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
         cluster.get(cluster.AttributeDefs.protection_only_ext_mode_restore.id) is True
     )
     assert cluster.get(cluster.AttributeDefs.protection_over_voltage_mv.id) == 250000
-    assert cluster.get(cluster.AttributeDefs.protection_over_voltage_enabled.id) is True
+    assert (
+        cluster.get(cluster.AttributeDefs.protection_over_voltage_enabled.id) is True
+    )
     assert cluster.get(cluster.AttributeDefs.protection_under_voltage_mv.id) == 180000
     assert (
         cluster.get(cluster.AttributeDefs.protection_under_voltage_enabled.id) is True
@@ -158,26 +162,8 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
 @pytest.mark.parametrize(
     ("result", "expected"),
     [
-        (
-            [
-                [
-                    foundation.WriteAttributesStatusRecord(
-                        status=foundation.Status.SUCCESS
-                    )
-                ]
-            ],
-            True,
-        ),
-        (
-            [
-                [
-                    foundation.WriteAttributesStatusRecord(
-                        status=foundation.Status.FAILURE
-                    )
-                ]
-            ],
-            False,
-        ),
+        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]], True),
+        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.FAILURE)]], False),
         ([], False),
         (None, False),
     ],
@@ -222,9 +208,7 @@ async def test_sonoff_minizb1gsp_fast_scene_propagation(zigpy_device_from_v2_qui
         == 567890
     )
     assert (
-        local_cluster.get(
-            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
-        )
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
         is True
     )
     assert (
@@ -347,9 +331,7 @@ async def test_sonoff_minizb1gsp_fast_scene_write_attributes_logic(
         == 1600
     )
     assert (
-        local_cluster.get(
-            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
-        )
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
         is False
     )
     assert local_cluster.get(local_cluster.AttributeDefs.protection_notify.id) is False

--- a/tests/test_sonoff_minizb1gsp.py
+++ b/tests/test_sonoff_minizb1gsp.py
@@ -135,9 +135,7 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
         cluster.get(cluster.AttributeDefs.protection_only_ext_mode_restore.id) is True
     )
     assert cluster.get(cluster.AttributeDefs.protection_over_voltage_mv.id) == 250000
-    assert (
-        cluster.get(cluster.AttributeDefs.protection_over_voltage_enabled.id) is True
-    )
+    assert cluster.get(cluster.AttributeDefs.protection_over_voltage_enabled.id) is True
     assert cluster.get(cluster.AttributeDefs.protection_under_voltage_mv.id) == 180000
     assert (
         cluster.get(cluster.AttributeDefs.protection_under_voltage_enabled.id) is True
@@ -149,8 +147,26 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
 @pytest.mark.parametrize(
     ("result", "expected"),
     [
-        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]], True),
-        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.FAILURE)]], False),
+        (
+            [
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        status=foundation.Status.SUCCESS
+                    )
+                ]
+            ],
+            True,
+        ),
+        (
+            [
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        status=foundation.Status.FAILURE
+                    )
+                ]
+            ],
+            False,
+        ),
         ([], False),
         (None, False),
     ],
@@ -195,7 +211,9 @@ async def test_sonoff_minizb1gsp_fast_scene_propagation(zigpy_device_from_v2_qui
         == 567890
     )
     assert (
-        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
+        local_cluster.get(
+            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
+        )
         is True
     )
     assert (
@@ -318,7 +336,9 @@ async def test_sonoff_minizb1gsp_fast_scene_write_attributes_logic(
         == 1600
     )
     assert (
-        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
+        local_cluster.get(
+            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
+        )
         is False
     )
     assert local_cluster.get(local_cluster.AttributeDefs.protection_notify.id) is False

--- a/tests/test_sonoff_minizb1gsp.py
+++ b/tests/test_sonoff_minizb1gsp.py
@@ -1,0 +1,369 @@
+"""Tests for Sonoff MINI-ZB1GSP quirks."""
+
+from unittest import mock
+
+import pytest
+from zigpy.zcl import ClusterType, foundation
+
+from tests.common import ClusterListener
+import zhaquirks
+from zhaquirks.sonoff.minizb1gsp import (
+    FAST_SCENE_PACKET_MODIFY,
+    FAST_SCENE_PACKET_REPORT,
+    FastSceneProtection,
+    FastSceneState,
+    SonoffCluster,
+    SonoffFastSceneConfigCluster,
+    decode_fast_scene_payload,
+    encode_fast_scene_payload,
+    fast_scene_array_from_payload,
+    fast_scene_payload_from_array,
+)
+
+zhaquirks.setup()
+
+
+def _sample_fast_scene_state() -> FastSceneState:
+    """Return a representative fast scene configuration."""
+
+    return FastSceneState(
+        packet_type=FAST_SCENE_PACKET_REPORT,
+        total_num=1,
+        current_data_index=1,
+        protection=FastSceneProtection(
+            scene_switch=1,
+            over_current_ma=1234,
+            over_load_mw=567890,
+            only_ext_mode_restore=1,
+            over_voltage_mv=250000,
+            over_voltage_en=1,
+            under_voltage_mv=180000,
+            under_voltage_en=1,
+            auto_recover_en=1,
+            notify_en=1,
+        ),
+    )
+
+
+def test_fast_scene_payload_roundtrip():
+    """Encoded fast scene payloads round-trip through the decoder."""
+
+    state = _sample_fast_scene_state()
+
+    payload = encode_fast_scene_payload(state, packet_type=FAST_SCENE_PACKET_MODIFY)
+    decoded = decode_fast_scene_payload(payload)
+
+    assert decoded.packet_type == FAST_SCENE_PACKET_MODIFY
+    assert decoded.total_num == state.total_num
+    assert decoded.current_data_index == state.current_data_index
+    assert decoded.protection == state.protection
+
+
+def test_fast_scene_payload_from_array_variants():
+    """Payload extraction supports the value types used by zigpy."""
+
+    payload = encode_fast_scene_payload(_sample_fast_scene_state())
+    zcl_array = fast_scene_array_from_payload(payload)
+
+    assert fast_scene_payload_from_array(zcl_array) == payload
+    assert fast_scene_payload_from_array(payload) == payload
+    assert fast_scene_payload_from_array(bytearray(payload)) == payload
+    assert fast_scene_payload_from_array(list(payload)) == payload
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        None,
+        object(),
+        foundation.Array(type=foundation.DataTypeId.uint8, value=None),
+    ],
+)
+def test_fast_scene_payload_from_array_invalid_values(bad_value):
+    """Invalid payload inputs raise a ValueError."""
+
+    with pytest.raises(ValueError):
+        fast_scene_payload_from_array(bad_value)
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_message"),
+    [
+        (b"\x01\x01", "Fast scene payload is too short"),
+        (b"\x01\x01\x01\x02", "Fast scene TLV header is incomplete"),
+        (b"\x01\x01\x01\x02\x14\x01", "Fast scene TLV length exceeds payload"),
+    ],
+)
+def test_decode_fast_scene_payload_invalid_values(payload, expected_message):
+    """Malformed fast scene payloads are rejected."""
+
+    with pytest.raises(ValueError, match=expected_message):
+        decode_fast_scene_payload(payload)
+
+
+def test_decode_fast_scene_payload_ignores_zero_padding():
+    """Trailing zero padding does not break decoding."""
+
+    payload = encode_fast_scene_payload(_sample_fast_scene_state()) + b"\x00\x00"
+
+    decoded = decode_fast_scene_payload(payload)
+
+    assert decoded.protection.over_current_ma == 1234
+    assert decoded.protection.notify_en == 1
+
+
+def test_sonoff_fast_scene_config_update_fast_scene_state():
+    """Decoded fast scene state is exposed as local attributes."""
+
+    cluster = object.__new__(SonoffFastSceneConfigCluster)
+    cluster._attr_cache = {}
+    cluster._fast_scene_state = FastSceneState()
+
+    state = _sample_fast_scene_state()
+    cluster.update_fast_scene_state(state)
+
+    assert cluster._fast_scene_state == state
+    assert (
+        cluster.get(cluster.AttributeDefs.protection_over_current_ma.id)
+        == state.protection.over_current_ma
+    )
+    assert (
+        cluster.get(cluster.AttributeDefs.protection_over_load_mw.id)
+        == state.protection.over_load_mw
+    )
+    assert (
+        cluster.get(cluster.AttributeDefs.protection_only_ext_mode_restore.id) is True
+    )
+    assert cluster.get(cluster.AttributeDefs.protection_over_voltage_mv.id) == 250000
+    assert (
+        cluster.get(cluster.AttributeDefs.protection_over_voltage_enabled.id) is True
+    )
+    assert cluster.get(cluster.AttributeDefs.protection_under_voltage_mv.id) == 180000
+    assert (
+        cluster.get(cluster.AttributeDefs.protection_under_voltage_enabled.id) is True
+    )
+    assert cluster.get(cluster.AttributeDefs.protection_auto_recover.id) is True
+    assert cluster.get(cluster.AttributeDefs.protection_notify.id) is True
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]], True),
+        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.FAILURE)]], False),
+        ([], False),
+        (None, False),
+    ],
+)
+def test_sonoff_fast_scene_config_write_succeeded(result, expected):
+    """Write success helper handles success and error payloads."""
+
+    assert SonoffFastSceneConfigCluster._write_succeeded(result) is expected
+
+
+async def test_sonoff_minizb1gsp_fast_scene_propagation(zigpy_device_from_v2_quirk):
+    """Fast scene reports propagate decoded values to the local cluster."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZB1GSP",
+        cluster_ids={
+            1: {
+                SonoffCluster.cluster_id: ClusterType.Server,
+                SonoffFastSceneConfigCluster.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    sonoff_cluster = device.endpoints[1].sonoff_cluster
+    local_cluster = device.endpoints[1].sonoff_fast_scene_config
+    local_listener = ClusterListener(local_cluster)
+
+    payload = encode_fast_scene_payload(_sample_fast_scene_state())
+    sonoff_cluster.update_attribute(
+        SonoffCluster.AttributeDefs.local_fast_scene_configuration.id,
+        fast_scene_array_from_payload(payload),
+    )
+
+    assert local_listener.attribute_updates
+    assert (
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_current_ma.id)
+        == 1234
+    )
+    assert (
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_load_mw.id)
+        == 567890
+    )
+    assert (
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
+        is True
+    )
+    assert (
+        local_cluster.get(
+            local_cluster.AttributeDefs.protection_under_voltage_enabled.id
+        )
+        is True
+    )
+
+
+async def test_sonoff_minizb1gsp_fast_scene_failed_write_does_not_propagate(
+    zigpy_device_from_v2_quirk,
+):
+    """Failed fast scene writes do not update local state."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZB1GSP",
+        cluster_ids={
+            1: {
+                SonoffCluster.cluster_id: ClusterType.Server,
+                SonoffFastSceneConfigCluster.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    sonoff_cluster = device.endpoints[1].sonoff_cluster
+    local_cluster = device.endpoints[1].sonoff_fast_scene_config
+    local_listener = ClusterListener(local_cluster)
+    sonoff_cluster._fast_scene_state = _sample_fast_scene_state()
+
+    write_response = [
+        [
+            foundation.WriteAttributesStatusRecord(
+                status=foundation.Status.FAILURE,
+                attrid=SonoffCluster.AttributeDefs.local_fast_scene_configuration.id,
+            )
+        ]
+    ]
+    with mock.patch.object(
+        sonoff_cluster,
+        "write_attributes_raw",
+        mock.AsyncMock(return_value=write_response),
+    ):
+        await local_cluster.write_attributes(
+            {
+                local_cluster.AttributeDefs.protection_over_current_ma.name: 1600,
+            }
+        )
+
+    assert local_listener.attribute_updates == []
+
+
+async def test_sonoff_minizb1gsp_fast_scene_write_attributes_logic(
+    zigpy_device_from_v2_quirk,
+):
+    """Local fast scene writes merge into the real Sonoff attribute payload."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZB1GSP",
+        cluster_ids={
+            1: {
+                SonoffCluster.cluster_id: ClusterType.Server,
+                SonoffFastSceneConfigCluster.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    sonoff_cluster = device.endpoints[1].sonoff_cluster
+    local_cluster = device.endpoints[1].sonoff_fast_scene_config
+    local_listener = ClusterListener(local_cluster)
+    sonoff_cluster._fast_scene_state = _sample_fast_scene_state()
+
+    write_response = [
+        [foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]
+    ]
+    with mock.patch.object(
+        sonoff_cluster,
+        "write_attributes_raw",
+        mock.AsyncMock(return_value=write_response),
+    ) as mock_write:
+        await local_cluster.write_attributes(
+            {
+                local_cluster.AttributeDefs.protection_over_current_ma.name: 1600,
+                local_cluster.AttributeDefs.protection_over_load_mw.name: 765432,
+                local_cluster.AttributeDefs.protection_only_ext_mode_restore.name: False,
+                local_cluster.AttributeDefs.protection_over_voltage_mv.name: 260000,
+                local_cluster.AttributeDefs.protection_over_voltage_enabled.name: False,
+                local_cluster.AttributeDefs.protection_under_voltage_mv.name: 170000,
+                local_cluster.AttributeDefs.protection_under_voltage_enabled.name: False,
+                local_cluster.AttributeDefs.protection_auto_recover.name: False,
+                local_cluster.AttributeDefs.protection_notify.name: False,
+            }
+        )
+
+    written_attrs = mock_write.call_args[0][0]
+    assert len(written_attrs) == 1
+    assert (
+        written_attrs[0].attrid
+        == SonoffCluster.AttributeDefs.local_fast_scene_configuration.id
+    )
+
+    payload = fast_scene_payload_from_array(written_attrs[0].value.value)
+    decoded = decode_fast_scene_payload(payload)
+
+    assert decoded.protection.over_current_ma == 1600
+    assert decoded.protection.over_load_mw == 765432
+    assert decoded.protection.only_ext_mode_restore == 0
+    assert decoded.protection.over_voltage_mv == 260000
+    assert decoded.protection.over_voltage_en == 0
+    assert decoded.protection.under_voltage_mv == 170000
+    assert decoded.protection.under_voltage_en == 0
+    assert decoded.protection.auto_recover_en == 0
+    assert decoded.protection.notify_en == 0
+
+    assert local_listener.attribute_updates
+    assert (
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_current_ma.id)
+        == 1600
+    )
+    assert (
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
+        is False
+    )
+    assert local_cluster.get(local_cluster.AttributeDefs.protection_notify.id) is False
+
+
+async def test_sonoff_minizb1gsp_apply_custom_configuration_reads_fast_scene(
+    zigpy_device_from_v2_quirk,
+):
+    """Custom configuration reads fast scene state and populates local attributes."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZB1GSP",
+        cluster_ids={
+            1: {
+                SonoffCluster.cluster_id: ClusterType.Server,
+                SonoffFastSceneConfigCluster.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    sonoff_cluster = device.endpoints[1].sonoff_cluster
+    local_cluster = device.endpoints[1].sonoff_fast_scene_config
+    local_listener = ClusterListener(local_cluster)
+
+    fast_scene_attr = SonoffCluster.AttributeDefs.local_fast_scene_configuration
+    payload = fast_scene_array_from_payload(
+        encode_fast_scene_payload(_sample_fast_scene_state())
+    )
+    read_response = foundation.ReadAttributeRecord(
+        attrid=fast_scene_attr.id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(type=fast_scene_attr.zcl_type, value=payload),
+    )
+
+    with mock.patch.object(
+        sonoff_cluster,
+        "_read_attributes",
+        mock.AsyncMock(return_value=[[read_response]]),
+    ) as mock_read:
+        await sonoff_cluster.apply_custom_configuration()
+
+    assert mock_read.call_args.args[0] == [fast_scene_attr.id]
+    assert local_listener.attribute_updates
+    assert (
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_current_ma.id)
+        == 1234
+    )

--- a/tests/test_sonoff_minizb1gsp.py
+++ b/tests/test_sonoff_minizb1gsp.py
@@ -148,9 +148,7 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
         cluster.get(cluster.AttributeDefs.protection_only_ext_mode_restore.id) is True
     )
     assert cluster.get(cluster.AttributeDefs.protection_over_voltage_mv.id) == 250000
-    assert (
-        cluster.get(cluster.AttributeDefs.protection_over_voltage_enabled.id) is True
-    )
+    assert cluster.get(cluster.AttributeDefs.protection_over_voltage_enabled.id) is True
     assert cluster.get(cluster.AttributeDefs.protection_under_voltage_mv.id) == 180000
     assert (
         cluster.get(cluster.AttributeDefs.protection_under_voltage_enabled.id) is True
@@ -162,8 +160,26 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
 @pytest.mark.parametrize(
     ("result", "expected"),
     [
-        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]], True),
-        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.FAILURE)]], False),
+        (
+            [
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        status=foundation.Status.SUCCESS
+                    )
+                ]
+            ],
+            True,
+        ),
+        (
+            [
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        status=foundation.Status.FAILURE
+                    )
+                ]
+            ],
+            False,
+        ),
         ([], False),
         (None, False),
     ],
@@ -208,7 +224,9 @@ async def test_sonoff_minizb1gsp_fast_scene_propagation(zigpy_device_from_v2_qui
         == 567890
     )
     assert (
-        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
+        local_cluster.get(
+            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
+        )
         is True
     )
     assert (
@@ -331,7 +349,9 @@ async def test_sonoff_minizb1gsp_fast_scene_write_attributes_logic(
         == 1600
     )
     assert (
-        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
+        local_cluster.get(
+            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
+        )
         is False
     )
     assert local_cluster.get(local_cluster.AttributeDefs.protection_notify.id) is False

--- a/tests/test_sonoff_minizb1gsp.py
+++ b/tests/test_sonoff_minizb1gsp.py
@@ -152,8 +152,26 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
 @pytest.mark.parametrize(
     ("result", "expected"),
     [
-        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]], True),
-        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.FAILURE)]], False),
+        (
+            [
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        status=foundation.Status.SUCCESS
+                    )
+                ]
+            ],
+            True,
+        ),
+        (
+            [
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        status=foundation.Status.FAILURE
+                    )
+                ]
+            ],
+            False,
+        ),
         ([], False),
         (None, False),
     ],
@@ -198,7 +216,9 @@ async def test_sonoff_minizb1gsp_fast_scene_propagation(zigpy_device_from_v2_qui
         == 567890
     )
     assert (
-        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
+        local_cluster.get(
+            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
+        )
         is True
     )
     assert (
@@ -321,7 +341,9 @@ async def test_sonoff_minizb1gsp_fast_scene_write_attributes_logic(
         == 1600
     )
     assert (
-        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
+        local_cluster.get(
+            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
+        )
         is False
     )
     assert local_cluster.get(local_cluster.AttributeDefs.protection_notify.id) is False

--- a/tests/test_sonoff_minizb1gsp.py
+++ b/tests/test_sonoff_minizb1gsp.py
@@ -146,9 +146,7 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
         cluster.get(cluster.AttributeDefs.protection_only_ext_mode_restore.id) is True
     )
     assert cluster.get(cluster.AttributeDefs.protection_over_voltage_mv.id) == 250000
-    assert (
-        cluster.get(cluster.AttributeDefs.protection_over_voltage_enabled.id) is True
-    )
+    assert cluster.get(cluster.AttributeDefs.protection_over_voltage_enabled.id) is True
     assert cluster.get(cluster.AttributeDefs.protection_under_voltage_mv.id) == 180000
     assert (
         cluster.get(cluster.AttributeDefs.protection_under_voltage_enabled.id) is True
@@ -160,8 +158,26 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
 @pytest.mark.parametrize(
     ("result", "expected"),
     [
-        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]], True),
-        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.FAILURE)]], False),
+        (
+            [
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        status=foundation.Status.SUCCESS
+                    )
+                ]
+            ],
+            True,
+        ),
+        (
+            [
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        status=foundation.Status.FAILURE
+                    )
+                ]
+            ],
+            False,
+        ),
         ([], False),
         (None, False),
     ],
@@ -206,7 +222,9 @@ async def test_sonoff_minizb1gsp_fast_scene_propagation(zigpy_device_from_v2_qui
         == 567890
     )
     assert (
-        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
+        local_cluster.get(
+            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
+        )
         is True
     )
     assert (
@@ -329,7 +347,9 @@ async def test_sonoff_minizb1gsp_fast_scene_write_attributes_logic(
         == 1600
     )
     assert (
-        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
+        local_cluster.get(
+            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
+        )
         is False
     )
     assert local_cluster.get(local_cluster.AttributeDefs.protection_notify.id) is False

--- a/zhaquirks/sonoff/mini-zb1gsp.py
+++ b/zhaquirks/sonoff/mini-zb1gsp.py
@@ -1,0 +1,795 @@
+"""Sonoff MINI-ZB1GSP - Zigbee Smart Plug."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Final
+
+from zigpy import types
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import (
+    EntityType,
+    NumberDeviceClass,
+    QuirkBuilder,
+    SensorDeviceClass,
+    SensorStateClass,
+    EntityPlatform,
+)
+from zigpy.quirks.v2.homeassistant import (
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTime,
+    UnitOfFrequency,
+)
+import zigpy.types as t
+from zigpy.zcl import (
+    AttributeReadEvent,
+    AttributeReportedEvent,
+    AttributeUpdatedEvent,
+    AttributeWrittenEvent,
+    foundation,
+)
+from zigpy.zcl.foundation import BaseAttributeDefs, Status, ZCLAttributeDef
+
+from zhaquirks import LocalDataCluster
+
+FAST_SCENE_PACKET_MODIFY = 0x00
+FAST_SCENE_PACKET_REPORT = 0x01
+FAST_SCENE_ARRAY_ITEM_TYPE = foundation.DataTypeId.uint8
+FAST_SCENE_VOLTAGE_ENABLE_BIT = 0x80000000
+FAST_SCENE_VOLTAGE_VALUE_MASK = 0x7FFFFFFF
+PROTECTION_CURRENT_MIN_MA = 100
+PROTECTION_CURRENT_MAX_MA = 16000
+PROTECTION_POWER_MIN_MW = 2000
+PROTECTION_POWER_MAX_MW = 3840000
+PROTECTION_VOLTAGE_MIN_MV = 85000
+PROTECTION_VOLTAGE_MAX_MV = 277000
+
+
+def _u32_le(data: bytes) -> int:
+    """Decode an unsigned little-endian 32-bit integer."""
+
+    return int.from_bytes(data[:4], "little")
+
+
+def _put_u32_le(value: int) -> list[int]:
+    """Encode an unsigned little-endian 32-bit integer."""
+
+    return list(int(value).to_bytes(4, "little"))
+
+
+@dataclass
+class FastSceneProtection:
+    """Electrical protection fast scene."""
+
+    scene_switch: int = 1
+    over_current_ma: int = 0
+    over_load_mw: int = 0
+    only_ext_mode_restore: int = 0
+    over_voltage_mv: int = 0
+    over_voltage_en: int = 0
+    under_voltage_mv: int = 0
+    under_voltage_en: int = 0
+    auto_recover_en: int = 0
+    notify_en: int = 0
+
+
+@dataclass
+class FastSceneState:
+    """Decoded Sonoff fast scene state."""
+
+    packet_type: int = FAST_SCENE_PACKET_REPORT
+    total_num: int = 1
+    current_data_index: int = 1
+    protection: FastSceneProtection = field(default_factory=FastSceneProtection)
+
+
+def fast_scene_array_from_payload(payload: bytes | list[int]) -> foundation.Array:
+    """Wrap a fast scene payload in a ZCL array value."""
+
+    return foundation.Array(
+        type=FAST_SCENE_ARRAY_ITEM_TYPE,
+        value=t.LVList[t.uint8_t, t.uint16_t](payload),
+    )
+
+
+def fast_scene_payload_from_array(value: Any) -> bytes:
+    """Extract the fast scene payload bytes from a decoded ZCL array value."""
+
+    if isinstance(value, foundation.Array):
+        if value.value is None:
+            raise ValueError("Fast scene payload is empty")
+        return bytes(value.value)
+    if isinstance(value, (bytes, bytearray)):
+        if len(value) >= 3 and value[0] == FAST_SCENE_ARRAY_ITEM_TYPE:
+            length = int.from_bytes(value[1:3], "little")
+            return bytes(value[3 : 3 + length])
+        return bytes(value)
+    if isinstance(value, list):
+        return bytes(value)
+    if isinstance(value, t.LVList):
+        return bytes(value)
+    raise ValueError("Unsupported fast scene payload value")
+
+
+def _decode_voltage(raw_value: int) -> tuple[int, int]:
+    """Split a firmware voltage threshold into value and enable flag."""
+
+    return raw_value & FAST_SCENE_VOLTAGE_VALUE_MASK, int(
+        bool(raw_value & FAST_SCENE_VOLTAGE_ENABLE_BIT)
+    )
+
+
+def _encode_voltage(value: int, enabled: int) -> int:
+    """Combine a voltage threshold value and enable flag."""
+
+    raw_value = value & FAST_SCENE_VOLTAGE_VALUE_MASK
+    if enabled:
+        raw_value |= FAST_SCENE_VOLTAGE_ENABLE_BIT
+    return raw_value
+
+
+def decode_fast_scene_payload(payload: bytes | list[int] | foundation.Array) -> FastSceneState:
+    """Decode a Sonoff fast scene payload."""
+
+    data = fast_scene_payload_from_array(payload)
+    if len(data) < 3:
+        raise ValueError("Fast scene payload is too short")
+
+    state = FastSceneState(
+        packet_type=data[0],
+        total_num=data[1],
+        current_data_index=data[2],
+    )
+    idx = 3
+
+    while idx < len(data):
+        if idx + 2 > len(data):
+            if all(byte == 0 for byte in data[idx:]):
+                break
+            raise ValueError("Fast scene TLV header is incomplete")
+
+        scene_type = data[idx]
+        scene_len = data[idx + 1]
+        idx += 2
+
+        if idx + scene_len > len(data):
+            if scene_type == 0 and all(byte == 0 for byte in data[idx - 2 :]):
+                break
+            raise ValueError("Fast scene TLV length exceeds payload")
+
+        scene_data = data[idx : idx + scene_len]
+        idx += scene_len
+
+        if not scene_data:
+            continue
+
+        if scene_type == 2 and len(scene_data) >= 20:
+            scene_switch = scene_data[0]
+            over_voltage_mv, over_voltage_en = _decode_voltage(_u32_le(scene_data[10:14]))
+            under_voltage_mv, under_voltage_en = _decode_voltage(
+                _u32_le(scene_data[14:18])
+            )
+            state.protection = FastSceneProtection(
+                scene_switch=scene_switch,
+                over_current_ma=_u32_le(scene_data[1:5]),
+                over_load_mw=_u32_le(scene_data[5:9]),
+                only_ext_mode_restore=scene_data[9],
+                over_voltage_mv=over_voltage_mv,
+                over_voltage_en=over_voltage_en,
+                under_voltage_mv=under_voltage_mv,
+                under_voltage_en=under_voltage_en,
+                auto_recover_en=scene_data[18],
+                notify_en=scene_data[19],
+            )
+
+    return state
+
+
+def encode_fast_scene_payload(
+    state: FastSceneState,
+    packet_type: int = FAST_SCENE_PACKET_MODIFY,
+) -> bytes:
+    """Encode a Sonoff fast scene payload."""
+
+    payload: list[int] = [
+        packet_type,
+        state.total_num,
+        state.current_data_index,
+    ]
+    protection = state.protection
+    payload.extend(
+        [
+            0x02,
+            20,
+            protection.scene_switch,
+            *_put_u32_le(protection.over_current_ma),
+            *_put_u32_le(protection.over_load_mw),
+            protection.only_ext_mode_restore,
+            *_put_u32_le(
+                _encode_voltage(
+                    protection.over_voltage_mv, protection.over_voltage_en
+                )
+            ),
+            *_put_u32_le(
+                _encode_voltage(
+                    protection.under_voltage_mv, protection.under_voltage_en
+                )
+            ),
+            protection.auto_recover_en,
+            protection.notify_en,
+        ]
+    )
+
+    return bytes(payload)
+
+
+class SonoffErrorCodeType(types.bitmap32):
+    """Fault Code Type."""
+    Normal = 0x07020000,
+    Overheat = 0x07020001,
+    Overload = 0x07020004,
+    Overload_And_Overheat = 0x07020005,
+
+
+class SonoffCluster(CustomCluster):
+    """Custom Sonoff cluster."""
+
+    cluster_id = 0xFC11
+    ep_attribute = "sonoff_cluster"
+    manufacturer_id_override = foundation.ZCLHeader.NO_MANUFACTURER_ID
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        network_led = ZCLAttributeDef(
+            name="network_led",
+            id=0x0001,
+            type=t.Bool,
+        )
+        fault_code = ZCLAttributeDef(
+            id=0x0010,
+            type=SonoffErrorCodeType,
+            access="rp",
+        )
+        turbo_mode = ZCLAttributeDef(
+            name="turbo_mode",
+            id=0x0012,
+            type=t.int16s,
+        )
+        delayed_power_on_state = ZCLAttributeDef(
+            name="delayed_power_on_state",
+            id=0x0014,
+            type=t.Bool,
+        )
+        delayed_power_on_time = ZCLAttributeDef(
+            name="delayed_power_on_time",
+            id=0x0015,
+            type=t.uint16_t,
+        )
+        external_trigger_mode = ZCLAttributeDef(
+            name="external_trigger_mode",
+            id=0x0016,
+            type=t.uint8_t,
+        )
+        detach_relay = ZCLAttributeDef(
+            name="detach_relay",
+            id=0x0019,
+            type=t.bitmap8,
+        )
+        local_fast_scene_configuration = ZCLAttributeDef(
+            name="local_fast_scene_configuration",
+            id=0x7016,
+            type=foundation.Array,
+        )
+        accurrent_current_value = ZCLAttributeDef(
+            name="accurrent_current_value",
+            id=0x7004,
+            type=t.uint32_t,
+        )
+        accurrent_voltage_value = ZCLAttributeDef(
+            name="accurrent_voltage_value",
+            id=0x7005,
+            type=t.uint32_t,
+        )
+        accurrent_power_value = ZCLAttributeDef(
+            name="accurrent_power_value",
+            id=0x7006,
+            type=t.uint32_t,
+        )
+        daily_forward_energy = ZCLAttributeDef(
+            name="daily_forward_energy",
+            id=0x7009,
+            type=t.uint32_t,
+        )
+        monthly_forward_energy = ZCLAttributeDef(
+            name="monthly_forward_energy",
+            id=0x700A,
+            type=t.uint32_t,
+        )
+        daily_reverse_energy = ZCLAttributeDef(
+            name="daily_reverse_energy",
+            id=0x7018,
+            type=t.uint32_t,
+        )
+        monthly_reverse_energy = ZCLAttributeDef(
+            name="monthly_reverse_energy",
+            id=0x7019,
+            type=t.uint32_t,
+        )
+        daily_run_time = ZCLAttributeDef(
+            name="daily_run_time",
+            id=0x701C,
+            type=t.uint32_t,
+        )
+        total_run_time = ZCLAttributeDef(
+            name="total_run_time",
+            id=0x701D,
+            type=t.uint32_t,
+        )
+        total_forward_energy = ZCLAttributeDef(
+            name="total_forward_energy",
+            id=0x701E,
+            type=t.uint32_t,
+        )
+        total_reverse_energy = ZCLAttributeDef(
+            name="total_reverse_energy",
+            id=0x701F,
+            type=t.uint32_t,
+        )
+        voltage_frequency = ZCLAttributeDef(
+            name="voltage_frequency",
+            id=0x7029,
+            type=t.uint32_t,
+        )
+
+    def __init__(self, *args, **kwargs):
+        """Init and listen for fast scene attribute changes."""
+        super().__init__(*args, **kwargs)
+        self._fast_scene_state = FastSceneState()
+        self.on_event(AttributeReadEvent.event_type, self._handle_fast_scene_change)
+        self.on_event(AttributeReportedEvent.event_type, self._handle_fast_scene_change)
+        self.on_event(AttributeUpdatedEvent.event_type, self._handle_fast_scene_change)
+        self.on_event(AttributeWrittenEvent.event_type, self._handle_fast_scene_change)
+
+    def _handle_fast_scene_change(
+        self,
+        event: AttributeReadEvent
+        | AttributeReportedEvent
+        | AttributeUpdatedEvent
+        | AttributeWrittenEvent,
+    ) -> None:
+        """Sync fast scene state to the local config cluster."""
+        if isinstance(event, AttributeWrittenEvent) and event.status != Status.SUCCESS:
+            return
+        if event.attribute_id != self.AttributeDefs.local_fast_scene_configuration.id:
+            return
+
+        values = [event.value]
+        if isinstance(event, AttributeReadEvent) and event.raw_value is not event.value:
+            values.append(event.raw_value)
+
+        for value in values:
+            try:
+                self._fast_scene_state = decode_fast_scene_payload(value)
+                break
+            except (TypeError, ValueError):
+                continue
+        else:
+            return
+
+        if hasattr(self.endpoint, "sonoff_fast_scene_config"):
+            self.endpoint.sonoff_fast_scene_config.update_fast_scene_state(
+                self._fast_scene_state
+            )
+
+    async def apply_custom_configuration(self, *args, **kwargs):
+        """Read fast scene configuration during pairing to populate entities."""
+        await self.read_attributes([self.AttributeDefs.local_fast_scene_configuration.id])
+
+    @property
+    def _is_manuf_specific(self):
+        return False
+
+
+class SonoffFastSceneConfigCluster(LocalDataCluster):
+    """Local cluster for individual fast scene configuration entities."""
+
+    cluster_id = 0xFBFD
+    ep_attribute = "sonoff_fast_scene_config"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        protection_over_current_ma: Final = ZCLAttributeDef(
+            id=0x0010, type=t.uint32_t
+        )
+        protection_over_load_mw: Final = ZCLAttributeDef(id=0x0011, type=t.uint32_t)
+        protection_only_ext_mode_restore: Final = ZCLAttributeDef(
+            id=0x0012, type=t.Bool
+        )
+        protection_over_voltage_mv: Final = ZCLAttributeDef(
+            id=0x0013, type=t.uint32_t
+        )
+        protection_over_voltage_enabled: Final = ZCLAttributeDef(
+            id=0x0014, type=t.Bool
+        )
+        protection_under_voltage_mv: Final = ZCLAttributeDef(
+            id=0x0015, type=t.uint32_t
+        )
+        protection_under_voltage_enabled: Final = ZCLAttributeDef(
+            id=0x0016, type=t.Bool
+        )
+        protection_auto_recover: Final = ZCLAttributeDef(id=0x0017, type=t.Bool)
+        protection_notify: Final = ZCLAttributeDef(id=0x0018, type=t.Bool)
+
+    def __init__(self, *args, **kwargs):
+        """Init with conservative default fast scene state."""
+        super().__init__(*args, **kwargs)
+        self._fast_scene_state = FastSceneState()
+
+    def update_fast_scene_state(self, state: FastSceneState) -> None:
+        """Update local attributes from decoded fast scene state."""
+        self._fast_scene_state = state
+        protection = state.protection
+
+        updates = {
+            self.AttributeDefs.protection_over_current_ma.id: protection.over_current_ma,
+            self.AttributeDefs.protection_over_load_mw.id: protection.over_load_mw,
+            self.AttributeDefs.protection_only_ext_mode_restore.id: bool(
+                protection.only_ext_mode_restore
+            ),
+            self.AttributeDefs.protection_over_voltage_mv.id: protection.over_voltage_mv,
+            self.AttributeDefs.protection_over_voltage_enabled.id: bool(
+                protection.over_voltage_en
+            ),
+            self.AttributeDefs.protection_under_voltage_mv.id: protection.under_voltage_mv,
+            self.AttributeDefs.protection_under_voltage_enabled.id: bool(
+                protection.under_voltage_en
+            ),
+            self.AttributeDefs.protection_auto_recover.id: bool(
+                protection.auto_recover_en
+            ),
+            self.AttributeDefs.protection_notify.id: bool(protection.notify_en),
+        }
+        for attr_id, value in updates.items():
+            self._update_attribute(attr_id, value)
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list:
+        """Merge local writes into the real fast scene aggregate attribute."""
+        state = self.endpoint.sonoff_cluster._fast_scene_state
+
+        for attr, value in attributes.items():
+            attr_def = self.find_attribute(attr)
+            attr_id = attr_def.id
+            if attr_id == self.AttributeDefs.protection_over_current_ma.id:
+                state.protection.over_current_ma = int(value)
+            elif attr_id == self.AttributeDefs.protection_over_load_mw.id:
+                state.protection.over_load_mw = int(value)
+            elif attr_id == self.AttributeDefs.protection_only_ext_mode_restore.id:
+                state.protection.only_ext_mode_restore = int(bool(value))
+            elif attr_id == self.AttributeDefs.protection_over_voltage_mv.id:
+                state.protection.over_voltage_mv = int(value)
+            elif attr_id == self.AttributeDefs.protection_over_voltage_enabled.id:
+                state.protection.over_voltage_en = int(bool(value))
+            elif attr_id == self.AttributeDefs.protection_under_voltage_mv.id:
+                state.protection.under_voltage_mv = int(value)
+            elif attr_id == self.AttributeDefs.protection_under_voltage_enabled.id:
+                state.protection.under_voltage_en = int(bool(value))
+            elif attr_id == self.AttributeDefs.protection_auto_recover.id:
+                state.protection.auto_recover_en = int(bool(value))
+            elif attr_id == self.AttributeDefs.protection_notify.id:
+                state.protection.notify_en = int(bool(value))
+
+        payload = encode_fast_scene_payload(state)
+        zcl_array = fast_scene_array_from_payload(payload)
+        result = await self.endpoint.sonoff_cluster.write_attributes(
+            {
+                SonoffCluster.AttributeDefs.local_fast_scene_configuration.id: zcl_array
+            }
+        )
+        if self._write_succeeded(result):
+            self.update_fast_scene_state(state)
+        return result
+
+    @staticmethod
+    def _write_succeeded(result: list) -> bool:
+        """Return whether a Zigpy write_attributes response succeeded."""
+        try:
+            records = result[0]
+        except (IndexError, TypeError):
+            return False
+        return all(record.status == Status.SUCCESS for record in records)
+
+
+class SonoffNetworkLedSetType(types.enum8):
+    """network led set type."""
+
+    Off = 0x00
+    On = 0x01
+
+class SonoffExternalTriggerMode(types.enum8):
+    """External trigger mode attribute values."""
+
+    Edge_trigger = 0x00
+    Pulse_trigger = 0x01
+    Normally_off_follow_trigger = 0x02
+    Normally_on_follow_trigger = 0x82
+
+
+(
+    QuirkBuilder("SONOFF", "MINI-ZB1GSP")
+    .replaces(SonoffCluster)
+    .adds(SonoffFastSceneConfigCluster)
+    .removes(0x0B04)
+    .removes(0x0702)
+    .enum(
+        SonoffCluster.AttributeDefs.network_led.name,
+        SonoffNetworkLedSetType,
+        SonoffCluster.cluster_id,
+        translation_key="network_led",
+        fallback_name="Network led",
+    )
+    .switch(
+        SonoffCluster.AttributeDefs.turbo_mode.name,
+        SonoffCluster.cluster_id,
+        off_value=9,
+        on_value=20,
+        translation_key="turbo_mode",
+        fallback_name="Turbo mode",
+    )
+    .switch(
+        SonoffCluster.AttributeDefs.delayed_power_on_state.name,
+        SonoffCluster.cluster_id,
+        off_value=0,
+        on_value=1,
+        translation_key="delayed_power_on_state",
+        fallback_name="Delayed power on state",
+    )
+    .number(
+        SonoffCluster.AttributeDefs.delayed_power_on_time.name,
+        SonoffCluster.cluster_id,
+        min_value=0.5,
+        max_value=3599.5,
+        step=0.5,
+        device_class=NumberDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        multiplier=0.5,
+        translation_key="delayed_power_on_time",
+        fallback_name="Delayed power on time",
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.external_trigger_mode.name,
+        SonoffExternalTriggerMode,
+        SonoffCluster.cluster_id,
+        translation_key="external_trigger_mode",
+        fallback_name="External trigger mode",
+    )
+    .switch(
+        SonoffCluster.AttributeDefs.detach_relay.name,
+        SonoffCluster.cluster_id,
+        off_value=0,
+        on_value=1,
+        translation_key="detach_relay",
+        fallback_name="Detach relay",
+    )
+    .number(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_over_current_ma.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        min_value=PROTECTION_CURRENT_MIN_MA,
+        max_value=PROTECTION_CURRENT_MAX_MA,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        unit="mA",
+        translation_key="protection_over_current_ma",
+        fallback_name="Protection over-current threshold",
+    )
+    .number(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_over_load_mw.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        min_value=PROTECTION_POWER_MIN_MW,
+        max_value=PROTECTION_POWER_MAX_MW,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        unit="mW",
+        translation_key="protection_over_load_mw",
+        fallback_name="Protection overload threshold",
+    )
+    .switch(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_only_ext_mode_restore.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="protection_only_ext_mode_restore",
+        fallback_name="Protection external switch restore",
+    )
+    .number(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_over_voltage_mv.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        min_value=PROTECTION_VOLTAGE_MIN_MV,
+        max_value=PROTECTION_VOLTAGE_MAX_MV,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        unit="mV",
+        translation_key="protection_over_voltage_mv",
+        fallback_name="Protection over-voltage threshold",
+    )
+    .switch(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_over_voltage_enabled.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="protection_over_voltage_enabled",
+        fallback_name="Protection over-voltage enabled",
+    )
+    .number(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_under_voltage_mv.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        min_value=PROTECTION_VOLTAGE_MIN_MV,
+        max_value=PROTECTION_VOLTAGE_MAX_MV,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        unit="mV",
+        translation_key="protection_under_voltage_mv",
+        fallback_name="Protection under-voltage threshold",
+    )
+    .switch(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_under_voltage_enabled.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="protection_under_voltage_enabled",
+        fallback_name="Protection under-voltage enabled",
+    )
+    .switch(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_auto_recover.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="protection_auto_recover",
+        fallback_name="Protection auto recover",
+    )
+    # .switch(
+    #     SonoffFastSceneConfigCluster.AttributeDefs.protection_notify.name,
+    #     SonoffFastSceneConfigCluster.cluster_id,
+    #     entity_type=EntityType.CONFIG,
+    #     translation_key="protection_notify",
+    #     fallback_name="Protection notification",
+    # )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.accurrent_current_value.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricCurrent.AMPERE,
+        translation_key="accurrent_current_value",
+        fallback_name="Current",
+        divisor=1000,
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.accurrent_voltage_value.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricPotential.VOLT,
+        divisor=1000,
+        translation_key="accurrent_voltage_value",
+        fallback_name="Voltage",
+
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.accurrent_power_value.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfPower.WATT,
+        divisor=1000,
+        translation_key="accurrent_power_value",
+        fallback_name="Power",
+
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.daily_forward_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="daily_forward_energy",
+        fallback_name="daily forward energy",
+        divisor=1000,
+
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.monthly_forward_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=1000,
+        translation_key="monthly_forward_energy",
+        fallback_name="monthly forward energy",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.daily_reverse_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=1000,
+        translation_key="daily_reverse_energy",
+        fallback_name="daily reverse energy",
+
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.monthly_reverse_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="monthly_reverse_energy",
+        fallback_name="monthly reverse energy",
+        divisor=1000,
+
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.total_forward_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=1000,
+        translation_key="total_forward_energy",
+        fallback_name="total forward energy",
+
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.total_reverse_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=1000,
+        translation_key="total_reverse_energy",
+        fallback_name="total reverse energy",
+
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.total_run_time.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfTime.SECONDS,
+        translation_key="total_run_time",
+        fallback_name="total run time",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.daily_run_time.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfTime.SECONDS,
+        translation_key="daily_run_time",
+        fallback_name="daily run time",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.voltage_frequency.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.FREQUENCY,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfFrequency.HERTZ,
+        translation_key="voltage_frequency",
+        fallback_name="voltage frequency",
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.fault_code.name,
+        SonoffErrorCodeType,
+        SonoffCluster.cluster_id,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="fault_code",
+        fallback_name="fault code",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/sonoff/mini-zb1gsp.py
+++ b/zhaquirks/sonoff/mini-zb1gsp.py
@@ -647,13 +647,6 @@ class SonoffExternalTriggerMode(types.enum8):
         translation_key="protection_auto_recover",
         fallback_name="Protection auto recover",
     )
-    # .switch(
-    #     SonoffFastSceneConfigCluster.AttributeDefs.protection_notify.name,
-    #     SonoffFastSceneConfigCluster.cluster_id,
-    #     entity_type=EntityType.CONFIG,
-    #     translation_key="protection_notify",
-    #     fallback_name="Protection notification",
-    # )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.accurrent_current_value.name,
         cluster_id=SonoffCluster.cluster_id,
@@ -691,7 +684,7 @@ class SonoffExternalTriggerMode(types.enum8):
         state_class=SensorStateClass.MEASUREMENT,
         unit=UnitOfEnergy.KILO_WATT_HOUR,
         translation_key="daily_forward_energy",
-        fallback_name="daily forward energy",
+        fallback_name="Daily forward energy",
         divisor=1000,
     )
     .sensor(
@@ -702,7 +695,7 @@ class SonoffExternalTriggerMode(types.enum8):
         unit=UnitOfEnergy.KILO_WATT_HOUR,
         divisor=1000,
         translation_key="monthly_forward_energy",
-        fallback_name="monthly forward energy",
+        fallback_name="Monthly forward energy",
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.daily_reverse_energy.name,
@@ -712,7 +705,7 @@ class SonoffExternalTriggerMode(types.enum8):
         unit=UnitOfEnergy.KILO_WATT_HOUR,
         divisor=1000,
         translation_key="daily_reverse_energy",
-        fallback_name="daily reverse energy",
+        fallback_name="Daily reverse energy",
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.monthly_reverse_energy.name,
@@ -721,7 +714,7 @@ class SonoffExternalTriggerMode(types.enum8):
         state_class=SensorStateClass.MEASUREMENT,
         unit=UnitOfEnergy.KILO_WATT_HOUR,
         translation_key="monthly_reverse_energy",
-        fallback_name="monthly reverse energy",
+        fallback_name="Monthly reverse energy",
         divisor=1000,
     )
     .sensor(
@@ -732,7 +725,7 @@ class SonoffExternalTriggerMode(types.enum8):
         unit=UnitOfEnergy.KILO_WATT_HOUR,
         divisor=1000,
         translation_key="total_forward_energy",
-        fallback_name="total forward energy",
+        fallback_name="Total forward energy",
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.total_reverse_energy.name,
@@ -742,7 +735,7 @@ class SonoffExternalTriggerMode(types.enum8):
         unit=UnitOfEnergy.KILO_WATT_HOUR,
         divisor=1000,
         translation_key="total_reverse_energy",
-        fallback_name="total reverse energy",
+        fallback_name="Total reverse energy",
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.total_run_time.name,
@@ -751,7 +744,7 @@ class SonoffExternalTriggerMode(types.enum8):
         state_class=SensorStateClass.MEASUREMENT,
         unit=UnitOfTime.SECONDS,
         translation_key="total_run_time",
-        fallback_name="total run time",
+        fallback_name="Total run time",
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.daily_run_time.name,
@@ -760,7 +753,7 @@ class SonoffExternalTriggerMode(types.enum8):
         state_class=SensorStateClass.MEASUREMENT,
         unit=UnitOfTime.SECONDS,
         translation_key="daily_run_time",
-        fallback_name="daily run time",
+        fallback_name="Daily run time",
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.voltage_frequency.name,
@@ -769,7 +762,7 @@ class SonoffExternalTriggerMode(types.enum8):
         state_class=SensorStateClass.MEASUREMENT,
         unit=UnitOfFrequency.HERTZ,
         translation_key="voltage_frequency",
-        fallback_name="voltage frequency",
+        fallback_name="Voltage frequency",
     )
     .enum(
         SonoffCluster.AttributeDefs.fault_code.name,
@@ -778,7 +771,7 @@ class SonoffExternalTriggerMode(types.enum8):
         entity_platform=EntityPlatform.SENSOR,
         entity_type=EntityType.DIAGNOSTIC,
         translation_key="fault_code",
-        fallback_name="fault code",
+        fallback_name="Fault code",
     )
     .add_to_registry()
 )

--- a/zhaquirks/sonoff/mini-zb1gsp.py
+++ b/zhaquirks/sonoff/mini-zb1gsp.py
@@ -530,7 +530,7 @@ class SonoffExternalTriggerMode(types.enum8):
         SonoffNetworkLedSetType,
         SonoffCluster.cluster_id,
         translation_key="network_led",
-        fallback_name="Network led",
+        fallback_name="Network LED",
     )
     .switch(
         SonoffCluster.AttributeDefs.turbo_mode.name,

--- a/zhaquirks/sonoff/mini-zb1gsp.py
+++ b/zhaquirks/sonoff/mini-zb1gsp.py
@@ -8,20 +8,20 @@ from typing import Any, Final
 from zigpy import types
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import (
+    EntityPlatform,
     EntityType,
     NumberDeviceClass,
     QuirkBuilder,
     SensorDeviceClass,
     SensorStateClass,
-    EntityPlatform,
 )
 from zigpy.quirks.v2.homeassistant import (
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
+    UnitOfFrequency,
     UnitOfPower,
     UnitOfTime,
-    UnitOfFrequency,
 )
 import zigpy.types as t
 from zigpy.zcl import (
@@ -131,7 +131,9 @@ def _encode_voltage(value: int, enabled: int) -> int:
     return raw_value
 
 
-def decode_fast_scene_payload(payload: bytes | list[int] | foundation.Array) -> FastSceneState:
+def decode_fast_scene_payload(
+    payload: bytes | list[int] | foundation.Array,
+) -> FastSceneState:
     """Decode a Sonoff fast scene payload."""
 
     data = fast_scene_payload_from_array(payload)
@@ -168,7 +170,9 @@ def decode_fast_scene_payload(payload: bytes | list[int] | foundation.Array) -> 
 
         if scene_type == 2 and len(scene_data) >= 20:
             scene_switch = scene_data[0]
-            over_voltage_mv, over_voltage_en = _decode_voltage(_u32_le(scene_data[10:14]))
+            over_voltage_mv, over_voltage_en = _decode_voltage(
+                _u32_le(scene_data[10:14])
+            )
             under_voltage_mv, under_voltage_en = _decode_voltage(
                 _u32_le(scene_data[14:18])
             )
@@ -209,9 +213,7 @@ def encode_fast_scene_payload(
             *_put_u32_le(protection.over_load_mw),
             protection.only_ext_mode_restore,
             *_put_u32_le(
-                _encode_voltage(
-                    protection.over_voltage_mv, protection.over_voltage_en
-                )
+                _encode_voltage(protection.over_voltage_mv, protection.over_voltage_en)
             ),
             *_put_u32_le(
                 _encode_voltage(
@@ -228,10 +230,11 @@ def encode_fast_scene_payload(
 
 class SonoffErrorCodeType(types.bitmap32):
     """Fault Code Type."""
-    Normal = 0x07020000,
-    Overheat = 0x07020001,
-    Overload = 0x07020004,
-    Overload_And_Overheat = 0x07020005,
+
+    Normal = (0x07020000,)
+    Overheat = (0x07020001,)
+    Overload = (0x07020004,)
+    Overload_And_Overheat = (0x07020005,)
 
 
 class SonoffCluster(CustomCluster):
@@ -387,7 +390,9 @@ class SonoffCluster(CustomCluster):
 
     async def apply_custom_configuration(self, *args, **kwargs):
         """Read fast scene configuration during pairing to populate entities."""
-        await self.read_attributes([self.AttributeDefs.local_fast_scene_configuration.id])
+        await self.read_attributes(
+            [self.AttributeDefs.local_fast_scene_configuration.id]
+        )
 
     @property
     def _is_manuf_specific(self):
@@ -403,22 +408,14 @@ class SonoffFastSceneConfigCluster(LocalDataCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
 
-        protection_over_current_ma: Final = ZCLAttributeDef(
-            id=0x0010, type=t.uint32_t
-        )
+        protection_over_current_ma: Final = ZCLAttributeDef(id=0x0010, type=t.uint32_t)
         protection_over_load_mw: Final = ZCLAttributeDef(id=0x0011, type=t.uint32_t)
         protection_only_ext_mode_restore: Final = ZCLAttributeDef(
             id=0x0012, type=t.Bool
         )
-        protection_over_voltage_mv: Final = ZCLAttributeDef(
-            id=0x0013, type=t.uint32_t
-        )
-        protection_over_voltage_enabled: Final = ZCLAttributeDef(
-            id=0x0014, type=t.Bool
-        )
-        protection_under_voltage_mv: Final = ZCLAttributeDef(
-            id=0x0015, type=t.uint32_t
-        )
+        protection_over_voltage_mv: Final = ZCLAttributeDef(id=0x0013, type=t.uint32_t)
+        protection_over_voltage_enabled: Final = ZCLAttributeDef(id=0x0014, type=t.Bool)
+        protection_under_voltage_mv: Final = ZCLAttributeDef(id=0x0015, type=t.uint32_t)
         protection_under_voltage_enabled: Final = ZCLAttributeDef(
             id=0x0016, type=t.Bool
         )
@@ -490,9 +487,7 @@ class SonoffFastSceneConfigCluster(LocalDataCluster):
         payload = encode_fast_scene_payload(state)
         zcl_array = fast_scene_array_from_payload(payload)
         result = await self.endpoint.sonoff_cluster.write_attributes(
-            {
-                SonoffCluster.AttributeDefs.local_fast_scene_configuration.id: zcl_array
-            }
+            {SonoffCluster.AttributeDefs.local_fast_scene_configuration.id: zcl_array}
         )
         if self._write_succeeded(result):
             self.update_fast_scene_state(state)
@@ -513,6 +508,7 @@ class SonoffNetworkLedSetType(types.enum8):
 
     Off = 0x00
     On = 0x01
+
 
 class SonoffExternalTriggerMode(types.enum8):
     """External trigger mode attribute values."""
@@ -677,7 +673,6 @@ class SonoffExternalTriggerMode(types.enum8):
         divisor=1000,
         translation_key="accurrent_voltage_value",
         fallback_name="Voltage",
-
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.accurrent_power_value.name,
@@ -688,7 +683,6 @@ class SonoffExternalTriggerMode(types.enum8):
         divisor=1000,
         translation_key="accurrent_power_value",
         fallback_name="Power",
-
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.daily_forward_energy.name,
@@ -699,7 +693,6 @@ class SonoffExternalTriggerMode(types.enum8):
         translation_key="daily_forward_energy",
         fallback_name="daily forward energy",
         divisor=1000,
-
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.monthly_forward_energy.name,
@@ -720,7 +713,6 @@ class SonoffExternalTriggerMode(types.enum8):
         divisor=1000,
         translation_key="daily_reverse_energy",
         fallback_name="daily reverse energy",
-
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.monthly_reverse_energy.name,
@@ -731,7 +723,6 @@ class SonoffExternalTriggerMode(types.enum8):
         translation_key="monthly_reverse_energy",
         fallback_name="monthly reverse energy",
         divisor=1000,
-
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.total_forward_energy.name,
@@ -742,7 +733,6 @@ class SonoffExternalTriggerMode(types.enum8):
         divisor=1000,
         translation_key="total_forward_energy",
         fallback_name="total forward energy",
-
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.total_reverse_energy.name,
@@ -753,7 +743,6 @@ class SonoffExternalTriggerMode(types.enum8):
         divisor=1000,
         translation_key="total_reverse_energy",
         fallback_name="total reverse energy",
-
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.total_run_time.name,


### PR DESCRIPTION
## Proposed change

Add support for `SONOFF MINI-ZB1GSP` by introducing a dedicated quirk for the
manufacturer-specific Sonoff cluster.

This quirk exposes the device's private attributes as usable ZHA entities,
including:

- network LED control
- turbo mode
- delayed power-on state and delay time
- external trigger mode
- detached relay mode
- electrical protection configuration from the local fast scene payload
- current, voltage, power, energy, runtime, frequency, and fault code reporting


## Additional information

This change is intended for `SONOFF MINI-ZB1GSP` only and should not affect
other Sonoff devices.

No known breaking changes.

## Device diagnostics
[zha-01KX3BYWTD022S44VCDM8CF7BT-SONOFF MINI-ZB1GSP-b642b67380e42249d6ea1c83e95f4a6f.json](https://github.com/user-attachments/files/29957769/zha-01KX3BYWTD022S44VCDM8CF7BT-SONOFF.MINI-ZB1GSP-b642b67380e42249d6ea1c83e95f4a6f.json)



## Checklist
- [x] The changes are tested and work correctly
- [ ]  `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached