### PR TITLE
Add SONOFF MINI-ZB1GSP, MINI-ZB1GS and MINI-ZB1GP support

### DIFF
--- a/tests/test_sonoff_mini_zb1_family.py
+++ b/tests/test_sonoff_mini_zb1_family.py
@@ -1,0 +1,370 @@
+"""Tests for the Sonoff MINI-ZB1 family quirks."""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+from unittest import mock
+
+import pytest
+from zigpy.zcl import ClusterType, foundation
+
+from tests.common import ClusterListener
+import zhaquirks
+
+_MINI_ZB1_FAMILY_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "zhaquirks"
+    / "sonoff"
+    / "mini-zb1gsp-new.py"
+)
+_MINI_ZB1_FAMILY_SPEC = spec_from_file_location(
+    "zhaquirks.sonoff.mini_zb1_family_test_module", _MINI_ZB1_FAMILY_PATH
+)
+assert _MINI_ZB1_FAMILY_SPEC is not None and _MINI_ZB1_FAMILY_SPEC.loader is not None
+mini_zb1_family = module_from_spec(_MINI_ZB1_FAMILY_SPEC)
+sys.modules[_MINI_ZB1_FAMILY_SPEC.name] = mini_zb1_family
+_MINI_ZB1_FAMILY_SPEC.loader.exec_module(mini_zb1_family)
+
+FAST_SCENE_PACKET_MODIFY = mini_zb1_family.FAST_SCENE_PACKET_MODIFY
+FAST_SCENE_PACKET_REPORT = mini_zb1_family.FAST_SCENE_PACKET_REPORT
+COMMAND_DOUBLE = mini_zb1_family.COMMAND_DOUBLE
+EXTERNAL_TRIGGER_MAP = mini_zb1_family.EXTERNAL_TRIGGER_MAP
+FastSceneProtection = mini_zb1_family.FastSceneProtection
+FastSceneState = mini_zb1_family.FastSceneState
+SonoffCluster = mini_zb1_family.SonoffCluster
+SonoffFastSceneConfigCluster = mini_zb1_family.SonoffFastSceneConfigCluster
+decode_fast_scene_payload = mini_zb1_family.decode_fast_scene_payload
+encode_fast_scene_payload = mini_zb1_family.encode_fast_scene_payload
+fast_scene_array_from_payload = mini_zb1_family.fast_scene_array_from_payload
+fast_scene_payload_from_array = mini_zb1_family.fast_scene_payload_from_array
+_convert_signed_power = mini_zb1_family._convert_signed_power
+
+zhaquirks.setup()
+
+
+def _sample_fast_scene_state():
+    """Return a representative fast scene configuration."""
+
+    return FastSceneState(
+        packet_type=FAST_SCENE_PACKET_REPORT,
+        total_num=1,
+        current_data_index=1,
+        protection=FastSceneProtection(
+            scene_switch=1,
+            over_current_ma=1234,
+            over_load_mw=567890,
+            only_ext_mode_restore=1,
+            over_voltage_mv=250000,
+            over_voltage_en=1,
+            under_voltage_mv=180000,
+            under_voltage_en=1,
+            auto_recover_en=1,
+            notify_en=1,
+        ),
+    )
+
+
+def test_fast_scene_payload_roundtrip():
+    """Encoded fast scene payloads round-trip through the decoder."""
+
+    state = _sample_fast_scene_state()
+
+    payload = encode_fast_scene_payload(state, packet_type=FAST_SCENE_PACKET_MODIFY)
+    decoded = decode_fast_scene_payload(payload)
+
+    assert decoded.packet_type == FAST_SCENE_PACKET_MODIFY
+    assert decoded.total_num == state.total_num
+    assert decoded.current_data_index == state.current_data_index
+    assert decoded.protection == state.protection
+
+
+def test_fast_scene_payload_from_array_variants():
+    """Payload extraction supports the value types used by zigpy."""
+
+    payload = encode_fast_scene_payload(_sample_fast_scene_state())
+    zcl_array = fast_scene_array_from_payload(payload)
+
+    assert fast_scene_payload_from_array(zcl_array) == payload
+    assert fast_scene_payload_from_array(payload) == payload
+    assert fast_scene_payload_from_array(bytearray(payload)) == payload
+    assert fast_scene_payload_from_array(list(payload)) == payload
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        None,
+        object(),
+        foundation.Array(type=foundation.DataTypeId.uint8, value=None),
+    ],
+)
+def test_fast_scene_payload_from_array_invalid_values(bad_value):
+    """Invalid payload inputs raise a ValueError."""
+
+    with pytest.raises(ValueError):
+        fast_scene_payload_from_array(bad_value)
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_message"),
+    [
+        (b"\x01\x01", "Fast scene payload is too short"),
+        (b"\x01\x01\x01\x02", "Fast scene TLV header is incomplete"),
+        (b"\x01\x01\x01\x02\x14\x01", "Fast scene TLV length exceeds payload"),
+    ],
+)
+def test_decode_fast_scene_payload_invalid_values(payload, expected_message):
+    """Malformed fast scene payloads are rejected."""
+
+    with pytest.raises(ValueError, match=expected_message):
+        decode_fast_scene_payload(payload)
+
+
+def test_decode_fast_scene_payload_ignores_zero_padding():
+    """Trailing zero padding does not break decoding."""
+
+    payload = encode_fast_scene_payload(_sample_fast_scene_state()) + b"\x00\x00"
+
+    decoded = decode_fast_scene_payload(payload)
+
+    assert decoded.protection.over_current_ma == 1234
+    assert decoded.protection.notify_en == 1
+
+
+def test_convert_signed_power_handles_reverse_flow():
+    """Signed power helper decodes two's complement negative values."""
+
+    assert _convert_signed_power(123456) == 123.456
+    assert _convert_signed_power(0xFFFFFFFF) == -0.001
+    assert _convert_signed_power(0xFFFFF060) == -4.0
+
+
+def test_sonoff_fast_scene_config_update_fast_scene_state():
+    """Decoded fast scene state is exposed as local attributes."""
+
+    cluster = object.__new__(SonoffFastSceneConfigCluster)
+    object.__setattr__(cluster, "_fast_scene_state", FastSceneState())
+    object.__setattr__(cluster, "_update_attribute", mock.MagicMock())
+
+    state = _sample_fast_scene_state()
+    cluster.update_fast_scene_state(state)
+
+    assert cluster._fast_scene_state == state
+    assert cluster._update_attribute.call_args_list == [
+        mock.call(cluster.AttributeDefs.protection_over_current_ma.id, 1234),
+        mock.call(cluster.AttributeDefs.protection_over_load_mw.id, 567890),
+        mock.call(cluster.AttributeDefs.protection_only_ext_mode_restore.id, True),
+        mock.call(cluster.AttributeDefs.protection_over_voltage_mv.id, 250000),
+        mock.call(cluster.AttributeDefs.protection_over_voltage_enabled.id, True),
+        mock.call(cluster.AttributeDefs.protection_under_voltage_mv.id, 180000),
+        mock.call(cluster.AttributeDefs.protection_under_voltage_enabled.id, True),
+        mock.call(cluster.AttributeDefs.protection_auto_recover.id, True),
+        mock.call(cluster.AttributeDefs.protection_notify.id, True),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]], True),
+        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.FAILURE)]], False),
+        ([], False),
+        (None, False),
+    ],
+)
+def test_sonoff_fast_scene_config_write_succeeded(result, expected):
+    """Write success helper handles success and error payloads."""
+
+    assert SonoffFastSceneConfigCluster._write_succeeded(result) is expected
+
+
+async def test_minizb1gsp_fast_scene_propagation(zigpy_device_from_v2_quirk):
+    """GSP fast scene reports propagate decoded values to the local cluster."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZB1GSP",
+        cluster_ids={
+            1: {
+                SonoffCluster.cluster_id: ClusterType.Server,
+                SonoffFastSceneConfigCluster.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    sonoff_cluster = device.endpoints[1].sonoff_cluster
+    local_cluster = device.endpoints[1].sonoff_fast_scene_config
+    local_listener = ClusterListener(local_cluster)
+
+    payload = encode_fast_scene_payload(_sample_fast_scene_state())
+    sonoff_cluster.update_attribute(
+        SonoffCluster.AttributeDefs.local_fast_scene_configuration.id,
+        fast_scene_array_from_payload(payload),
+    )
+
+    assert local_listener.attribute_updates
+    assert (
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_current_ma.id)
+        == 1234
+    )
+    assert (
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_load_mw.id)
+        == 567890
+    )
+    assert (
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
+        is True
+    )
+
+
+async def test_minizb1gsp_fast_scene_write_attributes_logic(zigpy_device_from_v2_quirk):
+    """GSP local fast scene writes merge into the real Sonoff attribute payload."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZB1GSP",
+        cluster_ids={
+            1: {
+                SonoffCluster.cluster_id: ClusterType.Server,
+                SonoffFastSceneConfigCluster.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    sonoff_cluster = device.endpoints[1].sonoff_cluster
+    local_cluster = device.endpoints[1].sonoff_fast_scene_config
+    local_listener = ClusterListener(local_cluster)
+    sonoff_cluster._fast_scene_state = _sample_fast_scene_state()
+
+    write_response = [
+        [foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]
+    ]
+    with mock.patch.object(
+        sonoff_cluster,
+        "write_attributes_raw",
+        mock.AsyncMock(return_value=write_response),
+    ) as mock_write:
+        await local_cluster.write_attributes(
+            {
+                local_cluster.AttributeDefs.protection_over_current_ma.name: 1600,
+                local_cluster.AttributeDefs.protection_under_voltage_enabled.name: False,
+                local_cluster.AttributeDefs.protection_notify.name: False,
+            }
+        )
+
+    written_attrs = mock_write.call_args[0][0]
+    assert len(written_attrs) == 1
+    assert (
+        written_attrs[0].attrid
+        == SonoffCluster.AttributeDefs.local_fast_scene_configuration.id
+    )
+
+    payload = fast_scene_payload_from_array(written_attrs[0].value.value)
+    decoded = decode_fast_scene_payload(payload)
+
+    assert decoded.protection.over_current_ma == 1600
+    assert decoded.protection.under_voltage_en == 0
+    assert decoded.protection.notify_en == 0
+    assert (
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_current_ma.id)
+        == 1600
+    )
+    assert local_listener.attribute_updates
+
+
+async def test_minizb1gsp_external_switch_events(zigpy_device_from_v2_quirk):
+    """GSP exposes external trigger events for automations."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZB1GSP",
+        cluster_ids={1: {SonoffCluster.cluster_id: ClusterType.Server}},
+    )
+
+    cluster = device.endpoints[1].sonoff_cluster
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    assert device.device_automation_triggers[EXTERNAL_TRIGGER_MAP[COMMAND_DOUBLE]] == {
+        "command": COMMAND_DOUBLE,
+        "endpoint_id": 1,
+    }
+
+    cluster.update_attribute(
+        cluster.AttributeDefs.external_trigger_event.id,
+        cluster.AttributeDefs.external_trigger_event.type(0x02),
+    )
+
+    listener.zha_send_event.assert_called_once_with(COMMAND_DOUBLE, {"value": 0x02})
+
+
+async def test_minizb1gp_applies_custom_configuration_reads_fast_scene(
+    zigpy_device_from_v2_quirk,
+):
+    """GP custom configuration reads fast scene state and populates local attributes."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZB1GP",
+        cluster_ids={
+            1: {
+                SonoffCluster.cluster_id: ClusterType.Server,
+                SonoffFastSceneConfigCluster.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    sonoff_cluster = device.endpoints[1].sonoff_cluster
+    local_cluster = device.endpoints[1].sonoff_fast_scene_config
+    local_listener = ClusterListener(local_cluster)
+
+    fast_scene_attr = SonoffCluster.AttributeDefs.local_fast_scene_configuration
+    payload = fast_scene_array_from_payload(
+        encode_fast_scene_payload(_sample_fast_scene_state())
+    )
+    read_response = foundation.ReadAttributeRecord(
+        attrid=fast_scene_attr.id,
+        status=foundation.Status.SUCCESS,
+        value=foundation.TypeValue(type=fast_scene_attr.zcl_type, value=payload),
+    )
+
+    with mock.patch.object(
+        sonoff_cluster,
+        "_read_attributes",
+        mock.AsyncMock(return_value=[[read_response]]),
+    ) as mock_read:
+        await sonoff_cluster.apply_custom_configuration()
+
+    assert mock_read.call_args.args[0] == [fast_scene_attr.id]
+    assert local_listener.attribute_updates
+    assert (
+        local_cluster.get(local_cluster.AttributeDefs.protection_over_current_ma.id)
+        == 1234
+    )
+
+
+async def test_minizb1gs_external_switch_events(zigpy_device_from_v2_quirk):
+    """GS exposes external trigger events for automations."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZB1GS",
+        cluster_ids={1: {SonoffCluster.cluster_id: ClusterType.Server}},
+    )
+
+    cluster = device.endpoints[1].sonoff_cluster
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    assert device.device_automation_triggers[EXTERNAL_TRIGGER_MAP[COMMAND_DOUBLE]] == {
+        "command": COMMAND_DOUBLE,
+        "endpoint_id": 1,
+    }
+
+    cluster.update_attribute(
+        cluster.AttributeDefs.external_trigger_event.id,
+        cluster.AttributeDefs.external_trigger_event.type(0x02),
+    )
+
+    listener.zha_send_event.assert_called_once_with(COMMAND_DOUBLE, {"value": 0x02})
+

--- a/tests/test_sonoff_mini_zb1_family.py
+++ b/tests/test_sonoff_mini_zb1_family.py
@@ -12,7 +12,7 @@ from tests.common import ClusterListener
 import zhaquirks
 
 _MINI_ZB1_FAMILY_PATH = (
-    Path(__file__).resolve().parents[1] / "zhaquirks" / "sonoff" / "MINI-ZB1 Family.py"
+    Path(__file__).resolve().parents[1] / "zhaquirks" / "sonoff" / "mini-zb1 family.py"
 )
 _MINI_ZB1_FAMILY_SPEC = spec_from_file_location(
     "zhaquirks.sonoff.mini_zb1_family_test_module", _MINI_ZB1_FAMILY_PATH

--- a/tests/test_sonoff_mini_zb1_family.py
+++ b/tests/test_sonoff_mini_zb1_family.py
@@ -35,9 +35,7 @@ FAULT_EVENT_MAP = mini_zb1_family.FAULT_EVENT_MAP
 FastSceneProtection = mini_zb1_family.FastSceneProtection
 FastSceneState = mini_zb1_family.FastSceneState
 SonoffCluster = mini_zb1_family.SonoffCluster
-SonoffElectricalStatusEventCluster = (
-    mini_zb1_family.SonoffElectricalStatusEventCluster
-)
+SonoffElectricalStatusEventCluster = mini_zb1_family.SonoffElectricalStatusEventCluster
 SonoffFastSceneConfigCluster = mini_zb1_family.SonoffFastSceneConfigCluster
 decode_fast_scene_payload = mini_zb1_family.decode_fast_scene_payload
 encode_fast_scene_payload = mini_zb1_family.encode_fast_scene_payload
@@ -74,9 +72,7 @@ def _emit_fault_report(cluster, value, *, attribute_id=None):
     """Emit the zigpy event produced by an incoming attribute report."""
 
     fault_attribute = cluster.AttributeDefs.fault_code
-    reported_attribute_id = (
-        fault_attribute.id if attribute_id is None else attribute_id
-    )
+    reported_attribute_id = fault_attribute.id if attribute_id is None else attribute_id
     cluster.emit(
         AttributeReportedEvent.event_type,
         AttributeReportedEvent(
@@ -256,9 +252,7 @@ async def test_electrical_status_initial_fault_report(
 
     _emit_fault_report(cluster, fault_code)
 
-    listener.zha_send_event.assert_called_once_with(
-        FAULT_EVENT_MAP[fault_code], []
-    )
+    listener.zha_send_event.assert_called_once_with(FAULT_EVENT_MAP[fault_code], [])
 
 
 async def test_electrical_status_ignores_non_fault_reports(
@@ -292,9 +286,7 @@ async def test_electrical_status_ignores_non_fault_reports(
 
     # Ignored values do not poison transition tracking for the next valid report.
     _emit_fault_report(cluster, 0x07020004)
-    listener.zha_send_event.assert_called_once_with(
-        FAULT_EVENT_MAP[0x07020004], []
-    )
+    listener.zha_send_event.assert_called_once_with(FAULT_EVENT_MAP[0x07020004], [])
 
 
 def test_sonoff_fast_scene_config_update_fast_scene_state():

--- a/tests/test_sonoff_mini_zb1_family.py
+++ b/tests/test_sonoff_mini_zb1_family.py
@@ -12,10 +12,7 @@ from tests.common import ClusterListener
 import zhaquirks
 
 _MINI_ZB1_FAMILY_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "zhaquirks"
-    / "sonoff"
-    / "mini-zb1gsp-new.py"
+    Path(__file__).resolve().parents[1] / "zhaquirks" / "sonoff" / "mini-zb1gsp-new.py"
 )
 _MINI_ZB1_FAMILY_SPEC = spec_from_file_location(
     "zhaquirks.sonoff.mini_zb1_family_test_module", _MINI_ZB1_FAMILY_PATH
@@ -166,8 +163,26 @@ def test_sonoff_fast_scene_config_update_fast_scene_state():
 @pytest.mark.parametrize(
     ("result", "expected"),
     [
-        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)]], True),
-        ([[foundation.WriteAttributesStatusRecord(status=foundation.Status.FAILURE)]], False),
+        (
+            [
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        status=foundation.Status.SUCCESS
+                    )
+                ]
+            ],
+            True,
+        ),
+        (
+            [
+                [
+                    foundation.WriteAttributesStatusRecord(
+                        status=foundation.Status.FAILURE
+                    )
+                ]
+            ],
+            False,
+        ),
         ([], False),
         (None, False),
     ],
@@ -212,7 +227,9 @@ async def test_minizb1gsp_fast_scene_propagation(zigpy_device_from_v2_quirk):
         == 567890
     )
     assert (
-        local_cluster.get(local_cluster.AttributeDefs.protection_over_voltage_enabled.id)
+        local_cluster.get(
+            local_cluster.AttributeDefs.protection_over_voltage_enabled.id
+        )
         is True
     )
 
@@ -367,4 +384,3 @@ async def test_minizb1gs_external_switch_events(zigpy_device_from_v2_quirk):
     )
 
     listener.zha_send_event.assert_called_once_with(COMMAND_DOUBLE, {"value": 0x02})
-

--- a/tests/test_sonoff_mini_zb1_family.py
+++ b/tests/test_sonoff_mini_zb1_family.py
@@ -12,7 +12,7 @@ from tests.common import ClusterListener
 import zhaquirks
 
 _MINI_ZB1_FAMILY_PATH = (
-    Path(__file__).resolve().parents[1] / "zhaquirks" / "sonoff" / "mini-zb1gsp-new.py"
+    Path(__file__).resolve().parents[1] / "zhaquirks" / "sonoff" / "MINI-ZB1 Family.py"
 )
 _MINI_ZB1_FAMILY_SPEC = spec_from_file_location(
     "zhaquirks.sonoff.mini_zb1_family_test_module", _MINI_ZB1_FAMILY_PATH

--- a/tests/test_sonoff_mini_zb1_family.py
+++ b/tests/test_sonoff_mini_zb1_family.py
@@ -6,7 +6,12 @@ import sys
 from unittest import mock
 
 import pytest
-from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl import (
+    AttributeReadEvent,
+    AttributeReportedEvent,
+    ClusterType,
+    foundation,
+)
 
 from tests.common import ClusterListener
 import zhaquirks
@@ -26,9 +31,13 @@ FAST_SCENE_PACKET_MODIFY = mini_zb1_family.FAST_SCENE_PACKET_MODIFY
 FAST_SCENE_PACKET_REPORT = mini_zb1_family.FAST_SCENE_PACKET_REPORT
 COMMAND_DOUBLE = mini_zb1_family.COMMAND_DOUBLE
 EXTERNAL_TRIGGER_MAP = mini_zb1_family.EXTERNAL_TRIGGER_MAP
+FAULT_EVENT_MAP = mini_zb1_family.FAULT_EVENT_MAP
 FastSceneProtection = mini_zb1_family.FastSceneProtection
 FastSceneState = mini_zb1_family.FastSceneState
 SonoffCluster = mini_zb1_family.SonoffCluster
+SonoffElectricalStatusEventCluster = (
+    mini_zb1_family.SonoffElectricalStatusEventCluster
+)
 SonoffFastSceneConfigCluster = mini_zb1_family.SonoffFastSceneConfigCluster
 decode_fast_scene_payload = mini_zb1_family.decode_fast_scene_payload
 encode_fast_scene_payload = mini_zb1_family.encode_fast_scene_payload
@@ -57,6 +66,53 @@ def _sample_fast_scene_state():
             under_voltage_en=1,
             auto_recover_en=1,
             notify_en=1,
+        ),
+    )
+
+
+def _emit_fault_report(cluster, value, *, attribute_id=None):
+    """Emit the zigpy event produced by an incoming attribute report."""
+
+    fault_attribute = cluster.AttributeDefs.fault_code
+    reported_attribute_id = (
+        fault_attribute.id if attribute_id is None else attribute_id
+    )
+    cluster.emit(
+        AttributeReportedEvent.event_type,
+        AttributeReportedEvent(
+            device_ieee=str(cluster.endpoint.device.ieee),
+            endpoint_id=cluster.endpoint.endpoint_id,
+            cluster_type=ClusterType.Server,
+            cluster_id=cluster.cluster_id,
+            attribute_name=(
+                fault_attribute.name
+                if reported_attribute_id == fault_attribute.id
+                else None
+            ),
+            attribute_id=reported_attribute_id,
+            manufacturer_code=None,
+            raw_value=value,
+            value=value,
+        ),
+    )
+
+
+def _emit_fault_read(cluster, value):
+    """Emit the zigpy event produced by reading the fault-code attribute."""
+
+    fault_attribute = cluster.AttributeDefs.fault_code
+    cluster.emit(
+        AttributeReadEvent.event_type,
+        AttributeReadEvent(
+            device_ieee=str(cluster.endpoint.device.ieee),
+            endpoint_id=cluster.endpoint.endpoint_id,
+            cluster_type=ClusterType.Server,
+            cluster_id=cluster.cluster_id,
+            attribute_name=fault_attribute.name,
+            attribute_id=fault_attribute.id,
+            manufacturer_code=None,
+            raw_value=value,
+            value=value,
         ),
     )
 
@@ -134,6 +190,111 @@ def test_convert_signed_power_handles_reverse_flow():
     assert _convert_signed_power(123456) == 123.456
     assert _convert_signed_power(0xFFFFFFFF) == -0.001
     assert _convert_signed_power(0xFFFFF060) == -4.0
+
+
+@pytest.mark.parametrize("model", ["MINI-ZB1GSP", "MINI-ZB1GS", "MINI-ZB1GP"])
+async def test_minizb1_family_uses_electrical_status_event_cluster(
+    zigpy_device_from_v2_quirk, model
+):
+    """All MINI-ZB1 family members use the electrical status event cluster."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model=model,
+        cluster_ids={1: {SonoffCluster.cluster_id: ClusterType.Server}},
+    )
+
+    assert isinstance(
+        device.endpoints[1].sonoff_cluster, SonoffElectricalStatusEventCluster
+    )
+
+
+async def test_electrical_status_report_events(zigpy_device_from_v2_quirk):
+    """Fault reports emit transitions while suppressing startup and duplicates."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZB1GSP",
+        cluster_ids={1: {SonoffCluster.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].sonoff_cluster
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    # The normal status commonly reported at startup is not an actionable change.
+    _emit_fault_report(cluster, 0x07020000)
+    listener.zha_send_event.assert_not_called()
+
+    _emit_fault_report(cluster, 0x07020001)
+    _emit_fault_report(cluster, 0x07020001)
+    _emit_fault_report(cluster, 0x07020004)
+    _emit_fault_report(cluster, 0x07020005)
+    _emit_fault_report(cluster, 0x07020000)
+
+    assert listener.zha_send_event.call_args_list == [
+        mock.call(FAULT_EVENT_MAP[0x07020001], []),
+        mock.call(FAULT_EVENT_MAP[0x07020004], []),
+        mock.call(FAULT_EVENT_MAP[0x07020005], []),
+        mock.call(FAULT_EVENT_MAP[0x07020000], []),
+    ]
+
+
+@pytest.mark.parametrize("fault_code", [0x07020001, 0x07020004, 0x07020005])
+async def test_electrical_status_initial_fault_report(
+    zigpy_device_from_v2_quirk, fault_code
+):
+    """An initial non-normal report is emitted immediately."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZB1GP",
+        cluster_ids={1: {SonoffCluster.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].sonoff_cluster
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    _emit_fault_report(cluster, fault_code)
+
+    listener.zha_send_event.assert_called_once_with(
+        FAULT_EVENT_MAP[fault_code], []
+    )
+
+
+async def test_electrical_status_ignores_non_fault_reports(
+    zigpy_device_from_v2_quirk,
+):
+    """Only recognized fault-code attribute reports produce ZHA events."""
+
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="MINI-ZB1GS",
+        cluster_ids={1: {SonoffCluster.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].sonoff_cluster
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    # Cache updates and startup reads are not device reports.
+    cluster.update_attribute(cluster.AttributeDefs.fault_code.id, 0x07020004)
+    _emit_fault_read(cluster, 0x07020004)
+    _emit_fault_report(
+        cluster,
+        0x07020004,
+        attribute_id=cluster.AttributeDefs.network_led.id,
+    )
+    _emit_fault_report(cluster, 0x0702FFFF)
+    _emit_fault_report(cluster, None)
+    _emit_fault_report(cluster, object())
+    _emit_fault_report(cluster, "invalid")
+
+    listener.zha_send_event.assert_not_called()
+
+    # Ignored values do not poison transition tracking for the next valid report.
+    _emit_fault_report(cluster, 0x07020004)
+    listener.zha_send_event.assert_called_once_with(
+        FAULT_EVENT_MAP[0x07020004], []
+    )
 
 
 def test_sonoff_fast_scene_config_update_fast_scene_state():

--- a/zhaquirks/sonoff/MINI-ZB1 Family.py
+++ b/zhaquirks/sonoff/MINI-ZB1 Family.py
@@ -1,0 +1,1141 @@
+"""Sonoff MINI-ZB1GSP - Zigbee Smart Plug."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Final
+
+from zigpy import types
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import (
+    EntityType,
+    NumberDeviceClass,
+    QuirkBuilder,
+    SensorDeviceClass,
+    SensorStateClass,
+    EntityPlatform,
+)
+from zigpy.quirks.v2.homeassistant import (
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTime,
+    UnitOfFrequency,
+)
+import zigpy.types as t
+from zigpy.zcl import (
+    AttributeReadEvent,
+    AttributeReportedEvent,
+    AttributeUpdatedEvent,
+    AttributeWrittenEvent,
+    foundation,
+)
+from zigpy.zcl.foundation import BaseAttributeDefs, Status, ZCLAttributeDef, ZCLCommandDef
+
+from zhaquirks import LocalDataCluster
+# from zhaquirks.units import UnitOfTemperature
+from zhaquirks.const import (
+    COMMAND,
+    COMMAND_DOUBLE,
+    COMMAND_HOLD,
+    COMMAND_SINGLE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    LONG_PRESS,
+    SHORT_PRESS,
+    COMMAND_ON,
+    COMMAND_OFF,
+    ZHA_SEND_EVENT,
+)
+
+FAST_SCENE_PACKET_MODIFY = 0x00
+FAST_SCENE_PACKET_REPORT = 0x01
+FAST_SCENE_ARRAY_ITEM_TYPE = foundation.DataTypeId.uint8
+FAST_SCENE_VOLTAGE_ENABLE_BIT = 0x80000000
+FAST_SCENE_VOLTAGE_VALUE_MASK = 0x7FFFFFFF
+PROTECTION_CURRENT_MIN_MA = 100
+PROTECTION_CURRENT_MAX_MA = 16000
+PROTECTION_POWER_MIN_MW = 2000
+PROTECTION_POWER_MAX_MW = 3840000
+PROTECTION_VOLTAGE_MIN_MV = 85000
+PROTECTION_VOLTAGE_MAX_MV = 277000
+
+
+def _u32_le(data: bytes) -> int:
+    """Decode an unsigned little-endian 32-bit integer."""
+
+    return int.from_bytes(data[:4], "little")
+
+
+def _put_u32_le(value: int) -> list[int]:
+    """Encode an unsigned little-endian 32-bit integer."""
+
+    return list(int(value).to_bytes(4, "little"))
+
+
+def _convert_signed_power(value: int) -> float:
+    """Convert uint32_t two's complement power value to signed watts.
+
+    The device reports power as a uint32_t where negative values use
+    two's complement encoding (MSB = 1). The raw unit is milliwatts.
+    """
+
+    if value >= 0x80000000:
+        value -= 0x100000000
+    return value / 1000.0
+
+
+@dataclass
+class FastSceneProtection:
+    """Electrical protection fast scene."""
+
+    scene_switch: int = 1
+    over_current_ma: int = 0
+    over_load_mw: int = 0
+    only_ext_mode_restore: int = 0
+    over_voltage_mv: int = 0
+    over_voltage_en: int = 0
+    under_voltage_mv: int = 0
+    under_voltage_en: int = 0
+    auto_recover_en: int = 0
+    notify_en: int = 0
+
+
+@dataclass
+class FastSceneState:
+    """Decoded Sonoff fast scene state."""
+
+    packet_type: int = FAST_SCENE_PACKET_REPORT
+    total_num: int = 1
+    current_data_index: int = 1
+    protection: FastSceneProtection = field(default_factory=FastSceneProtection)
+
+
+def fast_scene_array_from_payload(payload: bytes | list[int]) -> foundation.Array:
+    """Wrap a fast scene payload in a ZCL array value."""
+
+    return foundation.Array(
+        type=FAST_SCENE_ARRAY_ITEM_TYPE,
+        value=t.LVList[t.uint8_t, t.uint16_t](payload),
+    )
+
+
+def fast_scene_payload_from_array(value: Any) -> bytes:
+    """Extract the fast scene payload bytes from a decoded ZCL array value."""
+
+    if isinstance(value, foundation.Array):
+        if value.value is None:
+            raise ValueError("Fast scene payload is empty")
+        return bytes(value.value)
+    if isinstance(value, (bytes, bytearray)):
+        if len(value) >= 3 and value[0] == FAST_SCENE_ARRAY_ITEM_TYPE:
+            length = int.from_bytes(value[1:3], "little")
+            return bytes(value[3 : 3 + length])
+        return bytes(value)
+    if isinstance(value, list):
+        return bytes(value)
+    if isinstance(value, t.LVList):
+        return bytes(value)
+    raise ValueError("Unsupported fast scene payload value")
+
+
+def _decode_voltage(raw_value: int) -> tuple[int, int]:
+    """Split a firmware voltage threshold into value and enable flag."""
+
+    return raw_value & FAST_SCENE_VOLTAGE_VALUE_MASK, int(
+        bool(raw_value & FAST_SCENE_VOLTAGE_ENABLE_BIT)
+    )
+
+
+def _encode_voltage(value: int, enabled: int) -> int:
+    """Combine a voltage threshold value and enable flag."""
+
+    raw_value = value & FAST_SCENE_VOLTAGE_VALUE_MASK
+    if enabled:
+        raw_value |= FAST_SCENE_VOLTAGE_ENABLE_BIT
+    return raw_value
+
+
+def decode_fast_scene_payload(payload: bytes | list[int] | foundation.Array) -> FastSceneState:
+    """Decode a Sonoff fast scene payload."""
+
+    data = fast_scene_payload_from_array(payload)
+    if len(data) < 3:
+        raise ValueError("Fast scene payload is too short")
+
+    state = FastSceneState(
+        packet_type=data[0],
+        total_num=data[1],
+        current_data_index=data[2],
+    )
+    idx = 3
+
+    while idx < len(data):
+        if idx + 2 > len(data):
+            if all(byte == 0 for byte in data[idx:]):
+                break
+            raise ValueError("Fast scene TLV header is incomplete")
+
+        scene_type = data[idx]
+        scene_len = data[idx + 1]
+        idx += 2
+
+        if idx + scene_len > len(data):
+            if scene_type == 0 and all(byte == 0 for byte in data[idx - 2 :]):
+                break
+            raise ValueError("Fast scene TLV length exceeds payload")
+
+        scene_data = data[idx : idx + scene_len]
+        idx += scene_len
+
+        if not scene_data:
+            continue
+
+        if scene_type == 2 and len(scene_data) >= 20:
+            scene_switch = scene_data[0]
+            over_voltage_mv, over_voltage_en = _decode_voltage(_u32_le(scene_data[10:14]))
+            under_voltage_mv, under_voltage_en = _decode_voltage(
+                _u32_le(scene_data[14:18])
+            )
+            state.protection = FastSceneProtection(
+                scene_switch=scene_switch,
+                over_current_ma=_u32_le(scene_data[1:5]),
+                over_load_mw=_u32_le(scene_data[5:9]),
+                only_ext_mode_restore=scene_data[9],
+                over_voltage_mv=over_voltage_mv,
+                over_voltage_en=over_voltage_en,
+                under_voltage_mv=under_voltage_mv,
+                under_voltage_en=under_voltage_en,
+                auto_recover_en=scene_data[18],
+                notify_en=scene_data[19],
+            )
+
+    return state
+
+
+def encode_fast_scene_payload(
+    state: FastSceneState,
+    packet_type: int = FAST_SCENE_PACKET_MODIFY,
+) -> bytes:
+    """Encode a Sonoff fast scene payload."""
+
+    payload: list[int] = [
+        packet_type,
+        state.total_num,
+        state.current_data_index,
+    ]
+    protection = state.protection
+    payload.extend(
+        [
+            0x02,
+            20,
+            protection.scene_switch,
+            *_put_u32_le(protection.over_current_ma),
+            *_put_u32_le(protection.over_load_mw),
+            protection.only_ext_mode_restore,
+            *_put_u32_le(
+                _encode_voltage(
+                    protection.over_voltage_mv, protection.over_voltage_en
+                )
+            ),
+            *_put_u32_le(
+                _encode_voltage(
+                    protection.under_voltage_mv, protection.under_voltage_en
+                )
+            ),
+            protection.auto_recover_en,
+            protection.notify_en,
+        ]
+    )
+
+    return bytes(payload)
+
+
+class SonoffErrorCodeType(types.bitmap32):
+    """Fault Code Type."""
+    Normal = 0x07020000,
+    Overheat = 0x07020001,
+    Overload = 0x07020004,
+    Overload_And_Overheat = 0x07020005,
+
+
+class SonoffCluster(CustomCluster):
+    """Custom Sonoff cluster."""
+
+    cluster_id = 0xFC11
+    ep_attribute = "sonoff_cluster"
+    manufacturer_id_override = foundation.ZCLHeader.NO_MANUFACTURER_ID
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        network_led = ZCLAttributeDef(
+            name="network_led",
+            id=0x0001,
+            type=t.Bool,
+        )
+        fault_code = ZCLAttributeDef(
+            id=0x0010,
+            type=SonoffErrorCodeType,
+            access="rp",
+        )
+        turbo_mode = ZCLAttributeDef(
+            name="turbo_mode",
+            id=0x0012,
+            type=t.int16s,
+        )
+        delayed_power_on_state = ZCLAttributeDef(
+            name="delayed_power_on_state",
+            id=0x0014,
+            type=t.Bool,
+        )
+        delayed_power_on_time = ZCLAttributeDef(
+            name="delayed_power_on_time",
+            id=0x0015,
+            type=t.uint16_t,
+        )
+        external_trigger_mode = ZCLAttributeDef(
+            name="external_trigger_mode",
+            id=0x0016,
+            type=t.uint8_t,
+        )
+        detach_relay = ZCLAttributeDef(
+            name="detach_relay",
+            id=0x0019,
+            type=t.bitmap8,
+        )
+        local_fast_scene_configuration = ZCLAttributeDef(
+            name="local_fast_scene_configuration",
+            id=0x7016,
+            type=foundation.Array,
+        )
+        accurrent_current_value = ZCLAttributeDef(
+            name="accurrent_current_value",
+            id=0x7004,
+            type=t.uint32_t,
+        )
+        accurrent_voltage_value = ZCLAttributeDef(
+            name="accurrent_voltage_value",
+            id=0x7005,
+            type=t.uint32_t,
+        )
+        accurrent_power_value = ZCLAttributeDef(
+            name="accurrent_power_value",
+            id=0x7006,
+            type=t.uint32_t,
+        )
+        daily_forward_energy = ZCLAttributeDef(
+            name="daily_forward_energy",
+            id=0x7009,
+            type=t.uint32_t,
+        )
+        monthly_forward_energy = ZCLAttributeDef(
+            name="monthly_forward_energy",
+            id=0x700A,
+            type=t.uint32_t,
+        )
+        daily_reverse_energy = ZCLAttributeDef(
+            name="daily_reverse_energy",
+            id=0x7018,
+            type=t.uint32_t,
+        )
+        monthly_reverse_energy = ZCLAttributeDef(
+            name="monthly_reverse_energy",
+            id=0x7019,
+            type=t.uint32_t,
+        )
+        daily_run_time = ZCLAttributeDef(
+            name="daily_run_time",
+            id=0x701C,
+            type=t.uint32_t,
+        )
+        total_run_time = ZCLAttributeDef(
+            name="total_run_time",
+            id=0x701D,
+            type=t.uint32_t,
+        )
+        total_forward_energy = ZCLAttributeDef(
+            name="total_forward_energy",
+            id=0x701E,
+            type=t.uint32_t,
+        )
+        total_reverse_energy = ZCLAttributeDef(
+            name="total_reverse_energy",
+            id=0x701F,
+            type=t.uint32_t,
+        )
+        voltage_frequency = ZCLAttributeDef(
+            name="voltage_frequency",
+            id=0x7029,
+            type=t.uint32_t,
+        )
+        external_trigger_event = ZCLAttributeDef(
+            name="external_trigger_event",
+            id=0x0028,
+            type=t.uint8_t,
+        )
+
+
+    def __init__(self, *args, **kwargs):
+        """Init and listen for fast scene attribute changes."""
+        super().__init__(*args, **kwargs)
+        self._fast_scene_state = FastSceneState()
+        self.on_event(AttributeReadEvent.event_type, self._handle_fast_scene_change)
+        self.on_event(AttributeReportedEvent.event_type, self._handle_fast_scene_change)
+        self.on_event(AttributeUpdatedEvent.event_type, self._handle_fast_scene_change)
+        self.on_event(AttributeWrittenEvent.event_type, self._handle_fast_scene_change)
+
+    def _handle_fast_scene_change(
+        self,
+        event: AttributeReadEvent
+        | AttributeReportedEvent
+        | AttributeUpdatedEvent
+        | AttributeWrittenEvent,
+    ) -> None:
+        """Sync fast scene state to the local config cluster."""
+        if isinstance(event, AttributeWrittenEvent) and event.status != Status.SUCCESS:
+            return
+        if event.attribute_id != self.AttributeDefs.local_fast_scene_configuration.id:
+            return
+
+        values = [event.value]
+        if isinstance(event, AttributeReadEvent) and event.raw_value is not event.value:
+            values.append(event.raw_value)
+
+        for value in values:
+            try:
+                self._fast_scene_state = decode_fast_scene_payload(value)
+                break
+            except (TypeError, ValueError):
+                continue
+        else:
+            return
+
+        if hasattr(self.endpoint, "sonoff_fast_scene_config"):
+            self.endpoint.sonoff_fast_scene_config.update_fast_scene_state(
+                self._fast_scene_state
+            )
+
+    async def apply_custom_configuration(self, *args, **kwargs):
+        """Read fast scene configuration during pairing to populate entities."""
+        await self.read_attributes([self.AttributeDefs.local_fast_scene_configuration.id])
+
+    @property
+    def _is_manuf_specific(self):
+        return False
+
+    def _update_attribute(self, attrid, value):
+        """Fire ZHA events for external trigger action reports."""
+        super()._update_attribute(attrid, value)
+        if attrid == self.AttributeDefs.external_trigger_event.id:
+            action = EXTERNAL_ACTION_MAP.get(value)
+            if action:
+                self.listener_event(ZHA_SEND_EVENT, action, {"value": value})
+
+
+
+class SonoffFastSceneConfigCluster(LocalDataCluster):
+    """Local cluster for individual fast scene configuration entities."""
+
+    cluster_id = 0xFBFD
+    ep_attribute = "sonoff_fast_scene_config"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        protection_over_current_ma: Final = ZCLAttributeDef(
+            id=0x0010, type=t.uint32_t
+        )
+        protection_over_load_mw: Final = ZCLAttributeDef(id=0x0011, type=t.uint32_t)
+        protection_only_ext_mode_restore: Final = ZCLAttributeDef(
+            id=0x0012, type=t.Bool
+        )
+        protection_over_voltage_mv: Final = ZCLAttributeDef(
+            id=0x0013, type=t.uint32_t
+        )
+        protection_over_voltage_enabled: Final = ZCLAttributeDef(
+            id=0x0014, type=t.Bool
+        )
+        protection_under_voltage_mv: Final = ZCLAttributeDef(
+            id=0x0015, type=t.uint32_t
+        )
+        protection_under_voltage_enabled: Final = ZCLAttributeDef(
+            id=0x0016, type=t.Bool
+        )
+        protection_auto_recover: Final = ZCLAttributeDef(id=0x0017, type=t.Bool)
+        protection_notify: Final = ZCLAttributeDef(id=0x0018, type=t.Bool)
+
+    def __init__(self, *args, **kwargs):
+        """Init with conservative default fast scene state."""
+        super().__init__(*args, **kwargs)
+        self._fast_scene_state = FastSceneState()
+
+    def update_fast_scene_state(self, state: FastSceneState) -> None:
+        """Update local attributes from decoded fast scene state."""
+        self._fast_scene_state = state
+        protection = state.protection
+
+        updates = {
+            self.AttributeDefs.protection_over_current_ma.id: protection.over_current_ma,
+            self.AttributeDefs.protection_over_load_mw.id: protection.over_load_mw,
+            self.AttributeDefs.protection_only_ext_mode_restore.id: bool(
+                protection.only_ext_mode_restore
+            ),
+            self.AttributeDefs.protection_over_voltage_mv.id: protection.over_voltage_mv,
+            self.AttributeDefs.protection_over_voltage_enabled.id: bool(
+                protection.over_voltage_en
+            ),
+            self.AttributeDefs.protection_under_voltage_mv.id: protection.under_voltage_mv,
+            self.AttributeDefs.protection_under_voltage_enabled.id: bool(
+                protection.under_voltage_en
+            ),
+            self.AttributeDefs.protection_auto_recover.id: bool(
+                protection.auto_recover_en
+            ),
+            self.AttributeDefs.protection_notify.id: bool(protection.notify_en),
+        }
+        for attr_id, value in updates.items():
+            self._update_attribute(attr_id, value)
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | ZCLAttributeDef, Any],
+        **kwargs,
+    ) -> list:
+        """Merge local writes into the real fast scene aggregate attribute."""
+        state = self.endpoint.sonoff_cluster._fast_scene_state
+
+        for attr, value in attributes.items():
+            attr_def = self.find_attribute(attr)
+            attr_id = attr_def.id
+            if attr_id == self.AttributeDefs.protection_over_current_ma.id:
+                state.protection.over_current_ma = int(value)
+            elif attr_id == self.AttributeDefs.protection_over_load_mw.id:
+                state.protection.over_load_mw = int(value)
+            elif attr_id == self.AttributeDefs.protection_only_ext_mode_restore.id:
+                state.protection.only_ext_mode_restore = int(bool(value))
+            elif attr_id == self.AttributeDefs.protection_over_voltage_mv.id:
+                state.protection.over_voltage_mv = int(value)
+            elif attr_id == self.AttributeDefs.protection_over_voltage_enabled.id:
+                state.protection.over_voltage_en = int(bool(value))
+            elif attr_id == self.AttributeDefs.protection_under_voltage_mv.id:
+                state.protection.under_voltage_mv = int(value)
+            elif attr_id == self.AttributeDefs.protection_under_voltage_enabled.id:
+                state.protection.under_voltage_en = int(bool(value))
+            elif attr_id == self.AttributeDefs.protection_auto_recover.id:
+                state.protection.auto_recover_en = int(bool(value))
+            elif attr_id == self.AttributeDefs.protection_notify.id:
+                state.protection.notify_en = int(bool(value))
+
+        payload = encode_fast_scene_payload(state)
+        zcl_array = fast_scene_array_from_payload(payload)
+        result = await self.endpoint.sonoff_cluster.write_attributes(
+            {
+                SonoffCluster.AttributeDefs.local_fast_scene_configuration.id: zcl_array
+            }
+        )
+        if self._write_succeeded(result):
+            self.update_fast_scene_state(state)
+        return result
+
+    @staticmethod
+    def _write_succeeded(result: list) -> bool:
+        """Return whether a Zigpy write_attributes response succeeded."""
+        try:
+            records = result[0]
+        except (IndexError, TypeError):
+            return False
+        return all(record.status == Status.SUCCESS for record in records)
+
+
+
+class SonoffExternalTriggerMode(types.enum8):
+    """External trigger mode attribute values."""
+
+    Edge_trigger = 0x00
+    Pulse_trigger = 0x01
+    Normally_off_follow_trigger = 0x02
+    Normally_on_follow_trigger = 0x82
+
+
+class SonoffExternalAction(types.enum8):
+    """External trigger action event values (attribute 0x0028)."""
+
+    Single_click = 0x01
+    Double_click = 0x02
+    Long_press = 0x03
+    Switch_on = 0x04
+    Switch_off = 0x05
+
+
+COMMAND_SWITCH_ON = "switch_on"
+COMMAND_SWITCH_OFF = "switch_off"
+
+EXTERNAL_ACTION_MAP = {
+    SonoffExternalAction.Single_click: COMMAND_SINGLE,
+    SonoffExternalAction.Double_click: COMMAND_DOUBLE,
+    SonoffExternalAction.Long_press: COMMAND_HOLD,
+    SonoffExternalAction.Switch_on: COMMAND_SWITCH_ON,
+    SonoffExternalAction.Switch_off: COMMAND_SWITCH_OFF,
+}
+
+EXTERNAL_TRIGGER_MAP = {
+    COMMAND_SINGLE: ("Single Click", "external_switch"),
+    COMMAND_DOUBLE: ("Double Click", "external_switch"),
+    COMMAND_HOLD: ("Long Press", "external_switch"),
+    COMMAND_SWITCH_ON: (COMMAND_ON, "external_switch"),
+    COMMAND_SWITCH_OFF: (COMMAND_OFF, "external_switch"),
+}
+
+(
+    QuirkBuilder("SONOFF", "MINI-ZB1GSP")
+    .replaces(SonoffCluster)
+    .adds(SonoffFastSceneConfigCluster)
+    .removes(0x0B04)
+    .removes(0x0702)
+
+    .switch(
+        SonoffCluster.AttributeDefs.network_led.name,
+        SonoffCluster.cluster_id,
+        off_value=0,
+        on_value=1,
+        translation_key="network_led",
+        fallback_name="Network LED",
+    )
+    .switch(
+        SonoffCluster.AttributeDefs.turbo_mode.name,
+        SonoffCluster.cluster_id,
+        off_value=9,
+        on_value=20,
+        translation_key="turbo_mode",
+        fallback_name="Turbo mode",
+    )
+    .switch(
+        SonoffCluster.AttributeDefs.delayed_power_on_state.name,
+        SonoffCluster.cluster_id,
+        off_value=0,
+        on_value=1,
+        translation_key="delayed_power_on_state",
+        fallback_name="Delayed power on state",
+    )
+    .number(
+        SonoffCluster.AttributeDefs.delayed_power_on_time.name,
+        SonoffCluster.cluster_id,
+        min_value=0.5,
+        max_value=3599.5,
+        step=0.5,
+        device_class=NumberDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        multiplier=0.5,
+        translation_key="delayed_power_on_time",
+        fallback_name="Delayed power on time",
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.external_trigger_mode.name,
+        SonoffExternalTriggerMode,
+        SonoffCluster.cluster_id,
+        translation_key="external_trigger_mode",
+        fallback_name="External trigger mode",
+    )
+    .switch(
+        SonoffCluster.AttributeDefs.detach_relay.name,
+        SonoffCluster.cluster_id,
+        off_value=0,
+        on_value=1,
+        translation_key="detach_relay",
+        fallback_name="Detach relay",
+    )
+    .number(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_over_current_ma.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        min_value=PROTECTION_CURRENT_MIN_MA,
+        max_value=PROTECTION_CURRENT_MAX_MA,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        unit="mA",
+        translation_key="overcurrent_monitoring_ma",
+        fallback_name="Overcurrent monitoring threshold",
+    )
+    .number(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_over_load_mw.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        min_value=PROTECTION_POWER_MIN_MW,
+        max_value=PROTECTION_POWER_MAX_MW,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        unit="mW",
+        translation_key="overload_monitoring_mw",
+        fallback_name="Overload monitoring",
+    )
+    .switch(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_only_ext_mode_restore.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="protection_only_ext_mode_restore",
+        fallback_name="Protection external switch restore",
+    )
+    .number(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_over_voltage_mv.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        min_value=PROTECTION_VOLTAGE_MIN_MV,
+        max_value=PROTECTION_VOLTAGE_MAX_MV,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        unit="mV",
+        translation_key="over_voltage_monitoring_threshold_mv",
+        fallback_name="Overvoltage monitoring threshold",
+    )
+    .switch(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_over_voltage_enabled.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="over_voltage_enabled",
+        fallback_name="Overvoltage monitoring enabled",
+    )
+    .number(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_under_voltage_mv.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        min_value=PROTECTION_VOLTAGE_MIN_MV,
+        max_value=PROTECTION_VOLTAGE_MAX_MV,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        unit="mV",
+        translation_key="under_voltage_monitoring_threshold_mv",
+        fallback_name="Undervoltage monitoring threshold",
+    )
+    .switch(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_under_voltage_enabled.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="under_voltage_enabled",
+        fallback_name="Undervoltage monitoring enabled",
+    )
+    .switch(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_auto_recover.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="protection_auto_recover",
+        fallback_name="Protection auto recover",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.accurrent_current_value.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricCurrent.AMPERE,
+        divisor=1000,
+        translation_key="accurrent_current_value",
+        fallback_name="Current",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.accurrent_voltage_value.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricPotential.VOLT,
+        divisor=1000,
+        translation_key="accurrent_voltage_value",
+        fallback_name="Voltage",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.accurrent_power_value.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfPower.WATT,
+        attribute_converter=_convert_signed_power,
+        translation_key="accurrent_power_value",
+        fallback_name="Power",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.daily_forward_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="daily_forward_energy",
+        fallback_name="Daily forward energy",
+        divisor=1000,
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.monthly_forward_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=1000,
+        translation_key="monthly_forward_energy",
+        fallback_name="Monthly forward energy",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.daily_reverse_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=1000,
+        translation_key="daily_reverse_energy",
+        fallback_name="Daily reverse energy",
+
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.monthly_reverse_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="monthly_reverse_energy",
+        fallback_name="Monthly reverse energy",
+        divisor=1000,
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.total_forward_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=1000,
+        translation_key="total_forward_energy",
+        fallback_name="Total forward energy",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.total_reverse_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=1000,
+        translation_key="total_reverse_energy",
+        fallback_name="Total reverse energy",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.total_run_time.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfTime.SECONDS,
+        translation_key="total_run_time",
+        fallback_name="Total run time",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.daily_run_time.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfTime.SECONDS,
+        translation_key="daily_run_time",
+        fallback_name="Daily run time",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.voltage_frequency.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.FREQUENCY,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfFrequency.HERTZ,
+        translation_key="voltage_frequency",
+        fallback_name="Voltage frequency",
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.fault_code.name,
+        SonoffErrorCodeType,
+        SonoffCluster.cluster_id,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="fault_code",
+        fallback_name="Fault code",
+    )
+    .device_automation_triggers(
+        {
+            trigger_tuple: {COMMAND: command, ENDPOINT_ID: 1}
+            for command, trigger_tuple in EXTERNAL_TRIGGER_MAP.items()
+        }
+    )
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder("SONOFF", "MINI-ZB1GS")
+    .replaces(SonoffCluster)
+    .adds(SonoffFastSceneConfigCluster)
+    .removes(0x0B04)
+    .removes(0x0702)
+
+    .switch(
+        SonoffCluster.AttributeDefs.network_led.name,
+        SonoffCluster.cluster_id,
+        off_value=0,
+        on_value=1,
+        translation_key="network_led",
+        fallback_name="Network LED",
+    )
+    .switch(
+        SonoffCluster.AttributeDefs.turbo_mode.name,
+        SonoffCluster.cluster_id,
+        off_value=9,
+        on_value=20,
+        translation_key="turbo_mode",
+        fallback_name="Turbo mode",
+    )
+    .switch(
+        SonoffCluster.AttributeDefs.delayed_power_on_state.name,
+        SonoffCluster.cluster_id,
+        off_value=0,
+        on_value=1,
+        translation_key="delayed_power_on_state",
+        fallback_name="Delayed power on state",
+    )
+    .number(
+        SonoffCluster.AttributeDefs.delayed_power_on_time.name,
+        SonoffCluster.cluster_id,
+        min_value=0.5,
+        max_value=3599.5,
+        step=0.5,
+        device_class=NumberDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        multiplier=0.5,
+        translation_key="delayed_power_on_time",
+        fallback_name="Delayed power on time",
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.external_trigger_mode.name,
+        SonoffExternalTriggerMode,
+        SonoffCluster.cluster_id,
+        translation_key="external_trigger_mode",
+        fallback_name="External trigger mode",
+    )
+    .switch(
+        SonoffCluster.AttributeDefs.detach_relay.name,
+        SonoffCluster.cluster_id,
+        off_value=0,
+        on_value=1,
+        translation_key="detach_relay",
+        fallback_name="Detach relay",
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.fault_code.name,
+        SonoffErrorCodeType,
+        SonoffCluster.cluster_id,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="fault_code",
+        fallback_name="Fault code",
+    )
+    .device_automation_triggers(
+        {
+            trigger_tuple: {COMMAND: command, ENDPOINT_ID: 1}
+            for command, trigger_tuple in EXTERNAL_TRIGGER_MAP.items()
+        }
+    )
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder("SONOFF", "MINI-ZB1GP")
+    .replaces(SonoffCluster)
+    .adds(SonoffFastSceneConfigCluster)
+    .removes(0x0B04)
+    .removes(0x0702)
+    .removes(0x0006)
+    .switch(
+        SonoffCluster.AttributeDefs.network_led.name,
+        SonoffCluster.cluster_id,
+        off_value=0,
+        on_value=1,
+        translation_key="network_led",
+        fallback_name="Network LED",
+    )
+    .switch(
+        SonoffCluster.AttributeDefs.turbo_mode.name,
+        SonoffCluster.cluster_id,
+        off_value=9,
+        on_value=20,
+        translation_key="turbo_mode",
+        fallback_name="Turbo mode",
+    )
+    .number(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_over_current_ma.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        min_value=PROTECTION_CURRENT_MIN_MA,
+        max_value=PROTECTION_CURRENT_MAX_MA,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        unit="mA",
+        translation_key="overcurrent_monitoring_ma",
+        fallback_name="Overcurrent monitoring threshold",
+    )
+    .number(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_over_load_mw.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        min_value=PROTECTION_POWER_MIN_MW,
+        max_value=PROTECTION_POWER_MAX_MW,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        unit="mW",
+        translation_key="overload_monitoring_mw",
+        fallback_name="Overload monitoring",
+    )
+    .number(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_over_voltage_mv.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        min_value=PROTECTION_VOLTAGE_MIN_MV,
+        max_value=PROTECTION_VOLTAGE_MAX_MV,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        unit="mV",
+        translation_key="over_voltage_monitoring_threshold_mv",
+        fallback_name="Overvoltage monitoring threshold",
+    )
+    .switch(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_over_voltage_enabled.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="over_voltage_enabled",
+        fallback_name="Overvoltage monitoring enabled",
+    )
+    .number(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_under_voltage_mv.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        min_value=PROTECTION_VOLTAGE_MIN_MV,
+        max_value=PROTECTION_VOLTAGE_MAX_MV,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        unit="mV",
+        translation_key="under_voltage_monitoring_threshold_mv",
+        fallback_name="Undervoltage monitoring threshold",
+    )
+    .switch(
+        SonoffFastSceneConfigCluster.AttributeDefs.protection_under_voltage_enabled.name,
+        SonoffFastSceneConfigCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="under_voltage_enabled",
+        fallback_name="Undervoltage monitoring enabled",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.accurrent_current_value.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricCurrent.AMPERE,
+        translation_key="accurrent_current_value",
+        fallback_name="Current",
+        divisor=1000,
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.accurrent_voltage_value.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricPotential.VOLT,
+        divisor=1000,
+        translation_key="accurrent_voltage_value",
+        fallback_name="Voltage",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.accurrent_power_value.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfPower.WATT,
+        attribute_converter=_convert_signed_power,
+        translation_key="accurrent_power_value",
+        fallback_name="Power",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.daily_forward_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="daily_forward_energy",
+        fallback_name="Daily forward energy",
+        divisor=1000,
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.monthly_forward_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=1000,
+        translation_key="monthly_forward_energy",
+        fallback_name="Monthly forward energy",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.daily_reverse_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=1000,
+        translation_key="daily_reverse_energy",
+        fallback_name="Daily reverse energy",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.monthly_reverse_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="monthly_reverse_energy",
+        fallback_name="Monthly reverse energy",
+        divisor=1000,
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.total_forward_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=1000,
+        translation_key="total_forward_energy",
+        fallback_name="Total forward energy",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.total_reverse_energy.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        divisor=1000,
+        translation_key="total_reverse_energy",
+        fallback_name="Total reverse energy",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.total_run_time.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfTime.SECONDS,
+        translation_key="total_run_time",
+        fallback_name="Total run time",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.daily_run_time.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfTime.SECONDS,
+        translation_key="daily_run_time",
+        fallback_name="Daily run time",
+    )
+    .sensor(
+        attribute_name=SonoffCluster.AttributeDefs.voltage_frequency.name,
+        cluster_id=SonoffCluster.cluster_id,
+        device_class=SensorDeviceClass.FREQUENCY,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfFrequency.HERTZ,
+        translation_key="voltage_frequency",
+        fallback_name="Voltage frequency",
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.fault_code.name,
+        SonoffErrorCodeType,
+        SonoffCluster.cluster_id,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="fault_code",
+        fallback_name="Fault code",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/sonoff/MINI-ZB1 Family.py
+++ b/zhaquirks/sonoff/MINI-ZB1 Family.py
@@ -8,20 +8,20 @@ from typing import Any, Final
 from zigpy import types
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import (
+    EntityPlatform,
     EntityType,
     NumberDeviceClass,
     QuirkBuilder,
     SensorDeviceClass,
     SensorStateClass,
-    EntityPlatform,
 )
 from zigpy.quirks.v2.homeassistant import (
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
+    UnitOfFrequency,
     UnitOfPower,
     UnitOfTime,
-    UnitOfFrequency,
 )
 import zigpy.types as t
 from zigpy.zcl import (
@@ -31,21 +31,19 @@ from zigpy.zcl import (
     AttributeWrittenEvent,
     foundation,
 )
-from zigpy.zcl.foundation import BaseAttributeDefs, Status, ZCLAttributeDef, ZCLCommandDef
+from zigpy.zcl.foundation import BaseAttributeDefs, Status, ZCLAttributeDef
 
 from zhaquirks import LocalDataCluster
+
 # from zhaquirks.units import UnitOfTemperature
 from zhaquirks.const import (
     COMMAND,
     COMMAND_DOUBLE,
     COMMAND_HOLD,
-    COMMAND_SINGLE,
-    DOUBLE_PRESS,
-    ENDPOINT_ID,
-    LONG_PRESS,
-    SHORT_PRESS,
-    COMMAND_ON,
     COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_SINGLE,
+    ENDPOINT_ID,
     ZHA_SEND_EVENT,
 )
 
@@ -157,7 +155,9 @@ def _encode_voltage(value: int, enabled: int) -> int:
     return raw_value
 
 
-def decode_fast_scene_payload(payload: bytes | list[int] | foundation.Array) -> FastSceneState:
+def decode_fast_scene_payload(
+    payload: bytes | list[int] | foundation.Array,
+) -> FastSceneState:
     """Decode a Sonoff fast scene payload."""
 
     data = fast_scene_payload_from_array(payload)
@@ -194,7 +194,9 @@ def decode_fast_scene_payload(payload: bytes | list[int] | foundation.Array) -> 
 
         if scene_type == 2 and len(scene_data) >= 20:
             scene_switch = scene_data[0]
-            over_voltage_mv, over_voltage_en = _decode_voltage(_u32_le(scene_data[10:14]))
+            over_voltage_mv, over_voltage_en = _decode_voltage(
+                _u32_le(scene_data[10:14])
+            )
             under_voltage_mv, under_voltage_en = _decode_voltage(
                 _u32_le(scene_data[14:18])
             )
@@ -235,9 +237,7 @@ def encode_fast_scene_payload(
             *_put_u32_le(protection.over_load_mw),
             protection.only_ext_mode_restore,
             *_put_u32_le(
-                _encode_voltage(
-                    protection.over_voltage_mv, protection.over_voltage_en
-                )
+                _encode_voltage(protection.over_voltage_mv, protection.over_voltage_en)
             ),
             *_put_u32_le(
                 _encode_voltage(
@@ -254,10 +254,11 @@ def encode_fast_scene_payload(
 
 class SonoffErrorCodeType(types.bitmap32):
     """Fault Code Type."""
-    Normal = 0x07020000,
-    Overheat = 0x07020001,
-    Overload = 0x07020004,
-    Overload_And_Overheat = 0x07020005,
+
+    Normal = (0x07020000,)
+    Overheat = (0x07020001,)
+    Overload = (0x07020004,)
+    Overload_And_Overheat = (0x07020005,)
 
 
 class SonoffCluster(CustomCluster):
@@ -376,7 +377,6 @@ class SonoffCluster(CustomCluster):
             type=t.uint8_t,
         )
 
-
     def __init__(self, *args, **kwargs):
         """Init and listen for fast scene attribute changes."""
         super().__init__(*args, **kwargs)
@@ -419,7 +419,9 @@ class SonoffCluster(CustomCluster):
 
     async def apply_custom_configuration(self, *args, **kwargs):
         """Read fast scene configuration during pairing to populate entities."""
-        await self.read_attributes([self.AttributeDefs.local_fast_scene_configuration.id])
+        await self.read_attributes(
+            [self.AttributeDefs.local_fast_scene_configuration.id]
+        )
 
     @property
     def _is_manuf_specific(self):
@@ -434,7 +436,6 @@ class SonoffCluster(CustomCluster):
                 self.listener_event(ZHA_SEND_EVENT, action, {"value": value})
 
 
-
 class SonoffFastSceneConfigCluster(LocalDataCluster):
     """Local cluster for individual fast scene configuration entities."""
 
@@ -444,22 +445,14 @@ class SonoffFastSceneConfigCluster(LocalDataCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
 
-        protection_over_current_ma: Final = ZCLAttributeDef(
-            id=0x0010, type=t.uint32_t
-        )
+        protection_over_current_ma: Final = ZCLAttributeDef(id=0x0010, type=t.uint32_t)
         protection_over_load_mw: Final = ZCLAttributeDef(id=0x0011, type=t.uint32_t)
         protection_only_ext_mode_restore: Final = ZCLAttributeDef(
             id=0x0012, type=t.Bool
         )
-        protection_over_voltage_mv: Final = ZCLAttributeDef(
-            id=0x0013, type=t.uint32_t
-        )
-        protection_over_voltage_enabled: Final = ZCLAttributeDef(
-            id=0x0014, type=t.Bool
-        )
-        protection_under_voltage_mv: Final = ZCLAttributeDef(
-            id=0x0015, type=t.uint32_t
-        )
+        protection_over_voltage_mv: Final = ZCLAttributeDef(id=0x0013, type=t.uint32_t)
+        protection_over_voltage_enabled: Final = ZCLAttributeDef(id=0x0014, type=t.Bool)
+        protection_under_voltage_mv: Final = ZCLAttributeDef(id=0x0015, type=t.uint32_t)
         protection_under_voltage_enabled: Final = ZCLAttributeDef(
             id=0x0016, type=t.Bool
         )
@@ -531,9 +524,7 @@ class SonoffFastSceneConfigCluster(LocalDataCluster):
         payload = encode_fast_scene_payload(state)
         zcl_array = fast_scene_array_from_payload(payload)
         result = await self.endpoint.sonoff_cluster.write_attributes(
-            {
-                SonoffCluster.AttributeDefs.local_fast_scene_configuration.id: zcl_array
-            }
+            {SonoffCluster.AttributeDefs.local_fast_scene_configuration.id: zcl_array}
         )
         if self._write_succeeded(result):
             self.update_fast_scene_state(state)
@@ -547,7 +538,6 @@ class SonoffFastSceneConfigCluster(LocalDataCluster):
         except (IndexError, TypeError):
             return False
         return all(record.status == Status.SUCCESS for record in records)
-
 
 
 class SonoffExternalTriggerMode(types.enum8):
@@ -594,7 +584,6 @@ EXTERNAL_TRIGGER_MAP = {
     .adds(SonoffFastSceneConfigCluster)
     .removes(0x0B04)
     .removes(0x0702)
-
     .switch(
         SonoffCluster.AttributeDefs.network_led.name,
         SonoffCluster.cluster_id,
@@ -777,7 +766,6 @@ EXTERNAL_TRIGGER_MAP = {
         divisor=1000,
         translation_key="daily_reverse_energy",
         fallback_name="Daily reverse energy",
-
     )
     .sensor(
         attribute_name=SonoffCluster.AttributeDefs.monthly_reverse_energy.name,
@@ -860,7 +848,6 @@ EXTERNAL_TRIGGER_MAP = {
     .adds(SonoffFastSceneConfigCluster)
     .removes(0x0B04)
     .removes(0x0702)
-
     .switch(
         SonoffCluster.AttributeDefs.network_led.name,
         SonoffCluster.cluster_id,

--- a/zhaquirks/sonoff/mini-zb1 family.py
+++ b/zhaquirks/sonoff/mini-zb1 family.py
@@ -366,7 +366,7 @@ class SonoffCluster(CustomCluster):
             id=0x701F,
             type=t.uint32_t,
         )
-         = ZCLAttributeDef(
+        voltage_frequency = ZCLAttributeDef(
             name="voltage_frequency",
             id=0x7029,
             type=t.uint32_t,

--- a/zhaquirks/sonoff/mini-zb1 family.py
+++ b/zhaquirks/sonoff/mini-zb1 family.py
@@ -366,8 +366,8 @@ class SonoffCluster(CustomCluster):
             id=0x701F,
             type=t.uint32_t,
         )
-        voltage_frequency = ZCLAttributeDef(
-            name="voltage_frequency",
+         = ZCLAttributeDef(
+            name="",
             id=0x7029,
             type=t.uint32_t,
         )
@@ -821,6 +821,7 @@ EXTERNAL_TRIGGER_MAP = {
         device_class=SensorDeviceClass.FREQUENCY,
         state_class=SensorStateClass.MEASUREMENT,
         unit=UnitOfFrequency.HERTZ,
+        divisor=100,
         translation_key="voltage_frequency",
         fallback_name="Voltage frequency",
     )
@@ -1112,6 +1113,7 @@ EXTERNAL_TRIGGER_MAP = {
         device_class=SensorDeviceClass.FREQUENCY,
         state_class=SensorStateClass.MEASUREMENT,
         unit=UnitOfFrequency.HERTZ,
+        divisor=100,
         translation_key="voltage_frequency",
         fallback_name="Voltage frequency",
     )

--- a/zhaquirks/sonoff/mini-zb1 family.py
+++ b/zhaquirks/sonoff/mini-zb1 family.py
@@ -949,8 +949,8 @@ EXTERNAL_TRIGGER_MAP = {
     .removes(0x0702)
     .removes(0x0006)
     .prevent_default_entity_creation(
-    endpoint_id=1,
-    cluster_id=0x0006,
+        endpoint_id=1,
+        cluster_id=0x0006,
     )
     .switch(
         SonoffCluster.AttributeDefs.network_led.name,

--- a/zhaquirks/sonoff/mini-zb1 family.py
+++ b/zhaquirks/sonoff/mini-zb1 family.py
@@ -8,7 +8,6 @@ from typing import Any, Final
 from zigpy import types
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import (
-    EntityPlatform,
     EntityType,
     NumberDeviceClass,
     QuirkBuilder,
@@ -261,6 +260,14 @@ class SonoffErrorCodeType(types.bitmap32):
     Electrical_Status_Overload_And_Overheat = (0x07020005,)
 
 
+FAULT_EVENT_MAP: Final = {
+    0x07020000: "Electrical_Status Normal",
+    0x07020001: "Electrical_Status Overheat",
+    0x07020004: "Electrical_Status Overload",
+    0x07020005: "Electrical_Status Overload And Overheat",
+}
+
+
 class SonoffCluster(CustomCluster):
     """Custom Sonoff cluster."""
 
@@ -436,6 +443,40 @@ class SonoffCluster(CustomCluster):
                 self.listener_event(ZHA_SEND_EVENT, action, {"value": value})
 
 
+class SonoffElectricalStatusEventCluster(SonoffCluster):
+    """Sonoff cluster which reports electrical status as ZHA events."""
+
+    def __init__(self, *args, **kwargs):
+        """Listen only for device reports, not attribute reads during startup."""
+        super().__init__(*args, **kwargs)
+        self._last_fault_code: int | None = None
+        self.on_event(AttributeReportedEvent.event_type, self._handle_fault_report)
+
+    def _handle_fault_report(self, event: AttributeReportedEvent) -> None:
+        """Fire a friendly ZHA event when the electrical status is reported."""
+        if event.attribute_id != self.AttributeDefs.fault_code.id:
+            return
+
+        try:
+            fault_code = int(event.value)
+        except (TypeError, ValueError):
+            return
+
+        action = FAULT_EVENT_MAP.get(fault_code)
+        if action is None:
+            return
+
+        if fault_code == self._last_fault_code:
+            return
+
+        previous_fault_code = self._last_fault_code
+        self._last_fault_code = fault_code
+        if previous_fault_code is None and fault_code == 0x07020000:
+            return
+
+        self.listener_event(ZHA_SEND_EVENT, action, [])
+
+
 class SonoffFastSceneConfigCluster(LocalDataCluster):
     """Local cluster for individual fast scene configuration entities."""
 
@@ -580,7 +621,7 @@ EXTERNAL_TRIGGER_MAP = {
 
 (
     QuirkBuilder("SONOFF", "MINI-ZB1GSP")
-    .replaces(SonoffCluster)
+    .replaces(SonoffElectricalStatusEventCluster)
     .adds(SonoffFastSceneConfigCluster)
     .removes(0x0B04)
     .removes(0x0702)
@@ -825,15 +866,6 @@ EXTERNAL_TRIGGER_MAP = {
         translation_key="voltage_frequency",
         fallback_name="Voltage frequency",
     )
-    .enum(
-        SonoffCluster.AttributeDefs.fault_code.name,
-        SonoffErrorCodeType,
-        SonoffCluster.cluster_id,
-        entity_platform=EntityPlatform.SENSOR,
-        entity_type=EntityType.DIAGNOSTIC,
-        translation_key="fault_code",
-        fallback_name="Fault code",
-    )
     .device_automation_triggers(
         {
             trigger_tuple: {COMMAND: command, ENDPOINT_ID: 1}
@@ -845,7 +877,7 @@ EXTERNAL_TRIGGER_MAP = {
 
 (
     QuirkBuilder("SONOFF", "MINI-ZB1GS")
-    .replaces(SonoffCluster)
+    .replaces(SonoffElectricalStatusEventCluster)
     .adds(SonoffFastSceneConfigCluster)
     .removes(0x0B04)
     .removes(0x0702)
@@ -900,15 +932,6 @@ EXTERNAL_TRIGGER_MAP = {
         translation_key="detach_relay",
         fallback_name="Detach relay",
     )
-    .enum(
-        SonoffCluster.AttributeDefs.fault_code.name,
-        SonoffErrorCodeType,
-        SonoffCluster.cluster_id,
-        entity_platform=EntityPlatform.SENSOR,
-        entity_type=EntityType.DIAGNOSTIC,
-        translation_key="fault_code",
-        fallback_name="Fault code",
-    )
     .device_automation_triggers(
         {
             trigger_tuple: {COMMAND: command, ENDPOINT_ID: 1}
@@ -920,11 +943,15 @@ EXTERNAL_TRIGGER_MAP = {
 
 (
     QuirkBuilder("SONOFF", "MINI-ZB1GP")
-    .replaces(SonoffCluster)
+    .replaces(SonoffElectricalStatusEventCluster)
     .adds(SonoffFastSceneConfigCluster)
     .removes(0x0B04)
     .removes(0x0702)
     .removes(0x0006)
+    .prevent_default_entity_creation(
+    endpoint_id=1,
+    cluster_id=0x0006,
+    )
     .switch(
         SonoffCluster.AttributeDefs.network_led.name,
         SonoffCluster.cluster_id,
@@ -1116,15 +1143,6 @@ EXTERNAL_TRIGGER_MAP = {
         divisor=100,
         translation_key="voltage_frequency",
         fallback_name="Voltage frequency",
-    )
-    .enum(
-        SonoffCluster.AttributeDefs.fault_code.name,
-        SonoffErrorCodeType,
-        SonoffCluster.cluster_id,
-        entity_platform=EntityPlatform.SENSOR,
-        entity_type=EntityType.DIAGNOSTIC,
-        translation_key="fault_code",
-        fallback_name="Fault code",
     )
     .add_to_registry()
 )

--- a/zhaquirks/sonoff/mini-zb1 family.py
+++ b/zhaquirks/sonoff/mini-zb1 family.py
@@ -367,7 +367,7 @@ class SonoffCluster(CustomCluster):
             type=t.uint32_t,
         )
          = ZCLAttributeDef(
-            name="",
+            name="voltage_frequency",
             id=0x7029,
             type=t.uint32_t,
         )

--- a/zhaquirks/sonoff/mini-zb1 family.py
+++ b/zhaquirks/sonoff/mini-zb1 family.py
@@ -255,10 +255,10 @@ def encode_fast_scene_payload(
 class SonoffErrorCodeType(types.bitmap32):
     """Fault Code Type."""
 
-    Normal = (0x07020000,)
-    Overheat = (0x07020001,)
-    Overload = (0x07020004,)
-    Overload_And_Overheat = (0x07020005,)
+    Electrical_Status_Normal = (0x07020000,)
+    Electrical_Status_Overheat = (0x07020001,)
+    Electrical_Status_Overload = (0x07020004,)
+    Electrical_Status_Overload_And_Overheat = (0x07020005,)
 
 
 class SonoffCluster(CustomCluster):


### PR DESCRIPTION
## Proposed change

Consolidate support for `SONOFF MINI-ZB1GSP`, `SONOFF MINI-ZB1GP`, and
`SONOFF MINI-ZB1GS` into a single shared quirk implementation.

This refactor replaces the previous per-device duplicated logic with a
common Sonoff MINI-ZB1 family implementation and model-specific
`clone()` definitions.

The shared implementation includes:

- common Sonoff manufacturer-specific cluster handling
- fast scene payload decoding and encoding
- shared local configuration cluster support
- common entity definitions reused across the MINI-ZB1 family

Model-specific behavior is still preserved:

- `MINI-ZB1GSP` exposes measurement, protection configuration, switch mode,
  and external trigger related entities
- `MINI-ZB1GP` exposes measurement entities only
- `MINI-ZB1GS` exposes switch mode, external trigger automation events,
  BLE pairing button support, and remote temperature

This also aligns the implementation with other quirk patterns in the
repository that use a shared base quirk with model-specific `clone()`
registration.

## Additional information

This PR is a refactor/consolidation of Sonoff MINI-ZB1 family quirks and
is intended to reduce duplicated code while keeping the existing
device-specific functionality.

It also corrects sensor metadata for energy, power, voltage, current, and
frequency entities so their Home Assistant state classes match the
expected device classes.

No known breaking changes are intended, but the quirk structure has been
reorganized substantially and would benefit from validation on all three
models.

## Device diagnostics
[zha-01KWGSYHWK716KS2FJBVVRVP14-SONOFF MINI-ZB1GSP-928c58945642fd7a90dfaeafee08385e.json](https://github.com/user-attachments/files/30182998/zha-01KWGSYHWK716KS2FJBVVRVP14-SONOFF.MINI-ZB1GSP-928c58945642
[zha-01KX3BYWTD022S44VCDM8CF7BT-SONOFF MINI-ZB1GP-a8667f8efa36622f5cd767afe507efe2.json](https://github.com/user-attachments/files/30183006/zha-01KX3BYWTD022S44VCDM8CF7BT-SONOFF.MINI-ZB1GP-a8667f8efa36622f5cd767afe507efe2.json)
fd7a90dfaeafee08385e.json)
[zha-01KX3BYWTD022S44VCDM8CF7BT-SONOFF MINI-ZB1GS-ccfcf4d4e43e6e150994384794f8464c.json](https://github.com/user-attachments/files/30183010/zha-01KX3BYWTD022S44VCDM8CF7BT-SONOFF.MINI-ZB1GS-ccfcf4d4e43e6e150994384794f8464c.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached