### PR TITLE
Add Tuya TS0601 24GHz presence sensor (_TZE200_tyffvoij)

### DIFF
--- a/zhaquirks/tuya/ts0601_presence.py
+++ b/zhaquirks/tuya/ts0601_presence.py
@@ -1,0 +1,154 @@
+import zigpy.types as t
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya import TUYA_CLUSTER_ID, TuyaLocalCluster, TuyaPowerConfigurationCluster
+from zigpy.zcl.clusters.measurement import OccupancySensing, IlluminanceMeasurement
+from zigpy.zcl.clusters.security import IasZone
+from zigpy.quirks.v2 import EntityType
+
+
+class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
+    """OccupancySensing (0x0406)."""
+
+
+class TuyaIlluminanceMeasurement(IlluminanceMeasurement, TuyaLocalCluster):
+    """IlluminanceMeasurement (0x0400)."""
+
+
+class MotionDetectionMode(t.enum8):
+    """Motion detection mode enum (DP 122)."""
+    Motion_only = 0x00
+    Motion_and_presence = 0x01
+    Presence_only = 0x02
+
+
+def _cm_to_m(v: int) -> float:
+    return float(v) / 100.0
+
+
+def _m_to_cm(v: float) -> int:
+    return int(round(v * 100.0))
+
+
+(
+    TuyaQuirkBuilder("_TZE200_tyffvoij", "TS0601")
+
+    # Suppress duplicate native ZCL IAS Zone binary sensor
+    .removes(IasZone)
+
+    # Replace hardware PowerConfiguration (0x0001) with Tuya's virtual power cluster
+    # and bind DP 121 directly to battery_percentage_remaining
+    .adds(TuyaPowerConfigurationCluster)
+    .tuya_dp(
+        dp_id=121,
+        ep_attribute=TuyaPowerConfigurationCluster.ep_attribute,
+        attribute_name="battery_percentage_remaining",
+    )
+
+    # --- Occupancy via ZCL 0x0406 ---
+    .adds(TuyaOccupancySensing)
+    .tuya_dp(
+        dp_id=1,
+        ep_attribute=TuyaOccupancySensing.ep_attribute,
+        attribute_name="occupancy",
+    )
+
+    # --- Illuminance via ZCL 0x0400 ---
+    .adds(TuyaIlluminanceMeasurement)
+    .tuya_illuminance(dp_id=106)
+
+    # ---- DP 2: Radar Sensitivity ----
+    .tuya_number(
+        dp_id=2,
+        attribute_name="sensitivity",
+        type=t.uint8_t,
+        min_value=0,
+        max_value=10,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        translation_key="sensitivity",
+        fallback_name="Radar sensitivity",
+    )
+
+    # ---- DP 123: Motion Sensitivity ----
+    .tuya_number(
+        dp_id=123,
+        attribute_name="motion_sensitivity",
+        type=t.uint8_t,
+        min_value=0,
+        max_value=10,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        translation_key="motion_sensitivity",
+        fallback_name="Motion sensitivity",
+    )
+
+    # ---- DP 3: Minimum Detection Distance (m) ----
+    .tuya_dp_attribute(
+        dp_id=3,
+        attribute_name="near_detection_m",
+        type=t.uint32_t,
+        converter=_cm_to_m,
+        dp_converter=_m_to_cm,
+    )
+    .number(
+        cluster_id=TUYA_CLUSTER_ID,
+        attribute_name="near_detection_m",
+        min_value=0.0,
+        max_value=10.0,
+        step=0.1,
+        unit="m",
+        entity_type=EntityType.CONFIG,
+        translation_key="min_distance",
+        fallback_name="Minimum detection distance",
+    )
+
+    # ---- DP 4: Maximum Detection Distance (m) ----
+    .tuya_dp_attribute(
+        dp_id=4,
+        attribute_name="far_detection_m",
+        type=t.uint32_t,
+        converter=_cm_to_m,
+        dp_converter=_m_to_cm,
+    )
+    .number(
+        cluster_id=TUYA_CLUSTER_ID,
+        attribute_name="far_detection_m",
+        min_value=0.0,
+        max_value=10.0,
+        step=0.1,
+        unit="m",
+        entity_type=EntityType.CONFIG,
+        translation_key="max_distance",
+        fallback_name="Maximum detection distance",
+    )
+
+    # ---- DP 102: Presence Timeout (seconds) ----
+    .tuya_dp_attribute(
+        dp_id=102,
+        attribute_name="none_delay_s",
+        type=t.uint16_t,
+    )
+    .number(
+        cluster_id=TUYA_CLUSTER_ID,
+        attribute_name="none_delay_s",
+        min_value=10.0,
+        max_value=28800.0,
+        step=1.0,
+        unit="s",
+        entity_type=EntityType.CONFIG,
+        translation_key="fade_time",
+        fallback_name="Presence timeout",
+    )
+
+    # ---- DP 122: Detection Mode ----
+    .tuya_enum(
+        dp_id=122,
+        attribute_name="motion_detection_mode",
+        enum_class=MotionDetectionMode,
+        entity_type=EntityType.CONFIG,
+        translation_key="motion_detection_mode",
+        fallback_name="Detection mode",
+    )
+
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0601_presence.py
+++ b/zhaquirks/tuya/ts0601_presence.py
@@ -1,9 +1,14 @@
-import zigpy.types as t
-from zhaquirks.tuya.builder import TuyaQuirkBuilder
-from zhaquirks.tuya import TUYA_CLUSTER_ID, TuyaLocalCluster, TuyaPowerConfigurationCluster
-from zigpy.zcl.clusters.measurement import OccupancySensing, IlluminanceMeasurement
-from zigpy.zcl.clusters.security import IasZone
 from zigpy.quirks.v2 import EntityType
+import zigpy.types as t
+from zigpy.zcl.clusters.measurement import IlluminanceMeasurement, OccupancySensing
+from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks.tuya import (
+    TUYA_CLUSTER_ID,
+    TuyaLocalCluster,
+    TuyaPowerConfigurationCluster,
+)
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
 class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
@@ -16,6 +21,7 @@ class TuyaIlluminanceMeasurement(IlluminanceMeasurement, TuyaLocalCluster):
 
 class MotionDetectionMode(t.enum8):
     """Motion detection mode enum (DP 122)."""
+
     Motion_only = 0x00
     Motion_and_presence = 0x01
     Presence_only = 0x02
@@ -31,10 +37,8 @@ def _m_to_cm(v: float) -> int:
 
 (
     TuyaQuirkBuilder("_TZE200_tyffvoij", "TS0601")
-
     # Suppress duplicate native ZCL IAS Zone binary sensor
     .removes(IasZone)
-
     # Replace hardware PowerConfiguration (0x0001) with Tuya's virtual power cluster
     # and bind DP 121 directly to battery_percentage_remaining
     .adds(TuyaPowerConfigurationCluster)
@@ -43,7 +47,6 @@ def _m_to_cm(v: float) -> int:
         ep_attribute=TuyaPowerConfigurationCluster.ep_attribute,
         attribute_name="battery_percentage_remaining",
     )
-
     # --- Occupancy via ZCL 0x0406 ---
     .adds(TuyaOccupancySensing)
     .tuya_dp(
@@ -51,11 +54,9 @@ def _m_to_cm(v: float) -> int:
         ep_attribute=TuyaOccupancySensing.ep_attribute,
         attribute_name="occupancy",
     )
-
     # --- Illuminance via ZCL 0x0400 ---
     .adds(TuyaIlluminanceMeasurement)
     .tuya_illuminance(dp_id=106)
-
     # ---- DP 2: Radar Sensitivity ----
     .tuya_number(
         dp_id=2,
@@ -68,7 +69,6 @@ def _m_to_cm(v: float) -> int:
         translation_key="sensitivity",
         fallback_name="Radar sensitivity",
     )
-
     # ---- DP 123: Motion Sensitivity ----
     .tuya_number(
         dp_id=123,
@@ -81,7 +81,6 @@ def _m_to_cm(v: float) -> int:
         translation_key="motion_sensitivity",
         fallback_name="Motion sensitivity",
     )
-
     # ---- DP 3: Minimum Detection Distance (m) ----
     .tuya_dp_attribute(
         dp_id=3,
@@ -101,7 +100,6 @@ def _m_to_cm(v: float) -> int:
         translation_key="min_distance",
         fallback_name="Minimum detection distance",
     )
-
     # ---- DP 4: Maximum Detection Distance (m) ----
     .tuya_dp_attribute(
         dp_id=4,
@@ -121,7 +119,6 @@ def _m_to_cm(v: float) -> int:
         translation_key="max_distance",
         fallback_name="Maximum detection distance",
     )
-
     # ---- DP 102: Presence Timeout (seconds) ----
     .tuya_dp_attribute(
         dp_id=102,
@@ -139,7 +136,6 @@ def _m_to_cm(v: float) -> int:
         translation_key="fade_time",
         fallback_name="Presence timeout",
     )
-
     # ---- DP 122: Detection Mode ----
     .tuya_enum(
         dp_id=122,
@@ -149,6 +145,5 @@ def _m_to_cm(v: float) -> int:
         translation_key="motion_detection_mode",
         fallback_name="Detection mode",
     )
-
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0601_presence.py
+++ b/zhaquirks/tuya/ts0601_presence.py
@@ -1,14 +1,11 @@
-from zigpy.quirks.v2 import EntityType
+"""Tuya TS0601 presence sensor (_TZE200_tyffvoij)."""
+
 import zigpy.types as t
+from zhaquirks.tuya import TUYA_CLUSTER_ID, TuyaLocalCluster, TuyaPowerConfigurationCluster
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zigpy.quirks.v2 import EntityType
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement, OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
-
-from zhaquirks.tuya import (
-    TUYA_CLUSTER_ID,
-    TuyaLocalCluster,
-    TuyaPowerConfigurationCluster,
-)
-from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
 class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
@@ -37,8 +34,10 @@ def _m_to_cm(v: float) -> int:
 
 (
     TuyaQuirkBuilder("_TZE200_tyffvoij", "TS0601")
+
     # Suppress duplicate native ZCL IAS Zone binary sensor
     .removes(IasZone)
+
     # Replace hardware PowerConfiguration (0x0001) with Tuya's virtual power cluster
     # and bind DP 121 directly to battery_percentage_remaining
     .adds(TuyaPowerConfigurationCluster)
@@ -47,6 +46,7 @@ def _m_to_cm(v: float) -> int:
         ep_attribute=TuyaPowerConfigurationCluster.ep_attribute,
         attribute_name="battery_percentage_remaining",
     )
+
     # --- Occupancy via ZCL 0x0406 ---
     .adds(TuyaOccupancySensing)
     .tuya_dp(
@@ -54,9 +54,11 @@ def _m_to_cm(v: float) -> int:
         ep_attribute=TuyaOccupancySensing.ep_attribute,
         attribute_name="occupancy",
     )
+
     # --- Illuminance via ZCL 0x0400 ---
     .adds(TuyaIlluminanceMeasurement)
     .tuya_illuminance(dp_id=106)
+
     # ---- DP 2: Radar Sensitivity ----
     .tuya_number(
         dp_id=2,
@@ -67,8 +69,9 @@ def _m_to_cm(v: float) -> int:
         step=1,
         entity_type=EntityType.CONFIG,
         translation_key="sensitivity",
-        fallback_name="Radar sensitivity",
+        fallback_name="Sensitivity",
     )
+
     # ---- DP 123: Motion Sensitivity ----
     .tuya_number(
         dp_id=123,
@@ -81,6 +84,7 @@ def _m_to_cm(v: float) -> int:
         translation_key="motion_sensitivity",
         fallback_name="Motion sensitivity",
     )
+
     # ---- DP 3: Minimum Detection Distance (m) ----
     .tuya_dp_attribute(
         dp_id=3,
@@ -100,6 +104,7 @@ def _m_to_cm(v: float) -> int:
         translation_key="min_distance",
         fallback_name="Minimum detection distance",
     )
+
     # ---- DP 4: Maximum Detection Distance (m) ----
     .tuya_dp_attribute(
         dp_id=4,
@@ -119,6 +124,7 @@ def _m_to_cm(v: float) -> int:
         translation_key="max_distance",
         fallback_name="Maximum detection distance",
     )
+
     # ---- DP 102: Presence Timeout (seconds) ----
     .tuya_dp_attribute(
         dp_id=102,
@@ -136,6 +142,7 @@ def _m_to_cm(v: float) -> int:
         translation_key="fade_time",
         fallback_name="Presence timeout",
     )
+
     # ---- DP 122: Detection Mode ----
     .tuya_enum(
         dp_id=122,
@@ -145,5 +152,6 @@ def _m_to_cm(v: float) -> int:
         translation_key="motion_detection_mode",
         fallback_name="Detection mode",
     )
+
     .add_to_registry()
 )

