### PR TITLE
Add quirk for Tuya TS110E _TZ3210_k1msuvg6 dimmer

### DIFF
--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import LevelControl, OnOff
 
@@ -417,7 +418,9 @@ async def test_ts110e_k1msuvg6_on_before_brightness(ts110e_k1msuvg6):
             LevelControl.cluster_id,
         ]
 
-    # level 0 turns the light off: no on() beforehand
+    # level 0 (= "off with transition") would permanently zero the
+    # brightness the device restores on turn-on; a plain off() is sent
+    # instead and the level command never reaches the device
     with mock.patch.object(
         level_cluster.endpoint, "request", mock.AsyncMock(return_value=None)
     ) as m2:
@@ -428,9 +431,7 @@ async def test_ts110e_k1msuvg6_on_before_brightness(ts110e_k1msuvg6):
         )
         await wait_for_zigpy_tasks()
 
-        assert [call.kwargs["cluster"] for call in m2.mock_calls] == [
-            LevelControl.cluster_id
-        ]
+        assert [call.kwargs["cluster"] for call in m2.mock_calls] == [OnOff.cluster_id]
 
 
 async def test_ts110e_k1msuvg6_unknown_brightness_forced(ts110e_k1msuvg6):
@@ -476,4 +477,6 @@ def test_ts110e_k1msuvg6_switch_type_attribute(ts110e_k1msuvg6):
 
     attr_def = level_cluster.attributes_by_name["external_switch_type"]
     assert attr_def.id == 0xFC02
-    assert attr_def.type is TS110EExternalSwitchType
+    # uint8, not enum8: the device rejects enum8 writes with INVALID_DATA_TYPE
+    assert attr_def.type is t.uint8_t
+    assert TS110EExternalSwitchType.State == 0x02

--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -386,6 +386,13 @@ async def test_ts110e_k1msuvg6_cache_only_reads(ts110e_k1msuvg6):
         assert m1.call_count == 0
         assert succ["on_off"] == 1
 
+        # reading by attribute id is guarded the same way as by name
+        succ, fail = await on_off_cluster.read_attributes(
+            [OnOff.AttributeDefs.on_off.id]
+        )
+        assert m1.call_count == 0
+        assert succ[OnOff.AttributeDefs.on_off.id] == 1
+
         # reads of other attributes still go to the device
         await on_off_cluster.read_attributes(["start_up_on_off"])
         assert m1.call_count == 1

--- a/tests/test_tuya_dimmer.py
+++ b/tests/test_tuya_dimmer.py
@@ -4,11 +4,22 @@ from unittest import mock
 
 import pytest
 from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import LevelControl, OnOff
 
 from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
+from zhaquirks.tuya.ts110e import TS110EExternalSwitchType
 
 zhaquirks.setup()
