### PR TITLE
Remove stub metering clusters from non-metering Tuya TS000x/TS011F modules

### DIFF
--- a/tests/test_tuya_no_metering.py
+++ b/tests/test_tuya_no_metering.py
@@ -1,0 +1,129 @@
+"""Tests for Tuya TS000x/TS011F modules with stub (always-zero) metering clusters."""
+
+import pytest
+from zha.quirks import DEVICE_REGISTRY, TUYA_PLUG_ONOFF
+from zigpy.zcl import ClusterType
+from zigpy.zcl.clusters.general import Groups, Identify, OnOff, Scenes
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.smartenergy import Metering
+
+import zhaquirks
+from zhaquirks.builder.metadata import ZCLEnumMetadata
+from zhaquirks.tuya import (
+    TuyaZBE000Cluster,
+    TuyaZBExternalSwitchTypeCluster,
+    TuyaZBOnOffAttributeCluster,
+)
+
+zhaquirks.setup()
+
+STUB_METERING_EP1 = {
+    Identify.cluster_id: ClusterType.Server,
+    Groups.cluster_id: ClusterType.Server,
+    Scenes.cluster_id: ClusterType.Server,
+    OnOff.cluster_id: ClusterType.Server,
+    Metering.cluster_id: ClusterType.Server,
+    ElectricalMeasurement.cluster_id: ClusterType.Server,
+    TuyaZBE000Cluster.cluster_id: ClusterType.Server,
+    TuyaZBExternalSwitchTypeCluster.cluster_id: ClusterType.Server,
+}
+GANG_EP = {
+    Groups.cluster_id: ClusterType.Server,
+    Scenes.cluster_id: ClusterType.Server,
+    OnOff.cluster_id: ClusterType.Server,
+}
+
+
+@pytest.mark.parametrize(
+    "manufacturer,model,gangs,has_switch_type_select",
+    [
+        ("_TZ3000_tqlv4ug4", "TS0001", [], True),
+        ("_TZ3000_prits6g4", "TS0001", [], True),
+        ("_TZ3000_46t1rvdu", "TS0001", [], True),
+        ("_TZ3000_fdxihpp7", "TS0001", [], True),
+        ("_TZ3000_fdxihpp7", "TS000F", [], True),
+        ("_TZ3000_eei0ubpy", "TS0002", [2], True),
+        ("_TZ3000_lmlsduws", "TS0002", [2], True),
+        ("_TZ3000_zmy4lslw", "TS0002", [2], True),
+        ("_TZ3000_ly9apzky", "TS0003", [2, 3], True),
+        ("_TZ3000_knoj8lpk", "TS0004", [2, 3, 4], True),
+        ("_TZ3000_o1jzcxou", "TS011F", [], False),
+    ],
+)
+def test_no_metering_quirk(
+    zigpy_device_from_v2_quirk, manufacturer, model, gangs, has_switch_type_select
+):
+    """Devices with stub metering clusters lose them; the rest is preserved."""
+    quirked = zigpy_device_from_v2_quirk(
+        manufacturer,
+        model,
+        cluster_ids={1: dict(STUB_METERING_EP1), **{g: dict(GANG_EP) for g in gangs}},
+    )
+
+    ep1 = quirked.endpoints[1]
+    assert Metering.cluster_id not in ep1.in_clusters
+    assert ElectricalMeasurement.cluster_id not in ep1.in_clusters
+
+    for ep_id in [1, *gangs]:
+        onoff = quirked.endpoints[ep_id].in_clusters[OnOff.cluster_id]
+        assert isinstance(onoff, TuyaZBOnOffAttributeCluster)
+    assert isinstance(ep1.in_clusters[TuyaZBE000Cluster.cluster_id], TuyaZBE000Cluster)
+    assert isinstance(
+        ep1.in_clusters[TuyaZBExternalSwitchTypeCluster.cluster_id],
+        TuyaZBExternalSwitchTypeCluster,
+    )
+
+    # Tuya spell parity with the replaced v1 EnchantedDevice quirks
+    assert quirked.tuya_spell_read_attributes is True
+    assert quirked.tuya_spell_data_query is False
+
+    entry = DEVICE_REGISTRY.match_entry(quirked)
+    definition = entry.zha_device_factory.quirk_definition
+
+    # keeps backlight_mode / power_on_state selects (and child lock) working
+    assert TUYA_PLUG_ONOFF in {f.feature for f in definition.exposes_features}
+
+    switch_type_enums = [
+        m
+        for m in definition.entity_metadata
+        if isinstance(m, ZCLEnumMetadata)
+        and m.attribute_name
+        == TuyaZBExternalSwitchTypeCluster.AttributeDefs.external_switch_type.name
+    ]
+    assert bool(switch_type_enums) is has_switch_type_select
+
+
+def test_bseed_socket_without_stub_clusters(zigpy_device_from_v2_quirk):
+    """The BSEED firmware flavor without metering clusters resolves to the same quirk."""
+    quirked = zigpy_device_from_v2_quirk(
+        "_TZ3000_o1jzcxou",
+        "TS011F",
+        cluster_ids={
+            1: {
+                Identify.cluster_id: ClusterType.Server,
+                Groups.cluster_id: ClusterType.Server,
+                Scenes.cluster_id: ClusterType.Server,
+                OnOff.cluster_id: ClusterType.Server,
+                TuyaZBE000Cluster.cluster_id: ClusterType.Server,
+                TuyaZBExternalSwitchTypeCluster.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    ep1 = quirked.endpoints[1]
+    assert Metering.cluster_id not in ep1.in_clusters
+    assert ElectricalMeasurement.cluster_id not in ep1.in_clusters
+    assert isinstance(ep1.in_clusters[OnOff.cluster_id], TuyaZBOnOffAttributeCluster)
+    assert quirked.tuya_spell_read_attributes is True
+
+
+def test_metering_ts0001_variants_unaffected(zigpy_device_from_v2_quirk):
+    """Fingerprints with real metering hardware keep their metering clusters."""
+    quirked = zigpy_device_from_v2_quirk(
+        "_TZ3000_xkap8wtb",
+        "TS0001",
+        cluster_ids={1: dict(STUB_METERING_EP1)},
+    )
+    ep1 = quirked.endpoints[1]
+    assert Metering.cluster_id in ep1.in_clusters
+    assert ElectricalMeasurement.cluster_id in ep1.in_clusters

--- a/zhaquirks/tuya/ts0001_switch.py
+++ b/zhaquirks/tuya/ts0001_switch.py
@@ -1,11 +1,18 @@
 """Tuya switch device."""
 
+from zha.quirks import TUYA_PLUG_ONOFF
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
-from zhaquirks.builder import QuirkBuilder
+from zhaquirks.builder import EntityType, QuirkBuilder
 from zhaquirks.clusters import CustomCluster
-from zhaquirks.tuya import TuyaZBExternalSwitchTypeCluster, TuyaZBOnOffAttributeCluster
+from zhaquirks.tuya import (
+    ExternalSwitchType,
+    TuyaZBE000Cluster,
+    TuyaZBExternalSwitchTypeCluster,
+    TuyaZBOnOffAttributeCluster,
+)
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
 class CustomElectricalMeasurement(ElectricalMeasurement, CustomCluster):
@@ -48,5 +55,38 @@ class CustomMetering(Metering, CustomCluster):
     .replaces(CustomElectricalMeasurement)
     .replaces(TuyaZBOnOffAttributeCluster)
     .replaces(TuyaZBExternalSwitchTypeCluster)
+    .add_to_registry()
+)
+
+
+# TS0001 switch modules whose firmware exposes seMetering (0x0702) and
+# haElectricalMeasurement (0x0B04) clusters, but whose boards have no metering
+# front-end: every measurement attribute (including rms_voltage) always reads
+# as a constant 0. Verified with on-device reads under a real load; zigbee2mqtt
+# classifies these fingerprints as plain switch modules without power
+# monitoring (TS0001_switch_module / WHD02). The stub clusters are removed so
+# ZHA does not create dead, always-zero W/V/A/kWh sensors and does not poll
+# them every 30-45 seconds.
+(
+    TuyaQuirkBuilder("_TZ3000_tqlv4ug4", "TS0001")
+    .applies_to("_TZ3000_prits6g4", "TS0001")
+    .applies_to("_TZ3000_46t1rvdu", "TS0001")
+    .applies_to("_TZ3000_fdxihpp7", "TS0001")
+    .applies_to("_TZ3000_fdxihpp7", "TS000F")
+    .tuya_enchantment()
+    .removes(Metering.cluster_id)
+    .removes(ElectricalMeasurement.cluster_id)
+    .replace_cluster_occurrences(TuyaZBOnOffAttributeCluster)
+    .replace_cluster_occurrences(TuyaZBE000Cluster)
+    .replace_cluster_occurrences(TuyaZBExternalSwitchTypeCluster)
+    .exposes_feature(TUYA_PLUG_ONOFF)
+    .enum(
+        attribute_name=TuyaZBExternalSwitchTypeCluster.AttributeDefs.external_switch_type.name,
+        enum_class=ExternalSwitchType,
+        cluster_id=TuyaZBExternalSwitchTypeCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="external_switch_type",
+        fallback_name="External switch type",
+    )
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts000x_switch.py
+++ b/zhaquirks/tuya/ts000x_switch.py
@@ -1,0 +1,54 @@
+"""Tuya TS000X multi-gang switch modules without metering hardware.
+
+These fingerprints expose seMetering (0x0702) and haElectricalMeasurement
+(0x0B04) clusters from Tuya's shared TS000x firmware, but the boards have no
+metering front-end: every measurement attribute (including rms_voltage) always
+reads back as a constant 0. Long-term recorder statistics on live devices show
+years of all-zero readings under daily real load. zigbee2mqtt classifies the
+TS0002/TS0004 fingerprints as plain switch modules (TS0002_basic /
+TS0004_switch_module_2); _TZ3000_ly9apzky (TS0003) is not listed in
+zigbee2mqtt and is included based on a live unit showing the same all-zero
+behavior.
+
+The quirk removes the two stub clusters so ZHA does not create dead,
+always-zero W/V/A/kWh sensors (and does not poll them every 30-45 seconds),
+keeps the Tuya on/off extensions (backlight mode / power-on state selects) and
+exposes the external switch type selector, matching zigbee2mqtt's exposes.
+"""
+
+from zha.quirks import TUYA_PLUG_ONOFF
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.smartenergy import Metering
+
+from zhaquirks.builder import EntityType
+from zhaquirks.tuya import (
+    ExternalSwitchType,
+    TuyaZBE000Cluster,
+    TuyaZBExternalSwitchTypeCluster,
+    TuyaZBOnOffAttributeCluster,
+)
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+(
+    TuyaQuirkBuilder("_TZ3000_eei0ubpy", "TS0002")
+    .applies_to("_TZ3000_lmlsduws", "TS0002")
+    .applies_to("_TZ3000_zmy4lslw", "TS0002")
+    .applies_to("_TZ3000_ly9apzky", "TS0003")
+    .applies_to("_TZ3000_knoj8lpk", "TS0004")
+    .tuya_enchantment()
+    .removes(Metering.cluster_id)
+    .removes(ElectricalMeasurement.cluster_id)
+    .replace_cluster_occurrences(TuyaZBOnOffAttributeCluster)
+    .replace_cluster_occurrences(TuyaZBE000Cluster)
+    .replace_cluster_occurrences(TuyaZBExternalSwitchTypeCluster)
+    .exposes_feature(TUYA_PLUG_ONOFF)
+    .enum(
+        attribute_name=TuyaZBExternalSwitchTypeCluster.AttributeDefs.external_switch_type.name,
+        enum_class=ExternalSwitchType,
+        cluster_id=TuyaZBExternalSwitchTypeCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="external_switch_type",
+        fallback_name="External switch type",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts011f_plug_v2.py
+++ b/zhaquirks/tuya/ts011f_plug_v2.py
@@ -1,0 +1,36 @@
+"""Tuya TS011F plug variants handled by v2 quirks.
+
+BSEED wall-mounted socket `_TZ3000_o1jzcxou` ships in two firmware flavors:
+one that does not declare metering clusters at all (previously covered by the
+v1 `Plug_v7` quirk) and one that exposes seMetering (0x0702) and
+haElectricalMeasurement (0x0B04) as stubs answering every read with a constant
+0 — the socket has no metering hardware (zigbee2mqtt: TS011F_plug_2, "Smart
+plug (without power monitoring)").
+
+This quirk covers both flavors: the stub clusters are removed when present, so
+ZHA does not create dead, always-zero W/V/A/kWh sensors, while the Tuya on/off
+extensions (child lock, backlight mode, power-on state) keep working.
+"""
+
+from zha.quirks import TUYA_PLUG_ONOFF
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.smartenergy import Metering
+
+from zhaquirks.tuya import (
+    TuyaZBE000Cluster,
+    TuyaZBExternalSwitchTypeCluster,
+    TuyaZBOnOffAttributeCluster,
+)
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+(
+    TuyaQuirkBuilder("_TZ3000_o1jzcxou", "TS011F")
+    .tuya_enchantment()
+    .removes(Metering.cluster_id)
+    .removes(ElectricalMeasurement.cluster_id)
+    .replace_cluster_occurrences(TuyaZBOnOffAttributeCluster)
+    .replace_cluster_occurrences(TuyaZBE000Cluster)
+    .replace_cluster_occurrences(TuyaZBExternalSwitchTypeCluster)
+    .exposes_feature(TUYA_PLUG_ONOFF)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Several Tuya TS000x switch-module and TS011F socket fingerprints ship a firmware
that exposes seMetering (0x0702) and haElectricalMeasurement (0x0B04) clusters,
while the actual boards have no metering front-end. Every measurement attribute
— including `rms_voltage` on a mains-powered device — reads back as a constant 0.
As a result ZHA creates power/current/voltage/energy sensors that stay at 0
forever and polls the EM cluster every 30–45 s for nothing.

Evidence gathered on a live network (10 affected devices):
- On-device reads under a real load (chandeliers on): `active_power`,
  `rms_current`, `rms_voltage` all answer 0 with ZCL status SUCCESS;
- 1.5–2.5 years of HA long-term statistics for all affected devices:
  max(power) = max(voltage) = 0.0 over tens of thousands of hours of daily use,
  while a Tongou DIN rail relay (`_TZ3000_qeuvnohg`, real metering, polled by the
  same ZHA machinery) reports up to 9.4 kW on the same network;
- zigbee2mqtt classifies all included fingerprints as switch modules / plugs
  without power monitoring (see table below).

This PR removes the stub clusters for those fingerprints via v2 quirks, so the
dead entities are not created and the pointless polling stops. The quirks keep
behavior parity with the v1 `Switch_XG_Metering` quirks they replace:
`EnchantedDevice` spell, `TUYA_PLUG_ONOFF` exposed feature (backlight /
power-on-state selects and child lock keep working and keep their unique ids),
and add the `external_switch_type` select matching z2m's `switchType` expose.
Cluster operations are adaptive (`removes` no-ops when the cluster is absent,
`replace_cluster_occurrences` touches only endpoints that have the cluster), so
one quirk safely covers both firmware flavors of the BSEED socket (with and
without the stub clusters; the latter was previously covered by `Plug_v7`).

| Fingerprint | Model | z2m classification |
|---|---|---|
| _TZ3000_tqlv4ug4 | TS0001 | TS0001_switch_module (OXT SWTZ21 / Moes ZM-104 / AVATTO ZWSM16) |
| _TZ3000_prits6g4 | TS0001 | TS0001_switch_module |
| _TZ3000_46t1rvdu | TS0001 | WHD02 |
| _TZ3000_fdxihpp7 | TS0001 / TS000F | WHD02 |
| _TZ3000_eei0ubpy | TS0002 | TS0002_basic (OXT SWTZ22) |
| _TZ3000_lmlsduws | TS0002 | TS0002_basic |
| _TZ3000_zmy4lslw | TS0002 | TS0002_basic |
| _TZ3000_ly9apzky | TS0003 | not in z2m; included based on 21 months of all-zero readings on a live unit (same shared firmware family) — happy to drop if preferred |
| _TZ3000_knoj8lpk | TS0004 | TS0004_switch_module_2 (iHseno) |
| _TZ3000_o1jzcxou | TS011F | TS011F_plug_2 "Smart plug (without power monitoring)" (BSEED) |

Deliberately NOT included: `_TZ3000_aaifmpuq` (NOUS B3Z, reported in #3427) —
z2m classifies it as TS0002_power (with real power monitoring), so its zeros
likely have a different root cause.

Deliberately NOT changed: device_type (ON_OFF_LIGHT vs switch, see #4752) — out
of scope to avoid breaking existing entities.

Side note: the existing metering TS0001 v2 quirk in `ts0001_switch.py` does not
declare `.exposes_feature(TUYA_PLUG_ONOFF)`, so devices migrated from the v1
quirk lost their backlight/power-on-state selects; can fix in a follow-up.

## Additional information

Fixes #3427
Related: #1968 (closed as stale, same root cause for _TZ3000_46t1rvdu), #4435/#4450
(BSEED firmware flavor without the stub clusters: for `_TZ3000_o1jzcxou` the v2
quirk supersedes the signature-based `Plug_v7`; it is kept as a generic fallback
for other manufacturers with the same signature).

## Device diagnostics

[diagnostics-TS0001-_TZ3000_tqlv4ug4.json.txt](https://github.com/user-attachments/files/30208944/diagnostics-TS0001-_TZ3000_tqlv4ug4.json.txt)

## Checklist
- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