--- a/zhaquirks/tuya/ts0601_presence.py
+++ b/zhaquirks/tuya/ts0601_presence.py
@@ -1,11 +1,16 @@
 """Tuya TS0601 presence sensor (_TZE200_tyffvoij)."""
 
-import zigpy.types as t
-from zhaquirks.tuya import TUYA_CLUSTER_ID, TuyaLocalCluster, TuyaPowerConfigurationCluster
-from zhaquirks.tuya.builder import TuyaQuirkBuilder
 from zigpy.quirks.v2 import EntityType
+import zigpy.types as t
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement, OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks.tuya import (
+    TUYA_CLUSTER_ID,
+    TuyaLocalCluster,
+    TuyaPowerConfigurationCluster,
+)
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
 
 
 class TuyaOccupancySensing(OccupancySensing, TuyaLocalCluster):
@@ -34,10 +39,8 @@ def _m_to_cm(v: float) -> int:
 
 (
     TuyaQuirkBuilder("_TZE200_tyffvoij", "TS0601")
-
     # Suppress duplicate native ZCL IAS Zone binary sensor
     .removes(IasZone)
-
     # Replace hardware PowerConfiguration (0x0001) with Tuya's virtual power cluster
     # and bind DP 121 directly to battery_percentage_remaining
     .adds(TuyaPowerConfigurationCluster)
@@ -46,7 +49,6 @@ def _m_to_cm(v: float) -> int:
         ep_attribute=TuyaPowerConfigurationCluster.ep_attribute,
         attribute_name="battery_percentage_remaining",
     )
