### PR TITLE
Add Tuya TS0601 CO2 sensor _TZE204_pkpfn9hc

### DIFF
--- a/tests/test_tuya_air.py
+++ b/tests/test_tuya_air.py
@@ -350,6 +350,9 @@ PKPFN9HC_REPORTS = (
 # The unsolicited Basic report this device emits periodically and after a reboot.
 PKPFN9HC_BASIC_REPORT = b"\x08\x63\x0a\x01\x00\x20\x4a\xe2\xff\x20\x38\xe4\xff\x20\x00"
 
+# Its reply to one of the reads in the Tuya read attributes spell.
+PKPFN9HC_READ_ATTRS_RSP = b"\x18\x02\x01\xfe\xff\x00\x30\x00"
+
 
 @pytest.fixture
 def pkpfn9hc_device(zigpy_device_from_v2_quirk):
@@ -423,3 +426,24 @@ async def test_pkpfn9hc_does_not_requery_reporting_mcu(pkpfn9hc_device):
     assert created == []
     # The flag is cleared, so a second silent interval does trigger a query.
     assert not tuya_cluster.reported_since_last_check
+
+
+async def test_pkpfn9hc_ignores_non_attribute_reports(pkpfn9hc_device):
+    """Other Basic general commands do not re-query the MCU.
+
+    The MCU is silent here, so a Report_Attributes would trigger a query. Only
+    that command may do so, otherwise the read attributes spell would make the
+    device query itself in a loop.
+    """
+    tuya_cluster = pkpfn9hc_device.endpoints[1].in_clusters[TUYA_CLUSTER_ID]
+    assert not tuya_cluster.reported_since_last_check
+
+    created = []
+    with mock.patch.object(
+        pkpfn9hc_device,
+        "create_task",
+        side_effect=lambda coro, name=None: created.append(coro),
+    ):
+        _receive(pkpfn9hc_device, Basic.cluster_id, PKPFN9HC_READ_ATTRS_RSP)
+
+    assert created == []

--- a/tests/test_tuya_air.py
+++ b/tests/test_tuya_air.py
@@ -6,11 +6,13 @@ from unittest.mock import MagicMock
 import pytest
 import zigpy.profiles.zha
 import zigpy.types as t
+from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.clusters.measurement import PM25
 
 from tests.common import ClusterListener
 import zhaquirks
-from zhaquirks.tuya import TuyaNewManufCluster
+from zhaquirks.tuya import TUYA_CLUSTER_ID, TUYA_QUERY_DATA, TuyaNewManufCluster
+from zhaquirks.tuya.tuya_co import TuyaCO2Basic
 
 zhaquirks.setup()
 
@@ -332,3 +334,92 @@ async def test_smart_air_pm25_dropping_high_values(zigpy_device_from_v2_quirk):
     # check that invalid value is ignored
     pm25_cluster.update_attribute(PM25.AttributeDefs.measured_value.name, 1001)
     assert len(pm25_listener.attribute_updates) == 1
+
+
+# Frames captured from a real _TZE204_pkpfn9hc, cross-checked against its LCD.
+PKPFN9HC_REPORTS = (
+    (
+        b"\x09\x3b\x02\x00\x31\x02\x02\x00\x04\x00\x00\x02\x68",
+        "carbon_dioxide_concentration",
+        616 * 1e-6,
+    ),
+    (b"\x09\x39\x02\x00\x2f\x12\x02\x00\x04\x00\x00\x01\x2e", "temperature", 3020),
+    (b"\x09\x3a\x02\x00\x30\x13\x02\x00\x04\x00\x00\x00\x2a", "humidity", 4200),
+)
+
+# The unsolicited Basic report this device emits periodically and after a reboot.
+PKPFN9HC_BASIC_REPORT = b"\x08\x63\x0a\x01\x00\x20\x4a\xe2\xff\x20\x38\xe4\xff\x20\x00"
+
+
+@pytest.fixture
+def pkpfn9hc_device(zigpy_device_from_v2_quirk):
+    """Tuya TS0601 CO2 monitor built around a Winsen MH-Z19D."""
+    dev = zigpy_device_from_v2_quirk("_TZE204_pkpfn9hc", "TS0601")
+    dev._packet_debouncer.filter = MagicMock(return_value=False)
+    cluster = dev.endpoints[1].in_clusters[TuyaNewManufCluster.cluster_id]
+    with mock.patch.object(cluster, "send_default_rsp"):
+        yield dev
+
+
+def _receive(dev, cluster_id, data):
+    """Feed a raw ZCL frame to the device."""
+    dev.packet_received(
+        t.ZigbeePacket(
+            profile_id=zigpy.profiles.zha.PROFILE_ID,
+            cluster_id=cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(data),
+        )
+    )
+
+
+@pytest.mark.parametrize("data, ep_attr, expected_value", PKPFN9HC_REPORTS)
+def test_pkpfn9hc_datapoints(pkpfn9hc_device, data, ep_attr, expected_value):
+    """Test _TZE204_pkpfn9hc CO2, temperature and humidity datapoints."""
+    _receive(pkpfn9hc_device, TuyaNewManufCluster.cluster_id, data)
+
+    cluster = getattr(pkpfn9hc_device.endpoints[1], ep_attr)
+    assert cluster.get("measured_value") == expected_value
+
+
+async def test_pkpfn9hc_requeries_silent_mcu(pkpfn9hc_device):
+    """A Basic report with no datapoints since the last one re-queries the MCU."""
+    tuya_cluster = pkpfn9hc_device.endpoints[1].in_clusters[TUYA_CLUSTER_ID]
+    assert not tuya_cluster.reported_since_last_check
+
+    created = []
+    with (
+        mock.patch.object(TuyaCO2Basic, "QUERY_DELAY", 0),
+        mock.patch.object(
+            pkpfn9hc_device,
+            "create_task",
+            side_effect=lambda coro, name=None: created.append(coro),
+        ),
+        mock.patch.object(tuya_cluster, "command", new=mock.AsyncMock()) as command,
+    ):
+        _receive(pkpfn9hc_device, Basic.cluster_id, PKPFN9HC_BASIC_REPORT)
+        assert len(created) == 1
+        await created[0]
+
+    command.assert_awaited_once_with(TUYA_QUERY_DATA)
+
+
+async def test_pkpfn9hc_does_not_requery_reporting_mcu(pkpfn9hc_device):
+    """A Basic report is ignored while the MCU is still sending datapoints."""
+    # A datapoint report marks the MCU as alive.
+    _receive(pkpfn9hc_device, TuyaNewManufCluster.cluster_id, PKPFN9HC_REPORTS[0][0])
+    tuya_cluster = pkpfn9hc_device.endpoints[1].in_clusters[TUYA_CLUSTER_ID]
+    assert tuya_cluster.reported_since_last_check
+
+    created = []
+    with mock.patch.object(
+        pkpfn9hc_device,
+        "create_task",
+        side_effect=lambda coro, name=None: created.append(coro),
+    ):
+        _receive(pkpfn9hc_device, Basic.cluster_id, PKPFN9HC_BASIC_REPORT)
+
+    assert created == []
+    # The flag is cleared, so a second silent interval does trigger a query.
+    assert not tuya_cluster.reported_since_last_check

--- a/tuya.md
+++ b/tuya.md
@@ -5,10 +5,47 @@
 
 # Identify Tuya Data Points
 
-The first step in building a Tuya quirk is to identify the Tuya Datapoints (DPs) for the device. There are two ways ways to do this.
+The first step in building a Tuya quirk is to identify the Tuya Datapoints (DPs) for the device. There are three ways to do this.
 
 1. If the device is supported by Zigbee2MQTT, the DPs can be captured from the [herdsman converter](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts).
 2. Using a Tuya hub, the DPs can be captured from the Tuya developer's console. See [Zigbee2MQTT Documentation](https://www.zigbee2mqtt.io/advanced/support-new-devices/03_find_tuya_data_points.html)
+3. If the device is in neither, capture the DPs from the device itself. See below.
+
+> [!WARNING]
+> DPs from a *similar* device are a hypothesis, not an answer. Measurement DPs are often shared across a product family, but DPs above 100 are product-specific and frequently mean different things on devices that are otherwise identical. Scaling also varies: two CO2 sensors sharing DPs 2/18/19 may report humidity in tenths of a percent and in whole percent respectively. Always confirm against the device's own display or app.
+
+## Capturing datapoints from the device
+
+Register a minimal quirk so that zigpy parses the Tuya cluster at all. `force_add_cluster` is required because no DPs are mapped yet:
+
+```python
+(
+    TuyaQuirkBuilder("_TZE204_xxxxxxxx", "TS0601")
+    .skip_configuration()
+    .add_to_registry(force_add_cluster=True)
+)
+```
+
+Enable ZCL debug logging (`zigpy.zcl`) and every frame is logged as raw hex:
+
+```
+[0x5099:1:0xef00] Received ZCL frame: '09 3b 02 00 31 02 02 00 04 00 00 02 68'
+```
+
+After the 3 byte ZCL header the payload is `status(1)`, `tsn(1)`, then one or more datapoints of `dp(1)`, `datatype(1)`, `length(2, big endian)`, `payload(length)`. Datatypes are `0` raw, `1` bool, `2` value, `3` string, `4` enum, `5` bitmap. The frame above is DP 2, type value, 4 bytes, `0x00000268` = 616.
+
+Unmapped DPs are also logged by the Tuya cluster itself at debug level:
+
+```
+[0x5099:1:0xef00] No datapoint handler for TuyaDatapointData(dp=102, ...)
+```
+
+To identify a configuration DP, change one setting on the device and note which DP value changes.
+
+> [!IMPORTANT]
+> If the device produces **no** `0xEF00` traffic at all, it has not been given the Tuya spell. Add `.tuya_enchantment(data_query_spell=True)` and reconfigure the device. The spell is only cast during device configuration, so a Home Assistant restart is not enough; reconfigure the device from its device page.
+>
+> Some devices also return to that silent state after a power cycle. Always power cycle the device before considering a quirk finished.
 
 # Using the datapoints to develop a Tuya Quirk
 

--- a/zhaquirks/tuya/tuya_co.py
+++ b/zhaquirks/tuya/tuya_co.py
@@ -1,9 +1,14 @@
 """Tuya Air Quality sensor."""
 
+import asyncio
 from typing import Any
 
 import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import Basic
 
+from zhaquirks.clusters import CustomCluster
+from zhaquirks.tuya import TUYA_CLUSTER_ID, TUYA_QUERY_DATA
 from zhaquirks.tuya.builder import (
     MOL_VOL_AIR_NTP,
     TuyaFormaldehydeConcentration,
@@ -11,6 +16,7 @@ from zhaquirks.tuya.builder import (
     TuyaQuirkBuilder,
     TuyaTemperatureMeasurement,
 )
+from zhaquirks.tuya.mcu import TuyaMCUCluster
 
 
 def tuya_air_quality_temperature_converter(value: Any) -> int:
@@ -30,6 +36,68 @@ class TuyaPM25ConcentrationIgnoreValues(TuyaPM25Concentration):
         if attrid == self.AttributeDefs.measured_value.id and value > 1000:
             return
         super()._update_attribute(attrid, value)
+
+
+class TuyaCO2ManufCluster(TuyaMCUCluster):
+    """Tuya MCU cluster that records whether the MCU is still sending data."""
+
+    # Set whenever the MCU sends us anything, cleared when TuyaCO2Basic checks it.
+    reported_since_last_check: bool = False
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: Any | None = None,
+    ) -> None:
+        """Note that the MCU is talking to us, then handle the request."""
+        self.reported_since_last_check = True
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+
+class TuyaCO2Basic(CustomCluster, Basic):
+    """Basic cluster that re-queries the MCU when it has fallen silent.
+
+    _TZE204_pkpfn9hc sends nothing at all on the Tuya cluster until it receives
+    a data query, and it returns to that state after a power cycle. It emits no
+    ZDO announce when it reboots, so the only usable signal is its periodic
+    unsolicited Basic attribute report. If no datapoint arrived since the last
+    such report the MCU is presumed silent and is queried again, which restores
+    reporting within seconds instead of never.
+    """
+
+    # Give the MCU a moment to finish booting before asking it for data.
+    QUERY_DELAY = 2
+
+    def handle_cluster_general_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: Any | None = None,
+    ) -> None:
+        """Re-query the MCU if it produced no data since the last report."""
+        super().handle_cluster_general_request(hdr, args, dst_addressing=dst_addressing)
+
+        if hdr.command_id != foundation.GeneralCommand.Report_Attributes:
+            return
+
+        tuya_cluster = self.endpoint.in_clusters[TUYA_CLUSTER_ID]
+        if tuya_cluster.reported_since_last_check:
+            tuya_cluster.reported_since_last_check = False
+            return
+
+        self.debug("Tuya MCU has gone silent, re-sending data query")
+        self.endpoint.device.create_task(
+            self._query_data(tuya_cluster),
+            name=f"tuya_co2_query_data_{self.endpoint.device.ieee}",
+        )
+
+    async def _query_data(self, tuya_cluster: TuyaMCUCluster) -> None:
+        """Ask the MCU to resend every datapoint."""
+        await asyncio.sleep(self.QUERY_DELAY)
+        await tuya_cluster.command(TUYA_QUERY_DATA)
 
 
 base_air_quality = (
@@ -128,6 +196,27 @@ base_air_quality = (
     .tuya_humidity(dp_id=19, scale=10)
     .skip_configuration()
     .add_to_registry()
+)
+
+(
+    # Winsen MH-Z19D NDIR CO2 sensor in a desktop LCD monitor.
+    #
+    # Unlike the other NDIR CO2 sensors above, this one reports temperature as
+    # a plain scaled integer (302 -> 30.2 degC) rather than the packed struct
+    # tuya_air_quality_temperature_converter decodes, and reports humidity in
+    # whole percent rather than tenths.
+    #
+    # It also reports configuration datapoints that are left unmapped because
+    # their meaning is unconfirmed: 101 (enum, display mode), 102, 103, 104,
+    # 105 and 106 (60, matching the observed 60 second reporting interval).
+    TuyaQuirkBuilder("_TZE204_pkpfn9hc", "TS0601")
+    .tuya_enchantment(data_query_spell=True)
+    .replaces(TuyaCO2Basic)
+    .tuya_co2(dp_id=2)
+    .tuya_temperature(dp_id=18, scale=10)
+    .tuya_humidity(dp_id=19)
+    .skip_configuration()
+    .add_to_registry(replacement_cluster=TuyaCO2ManufCluster)
 )
 
 (


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

<img width="33%" alt="image" src="https://github.com/user-attachments/assets/f8ab9390-0e48-47cb-a552-511da5fca87b" /><img width="50%" alt="image" src="https://github.com/user-attachments/assets/50e4e0e8-1a76-4fce-8954-9d89138d88e5" />


Add support for Zigbee-enabled LCD CO2 monitor built around a Winsen MH-Z19D NDIR sensor, reporting CO2 on DP 2, temperature on DP 18 and humidity on DP 19.

Unlike the other NDIR CO2 sensors in this file it reports temperature as a plain scaled integer rather than the packed struct decoded by `tuya_air_quality_temperature_converter`, and reports humidity in whole percent rather than tenths. Both scalings were confirmed against the device's own display.

The device also needs the data query spell before it sends anything at all on the Tuya cluster, and it returns to that silent state after a power cycle without emitting a ZDO announce. `TuyaCO2Basic` watches the unsolicited Basic attribute report the device emits periodically and re-queries the MCU whenever no datapoint arrived since the previous report, which restores reporting a few seconds after a power cycle.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
