### PR TITLE
Add Arteco A89G12C soil sensor

### DIFF
--- a/tests/test_tuya_a89g12c_soil.py
+++ b/tests/test_tuya_a89g12c_soil.py
@@ -1,0 +1,86 @@
+"""Functional test for the A89G12C Arteco soil sensor quirk.
+
+Loads the quirk, applies it to a simulated device matching the real
+device signature, feeds it synthetic Tuya datapoint reports, and checks
+that soil_moisture / illuminance / soil_conductivity decode correctly and
+that the duplicate RelativeHumidity cluster is removed.
+"""
+
+import pytest
+
+import zhaquirks.tuya.tuya_a89g12c_soil  # noqa: F401  (registers the quirk)
+from zhaquirks.tuya import TuyaCommand, TuyaData, TuyaDatapointData
+
+
+def test_quirk_matches_removes_humidity_and_decodes_datapoints(
+    zigpy_device_from_v2_quirk,
+):
+    device = zigpy_device_from_v2_quirk(
+        "A89G12C",
+        "Arteco",
+        endpoint_ids=[1],
+        cluster_ids={
+            1: {
+                0x0001: 0,  # Power config
+                0x0003: 0,  # Identify
+                0x0402: 0,  # Temperature
+                0x0405: 0,  # Relative humidity - duplicates soil moisture, must be removed
+                0xEF00: 0,  # Tuya MCU cluster
+            }
+        },
+    )
+
+    ep = device.endpoints[1]
+    assert 0x0405 not in ep.in_clusters, "RelativeHumidity cluster should have been removed"
+    assert 0x0402 in ep.in_clusters, "Temperature cluster should stay untouched"
+    assert 0x0001 in ep.in_clusters, "Power (battery) cluster should stay untouched"
+
+    tuya_cluster = ep.in_clusters[0xEF00]
+
+    cmd = TuyaCommand(
+        status=0,
+        tsn=1,
+        datapoints=[
+            TuyaDatapointData(3, TuyaData(42)),      # soil_moisture
+            TuyaDatapointData(102, TuyaData(850)),   # illuminance
+            TuyaDatapointData(112, TuyaData(1200)),  # soil_conductivity
+        ],
+    )
+    tuya_cluster.handle_get_data(cmd)
+
+    assert tuya_cluster.get("soil_moisture") == 42
+    assert tuya_cluster.get("illuminance") == 850
+    assert tuya_cluster.get("soil_conductivity") == 1200
+
+
+def test_soil_conductivity_has_device_class_and_correct_unit():
+    """Regression test for the plant-monitor picker issue.
+
+    HA's plant integrations (Plant Monitor / homeassistant-plant) filter
+    candidate sensors by device_class, and validate the reported unit
+    against the device_class's allowed units. Both must be set correctly
+    or the entity silently won't show up as selectable.
+    """
+    from zha.units import UnitOfConductivity
+
+    from zha.quirks import DEVICE_REGISTRY
+
+    matches = [
+        q
+        for q in DEVICE_REGISTRY
+        if any(
+            m.manufacturer == "A89G12C" and m.model == "Arteco"
+            for m in q.device_match.applies_to
+        )
+    ]
+    assert matches, "quirk not found in registry"
+    quirk_def = matches[0].zha_device_factory.quirk_definition
+
+    ec_meta = next(
+        m
+        for m in quirk_def.entity_metadata
+        if getattr(m, "attribute_name", None) == "soil_conductivity"
+    )
+    assert ec_meta.device_class is not None, "soil_conductivity is missing device_class"
+    assert ec_meta.device_class.value == "conductivity"
+    assert ec_meta.unit == UnitOfConductivity.MICROSIEMENS_PER_CM

--- a/tests/test_tuya_a89g12c_soil.py
+++ b/tests/test_tuya_a89g12c_soil.py
@@ -6,15 +6,22 @@ that soil_moisture / illuminance / soil_conductivity decode correctly and
 that the duplicate RelativeHumidity cluster is removed.
 """
 
-import pytest
+from zha.quirks import DEVICE_REGISTRY
+from zha.units import UnitOfConductivity
 
-import zhaquirks.tuya.tuya_a89g12c_soil  # noqa: F401  (registers the quirk)
 from zhaquirks.tuya import TuyaCommand, TuyaData, TuyaDatapointData
+import zhaquirks.tuya.tuya_a89g12c_soil  # noqa: F401  (registers the quirk)
 
 
 def test_quirk_matches_removes_humidity_and_decodes_datapoints(
     zigpy_device_from_v2_quirk,
 ):
+    """Check that the quirk removes RelativeHumidity and decodes datapoints.
+
+    Applying the quirk should remove the duplicate humidity cluster and
+    correctly decode soil_moisture / illuminance / soil_conductivity from
+    their Tuya datapoints.
+    """
     device = zigpy_device_from_v2_quirk(
         "A89G12C",
         "Arteco",
@@ -31,7 +38,9 @@ def test_quirk_matches_removes_humidity_and_decodes_datapoints(
     )
 
     ep = device.endpoints[1]
-    assert 0x0405 not in ep.in_clusters, "RelativeHumidity cluster should have been removed"
+    assert 0x0405 not in ep.in_clusters, (
+        "RelativeHumidity cluster should have been removed"
+    )
     assert 0x0402 in ep.in_clusters, "Temperature cluster should stay untouched"
     assert 0x0001 in ep.in_clusters, "Power (battery) cluster should stay untouched"
 
@@ -41,8 +50,8 @@ def test_quirk_matches_removes_humidity_and_decodes_datapoints(
         status=0,
         tsn=1,
         datapoints=[
-            TuyaDatapointData(3, TuyaData(42)),      # soil_moisture
-            TuyaDatapointData(102, TuyaData(850)),   # illuminance
+            TuyaDatapointData(3, TuyaData(42)),  # soil_moisture
+            TuyaDatapointData(102, TuyaData(850)),  # illuminance
             TuyaDatapointData(112, TuyaData(1200)),  # soil_conductivity
         ],
     )
@@ -61,10 +70,6 @@ def test_soil_conductivity_has_device_class_and_correct_unit():
     against the device_class's allowed units. Both must be set correctly
     or the entity silently won't show up as selectable.
     """
