### PR TITLE
Add support for Moes ZM6LT1 1-phase energy meter (_TZE284_2fnssffc)

### DIFF
--- a/tests/test_tuya_power.py
+++ b/tests/test_tuya_power.py
@@ -1,5 +1,9 @@
 """Tests for Tuya quirks."""
 
+import asyncio
+import contextlib
+from unittest import mock
+
 import pytest
 from zigpy.zcl import foundation
 
@@ -114,3 +118,56 @@ async def test_zm6lt1_phase_dp_converter(zigpy_device_from_v2_quirk):
     assert electrical_meas_cluster.get("reactive_power") == 37
     assert electrical_meas_cluster.get("apparent_power") == 40
     assert electrical_meas_cluster.get("power_factor") == 39
+
+
+async def test_zm6lt1_poll_loop(zigpy_device_from_v2_quirk):
+    """Test the ZM6LT1 periodic data-query poll loop."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_2fnssffc", "TS0601")
+    cluster = quirked.endpoints[1].tuya_manufacturer
+
+    # instantiating the cluster inside a running loop starts the poller
+    assert cluster._poll_task is not None
+    cluster._poll_task.cancel()
+
+    calls = []
+
+    async def fake_command(command_id, expect_reply=True):
+        calls.append(command_id)
+        if len(calls) == 1:
+            # first poll fails (e.g. radio not ready), the loop must retry
+            raise RuntimeError("ApplicationController is not running")
+        raise asyncio.CancelledError
+
+    with (
+        mock.patch.object(type(cluster), "POLL_INTERVAL", 0),
+        mock.patch.object(cluster, "command", fake_command),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await cluster._poll_loop()
+
+    assert calls == [zhaquirks.tuya.TUYA_QUERY_DATA] * 2
+
+
+async def test_zm6lt1_poller_replaced_on_new_cluster(zigpy_device_from_v2_quirk):
+    """Test that re-instantiating the cluster cancels the previous poller."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_2fnssffc", "TS0601")
+    cluster = quirked.endpoints[1].tuya_manufacturer
+    first_task = cluster._poll_task
+    assert first_task is not None
+
+    new_cluster = type(cluster)(cluster.endpoint)
+    with contextlib.suppress(asyncio.CancelledError):
+        await first_task
+    assert first_task.cancelled()
+
+    new_cluster._poll_task.cancel()
+
+
+def test_zm6lt1_no_poller_without_event_loop(zigpy_device_from_v2_quirk):
+    """Test that no poller is started when there is no running event loop."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_2fnssffc", "TS0601")
+    cluster = quirked.endpoints[1].tuya_manufacturer
+    assert cluster._poll_task is None

--- a/tests/test_tuya_power.py
+++ b/tests/test_tuya_power.py
@@ -88,3 +88,29 @@ async def test_ts0601_power_converter(zigpy_device_from_v2_quirk, msg, expected_
     assert status == foundation.Status.SUCCESS
 
     assert tuya_manufacturer.get("power") == expected_power
+
+
+async def test_zm6lt1_phase_dp_converter(zigpy_device_from_v2_quirk):
+    """Test the packed DP 6 phase converter of the Moes ZM6LT1."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_2fnssffc", "TS0601")
+    ep = quirked.endpoints[1]
+
+    # real device capture: 234.9 V, 0.173 A, 16 W, 37 var, 40 VA, PF 39 %
+    msg = (
+        b"\x09\x18\x02\x00\x78\x06\x00\x00\x12"
+        b"\x02\x0f\x09\x2d\x00\x00\xad\x00\x00\x10\x00\x00\x25\x00\x00\x28\x27\x00"
+    )
+
+    tuya_manufacturer = ep.tuya_manufacturer
+    hdr, data = tuya_manufacturer.deserialize(msg)
+    status = tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+
+    electrical_meas_cluster = ep.electrical_measurement
+    assert electrical_meas_cluster.get("rms_voltage") == 2349
+    assert electrical_meas_cluster.get("rms_current") == 173
+    assert electrical_meas_cluster.get("active_power") == 16
+    assert electrical_meas_cluster.get("reactive_power") == 37
+    assert electrical_meas_cluster.get("apparent_power") == 40
+    assert electrical_meas_cluster.get("power_factor") == 39

