### PR TITLE
Remove legacy Bus routing and restore masked Tuya updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,6 @@ Now that we got that out of the way we can focus on the task at hand: make our d
 class Plug(XiaomiCustomDevice):
     """lumi.plug.maus01 plug."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.voltage_bus = Bus()
-        self.consumption_bus = Bus()
-        self.power_bus = Bus()
-        super().__init__(*args, **kwargs)
-
     signature = {
         MODELS_INFO: [(LUMI, "lumi.plug.maus01")],
         ENDPOINTS: {
@@ -277,21 +270,14 @@ class Plug(XiaomiCustomDevice):
 
 This quirk is for the US version of the Xiaomi plug. Xiaomi is notorious for not following the Zigbee specifications and most of their non Zigbee 3.0 devices need a quirk to function correctly. In this case we are correcting the `ElectricalMeasurement` cluster readings. Xiaomi decided to report the values for this cluster on the `AnalogInput` cluster instead. To fix this we will create a custom cluster to replace the `AnalogInput` and `ElectricalMeasurement` clusters. We will take the values that are reported on the `AnalogInput` cluster and publish them to the `ElectricalMeasurement` cluster. Doing this allows the device to work as if Xiaomi had implemented this in the first place. This is the act of translating that was mentioned in the Google Translate analogy above.
 
-First things first. All device definitions in quirks must extend `CustomDevice` or a derivative of it and all clusters that you define must extend `CustomCluster` or a derivative of it. If you want to send messages between `CustomCluster` definitions as we do here you need to create channels for the communication to flow through. We do this by adding instances of `Bus` on our `CustomDevice` implementation. `Bus` is a utility class used specifically for this purpose and adding it to the device implementation ensures that all clusters that you define will have access to the `Bus` so that they can communicate with each other.
+First things first. All device definitions in quirks must extend `CustomDevice` or a derivative of it and all clusters that you define must extend `CustomCluster` or a derivative of it. Clusters that need to relay data should call the destination cluster directly through their endpoint and device. Resolve the destination when the report or command is handled, after all replacement clusters have been constructed.
 
 ```python
 class Plug(XiaomiCustomDevice):
     """lumi.plug.maus01 plug."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.voltage_bus = Bus()
-        self.consumption_bus = Bus()
-        self.power_bus = Bus()
-        super().__init__(*args, **kwargs)
 ```
 
-You can see that we have extended `XiaomiCustomDevice` which is a derivative of `CustomDevice` shared by Xiaomi devices. You can also see that we have added some instances of `Bus` so that we can pass messages between `CustomCluster` definitions. To be clear, this is not always necessary. Quirks can be used to change formats of data on an existing cluster, to add manufacturer specific attributes or commands to clusters etc. In these instances you just need to create a derivative of `CustomCluster` and add your logic. This is more of an advanced example to illustrate what is possible.
+Here `Plug` extends `XiaomiCustomDevice`, a `CustomDevice` derivative shared by Xiaomi devices. No device-level communication objects are required. The source cluster can reach a server cluster on the same endpoint with `self.endpoint.<ep_attribute>`. For a different endpoint, use `self.endpoint.device.endpoints[endpoint_id].<ep_attribute>`. Client clusters must be resolved through `self.endpoint.out_clusters[cluster_id]` so cluster direction remains correct.
 
 Here are the custom cluster definitions:
 
@@ -309,7 +295,9 @@ class AnalogInputCluster(CustomCluster, AnalogInput):
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
         if value is not None and value >= 0:
-            self.endpoint.device.power_bus.listener_event(POWER_REPORTED, value)
+            self.endpoint.device.endpoints[1].electrical_measurement.power_reported(
+                value
+            )
 
 
 class ElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
@@ -319,13 +307,6 @@ class ElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
     POWER_ID = 0x050B
     VOLTAGE_ID = 0x0500
     CONSUMPTION_ID = 0x0304
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.voltage_bus.add_listener(self)
-        self.endpoint.device.consumption_bus.add_listener(self)
-        self.endpoint.device.power_bus.add_listener(self)
 
     def power_reported(self, value):
         """Power reported."""
@@ -340,15 +321,11 @@ class ElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
         self._update_attribute(self.CONSUMPTION_ID, value)
 ```
 
-In the `AnalogInput` cluster we override the `_update_attribute` method so that we can access the data that the cluster receives when the device sends a report and we send the data via an event on a bus to the `ElectricalMeasurement` cluster. This is the line that does the heavy lifting:
+In the `AnalogInput` cluster we override `_update_attribute` so that we can access the data when the device sends a report, then call the `ElectricalMeasurement` cluster on endpoint 1 directly. This line does the heavy lifting:
 
-`self.endpoint.device.power_bus.listener_event(POWER_REPORTED, value)`
+`self.endpoint.device.endpoints[1].electrical_measurement.power_reported(value)`
 
-Then in the `ElectricalMeasurement` cluster we need to subscribe to these events and handle them. This is how we subscribe to our custom events:
-
-`self.endpoint.device.power_bus.add_listener(self)`
-
-and this method (the method name must match the event name that you publish EXACTLY):
+The destination method handles updating the attribute on the correct Zigbee cluster:
 
 ```python
 def power_reported(self, value):
@@ -356,7 +333,7 @@ def power_reported(self, value):
     self._update_attribute(self.POWER_ID, value)
 ```
 
-receives the event and handles updating the attribute on the correct zigbee cluster. As you can see there really isn't much here that needs to be done to accomplish our goal.
+For cross-endpoint relays, resolve the destination through `self.endpoint.device.endpoints[...]`. Do not cache destination clusters in a cluster constructor because replacement endpoints and clusters may not yet exist. For output clusters, use `self.endpoint.out_clusters[...]` instead of endpoint attributes.
 
 Once we have created our `CustomCluster` implementations we have to tell the `CustomDevice` implementation to use them. We do this in the `replacement` dict in the quirk definition. Start by copying the `signature` dict and remove the `models_info` from it. Then we replace the cluster ids that we want to override with the names of our `CustomCluster` implementations that we have created. The result looks like this:
 

--- a/README.md
+++ b/README.md
@@ -335,6 +335,17 @@ def power_reported(self, value):
 
 For cross-endpoint relays, resolve the destination through `self.endpoint.device.endpoints[...]`. Do not cache destination clusters in a cluster constructor because replacement endpoints and clusters may not yet exist. For output clusters, use `self.endpoint.out_clusters[...]` instead of endpoint attributes.
 