-    from zha.units import UnitOfConductivity
-
-    from zha.quirks import DEVICE_REGISTRY
-
     matches = [
         q
         for q in DEVICE_REGISTRY

--- a/zhaquirks/tuya/tuya_a89g12c_soil.py
+++ b/zhaquirks/tuya/tuya_a89g12c_soil.py
@@ -1,0 +1,54 @@
+"""Tuya A89G12C Arteco soil sensor."""
+
+import zigpy.types as t
+from zigpy.zcl.clusters.measurement import RelativeHumidity
+
+from zhaquirks.builder import (
+    LIGHT_LUX,
+    PERCENTAGE,
+    EntityType,
+    SensorDeviceClass,
+    SensorStateClass,
+    UnitOfConductivity,
+)
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+(
+    TuyaQuirkBuilder("A89G12C", "Arteco")
+    .removes(RelativeHumidity.cluster_id)
+    .tuya_sensor(
+        dp_id=3,
+        attribute_name="soil_moisture",
+        type=t.uint8_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.MOISTURE,
+        entity_type=EntityType.STANDARD,
+        unit=PERCENTAGE,
+        translation_key="soil_moisture",
+        fallback_name="Soil moisture",
+    )
+    .tuya_sensor(
+        dp_id=102,
+        attribute_name="illuminance",
+        type=t.uint32_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        entity_type=EntityType.STANDARD,
+        unit=LIGHT_LUX,
+        translation_key="illuminance",
+        fallback_name="Illuminance",
+    )
+    .tuya_sensor(
+        dp_id=112,
+        attribute_name="soil_conductivity",
+        type=t.uint16_t,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.CONDUCTIVITY,
+        entity_type=EntityType.STANDARD,
+        unit=UnitOfConductivity.MICROSIEMENS_PER_CM,
+        translation_key="soil_conductivity",
+        fallback_name="Soil conductivity",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
 
<!--
  Explain your proposed change below.
-->
 
Adds a Tuya v2 quirk for the battery-powered `A89G12C` / `Arteco` soil
sensor, which appears to be a rebrand of the `Excellux ZS-300TF` (PCB
silkscreen reads "ZSSF40").
 
Datapoints (taken from the `ZS-300TF` converter in
zigbee-herdsman-converters, same DP IDs):
 
| DP  | Measurement                   | Type      | Unit / device_class              |
| --: | ------------------------------ | --------- | --------------------------------- |
| 3   | Soil moisture                  | uint8_t   | `%`, `device_class=moisture`      |
| 102 | Illuminance                    | uint32_t  | `lx`, `device_class=illuminance`  |
| 112 | Soil electrical conductivity    | uint16_t  | `μS/cm`, `device_class=conductivity` |
 
The device also exposes standard cluster `0x0405` (RelativeHumidity),
but its value duplicates soil moisture rather than ambient humidity
(reports 100% when the probe is in water). The quirk removes that
cluster; DP 3 covers soil moisture instead. Temperature (`0x0402`) and
battery (`0x0001`) are left on their standard clusters, since the
device already reports them correctly there.
 
`soil_conductivity` explicitly sets `device_class=CONDUCTIVITY` with
`UnitOfConductivity.MICROSIEMENS_PER_CM` rather than a bare unit
string — plant-monitoring integrations (HA's built-in Plant Monitor,
`homeassistant-plant`) filter candidate sensors by `device_class`, so
omitting it (or using a mismatched unit string) makes the entity
invisible to their sensor picker.
 
## Additional information
 
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
 
Fixes #5047
 
Not a breaking change; this is a new device signature match, no
existing quirk is affected.
 
Verified on physical hardware (re-paired device, observed live in Home
Assistant over ~2 days): soil_moisture, illuminance and
soil_conductivity all update over time with plausible values (moisture
stable ~63-66%, illuminance tracking the day/night cycle 0-217 lx,
conductivity 258-266 μS/cm). Home Assistant's Plant Monitor integration
picks up `soil_conductivity` automatically thanks to the
`device_class`/unit combination (confirmed: its derived
"Leitfähigkeit" entity mirrors the quirk's value via `external_sensor`).
 
## Device diagnostics
 
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.
  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
 
<!-- TODO: attach a fresh diagnostics download (device page → ⋮ → Download diagnostics)
     taken AFTER re-pairing with this quirk installed, so it shows quirk_applied: true. -->
 
## Checklist
 
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->
 
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached

[zha-01K21RBJNMS90YRKV5GTGRFKCB-A89G12C Arteco-8ce189e65a7c4b21018c5dac72bdd1e6 (1).json](https://github.com/user-attachments/files/30113938/zha-01K21RBJNMS90YRKV5GTGRFKCB-A89G12C.Arteco-8ce189e65a7c4b21018c5dac72bdd1e6.1.json)