+
+# real frames captured from a _TZ3210_k1msuvg6 dimmer:
+# genuine reports (physical toggle / command echo) have DDR=0,
+# the periodic reports with the stale MCU state have DDR=1
+TS110E_GENUINE_ON_REPORT = b"\x08\x89\x0a\x00\x00\x10\x01"
+TS110E_GENUINE_OFF_REPORT = b"\x08\x8a\x0a\x00\x00\x10\x00"
+TS110E_GENUINE_LEVEL_REPORT = b"\x08\x8b\x0a\x00\x00\x20\x94"  # level 148
+TS110E_STALE_ON_REPORT = b"\x18\x8f\x0a\x00\x00\x10\x01"
+TS110E_STALE_LEVEL_REPORT = b"\x18\x90\x0a\x00\x00\x20\x03"  # level 3 = "1%"
 
 
 @pytest.mark.parametrize(
@@ -313,3 +324,149 @@ async def test_doubledimmer_state_report(zigpy_device_from_quirk, quirk):
     assert len(dimmer2_listener.attribute_updates) == 2
     assert dimmer2_listener.attribute_updates[1][0] == 0x0000
     assert dimmer2_listener.attribute_updates[1][1] == 170
+
+
+@pytest.fixture
+def ts110e_k1msuvg6(zigpy_device_from_v2_quirk):
+    """TS110E _TZ3210_k1msuvg6 device with the v2 quirk applied."""
+    return zigpy_device_from_v2_quirk("_TZ3210_k1msuvg6", "TS110E")
+
+
+async def test_ts110e_k1msuvg6_stale_report_filter(ts110e_k1msuvg6):
+    """Genuine reports update the state, stale MCU reports are dropped."""
+    on_off_cluster = ts110e_k1msuvg6.endpoints[1].on_off
+    level_cluster = ts110e_k1msuvg6.endpoints[1].level
+    on_off_listener = ClusterListener(on_off_cluster)
+    level_listener = ClusterListener(level_cluster)
+
+    # seed a known level so the unknown-brightness logic stays out of the way
+    level_cluster.update_attribute(LevelControl.AttributeDefs.current_level.id, 148)
+
+    # genuine off report (DDR=0) is accepted
+    hdr, args = on_off_cluster.deserialize(TS110E_GENUINE_OFF_REPORT)
+    on_off_cluster.handle_message(hdr, args)
+    assert on_off_cluster.get(OnOff.AttributeDefs.on_off.id) == 0
+
+    # stale on report (DDR=1) is dropped, light stays off
+    hdr, args = on_off_cluster.deserialize(TS110E_STALE_ON_REPORT)
+    on_off_cluster.handle_message(hdr, args)
+    assert on_off_cluster.get(OnOff.AttributeDefs.on_off.id) == 0
+
+    # stale level report (DDR=1) is dropped, level stays intact
+    hdr, args = level_cluster.deserialize(TS110E_STALE_LEVEL_REPORT)
+    level_cluster.handle_message(hdr, args)
+    assert level_cluster.get(LevelControl.AttributeDefs.current_level.id) == 148
+
+    # genuine level report (DDR=0) is accepted
+    hdr, args = level_cluster.deserialize(TS110E_GENUINE_LEVEL_REPORT)
+    level_cluster.handle_message(hdr, args)
+    assert level_cluster.get(LevelControl.AttributeDefs.current_level.id) == 0x94
+
+    assert len(on_off_listener.attribute_updates) == 1
+    # seeded level + genuine report
+    assert len(level_listener.attribute_updates) == 2
+
+
+async def test_ts110e_k1msuvg6_cache_only_reads(ts110e_k1msuvg6):
+    """Reads of on_off/current_level are served from cache, others pass."""
+    on_off_cluster = ts110e_k1msuvg6.endpoints[1].on_off
+
+    with mock.patch.object(
+        on_off_cluster, "request", mock.AsyncMock(return_value=[[]])
+    ) as m1:
+        # not cached yet -> no result, but the device is not queried
+        succ, fail = await on_off_cluster.read_attributes(["on_off"])
+        assert m1.call_count == 0
+        assert "on_off" not in succ
+
+        # cached after a genuine report -> served from cache, no device query
+        hdr, args = on_off_cluster.deserialize(TS110E_GENUINE_ON_REPORT)
+        on_off_cluster.handle_message(hdr, args)
+        succ, fail = await on_off_cluster.read_attributes(["on_off"])
+        assert m1.call_count == 0
+        assert succ["on_off"] == 1
+
+        # reads of other attributes still go to the device
+        await on_off_cluster.read_attributes(["start_up_on_off"])
+        assert m1.call_count == 1
+
+
+async def test_ts110e_k1msuvg6_on_before_brightness(ts110e_k1msuvg6):
+    """An explicit on() is sent before move_to_level_with_on_off."""
+    level_cluster = ts110e_k1msuvg6.endpoints[1].level
+
+    with mock.patch.object(
+        level_cluster.endpoint, "request", mock.AsyncMock(return_value=None)
+    ) as m1:
+        await level_cluster.command(
+            LevelControl.ServerCommandDefs.move_to_level_with_on_off.id,
+            level=100,
+            transition_time=0,
+        )
+        await wait_for_zigpy_tasks()
+
+        assert [call.kwargs["cluster"] for call in m1.mock_calls] == [
+            OnOff.cluster_id,
+            LevelControl.cluster_id,
+        ]
+
+    # level 0 turns the light off: no on() beforehand
+    with mock.patch.object(
+        level_cluster.endpoint, "request", mock.AsyncMock(return_value=None)
+    ) as m2:
+        await level_cluster.command(
+            LevelControl.ServerCommandDefs.move_to_level_with_on_off.id,
+            level=0,
+            transition_time=0,
+        )
+        await wait_for_zigpy_tasks()
+
+        assert [call.kwargs["cluster"] for call in m2.mock_calls] == [
+            LevelControl.cluster_id
+        ]
+
+
+async def test_ts110e_k1msuvg6_unknown_brightness_forced(ts110e_k1msuvg6):
+    """Turning on with no known brightness forces full brightness."""
+    on_off_cluster = ts110e_k1msuvg6.endpoints[1].on_off
+    level_cluster = ts110e_k1msuvg6.endpoints[1].level
+
+    with mock.patch.object(
+        level_cluster.endpoint, "request", mock.AsyncMock(return_value=None)
+    ) as m1:
+        hdr, args = on_off_cluster.deserialize(TS110E_GENUINE_ON_REPORT)
+        on_off_cluster.handle_message(hdr, args)
+        await wait_for_zigpy_tasks()
+
+        assert level_cluster.get(LevelControl.AttributeDefs.current_level.id) == 254
+        # pre-on() plus the move_to_level_with_on_off command
+        assert [call.kwargs["cluster"] for call in m1.mock_calls] == [
+            OnOff.cluster_id,
+            LevelControl.cluster_id,
+        ]
+
+
+async def test_ts110e_k1msuvg6_known_brightness_untouched(ts110e_k1msuvg6):
+    """Turning on with a known brightness sends nothing to the device."""
+    on_off_cluster = ts110e_k1msuvg6.endpoints[1].on_off
+    level_cluster = ts110e_k1msuvg6.endpoints[1].level
+    level_cluster.update_attribute(LevelControl.AttributeDefs.current_level.id, 148)
+
+    with mock.patch.object(
+        level_cluster.endpoint, "request", mock.AsyncMock(return_value=None)
+    ) as m1:
+        hdr, args = on_off_cluster.deserialize(TS110E_GENUINE_ON_REPORT)
+        on_off_cluster.handle_message(hdr, args)
+        await wait_for_zigpy_tasks()
+
+        assert m1.call_count == 0
+        assert level_cluster.get(LevelControl.AttributeDefs.current_level.id) == 148
+
+
+def test_ts110e_k1msuvg6_switch_type_attribute(ts110e_k1msuvg6):
+    """The external switch type attribute and select entity are exposed."""
+    level_cluster = ts110e_k1msuvg6.endpoints[1].level
+
+    attr_def = level_cluster.attributes_by_name["external_switch_type"]
+    assert attr_def.id == 0xFC02
+    assert attr_def.type is TS110EExternalSwitchType

--- a/zhaquirks/tuya/ts110e.py
+++ b/zhaquirks/tuya/ts110e.py
@@ -17,6 +17,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.foundation import ZCLAttributeDef
 
+from zhaquirks.builder import QuirkBuilder
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -33,6 +34,10 @@ from zhaquirks.tuya import (
 
 TUYA_LEVEL_ATTRIBUTE = 0xF000
 TUYA_BULB_TYPE_ATTRIBUTE = 0xFC02
+# on some variants (e.g. _TZ3210_k1msuvg6) attribute 0xFC02 holds the
+# external switch type instead of the bulb type, matching the Zigbee2MQTT
+# TS110E_options/TS110E_switch_type converters
+TUYA_SWITCH_TYPE_ATTRIBUTE = 0xFC02
 TUYA_MIN_LEVEL_ATTRIBUTE = 0xFC03
 TUYA_MAX_LEVEL_ATTRIBUTE = 0xFC04
 TUYA_CUSTOM_LEVEL_COMMAND = 0x00F0
@@ -138,6 +143,174 @@ class F000LevelControlCluster(NoManufacturerCluster, LevelControl):
         return super().command(
             command_id, *args, manufacturer, expect_reply, tsn, **kwargs
         )
+
+
+class TS110EExternalSwitchType(t.enum8):
+    """External switch type attached to the dimmer.
+
+    Values match the Zigbee2MQTT ``TS110E_options`` converter
+    (``genLevelCtrl`` attribute 64514).
+    """
+
+    Momentary = 0x00
+    Toggle = 0x01
+    State = 0x02
+
+
+class TS110EStateGuardMixin:
+    """Workarounds for the desynced internal MCU of some TS110E dimmers.
+
+    The internal Tuya MCU of the ``_TZ3210_k1msuvg6`` dimmer desyncs from the
+    actual output state:
+
+    * Reading ``on_off``/``current_level`` returns the stale MCU state
+      (typically "on at 1%") regardless of reality, so reads of those
+      attributes are answered from the attribute cache instead of the device.
+    * The periodic unsolicited reports the device sends (roughly every 15
+      minutes) carry the same stale values. They can be told apart from
+      genuine reports (physical switch presses and echoes of received
+      commands): the stale reports have ``disable_default_response=1`` in
+      the ZCL frame control, genuine reports have it unset. The stale
+      reports are dropped.
+    """
+
+    CACHE_ONLY_READ_ATTRIBUTES = frozenset()
+
+    def _read_is_cache_only(self, attr) -> bool:
+        """Return whether reading this attribute must not hit the device."""
+        if isinstance(attr, str):
+            attr_def = self.attributes_by_name.get(attr)
+            return (
+                attr_def is not None and attr_def.id in self.CACHE_ONLY_READ_ATTRIBUTES
+            )
+        return attr in self.CACHE_ONLY_READ_ATTRIBUTES
+
+    async def read_attributes(
+        self,
+        attributes: list[int | str | ZCLAttributeDef],
+        allow_cache: bool = False,
+        only_cache: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Serve reads of the desynced state attributes from the cache."""
+        if any(self._read_is_cache_only(attr) for attr in attributes):
+            self.debug("Serving read of %s from the attribute cache", attributes)
+            allow_cache = True
+            only_cache = True
+        return await super().read_attributes(
+            attributes, allow_cache=allow_cache, only_cache=only_cache, **kwargs
+        )
+
+    def handle_cluster_general_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list,
+        *,
+        dst_addressing: t.AddrMode | None = None,
+    ) -> None:
+        """Drop the periodic reports carrying the stale MCU state."""
+        if (
+            hdr.command_id == foundation.GeneralCommand.Report_Attributes
+            and hdr.frame_control.disable_default_response
+        ):
+            self.debug("Dropping report with stale MCU state: %s", args)
+            return
+        super().handle_cluster_general_request(hdr, args, dst_addressing=dst_addressing)
+
+
+class TS110EOnOffCluster(TS110EStateGuardMixin, NoManufacturerCluster, OnOff):
+    """OnOff cluster for TS110E dimmers with a desynced internal MCU."""
+
+    CACHE_ONLY_READ_ATTRIBUTES = frozenset({OnOff.AttributeDefs.on_off.id})
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid != OnOff.AttributeDefs.on_off.id or not value:
+            return
+
+        # The device never reports a usable current_level on its own, so the
+        # brightness is unknown until it is set through Zigbee at least once.
+        # If the light turns on before that happened (physical switch press
+        # after a fresh pairing), force full brightness onto the device so
+        # Home Assistant and the light stay in sync.
+        level_cluster = getattr(self.endpoint, LevelControl.ep_attribute, None)
+        if (
+            level_cluster is None
+            or level_cluster.get(LevelControl.AttributeDefs.current_level.id)
+            is not None
+        ):
+            return
+
+        self.debug("Turned on with unknown brightness, forcing full brightness")
+        level_cluster.update_attribute(LevelControl.AttributeDefs.current_level.id, 254)
+        self.create_catching_task(
+            level_cluster.command(
+                LevelControl.ServerCommandDefs.move_to_level_with_on_off.id,
+                level=254,
+                transition_time=1,
+            )
+        )
+
+
+class TS110ELevelControlCluster(
+    TS110EStateGuardMixin, NoManufacturerCluster, LevelControl
+):
+    """LevelControl cluster for TS110E dimmers with a desynced internal MCU."""
+
+    CACHE_ONLY_READ_ATTRIBUTES = frozenset(
+        {LevelControl.AttributeDefs.current_level.id}
+    )
+
+    class AttributeDefs(LevelControl.AttributeDefs):
+        """Attribute definitions."""
+
+        # 0xFC02, the bulb type on other TS110E variants
+        external_switch_type: Final = ZCLAttributeDef(
+            id=TUYA_SWITCH_TYPE_ATTRIBUTE, type=TS110EExternalSwitchType
+        )
+
+    async def command(
+        self,
+        command_id: Union[foundation.GeneralCommand, int, t.uint8_t],
+        *args,
+        manufacturer: Union[int, t.uint16_t] | None = None,
+        expect_reply: bool = True,
+        tsn: Union[int, t.uint8_t] | None = None,
+        **kwargs: Any,
+    ):
+        """Send an explicit on() before switching on via a level command.
+
+        When the light is turned on with just move_to_level_with_on_off, the
+        physical switch cannot turn it off afterwards, see
+        https://github.com/Koenkk/zigbee2mqtt/issues/15902
+        """
+        if command_id == self.ServerCommandDefs.move_to_level_with_on_off.id:
+            level = kwargs["level"] if "level" in kwargs else args[0] if args else None
+            if level:
+                await self.endpoint.on_off.on()
+        return await super().command(
+            command_id,
+            *args,
+            manufacturer=manufacturer,
+            expect_reply=expect_reply,
+            tsn=tsn,
+            **kwargs,
+        )
+
+
+(
+    QuirkBuilder("_TZ3210_k1msuvg6", "TS110E")
+    .replaces(TS110EOnOffCluster)
+    .replaces(TS110ELevelControlCluster)
+    .enum(
+        attribute_name=TS110ELevelControlCluster.AttributeDefs.external_switch_type.name,
+        enum_class=TS110EExternalSwitchType,
+        cluster_id=TS110ELevelControlCluster.cluster_id,
+        translation_key="external_switch_type",
+        fallback_name="External switch type",
+    )
+    .add_to_registry()
+)
 
 
 class DimmerSwitchWithNeutral1Gang(TuyaDimmerSwitch):

--- a/zhaquirks/tuya/ts110e.py
+++ b/zhaquirks/tuya/ts110e.py
@@ -264,9 +264,11 @@ class TS110ELevelControlCluster(
     class AttributeDefs(LevelControl.AttributeDefs):
         """Attribute definitions."""
 
-        # 0xFC02, the bulb type on other TS110E variants
+        # 0xFC02, the bulb type on other TS110E variants; declared as uint8
+        # because the device rejects enum8 writes with INVALID_DATA_TYPE
+        # (Zigbee2MQTT also writes it as data type 0x20)
         external_switch_type: Final = ZCLAttributeDef(
-            id=TUYA_SWITCH_TYPE_ATTRIBUTE, type=TS110EExternalSwitchType
+            id=TUYA_SWITCH_TYPE_ATTRIBUTE, type=t.uint8_t
         )
 
     async def command(
@@ -278,14 +280,23 @@ class TS110ELevelControlCluster(
         tsn: Union[int, t.uint8_t] | None = None,
         **kwargs: Any,
     ):
-        """Send an explicit on() before switching on via a level command.
+        """Guard the level commands against firmware bugs.
 
         When the light is turned on with just move_to_level_with_on_off, the
         physical switch cannot turn it off afterwards, see
-        https://github.com/Koenkk/zigbee2mqtt/issues/15902
+        https://github.com/Koenkk/zigbee2mqtt/issues/15902 - so an explicit
+        on() is sent first.
+
+        move_to_level_with_on_off with level=0 (which is what "off with
+        transition" compiles to) permanently zeroes the brightness the device
+        restores on turn-on, even when the light is already off - the next
+        physical switch press then turns the light on at 0%, i.e. dark. Such
+        commands are sent as a plain off() instead, sacrificing the fade-out.
         """
         if command_id == self.ServerCommandDefs.move_to_level_with_on_off.id:
             level = kwargs["level"] if "level" in kwargs else args[0] if args else None
+            if level is not None and not level:
+                return await self.endpoint.on_off.off()
             if level:
                 await self.endpoint.on_off.on()
         return await super().command(


### PR DESCRIPTION
# Add quirk for Tuya TS110E `_TZ3210_k1msuvg6` dimmer (desynced-MCU workarounds + switch type select)

## Proposed change

Adds a new v2 quirk for the `_TZ3210_k1msuvg6` TS110E 1-gang dimmer module. This manufacturer ID currently has no quirk at all — the existing legacy `DimmerSwitchWithNeutral1Gang` in `ts110e.py` only covers `_TZ3210_ngqk6jia`, and this variant neither matches its signature (no 0xE001 in the simple descriptor) nor behaves like it (it dims correctly via standard `current_level`/`move_to_level_with_on_off`, not via the 0xF000/0x00F0 custom path).

Without a quirk the device is barely usable in ZHA, because its internal Tuya MCU desyncs from the actual dimmer output. All findings below were confirmed from `zigpy.zcl` debug traffic on six physical units:

**1. Reads of `on_off`/`current_level` return the stale MCU state.** Regardless of the real output state, `Read_Attributes` answers with the MCU's belief — typically `on_off=1, current_level=3`. ZHA's periodic light refresh (~48 min) therefore kept flipping lights to "on at 1%" in HA while they were physically off. The quirk answers reads of these two attributes from the attribute cache and never queries the device (other attributes still pass through).

**2. The device periodically sends unsolicited reports with the same stale values.** Roughly every 15 minutes it reports `on_off=1` followed one second later by `current_level=3`, again regardless of reality. These are reliably distinguishable from genuine reports: the stale reports have `disable_default_response=1` in the ZCL frame control and come from a separate TSN counter, while genuine reports (physical switch presses and echoes of received commands) always have `disable_default_response=0`. Captured examples from the same unit:

```
genuine physical off:  08 a9 0a 00 00 10 00
stale pair while off:  18 8f 0a 00 00 10 01     (on_off = on)
                       18 90 0a 00 00 20 03     (current_level = 3, i.e. "1%")
```

The quirk drops `Report_Attributes` frames with `disable_default_response=1` on both clusters.

**3. After a bare `move_to_level_with_on_off`, the physical switch can no longer turn the light off.** Known firmware issue, see Koenkk/zigbee2mqtt#15902 — Zigbee2MQTT works around it by sending an explicit `on()` before every brightness command, and this quirk does the same for `move_to_level_with_on_off` with a non-zero level.

**4. The device never reports a usable `current_level` on its own,** so brightness is unknowable until it has been set through Zigbee at least once. If the light turns on (physical press after a fresh pairing) before that happened, the quirk forces full brightness onto the device, so HA shows a defined state that matches reality instead of guessing.

**5. External switch type lives in `genLevelCtrl` attribute 0xFC02.** This variant does not implement the usual Tuya external switch type cluster — reads of 0xE001/0xD030 return `UNSUPPORTED_ATTRIBUTE` on all six units. The actual location matches the Zigbee2MQTT `TS110E_options` converter: attribute 64514 (0xFC02) on LevelControl with `{momentary: 0, toggle: 1, state: 2}`. Exposed as a config select entity. Note that 0xFC02 is defined as `bulb_type` on the `_TZ3210_ngqk6jia` variant (and Z2M's converters expose it per-fingerprint the same way), hence the variant-specific attribute definition instead of touching the existing `F000LevelControlCluster`.

## Additional information

- Tested on six physical units in one household (mixed rooms, mixed wall switches). Reading the new switch-type attribute returned `Toggle` on five units and `Momentary` on one, consistent with the physically installed switches.
- One caveat for transparency: a unit whose MCU is already fully wedged (stale state, physical switch dead even locally) is only recovered by a mains power-cycle. The quirk prevents the desync from corrupting HA state and avoids the command pattern that appears to trigger it, but it cannot un-wedge an already wedged MCU over the air.
- Dropping `disable_default_response=1` reports also drops the occasional heartbeat that happens to carry correct values on healthy units. This is harmless: every genuine state change (physical press, command echo) always arrives separately with `disable_default_response=0`.
- Tests cover the report filter, the cache-only reads, the pre-`on()` behaviour (including the level=0 off case), the unknown-brightness forcing and the switch-type attribute definition, using frames captured from real devices.

## Device diagnostics

- `_TZ3210_k1msuvg6` TS110E: [zha-01J33S1J3ZY9WBSP4BDVEF8C3T-_TZ3210_k1msuvg6 TS110E-2b47f0c493bab783f935f94c9f7bc229.json](https://github.com/user-attachments/files/30002952/zha-01J33S1J3ZY9WBSP4BDVEF8C3T-_TZ3210_k1msuvg6.TS110E-2b47f0c493bab783f935f94c9f7bc229.json)
  (captured with the proposed quirk active; the pre-quirk signature is included in the export under `original_signature`)

## Checklist

- [x] The changes are tested and work correctly
- [x] pre-commit checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
