### PR TITLE
Add v2 quirk for Tuya _TZE200_rmymn92d curtain motor

### DIFF
--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -10,7 +10,7 @@ import zhaquirks
 from zhaquirks.device import CustomZigpyDevice
 from zhaquirks.tuya import TuyaCommand, TuyaData, TuyaDatapointData
 from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaWindowCovering
-from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601
+from zhaquirks.tuya.ts0601_cover import MotorDirection, TuyaMoesCover0601
 
 zhaquirks.setup()
 
@@ -223,3 +223,183 @@ async def test_zemismart_zm16b_battery_report(zigpy_device_from_v2_quirk):
     # Battery percentage should be scaled by 2 (default tuya_battery scale)
     power_cluster = ep.power
     assert power_cluster.get("battery_percentage_remaining") == 170
+
+
+async def test_rmymn92d_quirk(zigpy_device_from_v2_quirk):
+    """Test the _TZE200_rmymn92d curtain motor v2 quirk applies."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_rmymn92d", "TS0601")
+    assert isinstance(quirked, CustomZigpyDevice)
+
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    assert cover_cluster is not None
+    assert isinstance(cover_cluster, TuyaWindowCovering)
+
+    tuya_cluster = ep.tuya_manufacturer
+    assert tuya_cluster is not None
+    assert isinstance(tuya_cluster, TuyaMCUCluster)
+
+
+async def test_rmymn92d_position_report(zigpy_device_from_v2_quirk):
+    """Test position DP reports update the cover position without inversion."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_rmymn92d", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    cover_listener = ClusterListener(cover_cluster)
+
+    tuya_cluster = ep.tuya_manufacturer
+
+    # This motor reports 0=open/100=closed already matching ZCL, so invert=False:
+    # DP 3 (position state) = 75 stays 75, not 25.
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[TuyaDatapointData(3, TuyaData(75))],
+        )
+    )
+
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 75
+    )
+
+    assert len(cover_listener.attribute_updates) == 1
+    assert (
+        cover_listener.attribute_updates[0][0]
+        == WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+    assert cover_listener.attribute_updates[0][1] == 75
+
+    # DP 2 (position control echo) = 0 stays 0 (would be 100 if inverted).
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=2,
+            datapoints=[TuyaDatapointData(2, TuyaData(0))],
+        )
+    )
+
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 0
+    )
+
+
+async def test_rmymn92d_open_command(zigpy_device_from_v2_quirk):
+    """Test that the open command sends DP 1 = 0 (Open)."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_rmymn92d", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.up_open.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[-1:] == b"\x00"  # Value = Open (0)
+
+
+async def test_rmymn92d_close_command(zigpy_device_from_v2_quirk):
+    """Test that the close command sends DP 1 = 2 (Close)."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_rmymn92d", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.down_close.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[-1:] == b"\x02"  # Value = Close (2)
+
+
+async def test_rmymn92d_stop_command(zigpy_device_from_v2_quirk):
+    """Test that the stop command sends DP 1 = 1 (Stop)."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_rmymn92d", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.stop.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[-1:] == b"\x01"  # Value = Stop (1)
+
+
+async def test_rmymn92d_go_to_lift_percentage(zigpy_device_from_v2_quirk):
+    """Test go_to_lift_percentage sends the position uninverted (invert=False)."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_rmymn92d", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        # ZCL go_to_lift_percentage 25% -> DP 2 gets 25 (0x19), NOT 75.
+        await cover_cluster.command(
+            WindowCovering.ServerCommandDefs.go_to_lift_percentage.id, 25
+        )
+        await wait_for_zigpy_tasks()
+
+        assert req_mock.call_count >= 1
+        found_correct_position = False
+        for call in req_mock.call_args_list:
+            call_data = call[1]["data"]
+            # DP 2 (position control), int32 value 25 = 0x19.
+            if b"\x02\x02\x00\x04\x00\x00\x00\x19" in call_data:
+                found_correct_position = True
+        assert found_correct_position, "Expected DP 2 with value 25 in sent data"
+
+
+async def test_rmymn92d_motor_direction(zigpy_device_from_v2_quirk):
+    """Test that the motor direction DP report updates the enum attribute."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_rmymn92d", "TS0601")
+    ep = quirked.endpoints[1]
+
+    tuya_cluster = ep.tuya_manufacturer
+
+    # DP 5 = 1 -> Back
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=3,
+            datapoints=[TuyaDatapointData(5, TuyaData(1))],
+        )
+    )
+
+    assert tuya_cluster.get("motor_direction") == MotorDirection.Back

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -705,3 +705,30 @@ class BorderSetting(t.enum8):
     .skip_configuration()
     .add_to_registry()
 )
+
+
+(
+    # Zemismart BCM500DS-TYZ curtain motor. Same hardware family as
+    # _TZE200_xaabybja (handled by the v1 TuyaMoesCover0601_inv_position). The
+    # motor already reports 0=open/100=closed, matching the ZCL lift-percentage
+    # convention, so invert=False -- the v2 equivalent of the v1
+    # tuya_cover_inverted_by_default=True. Travel limits cannot be set over Zigbee
+    # on this model (DP 16 is ACKed but silently ignored on hardware), so no
+    # border buttons are exposed.
+    TuyaQuirkBuilder("_TZE200_rmymn92d", "TS0601")
+    .tuya_cover(
+        control_dp=1,
+        position_state_dp=3,
+        position_control_dp=2,
+        invert=False,
+    )
+    .tuya_enum(
+        dp_id=5,
+        attribute_name="motor_direction",
+        enum_class=MotorDirection,
+        translation_key="motor_direction",
+        fallback_name="Motor direction",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
Adds the Tuya `_TZE200_rmymn92d` curtain motor (sold as the Zemismart BCM500DS-TYZ) as a v2 `TuyaQuirkBuilder` entry in `ts0601_cover.py`, reusing the file's existing `MotorDirection` enum. Same hardware family as `_TZE200_xaabybja` (v1 `TuyaMoesCover0601_inv_position`) and grouped as `TS0601_cover_1` in zigbee2mqtt.

**Datapoints:** control = DP1, current position = DP3, target position = DP2, motor direction = DP5.

`invert=False` because the motor already reports 0=open/100=closed (matching the ZCL lift-percentage convention) — the v2 equivalent of the v1 `tuya_cover_inverted_by_default=True`. No border/limit buttons are exposed: DP16 is ACKed at the ZCL layer but silently ignored on this hardware, so travel limits must be learned mechanically.

**Tested on hardware:** two `_TZE200_rmymn92d` units on Home Assistant 2026.7 / ZHA with a Sonoff dongle, including a full migration to a new Raspberry Pi 5. Confirmed:
- open / close / stop (DP1 = 0 / 1 / 2)
- accurate `set_position` to arbitrary targets (DP2)
- DP3 position feedback once the motor is mounted and calibrated — fully open reads 100%, fully closed 0% (no mirroring, confirming `invert=False`)
- the motor reports DP3 on stop (endpoint, set-position target, or manual stop), not streamed during travel

Adds 7 unit tests (quirk applies, position report is uninverted, open / close / stop commands, `go_to_lift_percentage`, motor direction). `pytest tests/test_tuya_cover.py` passes 15/15 and `ruff` is clean locally.

Resolves #3269.

Note: #3900 adds the same device as a **v1** class and is approved but unmerged. This is the **v2** equivalent — happy to have whichever the maintainers prefer; if this lands, #3900 can be closed. Cross-referencing @kbuck1 / @Jatus93 who authored/tested the v1 version.