-
     # --- Occupancy via ZCL 0x0406 ---
     .adds(TuyaOccupancySensing)
     .tuya_dp(
@@ -54,11 +56,9 @@ def _m_to_cm(v: float) -> int:
         ep_attribute=TuyaOccupancySensing.ep_attribute,
         attribute_name="occupancy",
     )
-
     # --- Illuminance via ZCL 0x0400 ---
     .adds(TuyaIlluminanceMeasurement)
     .tuya_illuminance(dp_id=106)
-
     # ---- DP 2: Radar Sensitivity ----
     .tuya_number(
         dp_id=2,
@@ -71,7 +71,6 @@ def _m_to_cm(v: float) -> int:
         translation_key="sensitivity",
         fallback_name="Sensitivity",
     )
-
     # ---- DP 123: Motion Sensitivity ----
     .tuya_number(
         dp_id=123,
@@ -84,7 +83,6 @@ def _m_to_cm(v: float) -> int:
         translation_key="motion_sensitivity",
         fallback_name="Motion sensitivity",
     )
-
     # ---- DP 3: Minimum Detection Distance (m) ----
     .tuya_dp_attribute(
         dp_id=3,
@@ -104,7 +102,6 @@ def _m_to_cm(v: float) -> int:
         translation_key="min_distance",
         fallback_name="Minimum detection distance",
     )
