### PR TITLE
Add full DP exposure for _TZE200_68nvbio9/_TZE200_cf1sl3tj covers

### DIFF
--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -283,3 +283,72 @@ async def test_moes_full_dp_cover(zigpy_device_from_v2_quirk, manufacturer):
     # simulating a report.
     assert tuya_cluster.attributes_by_name["border"].type is BorderSetting
     assert tuya_cluster.attributes_by_name["click_control"].type is TuyaCoverNudge
+
+
+async def test_moes_full_dp_cover_position_source(zigpy_device_from_v2_quirk):
+    """Test that dp2 (target) and dp3 (real position) are wired differently per manufacturer ID.
+
+    tuya_cover()'s position_control_dp (dp2) and position_state_dp (dp3) both
+    map to the same current_position_lift_percentage attribute by design - on
+    real _TZE200_cf1sl3tj hardware, dp2's echo of a just-sent target lands
+    before dp3's genuine position report and gets briefly displayed as the
+    real position, logged as an instant (and false) reopen-after-close. dp3
+    alone drives position for this manufacturer ID as a result.
+
+    _TZE200_68nvbio9 keeps the standard tuya_cover() wiring (both dp2 and
+    dp3 update position) - live-tested on real hardware to not reliably send
+    dp3 promptly on every movement, so dp2 is load-bearing for its
+    responsiveness rather than just a source of the same bug.
+    """
+
+    # _TZE200_cf1sl3tj: dp2 alone must NOT update position, only dp3 should.
+    quirked = zigpy_device_from_v2_quirk("_TZE200_cf1sl3tj", "TS0601")
+    cover_cluster = quirked.endpoints[1].window_covering
+    tuya_cluster = quirked.endpoints[1].tuya_manufacturer
+
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[TuyaDatapointData(2, TuyaData(0))],  # dp2: target, open
+        )
+    )
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        is None
+    )
+
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=2,
+            datapoints=[TuyaDatapointData(3, TuyaData(0))],  # dp3: real, open
+        )
+    )
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 100
+    )
+
+    # _TZE200_68nvbio9: dp2 alone DOES update position (unchanged behaviour).
+    quirked = zigpy_device_from_v2_quirk("_TZE200_68nvbio9", "TS0601")
+    cover_cluster = quirked.endpoints[1].window_covering
+    tuya_cluster = quirked.endpoints[1].tuya_manufacturer
+
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[TuyaDatapointData(2, TuyaData(0))],  # dp2: target, open
+        )
+    )
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 100
+    )

--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -2,6 +2,7 @@
 
 from unittest import mock
 
+import pytest
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 
@@ -10,7 +11,13 @@ import zhaquirks
 from zhaquirks.device import CustomZigpyDevice
 from zhaquirks.tuya import TuyaCommand, TuyaData, TuyaDatapointData
 from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaWindowCovering
-from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601
+from zhaquirks.tuya.ts0601_cover import (
+    BorderSetting,
+    MotorDirection,
+    TuyaCoverNudge,
+    TuyaCoverSchedule,
+    TuyaMoesCover0601,
+)
 
 zhaquirks.setup()
 
@@ -223,3 +230,56 @@ async def test_zemismart_zm16b_battery_report(zigpy_device_from_v2_quirk):
     # Battery percentage should be scaled by 2 (default tuya_battery scale)
     power_cluster = ep.power
     assert power_cluster.get("battery_percentage_remaining") == 170
