### PR TITLE
Add TS0601 pool sensor quirk with calibration

### DIFF
--- a/tests/test_tuya_pool_sensor.py
+++ b/tests/test_tuya_pool_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the Tuya pool sensor."""
 
+import asyncio
 from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
@@ -28,7 +29,10 @@ async def pool_sensor(zigpy_device_from_v2_quirk):
         "TS0601",
         cluster_ids={1: {TuyaMCUCluster.cluster_id: ClusterType.Server}},
     )
-    return device.endpoints[1].in_clusters[TuyaMCUCluster.cluster_id]
+    pool_sensor = device.endpoints[1].in_clusters[TuyaMCUCluster.cluster_id]
+    yield pool_sensor
+    pool_sensor.handle_auto_update_timers_cancel()
+    await asyncio.sleep(0)
 
 
 def test_pool_sensor_entities(device_mock):
@@ -127,13 +131,15 @@ async def test_auto_refresh(pool_sensor):
 
 
 async def test_auto_refresh_interval_change(pool_sensor):
-    """A changed refresh interval cancels and replaces the timer."""
+    """A changed refresh interval cancels and replaces the device task."""
     pool_sensor._update_attribute(
         pool_sensor.attributes_by_name["auto_refresh_interval"].id, 5
     )
     previous_timer = Mock()
     pool_sensor._update_timer_handle = previous_timer
-    pool_sensor._loop = Mock()
+    delay = Mock()
+    pool_sensor._handle_auto_update_delay = Mock(return_value=delay)
+    pool_sensor.endpoint.device.create_task = Mock()
     pool_sensor.debug = Mock()
 
     pool_sensor.handle_auto_update_setup_next_call()
@@ -141,10 +147,12 @@ async def test_auto_refresh_interval_change(pool_sensor):
     previous_timer.cancel.assert_called_once_with()
     assert pool_sensor.next_refresh_interval == 300
     pool_sensor.debug.assert_called_once_with("using refresh interval of %d minutes", 5)
-    pool_sensor._loop.call_later.assert_called_once_with(
-        300, pool_sensor.handle_auto_update_timer_wrapper
+    pool_sensor._handle_auto_update_delay.assert_called_once_with(300)
+    pool_sensor.endpoint.device.create_task.assert_called_once_with(delay)
+    assert (
+        pool_sensor._update_timer_handle
+        is pool_sensor.endpoint.device.create_task.return_value
     )
-    assert pool_sensor._update_timer_handle is pool_sensor._loop.call_later.return_value
 
 
 async def test_auto_refresh_timer_wrapper(pool_sensor):
@@ -162,20 +170,43 @@ async def test_auto_refresh_timer_wrapper(pool_sensor):
     )
 
 
+async def test_auto_refresh_delay(pool_sensor):
+    """The refresh task waits before invoking its timer wrapper."""
+    pool_sensor.handle_auto_update_timer_wrapper = Mock()
+
+    with patch(
+        "zhaquirks.tuya.ts0601_pool_sensor.asyncio.sleep", new=AsyncMock()
+    ) as sleep:
+        await pool_sensor._handle_auto_update_delay(300)
+
+    sleep.assert_awaited_once_with(300)
+    pool_sensor.handle_auto_update_timer_wrapper.assert_called_once_with()
+
+
+async def test_auto_refresh_check_delay(pool_sensor):
+    """The interval-check task waits before checking again."""
+    pool_sensor.handle_auto_update_check_change = Mock()
+
+    with patch(
+        "zhaquirks.tuya.ts0601_pool_sensor.asyncio.sleep", new=AsyncMock()
+    ) as sleep:
+        await pool_sensor._handle_auto_update_check_delay()
+
+    sleep.assert_awaited_once_with(60)
+    pool_sensor.handle_auto_update_check_change.assert_called_once_with()
+
+
 async def test_auto_refresh_timers_cancel_on_device_removal(pool_sensor):
-    """Device removal cancels the refresh and interval-check timers."""
-    pool_sensor.handle_auto_update_check_cancel()
-    pool_sensor.handle_auto_update_setup_next_call = Mock()
-    pool_sensor._loop = Mock()
-    pool_sensor.handle_auto_update_check_change()
+    """Device removal cancels refresh tasks created through the public API."""
     check_timer = pool_sensor._check_timer_handle
-    update_timer = Mock()
-    pool_sensor._update_timer_handle = update_timer
+    pool_sensor._update_attribute(
+        pool_sensor.attributes_by_name["auto_refresh_interval"].id, 5
+    )
+    pool_sensor.handle_auto_update_setup_next_call(force_new_interval=True)
+    update_timer = pool_sensor._update_timer_handle
 
     pool_sensor.endpoint.device.on_remove()
+    await asyncio.sleep(0)
 
-    pool_sensor.handle_auto_update_setup_next_call.assert_called_once_with()
-    check_timer.cancel.assert_called_once_with()
-    update_timer.cancel.assert_called_once_with()
-    assert pool_sensor._check_timer_handle is None
-    assert pool_sensor._update_timer_handle is None
+    assert check_timer.cancelled()
+    assert update_timer.cancelled()

--- a/tests/test_tuya_pool_sensor.py
+++ b/tests/test_tuya_pool_sensor.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
+from zha.application.platforms.button import Button
 from zigpy.zcl import ClusterType
 
 import zhaquirks
@@ -116,6 +117,53 @@ async def test_calibration_without_measurement(pool_sensor):
         await pool_sensor.calibrate_ph()
 
     pool_sensor._write_dp_value.assert_awaited_once_with(DP_CALIBRATION_KEEP_AWAKE, 1)
+    pool_sensor.command.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "method_name", ["calibrate_ph", "calibrate_ec", "calibrate_orp"]
+)
+async def test_calibration_button_press(pool_sensor, method_name):
+    """Calibration command buttons invoke the local cluster coroutine."""
+    method = AsyncMock()
+    setattr(pool_sensor, method_name, method)
+    button = Mock(
+        _cluster=pool_sensor,
+        _command_name=method_name,
+        args=[],
+        kwargs={},
+    )
+
+    await Button.async_press(button)
+
+    method.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    "error", [RuntimeError("write failed"), asyncio.CancelledError()]
+)
+async def test_calibration_clears_failed_value_write(pool_sensor, error):
+    """A failed or cancelled value write still attempts to clear the data point."""
+    pool_sensor._update_attribute(
+        pool_sensor.attributes_by_name["ph_measured_value"].id, 58
+    )
+    pool_sensor._write_dp_value = AsyncMock(side_effect=[None, error, None])
+    pool_sensor.command = AsyncMock()
+
+    with (
+        patch(
+            "zhaquirks.tuya.ts0601_pool_sensor.asyncio.sleep", new=AsyncMock()
+        ) as sleep,
+        pytest.raises(type(error)),
+    ):
+        await pool_sensor.calibrate_ph()
+
+    assert pool_sensor._write_dp_value.await_args_list == [
+        call(DP_CALIBRATION_KEEP_AWAKE, 1),
+        call(DP_PH_CALIBRATION, 58),
+        call(DP_PH_CALIBRATION, 0),
+    ]
+    sleep.assert_awaited_once_with(6)
     pool_sensor.command.assert_not_awaited()
 
 

--- a/tests/test_tuya_pool_sensor.py
+++ b/tests/test_tuya_pool_sensor.py
@@ -1,0 +1,126 @@
+"""Tests for the Tuya pool sensor."""
+
+from unittest.mock import AsyncMock, call, patch
+
+import pytest
+from zigpy.zcl import ClusterType
+
+import zhaquirks
+from zhaquirks.builder.metadata import ZCLCommandButtonMetadata, ZCLEnumMetadata
+from zhaquirks.tuya import TUYA_QUERY_DATA, TUYA_SET_DATA, TuyaNewManufCluster
+from zhaquirks.tuya.mcu import TuyaMCUCluster
+from zhaquirks.tuya.ts0601_pool_sensor import (
+    DP_CALIBRATION_KEEP_AWAKE,
+    DP_EC_CALIBRATION,
+    DP_ORP_CALIBRATION,
+    DP_PH_CALIBRATION,
+    TuyaPoolManufCluster,
+)
+
+zhaquirks.setup()
+
+
+@pytest.fixture
+async def pool_sensor(zigpy_device_from_v2_quirk):
+    """Create a quirked pool sensor."""
+    device = zigpy_device_from_v2_quirk(
+        "_TZE200_v1jqz5cy",
+        "TS0601",
+        cluster_ids={1: {TuyaMCUCluster.cluster_id: ClusterType.Server}},
+    )
+    return device.endpoints[1].in_clusters[TuyaMCUCluster.cluster_id]
+
+
+def test_pool_sensor_entities(device_mock):
+    """Verify that calibration controls are exposed by the quirk."""
+    device_mock.manufacturer = "_TZE200_v1jqz5cy"
+    device_mock.model = "TS0601"
+
+    entry = zhaquirks.ZHA_DEVICE_REGISTRY.match_entry(device_mock)
+    assert entry is not None
+
+    entity_metadata = entry.zha_device_factory.quirk_definition.entity_metadata
+    commands = {
+        metadata.command_name
+        for metadata in entity_metadata
+        if isinstance(metadata, ZCLCommandButtonMetadata)
+    }
+    enums = {
+        metadata.attribute_name
+        for metadata in entity_metadata
+        if isinstance(metadata, ZCLEnumMetadata)
+    }
+
+    assert commands == {"query_data", "calibrate_ph", "calibrate_ec", "calibrate_orp"}
+    assert enums == {"ph_calibration_standard"}
+
+
+async def test_calibration_payload(pool_sensor):
+    """Calibration writes use the raw four-byte Tuya value payload."""
+    pool_sensor.command = AsyncMock()
+
+    await pool_sensor._write_dp_value(DP_PH_CALIBRATION, 58)
+
+    command_id, command_data = pool_sensor.command.await_args.args
+    assert command_id == TUYA_SET_DATA
+    assert command_data.datapoints[0].dp == DP_PH_CALIBRATION
+    assert command_data.datapoints[0].data.raw == b"\x00\x00\x00\x3a"
+    assert pool_sensor.command.await_args.kwargs == {"expect_reply": True}
+
+
+@pytest.mark.parametrize(
+    ("method_name", "attribute_name", "calibration_dp", "raw_value"),
+    [
+        ("calibrate_ph", "ph_measured_value", DP_PH_CALIBRATION, 58),
+        ("calibrate_ec", "ec_measured_value", DP_EC_CALIBRATION, 1413),
+        ("calibrate_orp", "redox_potential", DP_ORP_CALIBRATION, 222),
+    ],
+)
+async def test_calibration_sequence(
+    pool_sensor, method_name, attribute_name, calibration_dp, raw_value
+):
+    """Calibration refreshes, writes the reading, clears, and queries."""
+    pool_sensor._update_attribute(
+        pool_sensor.attributes_by_name[attribute_name].id, raw_value
+    )
+    pool_sensor._write_dp_value = AsyncMock()
+    pool_sensor.command = AsyncMock()
+
+    with patch(
+        "zhaquirks.tuya.ts0601_pool_sensor.asyncio.sleep", new=AsyncMock()
+    ) as sleep:
+        await getattr(pool_sensor, method_name)()
+
+    assert pool_sensor._write_dp_value.await_args_list == [
+        call(DP_CALIBRATION_KEEP_AWAKE, 1),
+        call(calibration_dp, raw_value),
+        call(calibration_dp, 0),
+    ]
+    assert sleep.await_args_list == [call(6), call(3)]
+    pool_sensor.command.assert_awaited_once_with(TUYA_QUERY_DATA)
+
+
+async def test_calibration_without_measurement(pool_sensor):
+    """A missing measurement must not start calibration."""
+    pool_sensor._write_dp_value = AsyncMock()
+    pool_sensor.command = AsyncMock()
+
+    with (
+        patch("zhaquirks.tuya.ts0601_pool_sensor.asyncio.sleep", new=AsyncMock()),
+        pytest.raises(ValueError, match="No pH measurement"),
+    ):
+        await pool_sensor.calibrate_ph()
+
+    pool_sensor._write_dp_value.assert_awaited_once_with(DP_CALIBRATION_KEEP_AWAKE, 1)
+    pool_sensor.command.assert_not_awaited()
+
+
+async def test_auto_refresh(pool_sensor):
+    """Automatic refresh sends a Tuya data query."""
+    pool_sensor.command = AsyncMock()
+
+    await pool_sensor.handle_auto_update()
+
+    pool_sensor.command.assert_awaited_once_with(TUYA_QUERY_DATA)
+    assert isinstance(pool_sensor, TuyaPoolManufCluster)
+    assert pool_sensor.cluster_id == TuyaNewManufCluster.cluster_id

--- a/tests/test_tuya_pool_sensor.py
+++ b/tests/test_tuya_pool_sensor.py
@@ -134,11 +134,13 @@ async def test_auto_refresh_interval_change(pool_sensor):
     previous_timer = Mock()
     pool_sensor._update_timer_handle = previous_timer
     pool_sensor._loop = Mock()
+    pool_sensor.debug = Mock()
 
     pool_sensor.handle_auto_update_setup_next_call()
 
     previous_timer.cancel.assert_called_once_with()
     assert pool_sensor.next_refresh_interval == 300
+    pool_sensor.debug.assert_called_once_with("using refresh interval of %d minutes", 5)
     pool_sensor._loop.call_later.assert_called_once_with(
         300, pool_sensor.handle_auto_update_timer_wrapper
     )
@@ -158,3 +160,22 @@ async def test_auto_refresh_timer_wrapper(pool_sensor):
     pool_sensor.handle_auto_update_setup_next_call.assert_called_once_with(
         force_new_interval=True
     )
+
+
+async def test_auto_refresh_timers_cancel_on_device_removal(pool_sensor):
+    """Device removal cancels the refresh and interval-check timers."""
+    pool_sensor.handle_auto_update_check_cancel()
+    pool_sensor.handle_auto_update_setup_next_call = Mock()
+    pool_sensor._loop = Mock()
+    pool_sensor.handle_auto_update_check_change()
+    check_timer = pool_sensor._check_timer_handle
+    update_timer = Mock()
+    pool_sensor._update_timer_handle = update_timer
+
+    pool_sensor.endpoint.device.on_remove()
+
+    pool_sensor.handle_auto_update_setup_next_call.assert_called_once_with()
+    check_timer.cancel.assert_called_once_with()
+    update_timer.cancel.assert_called_once_with()
+    assert pool_sensor._check_timer_handle is None
+    assert pool_sensor._update_timer_handle is None

--- a/tests/test_tuya_pool_sensor.py
+++ b/tests/test_tuya_pool_sensor.py
@@ -1,6 +1,6 @@
 """Tests for the Tuya pool sensor."""
 
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
 from zigpy.zcl import ClusterType
@@ -124,3 +124,37 @@ async def test_auto_refresh(pool_sensor):
     pool_sensor.command.assert_awaited_once_with(TUYA_QUERY_DATA)
     assert isinstance(pool_sensor, TuyaPoolManufCluster)
     assert pool_sensor.cluster_id == TuyaNewManufCluster.cluster_id
+
+
+async def test_auto_refresh_interval_change(pool_sensor):
+    """A changed refresh interval cancels and replaces the timer."""
+    pool_sensor._update_attribute(
+        pool_sensor.attributes_by_name["auto_refresh_interval"].id, 5
+    )
+    previous_timer = Mock()
+    pool_sensor._update_timer_handle = previous_timer
+    pool_sensor._loop = Mock()
+
+    pool_sensor.handle_auto_update_setup_next_call()
+
+    previous_timer.cancel.assert_called_once_with()
+    assert pool_sensor.next_refresh_interval == 300
+    pool_sensor._loop.call_later.assert_called_once_with(
+        300, pool_sensor.handle_auto_update_timer_wrapper
+    )
+    assert pool_sensor._update_timer_handle is pool_sensor._loop.call_later.return_value
+
+
+async def test_auto_refresh_timer_wrapper(pool_sensor):
+    """The timer wrapper starts a refresh and schedules the next one."""
+    refresh_task = Mock()
+    pool_sensor.handle_auto_update = Mock(return_value=refresh_task)
+    pool_sensor.create_catching_task = Mock()
+    pool_sensor.handle_auto_update_setup_next_call = Mock()
+
+    pool_sensor.handle_auto_update_timer_wrapper()
+
+    pool_sensor.create_catching_task.assert_called_once_with(refresh_task)
+    pool_sensor.handle_auto_update_setup_next_call.assert_called_once_with(
+        force_new_interval=True
+    )

--- a/zhaquirks/tuya/ts0601_pool_sensor.py
+++ b/zhaquirks/tuya/ts0601_pool_sensor.py
@@ -1,0 +1,382 @@
+"""Tuya pool sensor."""
+
+import asyncio
+from typing import Final
+
+from zha.application.platforms.number.device_class import NumberDeviceClass
+from zha.application.platforms.sensor.device_class import (
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from zha.units import (
+    CONCENTRATION_PARTS_PER_MILLION,
+    UnitOfElectricPotential,
+    UnitOfTime,
+)
+import zigpy.types as t
+
+from zhaquirks.const import BatterySize
+from zhaquirks.tuya import (
+    TUYA_QUERY_DATA,
+    TUYA_SET_DATA,
+    TuyaCommand,
+    TuyaDatapointData,
+    TuyaNewManufCluster,
+)
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.mcu import TuyaMCUCluster
+
+CONDUCTIVITY_MICROSIEMENS_PER_CENTIMETER: Final = "µS/cm"
+
+DP_PH_CALIBRATION_STANDARD: Final = 103
+DP_CALIBRATION_KEEP_AWAKE: Final = 105
+DP_PH_CALIBRATION: Final = 114
+DP_EC_CALIBRATION: Final = 115
+DP_ORP_CALIBRATION: Final = 116
+
+
+class PHCalibrationStandard(t.enum8):
+    """Supported pH buffer sets."""
+
+    ASIA = 0
+    EUROPE = 1
+
+
+class TuyaPoolManufCluster(TuyaMCUCluster):
+    """Tuya Manufacturer cluster with refresh and calibration logic."""
+
+    CALIBRATION_MEASUREMENT_DELAY: Final = 6
+    CALIBRATION_SETTLE_DELAY: Final = 3
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self._update_timer_handle = None
+        self.check_interval = 60
+        self.next_refresh_interval = 0
+        self._loop = asyncio.get_running_loop()
+        self.handle_auto_update_check_change()
+
+    def handle_auto_update_cancel(self):
+        """Auto update timer cancel."""
+        if self._update_timer_handle:
+            self._update_timer_handle.cancel()
+            self._update_timer_handle = None
+
+    def handle_auto_update_setup_next_call(self, force_new_interval=False):
+        """Auto update schedule next update."""
+        tuya_cluster = self.endpoint.device.endpoints[1].in_clusters.get(
+            TuyaMCUCluster.cluster_id, None
+        )
+        if tuya_cluster and "auto_refresh_interval" in tuya_cluster.attributes_by_name:
+            interval = tuya_cluster.get("auto_refresh_interval", 0) * 60
+            if interval != self.next_refresh_interval:
+                self.handle_auto_update_cancel()
+                self.next_refresh_interval = interval
+                force_new_interval = True
+
+        if force_new_interval and self.next_refresh_interval > 0:
+            self.debug(
+                "using refresh interval of %d minutes", self.next_refresh_interval
+            )
+            self._update_timer_handle = self._loop.call_later(
+                self.next_refresh_interval, self.handle_auto_update_timer_wrapper
+            )
+
+    def handle_auto_update_check_change(self):
+        """Auto update schedule next interval check."""
+        self.handle_auto_update_setup_next_call()
+        self._loop.call_later(self.check_interval, self.handle_auto_update_check_change)
+
+    def handle_auto_update_timer_wrapper(self):
+        """Auto update handle refresh and schedule next update."""
+        self.create_catching_task(self.handle_auto_update())
+        self.handle_auto_update_setup_next_call(force_new_interval=True)
+
+    async def handle_auto_update(self):
+        """Auto update invoke data refresh command."""
+        tuya_cluster = self.endpoint.device.endpoints[1].in_clusters[
+            TuyaMCUCluster.cluster_id
+        ]
+        self.debug("sending refresh query command")
+        await tuya_cluster.command(TUYA_QUERY_DATA)
+
+    async def _write_dp_value(self, dp_id: int, value: int) -> None:
+        """Write an integer Tuya data point."""
+        command = TuyaCommand(
+            status=0,
+            tsn=self.endpoint.device.application.get_sequence(),
+            datapoints=[TuyaDatapointData(dp_id, value)],
+        )
+        await self.command(TUYA_SET_DATA, command, expect_reply=True)
+
+    async def _calibrate(
+        self, source_attribute: str, calibration_dp: int, label: str
+    ) -> None:
+        """Calibrate from a freshly reported raw sensor reading."""
+        await self._write_dp_value(DP_CALIBRATION_KEEP_AWAKE, 1)
+        await asyncio.sleep(self.CALIBRATION_MEASUREMENT_DELAY)
+
+        raw_value = self.get(source_attribute)
+        if raw_value is None:
+            raise ValueError(f"No {label} measurement is available for calibration")
+
+        self.debug(
+            "calibrating %s with raw value %d on data point %d",
+            label,
+            raw_value,
+            calibration_dp,
+        )
+        await self._write_dp_value(calibration_dp, int(raw_value))
+        try:
+            await asyncio.sleep(self.CALIBRATION_SETTLE_DELAY)
+        finally:
+            await self._write_dp_value(calibration_dp, 0)
+
+        await self.command(TUYA_QUERY_DATA)
+
+    async def calibrate_ph(self) -> None:
+        """Calibrate pH using the closest point in the selected buffer set."""
+        await self._calibrate("ph_measured_value", DP_PH_CALIBRATION, "pH")
+
+    async def calibrate_ec(self) -> None:
+        """Calibrate electrical conductivity using the current reading."""
+        await self._calibrate("ec_measured_value", DP_EC_CALIBRATION, "EC")
+
+    async def calibrate_orp(self) -> None:
+        """Calibrate oxidation-reduction potential using the current reading."""
+        await self._calibrate("redox_potential", DP_ORP_CALIBRATION, "ORP")
+
+
+(
+    TuyaQuirkBuilder("_TZE200_v1jqz5cy", "TS0601")
+    .tuya_enchantment(read_attr_spell=True, data_query_spell=True)
+    .tuya_battery(
+        dp_id=7,
+        battery_type=BatterySize.Built_in,
+        battery_qty=4,
+        battery_voltage=36,
+        scale=1,
+    )
+    .tuya_temperature(dp_id=2, scale=10)
+    .tuya_sensor(
+        dp_id=10,
+        attribute_name="ph_measured_value",
+        divisor=100,
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.PH,
+        translation_key="ph_measured_value",
+        fallback_name="pH",
+    )
+    .tuya_sensor(
+        dp_id=1,
+        attribute_name="total_dissolved_solids",
+        type=t.uint16_t,
+        unit=CONCENTRATION_PARTS_PER_MILLION,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="total_dissolved_solids",
+        fallback_name="Total dissolved solids",
+    )
+    .tuya_sensor(
+        dp_id=11,
+        attribute_name="ec_measured_value",
+        type=t.uint16_t,
+        unit=CONDUCTIVITY_MICROSIEMENS_PER_CENTIMETER,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="ec_measured_value",
+        fallback_name="Electrical conductivity",
+    )
+    .tuya_sensor(
+        dp_id=117,
+        attribute_name="salt_measured_value",
+        type=t.uint16_t,
+        unit=CONCENTRATION_PARTS_PER_MILLION,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="salt_measured_value",
+        fallback_name="Salt concentration",
+    )
+    .tuya_sensor(
+        dp_id=101,
+        attribute_name="redox_potential",
+        type=t.int16s,
+        unit=UnitOfElectricPotential.MILLIVOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="redox_potential",
+        fallback_name="ORP level",
+    )
+    .tuya_sensor(
+        dp_id=102,
+        attribute_name="cl_measured_value",
+        type=t.uint16_t,
+        divisor=10,
+        unit=CONCENTRATION_PARTS_PER_MILLION,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="cl_measured_value",
+        fallback_name="Chlorine concentration",
+    )
+    .tuya_enum(
+        dp_id=DP_PH_CALIBRATION_STANDARD,
+        attribute_name="ph_calibration_standard",
+        enum_class=PHCalibrationStandard,
+        translation_key="ph_calibration_standard",
+        fallback_name="pH calibration standard",
+    )
+    .tuya_number(
+        dp_id=106,
+        attribute_name="ph_max_value",
+        type=t.uint16_t,
+        multiplier=0.1,
+        step=0.1,
+        min_value=0,
+        max_value=14,
+        mode="box",
+        device_class=NumberDeviceClass.PH,
+        translation_key="ph_max_value",
+        fallback_name="pH maximum value",
+    )
+    .tuya_number(
+        dp_id=107,
+        attribute_name="ph_min_value",
+        type=t.uint16_t,
+        multiplier=0.1,
+        step=0.1,
+        min_value=0,
+        max_value=14,
+        mode="box",
+        device_class=NumberDeviceClass.PH,
+        translation_key="ph_min_value",
+        fallback_name="pH minimum value",
+    )
+    .tuya_number(
+        dp_id=108,
+        attribute_name="ec_max_value",
+        type=t.uint16_t,
+        multiplier=1,
+        step=1,
+        min_value=0,
+        max_value=20000,
+        mode="box",
+        unit=CONDUCTIVITY_MICROSIEMENS_PER_CENTIMETER,
+        translation_key="ec_max_value",
+        fallback_name="EC maximum value",
+    )
+    .tuya_number(
+        dp_id=109,
+        attribute_name="ec_min_value",
+        type=t.uint16_t,
+        multiplier=1,
+        step=1,
+        min_value=0,
+        max_value=20000,
+        mode="box",
+        unit=CONDUCTIVITY_MICROSIEMENS_PER_CENTIMETER,
+        translation_key="ec_min_value",
+        fallback_name="EC minimum value",
+    )
+    .tuya_number(
+        dp_id=110,
+        attribute_name="orp_max_value",
+        type=t.int16s,
+        multiplier=1,
+        step=1,
+        min_value=-999,
+        max_value=999,
+        mode="box",
+        unit=UnitOfElectricPotential.MILLIVOLT,
+        device_class=NumberDeviceClass.VOLTAGE,
+        translation_key="orp_max_value",
+        fallback_name="ORP maximum value",
+    )
+    .tuya_number(
+        dp_id=111,
+        attribute_name="orp_min_value",
+        type=t.int16s,
+        multiplier=1,
+        step=1,
+        min_value=-999,
+        max_value=999,
+        mode="box",
+        unit=UnitOfElectricPotential.MILLIVOLT,
+        device_class=NumberDeviceClass.VOLTAGE,
+        translation_key="orp_min_value",
+        fallback_name="ORP minimum value",
+    )
+    .tuya_number(
+        dp_id=112,
+        attribute_name="cl_max_value",
+        type=t.uint16_t,
+        multiplier=0.1,
+        step=0.1,
+        min_value=0,
+        max_value=4,
+        mode="box",
+        unit=CONCENTRATION_PARTS_PER_MILLION,
+        translation_key="cl_max_value",
+        fallback_name="Cl maximum value",
+    )
+    .tuya_number(
+        dp_id=113,
+        attribute_name="cl_min_value",
+        type=t.uint16_t,
+        multiplier=0.1,
+        step=0.1,
+        min_value=0,
+        max_value=4,
+        mode="box",
+        unit=CONCENTRATION_PARTS_PER_MILLION,
+        translation_key="cl_min_value",
+        fallback_name="Cl minimum value",
+    )
+    .tuya_dp_attribute(
+        dp_id=DP_PH_CALIBRATION,
+        attribute_name="ph_calibration_result",
+        type=t.int32s,
+    )
+    .tuya_dp_attribute(
+        dp_id=DP_EC_CALIBRATION,
+        attribute_name="ec_calibration_result",
+        type=t.int32s,
+    )
+    .tuya_dp_attribute(
+        dp_id=DP_ORP_CALIBRATION,
+        attribute_name="orp_calibration_result",
+        type=t.int32s,
+    )
+    .command_button(
+        command_name="query_data",
+        cluster_id=TuyaNewManufCluster.cluster_id,
+        translation_key="update",
+        fallback_name="Update",
+    )
+    .command_button(
+        command_name="calibrate_ph",
+        cluster_id=TuyaNewManufCluster.cluster_id,
+        translation_key="calibrate_ph",
+        fallback_name="Calibrate pH",
+    )
+    .command_button(
+        command_name="calibrate_ec",
+        cluster_id=TuyaNewManufCluster.cluster_id,
+        translation_key="calibrate_ec",
+        fallback_name="Calibrate EC",
+    )
+    .command_button(
+        command_name="calibrate_orp",
+        cluster_id=TuyaNewManufCluster.cluster_id,
+        translation_key="calibrate_orp",
+        fallback_name="Calibrate ORP",
+    )
+    .tuya_number(
+        dp_id=9,
+        attribute_name="auto_refresh_interval",
+        type=t.uint16_t,
+        translation_key="auto_refresh_interval",
+        fallback_name="Refresh interval",
+        unit=UnitOfTime.MINUTES,
+        step=5,
+        min_value=0,
+        max_value=1440,
+    )
+    .add_to_registry(replacement_cluster=TuyaPoolManufCluster)
+)

--- a/zhaquirks/tuya/ts0601_pool_sensor.py
+++ b/zhaquirks/tuya/ts0601_pool_sensor.py
@@ -149,8 +149,8 @@ class TuyaPoolManufCluster(TuyaMCUCluster):
             raw_value,
             calibration_dp,
         )
-        await self._write_dp_value(calibration_dp, int(raw_value))
         try:
+            await self._write_dp_value(calibration_dp, int(raw_value))
             await asyncio.sleep(self.CALIBRATION_SETTLE_DELAY)
         finally:
             await self._write_dp_value(calibration_dp, 0)

--- a/zhaquirks/tuya/ts0601_pool_sensor.py
+++ b/zhaquirks/tuya/ts0601_pool_sensor.py
@@ -53,10 +53,6 @@ class TuyaPoolManufCluster(TuyaMCUCluster):
         self._check_timer_handle = None
         self.check_interval = 60
         self.next_refresh_interval = 0
-        self._loop = asyncio.get_running_loop()
-        self.endpoint.device._on_remove_callbacks.append(
-            self.handle_auto_update_timers_cancel
-        )
         self.handle_auto_update_check_change()
 
     def handle_auto_update_cancel(self):
@@ -76,6 +72,16 @@ class TuyaPoolManufCluster(TuyaMCUCluster):
         self.handle_auto_update_cancel()
         self.handle_auto_update_check_cancel()
 
+    async def _handle_auto_update_delay(self, delay: int):
+        """Wait before running the next auto update."""
+        await asyncio.sleep(delay)
+        self.handle_auto_update_timer_wrapper()
+
+    async def _handle_auto_update_check_delay(self):
+        """Wait before checking the auto update interval again."""
+        await asyncio.sleep(self.check_interval)
+        self.handle_auto_update_check_change()
+
     def handle_auto_update_setup_next_call(self, force_new_interval=False):
         """Auto update schedule next update."""
         tuya_cluster = self.endpoint.device.endpoints[1].in_clusters.get(
@@ -93,15 +99,15 @@ class TuyaPoolManufCluster(TuyaMCUCluster):
                 "using refresh interval of %d minutes",
                 self.next_refresh_interval // 60,
             )
-            self._update_timer_handle = self._loop.call_later(
-                self.next_refresh_interval, self.handle_auto_update_timer_wrapper
+            self._update_timer_handle = self.endpoint.device.create_task(
+                self._handle_auto_update_delay(self.next_refresh_interval)
             )
 
     def handle_auto_update_check_change(self):
         """Auto update schedule next interval check."""
         self.handle_auto_update_setup_next_call()
-        self._check_timer_handle = self._loop.call_later(
-            self.check_interval, self.handle_auto_update_check_change
+        self._check_timer_handle = self.endpoint.device.create_task(
+            self._handle_auto_update_check_delay()
         )
 
     def handle_auto_update_timer_wrapper(self):
@@ -360,7 +366,7 @@ class TuyaPoolManufCluster(TuyaMCUCluster):
         type=t.int32s,
     )
     .command_button(
-        command_name="query_data",
+        command_name=TuyaNewManufCluster.ServerCommandDefs.query_data.name,
         cluster_id=TuyaNewManufCluster.cluster_id,
         translation_key="update",
         fallback_name="Update",

--- a/zhaquirks/tuya/ts0601_pool_sensor.py
+++ b/zhaquirks/tuya/ts0601_pool_sensor.py
@@ -3,18 +3,16 @@
 import asyncio
 from typing import Final
 
-from zha.application.platforms.number.device_class import NumberDeviceClass
-from zha.application.platforms.sensor.device_class import (
+import zigpy.types as t
+
+from zhaquirks.builder import (
+    CONCENTRATION_PARTS_PER_MILLION,
+    NumberDeviceClass,
     SensorDeviceClass,
     SensorStateClass,
-)
-from zha.units import (
-    CONCENTRATION_PARTS_PER_MILLION,
     UnitOfElectricPotential,
     UnitOfTime,
 )
-import zigpy.types as t
-
 from zhaquirks.const import BatterySize
 from zhaquirks.tuya import (
     TUYA_QUERY_DATA,
@@ -52,9 +50,13 @@ class TuyaPoolManufCluster(TuyaMCUCluster):
         """Init."""
         super().__init__(*args, **kwargs)
         self._update_timer_handle = None
+        self._check_timer_handle = None
         self.check_interval = 60
         self.next_refresh_interval = 0
         self._loop = asyncio.get_running_loop()
+        self.endpoint.device._on_remove_callbacks.append(
+            self.handle_auto_update_timers_cancel
+        )
         self.handle_auto_update_check_change()
 
     def handle_auto_update_cancel(self):
@@ -62,6 +64,17 @@ class TuyaPoolManufCluster(TuyaMCUCluster):
         if self._update_timer_handle:
             self._update_timer_handle.cancel()
             self._update_timer_handle = None
+
+    def handle_auto_update_check_cancel(self):
+        """Auto update interval check timer cancel."""
+        if self._check_timer_handle:
+            self._check_timer_handle.cancel()
+            self._check_timer_handle = None
+
+    def handle_auto_update_timers_cancel(self):
+        """Cancel all auto update timers."""
+        self.handle_auto_update_cancel()
+        self.handle_auto_update_check_cancel()
 
     def handle_auto_update_setup_next_call(self, force_new_interval=False):
         """Auto update schedule next update."""
@@ -77,7 +90,8 @@ class TuyaPoolManufCluster(TuyaMCUCluster):
 
         if force_new_interval and self.next_refresh_interval > 0:
             self.debug(
-                "using refresh interval of %d minutes", self.next_refresh_interval
+                "using refresh interval of %d minutes",
+                self.next_refresh_interval // 60,
             )
             self._update_timer_handle = self._loop.call_later(
                 self.next_refresh_interval, self.handle_auto_update_timer_wrapper
@@ -86,7 +100,9 @@ class TuyaPoolManufCluster(TuyaMCUCluster):
     def handle_auto_update_check_change(self):
         """Auto update schedule next interval check."""
         self.handle_auto_update_setup_next_call()
-        self._loop.call_later(self.check_interval, self.handle_auto_update_check_change)
+        self._check_timer_handle = self._loop.call_later(
+            self.check_interval, self.handle_auto_update_check_change
+        )
 
     def handle_auto_update_timer_wrapper(self):
         """Auto update handle refresh and schedule next update."""


### PR DESCRIPTION
## Proposed change

Add a v2 quirk for the `_TZE200_v1jqz5cy` TS0601 pool water sensor, based on and extending #3673.

The quirk exposes:

- temperature, battery, pH, TDS, EC, salinity, ORP, and chlorine measurements
- configurable measurement limits and refresh interval
- a manual refresh button
- a pH calibration-standard selector for the Asia and Europe buffer sets
- pH, EC, and ORP calibration buttons

Calibration keeps the device awake, uses the latest raw measurement as the calibration input, clears the calibration datapoint after the device processes it, and then requests updated data. The pH sequence and datapoints come from the captured Tuya calibration traffic linked in #2565. EC and ORP use the corresponding schema datapoints and the same device handshake.

The quirk also uses signed values for ORP and applies the chlorine scale observed on the device.

## Testing

- Tested as a custom quirk on Home Assistant Core 2026.7.2 with `zha-quirks` 2.1.1
- Confirmed all measurement entities, the pH-standard selector, and all three calibration buttons are registered
- Confirmed sensor reports resume after a Home Assistant restart
- Added tests for entity metadata, calibration payloads and command sequences, missing measurements, and automatic refresh
- `pytest -q tests/test_tuya_pool_sensor.py tests/test_quirks_v2.py`
- `pre-commit run --all-files`

The pH path is backed by captured device traffic. EC and ORP reference-fluid calibration still needs independent hardware confirmation, so this PR is opened as a draft.

References #2565 and #3673.

## Checklist

- [x] The changes are tested and work correctly
- [x] Pre-commit checks pass
- [x] Tests verify the custom logic and exposed entities