-
     # ---- DP 4: Maximum Detection Distance (m) ----
     .tuya_dp_attribute(
         dp_id=4,
@@ -124,7 +121,6 @@ def _m_to_cm(v: float) -> int:
         translation_key="max_distance",
         fallback_name="Maximum detection distance",
     )
-
     # ---- DP 102: Presence Timeout (seconds) ----
     .tuya_dp_attribute(
         dp_id=102,
@@ -142,7 +138,6 @@ def _m_to_cm(v: float) -> int:
         translation_key="fade_time",
         fallback_name="Presence timeout",
     )
-
     # ---- DP 122: Detection Mode ----
     .tuya_enum(
         dp_id=122,
@@ -152,6 +147,5 @@ def _m_to_cm(v: float) -> int:
         translation_key="motion_detection_mode",
         fallback_name="Detection mode",
     )
-
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change
Adds a new v2 `TuyaQuirkBuilder` quirk for the **Tuya TS0601 radar presence/motion sensor** (`_TZE200_tyffvoij`).

**Supported Features:**
* **Occupancy:** Native binary sensor (`0x0406` mapped via DP 1)
* **Illuminance:** Lux sensor (`0x0400` mapped via DP 106)
* **Battery:** Battery percentage reporting via `TuyaPowerConfigurationCluster` (DP 121)
* **Configuration Controls:**
  * Radar sensitivity (DP 2)
  * Motion sensitivity (DP 123)
  * Minimum detection distance (DP 3, with `cm` to `m` conversions)
  * Maximum detection distance (DP 4, with `cm` to `m` conversions)
  * Presence timeout / fade time (DP 102)
  * Detection mode select (`Motion only`, `Motion and presence`, `Presence only` via DP 122)