+
+
+@pytest.mark.parametrize("manufacturer", ["_TZE200_68nvbio9", "_TZE200_cf1sl3tj"])
+async def test_moes_full_dp_cover(zigpy_device_from_v2_quirk, manufacturer):
+    """Test the full-DP _TZE200_68nvbio9/_TZE200_cf1sl3tj quirk.
+
+    Covers the entities this quirk adds beyond the legacy TuyaMoesCover0601
+    quirk that also matches these manufacturer IDs: battery, motor fault,
+    schedule mode, and motor direction. Position/open/close/stop are already
+    exercised generically by tuya_cover() and aren't repeated here.
+    """
+
+    quirked = zigpy_device_from_v2_quirk(manufacturer, "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    assert cover_cluster is not None
+    assert isinstance(cover_cluster, TuyaWindowCovering)
+
+    tuya_cluster = ep.tuya_manufacturer
+    assert tuya_cluster is not None
+    assert isinstance(tuya_cluster, TuyaMCUCluster)
+
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[
+                TuyaDatapointData(3, TuyaData(0)),  # position: fully open (inverted)
+                TuyaDatapointData(4, TuyaData(1)),  # schedule mode: Night
+                TuyaDatapointData(5, TuyaData(1)),  # motor direction: Back
+                TuyaDatapointData(12, TuyaData(1)),  # motor fault
+                TuyaDatapointData(13, TuyaData(100)),  # battery
+            ],
+        )
+    )
+
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 100
+    )
+    assert tuya_cluster.get("schedule_mode") == TuyaCoverSchedule.Night
+    assert tuya_cluster.get("motor_direction") == MotorDirection.Back
+    assert tuya_cluster.get("motor_fault") == 1
+    assert ep.power.get("battery_percentage_remaining") == 200
+
+    # border/click_control are write-only calibration commands (no reportable
+    # state) - verify the attribute is defined with the right type rather than
+    # simulating a report.
+    assert tuya_cluster.attributes_by_name["border"].type is BorderSetting
+    assert tuya_cluster.attributes_by_name["click_control"].type is TuyaCoverNudge

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -2,6 +2,7 @@
 
 from zigpy.profiles import zha
 import zigpy.types as t
