### PR TITLE
Add network LED switch for Sonoff S60ZBTPF smart plug

### DIFF
--- a/zhaquirks/sonoff/s60zbtpf.py
+++ b/zhaquirks/sonoff/s60zbtpf.py
@@ -20,6 +20,7 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 from zhaquirks.builder import QuirkBuilder
 from zhaquirks.clusters import CustomCluster
@@ -48,6 +49,23 @@ class SonoffS60OnOff(CustomCluster, OnOff):
             )
 
         super()._update_attribute(attrid, value)
+
+
+class SonoffEwelinkCluster(CustomCluster):
+    """Sonoff/eWeLink cluster."""
+
+    cluster_id = 0xFC11
+    name = "SONOFF eWeLink cluster"
+    ep_attribute = "ewelink"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        network_led = ZCLAttributeDef(
+            id=0x0001,
+            type=t.Bool,
+            manufacturer_code=None,
+        )
 
 
 class SonoffS60ElectricalMeasurement(CustomCluster, ElectricalMeasurement):
@@ -80,6 +98,14 @@ S60_POWER_FIX_FW_VERSION = 0x00002003
 s60_base_quirk = (
     QuirkBuilder("SONOFF", "S60ZBTPF")
     .applies_to("SONOFF", "S60ZBTPG")
+    .replaces(SonoffEwelinkCluster, endpoint_id=1)
+    .switch(
+        attribute_name=SonoffEwelinkCluster.AttributeDefs.network_led.name,
+        cluster_id=SonoffEwelinkCluster.cluster_id,
+        endpoint_id=1,
+        translation_key="network_led",
+        fallback_name="Network LED",
+    )
     .prevent_default_entity_creation(
         endpoint_id=1,
         cluster_id=Metering.cluster_id,


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Adds a binary switch for the network LED attribute in the Sonoff/eWeLink cluster (0xFC11). Turning this off, turns off the blue status indicator LED on the plug.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