---

## Additional information
* Replaces static/fake ZCL Cluster `0x0001` battery reporting ($200 = 100\%$) with dynamic battery percentage payloads sent via Tuya DP 121.
* Suppresses duplicate native `IASZone` motion binary sensors to clean up entity registry clutter.

---

## Device diagnostics
```json
{
  "home_assistant": {
    "arch": "x86_64",
    "docker": true,
    "installation_type": "Home Assistant Container",
    "os_name": "Linux",
    "version": "2026.7.3"
  },
  "data": {
    "ieee": "**REDACTED**",
    "nwk": "0x0145",
    "manufacturer": "_TZE200_tyffvoij",
    "model": "TS0601",
    "friendly_manufacturer": "_TZE200_tyffvoij",
    "friendly_model": "TS0601",
    "quirk_applied": true,
    "quirk_class": "zhaquirks.tuya.builder:(_TZE200_tyffvoij / TS0601)",
    "manufacturer_code": 4742,
    "power_source": "Battery or Unknown",
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "IAS_ZONE",
          "id": 1026
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic"
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power"
          },
          {
            "cluster_id": "0x0400",
            "endpoint_attribute": "illuminance"
          },
          {
            "cluster_id": "0x0406",
            "endpoint_attribute": "occupancy"
          },
          {
            "cluster_id": "0x0500",
            "endpoint_attribute": "ias_zone"
          },
          {
            "cluster_id": "0xef00",
            "endpoint_attribute": "tuya_manufacturer"
          }
        ]
      }
    }
  }
}
```
[x] The changes are tested and work correctly

[x] pre-commit checks pass / the code has been formatted using Black

[ ] Tests have been added to verify that the new code works

[x] Device diagnostics data has been attached