+#### Migrating custom quirks from legacy Bus routing
+
+The top-level `zhaquirks.Bus` helper and the Tuya `TUYA_MCU_COMMAND`, `SWITCH_EVENT`, `LEVEL_EVENT`, and `COVER_EVENT` constants are no longer available. Device-level attributes such as `command_bus`, `switch_bus`, and other legacy `*_bus` routing channels are likewise no longer created. Custom quirks using those interfaces must route to concrete clusters instead:
+
+- For a server/input cluster on the same endpoint, call `self.endpoint.<ep_attribute>.<method>(...)`.
+- For a server/input cluster on another endpoint, call `self.endpoint.device.endpoints[endpoint_id].<ep_attribute>.<method>(...)`.
+- For a client/output cluster, resolve it from `self.endpoint.out_clusters[ClusterClass.cluster_id]`.
+- For a Tuya local cluster sending an MCU command, place the physical EF00 input cluster on endpoint 1 and route through `get_tuya_mcu_cluster(self.endpoint).tuya_mcu_command(...)`.
+
+Resolve the destination when the report or command is handled. An import-only compatibility alias would not preserve the old runtime device attributes or listener registrations, so legacy custom quirks must be migrated as a unit.
+
 Once we have created our `CustomCluster` implementations we have to tell the `CustomDevice` implementation to use them. We do this in the `replacement` dict in the quirk definition. Start by copying the `signature` dict and remove the `models_info` from it. Then we replace the cluster ids that we want to override with the names of our `CustomCluster` implementations that we have created. The result looks like this:
 
 ```python

--- a/tests/test_cluster_routing.py
+++ b/tests/test_cluster_routing.py
@@ -1,0 +1,352 @@
+"""Tests for direct routing between custom clusters."""
+
+import asyncio
+from unittest import mock
+
+import pytest
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.closures import DoorLock
+from zigpy.zcl.clusters.general import LevelControl, OnOff, PowerConfiguration, Scenes
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
+from zigpy.zcl.clusters.measurement import PM25
+
+from tests.common import ZCL_IAS_MOTION_COMMAND, ClusterListener
+import zhaquirks
+from zhaquirks.adeo.color_controller import (
+    SCENE_NO_GROUP,
+    AdeoColorController,
+    AdeoManufacturerCluster,
+)
+from zhaquirks.const import COMMAND_OFF, COMMAND_ON, COMMAND_STEP, OFF, ON
+from zhaquirks.elko.smart_super_thermostat import (
+    CHILD_LOCK,
+    HEATING_ACTIVE,
+    POWER_CONSUMPTION,
+    ElkoSuperTRThermostat,
+)
+from zhaquirks.ikea.starkvind import IkeaAirpurifier, IkeaSTARKVIND, IkeaSTARKVIND_v2
+from zhaquirks.konke.motion import KonkeMotion
+from zhaquirks.mli.tint import TINT_SCENE_ATTR, TintRemote
+from zhaquirks.sengled.e1e_g7f import (
+    SengledE1EG7F,
+    SengledE1EG7FManufacturerSpecificCluster,
+)
+from zhaquirks.smartthings.tag_v4 import SmartThingsTagV4
+from zhaquirks.terncy import TerncyRawCluster
+from zhaquirks.terncy.pp01 import TerncyAwarenessSwitch
+from zhaquirks.tuya.ts0210 import TuyaVibration, TuyaVibration_TO
+from zhaquirks.waxman.leaksmart import WAXMANleakSMARTv2, WAXMANleakSMARTv2NOPOLL
+from zhaquirks.xiaomi.aqara.vibration_aq1 import (
+    DROP_VALUE,
+    ORIENTATION_ATTR,
+    RECENT_ACTIVITY_LEVEL_ATTR,
+    ROTATION_DEGREES_ATTR,
+    STATUS_TYPE_ATTR,
+    VIBE_VALUE,
+    VibrationAQ1,
+)
+from zhaquirks.zhongxing.motion import SN10ZW
+
+zhaquirks.setup()
+
+
+@pytest.mark.parametrize("preset", (1, 2, 3, 4))
+def test_adeo_preset_routes_to_output_scenes(zigpy_device_from_quirk, preset):
+    """Adeo preset commands must originate from the output Scenes cluster."""
+    device = zigpy_device_from_quirk(AdeoColorController)
+    source = device.endpoints[1].out_clusters[AdeoManufacturerCluster.cluster_id]
+    scenes = device.endpoints[1].out_clusters[Scenes.cluster_id]
+    listener = mock.MagicMock()
+    scenes.add_listener(listener)
+
+    source.handle_cluster_request(mock.Mock(command_id=0), [preset, 0])
+
+    listener.zha_send_event.assert_called_once_with("view", [SCENE_NO_GROUP, preset])
+
+
+def test_tint_scene_write_routes_to_output_scenes(zigpy_device_from_quirk):
+    """Tint's manufacturer attribute must update its output Scenes cluster."""
+    device = zigpy_device_from_quirk(TintRemote)
+    source = device.endpoints[1].basic
+    scenes = device.endpoints[1].out_clusters[Scenes.cluster_id]
+    attribute = mock.Mock(attrid=TINT_SCENE_ATTR)
+    attribute.value.value = 3
+
+    source.handle_cluster_general_request(
+        mock.Mock(command_id=foundation.GeneralCommand.Write_Attributes),
+        [[attribute]],
+    )
+
+    assert scenes.get(Scenes.AttributeDefs.current_scene.name) == 3
+
+    attribute.value.value = 4
+    source.handle_cluster_general_request(mock.Mock(command_id=0), [[attribute]])
+    source.handle_cluster_general_request(
+        mock.Mock(command_id=foundation.GeneralCommand.Write_Attributes),
+        [[mock.Mock(attrid=TINT_SCENE_ATTR + 1)]],
+    )
+    assert scenes.get(Scenes.AttributeDefs.current_scene.name) == 3
+
+
+@pytest.mark.parametrize(
+    ("action", "step_size", "target_cluster_id", "command", "args"),
+    (
+        (1, 0, OnOff.cluster_id, COMMAND_ON, []),
+        (2, 2, LevelControl.cluster_id, COMMAND_STEP, [0, 2, 0]),
+        (2, 1, LevelControl.cluster_id, COMMAND_STEP, [0, 1, 0]),
+        (3, 2, LevelControl.cluster_id, COMMAND_STEP, [1, 2, 0]),
+        (3, 1, LevelControl.cluster_id, COMMAND_STEP, [1, 1, 0]),
+        (4, 0, OnOff.cluster_id, COMMAND_OFF, []),
+        (5, 0, OnOff.cluster_id, "on_double", []),
+        (6, 0, OnOff.cluster_id, "on_long", []),
+        (7, 0, OnOff.cluster_id, "off_double", []),
+        (8, 0, OnOff.cluster_id, "off_long", []),
+    ),
+)
+def test_sengled_actions_route_to_output_clusters(
+    zigpy_device_from_quirk,
+    action,
+    step_size,
+    target_cluster_id,
+    command,
+    args,
+):
+    """Sengled actions must retain their output-cluster event provenance."""
+    device = zigpy_device_from_quirk(SengledE1EG7F)
+    endpoint = device.endpoints[1]
+    source = endpoint.out_clusters[SengledE1EG7FManufacturerSpecificCluster.cluster_id]
+    on_off_listener = mock.MagicMock()
+    level_listener = mock.MagicMock()
+    endpoint.out_clusters[OnOff.cluster_id].add_listener(on_off_listener)
+    endpoint.out_clusters[LevelControl.cluster_id].add_listener(level_listener)
+
+    source.handle_cluster_request(mock.Mock(command_id=0), [action, 0, step_size, 0])
+
+    target_listener = (
+        on_off_listener if target_cluster_id == OnOff.cluster_id else level_listener
+    )
+    other_listener = (
+        level_listener if target_cluster_id == OnOff.cluster_id else on_off_listener
+    )
+    target_listener.zha_send_event.assert_called_once_with(command, args)
+    other_listener.zha_send_event.assert_not_called()
+
+
+async def test_terncy_motion_routes_by_side_and_updates_occupancy(
+    zigpy_device_from_quirk,
+):
+    """Terncy raw reports must select the correct IAS endpoint."""
+    device = zigpy_device_from_quirk(TerncyAwarenessSwitch)
+    raw = device.endpoints[1].in_clusters[TerncyRawCluster.cluster_id]
+    left = device.endpoints[1].ias_zone
+    right = device.endpoints[2].ias_zone
+    occupancy = device.endpoints[1].occupancy
+    left_listener = ClusterListener(left)
+    right_listener = ClusterListener(right)
+    occupancy_listener = ClusterListener(occupancy)
+
+    with (
+        mock.patch.object(left, "reset_s", 0),
+        mock.patch.object(right, "reset_s", 0),
+        mock.patch.object(occupancy, "reset_s", 0),
+    ):
+        raw.handle_cluster_request(mock.Mock(command_id=4), [0, 0, 40])
+        await asyncio.sleep(0.05)
+        raw.handle_cluster_request(mock.Mock(command_id=4), [0, 0, 5])
+        await asyncio.sleep(0.05)
+
+    assert [command[2][0] for command in left_listener.cluster_commands] == [ON, OFF]
+    assert [command[2][0] for command in right_listener.cluster_commands] == [ON, OFF]
+    assert occupancy_listener.attribute_updates == [
+        (0, 1),
+        (0, 0),
+        (0, 1),
+        (0, 0),
+    ]
+
+
+async def test_zhongxing_motion_does_not_require_occupancy(
+    zigpy_device_from_quirk,
+):
+    """Zhongxing motion reports must work without an occupancy cluster."""
+    device = zigpy_device_from_quirk(SN10ZW)
+    motion = device.endpoints[1].ias_zone
+    listener = ClusterListener(motion)
+    hdr, args = motion.deserialize(ZCL_IAS_MOTION_COMMAND)
+
+    with mock.patch.object(motion, "reset_s", 0):
+        motion.handle_message(hdr, args)
+        await asyncio.sleep(0.05)
+
+    assert not hasattr(device.endpoints[1], "occupancy")
+    assert [command[2][0] for command in listener.cluster_commands] == [ON, OFF]
+
+
+async def test_direct_motion_retrigger_cancels_the_first_reset(
+    zigpy_device_from_quirk,
+):
+    """A retrigger must postpone both motion and occupancy reset timers."""
+    device = zigpy_device_from_quirk(KonkeMotion)
+    motion = device.endpoints[1].ias_zone
+    occupancy = device.endpoints[1].occupancy
+    motion_listener = ClusterListener(motion)
+    occupancy_listener = ClusterListener(occupancy)
+    hdr, args = motion.deserialize(ZCL_IAS_MOTION_COMMAND)
+
+    with (
+        mock.patch.object(motion, "reset_s", 0.1),
+        mock.patch.object(occupancy, "reset_s", 0.1),
+    ):
+        motion.handle_message(hdr, args)
+        await asyncio.sleep(0.03)
+        motion.handle_message(hdr, args)
+        await asyncio.sleep(0.08)
+
+        assert [command[2][0] for command in motion_listener.cluster_commands] == [
+            ON,
+            ON,
+        ]
+        assert occupancy_listener.attribute_updates == [(0, 1), (0, 1)]
+
+        await asyncio.sleep(0.06)
+
+    assert [command[2][0] for command in motion_listener.cluster_commands] == [
+        ON,
+        ON,
+        OFF,
+    ]
+    assert occupancy_listener.attribute_updates == [(0, 1), (0, 1), (0, 0)]
+
+
+def test_smartthings_battery_report_updates_tracking_cluster(
+    zigpy_device_from_quirk,
+):
+    """SmartThings battery reports must update the co-resident tracking cluster."""
+    device = zigpy_device_from_quirk(SmartThingsTagV4)
+    power = device.endpoints[1].power
+    tracking = device.endpoints[1].binary_input
+    tracking_listener = ClusterListener(tracking)
+
+    power.update_attribute(PowerConfiguration.AttributeDefs.battery_voltage.id, 30)
+
+    assert tracking_listener.attribute_updates == [(0, 1)]
+    assert power.get(PowerConfiguration.AttributeDefs.battery_voltage.name) == 30
+
+
+@pytest.mark.parametrize("quirk", (WAXMANleakSMARTv2, WAXMANleakSMARTv2NOPOLL))
+def test_waxman_alerts_route_to_emulated_ias(zigpy_device_from_quirk, quirk):
+    """Waxman wet and dry reports must be emitted by the emulated IAS cluster."""
+    device = zigpy_device_from_quirk(quirk)
+    source = device.endpoints[1].appliance_event
+    target = device.endpoints[1].ias_zone
+    listener = ClusterListener(target)
+
+    source.handle_cluster_request(mock.Mock(command_id=1), [0, 0x1000])
+    source.handle_cluster_request(mock.Mock(command_id=1), [0, 0])
+    source.handle_cluster_request(mock.Mock(command_id=2), [0, 0x1000])
+
+    assert [command[2] for command in listener.cluster_commands] == [[True], [False]]
+
+
+def test_elko_reports_route_to_standard_clusters(zigpy_device_from_quirk):
+    """Elko manufacturer attributes must update standard thermostat clusters."""
+    device = zigpy_device_from_quirk(ElkoSuperTRThermostat)
+    thermostat = device.endpoints[1].thermostat
+    ui = device.endpoints[1].thermostat_ui
+    electrical = device.endpoints[1].electrical_measurement
+
+    thermostat.update_attribute(HEATING_ACTIVE, 1)
+    assert thermostat.get(Thermostat.AttributeDefs.running_mode.name) == 4
+    assert thermostat.get(Thermostat.AttributeDefs.running_state.name) == 1
+    thermostat.update_attribute(HEATING_ACTIVE, 0)
+    assert thermostat.get(Thermostat.AttributeDefs.running_mode.name) == 0
+    assert thermostat.get(Thermostat.AttributeDefs.running_state.name) == 0
+
+    thermostat.update_attribute(CHILD_LOCK, 1)
+    assert ui.get(UserInterface.AttributeDefs.keypad_lockout.name) == 1
+    thermostat.update_attribute(CHILD_LOCK, 0)
+    assert ui.get(UserInterface.AttributeDefs.keypad_lockout.name) == 0
+
+    thermostat.update_attribute(POWER_CONSUMPTION, 42)
+    thermostat.update_attribute(POWER_CONSUMPTION, -1)
+    assert electrical.get(ElectricalMeasurement.AttributeDefs.active_power.name) == 42
+
+
+@pytest.mark.parametrize("quirk", (IkeaSTARKVIND, IkeaSTARKVIND_v2))
+def test_starkvind_pm25_reports_route_to_pm25_cluster(zigpy_device_from_quirk, quirk):
+    """Valid Starkvind manufacturer reports must update the PM2.5 cluster."""
+    device = zigpy_device_from_quirk(quirk)
+    source = device.endpoints[1].in_clusters[IkeaAirpurifier.cluster_id]
+    target = device.endpoints[1].in_clusters[PM25.cluster_id]
+
+    for value in (0, 42, 5499):
+        source.update_attribute(
+            IkeaAirpurifier.AttributeDefs.air_quality_25pm.id, value
+        )
+        assert target.get(PM25.AttributeDefs.measured_value.name) == value
+
+    for value in (5500, 65535, None):
+        source.update_attribute(
+            IkeaAirpurifier.AttributeDefs.air_quality_25pm.id, value
+        )
+        assert target.get(PM25.AttributeDefs.measured_value.name) == 5499
+
+
+@pytest.mark.parametrize("quirk", (TuyaVibration, TuyaVibration_TO))
+async def test_tuya_vibration_report_triggers_motion(zigpy_device_from_quirk, quirk):
+    """TS0210 source requests must trigger their IAS motion cluster directly."""
+    device = zigpy_device_from_quirk(quirk)
+    motion = device.endpoints[1].ias_zone
+    listener = ClusterListener(motion)
+
+    with mock.patch.object(motion, "reset_s", 0):
+        motion.handle_cluster_request(mock.Mock(command_id=0), ())
+        await asyncio.sleep(0.05)
+
+    assert [command[2][0] for command in listener.cluster_commands] == [ON, OFF]
+
+
+async def test_xiaomi_vibration_routes_motion_and_named_events(
+    zigpy_device_from_quirk,
+):
+    """Xiaomi vibration reports must reach the co-resident IAS cluster."""
+    device = zigpy_device_from_quirk(VibrationAQ1)
+    source = device.endpoints[1].in_clusters[DoorLock.cluster_id]
+    motion = device.endpoints[1].ias_zone
+    motion_listener = ClusterListener(motion)
+    event_listener = mock.MagicMock()
+    motion.add_listener(event_listener)
+
+    with mock.patch.object(motion, "reset_s", 0):
+        source.update_attribute(STATUS_TYPE_ATTR, VIBE_VALUE)
+        await asyncio.sleep(0.05)
+
+    assert [command[2][0] for command in motion_listener.cluster_commands] == [ON, OFF]
+
+    source.update_attribute(STATUS_TYPE_ATTR, DROP_VALUE)
+    source.update_attribute(ROTATION_DEGREES_ATTR, 12)
+    source.update_attribute(ORIENTATION_ATTR, 1 | (2 << 16) | (3 << 32))
+    source.update_attribute(RECENT_ACTIVITY_LEVEL_ATTR, 0x341200)
+
+    assert event_listener.zha_send_event.call_args_list == [
+        mock.call("Drop", {}),
+        mock.call("Drop", {"degrees": 12}),
+        mock.call(
+            "current_orientation",
+            {
+                "rawValueX": 1,
+                "rawValueY": 2,
+                "rawValueZ": 3,
+                "X": 16,
+                "Y": 32,
+                "Z": 53,
+            },
+        ),
+        mock.call("vibration_strength", {"strength": 0x1234}),
+    ]
+
+    event_listener.reset_mock()
+    source.update_attribute(STATUS_TYPE_ATTR, 0)
+    source.update_attribute(STATUS_TYPE_ATTR, 99)
+    event_listener.zha_send_event.assert_not_called()

--- a/tests/test_cluster_routing.py
+++ b/tests/test_cluster_routing.py
@@ -133,6 +133,13 @@ def test_sengled_actions_route_to_output_clusters(
     other_listener.zha_send_event.assert_not_called()
 
 
+def test_sengled_unknown_action_does_not_resolve_output_clusters(device_mock):
+    """Unknown Sengled actions must remain inert without requiring output clusters."""
+    source = SengledE1EG7FManufacturerSpecificCluster(device_mock.endpoints[1])
+
+    source.handle_cluster_request(mock.Mock(command_id=0), [99, 0, 0, 0])
+
+
 async def test_terncy_motion_routes_by_side_and_updates_occupancy(
     zigpy_device_from_quirk,
 ):

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import ast
 import collections
 import importlib
 import json
 from pathlib import Path
+import re
 from unittest import mock
 
 import pytest
@@ -74,6 +76,61 @@ del quirk, model_quirk_list, manufacturer
 
 
 ALL_ZIGPY_CLUSTERS = frozenset(zcl.clusters.CLUSTERS_BY_NAME.values())
+
+
+def test_no_legacy_bus_usage():
+    """Prevent reintroduction of the removed cluster-routing mechanism."""
+    source_root = Path(zhaquirks.__file__).parent
+    violations = []
+
+    for path in source_root.rglob("*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            name = None
+            if isinstance(node, ast.ClassDef):
+                name = node.name
+            elif isinstance(node, ast.Name):
+                name = node.id
+            elif isinstance(node, ast.Attribute):
+                name = node.attr
+            elif isinstance(node, ast.arg):
+                name = node.arg
+            elif isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    for imported_name in (alias.name, alias.asname):
+                        if imported_name == "Bus" or (
+                            imported_name is not None and imported_name.endswith("_bus")
+                        ):
+                            violations.append(
+                                f"{path.relative_to(source_root.parent)}:{node.lineno}:"
+                                f" {imported_name}"
+                            )
+
+            if name == "Bus" or (name is not None and name.endswith("_bus")):
+                violations.append(
+                    f"{path.relative_to(source_root.parent)}:{node.lineno}: {name}"
+                )
+
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id in {"getattr", "setattr", "hasattr"}
+                and len(node.args) >= 2
+                and isinstance(node.args[1], ast.Constant)
+                and isinstance(node.args[1].value, str)
+                and node.args[1].value.endswith("_bus")
+            ):
+                violations.append(
+                    f"{path.relative_to(source_root.parent)}:{node.lineno}: "
+                    f"{node.args[1].value}"
+                )
+
+    readme = source_root.parent / "README.md"
+    old_readme_patterns = re.findall(
+        r"\bBus\b|\b[A-Za-z_][A-Za-z0-9_]*_bus\b", readme.read_text()
+    )
+    assert not violations
+    assert not old_readme_patterns
 
 
 SIGNATURE_ALLOWED = {

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -77,60 +77,138 @@ del quirk, model_quirk_list, manufacturer
 
 ALL_ZIGPY_CLUSTERS = frozenset(zcl.clusters.CLUSTERS_BY_NAME.values())
 
+LEGACY_BUS_IDENTIFIERS = frozenset(
+    {
+        "Bus",
+        "COVER_EVENT",
+        "LEVEL_EVENT",
+        "SWITCH_EVENT",
+        "TUYA_MCU_COMMAND",
+        "battery_bus",
+        "boost_bus",
+        "change_fan_mode_bus",
+        "change_fan_mode_ha_bus",
+        "child_lock_bus",
+        "command_bus",
+        "consumption_bus",
+        "cover_bus",
+        "dimmer_bus",
+        "ias_bus",
+        "level_control_bus",
+        "motion_bus",
+        "motion_left_bus",
+        "motion_right_bus",
+        "occupancy_bus",
+        "on_off_bus",
+        "online_mode_bus",
+        "pm25_bus",
+        "power_bus",
+        "scene_bus",
+        "scenes_bus",
+        "switch_bus",
+        "temperature_calibration_bus",
+        "thermostat_bus",
+        "tracking_bus",
+        "ui_bus",
+        "voltage_bus",
+        "window_detection_bus",
+        "window_temperature_bus",
+    }
+)
+LEGACY_BUS_PATTERN = re.compile(
+    r"\b(?:"
+    + "|".join(re.escape(name) for name in sorted(LEGACY_BUS_IDENTIFIERS))
+    + r")\b"
+)
+
+
+def _legacy_bus_identifiers(tree: ast.AST) -> set[tuple[int, str]]:
+    """Return exact legacy Bus-routing identifiers used by an AST."""
+    violations: set[tuple[int, str]] = set()
+
+    for node in ast.walk(tree):
+        names: list[str | None] = []
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            names.append(node.name)
+        elif isinstance(node, ast.Name):
+            names.append(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.append(node.attr)
+        elif isinstance(node, (ast.arg, ast.keyword)):
+            names.append(node.arg)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                names.extend((alias.name.rsplit(".", 1)[-1], alias.asname))
+
+        for name in names:
+            if name in LEGACY_BUS_IDENTIFIERS:
+                violations.add((node.lineno, name))
+
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in {"getattr", "setattr", "hasattr"}
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+            and node.args[1].value in LEGACY_BUS_IDENTIFIERS
+        ):
+            violations.add((node.lineno, node.args[1].value))
+
+    return violations
+
+
+def test_legacy_bus_guard_uses_exact_identifiers():
+    """The guard must reject legacy routing without banning unrelated buses."""
+    unrelated = ast.parse(
+        "def route(can_bus, dali_bus=None):\n"
+        "    return getattr(can_bus, 'transport_bus', dali_bus)\n"
+    )
+    legacy = ast.parse(
+        "device.command_bus\n"
+        "getattr(device, 'switch_bus')\n"
+        "def send(TUYA_MCU_COMMAND=None):\n"
+        "    pass\n"
+    )
+
+    assert _legacy_bus_identifiers(unrelated) == set()
+    assert {name for _, name in _legacy_bus_identifiers(legacy)} == {
+        "TUYA_MCU_COMMAND",
+        "command_bus",
+        "switch_bus",
+    }
+
 
 def test_no_legacy_bus_usage():
     """Prevent reintroduction of the removed cluster-routing mechanism."""
     source_root = Path(zhaquirks.__file__).parent
-    violations = []
+    violations: list[str] = []
 
     for path in source_root.rglob("*.py"):
         tree = ast.parse(path.read_text(), filename=str(path))
-        for node in ast.walk(tree):
-            name = None
-            if isinstance(node, ast.ClassDef):
-                name = node.name
-            elif isinstance(node, ast.Name):
-                name = node.id
-            elif isinstance(node, ast.Attribute):
-                name = node.attr
-            elif isinstance(node, ast.arg):
-                name = node.arg
-            elif isinstance(node, (ast.Import, ast.ImportFrom)):
-                for alias in node.names:
-                    for imported_name in (alias.name, alias.asname):
-                        if imported_name == "Bus" or (
-                            imported_name is not None and imported_name.endswith("_bus")
-                        ):
-                            violations.append(
-                                f"{path.relative_to(source_root.parent)}:{node.lineno}:"
-                                f" {imported_name}"
-                            )
-
-            if name == "Bus" or (name is not None and name.endswith("_bus")):
-                violations.append(
-                    f"{path.relative_to(source_root.parent)}:{node.lineno}: {name}"
-                )
-
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Name)
-                and node.func.id in {"getattr", "setattr", "hasattr"}
-                and len(node.args) >= 2
-                and isinstance(node.args[1], ast.Constant)
-                and isinstance(node.args[1].value, str)
-                and node.args[1].value.endswith("_bus")
-            ):
-                violations.append(
-                    f"{path.relative_to(source_root.parent)}:{node.lineno}: "
-                    f"{node.args[1].value}"
-                )
+        for lineno, name in sorted(_legacy_bus_identifiers(tree)):
+            violations.append(
+                f"{path.relative_to(source_root.parent)}:{lineno}: {name}"
+            )
 
     readme = source_root.parent / "README.md"
-    old_readme_patterns = re.findall(
-        r"\bBus\b|\b[A-Za-z_][A-Za-z0-9_]*_bus\b", readme.read_text()
+    readme_text = readme.read_text()
+    for block in re.finditer(
+        r"```(?:python)?\n(?P<code>.*?)```",
+        readme_text,
+        flags=re.DOTALL,
+    ):
+        code = block.group("code")
+        first_line = readme_text.count("\n", 0, block.start("code")) + 1
+        for match in LEGACY_BUS_PATTERN.finditer(code):
+            lineno = first_line + code.count("\n", 0, match.start())
+            violations.append(f"README.md:{lineno}: {match.group()}")
+
+    assert not violations, (
+        "Legacy Bus routing is prohibited; route directly through endpoint input "
+        "clusters, endpoint.out_clusters, or device.endpoints instead:\n"
+        + "\n".join(violations)
     )
-    assert not violations
-    assert not old_readme_patterns
 
 
 SIGNATURE_ALLOWED = {

--- a/tests/test_tuya_direct_routing.py
+++ b/tests/test_tuya_direct_routing.py
@@ -27,7 +27,9 @@ from zhaquirks.tuya import (
     TUYA_GET_DATA,
     TUYA_LEVEL_COMMAND,
     TuyaLevelControl,
+    TuyaManufacturerClusterOnOff,
     TuyaManufacturerLevelControl,
+    TuyaOnOff,
 )
 from zhaquirks.tuya.ts0601_cover import (
     TuyaZemismartSmartCover0601,
@@ -67,6 +69,7 @@ from zhaquirks.tuya.ts0601_trv import (
     MOES_WINDOW_DETECT_ATTR,
     SITERWELL_BATTERY_ATTR,
     SITERWELL_CHILD_LOCK_ATTR,
+    SITERWELL_VALVE_STATE_ATTR,
     ZONNSMART_BATTERY_ATTR,
     ZONNSMART_BOOST_TIME_ATTR,
     ZONNSMART_CHILD_LOCK_ATTR,
@@ -150,6 +153,42 @@ def test_legacy_level_report_routes_to_level_clusters_without_visiting_zdo(
     assert (
         second_level_cluster.get(LevelControl.AttributeDefs.current_level.name) == 127
     )
+
+
+@pytest.mark.parametrize(
+    "manufacturer_cluster_type",
+    (TuyaManufacturerClusterOnOff, TuyaManufacturerLevelControl),
+)
+def test_legacy_switch_report_routes_to_matching_endpoint(
+    device_mock, manufacturer_cluster_type
+):
+    """Legacy switch reports must update only the endpoint named by the channel."""
+    first_endpoint = device_mock.endpoints[1]
+    manufacturer_cluster = manufacturer_cluster_type(first_endpoint)
+    first_on_off = TuyaOnOff(first_endpoint)
+    first_endpoint.add_input_cluster(
+        manufacturer_cluster.cluster_id, manufacturer_cluster
+    )
+    first_endpoint.add_input_cluster(OnOff.cluster_id, first_on_off)
+
+    second_endpoint = device_mock.add_endpoint(2)
+    second_on_off = TuyaOnOff(second_endpoint)
+    second_endpoint.add_input_cluster(OnOff.cluster_id, second_on_off)
+
+    payload = mock.Mock(
+        status=0,
+        tsn=1,
+        command_id=TUYA_CMD_BASE + second_endpoint.endpoint_id,
+        function=0,
+        data=[1, 1],
+    )
+    header = mock.Mock(command_id=TUYA_GET_DATA)
+    header.frame_control.disable_default_response = True
+
+    manufacturer_cluster.handle_cluster_request(header, [payload])
+
+    assert first_on_off.get(OnOff.AttributeDefs.on_off.name) is None
+    assert second_on_off.get(OnOff.AttributeDefs.on_off.name) == 1
 
 
 @pytest.mark.parametrize(
@@ -349,6 +388,24 @@ def test_siterwell_lock_and_battery_reports(zigpy_device_from_quirk, quirk):
 
     assert device.endpoints[1].thermostat_ui.get("keypad_lockout") == 1
     assert device.endpoints[1].power.get("battery_percentage_remaining") == 152
+
+
+@pytest.mark.parametrize("quirk", (SiterwellGS361_Type1, SiterwellGS361_Type2))
+def test_siterwell_valve_state_reports_update_running_state(
+    zigpy_device_from_quirk, quirk
+):
+    """Siterwell valve reports must drive thermostat running mode and state."""
+    device = zigpy_device_from_quirk(quirk)
+    source = device.endpoints[1].tuya_manufacturer
+    thermostat = device.endpoints[1].thermostat
+
+    source.update_attribute(SITERWELL_VALVE_STATE_ATTR, 50)
+    assert thermostat.get("running_mode") == Thermostat.RunningMode.Heat
+    assert thermostat.get("running_state") == Thermostat.RunningState.Heat_State_On
+
+    source.update_attribute(SITERWELL_VALVE_STATE_ATTR, 0)
+    assert thermostat.get("running_mode") == Thermostat.RunningMode.Off
+    assert thermostat.get("running_state") == Thermostat.RunningState.Idle
 
 
 @pytest.mark.parametrize("quirk", (MoesHY368_Type1new, MoesHY368_Type2))

--- a/tests/test_tuya_direct_routing.py
+++ b/tests/test_tuya_direct_routing.py
@@ -1,0 +1,435 @@
+"""Tests for direct routing between legacy Tuya clusters."""
+
+from unittest import mock
+
+import pytest
+import zigpy.types as t
+from zigpy.zcl.clusters.general import (
+    AnalogOutput,
+    BinaryInput,
+    LevelControl,
+    OnOff,
+    PowerConfiguration,
+)
+from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
+
+import zhaquirks
+from zhaquirks.tuya import (
+    ATTR_COVER_DIRECTION,
+    ATTR_COVER_INVERTED,
+    ATTR_COVER_POSITION,
+    TUYA_CMD_BASE,
+    TUYA_DP_ID_COVER_INVERTED,
+    TUYA_DP_ID_DIRECTION_CHANGE,
+    TUYA_DP_ID_PERCENT_STATE,
+    TUYA_DP_TYPE_ENUM,
+    TUYA_DP_TYPE_VALUE,
+    TUYA_GET_DATA,
+    TUYA_LEVEL_COMMAND,
+    TuyaLevelControl,
+    TuyaManufacturerLevelControl,
+)
+from zhaquirks.tuya.ts0601_cover import (
+    TuyaZemismartSmartCover0601,
+    TuyaZemismartSmartCover0601_inv_position,
+)
+from zhaquirks.tuya.ts0601_din_power import (
+    HIKING_DIN_SWITCH_ATTR,
+    TUYA_DIN_SWITCH_ATTR,
+    HikingPowerMeter,
+    TuyaPowerMeter,
+)
+from zhaquirks.tuya.ts0601_electric_heating import (
+    MOESBHT_CHILD_LOCK_ATTR,
+    MOESBHT_ENABLED_ATTR,
+    MOESBHT_MANUAL_MODE_ATTR,
+    MOESBHT_RUNNING_MODE_ATTR,
+    MOESBHT_SCHEDULE_MODE_ATTR,
+    MoesBHT,
+)
+from zhaquirks.tuya.ts0601_haozee import (
+    HAOZEE_AWAY_DAYS_ATTR,
+    HAOZEE_AWAY_TEMP_ATTR,
+    HAOZEE_CHILD_LOCK_ATTR,
+    HAOZEE_CURRENT_MODE_ATTR,
+    HAOZEE_CURRENT_ROOM_TEMP_ATTR,
+    HAOZEE_ENABLED_ATTR,
+    HAOZEE_HEATING_ENABLED_ATTR,
+    HAOZEE_MAX_TEMP_LIMIT_ATTR,
+    HAOZEE_MIN_TEMP_LIMIT_ATTR,
+    HAOZEE_TARGET_TEMP_ATTR,
+    HAOZEE_TEMP_CALIBRATION_ATTR,
+    HY08WE,
+)
+from zhaquirks.tuya.ts0601_trv import (
+    MOES_BATTERY_LOW_ATTR,
+    MOES_CHILD_LOCK_ATTR,
+    MOES_WINDOW_DETECT_ATTR,
+    SITERWELL_BATTERY_ATTR,
+    SITERWELL_CHILD_LOCK_ATTR,
+    ZONNSMART_BATTERY_ATTR,
+    ZONNSMART_BOOST_TIME_ATTR,
+    ZONNSMART_CHILD_LOCK_ATTR,
+    ZONNSMART_MAX_TEMPERATURE_VAL,
+    ZONNSMART_MIN_TEMPERATURE_VAL,
+    ZONNSMART_ONLINE_MODE_ENUM_ATTR,
+    ZONNSMART_OPENED_WINDOW_TEMP,
+    ZONNSMART_TARGET_TEMP_ATTR,
+    ZONNSMART_TEMPERATURE_ATTR,
+    ZONNSMART_TEMPERATURE_CALIBRATION_ATTR,
+    ZONNSMART_WINDOW_DETECT_ATTR,
+    MoesHY368_Type1new,
+    MoesHY368_Type2,
+    SiterwellGS361_Type1,
+    SiterwellGS361_Type2,
+    ZonnsmartTV01_ZG,
+)
+
+zhaquirks.setup()
+
+
+def test_tuya_din_reports_route_to_exact_on_off_endpoint(
+    zigpy_device_from_quirk,
+):
+    """DIN meter reports must update the intended OnOff endpoint only."""
+    tuya_device = zigpy_device_from_quirk(TuyaPowerMeter)
+    tuya_device.endpoints[1].tuya_manufacturer.update_attribute(TUYA_DIN_SWITCH_ATTR, 1)
+    assert tuya_device.endpoints[1].on_off.get("on_off") == 1
+
+    hiking_device = zigpy_device_from_quirk(HikingPowerMeter)
+    hiking_device.endpoints[1].tuya_manufacturer.update_attribute(
+        HIKING_DIN_SWITCH_ATTR, 1
+    )
+    assert hiking_device.endpoints[16].on_off.get("on_off") == 1
+
+
+async def test_hiking_endpoint_16_command_routes_to_endpoint_1_ef00(
+    zigpy_device_from_quirk,
+):
+    """Synthetic endpoint commands must use the real endpoint 1 EF00 cluster."""
+    device = zigpy_device_from_quirk(HikingPowerMeter)
+    tuya_cluster = device.endpoints[1].tuya_manufacturer
+
+    with mock.patch.object(tuya_cluster, "tuya_mcu_command") as command_mock:
+        await device.endpoints[16].on_off.command(OnOff.ServerCommandDefs.on.id)
+
+    command_mock.assert_called_once()
+    payload = command_mock.call_args.args[0]
+    assert payload.command_id == TUYA_CMD_BASE + 16
+    assert payload.data == [1, OnOff.ServerCommandDefs.on.id]
+
+
+def test_legacy_level_report_routes_to_level_clusters_without_visiting_zdo(
+    device_mock,
+):
+    """Legacy level reports must fan out only across Zigbee endpoints."""
+    endpoint = device_mock.endpoints[1]
+    manufacturer_cluster = TuyaManufacturerLevelControl(endpoint)
+    level_cluster = TuyaLevelControl(endpoint)
+    endpoint.add_input_cluster(manufacturer_cluster.cluster_id, manufacturer_cluster)
+    endpoint.add_input_cluster(LevelControl.cluster_id, level_cluster)
+
+    second_endpoint = device_mock.add_endpoint(2)
+    second_level_cluster = TuyaLevelControl(second_endpoint)
+    second_endpoint.add_input_cluster(LevelControl.cluster_id, second_level_cluster)
+
+    assert 0 in device_mock.endpoints
+
+    payload = mock.Mock(
+        status=0,
+        tsn=1,
+        command_id=TUYA_LEVEL_COMMAND,
+        function=0,
+        data=[0, 0, 0, 1, 244],
+    )
+    manufacturer_cluster.handle_cluster_request(
+        mock.Mock(command_id=TUYA_GET_DATA), [payload]
+    )
+
+    assert level_cluster.get(LevelControl.AttributeDefs.current_level.name) == 127
+    assert (
+        second_level_cluster.get(LevelControl.AttributeDefs.current_level.name) == 127
+    )
+
+
+@pytest.mark.parametrize(
+    ("attrid", "value", "attribute_name", "expected"),
+    (
+        (HAOZEE_CURRENT_ROOM_TEMP_ATTR, 215, "local_temperature", 2150),
+        (HAOZEE_TARGET_TEMP_ATTR, 205, "occupied_heating_setpoint", 2050),
+        (HAOZEE_AWAY_TEMP_ATTR, 17, "unoccupied_heating_setpoint", 1700),
+        (
+            HAOZEE_TEMP_CALIBRATION_ATTR,
+            -3,
+            "local_temperature_calibration",
+            -30,
+        ),
+        (HAOZEE_MIN_TEMP_LIMIT_ATTR, 5, "min_heat_setpoint_limit", 500),
+        (HAOZEE_MAX_TEMP_LIMIT_ATTR, 30, "max_heat_setpoint_limit", 3000),
+        (HAOZEE_AWAY_DAYS_ATTR, 7, "unoccupied_duration_days", 7),
+    ),
+)
+def test_haozee_direct_mapped_reports(
+    zigpy_device_from_quirk, attrid, value, attribute_name, expected
+):
+    """Every Haozee direct mapping must update the thermostat attribute."""
+    device = zigpy_device_from_quirk(HY08WE)
+    device.endpoints[1].tuya_manufacturer.update_attribute(attrid, value)
+
+    assert device.endpoints[1].thermostat.get(attribute_name) == expected
+
+
+def test_haozee_state_and_ui_reports(zigpy_device_from_quirk):
+    """Haozee state, mode, and lock reports must reach standard clusters."""
+    device = zigpy_device_from_quirk(HY08WE)
+    source = device.endpoints[1].tuya_manufacturer
+    thermostat = device.endpoints[1].thermostat
+    ui = device.endpoints[1].thermostat_ui
+
+    source.update_attribute(HAOZEE_ENABLED_ATTR, 1)
+    source.update_attribute(HAOZEE_HEATING_ENABLED_ATTR, 1)
+    source.update_attribute(HAOZEE_CURRENT_MODE_ATTR, 2)
+    source.update_attribute(HAOZEE_CHILD_LOCK_ATTR, 1)
+
+    assert thermostat.get("system_mode") == Thermostat.SystemMode.Heat
+    assert thermostat.get("running_state") == Thermostat.RunningState.Heat_State_On
+    assert thermostat.get("programing_oper_mode") == (
+        Thermostat.ProgrammingOperationMode.Simple
+    )
+    assert thermostat.get("occupancy") == Thermostat.Occupancy.Unoccupied
+    assert ui.get("keypad_lockout") == UserInterface.KeypadLockout.Level_1_lockout
+
+
+@pytest.mark.parametrize(
+    ("first_attr", "first_value", "second_attr", "second_value", "expected_state"),
+    (
+        (
+            ZONNSMART_TEMPERATURE_ATTR,
+            200,
+            ZONNSMART_TARGET_TEMP_ATTR,
+            210,
+            Thermostat.RunningState.Heat_State_On,
+        ),
+        (
+            ZONNSMART_TARGET_TEMP_ATTR,
+            190,
+            ZONNSMART_TEMPERATURE_ATTR,
+            200,
+            Thermostat.RunningState.Idle,
+        ),
+    ),
+)
+def test_zonnsmart_temperature_reports_are_order_independent(
+    zigpy_device_from_quirk,
+    first_attr,
+    first_value,
+    second_attr,
+    second_value,
+    expected_state,
+):
+    """Either first temperature report must be safe on a cold cache."""
+    device = zigpy_device_from_quirk(ZonnsmartTV01_ZG)
+    source = device.endpoints[1].tuya_manufacturer
+    thermostat = device.endpoints[1].thermostat
+
+    assert thermostat.get("min_heat_setpoint_limit") == ZONNSMART_MIN_TEMPERATURE_VAL
+    assert thermostat.get("max_heat_setpoint_limit") == ZONNSMART_MAX_TEMPERATURE_VAL
+
+    source.update_attribute(first_attr, first_value)
+    assert thermostat.get("running_state") is None
+    source.update_attribute(second_attr, second_value)
+
+    assert thermostat.get("running_state") == expected_state
+
+
+def test_zonnsmart_reports_route_to_all_declared_endpoints(
+    zigpy_device_from_quirk,
+):
+    """Zonnsmart auxiliary reports must reach their declared clusters."""
+    device = zigpy_device_from_quirk(ZonnsmartTV01_ZG)
+    source = device.endpoints[1].tuya_manufacturer
+
+    source.update_attribute(ZONNSMART_WINDOW_DETECT_ATTR, 1)
+    source.update_attribute(ZONNSMART_OPENED_WINDOW_TEMP, 185)
+    source.update_attribute(ZONNSMART_BATTERY_ATTR, 87)
+    source.update_attribute(ZONNSMART_TEMPERATURE_CALIBRATION_ATTR, 11)
+
+    assert (
+        device.endpoints[1].binary_input.get(
+            BinaryInput.AttributeDefs.present_value.name
+        )
+        == 1
+    )
+    assert (
+        device.endpoints[2].analog_output.get(
+            AnalogOutput.AttributeDefs.present_value.name
+        )
+        == 18.5
+    )
+    assert (
+        device.endpoints[1].power.get(
+            PowerConfiguration.AttributeDefs.battery_percentage_remaining.name
+        )
+        == 174
+    )
+    assert (
+        device.endpoints[1].analog_output.get(
+            AnalogOutput.AttributeDefs.present_value.name
+        )
+        == 1.1
+    )
+
+
+@pytest.mark.parametrize(
+    ("attrid", "value", "target_endpoint"),
+    (
+        (ZONNSMART_BOOST_TIME_ATTR, 60, 1),
+        (ZONNSMART_CHILD_LOCK_ATTR, 1, 2),
+        (ZONNSMART_ONLINE_MODE_ENUM_ATTR, 1, 3),
+    ),
+)
+def test_zonnsmart_on_off_reports_route_to_exact_endpoint(
+    zigpy_device_from_quirk,
+    attrid,
+    value,
+    target_endpoint,
+):
+    """Each Zonnsmart OnOff report must update only its intended endpoint."""
+    device = zigpy_device_from_quirk(ZonnsmartTV01_ZG)
+
+    device.endpoints[1].tuya_manufacturer.update_attribute(attrid, value)
+
+    for endpoint_id in (1, 2, 3):
+        expected = 1 if endpoint_id == target_endpoint else None
+        assert device.endpoints[endpoint_id].on_off.get("on_off") == expected
+
+    if attrid == ZONNSMART_CHILD_LOCK_ATTR:
+        assert device.endpoints[1].thermostat_ui.get("keypad_lockout") == 1
+
+
+async def test_zonnsmart_cross_endpoint_writes_are_device_isolated(
+    zigpy_device_from_quirk,
+):
+    """Helper writes must use endpoint 1 of their own device."""
+    first = zigpy_device_from_quirk(
+        ZonnsmartTV01_ZG, ieee=t.EUI64([1, 1, 1, 1, 1, 1, 1, 1])
+    )
+    second = zigpy_device_from_quirk(
+        ZonnsmartTV01_ZG, ieee=t.EUI64([2, 2, 2, 2, 2, 2, 2, 2])
+    )
+    first_manufacturer = first.endpoints[1].tuya_manufacturer
+    second_manufacturer = second.endpoints[1].tuya_manufacturer
+
+    with (
+        mock.patch.object(
+            first_manufacturer, "write_attributes", new=mock.AsyncMock()
+        ) as first_write,
+        mock.patch.object(
+            second_manufacturer, "write_attributes", new=mock.AsyncMock()
+        ) as second_write,
+    ):
+        await first.endpoints[2].on_off.write_attributes({"on_off": True})
+        await first.endpoints[2].analog_output.write_attributes({"present_value": 18.5})
+
+    assert first_write.await_args_list == [
+        mock.call({ZONNSMART_CHILD_LOCK_ATTR: t.Bool.true}),
+        mock.call({ZONNSMART_OPENED_WINDOW_TEMP: 185.0}),
+    ]
+    second_write.assert_not_awaited()
+
+
+@pytest.mark.parametrize("quirk", (SiterwellGS361_Type1, SiterwellGS361_Type2))
+def test_siterwell_lock_and_battery_reports(zigpy_device_from_quirk, quirk):
+    """Siterwell lock and battery reports must reach UI and power clusters."""
+    device = zigpy_device_from_quirk(quirk)
+    source = device.endpoints[1].tuya_manufacturer
+
+    source.update_attribute(SITERWELL_CHILD_LOCK_ATTR, 1)
+    source.update_attribute(SITERWELL_BATTERY_ATTR, 76)
+
+    assert device.endpoints[1].thermostat_ui.get("keypad_lockout") == 1
+    assert device.endpoints[1].power.get("battery_percentage_remaining") == 152
+
+
+@pytest.mark.parametrize("quirk", (MoesHY368_Type1new, MoesHY368_Type2))
+def test_moes_alternate_topologies_route_auxiliary_reports(
+    zigpy_device_from_quirk, quirk
+):
+    """Alternate Moes topologies must retain window, lock, and battery routing."""
+    device = zigpy_device_from_quirk(quirk)
+    source = device.endpoints[1].tuya_manufacturer
+
+    source.update_attribute(MOES_WINDOW_DETECT_ATTR, [5, 20, 1])
+    source.update_attribute(MOES_CHILD_LOCK_ATTR, 1)
+    source.update_attribute(MOES_BATTERY_LOW_ATTR, 1)
+
+    assert device.endpoints[1].on_off.get("on_off") == 1
+    assert device.endpoints[1].on_off.get("window_detection_temperature") == 2000
+    assert device.endpoints[1].on_off.get("window_detection_timeout_minutes") == 5
+    assert device.endpoints[1].thermostat_ui.get("keypad_lockout") == 1
+    assert device.endpoints[1].power.get("battery_percentage_remaining") == 10
+
+
+def test_electric_heating_mode_state_and_ui_reports(zigpy_device_from_quirk):
+    """Electric heating reports must route to thermostat and UI clusters."""
+    device = zigpy_device_from_quirk(MoesBHT)
+    source = device.endpoints[1].tuya_manufacturer
+    thermostat = device.endpoints[1].thermostat
+
+    source.update_attribute(MOESBHT_SCHEDULE_MODE_ATTR, 0)
+    assert thermostat.get("programing_oper_mode") == 1
+    source.update_attribute(MOESBHT_MANUAL_MODE_ATTR, 0)
+    assert thermostat.get("programing_oper_mode") == 0
+    source.update_attribute(MOESBHT_ENABLED_ATTR, 1)
+    source.update_attribute(MOESBHT_RUNNING_MODE_ATTR, 0)
+    source.update_attribute(MOESBHT_CHILD_LOCK_ATTR, 1)
+
+    assert thermostat.get("system_mode") == Thermostat.SystemMode.Heat
+    assert thermostat.get("running_state") == Thermostat.RunningState.Heat_State_On
+    assert device.endpoints[1].thermostat_ui.get("keypad_lockout") == 1
+
+
+@pytest.mark.parametrize(
+    ("quirk", "expected_position"),
+    (
+        (TuyaZemismartSmartCover0601, 75),
+        (TuyaZemismartSmartCover0601_inv_position, 25),
+    ),
+)
+def test_legacy_cover_reports_route_to_window_covering(
+    zigpy_device_from_quirk, quirk, expected_position
+):
+    """Legacy cover reports must update the co-resident WindowCovering cluster."""
+    device = zigpy_device_from_quirk(quirk)
+    source = device.endpoints[1].tuya_manufacturer
+    cover = device.endpoints[1].window_covering
+    hdr = mock.Mock(command_id=TUYA_GET_DATA)
+
+    position = mock.Mock(
+        status=0,
+        tsn=1,
+        command_id=TUYA_DP_TYPE_VALUE + TUYA_DP_ID_PERCENT_STATE,
+        function=0,
+        data=[4, 0, 0, 0, 25],
+    )
+    direction = mock.Mock(
+        status=0,
+        tsn=2,
+        command_id=TUYA_DP_TYPE_ENUM + TUYA_DP_ID_DIRECTION_CHANGE,
+        function=0,
+        data=[1, 1],
+    )
+    inverted = mock.Mock(
+        status=0,
+        tsn=3,
+        command_id=TUYA_DP_TYPE_ENUM + TUYA_DP_ID_COVER_INVERTED,
+        function=0,
+        data=[1, 1],
+    )
+
+    for payload in (position, direction, inverted):
+        source.handle_cluster_request(hdr, [payload])
+
+    assert cover.get(ATTR_COVER_POSITION) == expected_position
+    assert cover.get(ATTR_COVER_DIRECTION) == 1
+    assert cover.get(ATTR_COVER_INVERTED) == 1

--- a/tests/test_tuya_direct_routing.py
+++ b/tests/test_tuya_direct_routing.py
@@ -18,6 +18,7 @@ from zhaquirks.tuya import (
     ATTR_COVER_DIRECTION,
     ATTR_COVER_INVERTED,
     ATTR_COVER_POSITION,
+    TUYA_CLUSTER_ID,
     TUYA_CMD_BASE,
     TUYA_DP_ID_COVER_INVERTED,
     TUYA_DP_ID_DIRECTION_CHANGE,
@@ -30,6 +31,7 @@ from zhaquirks.tuya import (
     TuyaManufacturerClusterOnOff,
     TuyaManufacturerLevelControl,
     TuyaOnOff,
+    get_tuya_mcu_cluster,
 )
 from zhaquirks.tuya.ts0601_cover import (
     TuyaZemismartSmartCover0601,
@@ -122,6 +124,29 @@ async def test_hiking_endpoint_16_command_routes_to_endpoint_1_ef00(
     assert payload.data == [1, OnOff.ServerCommandDefs.on.id]
 
 
+def test_get_tuya_mcu_cluster_returns_endpoint_1_ef00(device_mock):
+    """Tuya command routing must return the endpoint 1 MCU cluster."""
+    endpoint = device_mock.endpoints[1]
+    tuya_cluster = TuyaManufacturerClusterOnOff(endpoint)
+    endpoint.add_input_cluster(TUYA_CLUSTER_ID, tuya_cluster)
+
+    assert get_tuya_mcu_cluster(endpoint) is tuya_cluster
+
+
+@pytest.mark.parametrize("remove_endpoint", (False, True))
+def test_get_tuya_mcu_cluster_rejects_missing_topology(device_mock, remove_endpoint):
+    """Missing endpoint 1 MCU topology must produce a legible failure."""
+    endpoint = device_mock.endpoints[1]
+    if remove_endpoint:
+        device_mock.endpoints.pop(1)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"no Tuya MCU cluster \(0xEF00\) on endpoint 1",
+    ):
+        get_tuya_mcu_cluster(endpoint)
+
+
 def test_legacy_level_report_routes_to_level_clusters_without_visiting_zdo(
     device_mock,
 ):
@@ -189,6 +214,35 @@ def test_legacy_switch_report_routes_to_matching_endpoint(
 
     assert first_on_off.get(OnOff.AttributeDefs.on_off.name) is None
     assert second_on_off.get(OnOff.AttributeDefs.on_off.name) == 1
+
+
+@pytest.mark.parametrize(
+    "manufacturer_cluster_type",
+    (TuyaManufacturerClusterOnOff, TuyaManufacturerLevelControl),
+)
+def test_legacy_switch_report_ignores_zdo_channel(
+    device_mock, manufacturer_cluster_type
+):
+    """Legacy channel zero reports must remain harmless no-ops."""
+    endpoint = device_mock.endpoints[1]
+    manufacturer_cluster = manufacturer_cluster_type(endpoint)
+    on_off_cluster = TuyaOnOff(endpoint)
+    endpoint.add_input_cluster(manufacturer_cluster.cluster_id, manufacturer_cluster)
+    endpoint.add_input_cluster(OnOff.cluster_id, on_off_cluster)
+
+    payload = mock.Mock(
+        status=0,
+        tsn=1,
+        command_id=TUYA_CMD_BASE,
+        function=0,
+        data=[1, 1],
+    )
+    header = mock.Mock(command_id=TUYA_GET_DATA)
+    header.frame_control.disable_default_response = True
+
+    manufacturer_cluster.handle_cluster_request(header, [payload])
+
+    assert on_off_cluster.get(OnOff.AttributeDefs.on_off.name) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -430,13 +430,6 @@ async def test_from_cluster_data_multi_dp_cross_endpoint(device_mock):
 
     tuya_cluster = ep1.tuya_manufacturer
 
-    # Pre-set rms_current on endpoint 2 to a known value
-    ep2_meas = ep2.electrical_measurement
-    ep2_meas.update_attribute("rms_current", 42)
-    assert ep2_meas.get("rms_current") == 42
-
-    # Call from_cluster_data as if writing active_power=7 on ep1.
-    # The converter should read rms_current from ep2 (not ep1).
     cluster_data = TuyaClusterData(
         endpoint_id=1,
         cluster_name=Ep1Measurement.ep_attribute,
@@ -446,6 +439,17 @@ async def test_from_cluster_data_multi_dp_cross_endpoint(device_mock):
         manufacturer=-1,
     )
 
+    # The converter requires rms_current and must defer while that companion
+    # value is absent from the endpoint 2 cache.
+    assert tuya_cluster.from_cluster_data(cluster_data) == []
+
+    # Pre-set rms_current on endpoint 2 to a known value
+    ep2_meas = ep2.electrical_measurement
+    ep2_meas.update_attribute("rms_current", 42)
+    assert ep2_meas.get("rms_current") == 42
+
+    # Call from_cluster_data as if writing active_power=7 on ep1.
+    # The converter should read rms_current from ep2 (not ep1).
     result = tuya_cluster.from_cluster_data(cluster_data)
     assert len(result) == 1
     assert result[0].datapoints[0].dp == 1

--- a/tests/test_tuya_trv.py
+++ b/tests/test_tuya_trv.py
@@ -294,6 +294,41 @@ async def test_handle_get_data(
         ]
 
 
+async def test_moes_trv_system_mode_write_with_uncached_preset(
+    zigpy_device_from_v2_quirk,
+):
+    """A converter may intentionally ignore an uncached companion attribute."""
+    device = zigpy_device_from_v2_quirk("_TZE204_qyr2m29i", "TS0601")
+    endpoint = device.endpoints[1]
+
+    assert endpoint.tuya_manufacturer.get("preset_mode") is None
+
+    with mock.patch.object(
+        endpoint.tuya_manufacturer.endpoint,
+        "request",
+        return_value=foundation.Status.SUCCESS,
+    ) as request_mock:
+        (status,) = await endpoint.thermostat.write_attributes(
+            {"system_mode": Thermostat.SystemMode.Heat}
+        )
+        await wait_for_zigpy_tasks()
+
+    request_mock.assert_called_once_with(
+        cluster=0xEF00,
+        sequence=1,
+        data=b"\x01\x01\x00\x00\x01\x02\x04\x00\x01\x03",
+        command_id=0,
+        timeout=5,
+        expect_reply=False,
+        use_ieee=False,
+        ask_for_ack=None,
+        priority=None,
+        retries=None,
+        retry_delay=None,
+    )
+    assert status == [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+
+
 @pytest.mark.parametrize(
     "manuf,msg,dp_id,value",
     [

--- a/tests/test_tuya_trv.py
+++ b/tests/test_tuya_trv.py
@@ -329,13 +329,15 @@ async def test_moes_trv_system_mode_write_with_uncached_preset(
     assert status == [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
 
 
-async def test_moes_trv_complete_converter_error_is_not_deferred(
-    zigpy_device_from_v2_quirk,
+@pytest.mark.parametrize("preset_mode", (None, 0))
+async def test_moes_trv_converter_error_is_not_deferred(
+    zigpy_device_from_v2_quirk, preset_mode
 ):
-    """Complete compound conversions must surface invalid values and send nothing."""
+    """Compound conversions must surface invalid values and send nothing."""
     device = zigpy_device_from_v2_quirk("_TZE204_qyr2m29i", "TS0601")
     endpoint = device.endpoints[1]
-    endpoint.tuya_manufacturer.update_attribute("preset_mode", 0)
+    if preset_mode is not None:
+        endpoint.tuya_manufacturer.update_attribute("preset_mode", preset_mode)
 
     with (
         mock.patch.object(

--- a/tests/test_tuya_trv.py
+++ b/tests/test_tuya_trv.py
@@ -329,6 +329,28 @@ async def test_moes_trv_system_mode_write_with_uncached_preset(
     assert status == [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
 
 
+async def test_moes_trv_complete_converter_error_is_not_deferred(
+    zigpy_device_from_v2_quirk,
+):
+    """Complete compound conversions must surface invalid values and send nothing."""
+    device = zigpy_device_from_v2_quirk("_TZE204_qyr2m29i", "TS0601")
+    endpoint = device.endpoints[1]
+    endpoint.tuya_manufacturer.update_attribute("preset_mode", 0)
+
+    with (
+        mock.patch.object(
+            endpoint.tuya_manufacturer.endpoint,
+            "request",
+        ) as request_mock,
+        pytest.raises(KeyError),
+    ):
+        await endpoint.thermostat.write_attributes(
+            {"system_mode": Thermostat.SystemMode.Cool}
+        )
+
+    request_mock.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "manuf,msg,dp_id,value",
     [

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -156,6 +156,7 @@ def test_basic_cluster_deserialize_wrong_len_2():
 @pytest.mark.parametrize(
     "quirk",
     (
+        zhaquirks.xiaomi.aqara.motion_agl04.LumiLumiMotionAgl04,
         zhaquirks.xiaomi.aqara.motion_aq2.MotionAQ2,
         zhaquirks.xiaomi.aqara.motion_aq2b.MotionAQ2,
         zhaquirks.xiaomi.mija.motion.Motion,

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -25,7 +25,6 @@ import zigpy.device
 import zigpy.endpoint
 import zigpy.types as t
 from zigpy.typing import UNDEFINED, UndefinedType
-from zigpy.util import ListenableMixin
 from zigpy.zcl import (
     AttributeReportedEvent,
     AttributeUnsupportedEvent,
@@ -56,9 +55,7 @@ from .const import (
     MANUFACTURER,
     MODEL,
     MODELS_INFO,
-    MOTION_EVENT,
     NODE_DESCRIPTOR,
-    OCCUPANCY_EVENT,
     OCCUPANCY_STATE,
     OFF,
     ON,
@@ -71,15 +68,6 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class Bus(ListenableMixin):
-    """Event bus implementation."""
-
-    def __init__(self, *args, **kwargs):
-        """Init event bus."""
-        super().__init__(*args, **kwargs)
-        self._listeners = {}
 
 
 class LocalDataCluster(CustomCluster):
@@ -338,7 +326,7 @@ class _Motion(CustomCluster, IasZone):
 class MotionWithReset(_Motion):
     """Self reset Motion cluster.
 
-    Optionally send event over device bus.
+    Optionally update a co-resident occupancy cluster.
     """
 
     send_occupancy_event: bool = False
@@ -357,18 +345,13 @@ class MotionWithReset(_Motion):
                 self._timer_handle.cancel()
             self._timer_handle = self._loop.call_later(self.reset_s, self._turn_off)
             if self.send_occupancy_event:
-                self.endpoint.device.occupancy_bus.listener_event(OCCUPANCY_EVENT)
+                self.endpoint.occupancy.occupancy_event()
 
 
 class MotionOnEvent(_Motion):
     """Motion based on received events from occupancy."""
 
     reset_s: int = 120
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.motion_bus.add_listener(self)
 
     def motion_event(self):
         """Motion event."""
@@ -401,12 +384,7 @@ class _Occupancy(CustomCluster, OccupancySensing):
 
 
 class OccupancyOnEvent(_Occupancy):
-    """Self reset occupancy from bus."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.occupancy_bus.add_listener(self)
+    """Self reset occupancy from another cluster."""
 
     def occupancy_event(self):
         """Occupancy event."""
@@ -419,7 +397,7 @@ class OccupancyOnEvent(_Occupancy):
 
 
 class OccupancyWithReset(_Occupancy):
-    """Self reset Occupancy cluster and send event on motion bus."""
+    """Self reset Occupancy cluster and update the IAS motion cluster."""
 
     def __init__(self, *args, **kwargs):
         """Init."""
@@ -434,7 +412,7 @@ class OccupancyWithReset(_Occupancy):
         if event.attribute_id == OCCUPANCY_STATE and event.value == ON:
             if self._timer_handle:
                 self._timer_handle.cancel()
-            self.endpoint.device.motion_bus.listener_event(MOTION_EVENT)
+            self.endpoint.ias_zone.motion_event()
             self._timer_handle = self._loop.call_later(self.reset_s, self._turn_off)
 
 

--- a/zhaquirks/adeo/color_controller.py
+++ b/zhaquirks/adeo/color_controller.py
@@ -20,7 +20,7 @@ from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 from zigpy.zcl.foundation import BaseCommandDefs
 
-from zhaquirks import Bus, EventableCluster
+from zhaquirks import EventableCluster
 from zhaquirks.const import (
     ARGS,
     BUTTON_1,
@@ -88,8 +88,8 @@ class AdeoManufacturerCluster(EventableCluster):
     ):
         """Handle the cluster command."""
         if hdr.command_id == 0x0000:
-            self.endpoint.device.scenes_bus.listener_event(
-                "listener_event", ZHA_SEND_EVENT, "view", [SCENE_NO_GROUP, args[0]]
+            self.endpoint.out_clusters[Scenes.cluster_id].listener_event(
+                ZHA_SEND_EVENT, "view", [SCENE_NO_GROUP, args[0]]
             )
         else:
             super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
@@ -98,19 +98,9 @@ class AdeoManufacturerCluster(EventableCluster):
 class AdeoScenesCluster(Scenes, EventableCluster):
     """Scenes cluster to map preset buttons to the "view" command."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.scenes_bus.add_listener(self)
-
 
 class AdeoColorController(CustomDevice):
     """Custom device representing ADEO color controller."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.scenes_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=2048

--- a/zhaquirks/elko/__init__.py
+++ b/zhaquirks/elko/__init__.py
@@ -3,7 +3,7 @@
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 
-from zhaquirks import Bus, LocalDataCluster
+from zhaquirks import LocalDataCluster
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.legacy import CustomDevice
 
@@ -15,11 +15,6 @@ class ElkoThermostatCluster(CustomCluster, Thermostat):
 
     class AttributeDefs(Thermostat.AttributeDefs):
         """Cluster attributes."""
-
-    def __init__(self, *args, **kwargs):
-        """Init thermostat cluster."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.thermostat_bus.add_listener(self)
 
     def heating_active_change(self, value):
         """State update from device."""
@@ -37,11 +32,6 @@ class ElkoThermostatCluster(CustomCluster, Thermostat):
 class ElkoUserInterfaceCluster(LocalDataCluster, UserInterface):
     """User interface cluster for Elko Thermostats."""
 
-    def __init__(self, *args, **kwargs):
-        """Init UI cluster."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.ui_bus.add_listener(self)
-
     def child_lock_change(self, mode):
         """Enable/disable child lock."""
         if mode:
@@ -57,11 +47,6 @@ class ElkoElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
 
     ACTIVE_POWER_ID = 0x050B
 
-    def __init__(self, *args, **kwargs):
-        """Init electrical measurement cluster."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.power_bus.add_listener(self)
-
     def power_reported(self, value):
         """Report consumption."""
         self._update_attribute(self.ACTIVE_POWER_ID, value)
@@ -69,10 +54,3 @@ class ElkoElectricalMeasurementCluster(LocalDataCluster, ElectricalMeasurement):
 
 class ElkoThermostat(CustomDevice):
     """Generic Elko Thermostat device."""
-
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.thermostat_bus = Bus()
-        self.ui_bus = Bus()
-        self.power_bus = Bus()
-        super().__init__(*args, **kwargs)

--- a/zhaquirks/elko/smart_super_thermostat.py
+++ b/zhaquirks/elko/smart_super_thermostat.py
@@ -113,11 +113,9 @@ class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
 
     def _update_attribute(self, attrid, value):
         if attrid == HEATING_ACTIVE:
-            self.endpoint.device.thermostat_bus.listener_event(
-                "heating_active_change", value
-            )
+            self.heating_active_change(value)
         elif attrid == CHILD_LOCK:
-            self.endpoint.device.ui_bus.listener_event("child_lock_change", value)
+            self.endpoint.thermostat_ui.child_lock_change(value)
         elif attrid == ACTIVE_SENSOR:
             self.active_sensor = value
         elif attrid == LOCAL_TEMP:
@@ -135,7 +133,7 @@ class ElkoSuperTRThermostatCluster(ElkoThermostatCluster):
                 attrid = LOCAL_TEMP
         elif attrid == POWER_CONSUMPTION:
             if value is not None and value >= 0:
-                self.endpoint.device.power_bus.listener_event("power_reported", value)
+                self.endpoint.electrical_measurement.power_reported(value)
 
         super()._update_attribute(attrid, value)
 

--- a/zhaquirks/ikea/starkvind.py
+++ b/zhaquirks/ikea/starkvind.py
@@ -19,7 +19,6 @@ from zigpy.zcl.clusters.hvac import Fan
 from zigpy.zcl.clusters.measurement import PM25, IlluminanceMeasurement
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
-from zhaquirks import Bus
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -71,14 +70,13 @@ class IkeaAirpurifier(CustomCluster):
         """Init."""
         self._current_state = {}
         super().__init__(*args, **kwargs)
-        self.endpoint.device.change_fan_mode_bus.add_listener(self)
 
     def _update_attribute(self, attrid, value):
         if attrid == 0x0004:
             if (
                 value is not None and value < 5500
             ):  # > 5500 = out of scale; if value is 65535 (0xFFFF), device is off
-                self.endpoint.device.pm25_bus.listener_event("update_state", value)
+                self.endpoint.pm25.update_state(value)
         elif attrid in (0x0006, 0x0007):
             if value >= 10 and value <= 50:
                 value = value // 5
@@ -100,11 +98,6 @@ class IkeaAirpurifier(CustomCluster):
 
 class PM25Cluster(CustomCluster, PM25):
     """PM25 input cluster, only used to show PM2.5 values from IKEA cluster."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.pm25_bus.add_listener(self)
 
     def update_state(self, value):
         """25pm reported."""
@@ -136,13 +129,6 @@ class PM25Cluster(CustomCluster, PM25):
 
 class IkeaSTARKVIND(CustomDevice):
     """STARKVIND Air purifier by IKEA of Sweden."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.pm25_bus = Bus()
-        self.change_fan_mode_bus = Bus()
-        self.change_fan_mode_ha_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=7 (0x0007)

--- a/zhaquirks/konke/motion.py
+++ b/zhaquirks/konke/motion.py
@@ -4,7 +4,7 @@ from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
 from zigpy.zcl.clusters.security import IasZone
 
-from zhaquirks import Bus, PowerConfigurationCluster
+from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -21,11 +21,6 @@ KONKE_CLUSTER_ID = 0xFCC0
 
 class KonkeMotion(CustomDevice):
     """Custom device representing konke motion sensors."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.occupancy_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
@@ -72,11 +67,6 @@ class KonkeMotion(CustomDevice):
 
 class KonkeMotionB(CustomDevice):
     """Custom device representing konke motion sensors."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.occupancy_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026

--- a/zhaquirks/mli/tint.py
+++ b/zhaquirks/mli/tint.py
@@ -14,7 +14,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from zhaquirks import Bus, LocalDataCluster
+from zhaquirks import LocalDataCluster
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -31,12 +31,6 @@ TINT_SCENE_ATTR = 0x4005
 
 class TintRemoteScenesCluster(LocalDataCluster, Scenes):
     """Tint remote cluster."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-
-        self.endpoint.device.scene_bus.add_listener(self)
 
     def change_scene(self, value):
         """Change scene attribute to new value."""
@@ -56,16 +50,11 @@ class TintRemoteBasicCluster(CustomCluster, Basic):
             return
 
         value = attr.value.value
-        self.endpoint.device.scene_bus.listener_event("change_scene", value)
+        self.endpoint.out_clusters[Scenes.cluster_id].change_scene(value)
 
 
 class TintRemote(CustomDevice):
     """Tint remote quirk."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.scene_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         # endpoint=1 profile=260 device_type=2048 device_version=1 input_clusters=[0, 3, 4096]

--- a/zhaquirks/orvibo/motion.py
+++ b/zhaquirks/orvibo/motion.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.security import IasZone
 
-from zhaquirks import Bus, PowerConfigurationCluster
+from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -30,11 +30,6 @@ ORVIBO_CLUSTER_ID = 0xFFFF
 
 class SN10ZW(CustomDevice):
     """SN10ZW motion sensor."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.occupancy_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026

--- a/zhaquirks/sengled/e1e_g7f.py
+++ b/zhaquirks/sengled/e1e_g7f.py
@@ -79,39 +79,48 @@ class SengledE1EG7FManufacturerSpecificCluster(CustomCluster):
     ):
         """Handle cluster request."""
 
-        on_off_cluster = self.endpoint.out_clusters[OnOff.cluster_id]
-        level_control_cluster = self.endpoint.out_clusters[LevelControl.cluster_id]
-
         if args[0] == 1:
-            on_off_cluster.listener_event(ZHA_SEND_EVENT, COMMAND_ON, [])
+            self.endpoint.out_clusters[OnOff.cluster_id].listener_event(
+                ZHA_SEND_EVENT, COMMAND_ON, []
+            )
         elif args[0] == 2:
             if args[2] == 2:
-                level_control_cluster.listener_event(
+                self.endpoint.out_clusters[LevelControl.cluster_id].listener_event(
                     ZHA_SEND_EVENT, COMMAND_STEP, [0, 2, 0]
                 )
             else:
-                level_control_cluster.listener_event(
+                self.endpoint.out_clusters[LevelControl.cluster_id].listener_event(
                     ZHA_SEND_EVENT, COMMAND_STEP, [0, 1, 0]
                 )
         elif args[0] == 3:
             if args[2] == 2:
-                level_control_cluster.listener_event(
+                self.endpoint.out_clusters[LevelControl.cluster_id].listener_event(
                     ZHA_SEND_EVENT, COMMAND_STEP, [1, 2, 0]
                 )
             else:
-                level_control_cluster.listener_event(
+                self.endpoint.out_clusters[LevelControl.cluster_id].listener_event(
                     ZHA_SEND_EVENT, COMMAND_STEP, [1, 1, 0]
                 )
         elif args[0] == 4:
-            on_off_cluster.listener_event(ZHA_SEND_EVENT, COMMAND_OFF, [])
+            self.endpoint.out_clusters[OnOff.cluster_id].listener_event(
+                ZHA_SEND_EVENT, COMMAND_OFF, []
+            )
         elif args[0] == 5:
-            on_off_cluster.listener_event(ZHA_SEND_EVENT, "on_double", [])
+            self.endpoint.out_clusters[OnOff.cluster_id].listener_event(
+                ZHA_SEND_EVENT, "on_double", []
+            )
         elif args[0] == 6:
-            on_off_cluster.listener_event(ZHA_SEND_EVENT, "on_long", [])
+            self.endpoint.out_clusters[OnOff.cluster_id].listener_event(
+                ZHA_SEND_EVENT, "on_long", []
+            )
         elif args[0] == 7:
-            on_off_cluster.listener_event(ZHA_SEND_EVENT, "off_double", [])
+            self.endpoint.out_clusters[OnOff.cluster_id].listener_event(
+                ZHA_SEND_EVENT, "off_double", []
+            )
         elif args[0] == 8:
-            on_off_cluster.listener_event(ZHA_SEND_EVENT, "off_long", [])
+            self.endpoint.out_clusters[OnOff.cluster_id].listener_event(
+                ZHA_SEND_EVENT, "off_long", []
+            )
 
 
 class SengledE1EG7F(CustomDevice):

--- a/zhaquirks/sengled/e1e_g7f.py
+++ b/zhaquirks/sengled/e1e_g7f.py
@@ -16,7 +16,6 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.foundation import BaseCommandDefs
 
-from zhaquirks import Bus
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.const import (
     COMMAND,
@@ -45,23 +44,9 @@ from zhaquirks.legacy import CustomDevice
 class SengledE1EG7FOnOffCluster(CustomCluster, OnOff):
     """Sengled E1E-G7F OnOff cluster."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-
-        super().__init__(*args, **kwargs)
-
-        self.endpoint.device.on_off_bus.add_listener(self)
-
 
 class SengledE1EG7FLevelControlCluster(CustomCluster, LevelControl):
     """Sengled E1E-G7F LevelControl cluster."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-
-        super().__init__(*args, **kwargs)
-
-        self.endpoint.device.level_control_bus.add_listener(self)
 
 
 class SengledE1EG7FManufacturerSpecificCluster(CustomCluster):
@@ -94,60 +79,43 @@ class SengledE1EG7FManufacturerSpecificCluster(CustomCluster):
     ):
         """Handle cluster request."""
 
+        on_off_cluster = self.endpoint.out_clusters[OnOff.cluster_id]
+        level_control_cluster = self.endpoint.out_clusters[LevelControl.cluster_id]
+
         if args[0] == 1:
-            self.endpoint.device.on_off_bus.listener_event(
-                "listener_event", ZHA_SEND_EVENT, COMMAND_ON, []
-            )
+            on_off_cluster.listener_event(ZHA_SEND_EVENT, COMMAND_ON, [])
         elif args[0] == 2:
             if args[2] == 2:
-                self.endpoint.device.level_control_bus.listener_event(
-                    "listener_event", ZHA_SEND_EVENT, COMMAND_STEP, [0, 2, 0]
+                level_control_cluster.listener_event(
+                    ZHA_SEND_EVENT, COMMAND_STEP, [0, 2, 0]
                 )
             else:
-                self.endpoint.device.level_control_bus.listener_event(
-                    "listener_event", ZHA_SEND_EVENT, COMMAND_STEP, [0, 1, 0]
+                level_control_cluster.listener_event(
+                    ZHA_SEND_EVENT, COMMAND_STEP, [0, 1, 0]
                 )
         elif args[0] == 3:
             if args[2] == 2:
-                self.endpoint.device.level_control_bus.listener_event(
-                    "listener_event", ZHA_SEND_EVENT, COMMAND_STEP, [1, 2, 0]
+                level_control_cluster.listener_event(
+                    ZHA_SEND_EVENT, COMMAND_STEP, [1, 2, 0]
                 )
             else:
-                self.endpoint.device.level_control_bus.listener_event(
-                    "listener_event", ZHA_SEND_EVENT, COMMAND_STEP, [1, 1, 0]
+                level_control_cluster.listener_event(
+                    ZHA_SEND_EVENT, COMMAND_STEP, [1, 1, 0]
                 )
         elif args[0] == 4:
-            self.endpoint.device.on_off_bus.listener_event(
-                "listener_event", ZHA_SEND_EVENT, COMMAND_OFF, []
-            )
+            on_off_cluster.listener_event(ZHA_SEND_EVENT, COMMAND_OFF, [])
         elif args[0] == 5:
-            self.endpoint.device.on_off_bus.listener_event(
-                "listener_event", ZHA_SEND_EVENT, "on_double", []
-            )
+            on_off_cluster.listener_event(ZHA_SEND_EVENT, "on_double", [])
         elif args[0] == 6:
-            self.endpoint.device.on_off_bus.listener_event(
-                "listener_event", ZHA_SEND_EVENT, "on_long", []
-            )
+            on_off_cluster.listener_event(ZHA_SEND_EVENT, "on_long", [])
         elif args[0] == 7:
-            self.endpoint.device.on_off_bus.listener_event(
-                "listener_event", ZHA_SEND_EVENT, "off_double", []
-            )
+            on_off_cluster.listener_event(ZHA_SEND_EVENT, "off_double", [])
         elif args[0] == 8:
-            self.endpoint.device.on_off_bus.listener_event(
-                "listener_event", ZHA_SEND_EVENT, "off_long", []
-            )
+            on_off_cluster.listener_event(ZHA_SEND_EVENT, "off_long", [])
 
 
 class SengledE1EG7F(CustomDevice):
     """Sengled E1E-G7F device."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-
-        self.on_off_bus = Bus()
-        self.level_control_bus = Bus()
-
-        super().__init__(*args, **kwargs)
 
     signature = {
         MODELS_INFO: [("sengled", "E1E-G7F")],

--- a/zhaquirks/smartthings/tag_v4.py
+++ b/zhaquirks/smartthings/tag_v4.py
@@ -3,7 +3,7 @@
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, BinaryInput, Identify, Ota, PollControl
 
-from zhaquirks import Bus, LocalDataCluster, PowerConfigurationCluster
+from zhaquirks import LocalDataCluster, PowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -40,20 +40,13 @@ class FastPollingPowerConfigurationCluster(PowerConfigurationCluster):
         return result
 
     def _update_attribute(self, attrid, value):
-        self.endpoint.device.tracking_bus.listener_event(
-            "update_tracking", attrid, value
-        )
+        self.endpoint.binary_input.update_tracking(attrid, value)
         super()._update_attribute(attrid, value)
 
 
 # stealing this for tracking alerts
 class TrackingCluster(LocalDataCluster, BinaryInput):
     """Tracking cluster."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.tracking_bus.add_listener(self)
 
     def update_tracking(self, attrid, value):
         """Update tracking info."""
@@ -63,11 +56,6 @@ class TrackingCluster(LocalDataCluster, BinaryInput):
 
 class SmartThingsTagV4(CustomDevice):
     """Custom device representing smartthings tagV4 sensors."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.tracking_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=12

--- a/zhaquirks/terncy/__init__.py
+++ b/zhaquirks/terncy/__init__.py
@@ -20,8 +20,6 @@ from zhaquirks.const import (
     COMMAND,
     DOUBLE_PRESS,
     LEFT,
-    MOTION_EVENT,
-    OCCUPANCY_EVENT,
     ON,
     PRESS_TYPE,
     QUADRUPLE_PRESS,
@@ -101,25 +99,15 @@ class MotionCluster(LocalDataCluster, _Motion):
         self._timer_handle = self._loop.call_later(self.reset_s, self._turn_off)
 
         if self.send_occupancy_event:
-            self.endpoint.device.occupancy_bus.listener_event(OCCUPANCY_EVENT)
+            self.endpoint.device.endpoints[1].occupancy.occupancy_event()
 
 
 class MotionClusterLeft(MotionCluster):
     """Motion cluster."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.motion_left_bus.add_listener(self)
-
 
 class MotionClusterRight(MotionCluster):
     """Motion cluster."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.motion_right_bus.add_listener(self)
 
 
 class TerncyRawCluster(CustomCluster):
@@ -170,9 +158,9 @@ class TerncyRawCluster(CustomCluster):
             state = args[2]
             side = SIDE_LOOKUP[state]
             if side == LEFT:
-                self.endpoint.device.motion_left_bus.listener_event(MOTION_EVENT)
+                self.endpoint.device.endpoints[1].ias_zone.motion_event()
             elif side == RIGHT:
-                self.endpoint.device.motion_right_bus.listener_event(MOTION_EVENT)
+                self.endpoint.device.endpoints[2].ias_zone.motion_event()
 
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)

--- a/zhaquirks/terncy/pp01.py
+++ b/zhaquirks/terncy/pp01.py
@@ -14,7 +14,7 @@ from zigpy.zcl.clusters.measurement import (
     TemperatureMeasurement,
 )
 
-from zhaquirks import Bus, DoublingPowerConfigurationCluster
+from zhaquirks import DoublingPowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -39,13 +39,6 @@ TERNCY_AWARENESS_DEVICE_TYPE = 0x01F0
 
 class TerncyAwarenessSwitch(CustomDevice):
     """Terncy awareness switch."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.motion_left_bus = Bus()
-        self.motion_right_bus = Bus()
-        self.occupancy_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=496

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -19,7 +19,7 @@ from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.clusters.smartenergy import Metering
 from zigpy.zcl.foundation import BaseCommandDefs, ZCLAttributeDef
 
-from zhaquirks import Bus, EventableCluster, LocalDataCluster
+from zhaquirks import EventableCluster, LocalDataCluster
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.const import (
     DOUBLE_PRESS,
@@ -55,9 +55,6 @@ TUYA_SET_TIME = 0x24
 TUYA_MCU_VERSION_REQ = 0x10
 TUYA_MCU_VERSION_RSP = 0x11
 TUYA_LEVEL_COMMAND = 514
-
-LEVEL_EVENT = "level_event"
-TUYA_MCU_COMMAND = "tuya_mcu_command"
 
 # Rotating for remotes
 STOP = "stop"  # To constants
@@ -107,7 +104,6 @@ WINDOW_COVER_COMMAND_CUSTOM = 0x0006
 # ---------------------------------------------------------
 # TUYA Cover Custom Values
 # ---------------------------------------------------------
-COVER_EVENT = "cover_event"
 ATTR_COVER_POSITION = 0x0008
 ATTR_COVER_DIRECTION = 0x8001
 ATTR_COVER_INVERTED = 0x8002
@@ -115,7 +111,6 @@ ATTR_COVER_INVERTED = 0x8002
 # ---------------------------------------------------------
 # TUYA Switch Custom Values
 # ---------------------------------------------------------
-SWITCH_EVENT = "switch_event"
 ATTR_ON_OFF = 0x0000
 TUYA_CMD_BASE = 0x0100
 # ---------------------------------------------------------
@@ -134,6 +129,11 @@ TUYA_CMD_BASE = 0x0100
 # ---------------------------------------------------------
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def get_tuya_mcu_cluster(endpoint):
+    """Return the endpoint 1 Tuya manufacturer cluster for a device."""
+    return endpoint.device.endpoints[1].in_clusters[TUYA_CLUSTER_ID]
 
 
 class TuyaTimePayload(t.LVList, item_type=t.uint8_t, length_type=t.uint16_t_be):
@@ -411,12 +411,6 @@ class TuyaManufCluster(CustomCluster):
             id=0x0024, schema={"param": t.data16}, manufacturer_code=None
         )
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.command_bus = Bus()
-        self.endpoint.device.command_bus.add_listener(self)  # listen MCU commands
-
     def tuya_mcu_command(self, command: Command):  # type:ignore[valid-type]
         """Tuya MCU command listener. Only endpoint:1 must listen to MCU commands."""
 
@@ -608,11 +602,6 @@ class EnchantedDevice(CustomDevice, BaseEnchantedDevice):
 class TuyaOnOff(CustomCluster, OnOff):
     """Tuya On/Off cluster for On/Off device."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.switch_bus.add_listener(self)
-
     def switch_event(self, channel, state):
         """Switch event."""
         _LOGGER.debug(
@@ -645,10 +634,7 @@ class TuyaOnOff(CustomCluster, OnOff):
             cmd_payload.function = 0
             cmd_payload.data = [1, command_id]
 
-            self.endpoint.device.command_bus.listener_event(
-                TUYA_MCU_COMMAND,
-                cmd_payload,
-            )
+            get_tuya_mcu_cluster(self.endpoint).tuya_mcu_command(cmd_payload)
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
@@ -676,11 +662,12 @@ class TuyaManufacturerClusterOnOff(TuyaManufCluster):
                 self.send_default_rsp(hdr, status=foundation.Status.SUCCESS)
 
             tuya_payload = args[0]
-            self.endpoint.device.switch_bus.listener_event(
-                SWITCH_EVENT,
-                tuya_payload.command_id - TUYA_CMD_BASE,
-                tuya_payload.data[1],
-            )
+            channel = tuya_payload.command_id - TUYA_CMD_BASE
+            endpoint = self.endpoint.device.endpoints.get(channel)
+            if endpoint is not None:
+                on_off_cluster = endpoint.in_clusters.get(OnOff.cluster_id)
+                if isinstance(on_off_cluster, TuyaOnOff):
+                    on_off_cluster.switch_event(channel, tuya_payload.data[1])
         elif hdr.command_id == TUYA_SET_TIME:
             """Time event call super"""
             _LOGGER.debug("TUYA_SET_TIME --> hdr: %s, args: %s", hdr, args)
@@ -692,19 +679,9 @@ class TuyaManufacturerClusterOnOff(TuyaManufCluster):
 class TuyaSwitch(CustomDevice):
     """Tuya switch device."""
 
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.switch_bus = Bus()
-        super().__init__(*args, **kwargs)
-
 
 class TuyaDimmerSwitch(TuyaSwitch):
     """Tuya dimmer switch device."""
-
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.dimmer_bus = Bus()
-        super().__init__(*args, **kwargs)
 
 
 class TuyaThermostatCluster(LocalDataCluster, Thermostat):
@@ -714,11 +691,6 @@ class TuyaThermostatCluster(LocalDataCluster, Thermostat):
 
     class AttributeDefs(Thermostat.AttributeDefs):
         """Cluster attributes."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.thermostat_bus.add_listener(self)
 
     def temperature_change(self, attr, value):
         """Local or target temperature change from device."""
@@ -838,11 +810,6 @@ class TuyaUserInterfaceCluster(LocalDataCluster, UserInterface):
     class AttributeDefs(UserInterface.AttributeDefs):
         """Cluster attributes."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.ui_bus.add_listener(self)
-
     def child_lock_change(self, mode):
         """Change of child lock setting."""
         if mode == 0:
@@ -938,13 +905,6 @@ class TuyaNoBindPowerConfigurationCluster(CustomCluster, PowerConfiguration):
 class TuyaPowerConfigurationCluster(PowerConfiguration, TuyaLocalCluster):
     """PowerConfiguration cluster for battery-operated thermostats."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        # listening to battery_bus required for legacy and custom Tuya TRV quirks
-        if hasattr(self.endpoint.device, "battery_bus"):
-            self.endpoint.device.battery_bus.add_listener(self)
-
     def battery_change(self, value):
         """Change of reported battery percentage remaining."""
         self.update_attribute("battery_percentage_remaining", value * 2)
@@ -1002,13 +962,6 @@ class TuyaPowerConfigurationClusterOther(PowerConfiguration, TuyaLocalCluster):
 
 class TuyaThermostat(CustomDevice):
     """Generic Tuya thermostat device."""
-
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.thermostat_bus = Bus()
-        self.ui_bus = Bus()
-        self.battery_bus = Bus()
-        super().__init__(*args, **kwargs)
 
 
 # Tuya Zigbee OnOff Cluster Attribute Implementation
@@ -1223,25 +1176,20 @@ class TuyaManufacturerWindowCover(TuyaManufCluster):
                 TUYA_DP_TYPE_VALUE + TUYA_DP_ID_PERCENT_CONTROL,
             ]
             if tuya_payload.command_id in ids:
-                self.endpoint.device.cover_bus.listener_event(
-                    COVER_EVENT,
-                    ATTR_COVER_POSITION,
-                    tuya_payload.data[4],
+                self.endpoint.window_covering.cover_event(
+                    ATTR_COVER_POSITION, tuya_payload.data[4]
                 )
             elif (
                 tuya_payload.command_id
                 == TUYA_DP_TYPE_ENUM + TUYA_DP_ID_DIRECTION_CHANGE
             ):
-                self.endpoint.device.cover_bus.listener_event(
-                    COVER_EVENT,
-                    ATTR_COVER_DIRECTION,
-                    tuya_payload.data[1],
+                self.endpoint.window_covering.cover_event(
+                    ATTR_COVER_DIRECTION, tuya_payload.data[1]
                 )
             elif (
                 tuya_payload.command_id == TUYA_DP_TYPE_ENUM + TUYA_DP_ID_COVER_INVERTED
             ):
-                self.endpoint.device.cover_bus.listener_event(
-                    COVER_EVENT,
+                self.endpoint.window_covering.cover_event(
                     ATTR_COVER_INVERTED,
                     tuya_payload.data[1],  # Check this
                 )
@@ -1266,11 +1214,6 @@ class TuyaWindowCoverControl(LocalDataCluster, WindowCovering):
 
         motor_direction: Final = ZCLAttributeDef(id=ATTR_COVER_DIRECTION, type=t.Bool)
         cover_inverted: Final = ZCLAttributeDef(id=ATTR_COVER_INVERTED, type=t.Bool)
-
-    def __init__(self, *args, **kwargs):
-        """Initialize instance."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.cover_bus.add_listener(self)
 
     def cover_event(self, attribute, value):
         """Event listener for cover events."""
@@ -1387,11 +1330,6 @@ class TuyaWindowCover(CustomDevice):
     # Don't invert _TZE200_cowvfni3: https://github.com/Koenkk/zigbee2mqtt/issues/6043
     tuya_cover_inverted_by_default = False
 
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.cover_bus = Bus()
-        super().__init__(*args, **kwargs)
-
 
 class TuyaManufacturerLevelControl(TuyaManufCluster):
     """Manufacturer Specific Cluster for cover device."""
@@ -1420,32 +1358,31 @@ class TuyaManufacturerLevelControl(TuyaManufCluster):
 
         if hdr.command_id in (0x0002, 0x0001):
             if tuya_payload.command_id == TUYA_LEVEL_COMMAND:
-                self.endpoint.device.dimmer_bus.listener_event(
-                    LEVEL_EVENT,
-                    tuya_payload.command_id,
-                    tuya_payload.data,
-                )
+                for endpoint_id, endpoint in self.endpoint.device.endpoints.items():
+                    if endpoint_id == 0:
+                        continue
+                    level_cluster = endpoint.in_clusters.get(LevelControl.cluster_id)
+                    if isinstance(level_cluster, TuyaLevelControl):
+                        level_cluster.level_event(
+                            tuya_payload.command_id, tuya_payload.data
+                        )
             else:
-                self.endpoint.device.switch_bus.listener_event(
-                    SWITCH_EVENT,
-                    tuya_payload.command_id - TUYA_CMD_BASE,
-                    tuya_payload.data[1],
-                )
+                channel = tuya_payload.command_id - TUYA_CMD_BASE
+                endpoint = self.endpoint.device.endpoints.get(channel)
+                if endpoint is not None:
+                    on_off_cluster = endpoint.in_clusters.get(OnOff.cluster_id)
+                    if isinstance(on_off_cluster, TuyaOnOff):
+                        on_off_cluster.switch_event(channel, tuya_payload.data[1])
 
 
 class TuyaLevelControl(CustomCluster, LevelControl):
     """Tuya Level cluster for dimmable device."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.dimmer_bus.add_listener(self)
-
     def level_event(self, channel, state):
         """Level event."""
         level = (((state[3] << 8) + state[4]) * 255) // 1000
         _LOGGER.debug(
-            "%s - Received level event message, channel: %d, level: %d, data: %d",
+            "%s - Received level event message, channel: %d, level: %d, data: %s",
             self.endpoint.device.ieee,
             channel,
             level,

--- a/zhaquirks/tuya/__init__.py
+++ b/zhaquirks/tuya/__init__.py
@@ -7,8 +7,9 @@ import dataclasses
 import datetime
 import enum
 import logging
-from typing import Any, Final
+from typing import Any, Final, Protocol, cast
 
+import zigpy.endpoint
 import zigpy.types as t
 from zigpy.typing import UNDEFINED, AddressingMode, UndefinedType
 from zigpy.zcl import BaseAttributeDefs, foundation
@@ -131,9 +132,39 @@ TUYA_CMD_BASE = 0x0100
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_tuya_mcu_cluster(endpoint):
-    """Return the endpoint 1 Tuya manufacturer cluster for a device."""
-    return endpoint.device.endpoints[1].in_clusters[TUYA_CLUSTER_ID]
+class _TuyaMCUCommandCluster(Protocol):
+    """Cluster capable of handling a local Tuya MCU command."""
+
+    def tuya_mcu_command(self, command: Any) -> Any:
+        """Handle a local Tuya MCU command."""
+
+
+def get_tuya_mcu_cluster(
+    endpoint: zigpy.endpoint.Endpoint,
+) -> _TuyaMCUCommandCluster:
+    """Return the endpoint 1 Tuya MCU (0xEF00) input cluster for a device.
+
+    Tuya command routing requires the physical MCU cluster on endpoint 1. Local
+    clusters on synthetic or secondary endpoints route their commands there.
+    """
+    endpoint_1 = endpoint.device.endpoints.get(1)
+    if endpoint_1 is None:
+        raise RuntimeError(
+            f"{endpoint.device.ieee}: no Tuya MCU cluster "
+            f"(0x{TUYA_CLUSTER_ID:04X}) on endpoint 1; "
+            "direct Tuya command routing requires it"
+        )
+
+    endpoint_1 = cast(zigpy.endpoint.Endpoint, endpoint_1)
+    cluster = endpoint_1.in_clusters.get(TUYA_CLUSTER_ID)
+    if cluster is None or not hasattr(cluster, "tuya_mcu_command"):
+        raise RuntimeError(
+            f"{endpoint.device.ieee}: no Tuya MCU cluster "
+            f"(0x{TUYA_CLUSTER_ID:04X}) on endpoint 1; "
+            "direct Tuya command routing requires it"
+        )
+
+    return cast(_TuyaMCUCommandCluster, cluster)
 
 
 class TuyaTimePayload(t.LVList, item_type=t.uint8_t, length_type=t.uint16_t_be):
@@ -664,7 +695,7 @@ class TuyaManufacturerClusterOnOff(TuyaManufCluster):
             tuya_payload = args[0]
             channel = tuya_payload.command_id - TUYA_CMD_BASE
             endpoint = self.endpoint.device.endpoints.get(channel)
-            if endpoint is not None:
+            if isinstance(endpoint, zigpy.endpoint.Endpoint):
                 on_off_cluster = endpoint.in_clusters.get(OnOff.cluster_id)
                 if isinstance(on_off_cluster, TuyaOnOff):
                     on_off_cluster.switch_event(channel, tuya_payload.data[1])
@@ -1369,7 +1400,7 @@ class TuyaManufacturerLevelControl(TuyaManufCluster):
             else:
                 channel = tuya_payload.command_id - TUYA_CMD_BASE
                 endpoint = self.endpoint.device.endpoints.get(channel)
-                if endpoint is not None:
+                if isinstance(endpoint, zigpy.endpoint.Endpoint):
                     on_off_cluster = endpoint.in_clusters.get(OnOff.cluster_id)
                     if isinstance(on_off_cluster, TuyaOnOff):
                         on_off_cluster.switch_event(channel, tuya_payload.data[1])

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -14,11 +14,10 @@ from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import LevelControl, OnOff
 from zigpy.zcl.foundation import ZCLAttributeDef
 
-from zhaquirks import Bus, DoublingPowerConfigurationCluster
+from zhaquirks import DoublingPowerConfigurationCluster
 
 # add EnchantedDevice import for custom quirks backwards compatibility
 from zhaquirks.tuya import (
-    TUYA_MCU_COMMAND,
     TUYA_MCU_VERSION_RSP,
     TUYA_SET_TIME,
     DPToAttributeMapping as DpToAttributeMappingBase,
@@ -30,6 +29,7 @@ from zhaquirks.tuya import (
     TuyaLocalCluster,
     TuyaNewManufCluster,
     TuyaTimePayload,
+    get_tuya_mcu_cluster,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -130,10 +130,7 @@ class TuyaAttributesCluster(TuyaLocalCluster):
                 expect_reply=False,
                 manufacturer=manufacturer,
             )
-            self.endpoint.device.command_bus.listener_event(
-                TUYA_MCU_COMMAND,
-                cluster_data,
-            )
+            get_tuya_mcu_cluster(self.endpoint).tuya_mcu_command(cluster_data)
 
         return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
 
@@ -234,10 +231,6 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
                     if hasattr(dp_mapping, "dp_converter") and dp_mapping.dp_converter:
                         self._attributes_to_dp_converters[dp] = dp_mapping.dp_converter
 
-        # Cluster for endpoint: 1 (listen MCU commands)
-        self.endpoint.device.command_bus = Bus()
-        self.endpoint.device.command_bus.add_listener(self)
-
     def from_cluster_data(self, data: TuyaClusterData) -> list[TuyaCommand]:
         """Convert from cluster data to a tuya data payload."""
 
@@ -254,23 +247,36 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
         tuya_commands: list[TuyaCommand] = []
         for dp in dp_mapping:
             val = data.attr_value
+            converter_args: list[Any] | None = None
 
-            if attr_to_dp_converter := self._attributes_to_dp_converters.get(dp):
-                args = []
-                for dp_attr in self._dp_to_attributes[dp]:
-                    if dp_attr.attribute_name == data.cluster_attr:
-                        args.append(val)
-                        continue
-                    endpoint = self.endpoint
-                    if dp_attr.endpoint_id:
-                        endpoint = endpoint.device.endpoints[dp_attr.endpoint_id]
-                    cluster = getattr(endpoint, dp_attr.ep_attribute)
-                    args.append(cluster.get(dp_attr.attribute_name))
-                val = attr_to_dp_converter(*args)
-            self.debug("value: %s", val)
+            try:
+                if attr_to_dp_converter := self._attributes_to_dp_converters.get(dp):
+                    converter_args = []
+                    for dp_attr in self._dp_to_attributes[dp]:
+                        if dp_attr.attribute_name == data.cluster_attr:
+                            converter_args.append(val)
+                            continue
+                        endpoint = self.endpoint
+                        if dp_attr.endpoint_id:
+                            endpoint = endpoint.device.endpoints[dp_attr.endpoint_id]
+                        cluster = getattr(endpoint, dp_attr.ep_attribute)
+                        converter_args.append(cluster.get(dp_attr.attribute_name))
+                    val = attr_to_dp_converter(*converter_args)
+                self.debug("value: %s", val)
 
-            dpd = TuyaDatapointData(dp, val)
-            self.debug("raw: %s", dpd.data.raw)
+                dpd = TuyaDatapointData(dp, val)
+                self.debug("raw: %s", dpd.data.raw)
+            except Exception as exc:  # noqa: BLE001
+                if converter_args is None or all(
+                    arg is not None for arg in converter_args
+                ):
+                    raise
+                self.debug(
+                    "Cannot build DP %s from an incomplete attribute cache: %s",
+                    dp,
+                    exc,
+                )
+                return []
 
             tuya_commands.append(
                 TuyaCommand(
@@ -420,10 +426,7 @@ class TuyaOnOff(OnOff, TuyaLocalCluster):
                 expect_reply=expect_reply,
                 manufacturer=manufacturer,
             )
-            self.endpoint.device.command_bus.listener_event(
-                TUYA_MCU_COMMAND,
-                cluster_data,
-            )
+            get_tuya_mcu_cluster(self.endpoint).tuya_mcu_command(cluster_data)
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
@@ -483,10 +486,7 @@ class TuyaWindowCovering(WindowCovering, TuyaLocalCluster):
                 expect_reply=expect_reply,
                 manufacturer=manufacturer,
             )
-            self.endpoint.device.command_bus.listener_event(
-                TUYA_MCU_COMMAND,
-                cluster_data,
-            )
+            get_tuya_mcu_cluster(self.endpoint).tuya_mcu_command(cluster_data)
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
@@ -501,10 +501,7 @@ class TuyaWindowCovering(WindowCovering, TuyaLocalCluster):
                 expect_reply=expect_reply,
                 manufacturer=manufacturer,
             )
-            self.endpoint.device.command_bus.listener_event(
-                TUYA_MCU_COMMAND,
-                cluster_data,
-            )
+            get_tuya_mcu_cluster(self.endpoint).tuya_mcu_command(cluster_data)
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
@@ -519,10 +516,7 @@ class TuyaWindowCovering(WindowCovering, TuyaLocalCluster):
                 expect_reply=expect_reply,
                 manufacturer=manufacturer,
             )
-            self.endpoint.device.command_bus.listener_event(
-                TUYA_MCU_COMMAND,
-                cluster_data,
-            )
+            get_tuya_mcu_cluster(self.endpoint).tuya_mcu_command(cluster_data)
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
@@ -537,10 +531,7 @@ class TuyaWindowCovering(WindowCovering, TuyaLocalCluster):
                 expect_reply=expect_reply,
                 manufacturer=manufacturer,
             )
-            self.endpoint.device.command_bus.listener_event(
-                TUYA_MCU_COMMAND,
-                cluster_data,
-            )
+            get_tuya_mcu_cluster(self.endpoint).tuya_mcu_command(cluster_data)
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
@@ -735,10 +726,7 @@ class TuyaLevelControl(LevelControl, TuyaLocalCluster):
                 expect_reply=expect_reply,
                 manufacturer=manufacturer,
             )
-            self.endpoint.device.command_bus.listener_event(
-                TUYA_MCU_COMMAND,
-                cluster_data,
-            )
+            get_tuya_mcu_cluster(self.endpoint).tuya_mcu_command(cluster_data)
 
         # level 0 --> switched off
         if command_id == 0x0004 and not on_off:
@@ -756,10 +744,7 @@ class TuyaLevelControl(LevelControl, TuyaLocalCluster):
                 expect_reply=expect_reply,
                 manufacturer=manufacturer,
             )
-            self.endpoint.device.command_bus.listener_event(
-                TUYA_MCU_COMMAND,
-                cluster_data,
-            )
+            get_tuya_mcu_cluster(self.endpoint).tuya_mcu_command(cluster_data)
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=foundation.Status.SUCCESS)

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -247,29 +247,39 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
         tuya_commands: list[TuyaCommand] = []
         for dp in dp_mapping:
             val = data.attr_value
-            converter_args: list[Any] | None = None
+            cache_incomplete = False
+
+            if attr_to_dp_converter := self._attributes_to_dp_converters.get(dp):
+                converter_args: list[Any] = []
+                for dp_attr in self._dp_to_attributes[dp]:
+                    if dp_attr.attribute_name == data.cluster_attr:
+                        converter_args.append(val)
+                        continue
+                    endpoint = self.endpoint
+                    if dp_attr.endpoint_id:
+                        endpoint = endpoint.device.endpoints[dp_attr.endpoint_id]
+                    cluster = getattr(endpoint, dp_attr.ep_attribute)
+                    converter_args.append(cluster.get(dp_attr.attribute_name))
+
+                cache_incomplete = any(arg is None for arg in converter_args)
+                try:
+                    val = attr_to_dp_converter(*converter_args)
+                except (TypeError, ValueError) as exc:
+                    if not cache_incomplete:
+                        raise
+                    self.debug(
+                        "Cannot build DP %s from an incomplete attribute cache: %s",
+                        dp,
+                        exc,
+                    )
+                    return []
+
+            self.debug("value: %s", val)
 
             try:
-                if attr_to_dp_converter := self._attributes_to_dp_converters.get(dp):
-                    converter_args = []
-                    for dp_attr in self._dp_to_attributes[dp]:
-                        if dp_attr.attribute_name == data.cluster_attr:
-                            converter_args.append(val)
-                            continue
-                        endpoint = self.endpoint
-                        if dp_attr.endpoint_id:
-                            endpoint = endpoint.device.endpoints[dp_attr.endpoint_id]
-                        cluster = getattr(endpoint, dp_attr.ep_attribute)
-                        converter_args.append(cluster.get(dp_attr.attribute_name))
-                    val = attr_to_dp_converter(*converter_args)
-                self.debug("value: %s", val)
-
                 dpd = TuyaDatapointData(dp, val)
-                self.debug("raw: %s", dpd.data.raw)
-            except Exception as exc:  # noqa: BLE001
-                if converter_args is None or all(
-                    arg is not None for arg in converter_args
-                ):
+            except (TypeError, ValueError) as exc:
+                if not cache_incomplete:
                     raise
                 self.debug(
                     "Cannot build DP %s from an incomplete attribute cache: %s",
@@ -277,6 +287,7 @@ class TuyaMCUCluster(TuyaAttributesCluster, TuyaNewManufCluster):
                     exc,
                 )
                 return []
+            self.debug("raw: %s", dpd.data.raw)
 
             tuya_commands.append(
                 TuyaCommand(

--- a/zhaquirks/tuya/ts0210.py
+++ b/zhaquirks/tuya/ts0210.py
@@ -6,13 +6,12 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Ota, PowerConfiguration, Time
 from zigpy.zcl.clusters.security import IasZone
 
-from zhaquirks import Bus, LocalDataCluster, MotionOnEvent
+from zhaquirks import LocalDataCluster, MotionOnEvent
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODEL,
-    MOTION_EVENT,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
@@ -37,16 +36,11 @@ class VibrationCluster(LocalDataCluster, MotionOnEvent, IasZone):
         dst_addressing: t.AddrMode | None = None,
     ) -> None:
         """Handle cluster request."""
-        self.endpoint.device.motion_bus.listener_event(MOTION_EVENT)
+        self.motion_event()
 
 
 class TuyaVibration(CustomDevice):
     """Tuya vibration sensor."""
-
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.motion_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=1026, device_version=0,
@@ -86,11 +80,6 @@ class TuyaVibration(CustomDevice):
 
 class TuyaVibration_TO(CustomDevice):
     """Tuya vibration sensor (TO)."""
-
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.motion_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         MODEL: "TS0210",

--- a/zhaquirks/tuya/ts0601_din_power.py
+++ b/zhaquirks/tuya/ts0601_din_power.py
@@ -9,7 +9,7 @@ from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 from zigpy.zcl.foundation import ZCLAttributeDef
 
-from zhaquirks import Bus, LocalDataCluster
+from zhaquirks import LocalDataCluster
 from zhaquirks.builder import (
     PERCENTAGE,
     SensorDeviceClass,
@@ -37,8 +37,6 @@ TUYA_CURRENT_ATTR = 0x0212
 TUYA_POWER_ATTR = 0x0213
 TUYA_VOLTAGE_ATTR = 0x0214
 TUYA_DIN_SWITCH_ATTR = 0x0101
-
-SWITCH_EVENT = "switch_event"
 
 """Hiking Power Meter Attributes"""
 HIKING_DIN_SWITCH_ATTR = 0x0110
@@ -85,9 +83,7 @@ class TuyaManufClusterDinPower(TuyaManufClusterAttributes):
         elif attrid == TUYA_VOLTAGE_ATTR:
             self.endpoint.electrical_measurement.voltage_reported(value / 10)
         elif attrid == TUYA_DIN_SWITCH_ATTR:
-            self.endpoint.device.switch_bus.listener_event(
-                SWITCH_EVENT, self.endpoint.endpoint_id, value
-            )
+            self.endpoint.on_off.switch_event(self.endpoint.endpoint_id, value)
 
 
 class TuyaPowerMeasurement(LocalDataCluster, ElectricalMeasurement):
@@ -204,7 +200,7 @@ class HikingManufClusterDinPower(TuyaManufClusterAttributes):
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
         if attrid == HIKING_DIN_SWITCH_ATTR:
-            self.endpoint.device.switch_bus.listener_event(SWITCH_EVENT, 16, value)
+            self.endpoint.device.endpoints[16].on_off.switch_event(16, value)
         elif attrid == HIKING_TOTAL_ENERGY_DELIVERED_ATTR:
             self.endpoint.smartenergy_metering.energy_deliver_reported(value / 100)
         elif attrid == HIKING_TOTAL_ENERGY_RECEIVED_ATTR:
@@ -228,11 +224,6 @@ class HikingManufClusterDinPower(TuyaManufClusterAttributes):
 
 class TuyaPowerMeter(TuyaSwitch):
     """Tuya power meter device."""
-
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.switch_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         # "node_descriptor": "<NodeDescriptor byte1=1 byte2=64 mac_capability_flags=142 manufacturer_code=4098

--- a/zhaquirks/tuya/ts0601_electric_heating.py
+++ b/zhaquirks/tuya/ts0601_electric_heating.py
@@ -65,36 +65,28 @@ class MoesBHTManufCluster(TuyaManufClusterAttributes):
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
         if attrid == MOESBHT_TARGET_TEMP_ATTR:
-            self.endpoint.device.thermostat_bus.listener_event(
-                "temperature_change",
+            self.endpoint.thermostat.temperature_change(
                 "occupied_heating_setpoint",
                 value * 100,  # degree to centidegree
             )
         elif attrid == MOESBHT_TEMPERATURE_ATTR:
-            self.endpoint.device.thermostat_bus.listener_event(
-                "temperature_change",
+            self.endpoint.thermostat.temperature_change(
                 "local_temperature",
                 value * 10,  # decidegree to centidegree
             )
         elif attrid == MOESBHT_SCHEDULE_MODE_ATTR:
             if value == 0:  # value is inverted
-                self.endpoint.device.thermostat_bus.listener_event(
-                    "program_change", "scheduled"
-                )
+                self.endpoint.thermostat.program_change("scheduled")
         elif attrid == MOESBHT_MANUAL_MODE_ATTR:
             if value == 0:  # value is inverted
-                self.endpoint.device.thermostat_bus.listener_event(
-                    "program_change", "manual"
-                )
+                self.endpoint.thermostat.program_change("manual")
         elif attrid == MOESBHT_ENABLED_ATTR:
-            self.endpoint.device.thermostat_bus.listener_event("enabled_change", value)
+            self.endpoint.thermostat.enabled_change(value)
         elif attrid == MOESBHT_RUNNING_MODE_ATTR:
             # value is inverted
-            self.endpoint.device.thermostat_bus.listener_event(
-                "state_change", 1 - value
-            )
+            self.endpoint.thermostat.state_change(1 - value)
         elif attrid == MOESBHT_CHILD_LOCK_ATTR:
-            self.endpoint.device.ui_bus.listener_event("child_lock_change", value)
+            self.endpoint.thermostat_ui.child_lock_change(value)
 
 
 class MoesBHTThermostat(TuyaThermostatCluster):

--- a/zhaquirks/tuya/ts0601_haozee.py
+++ b/zhaquirks/tuya/ts0601_haozee.py
@@ -199,7 +199,7 @@ class HY08WEThermostat(TuyaThermostatCluster):
         """Attribute definitions."""
 
         unoccupied_duration_days: Final = ZCLAttributeDef(
-            id=0x4007, type=t.uint32_t, is_manufacturer_specific=True
+            id=0x4007, type=t.uint32_t, manufacturer_code=None
         )
 
     DIRECT_MAPPING_ATTRS = {

--- a/zhaquirks/tuya/ts0601_haozee.py
+++ b/zhaquirks/tuya/ts0601_haozee.py
@@ -144,7 +144,10 @@ class HY08WEManufCluster(TuyaManufClusterAttributes):
         fault: Final = ZCLAttributeDef(id=HAOZEE_FAULT_ATTR, type=t.uint8_t)
 
     DIRECT_MAPPED_ATTRS = {
-        HAOZEE_CURRENT_ROOM_TEMP_ATTR: ("local_temp", lambda value: value * 10),
+        HAOZEE_CURRENT_ROOM_TEMP_ATTR: (
+            "local_temperature",
+            lambda value: value * 10,
+        ),
         HAOZEE_TARGET_TEMP_ATTR: (
             "occupied_heating_setpoint",
             lambda value: value * 10,
@@ -171,8 +174,7 @@ class HY08WEManufCluster(TuyaManufClusterAttributes):
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
         if attrid in self.DIRECT_MAPPED_ATTRS:
-            self.endpoint.device.thermostat_bus.listener_event(
-                "temperature_change",
+            self.endpoint.thermostat.temperature_change(
                 self.DIRECT_MAPPED_ATTRS[attrid][0],
                 value
                 if self.DIRECT_MAPPED_ATTRS[attrid][1] is None
@@ -181,17 +183,24 @@ class HY08WEManufCluster(TuyaManufClusterAttributes):
                 ),  # decidegree to centidegree
             )
         elif attrid == HAOZEE_ENABLED_ATTR:
-            self.endpoint.device.thermostat_bus.listener_event("enabled_change", value)
+            self.endpoint.thermostat.enabled_change(value)
         elif attrid == HAOZEE_HEATING_ENABLED_ATTR:
-            self.endpoint.device.thermostat_bus.listener_event("state_change", value)
+            self.endpoint.thermostat.state_change(value)
         elif attrid == HAOZEE_CURRENT_MODE_ATTR:
-            self.endpoint.device.thermostat_bus.listener_event("mode_change", value)
+            self.endpoint.thermostat.mode_change(value)
         elif attrid == HAOZEE_CHILD_LOCK_ATTR:
-            self.endpoint.device.ui_bus.listener_event("child_lock_change", value)
+            self.endpoint.thermostat_ui.child_lock_change(value)
 
 
 class HY08WEThermostat(TuyaThermostatCluster):
     """Thermostat cluster for some thermostatic valves."""
+
+    class AttributeDefs(TuyaThermostatCluster.AttributeDefs):
+        """Attribute definitions."""
+
+        unoccupied_duration_days: Final = ZCLAttributeDef(
+            id=0x4007, type=t.uint32_t, is_manufacturer_specific=True
+        )
 
     DIRECT_MAPPING_ATTRS = {
         "occupied_heating_setpoint": (

--- a/zhaquirks/tuya/ts0601_rcbo.py
+++ b/zhaquirks/tuya/ts0601_rcbo.py
@@ -27,7 +27,7 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.legacy import CustomDevice
-from zhaquirks.tuya import TUYA_MCU_COMMAND, AttributeWithMask, PowerOnState
+from zhaquirks.tuya import AttributeWithMask, PowerOnState, get_tuya_mcu_cluster
 from zhaquirks.tuya.mcu import (
     DPToAttributeMapping,
     TuyaAttributesCluster,
@@ -183,10 +183,7 @@ class TuyaRCBOOnOff(TuyaOnOff, TuyaAttributesCluster):
                 expect_reply=expect_reply,
                 manufacturer=manufacturer,
             )
-            self.endpoint.device.command_bus.listener_event(
-                TUYA_MCU_COMMAND,
-                cluster_data,
-            )
+            get_tuya_mcu_cluster(self.endpoint).tuya_mcu_command(cluster_data)
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
@@ -314,10 +311,7 @@ class TuyaRCBOMetering(Metering, TuyaAttributesCluster):
                 expect_reply=expect_reply,
                 manufacturer=manufacturer,
             )
-            self.endpoint.device.command_bus.listener_event(
-                TUYA_MCU_COMMAND,
-                cluster_data,
-            )
+            get_tuya_mcu_cluster(self.endpoint).tuya_mcu_command(cluster_data)
             return foundation.GENERAL_COMMANDS[
                 foundation.GeneralCommand.Default_Response
             ].schema(command_id=command_id, status=foundation.Status.SUCCESS)

--- a/zhaquirks/tuya/ts0601_trv.py
+++ b/zhaquirks/tuya/ts0601_trv.py
@@ -21,7 +21,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.hvac import Thermostat
 from zigpy.zcl.foundation import ZCLAttributeDef
 
-from zhaquirks import Bus, LocalDataCluster
+from zhaquirks import LocalDataCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -104,23 +104,20 @@ class SiterwellManufCluster(TuyaManufClusterAttributes):
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
         if attrid in self.TEMPERATURE_ATTRS:
-            self.endpoint.device.thermostat_bus.listener_event(
-                "temperature_change",
+            self.endpoint.thermostat.temperature_change(
                 self.TEMPERATURE_ATTRS[attrid],
                 value * 10,  # decidegree to centidegree
             )
         elif attrid == SITERWELL_MODE_ATTR:
-            self.endpoint.device.thermostat_bus.listener_event("mode_change", value)
-            self.endpoint.device.thermostat_bus.listener_event(
-                "state_change", value > 0
-            )
+            self.endpoint.thermostat.mode_change(value)
+            self.endpoint.thermostat.state_change(value > 0)
         elif attrid == SITERWELL_VALVE_STATE_ATTR:
-            self.endpoint.device.thermostat_bus.listener_event("state_change", value)
+            self.endpoint.thermostat.state_change(value)
         elif attrid == SITERWELL_CHILD_LOCK_ATTR:
             mode = 1 if value else 0
-            self.endpoint.device.ui_bus.listener_event("child_lock_change", mode)
+            self.endpoint.thermostat_ui.child_lock_change(mode)
         elif attrid == SITERWELL_BATTERY_ATTR:
-            self.endpoint.device.battery_bus.listener_event("battery_change", value)
+            self.endpoint.power.battery_change(value)
 
 
 class SiterwellThermostat(TuyaThermostatCluster):
@@ -317,8 +314,7 @@ class MoesManufCluster(TuyaManufClusterAttributes):
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
         if attrid in self.DIRECT_MAPPED_ATTRS:
-            self.endpoint.device.thermostat_bus.listener_event(
-                "temperature_change",
+            self.endpoint.thermostat.temperature_change(
                 self.DIRECT_MAPPED_ATTRS[attrid][0],
                 value
                 if self.DIRECT_MAPPED_ATTRS[attrid][1] is None
@@ -327,28 +323,22 @@ class MoesManufCluster(TuyaManufClusterAttributes):
                 ),  # decidegree to centidegree
             )
         elif attrid in (MOES_SCHEDULE_WORKDAY_ATTR, MOES_SCHEDULE_WEEKEND_ATTR):
-            self.endpoint.device.thermostat_bus.listener_event(
-                "schedule_change", attrid, value
-            )
+            self.endpoint.thermostat.schedule_change(attrid, value)
 
         if attrid == MOES_WINDOW_DETECT_ATTR:
-            self.endpoint.device.window_detection_bus.listener_event(
-                "window_detect_change", value
-            )
+            self.endpoint.on_off.window_detect_change(value)
         elif attrid == MOES_MODE_ATTR:
-            self.endpoint.device.thermostat_bus.listener_event("mode_change", value)
+            self.endpoint.thermostat.mode_change(value)
         elif attrid == MOES_VALVE_STATE_ATTR:
-            self.endpoint.device.thermostat_bus.listener_event("state_change", value)
+            self.endpoint.thermostat.state_change(value)
         elif attrid == MOES_CHILD_LOCK_ATTR:
             mode = 1 if value else 0
-            self.endpoint.device.ui_bus.listener_event("child_lock_change", mode)
+            self.endpoint.thermostat_ui.child_lock_change(mode)
         elif attrid == MOES_AUTO_LOCK_ATTR:
             mode = 1 if value else 0
-            self.endpoint.device.ui_bus.listener_event("autolock_change", mode)
+            self.endpoint.thermostat_ui.autolock_change(mode)
         elif attrid == MOES_BATTERY_LOW_ATTR:
-            self.endpoint.device.battery_bus.listener_event(
-                "battery_change", 5 if value else 100
-            )
+            self.endpoint.power.battery_change(5 if value else 100)
 
 
 class MoesManufClusterNew(MoesManufCluster):
@@ -932,11 +922,6 @@ class MoesUserInterface(TuyaUserInterfaceCluster):
 class MoesWindowDetection(LocalDataCluster, OnOff):
     """On/Off cluster for the window detection function of the electric heating thermostats."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.window_detection_bus.add_listener(self)
-
     class AttributeDefs(OnOff.AttributeDefs):
         """Attribute definitions."""
 
@@ -1092,17 +1077,10 @@ ZONNSMART_ONLINE_MODE_BOOL_ATTR = 0x0173  # but expects to receive bool datatype
 
 ZONNSMART_MAX_TEMPERATURE_VAL = 3000
 ZONNSMART_MIN_TEMPERATURE_VAL = 500
-ZonnsmartManuClusterSelf = None
 
 
 class ZONNSMARTManufCluster(TuyaManufClusterAttributes):
     """Manufacturer Specific Cluster of some thermostatic valves."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        global ZonnsmartManuClusterSelf  # noqa: PLW0603
-        ZonnsmartManuClusterSelf = self
 
     class AttributeDefs(TuyaManufClusterAttributes.AttributeDefs):
         """Attribute definitions."""
@@ -1214,47 +1192,34 @@ class ZONNSMARTManufCluster(TuyaManufClusterAttributes):
     def _update_attribute(self, attrid, value):
         super()._update_attribute(attrid, value)
         if attrid in self.DIRECT_MAPPED_ATTRS:
-            self.endpoint.device.thermostat_bus.listener_event(
-                "temperature_change",
+            self.endpoint.thermostat.temperature_change(
                 self.DIRECT_MAPPED_ATTRS[attrid][0],
                 value
                 if self.DIRECT_MAPPED_ATTRS[attrid][1] is None
                 else self.DIRECT_MAPPED_ATTRS[attrid][1](value),
             )
         elif attrid == ZONNSMART_WINDOW_DETECT_ATTR:
-            self.endpoint.device.window_detection_bus.listener_event("set_value", value)
+            self.endpoint.binary_input.set_value(value)
         elif attrid == ZONNSMART_OPENED_WINDOW_TEMP:
-            self.endpoint.device.window_temperature_bus.listener_event(
-                "set_value", value
-            )
+            self.endpoint.device.endpoints[2].analog_output.set_value(value)
         elif attrid in (ZONNSMART_MODE_ATTR, ZONNSMART_FROST_PROTECT_ATTR):
-            self.endpoint.device.thermostat_bus.listener_event(
-                "mode_change", attrid, value
-            )
+            self.endpoint.thermostat.mode_change(attrid, value)
         elif attrid == ZONNSMART_HEATING_STOPPING_ATTR:
-            self.endpoint.device.thermostat_bus.listener_event(
-                "system_mode_change", value == 0
-            )
+            self.endpoint.thermostat.system_mode_change(value == 0)
         elif attrid == ZONNSMART_CHILD_LOCK_ATTR:
-            self.endpoint.device.ui_bus.listener_event("child_lock_change", value)
-            self.endpoint.device.child_lock_bus.listener_event("set_change", value)
+            self.endpoint.thermostat_ui.child_lock_change(value)
+            self.endpoint.device.endpoints[2].on_off.set_change(value)
         elif attrid == ZONNSMART_BATTERY_ATTR:
-            self.endpoint.device.battery_bus.listener_event("battery_change", value)
+            self.endpoint.power.battery_change(value)
         elif attrid == ZONNSMART_ONLINE_MODE_ENUM_ATTR:
-            self.endpoint.device.online_mode_bus.listener_event("set_change", value)
+            self.endpoint.device.endpoints[3].on_off.set_change(value)
         elif attrid == ZONNSMART_BOOST_TIME_ATTR:
-            self.endpoint.device.boost_bus.listener_event(
-                "set_change", 1 if value > 0 else 0
-            )
+            self.endpoint.on_off.set_change(1 if value > 0 else 0)
 
         if attrid == ZONNSMART_TEMPERATURE_CALIBRATION_ATTR:
-            self.endpoint.device.temperature_calibration_bus.listener_event(
-                "set_value", value / 10
-            )
+            self.endpoint.analog_output.set_value(value / 10)
         elif attrid in (ZONNSMART_TEMPERATURE_ATTR, ZONNSMART_TARGET_TEMP_ATTR):
-            self.endpoint.device.thermostat_bus.listener_event(
-                "state_temp_change", attrid, value
-            )
+            self.endpoint.thermostat.state_temp_change(attrid, value)
 
 
 class ZONNSMARTThermostat(TuyaThermostatCluster):
@@ -1286,13 +1251,11 @@ class ZONNSMARTThermostat(TuyaThermostatCluster):
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
-        self.endpoint.device.thermostat_bus.listener_event(
-            "temperature_change",
+        self.temperature_change(
             "min_heat_setpoint_limit",
             ZONNSMART_MIN_TEMPERATURE_VAL,
         )
-        self.endpoint.device.thermostat_bus.listener_event(
-            "temperature_change",
+        self.temperature_change(
             "max_heat_setpoint_limit",
             ZONNSMART_MAX_TEMPERATURE_VAL,
         )
@@ -1395,8 +1358,11 @@ class ZONNSMARTThermostat(TuyaThermostatCluster):
         else:
             return
 
+        if temp_current is None or temp_set is None:
+            return
+
         state = 0 if (int(temp_current) >= int(temp_set)) else 1
-        self.endpoint.device.thermostat_bus.listener_event("state_change", state)
+        self.state_change(state)
 
 
 class ZONNSMARTUserInterface(TuyaUserInterfaceCluster):
@@ -1411,11 +1377,6 @@ class ZONNSMARTWindowDetection(LocalDataCluster, BinaryInput):
     _CONSTANT_ATTRIBUTES = {
         BinaryInput.AttributeDefs.description.id: "Open Window Detected",
     }
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.window_detection_bus.add_listener(self)
 
     def set_value(self, value):
         """Set opened window value."""
@@ -1453,10 +1414,9 @@ class ZONNSMARTHelperOnOff(LocalDataCluster, OnOff):
         if has_change:
             attr_val = self.get_attr_val_to_write(value)
             if attr_val is not None:
-                # global self in case when different endpoint has to exist
-                return await ZonnsmartManuClusterSelf.endpoint.tuya_manufacturer.write_attributes(
-                    attr_val, **kwargs
-                )
+                return await self.endpoint.device.endpoints[
+                    1
+                ].tuya_manufacturer.write_attributes(attr_val, **kwargs)
 
         return [
             [
@@ -1511,11 +1471,6 @@ class ZONNSMARTHelperOnOff(LocalDataCluster, OnOff):
 class ZONNSMARTBoost(ZONNSMARTHelperOnOff):
     """On/Off cluster for the boost function of the heating thermostats."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.boost_bus.add_listener(self)
-
     def get_attr_val_to_write(self, value):
         """Return dict with attribute and value for boot mode."""
         return {ZONNSMART_BOOST_TIME_ATTR: 299 if value else 0}
@@ -1524,11 +1479,6 @@ class ZONNSMARTBoost(ZONNSMARTHelperOnOff):
 class ZONNSMARTChildLock(ZONNSMARTHelperOnOff):
     """On/Off cluster for the child lock of the heating thermostats."""
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.child_lock_bus.add_listener(self)
-
     def get_attr_val_to_write(self, value):
         """Return dict with attribute and value for child lock."""
         return {ZONNSMART_CHILD_LOCK_ATTR: value}
@@ -1536,11 +1486,6 @@ class ZONNSMARTChildLock(ZONNSMARTHelperOnOff):
 
 class ZONNSMARTOnlineMode(ZONNSMARTHelperOnOff):
     """On/Off cluster for the online mode of the heating thermostats."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.online_mode_bus.add_listener(self)
 
     def get_attr_val_to_write(self, value):
         """Return dict with attribute and value for online mode."""
@@ -1558,11 +1503,6 @@ class ZONNSMARTTemperatureOffset(LocalDataCluster, AnalogOutput):
         AnalogOutput.AttributeDefs.application_type.id: 0x0009,
         AnalogOutput.AttributeDefs.engineering_units.id: 62,
     }
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.temperature_calibration_bus.add_listener(self)
 
     def set_value(self, value):
         """Set new temperature offset value."""
@@ -1606,11 +1546,6 @@ class ZONNSMARTWindowOpenedTemp(LocalDataCluster, AnalogOutput):
         AnalogOutput.AttributeDefs.engineering_units.id: 62,
     }
 
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.window_temperature_bus.add_listener(self)
-
     def set_value(self, value):
         """Set temperature value when opened window detected."""
         self._update_attribute(self.attributes_by_name["present_value"].id, value / 10)
@@ -1633,8 +1568,7 @@ class ZONNSMARTWindowOpenedTemp(LocalDataCluster, AnalogOutput):
                 continue
             self._update_attribute(attrid, value)
 
-            # different Endpoint for compatibility issue
-            await ZonnsmartManuClusterSelf.endpoint.tuya_manufacturer.write_attributes(
+            await self.endpoint.device.endpoints[1].tuya_manufacturer.write_attributes(
                 {ZONNSMART_OPENED_WINDOW_TEMP: value * 10}, **kwargs
             )
         return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
@@ -1742,11 +1676,6 @@ class SiterwellGS361_Type2(TuyaThermostat):
 class MoesHY368_Type1(TuyaThermostat):
     """MoesHY368 Thermostatic radiator valve."""
 
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.window_detection_bus = Bus()
-        super().__init__(*args, **kwargs)
-
     signature = {
         #  endpoint=1 profile=260 device_type=81 device_version=0 input_clusters=[0, 4, 5, 61184]
         #  output_clusters=[10, 25]>
@@ -1804,11 +1733,6 @@ class MoesHY368_Type1(TuyaThermostat):
 class MoesHY368_Type1new(TuyaThermostat):
     """MoesHY368 Thermostatic radiator valve."""
 
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.window_detection_bus = Bus()
-        super().__init__(*args, **kwargs)
-
     signature = {
         #  endpoint=1 profile=260 device_type=81 device_version=0 input_clusters=[0, 4, 5, 61184]
         #  output_clusters=[10, 25]>
@@ -1854,11 +1778,6 @@ class MoesHY368_Type1new(TuyaThermostat):
 class MoesHY368_Type2(TuyaThermostat):
     """MoesHY368 Thermostatic radiator valve (2nd cluster signature)."""
 
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.window_detection_bus = Bus()
-        super().__init__(*args, **kwargs)
-
     signature = {
         #  endpoint=1 profile=260 device_type=0 device_version=0 input_clusters=[0, 3]
         #  output_clusters=[3, 25]>
@@ -1900,16 +1819,6 @@ class MoesHY368_Type2(TuyaThermostat):
 
 class ZonnsmartTV01_ZG(TuyaThermostat):
     """ZONNSMART TV01-ZG Thermostatic radiator valve."""
-
-    def __init__(self, *args, **kwargs):
-        """Init device."""
-        self.boost_bus = Bus()
-        self.child_lock_bus = Bus()
-        self.online_mode_bus = Bus()
-        self.temperature_calibration_bus = Bus()
-        self.window_detection_bus = Bus()
-        self.window_temperature_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         #  endpoint=1 profile=260 device_type=81 device_version=0 input_clusters=[0, 4, 5, 61184]

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -18,7 +18,7 @@ from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zcl.foundation import BaseCommandDefs
 
-from zhaquirks import Bus, LocalDataCluster
+from zhaquirks import LocalDataCluster
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.const import (
     CLUSTER_COMMAND,
@@ -45,11 +45,6 @@ class EmulatedIasZone(LocalDataCluster, IasZone):
     _CONSTANT_ATTRIBUTES = {
         ZONE_TYPE: MOISTURE_TYPE,
     }
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        super().__init__(*args, **kwargs)
-        self.endpoint.device.ias_bus.add_listener(self)
 
     async def bind(self):
         """Bind cluster."""
@@ -96,16 +91,11 @@ class WAXMANApplianceEventAlerts(CustomCluster, ApplianceEventAlerts):
         if hdr.command_id == WAXMAN_CMDID:
             state = bool(args[1] & 0x1000)
 
-            self.endpoint.device.ias_bus.listener_event("update_state", state)
+            self.endpoint.ias_zone.update_state(state)
 
 
 class WAXMANleakSMARTv2(CustomDevice):
     """Custom device representing WAXMAN leakSMART v2."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.ias_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=770
@@ -153,11 +143,6 @@ class WAXMANleakSMARTv2(CustomDevice):
 
 class WAXMANleakSMARTv2NOPOLL(CustomDevice):
     """Custom WAXMAN leakSMART v2 without PollControl cluster."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.ias_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=770

--- a/zhaquirks/xiaomi/aqara/motion_ac02.py
+++ b/zhaquirks/xiaomi/aqara/motion_ac02.py
@@ -10,7 +10,7 @@ from zigpy.profiles import zha
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 
-from zhaquirks import Bus, LocalDataCluster
+from zhaquirks import LocalDataCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -97,7 +97,6 @@ class LumiMotionAC02(CustomDevice):
         """Init."""
         self.battery_size = BatterySize.CR1632
         self.battery_quantity = 2
-        self.motion_bus = Bus()
         super().__init__(*args, **kwargs)
 
     signature = {

--- a/zhaquirks/xiaomi/aqara/motion_acn001.py
+++ b/zhaquirks/xiaomi/aqara/motion_acn001.py
@@ -3,7 +3,6 @@
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Identify, Ota
 
-from zhaquirks import Bus
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -32,7 +31,6 @@ class MotionE1(XiaomiCustomDevice):
     def __init__(self, *args, **kwargs):
         """Init."""
         self.battery_size = BatterySize.CR1632
-        self.motion_bus = Bus()
         super().__init__(*args, **kwargs)
 
     signature = {

--- a/zhaquirks/xiaomi/aqara/motion_agl02.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl02.py
@@ -6,7 +6,6 @@ from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Identify, Ota
 from zigpy.zcl.clusters.measurement import OccupancySensing
 
-from zhaquirks import Bus
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -34,7 +33,6 @@ class MotionT1(XiaomiCustomDevice):
     def __init__(self, *args, **kwargs):
         """Init."""
         self.battery_size = BatterySize.CR1632
-        self.motion_bus = Bus()
         super().__init__(*args, **kwargs)
 
     signature = {

--- a/zhaquirks/xiaomi/aqara/motion_agl04.py
+++ b/zhaquirks/xiaomi/aqara/motion_agl04.py
@@ -10,7 +10,6 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.measurement import OccupancySensing
 
-from zhaquirks import Bus
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -70,7 +69,6 @@ class LumiLumiMotionAgl04(XiaomiCustomDevice):
         """Init."""
         self.battery_size = BatterySize.CR1632
         self.battery_quantity = 2
-        self.motion_bus = Bus()
         super().__init__(*args, **kwargs)
 
     signature = {

--- a/zhaquirks/xiaomi/aqara/motion_aq2.py
+++ b/zhaquirks/xiaomi/aqara/motion_aq2.py
@@ -5,7 +5,6 @@ from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
 
-from zhaquirks import Bus
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -38,7 +37,6 @@ class MotionAQ2(XiaomiQuickInitDevice):
     def __init__(self, *args, **kwargs):
         """Init."""
         self.battery_size = BatterySize.CR2450
-        self.motion_bus = Bus()
         super().__init__(*args, **kwargs)
 
     signature = {

--- a/zhaquirks/xiaomi/aqara/motion_aq2b.py
+++ b/zhaquirks/xiaomi/aqara/motion_aq2b.py
@@ -4,7 +4,6 @@ from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, Ota
 from zigpy.zcl.clusters.measurement import OccupancySensing
 
-from zhaquirks import Bus
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -34,7 +33,6 @@ class MotionAQ2(XiaomiCustomDevice):
     def __init__(self, *args, **kwargs):
         """Init."""
         self.battery_size = BatterySize.CR2450
-        self.motion_bus = Bus()
         super().__init__(*args, **kwargs)
 
     signature = {

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -18,7 +18,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zcl.foundation import ZCLAttributeDef
 
-from zhaquirks import Bus, LocalDataCluster, MotionOnEvent
+from zhaquirks import LocalDataCluster, MotionOnEvent
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.const import (
     CLUSTER_ID,
@@ -29,7 +29,6 @@ from zhaquirks.const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
-    MOTION_EVENT,
     NODE_DESCRIPTOR,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
@@ -51,7 +50,6 @@ DROP_VALUE = 3
 ORIENTATION_ATTR = 0x0508  # decimal = 1288
 RECENT_ACTIVITY_LEVEL_ATTR = 0x0505  # decimal = 1285
 ROTATION_DEGREES_ATTR = 0x0503  # decimal = 1283
-SEND_EVENT = "send_event"
 STATIONARY_VALUE = 0
 STATUS_TYPE_ATTR = 0x0055  # decimal = 85
 TILT_VALUE = 2
@@ -73,11 +71,6 @@ class VibrationAQ1(XiaomiQuickInitDevice):
     quirk_id = XIAOMI_AQARA_VIBRATION_AQ1
 
     manufacturer_id_override = 0x115F
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.motion_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     class VibrationBasicCluster(BasicCluster):
         """Vibration cluster."""
@@ -106,10 +99,10 @@ class VibrationAQ1(XiaomiQuickInitDevice):
                     value, UNKNOWN
                 )
                 if value == VIBE_VALUE:
-                    self.endpoint.device.motion_bus.listener_event(MOTION_EVENT)
+                    self.endpoint.ias_zone.motion_event()
                 elif value == DROP_VALUE:
-                    self.endpoint.device.motion_bus.listener_event(
-                        SEND_EVENT, self._current_state[STATUS_TYPE_ATTR], {}
+                    self.endpoint.ias_zone.send_event(
+                        self._current_state[STATUS_TYPE_ATTR], {}
                     )
             elif attrid == ORIENTATION_ATTR:
                 x = value & 0xFFFF
@@ -122,8 +115,7 @@ class VibrationAQ1(XiaomiQuickInitDevice):
                 angleY = round(math.atan(Y / math.sqrt(X * X + Z * Z)) * 180 / math.pi)
                 angleZ = round(math.atan(Z / math.sqrt(X * X + Y * Y)) * 180 / math.pi)
 
-                self.endpoint.device.motion_bus.listener_event(
-                    SEND_EVENT,
+                self.endpoint.ias_zone.send_event(
                     "current_orientation",
                     {
                         "rawValueX": x,
@@ -135,8 +127,7 @@ class VibrationAQ1(XiaomiQuickInitDevice):
                     },
                 )
             elif attrid == ROTATION_DEGREES_ATTR:
-                self.endpoint.device.motion_bus.listener_event(
-                    SEND_EVENT,
+                self.endpoint.ias_zone.send_event(
                     self._current_state[STATUS_TYPE_ATTR],
                     {"degrees": value},
                 )
@@ -144,8 +135,7 @@ class VibrationAQ1(XiaomiQuickInitDevice):
                 # these seem to be sent every minute when vibration is active
                 strength = value >> 8
                 strength = ((strength & 0xFF) << 8) | ((strength >> 8) & 0xFF)
-                self.endpoint.device.motion_bus.listener_event(
-                    SEND_EVENT,
+                self.endpoint.ias_zone.send_event(
                     "vibration_strength",
                     {"strength": strength},
                 )

--- a/zhaquirks/xiaomi/mija/motion.py
+++ b/zhaquirks/xiaomi/mija/motion.py
@@ -11,7 +11,6 @@ from zigpy.zcl.clusters.general import (
     Scenes,
 )
 
-from zhaquirks import Bus
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -42,7 +41,6 @@ class Motion(XiaomiQuickInitDevice):
     def __init__(self, *args, **kwargs):
         """Init."""
         self.battery_size = BatterySize.CR2450
-        self.motion_bus = Bus()
         super().__init__(*args, **kwargs)
 
     signature = {

--- a/zhaquirks/zhongxing/__init__.py
+++ b/zhaquirks/zhongxing/__init__.py
@@ -14,4 +14,3 @@ class MotionCluster(MotionWithReset):
     """Motion cluster."""
 
     reset_s: int = 30
-    send_occupancy_event: bool = True

--- a/zhaquirks/zhongxing/motion.py
+++ b/zhaquirks/zhongxing/motion.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.security import IasZone
 
-from zhaquirks import Bus, PowerConfigurationCluster
+from zhaquirks import PowerConfigurationCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -28,11 +28,6 @@ from zhaquirks.zhongxing import ZHONGXING, MotionCluster
 
 class SN10ZW(CustomDevice):
     """SN10ZW motion sensor."""
-
-    def __init__(self, *args, **kwargs):
-        """Init."""
-        self.occupancy_bus = Bus()
-        super().__init__(*args, **kwargs)
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026


### PR DESCRIPTION
## Proposed change

This PR removes the legacy `Bus` abstraction from `zha-device-handlers` and replaces every Bus-based communication path with explicit cluster-to-cluster routing.

The routing model now reflects the actual Zigbee topology at each call site:

- same-endpoint server/input clusters are reached through their endpoint attribute;
- client/output clusters are resolved through `endpoint.out_clusters[cluster_id]`;
- cross-endpoint communication uses `endpoint.device.endpoints[endpoint_id]`;
- Tuya commands emitted by synthetic or secondary endpoints are sent directly to the physical endpoint 1 EF00 input cluster;
- the one legacy dimmer broadcast path explicitly iterates real Zigbee endpoints while excluding endpoint 0/ZDO.

The `Bus` class itself, its imports, device-level Bus instances, listener registration, event-name constants, and Bus-oriented README examples are removed.

### Why this change

The old Bus pattern hid producer/consumer relationships behind string-named broadcast events. That obscured endpoint ownership and cluster direction, required device constructors to allocate routing objects before cluster construction, and allowed listener exceptions to be swallowed by `ListenableMixin.listener_event()`.

Direct routing makes the intended destination explicit and keeps the Zigbee model visible in the code. It also removes intermediary device state, prevents process-global or device-level routing from coupling devices accidentally, and makes tests capable of asserting the exact endpoint and cluster that receives each report or command.

### Routing patterns used

#### Same-endpoint input clusters

When a manufacturer-specific or synthetic input cluster updates another server cluster on the same endpoint, the source calls the destination directly through `self.endpoint.<ep_attribute>`.

This covers shared motion/occupancy relays and manufacturer-specific state propagation for ELKO, IKEA, SmartThings, Waxman, Xiaomi, and several Tuya thermostat implementations.

#### Output/client clusters

ADEO, MLI Tint, and Sengled remotes relay actions through client clusters. These destinations are deliberately resolved from `out_clusters`, rather than endpoint attributes, so event provenance and cluster direction remain unchanged.

#### Explicit cross-endpoint routing

Terncy motion, Hiking DIN power, Zonnsmart auxiliary entities, and other multi-endpoint devices select their target through `device.endpoints[endpoint_id]`. Destination clusters are resolved when the report or command is handled, after replacement endpoints and clusters have been constructed.

#### Tuya endpoint 1 EF00 dispatch

A shared, typed `get_tuya_mcu_cluster(endpoint)` helper resolves the device's endpoint 1 input cluster with cluster ID `0xEF00`. Local Tuya OnOff, level, cover, attribute, RCBO, and secondary-endpoint command handlers call `tuya_mcu_command()` on that concrete cluster.

The helper documents the endpoint 1 invariant and raises a descriptive `RuntimeError` if the expected topology is absent. This preserves the historical purpose of the former command Bus—allowing local clusters on other endpoints to reach the physical MCU endpoint—without retaining a broadcast mechanism.

### Detailed scope

#### Core infrastructure

- Remove the `Bus` class from `zhaquirks`.
- Remove production imports, allocations, listener registrations, `listener_event()` relays, and obsolete event constants associated with Bus communication.
- Update shared motion and occupancy reset clusters to call their co-resident destination clusters directly.
- Keep destination resolution at event time where replacement construction order matters.

#### Non-Tuya handlers

The migration covers:

- ADEO color-controller scene actions;
- ELKO thermostat, UI-lock, and electrical-measurement relays;
- IKEA Starkvind PM2.5 updates;
- Konke and Orvibo motion/occupancy propagation;
- MLI Tint scene updates;
- Sengled OnOff and LevelControl actions;
- SmartThings tag tracking state;
- Terncy left/right IAS routing and endpoint 1 occupancy state;
- both Waxman leakSMART variants;
- Xiaomi motion and vibration devices;
- Zhongxing motion behavior, whose current replacement intentionally contains no occupancy cluster.

Existing device signatures, replacement topology, device automation triggers, and entity declarations are retained.

#### Tuya handlers

The migration covers both legacy Tuya clusters and current MCU-based implementations:

- switch-state routing remains channel- and endpoint-specific;
- malformed channel-zero switch reports remain harmless no-ops rather than resolving endpoint 0/ZDO;
- legacy dimmer reports retain their multi-endpoint fan-out;
- cover state, direction, and inversion continue to update WindowCovering state;
- DIN and Hiking power handlers target their intended OnOff endpoints;
- TS0210 vibration reports update IAS directly;
- electric-heating, Haozee, Moes, Siterwell, and Zonnsmart thermostat state routes to the concrete thermostat, UI, power, OnOff, BinaryInput, or AnalogOutput cluster;
- Zonnsmart helper writes resolve endpoint 1 on their own device instead of using a process-global manufacturer-cluster reference;
- Tuya compound-DP conversion still permits converters that intentionally ignore an uncached companion value, defers known incomplete-cache construction failures, and continues to propagate genuine converter failures.

### Intentional behavior changes exposed by removing Bus

The Bus previously swallowed several exceptions, which made some paths look behavior-preserving even though the intended update never occurred. This PR intentionally restores those masked updates:

- Haozee HY08WE current-temperature reports now update the real `local_temperature` thermostat attribute.
- Haozee away-duration reports now have a defined `unoccupied_duration_days` backing attribute.
- Zonnsmart running-state calculation waits until both current and target temperatures are cached.
- The legacy Tuya level-event debug message formats its list payload correctly.

These are called out explicitly because they are observable fixes, not merely mechanical routing rewrites.

### Breaking change for custom quirks

This PR deliberately removes the out-of-tree custom-quirk interfaces that depended on the legacy mechanism:

- `from zhaquirks import Bus`;
- Tuya constants `TUYA_MCU_COMMAND`, `SWITCH_EVENT`, `LEVEL_EVENT`, and `COVER_EVENT`;
- device attributes such as `command_bus`, `switch_bus`, `dimmer_bus`, and the other removed Bus channels.

A custom quirk that imports or uses those interfaces must migrate the complete producer/consumer path to direct cluster access. An import-only compatibility alias would be incomplete because it could not recreate the removed device attributes, listener registrations, or runtime routing contract. The README now documents same-endpoint, cross-endpoint, output-cluster, and Tuya EF00 migration patterns.

### Review remediation included

The follow-up review changes in this branch:

- document and type the Tuya endpoint 1 EF00 invariant, with a legible error for invalid custom topology;
- prevent both legacy Tuya switch handlers from treating ZDO as a Zigbee endpoint;
- narrow incomplete-cache handling so the known deferrable `TypeError`/`ValueError` cases remain deferred while unrelated converter errors, including the Moes invalid-mode `KeyError`, propagate even when a companion cache value is absent;
- resolve Sengled output clusters only inside the action branches that use them;
- use `manufacturer_code=None` for the new local Haozee attribute;
- narrow the AST guard to the exact removed Bus identifiers and event constants;
- scan README code examples rather than banning the word “Bus” from prose;
- emit one actionable guard failure containing every violation and the direct-routing replacement guidance.

The pre-existing Terncy single-endpoint edge and Zhongxing occupancy-topology ambiguity are intentionally not expanded here: neither is a regression from this migration, and resolving either would require a separate device-behavior decision.

### Regression protection

Producer-driven tests exercise the routing boundaries affected by this migration, including:

- exact input-versus-output cluster selection;
- same-endpoint and cross-endpoint routing;
- endpoint-specific and multi-endpoint fan-out;
- endpoint 0/ZDO exclusion;
- motion and occupancy reset/retrigger behavior;
- multi-device isolation;
- exact Tuya EF00 command payloads and invalid-topology errors;
- cold-cache report ordering and compound-DP construction;
- valid Moes writes with an uncached companion plus invalid-mode propagation with cached and uncached companions;
- legacy cover, dimmer, thermostat, and auxiliary-cluster behavior;
- unknown Sengled actions remaining inert without resolving unused outputs;
- Xiaomi vibration events and state transformations.

The repository guard rejects reintroduction of the exact removed production definitions, imports, references, attributes, arguments, dynamic string access, and legacy README code examples. Its own tests prove unrelated names such as `can_bus`, `dali_bus`, and `transport_bus` remain allowed.

### Compatibility and non-goals

- No new devices, signatures, firmware filters, endpoints, entities, or automation triggers are introduced.
- Existing endpoint direction and event provenance are preserved.
- Existing entity identifiers and Home Assistant discovery behavior are not intentionally changed.
- No companion changes are required in ZHA, zigpy, or Home Assistant Core.
- The custom-quirk Bus API removal described above is intentional and requires custom quirks using it to migrate.
- Device diagnostics are not required because this is an internal routing migration for already-supported devices rather than new device support.
- The work remains one atomic migration so the repository guard lands with the final in-tree Bus removal rather than leaving an intermediate state that can regress.

## Additional information

This work follows the direct-cluster pattern used by prior Bus-removal changes in the project and makes the remaining routing paths consistent with that architecture.

**Codex attribution:** The implementation, regression tests, documentation updates, repository-history analysis, review-comment remediation, and iterative adversarial review for this PR were performed by OpenAI Codex under human direction.

## Device diagnostics

Not applicable. This PR does not add a new quirk, model, signature, or entity topology.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached — not applicable; no new device support is added