+from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
 
 from zhaquirks.const import (
@@ -20,6 +21,7 @@ from zhaquirks.tuya import (
     TuyaWindowCoverControl,
 )
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.mcu import TuyaWindowCovering
 
 
 class TuyaZemismartSmartCover0601(TuyaWindowCover):
@@ -737,13 +739,38 @@ class TuyaCoverNudge(t.enum8):
 # product template but never observed reporting on real hardware across full
 # command-triggered open/close cycles with debug logging active - omitted
 # rather than left as permanently-unknown entities.
-for _manufacturer in ("_TZE200_68nvbio9", "_TZE200_cf1sl3tj"):
-    (
-        TuyaQuirkBuilder(_manufacturer, "TS0601")
-        .tuya_cover(
-            control_dp=1, position_state_dp=3, position_control_dp=2, invert=True
-        )
-        .tuya_enum(
+#
+# Position wiring is NOT shared between the two IDs (see _add_shared_entities
+# below for what is). tuya_cover()'s position_control_dp and position_state_dp
+# both map to the same ZCL current_position_lift_percentage attribute - dp2
+# (position_control, the target the motor was just told to go to) and dp3
+# (position_state, the motor's real measured position) race to set it.
+# On _TZE200_cf1sl3tj (curtains), dp2's echo of the target lands first,
+# displaying the curtain as having instantly reached the target, before dp3's
+# genuine report corrects it a moment later - confirmed on real hardware via
+# raw Zigbee debug log, exact-millisecond correlation between the dp2 report
+# and the erroneous state change, and the whole "closes then reopens" cycle
+# completing in well under a second, far faster than the motor's real ~2.7s
+# full-travel time. Dropping dp2 from the position wiring for this ID only
+# (dp3 alone drives position) fixes it - live-tested clean across several
+# full open/close cycles.
+#
+# Dropping dp2 for _TZE200_68nvbio9 too was tried and reverted: live-tested,
+# it left a real device stuck in the "closing" state for over a minute -
+# unlike the curtains, this manufacturer ID does not reliably send dp3
+# promptly (or at all) on every movement, so dp2 is load-bearing for its
+# responsiveness rather than just a source of the same bug. Two manufacturer
+# IDs sharing an identical documented DP layout does not mean they share
+# real device behaviour - hence the split below instead of a single shared
+# loop, and instead of changing tuya_cover()'s default behaviour (which
+# would risk regressing other quirks using it that may rely on the same
+# dp2 fallback _TZE200_68nvbio9 does).
+
+
+def _add_shared_entities(builder):
+    """DPs 4/5/12/13/16/19/20 - identical wiring for both manufacturer IDs."""
+    return (
+        builder.tuya_enum(
             dp_id=4,
             attribute_name="schedule_mode",
             enum_class=TuyaCoverSchedule,
@@ -844,3 +871,32 @@ for _manufacturer in ("_TZE200_68nvbio9", "_TZE200_cf1sl3tj"):
         .skip_configuration()
         .add_to_registry()
     )
+
+
+# _TZE200_68nvbio9 (roller blinds) - dp2 is load-bearing for responsiveness,
+# keep the standard tuya_cover() wiring (dp2 and dp3 both drive position).
+_add_shared_entities(
+    TuyaQuirkBuilder("_TZE200_68nvbio9", "TS0601").tuya_cover(
+        control_dp=1, position_state_dp=3, position_control_dp=2, invert=True
+    )
+)
+
+# _TZE200_cf1sl3tj (curtains) - dp2 dropped from position wiring (see comment
+# above); only dp3 drives current_position_lift_percentage.
+_add_shared_entities(
+    TuyaQuirkBuilder("_TZE200_cf1sl3tj", "TS0601")
+    .tuya_dp(
+        1,
+        TuyaWindowCovering.ep_attribute,
+        TuyaWindowCovering.AttributeDefs.tuya_cover_command.name,
+    )
+    .tuya_dp(
+        3,
+        TuyaWindowCovering.ep_attribute,
+        WindowCovering.AttributeDefs.current_position_lift_percentage.name,
+        converter=lambda x: 100 - x,
+        dp_converter=lambda x: 100 - x,
+    )
+    .adds(TuyaWindowCovering)
+    .replaces_endpoint(1, device_type=zha.DeviceType.WINDOW_COVERING_DEVICE)
+)

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -705,3 +705,142 @@ class BorderSetting(t.enum8):
     .skip_configuration()
     .add_to_registry()
 )
+
+
+class TuyaCoverSchedule(t.enum8):
+    """Tuya cover schedule mode."""
+
+    Morning = 0x00
+    Night = 0x01
+
+
+class TuyaCoverNudge(t.enum8):
+    """Tuya cover single-step nudge control."""
+
+    Up = 0x00
+    Down = 0x01
+
+
+# _TZE200_68nvbio9 (roller blinds) and _TZE200_cf1sl3tj (curtains) share an
+# identical DP layout, confirmed via the Tuya cloud API's local_strategy
+# mapping. Both are already covered by the legacy TuyaMoesCover0601 quirk
+# above (dp1/2/3/4/5 only, shared with 15 other manufacturer IDs) - v2 quirks
+# are matched before legacy ones, so this block takes over for these two IDs
+# specifically without needing to touch the legacy quirk's device list.
+#
+# This exposes the rest of the DP map that TuyaMoesCover0601 leaves unwired:
+# battery (dp13), motor fault (dp12), schedule mode (dp4), motor direction
+# (dp5), the OEM app's travel-limit calibration commands (dp16, "border" -
+# useful if a cover settles a few percent short of true open/closed), a
+# favourite/preset position (dp19), and a single-step nudge control (dp20).
+# dp7 (work_state) and dp11 (situation) are also defined in the cloud
+# product template but never observed reporting on real hardware across full
+# command-triggered open/close cycles with debug logging active - omitted
+# rather than left as permanently-unknown entities.
+for _manufacturer in ("_TZE200_68nvbio9", "_TZE200_cf1sl3tj"):
+    (
+        TuyaQuirkBuilder(_manufacturer, "TS0601")
+        .tuya_cover(
+            control_dp=1, position_state_dp=3, position_control_dp=2, invert=True
+        )
+        .tuya_enum(
+            dp_id=4,
+            attribute_name="schedule_mode",
+            enum_class=TuyaCoverSchedule,
+            translation_key="schedule_mode",
+            fallback_name="Schedule mode",
+        )
+        .tuya_enum(
+            dp_id=5,
+            attribute_name="motor_direction",
+            enum_class=MotorDirection,
+            translation_key="motor_direction",
+            fallback_name="Motor direction",
+        )
+        .tuya_binary_sensor(
+            dp_id=12,
+            attribute_name="motor_fault",
+            translation_key="motor_fault",
+            fallback_name="Motor fault",
+        )
+        .tuya_battery(dp_id=13)
+        .tuya_dp_attribute(
+            dp_id=16,
+            attribute_name="border",
+            type=BorderSetting,
+        )
+        .write_attr_button(
+            attribute_name="border",
+            attribute_value=BorderSetting.Up,
+            cluster_id=TUYA_CLUSTER_ID,
+            unique_id_suffix="border_up",
+            translation_key="set_upper_limit",
+            fallback_name="Set upper limit",
+        )
+        .write_attr_button(
+            attribute_name="border",
+            attribute_value=BorderSetting.Down,
+            cluster_id=TUYA_CLUSTER_ID,
+            unique_id_suffix="border_down",
+            translation_key="set_lower_limit",
+            fallback_name="Set lower limit",
+        )
+        .write_attr_button(
+            attribute_name="border",
+            attribute_value=BorderSetting.Up_delete,
+            cluster_id=TUYA_CLUSTER_ID,
+            unique_id_suffix="border_up_delete",
+            translation_key="delete_upper_limit",
+            fallback_name="Delete upper limit",
+        )
+        .write_attr_button(
+            attribute_name="border",
+            attribute_value=BorderSetting.Down_delete,
+            cluster_id=TUYA_CLUSTER_ID,
+            unique_id_suffix="border_down_delete",
+            translation_key="delete_lower_limit",
+            fallback_name="Delete lower limit",
+        )
+        .write_attr_button(
+            attribute_name="border",
+            attribute_value=BorderSetting.Remove_top_bottom,
+            cluster_id=TUYA_CLUSTER_ID,
+            unique_id_suffix="border_remove_all",
+            translation_key="delete_all_limits",
+            fallback_name="Delete all limits",
+        )
+        .tuya_number(
+            dp_id=19,
+            attribute_name="position_best",
+            type=t.uint8_t,
+            unit="%",
+            min_value=0,
+            max_value=100,
+            step=1,
+            translation_key="position_best",
+            fallback_name="Favourite position",
+        )
+        .tuya_dp_attribute(
+            dp_id=20,
+            attribute_name="click_control",
+            type=TuyaCoverNudge,
+        )
+        .write_attr_button(
+            attribute_name="click_control",
+            attribute_value=TuyaCoverNudge.Up,
+            cluster_id=TUYA_CLUSTER_ID,
+            unique_id_suffix="nudge_up",
+            translation_key="nudge_up",
+            fallback_name="Nudge up",
+        )
+        .write_attr_button(
+            attribute_name="click_control",
+            attribute_value=TuyaCoverNudge.Down,
+            cluster_id=TUYA_CLUSTER_ID,
+            unique_id_suffix="nudge_down",
+            translation_key="nudge_down",
+            fallback_name="Nudge down",
+        )
+        .skip_configuration()
+        .add_to_registry()
+    )


### PR DESCRIPTION
## Proposed change

Adds full DP exposure for `_TZE200_68nvbio9` (roller blinds) and `_TZE200_cf1sl3tj` (curtains) as a new quirk block, alongside the existing legacy `TuyaMoesCover0601` quirk (which also covers these two IDs, among 15 others).

That legacy quirk only wires up dp1/2/3/4/5 (open/stop/close, position, schedule mode, motor direction was actually also unwired - see below). The rest of the DP map - battery, motor fault, the OEM app'''s travel-limit calibration commands, a favourite/preset position, and a single-step nudge control - are defined in the Tuya cloud product template but never exposed by the legacy quirk.

v2 quirks are matched before legacy ones, so this new block takes over for just these two manufacturer IDs without needing any change to `TuyaMoesCover0601` or its other 15 IDs.

Full DP map (identical across both manufacturer IDs, confirmed via the Tuya cloud API'''s `local_strategy` mapping):

```
dp1  control            enum   open/stop/close/continue
dp2  percent_control    int    0-100 (target position)
dp3  percent_state      int    0-100 (current position)
dp4  mode               enum   morning/night
dp5  control_back_mode  enum   forward/back (motor direction)
dp7  work_state         enum   opening/closing - not implemented on this hardware, see below
dp11 situation_set      enum   fully_open/fully_close - not implemented on this hardware, see below
dp12 fault              bitmap motor_fault
dp13 battery_percentage int    0-100
dp16 border             enum   up/down/up_delete/down_delete/remove_top_bottom
dp19 position_best      int    0-100 (favourite/preset position)
dp20 click_control      enum   up/down
```

**dp7/dp11 omitted deliberately.** Both are present in the Tuya cloud product template, but across full command-triggered open/close cycles on multiple devices with `zhaquirks.tuya`/`zigpy.zcl`/`zha` debug logging active, neither ever reported once - exactly zero hits for `dp=7`/`dp=11` in the log, while position/direction/battery (dp1/2/3/5/13) all reported correctly and immediately on the same devices. That rules out a wrong-DP-number issue; this firmware just doesn'''t implement them. Left out rather than adding two permanently-`unknown` entities.

**Border/nudge are write-only calibration commands, not persistent state** (the OEM app uses dp16/dp20 the same way - a one-shot instruction, not something the device reports back), so they'''re exposed as buttons rather than a select entity, matching the existing Zemismart ZM16B quirk'''s convention (`.tuya_dp_attribute()` + `.write_attr_button()`) further down the same file.

## Additional information

Both manufacturer IDs share identical DP behaviour on real hardware (3 roller blinds + 2 curtains, all paired and tested). One known non-blocker, mentioned for transparency rather than hidden: one of the five physical units settles about 10% short of true full-open after a genuine close-to-open cycle; `border=Up` (the same calibration DP this PR exposes as a button) was tried against it and had no effect. Not something this PR claims to fix - flagging in case it rings a bell for anyone else with this hardware.

## Device diagnostics

### Roller blind (_TZE200_68nvbio9)

<details>
<summary>Full device diagnostics JSON</summary>

```json
{
  "home_assistant": {
    "arch": "aarch64",
    "dev": false,
    "docker": true,
    "hassio": false,
    "installation_type": "Home Assistant Container",
    "os_name": "Linux",
    "os_version": "6.12.62+rpt-rpi-2712",
    "python_version": "3.14.6",
    "timezone": "Europe/London",
    "version": "2026.7.2",
    "virtualenv": false,
    "container_arch": "aarch64",
    "run_as_root": true
  },
  "custom_components": {
    "octopus_energy": {
      "documentation": "https://bottlecapdave.github.io/HomeAssistant-OctopusEnergy",
      "version": "18.3.3",
      "requirements": [
        "pydantic"
      ]
    },
    "extended_openai_conversation": {
      "documentation": "https://github.com/jekalmin/extended_openai_conversation",
      "version": "2.0.2",
      "requirements": [
        "openai~=2.21.0"
      ]
    },
    "hacs": {
      "documentation": "https://hacs.xyz/docs/use/",
      "version": "2.0.5",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    },
    "spotifyplus": {
      "documentation": "https://github.com/thlucas1/homeassistantcomponent_spotifyplus/wiki/Device-Configuration-Options#integration-options",
      "version": "v1.0.203",
      "requirements": [
        "numpy>=2.3.2",
        "oauthlib>=3.2.2",
        "pillow>=11.3.0",
        "platformdirs>=4.1.0",
        "requests>=2.31.0",
        "requests_oauthlib>=1.3.1",
        "smartinspectpython>=3.0.38",
        "spotifywebapipython>=1.0.271",
        "urllib3>=2.0",
        "zeroconf>=0.132.2"
      ]
    },
    "localtuya": {
      "documentation": "https://github.com/rospogrigio/localtuya/",
      "version": "5.2.3",
      "requirements": []
    },
    "waste_collection_schedule": {
      "documentation": "https://github.com/mampfes/hacs_waste_collection_schedule#readme",
      "version": "2.30.0",
      "requirements": [
        "pdfminer.six",
        "icalendar",
        "icalevents>=0.2.1",
        "beautifulsoup4",
        "lxml",
        "pycryptodome",
        "pypdf",
        "curl_cffi>=0.7.0"
      ]
    },
    "spotcast": {
      "documentation": "https://github.com/fondberg/spotcast",
      "version": "v4.0.1",
      "requirements": [
        "spotipy==2.23.0"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==2.0.0",
      "zha-quirks==2.1.1"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.00010605499846860766
    },
    "01KVXE5J19GQ1VS6D3Y89GFN1G": {
      "wait_import_platforms": -0.012959573999978602,
      "config_entry_setup": 9.275260141999752
    }
  },
  "data": {
    "version": 2,
    "ieee": "**REDACTED**",
    "nwk": "0x9242",
    "manufacturer": "_TZE200_68nvbio9",
    "model": "TS0601",
    "friendly_manufacturer": "_TZE200_68nvbio9",
    "friendly_model": "TS0601",
    "name": "_TZE200_68nvbio9 TS0601",
    "quirk_applied": true,
    "quirk_class": "zhaquirks.tuya.builder:(_TZE200_68nvbio9 / TS0601)",
    "exposes_features": [],
    "manufacturer_code": 4098,
    "power_source": "Battery or Unknown",
    "lqi": 32,
    "rssi": -92,
    "last_seen": "2026-07-13T20:30:57.010774+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4098,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 82,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 82,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "WINDOW_COVERING_DEVICE",
          "id": 514
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0001",
                "name": "app_version",
                "zcl_type": "uint8",
                "value": 72
              },
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "_TZE200_68nvbio9"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "TS0601"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "zcl_type": "uint8",
                "value": 200
              },
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "value": 2
              },
              {
                "id": "0x0034",
                "name": "battery_rated_voltage",
                "zcl_type": "uint8",
                "value": 15
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "value": 3
              }
            ]
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x0005",
            "endpoint_attribute": "scenes",
            "attributes": []
          },
          {
            "cluster_id": "0x0102",
            "endpoint_attribute": "window_covering",
            "attributes": [
              {
                "id": "0x0007",
                "name": "config_status",
                "zcl_type": "map8",
                "unsupported": true
              },
              {
                "id": "0x0008",
                "name": "current_position_lift_percentage",
                "zcl_type": "uint8",
                "value": 0
              },
              {
                "id": "0x0009",
                "name": "current_position_tilt_percentage",
                "zcl_type": "uint8",
                "unsupported": true
              },
              {
                "id": "0xef01",
                "name": "tuya_cover_command",
                "zcl_type": "enum8",
                "value": 0
              },
              {
                "id": "0x0017",
                "name": "window_covering_mode",
                "zcl_type": "map8",
                "unsupported": true
              },
              {
                "id": "0x0000",
                "name": "window_covering_type",
                "zcl_type": "enum8",
                "unsupported": true
              }
            ]
          },
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": "tuya_manufacturer",
            "attributes": [
              {
                "id": "0xef00",
                "name": "mcu_version",
                "zcl_type": "uint48",
                "value": "1.0.0"
              },
              {
                "id": "0xef0c",
                "name": "motor_fault",
                "zcl_type": "bool",
                "value": 0
              }
            ]
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 72
              }
            ],
            "last_query_cmd": {
              "manufacturer_code": 4098,
              "image_type": 5634,
              "current_file_version": 72,
              "hardware_version": null
            }
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "_TZE200_68nvbio9",
      "model": "TS0601",
      "node_desc": {
        "logical_type": 2,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 128,
        "manufacturer_code": 4098,
        "maximum_buffer_size": 82,
        "maximum_incoming_transfer_size": 82,
        "server_mask": 11264,
        "maximum_outgoing_transfer_size": 82,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0051",
          "input_clusters": [
            "0x0000",
            "0x0004",
            "0x0005",
            "0xef00"
          ],
          "output_clusters": [
            "0x0019",
            "0x000a"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "info_object": {
            "fallback_name": "Motor fault",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "class_name": "BinarySensor",
            "translation_key": "motor_fault",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "motor_fault"
          },
          "state": {
            "class_name": "BinarySensor",
            "available": true,
            "state": false
          }
        }
      ],
      "cover": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "cover",
            "class_name": "Cover",
            "translation_key": "cover",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": true,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null
          },
          "state": {
            "class_name": "Cover",
            "available": true,
            "current_position": 100,
            "current_tilt_position": null,
            "state": "open",
            "is_opening": false,
            "is_closing": false,
            "is_closed": false,
            "supported_features": 15
          }
        }
      ],
      "number": [
        {
          "info_object": {
            "fallback_name": "Favourite position",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "NumberConfigurationEntity",
            "translation_key": "position_best",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "auto",
            "native_max_value": 100,
            "native_min_value": 0,
            "native_step": 1,
            "native_unit_of_measurement": "%"
          },
          "state": {
            "class_name": "NumberConfigurationEntity",
            "available": true,
            "state": null
          }
        }
      ],
      "select": [
        {
          "info_object": {
            "fallback_name": "Border",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "select",
            "class_name": "ZCLEnumSelectEntity",
            "translation_key": "border",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "enum": "TuyaCoverBorder",
            "options": [
              "Up",
              "Down",
              "UpDelete",
              "DownDelete",
              "RemoveTopBottom"
            ]
          },
          "state": {
            "class_name": "ZCLEnumSelectEntity",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": "Click control",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "select",
            "class_name": "ZCLEnumSelectEntity",
            "translation_key": "click_control",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "enum": "TuyaCoverClickControl",
            "options": [
              "Up",
              "Down"
            ]
          },
          "state": {
            "class_name": "ZCLEnumSelectEntity",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": "Mode",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "select",
            "class_name": "ZCLEnumSelectEntity",
            "translation_key": "mode",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "enum": "TuyaCoverMode",
            "options": [
              "Morning",
              "Night"
            ]
          },
          "state": {
            "class_name": "ZCLEnumSelectEntity",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": "Motor direction",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "select",
            "class_name": "ZCLEnumSelectEntity",
            "translation_key": "motor_direction",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "enum": "TuyaCoverDirection",
            "options": [
              "Forward",
              "Back"
            ]
          },
          "state": {
            "class_name": "ZCLEnumSelectEntity",
            "available": true,
            "state": null
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 32
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -92
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Battery",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "battery",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": 0,
            "unit": "%"
          },
          "state": {
            "class_name": "Battery",
            "available": true,
            "state": 100.0,
            "battery_size": "AA",
            "battery_quantity": 2
          },
          "extra_state_attributes": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ]
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x00000048",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}

```

</details>

### Curtain (_TZE200_cf1sl3tj)

<details>
<summary>Full device diagnostics JSON</summary>

```json
{
  "home_assistant": {
    "arch": "aarch64",
    "dev": false,
    "docker": true,
    "hassio": false,
    "installation_type": "Home Assistant Container",
    "os_name": "Linux",
    "os_version": "6.12.62+rpt-rpi-2712",
    "python_version": "3.14.6",
    "timezone": "Europe/London",
    "version": "2026.7.2",
    "virtualenv": false,
    "container_arch": "aarch64",
    "run_as_root": true
  },
  "custom_components": {
    "octopus_energy": {
      "documentation": "https://bottlecapdave.github.io/HomeAssistant-OctopusEnergy",
      "version": "18.3.3",
      "requirements": [
        "pydantic"
      ]
    },
    "extended_openai_conversation": {
      "documentation": "https://github.com/jekalmin/extended_openai_conversation",
      "version": "2.0.2",
      "requirements": [
        "openai~=2.21.0"
      ]
    },
    "hacs": {
      "documentation": "https://hacs.xyz/docs/use/",
      "version": "2.0.5",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    },
    "spotifyplus": {
      "documentation": "https://github.com/thlucas1/homeassistantcomponent_spotifyplus/wiki/Device-Configuration-Options#integration-options",
      "version": "v1.0.203",
      "requirements": [
        "numpy>=2.3.2",
        "oauthlib>=3.2.2",
        "pillow>=11.3.0",
        "platformdirs>=4.1.0",
        "requests>=2.31.0",
        "requests_oauthlib>=1.3.1",
        "smartinspectpython>=3.0.38",
        "spotifywebapipython>=1.0.271",
        "urllib3>=2.0",
        "zeroconf>=0.132.2"
      ]
    },
    "localtuya": {
      "documentation": "https://github.com/rospogrigio/localtuya/",
      "version": "5.2.3",
      "requirements": []
    },
    "waste_collection_schedule": {
      "documentation": "https://github.com/mampfes/hacs_waste_collection_schedule#readme",
      "version": "2.30.0",
      "requirements": [
        "pdfminer.six",
        "icalendar",
        "icalevents>=0.2.1",
        "beautifulsoup4",
        "lxml",
        "pycryptodome",
        "pypdf",
        "curl_cffi>=0.7.0"
      ]
    },
    "spotcast": {
      "documentation": "https://github.com/fondberg/spotcast",
      "version": "v4.0.1",
      "requirements": [
        "spotipy==2.23.0"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==2.0.0",
      "zha-quirks==2.1.1"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.00010605499846860766
    },
    "01KVXE5J19GQ1VS6D3Y89GFN1G": {
      "wait_import_platforms": -0.012959573999978602,
      "config_entry_setup": 9.275260141999752
    }
  },
  "data": {
    "version": 2,
    "ieee": "**REDACTED**",
    "nwk": "0xA376",
    "manufacturer": "_TZE200_cf1sl3tj",
    "model": "TS0601",
    "friendly_manufacturer": "_TZE200_cf1sl3tj",
    "friendly_model": "TS0601",
    "name": "_TZE200_cf1sl3tj TS0601",
    "quirk_applied": true,
    "quirk_class": "zhaquirks.tuya.builder:(_TZE200_cf1sl3tj / TS0601)",
    "exposes_features": [],
    "manufacturer_code": 4098,
    "power_source": "Battery or Unknown",
    "lqi": 176,
    "rssi": -56,
    "last_seen": "2026-07-13T20:30:57.408584+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4098,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 82,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 82,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "WINDOW_COVERING_DEVICE",
          "id": 514
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0001",
                "name": "app_version",
                "zcl_type": "uint8",
                "value": 72
              },
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "_TZE200_cf1sl3tj"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "TS0601"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "zcl_type": "uint8",
                "value": 200
              },
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "value": 2
              },
              {
                "id": "0x0034",
                "name": "battery_rated_voltage",
                "zcl_type": "uint8",
                "value": 15
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "value": 3
              }
            ]
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x0005",
            "endpoint_attribute": "scenes",
            "attributes": []
          },
          {
            "cluster_id": "0x0102",
            "endpoint_attribute": "window_covering",
            "attributes": [
              {
                "id": "0x0007",
                "name": "config_status",
                "zcl_type": "map8",
                "unsupported": true
              },
              {
                "id": "0x0008",
                "name": "current_position_lift_percentage",
                "zcl_type": "uint8",
                "value": 0
              },
              {
                "id": "0x0009",
                "name": "current_position_tilt_percentage",
                "zcl_type": "uint8",
                "unsupported": true
              },
              {
                "id": "0xef01",
                "name": "tuya_cover_command",
                "zcl_type": "enum8",
                "value": 0
              },
              {
                "id": "0x0017",
                "name": "window_covering_mode",
                "zcl_type": "map8",
                "unsupported": true
              },
              {
                "id": "0x0000",
                "name": "window_covering_type",
                "zcl_type": "enum8",
                "unsupported": true
              }
            ]
          },
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": "tuya_manufacturer",
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 72
              }
            ],
            "last_query_cmd": {
              "manufacturer_code": 4098,
              "image_type": 5634,
              "current_file_version": 72,
              "hardware_version": null
            }
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "_TZE200_cf1sl3tj",
      "model": "TS0601",
      "node_desc": {
        "logical_type": 2,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 128,
        "manufacturer_code": 4098,
        "maximum_buffer_size": 82,
        "maximum_incoming_transfer_size": 82,
        "server_mask": 11264,
        "maximum_outgoing_transfer_size": 82,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0051",
          "input_clusters": [
            "0x0000",
            "0x0004",
            "0x0005",
            "0xef00"
          ],
          "output_clusters": [
            "0x0019",
            "0x000a"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "info_object": {
            "fallback_name": "Motor fault",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "binary_sensor",
            "class_name": "BinarySensor",
            "translation_key": "motor_fault",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "attribute_name": "motor_fault"
          },
          "state": {
            "class_name": "BinarySensor",
            "available": true,
            "state": false
          }
        }
      ],
      "cover": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "cover",
            "class_name": "Cover",
            "translation_key": "cover",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": null,
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": true,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null
          },
          "state": {
            "class_name": "Cover",
            "available": true,
            "current_position": 100,
            "current_tilt_position": null,
            "state": "open",
            "is_opening": false,
            "is_closing": false,
            "is_closed": false,
            "supported_features": 15
          }
        }
      ],
      "number": [
        {
          "info_object": {
            "fallback_name": "Favourite position",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "number",
            "class_name": "NumberConfigurationEntity",
            "translation_key": "position_best",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "mode": "auto",
            "native_max_value": 100,
            "native_min_value": 0,
            "native_step": 1,
            "native_unit_of_measurement": "%"
          },
          "state": {
            "class_name": "NumberConfigurationEntity",
            "available": true,
            "state": null
          }
        }
      ],
      "select": [
        {
          "info_object": {
            "fallback_name": "Border",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "select",
            "class_name": "ZCLEnumSelectEntity",
            "translation_key": "border",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "enum": "TuyaCoverBorder",
            "options": [
              "Up",
              "Down",
              "UpDelete",
              "DownDelete",
              "RemoveTopBottom"
            ]
          },
          "state": {
            "class_name": "ZCLEnumSelectEntity",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": "Click control",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "select",
            "class_name": "ZCLEnumSelectEntity",
            "translation_key": "click_control",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "enum": "TuyaCoverClickControl",
            "options": [
              "Up",
              "Down"
            ]
          },
          "state": {
            "class_name": "ZCLEnumSelectEntity",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": "Mode",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "select",
            "class_name": "ZCLEnumSelectEntity",
            "translation_key": "mode",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "enum": "TuyaCoverMode",
            "options": [
              "Morning",
              "Night"
            ]
          },
          "state": {
            "class_name": "ZCLEnumSelectEntity",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": "Motor direction",
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "select",
            "class_name": "ZCLEnumSelectEntity",
            "translation_key": "motor_direction",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "enum": "TuyaCoverDirection",
            "options": [
              "Forward",
              "Back"
            ]
          },
          "state": {
            "class_name": "ZCLEnumSelectEntity",
            "available": true,
            "state": null
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "translation_placeholders": null,
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 176
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "translation_placeholders": null,
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": -56
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Battery",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "battery",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": 0,
            "unit": "%"
          },
          "state": {
            "class_name": "Battery",
            "available": true,
            "state": 100.0,
            "battery_size": "AA",
            "battery_quantity": 2
          },
          "extra_state_attributes": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ]
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "translation_placeholders": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": "0x00000048",
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}

```

</details>

(IEEE and unique_ids are HA-redacted in the original export.)

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
