### PR TITLE
Add Tuya TS0601 pressure/occupancy mat (_TZE200_seq9cm6u)

### DIFF
--- a/zhaquirks/tuya/tuya_pressure_mat.py
+++ b/zhaquirks/tuya/tuya_pressure_mat.py
@@ -1,78 +1,27 @@
 """Custom ZHA Quirk for Tuya TS0601 _TZE200_seq9cm6u Pressure/Occupancy Mat."""
 
-from zigpy.profiles import zha
-from zigpy.quirks import CustomDevice
-from zigpy.zcl.clusters.general import Basic, Ota, Time
 from zigpy.zcl.clusters.measurement import OccupancySensing
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.mcu import TuyaPowerConfigurationCluster
 
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
+(
+    TuyaQuirkBuilder("_TZE200_seq9cm6u", "TS0601")
+    .applies_to(
+        b_input_clusters=[0x0000, 0xEF00],
+        b_output_clusters=[0x000A, 0x0019],
+    )
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=OccupancySensing.ep_attribute,
+        attribute_name="occupancy",
+        converter=lambda x: not x,
+    )
+    .tuya_dp(
+        dp_id=4,
+        ep_attribute=TuyaPowerConfigurationCluster.ep_attribute,
+        attribute_name="battery_percentage_remaining",
+    )
+    .adds(OccupancySensing)
+    .adds(TuyaPowerConfigurationCluster)
+    .add_to_registry()
 )
-from zhaquirks.tuya import TuyaLocalCluster
-from zhaquirks.tuya.mcu import (
-    DPToAttributeMapping,
-    TuyaMCUCluster,
-    TuyaPowerConfigurationCluster,
-)
-
-
-class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
-    """Tuya local OccupancySensing cluster."""
-
-
-class TuyaBedOccupancyMCUCluster(TuyaMCUCluster):
-    """Tuya MCU Cluster for Bed Occupancy."""
-
-    dp_to_attribute: dict[int, DPToAttributeMapping] = {
-        1: DPToAttributeMapping(
-            TuyaOccupancySensing.ep_attribute,
-            "occupancy",
-            converter=lambda x: not x,
-        ),
-        4: DPToAttributeMapping(
-            TuyaPowerConfigurationCluster.ep_attribute,
-            "battery_percentage_remaining",
-        ),
-    }
-
-    data_point_handlers = {
-        1: "_dp_2_attr_update",
-        4: "_dp_2_attr_update",
-    }
-
-
-class TuyaPressureMat(CustomDevice):
-    """Tuya pressure mat replacement."""
-
-    signature = {
-        MODELS_INFO: [("_TZE200_seq9cm6u", "TS0601")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: 0x0104,
-                DEVICE_TYPE: 0x000C,
-                INPUT_CLUSTERS: [0x0000, 0xEF00],
-                OUTPUT_CLUSTERS: [0x000A, 0x0019],
-            }
-        },
-    }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    TuyaBedOccupancyMCUCluster,
-                    TuyaPowerConfigurationCluster,
-                    TuyaOccupancySensing,
-                ],
-                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
-            }
-        }
-    }

--- a/zhaquirks/tuya/tuya_pressure_mat.py
+++ b/zhaquirks/tuya/tuya_pressure_mat.py
@@ -1,0 +1,77 @@
+"""Custom ZHA Quirk for Tuya TS0601 _TZE200_seq9cm6u Pressure/Occupancy Mat."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import Basic, Ota, Time
+from zigpy.zcl.clusters.measurement import OccupancySensing
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+from zhaquirks.tuya import TuyaLocalCluster
+from zhaquirks.tuya.mcu import (
+    DPToAttributeMapping,
+    TuyaMCUCluster,
+    TuyaPowerConfigurationCluster,
+)
+
+
+class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
+    """Tuya local OccupancySensing cluster."""
+
+
+class TuyaBedOccupancyMCUCluster(TuyaMCUCluster):
+    """Tuya MCU Cluster for Bed Occupancy."""
+
+    dp_to_attribute: dict[int, DPToAttributeMapping] = {
+        1: DPToAttributeMapping(
+            TuyaOccupancySensing.ep_attribute,
+            "occupancy",
+            converter=lambda x: not x,
+        ),
+        4: DPToAttributeMapping(
+            TuyaPowerConfigurationCluster.ep_attribute,
+            "battery_percentage_remaining",
+        ),
+    }
+
+    data_point_handlers = {
+        1: "_dp_2_attr_update",
+        4: "_dp_2_attr_update",
+    }
+
+
+class TuyaPressureMat(CustomDevice):
+    """Tuya pressure mat replacement."""
+
+    signature = {
+        MODELS_INFO: [("_TZE200_seq9cm6u", "TS0601")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: 0x0104,
+                DEVICE_TYPE: 0x000C,
+                INPUT_CLUSTERS: [0x0000, 0xEF00],
+                OUTPUT_CLUSTERS: [0x000A, 0x0019],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    TuyaBedOccupancyMCUCluster,
+                    TuyaPowerConfigurationCluster,
+                    TuyaOccupancySensing,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            }
+        }
+    }

--- a/zhaquirks/tuya/tuya_pressure_mat.py
+++ b/zhaquirks/tuya/tuya_pressure_mat.py
@@ -1,4 +1,5 @@
 """Custom ZHA Quirk for Tuya TS0601 _TZE200_seq9cm6u Pressure/Occupancy Mat."""
+
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import Basic, Ota, Time

--- a/zhaquirks/tuya/tuya_pressure_mat.py
+++ b/zhaquirks/tuya/tuya_pressure_mat.py
@@ -1,6 +1,7 @@
 """Custom ZHA Quirk for Tuya TS0601 _TZE200_seq9cm6u Pressure/Occupancy Mat."""
 
 from zigpy.zcl.clusters.measurement import OccupancySensing
+
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zhaquirks.tuya.mcu import TuyaPowerConfigurationCluster
 

--- a/zhaquirks/tuya/tuya_pressure_mat.py
+++ b/zhaquirks/tuya/tuya_pressure_mat.py
@@ -1,16 +1,11 @@
 """Custom ZHA Quirk for Tuya TS0601 _TZE200_seq9cm6u Pressure/Occupancy Mat."""
 
 from zigpy.zcl.clusters.measurement import OccupancySensing
-
 from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zhaquirks.tuya.mcu import TuyaPowerConfigurationCluster
 
 (
     TuyaQuirkBuilder("_TZE200_seq9cm6u", "TS0601")
-    .applies_to(
-        b_input_clusters=[0x0000, 0xEF00],
-        b_output_clusters=[0x000A, 0x0019],
-    )
     .tuya_dp(
         dp_id=1,
         ep_attribute=OccupancySensing.ep_attribute,


### PR DESCRIPTION
## Proposed change
<!--
  Support for bed/couch/chair pressure mat/sensor
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
