### PR TITLE
Add TuyaQuirkBuilder support for TS0603 garage door openers

### DIFF
--- a/zhaquirks/tuya/tuya_garage_door.py
+++ b/zhaquirks/tuya/tuya_garage_door.py
@@ -11,11 +11,15 @@ TS0601 variants (_TZE200_nklqjk62, _TZE204_nklqjk62, _TZE284_nklqjk62) are
 handled by the legacy ts0601_garage.py quirk.
 """
 
-from zigpy.quirks.v2 import BinarySensorDeviceClass, EntityPlatform, EntityType
-from zigpy.quirks.v2.homeassistant import UnitOfTime
-from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 import zigpy.types as t
 
+from zhaquirks.builder import (
+    BinarySensorDeviceClass,
+    EntityPlatform,
+    EntityType,
+    NumberDeviceClass,
+    UnitOfTime,
+)
 from zhaquirks.tuya import TUYA_CLUSTER_ID
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 

--- a/zhaquirks/tuya/tuya_garage_door.py
+++ b/zhaquirks/tuya/tuya_garage_door.py
@@ -1,0 +1,109 @@
+"""Tuya garage door openers (TS0603).
+
+Adds v2 quirk support for TS0603-based garage door openers that are not
+covered by the legacy ts0601_garage.py quirk.
+
+Devices:
+  - _TZE608_c75zqghm (TS0603) — single toggle button, inverted door contact
+  - _TZE608_fmemczv1 (TS0603) — single toggle button, inverted door contact
+
+TS0601 variants (_TZE200_nklqjk62, _TZE204_nklqjk62, _TZE284_nklqjk62) are
+handled by the legacy ts0601_garage.py quirk.
+"""
+
+from zigpy.quirks.v2 import BinarySensorDeviceClass, EntityPlatform, EntityType
+from zigpy.quirks.v2.homeassistant import UnitOfTime
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
+import zigpy.types as t
+
+from zhaquirks.tuya import TUYA_CLUSTER_ID
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+
+class TuyaDoorAlarm(t.enum8):
+    """Tuya garage door alarm status enum."""
+
+    Open_time_alarm = 0x00
+    Run_time_alarm = 0x01
+    Normal = 0x02
+
+
+(
+    TuyaQuirkBuilder("_TZE608_c75zqghm", "TS0603")
+    .applies_to("_TZE608_fmemczv1", "TS0603")
+    .tuya_dp_attribute(
+        dp_id=1,
+        attribute_name="garage_door_trigger",
+        type=t.Bool,
+    )
+    .write_attr_button(
+        attribute_name="garage_door_trigger",
+        entity_type=EntityType.STANDARD,
+        cluster_id=TUYA_CLUSTER_ID,
+        attribute_value=True,
+        translation_key="toggle_door",
+        fallback_name="Toggle door",
+    )
+    .tuya_number(
+        dp_id=2,
+        attribute_name="relay_countdown",
+        type=t.uint32_t,
+        min_value=0,
+        max_value=43200,
+        step=1,
+        device_class=NumberDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        translation_key="relay_countdown",
+        fallback_name="Relay countdown",
+    )
+    .tuya_dp_attribute(
+        dp_id=3,
+        attribute_name="door_contact",
+        type=t.Bool,
+        dp_converter=lambda x: not x,
+    )
+    .binary_sensor(
+        attribute_name="door_contact",
+        cluster_id=TUYA_CLUSTER_ID,
+        entity_type=EntityType.STANDARD,
+        device_class=BinarySensorDeviceClass.GARAGE_DOOR,
+        translation_key="door_contact",
+        fallback_name="Door state",
+    )
+    .tuya_number(
+        dp_id=4,
+        attribute_name="run_time",
+        type=t.uint32_t,
+        min_value=0,
+        max_value=120,
+        step=1,
+        device_class=NumberDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        translation_key="run_time",
+        fallback_name="Run time",
+    )
+    .tuya_number(
+        dp_id=5,
+        attribute_name="open_alarm_time",
+        type=t.uint32_t,
+        min_value=0,
+        max_value=86400,
+        step=1,
+        device_class=NumberDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        translation_key="open_alarm_time",
+        fallback_name="Open alarm time",
+    )
+    .tuya_enum(
+        dp_id=12,
+        attribute_name="alarm",
+        enum_class=TuyaDoorAlarm,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="alarm",
+        fallback_name="Alarm",
+    )
+    .tuya_enchantment()
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Add v2 quirk (`TuyaQuirkBuilder`) support for TS0603-based Tuya garage door openers that are not covered by the existing legacy `ts0601_garage.py` quirk.

| Manufacturer | Model |
|---|---|
| `_TZE608_c75zqghm` | TS0603 |
| `_TZE608_fmemczv1` | TS0603 |

## Entities exposed

| DP | Entity | Type | Range |
|---|---|---|---|
| DP1 | Toggle door | button | — |
| DP2 | Relay countdown | number | 0–43200 s |
| DP3 | Door state | binary_sensor (`garage_door`) | inverted |
| DP4 | Run time | number | 0–120 s |
| DP5 | Open alarm time | number | 0–86400 s |
| DP12 | Alarm | enum sensor (diagnostic) | Open/Run/Normal |

## Additional information

**Why a new file (`tuya_garage_door.py`) instead of extending `ts0601_garage.py`:** the legacy quirk handles TS0601 variants (`_TZE200_nklqjk62`, `_TZE204_nklqjk62`, `_TZE284_nklqjk62`) via a v1 `CustomDevice` with manufacturer cluster replacement. TS0603 devices use a different DP layout and, per current repo practice, new Tuya devices are implemented with `TuyaQuirkBuilder` (v2) rather than extending legacy v1 files. TS0601 support stays untouched.

**DP3 inversion:** `dp_converter=lambda x: not x` — TS0603 hardware reports `True` when the magnet is present (gate closed). The `garage_door` binary sensor must show `on` when the gate is open/moving, so the DP value is inverted to match the device class semantics.

- No breaking changes
- Closes #3263
- Closes #4583

## Device diagnostics

- [`_TZE608_c75zqghm` / TS0603 (a4:c1:38:8f:c2:d3:91:ec)](https://github.com/FerrumLogic/zha-device-handlers/blob/diagnostics/diagnostics/5190_ts0603_TS0603_a4-c1-38-8f-c2-d3-91-ec.json) — currently matched by the legacy `_TZE200_wfxuhoea / TS0601` v2 quirk on the production instance (captured before this quirk was deployed), which also demonstrates why the dedicated TS0603 quirk is needed

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works — not applicable: definition-only v2 quirk, covered by the general quirks validation and ZHA diagnostics snapshots
- [x] Device diagnostics data has been attached