--- a/zhaquirks/tuya/ts0601_power.py
+++ b/zhaquirks/tuya/ts0601_power.py
@@ -1,11 +1,14 @@
 """Tuya Power Meter."""
 
+import asyncio
+
 import zigpy.types as t
 from zigpy.zcl.clusters.general import LevelControl, OnOff
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 
 from zhaquirks.builder import (
     PERCENTAGE,
+    BinarySensorDeviceClass,
     EntityType,
     SensorDeviceClass,
     SensorStateClass,
@@ -14,9 +17,9 @@ from zhaquirks.builder import (
     UnitOfPower,
     UnitOfTime,
 )
-from zhaquirks.tuya import TuyaLocalCluster
+from zhaquirks.tuya import TUYA_QUERY_DATA, TuyaLocalCluster
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
-from zhaquirks.tuya.mcu import DPToAttributeMapping
+from zhaquirks.tuya.mcu import DPToAttributeMapping, TuyaMCUCluster
 
 
 def dp_to_power(data: bytes) -> int:
@@ -517,4 +520,221 @@ class Tuya3PhaseElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
     .adds(Tuya3PhaseElectricalMeasurement)
     .skip_configuration()
     .add_to_registry()
+)
+
+
+# Moes ZM6LT1 single-phase energy meter with CT clamp.
+# DP 6 packs phase data into an 18 byte buffer (confirmed from device capture):
+#   [0:2]   constant header
+#   [2:4]   voltage, V * 10 (16-bit)
+#   [4:7]   current, mA (24-bit)
+#   [7:10]  active power, W (24-bit)
+#   [10:13] reactive power, var (24-bit)
+#   [13:16] apparent power, VA (24-bit)
+#   [16]    power factor, %
+#   [17]    padding
+def zm6lt1_dp6_to_voltage(data: bytes) -> int:
+    """Extract voltage (V * 10) from the packed phase datapoint."""
+    return (data[2] << 8) | data[3]
+
+
+def zm6lt1_dp6_to_current(data: bytes) -> int:
+    """Extract current (mA, 24-bit) from the packed phase datapoint."""
+    return (data[4] << 16) | (data[5] << 8) | data[6]
+
+
+def zm6lt1_dp6_to_power(data: bytes) -> int:
+    """Extract active power (W, 24-bit) from the packed phase datapoint."""
+    return (data[7] << 16) | (data[8] << 8) | data[9]
+
+
+def zm6lt1_dp6_to_reactive_power(data: bytes) -> int:
+    """Extract reactive power (var, 24-bit) from the packed phase datapoint."""
+    return (data[10] << 16) | (data[11] << 8) | data[12]
+
+
+def zm6lt1_dp6_to_apparent_power(data: bytes) -> int:
+    """Extract apparent power (VA, 24-bit) from the packed phase datapoint."""
+    return (data[13] << 16) | (data[14] << 8) | data[15]
+
+
+def zm6lt1_dp6_to_power_factor(data: bytes) -> int:
+    """Extract power factor (%) from the packed phase datapoint."""
+    return data[16]
+
+
+class ZM6LT1ElectricalMeasurement(ElectricalMeasurement, TuyaLocalCluster):
+    """Electrical measurement cluster fed by Tuya datapoints."""
+
+    _CONSTANT_ATTRIBUTES = {
+        ElectricalMeasurement.AttributeDefs.ac_voltage_multiplier.id: 1,
+        ElectricalMeasurement.AttributeDefs.ac_voltage_divisor.id: 10,
+        ElectricalMeasurement.AttributeDefs.ac_current_multiplier.id: 1,
+        ElectricalMeasurement.AttributeDefs.ac_current_divisor.id: 1000,
+        ElectricalMeasurement.AttributeDefs.ac_frequency_multiplier.id: 1,
+        ElectricalMeasurement.AttributeDefs.ac_frequency_divisor.id: 100,
+    }
+
+
+class ZM6LT1ManufCluster(TuyaMCUCluster):
+    """Tuya MCU cluster that periodically queries the meter for datapoints.
+
+    The ZM6LT1 does not report DP 6 (voltage/current/power) on its own, so a
+    Tuya data-query command is sent every 60 seconds, matching the polling
+    interval Zigbee2MQTT uses for this device.
+    """
+
+    POLL_INTERVAL = 60
+
+    # one poller per device, survives cluster re-instantiation
+    _pollers: dict[t.EUI64, asyncio.Task] = {}
+
+    def __init__(self, *args, **kwargs):
+        """Init and start the polling task."""
+        super().__init__(*args, **kwargs)
+        self._poll_task = None
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return  # no event loop (e.g. import-time tooling); skip polling
+
+        ieee = self.endpoint.device.ieee
+        prev = ZM6LT1ManufCluster._pollers.pop(ieee, None)
+        if prev is not None and not prev.done():
+            prev.cancel()
+        self._poll_task = self.create_catching_task(self._poll_loop())
+        ZM6LT1ManufCluster._pollers[ieee] = self._poll_task
+
+    async def _poll_loop(self):
+        while True:
+            await asyncio.sleep(self.POLL_INTERVAL)
+            try:
+                # fire-and-forget: the meter answers with DP reports
+                await self.command(TUYA_QUERY_DATA, expect_reply=False)
+            except asyncio.CancelledError:
+                raise
+            except Exception as ex:  # noqa: BLE001 - keep polling on failure
+                self.debug("ZM6LT1 data query failed: %r", ex)
+
+
+(
+    TuyaQuirkBuilder("_TZE284_2fnssffc", "TS0601")  # Moes ZM6LT1
+    .tuya_enchantment(read_attr_spell=True, data_query_spell=True)
+    .tuya_sensor(
+        dp_id=1,
+        attribute_name="energy",
+        type=t.uint32_t,
+        divisor=100,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        fallback_name="Total energy",
+    )
+    .tuya_sensor(
+        dp_id=2,
+        attribute_name="reverse_energy",
+        type=t.uint32_t,
+        divisor=100,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="reverse_energy",
+        fallback_name="Total reverse energy",
+    )
+    .tuya_dp_multi(
+        dp_id=6,
+        attribute_mapping=[
+            DPToAttributeMapping(
+                ep_attribute=ZM6LT1ElectricalMeasurement.ep_attribute,
+                attribute_name="rms_voltage",
+                converter=zm6lt1_dp6_to_voltage,
+            ),
+            DPToAttributeMapping(
+                ep_attribute=ZM6LT1ElectricalMeasurement.ep_attribute,
+                attribute_name="rms_current",
+                converter=zm6lt1_dp6_to_current,
+            ),
+            DPToAttributeMapping(
+                ep_attribute=ZM6LT1ElectricalMeasurement.ep_attribute,
+                attribute_name="active_power",
+                converter=zm6lt1_dp6_to_power,
+            ),
+            DPToAttributeMapping(
+                ep_attribute=ZM6LT1ElectricalMeasurement.ep_attribute,
+                attribute_name="reactive_power",
+                converter=zm6lt1_dp6_to_reactive_power,
+            ),
+            DPToAttributeMapping(
+                ep_attribute=ZM6LT1ElectricalMeasurement.ep_attribute,
+                attribute_name="apparent_power",
+                converter=zm6lt1_dp6_to_apparent_power,
+            ),
+            DPToAttributeMapping(
+                ep_attribute=ZM6LT1ElectricalMeasurement.ep_attribute,
+                attribute_name="power_factor",
+                converter=zm6lt1_dp6_to_power_factor,
+            ),
+        ],
+    )
+    .tuya_sensor(
+        dp_id=10,
+        attribute_name="fault",
+        type=t.uint32_t,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="fault",
+        fallback_name="Fault",
+    )
+    .tuya_switch(
+        dp_id=20,
+        attribute_name="clear_event",
+        entity_type=EntityType.CONFIG,
+        translation_key="clear_event",
+        fallback_name="Clear event",
+    )
+    .tuya_binary_sensor(
+        dp_id=44,
+        attribute_name="online_state",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="online_state",
+        fallback_name="Online state",
+    )
+    .tuya_dp(
+        dp_id=49,
+        ep_attribute=ZM6LT1ElectricalMeasurement.ep_attribute,
+        attribute_name="ac_frequency",
+    )
+    .tuya_sensor(
+        dp_id=51,
+        attribute_name="active_energy",
+        type=t.uint32_t,
+        divisor=100,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="active_energy",
+        fallback_name="Total active energy",
+    )
+    .tuya_number(
+        dp_id=101,
+        attribute_name="countdown_1",
+        type=t.uint16_t,
+        unit=UnitOfTime.SECONDS,
+        min_value=0,
+        max_value=2000,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        translation_key="countdown",
+        fallback_name="Countdown",
+    )
+    .tuya_switch(
+        dp_id=104,
+        attribute_name="device_restart",
+        entity_type=EntityType.CONFIG,
+        translation_key="device_restart",
+        fallback_name="Device restart",
+    )
+    .adds(ZM6LT1ElectricalMeasurement)
+    .skip_configuration()
+    .add_to_registry(replacement_cluster=ZM6LT1ManufCluster)
 )

