### PR TITLE
Add support for _TZE284_0ints6wl soil sensor (corrected battery DP + illuminance)

### DIFF
--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -1,7 +1,5 @@
 """Tests for Tuya Sensor quirks."""
 
-import math
-
 import pytest
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, PowerConfiguration
@@ -161,47 +159,23 @@ async def test_handle_get_data_enum_batt(
 
 @pytest.mark.parametrize(
     "raw_battery_state,expected_percent",
-    [
-        (0, 40),  # Low
-        (1, 120),  # Middle
-        (2, 200),  # High
-        (99, 0),  # unmapped/unexpected raw value -> defaults to 0 rather than raising
-    ],
+    [(0, 40), (1, 120), (2, 200), (99, 0)],
 )
-async def test_soil_sensor_0ints6wl(
+async def test_soil_sensor_0ints6wl_battery(
     zigpy_device_from_v2_quirk, raw_battery_state, expected_percent
 ):
-    """Test _TZE284_0ints6wl: enum battery (dp=14) and illuminance (dp=102).
-
-    This variant differs from the _TZE284_aao3yzhs group: battery is a 3-tier
-    enum on dp=14 (not a 0-100 percentage on dp=15), and it also reports
-    illuminance on dp=102, which no known upstream quirk maps.
-    """
-
+    """Test _TZE284_0ints6wl enum battery (dp=14) conversion."""
     quirked = zigpy_device_from_v2_quirk("_TZE284_0ints6wl", "TS0601")
     ep = quirked.endpoints[1]
 
-    assert ep.tuya_manufacturer is not None
-    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
-
-    tuya_cluster = ep.tuya_manufacturer
-
-    tuya_cluster.handle_get_data(
+    ep.tuya_manufacturer.handle_get_data(
         TuyaCommand(
             status=0,
             tsn=1,
-            datapoints=[
-                TuyaDatapointData(5, TuyaData(215)),  # temperature, scale 10
-                TuyaDatapointData(3, TuyaData(42)),  # soil moisture, default scale 100
-                TuyaDatapointData(102, TuyaData(6377)),  # illuminance, raw lux
-                TuyaDatapointData(14, TuyaData(raw_battery_state)),  # battery enum
-            ],
+            datapoints=[TuyaDatapointData(14, TuyaData(raw_battery_state))],
         )
     )
 
-    assert ep.temperature.get("measured_value") == 2150
-    assert ep.soil_moisture.get("measured_value") == 4200
-    assert ep.illuminance.get("measured_value") == 10000 * math.log10(6377) + 1
     assert ep.power.get("battery_percentage_remaining") == expected_percent
 
 

--- a/tests/test_tuya_sensor.py
+++ b/tests/test_tuya_sensor.py
@@ -1,12 +1,14 @@
 """Tests for Tuya Sensor quirks."""
 
+import math
+
 import pytest
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, PowerConfiguration
 from zigpy.zcl.clusters.measurement import RelativeHumidity, TemperatureMeasurement
 
 import zhaquirks
-from zhaquirks.tuya import TuyaLocalCluster
+from zhaquirks.tuya import TuyaCommand, TuyaData, TuyaDatapointData, TuyaLocalCluster
 from zhaquirks.tuya.mcu import TuyaMCUCluster
 
 # Temp DP 1, Humidity DP 2, Battery DP 3
@@ -155,6 +157,52 @@ async def test_handle_get_data_enum_batt(
 
     status = ep.tuya_manufacturer.handle_get_data(data.data)
     assert status == foundation.Status.UNSUPPORTED_ATTRIBUTE
+
+
+@pytest.mark.parametrize(
+    "raw_battery_state,expected_percent",
+    [
+        (0, 40),  # Low
+        (1, 120),  # Middle
+        (2, 200),  # High
+        (99, 0),  # unmapped/unexpected raw value -> defaults to 0 rather than raising
+    ],
+)
+async def test_soil_sensor_0ints6wl(
+    zigpy_device_from_v2_quirk, raw_battery_state, expected_percent
+):
+    """Test _TZE284_0ints6wl: enum battery (dp=14) and illuminance (dp=102).
+
+    This variant differs from the _TZE284_aao3yzhs group: battery is a 3-tier
+    enum on dp=14 (not a 0-100 percentage on dp=15), and it also reports
+    illuminance on dp=102, which no known upstream quirk maps.
+    """
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_0ints6wl", "TS0601")
+    ep = quirked.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+
+    tuya_cluster = ep.tuya_manufacturer
+
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[
+                TuyaDatapointData(5, TuyaData(215)),  # temperature, scale 10
+                TuyaDatapointData(3, TuyaData(42)),  # soil moisture, default scale 100
+                TuyaDatapointData(102, TuyaData(6377)),  # illuminance, raw lux
+                TuyaDatapointData(14, TuyaData(raw_battery_state)),  # battery enum
+            ],
+        )
+    )
+
+    assert ep.temperature.get("measured_value") == 2150
+    assert ep.soil_moisture.get("measured_value") == 4200
+    assert ep.illuminance.get("measured_value") == 10000 * math.log10(6377) + 1
+    assert ep.power.get("battery_percentage_remaining") == expected_percent
 
 
 def test_valid_attributes(zigpy_device_from_v2_quirk):

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -285,12 +285,12 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
 
 
 (
-    # Battery is a 3-tier enum (dp=14, low/middle/high), not a 0-100 percentage
-    # like the aao3yzhs group above (dp=15) - confirmed via debug-log capture on
-    # real hardware, dp=15 never reported despite temperature/soil-moisture DPs
-    # firing hourly. Illuminance (dp=102) is present on this variant but is not
-    # mapped by any known upstream quirk.
+    # Battery is a 3-tier enum on dp=14, not a percentage on dp=15 like the
+    # aao3yzhs group above.
     TuyaQuirkBuilder("_TZE284_0ints6wl", "TS0601")
+    .applies_to(
+        "_TZE2841000000_0ints6wl", "TS0601"
+    )  # same device, corrupted manufacturer ID
     .tuya_temperature(dp_id=5, scale=10)
     .tuya_soil_moisture(dp_id=3)
     .tuya_illuminance(dp_id=102)
@@ -298,11 +298,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
         dp_id=14,
         ep_attribute=TuyaPowerConfigurationCluster2AA.ep_attribute,
         attribute_name="battery_percentage_remaining",
-        # Low/Middle/High (raw 0/1/2) -> stored half-percent ZCL units, chosen
-        # from real percentage bands rather than a linear scale (a linear
-        # scale would map Low=0 -> displayed 0%, reading as "dead" not "low").
-        # Unexpected raw values default to 0 rather than raising, since this
-        # device is known to report other unmapped DPs (e.g. dp=111).
+        # Low/Middle/High (raw 0/1/2) -> 20/60/100%, in half-percent units.
         converter=lambda x: {0: 40, 1: 120, 2: 200}.get(x, 0),
     )
     .adds(TuyaPowerConfigurationCluster2AA)

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -15,6 +15,7 @@ from zhaquirks.builder import (
 )
 from zhaquirks.tuya import (
     TUYA_SET_TIME,
+    TuyaPowerConfigurationCluster2AA,
     TuyaPowerConfigurationCluster2AAA,
     TuyaTimePayload,
 )
@@ -278,6 +279,34 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .tuya_temperature(dp_id=5, scale=10)
     .tuya_battery(dp_id=15)
     .tuya_soil_moisture(dp_id=3)
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+(
+    # Battery is a 3-tier enum (dp=14, low/middle/high), not a 0-100 percentage
+    # like the aao3yzhs group above (dp=15) - confirmed via debug-log capture on
+    # real hardware, dp=15 never reported despite temperature/soil-moisture DPs
+    # firing hourly. Illuminance (dp=102) is present on this variant but is not
+    # mapped by any known upstream quirk.
+    TuyaQuirkBuilder("_TZE284_0ints6wl", "TS0601")
+    .tuya_temperature(dp_id=5, scale=10)
+    .tuya_soil_moisture(dp_id=3)
+    .tuya_illuminance(dp_id=102)
+    .tuya_dp(
+        dp_id=14,
+        ep_attribute=TuyaPowerConfigurationCluster2AA.ep_attribute,
+        attribute_name="battery_percentage_remaining",
+        # Low/Middle/High (raw 0/1/2) -> stored half-percent ZCL units, chosen
+        # from real percentage bands rather than a linear scale (a linear
+        # scale would map Low=0 -> displayed 0%, reading as "dead" not "low").
+        # Unexpected raw values default to 0 rather than raising, since this
+        # device is known to report other unmapped DPs (e.g. dp=111).
+        converter=lambda x: {0: 40, 1: 120, 2: 200}.get(x, 0),
+    )
+    .adds(TuyaPowerConfigurationCluster2AA)
+    .tuya_enchantment(data_query_spell=True)
     .skip_configuration()
     .add_to_registry()
 )

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -288,9 +288,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     # Battery is a 3-tier enum on dp=14, not a percentage on dp=15 like the
     # aao3yzhs group above.
     TuyaQuirkBuilder("_TZE284_0ints6wl", "TS0601")
-    .applies_to(
-        "_TZE2841000000_0ints6wl", "TS0601"
-    )  # same device, corrupted manufacturer ID
+    .applies_to("_TZE2841000000_0ints6wl", "TS0601")
     .tuya_temperature(dp_id=5, scale=10)
     .tuya_soil_moisture(dp_id=3)
     .tuya_illuminance(dp_id=102)


### PR DESCRIPTION
## Proposed change

Adds support for `_TZE284_0ints6wl` (Zigbee Soil Moisture/Temperature/Humidity/Light sensor, "4in1" variant) as its own quirk block, distinct from the existing `_TZE284_aao3yzhs` group.

This supersedes #4987, which added this manufacturer ID under the assumption it matched the `aao3yzhs` group's DP layout exactly. Having run that assumption on real hardware for several weeks, two things turned out to differ:

1. **Battery is a 3-tier enum on dp=14 (low/middle/high), not a 0-100 percentage on dp=15.** dp=15 (the `aao3yzhs` group's battery DP) never reported once, despite temperature/soil-moisture DPs firing hourly over 3+ days of observation. Enabling `zhaquirks.tuya`/`zigpy.zcl`/`zha` debug logging and physically waking the device captured every DP it actually sends — dp=14 fired as an enum (raw value 1). Cross-referencing against this device's old Tuya-cloud-integration entity (still carrying its original schema before going `unavailable`) confirmed `options: ['low','middle','high']`, raw value 1 = `middle` — an exact match.

   To still surface a normal HA battery icon rather than a plain enum tile, Low/Middle/High map to display percentages **derived from real percentage bands** (20/60/100%) via a lookup-table converter, rather than a linear scale (which would map Low=0 → displayed 0%, reading as "dead" rather than "low"). An unmapped/unexpected raw value defaults to 0 rather than raising, since this device is known to report other DPs no one has identified yet (e.g. dp=111).

2. **Illuminance works on dp=102.** #4987 noted "I have not managed to make the Illumination sensor work yet" — confirmed via the same debug-log technique: shone a torch on the sensor mid-wake and watched the raw value track the light directly (baseline 277 → 6377→8294 across successive wake packets).

Also required: `.tuya_enchantment(data_query_spell=True)` — without it, none of dp=14/dp=102 (or the original dp=15 assumption) ever volunteer a report; this spell actively queries the device during configuration instead of passively waiting.

## Additional information

Fixes/supersedes #4987 (same manufacturer ID, corrected DP mapping + illuminance added + tests included, which that PR was missing).

## Device diagnostics

```json
{
  "manufacturer": "_TZE284_0ints6wl",
  "model": "TS0601",
  "quirk_applied": true,
  "quirk_class": "zhaquirks.tuya.builder:(_TZE284_0ints6wl / TS0601)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "in_clusters": {
        "power (0x0001)": {
          "battery_percentage_remaining": 120,
          "battery_quantity": 2,
          "battery_rated_voltage": 15,
          "battery_size": "AA (enum8=3)"
        },
        "illuminance (0x0400)": {
          "measured_value": 17924.91689498254,
          "light_sensor_type": 0
        },
        "temperature (0x0402)": {
          "measured_value": 2290
        },
        "soil_moisture (0x0408)": {
          "measured_value": 10000
        },
        "tuya_manufacturer (0xef00)": {
          "mcu_version": "0.0.2"
        }
      }
    }
  },
  "zha_lib_entities_state": {
    "Battery": { "state": 60.0, "battery_size": "AA", "battery_quantity": 2 },
    "Illuminance": { "state": 62, "unit": "lx" },
    "Temperature": { "state": 22.9, "unit": "°C" },
    "SoilMoisture": { "state": 100.0, "unit": "%" }
  }
}
```

(Trimmed to the relevant device/entity data; full HA diagnostics export includes unrelated integration/environment metadata. IEEE and unique_ids are HA-redacted in the original export.)

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
