### PR TITLE
Add Excellux ZG-104PLV motion, vibration and illuminance sensor

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -392,7 +392,6 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
 
 (
     TuyaQuirkBuilder("PIRIV01", "Excellux")
-    .applies_to("PIRIV01", "Excellux")
     .tuya_battery(dp_id=4)
     .tuya_illuminance(dp_id=20)
     .tuya_binary_sensor(

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -6,6 +6,8 @@ import zigpy.types as t
 from zigpy.zcl import foundation
 
 from zhaquirks.builder import (
+    BinarySensorDeviceClass,
+    SensorStateClass,
     PERCENTAGE,
     EntityPlatform,
     EntityType,
@@ -44,6 +46,10 @@ class TuyaNousTempHumiAlarm(t.enum8):
     UpperAlarm = 0x01
     Canceled = 0x02
 
+class TuyaIlluminanceAlarm(t.enum8):
+    None = 0x00
+    Low = 0x01
+    High = 0x02
 
 class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     """Tuya Manufacturer Cluster with set_time mod."""
@@ -375,6 +381,77 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
         fallback_name="Display unit",
     )
     .adds(TuyaPowerConfigurationCluster2AAA)
+    .tuya_enchantment(data_query_spell=True)
+    .skip_configuration()
+    .add_to_registry()
+)
+
+(
+    TuyaQuirkBuilder("PIRIV01","Excellux")
+    .applies_to("PIRIV01","Excellux")
+    .tuya_battery(dp_id=4)
+    .tuya_illuminance(dp_id=20)
+    .tuya_binary_sensor(
+        dp_id=1,
+        attribute_name="on_off",
+        entity_type=EntityType.STANDARD,
+        device_class=BinarySensorDeviceClass.MOTION,
+        fallback_name="Occupancy",
+    )
+    .tuya_binary_sensor(
+        dp_id=3,
+        attribute_name="vibration_detected",
+        entity_type=EntityType.STANDARD,
+        device_class=BinarySensorDeviceClass.VIBRATION,
+        fallback_name="Vibration",
+    )
+    .tuya_number(
+        dp_id=101,
+        attribute_name="sampling_cycle",
+        type=t.uint32_t,
+        min_value=5,
+        max_value=1200,
+        step=5,
+        entity_type=EntityType.CONFIG,
+        device_class=SensorDeviceClass.DURATION,
+        unit="s",
+        translation_key="sampling_cycle",
+        fallback_name="sampling cycle"
+    )
+    .tuya_number(
+        dp_id=104,
+        attribute_name="illuminance_v0",
+        type=t.uint32_t,
+        min_value=0,
+        max_value=10000,
+        step=100,
+        entity_type=EntityType.CONFIG,
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        translation_key="illuminance_v0",
+        fallback_name="illuminance v0"
+    )
+    .tuya_number(
+        dp_id=105,
+        attribute_name="illuminance_v1",
+        type=t.uint32_t,
+        min_value=0,
+        max_value=10000,
+        step=100,
+        entity_type=EntityType.CONFIG,
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        translation_key="illuminance_v1",
+        fallback_name="illuminance v1"
+    )
+    .tuya_sensor(
+        dp_id=50,
+        attribute_name="vibration_count",
+        type=t.uint32_t,
+        entity_type=EntityType.DIAGNOSTIC,
+        device_class=SensorDeviceClass.FREQUENCY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        unit="times",
+        fallback_name="Vibration count"
+    )
     .tuya_enchantment(data_query_spell=True)
     .skip_configuration()
     .add_to_registry()

--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -6,12 +6,12 @@ import zigpy.types as t
 from zigpy.zcl import foundation
 
 from zhaquirks.builder import (
-    BinarySensorDeviceClass,
-    SensorStateClass,
     PERCENTAGE,
+    BinarySensorDeviceClass,
     EntityPlatform,
     EntityType,
     SensorDeviceClass,
+    SensorStateClass,
     UnitOfTemperature,
     UnitOfTime,
 )
@@ -46,10 +46,14 @@ class TuyaNousTempHumiAlarm(t.enum8):
     UpperAlarm = 0x01
     Canceled = 0x02
 
+
 class TuyaIlluminanceAlarm(t.enum8):
-    None = 0x00
+    """Tuya Illuminance Alarm enum."""
+
+    Normal = 0x00
     Low = 0x01
     High = 0x02
+
 
 class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     """Tuya Manufacturer Cluster with set_time mod."""
@@ -387,8 +391,8 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
 )
 
 (
-    TuyaQuirkBuilder("PIRIV01","Excellux")
-    .applies_to("PIRIV01","Excellux")
+    TuyaQuirkBuilder("PIRIV01", "Excellux")
+    .applies_to("PIRIV01", "Excellux")
     .tuya_battery(dp_id=4)
     .tuya_illuminance(dp_id=20)
     .tuya_binary_sensor(
@@ -416,7 +420,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
         device_class=SensorDeviceClass.DURATION,
         unit="s",
         translation_key="sampling_cycle",
-        fallback_name="sampling cycle"
+        fallback_name="sampling cycle",
     )
     .tuya_number(
         dp_id=104,
@@ -428,7 +432,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
         entity_type=EntityType.CONFIG,
         device_class=SensorDeviceClass.ILLUMINANCE,
         translation_key="illuminance_v0",
-        fallback_name="illuminance v0"
+        fallback_name="illuminance v0",
     )
     .tuya_number(
         dp_id=105,
@@ -440,7 +444,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
         entity_type=EntityType.CONFIG,
         device_class=SensorDeviceClass.ILLUMINANCE,
         translation_key="illuminance_v1",
-        fallback_name="illuminance v1"
+        fallback_name="illuminance v1",
     )
     .tuya_sensor(
         dp_id=50,
@@ -450,7 +454,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
         device_class=SensorDeviceClass.FREQUENCY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         unit="times",
-        fallback_name="Vibration count"
+        fallback_name="Vibration count",
     )
     .tuya_enchantment(data_query_spell=True)
     .skip_configuration()


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
```

{
  "node_descriptor": {
    "logical_type": 2,
    "complex_descriptor_available": 0,
    "user_descriptor_available": 0,
    "reserved": 0,
    "aps_flags": 0,
    "frequency_band": 8,
    "mac_capability_flags": 128,
    "manufacturer_code": 4417,
    "maximum_buffer_size": 74,
    "maximum_incoming_transfer_size": 404,
    "server_mask": 10752,
    "maximum_outgoing_transfer_size": 404,
    "descriptor_capability_field": 0
  },
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0402",
      "input_clusters": [
        "0x0000",
        "0x0001",
        "0x0003",
        "0x0500",
        "0x1000",
        "0xef00"
      ],
      "output_clusters": [
        "0x0003",
        "0x1000",
        "0xef00"
      ]
    }
  },
  "manufacturer": "PIRIV01",
  "model": "Excellux",
  "class": "zhaquirks.tuya.builder.EnchantedDeviceV2"
}
```
## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->

<img width="1005" height="910" alt="device" src="https://github.com/user-attachments/assets/44fa452d-c18a-4198-8158-0b74b9f1075a" />


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
[zha-01KY92BC48J3PV3WHDYTTVD8VR-PIRIV01 Excellux-1c38e5817983775c10084d116bed419b(1).json](https://github.com/user-attachments/files/30407902/zha-01KY92BC48J3PV3WHDYTTVD8VR-PIRIV01.Excellux-1c38e5817983775c10084d116bed419b.1.json)