--- a/zhaquirks/tuya/ts0601_power.py
+++ b/zhaquirks/tuya/ts0601_power.py
@@ -594,7 +594,7 @@ class ZM6LT1ManufCluster(TuyaMCUCluster):
         super().__init__(*args, **kwargs)
         self._poll_task = None
         try:
-            asyncio.get_running_loop()
+            loop = asyncio.get_running_loop()
         except RuntimeError:
             return  # no event loop (e.g. import-time tooling); skip polling
 
@@ -602,7 +602,7 @@ class ZM6LT1ManufCluster(TuyaMCUCluster):
         prev = ZM6LT1ManufCluster._pollers.pop(ieee, None)
         if prev is not None and not prev.done():
             prev.cancel()
-        self._poll_task = self.create_catching_task(self._poll_loop())
+        self._poll_task = loop.create_task(self._poll_loop())
         ZM6LT1ManufCluster._pollers[ieee] = self._poll_task
 
     async def _poll_loop(self):


### PR DESCRIPTION
## Proposed change

Adds support for the Moes ZM6LT1, a Tuya TS0601 single-phase energy power meter with a CT sensor clamp (manufacturer `_TZE284_2fnssffc`).

- Exposes voltage, current, active/reactive/apparent power, power factor, and AC frequency via a standard ElectricalMeasurement cluster, plus forward/reverse/total energy sensors (kWh) and diagnostic/config entities (fault, online state, clear event, countdown, device restart).
- DP 6 packs the phase measurements into an 18-byte buffer; the byte layout was confirmed from a real device capture (voltage/current/power/reactive/apparent/PF all cross-check arithmetically: 234.9 V x 0.173 A = 40 VA, 16 W / 40 VA = 39% PF).
- The device does not report DP 6 on its own, so the quirk polls it with a Tuya data-query command every 60 s — the same interval the Zigbee2MQTT converter for this device uses (`queryIntervalSeconds: 60`).

Datapoint IDs match the official Moes DP table shared in Koenkk/zigbee2mqtt#32416.

## Checklist

- [x] The changes are tested and work correctly (running on my own device)
- [x] Tests have been added to verify that the new code works (`test_zm6lt1_phase_dp_converter`, using a real device capture)
