### PR TITLE
Add `attribute_converter`/`value_converter` to `QuirkBuilder.number()`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -201,6 +201,8 @@ from zhaquirks.builder import ReportingConfig
     unit=UnitOfTime.SECONDS,          # Optional: unit constant
     mode="box",                       # Optional: "box" for text input, "slider" for slider
     multiplier=1,                     # Optional: scale between HA value and raw attribute (default 1)
+    attribute_converter=lambda x: x,  # Optional: raw attribute -> HA value (needs value_converter)
+    value_converter=lambda x: int(x),  # Optional: HA value -> raw attribute (needs attribute_converter)
     device_class=NumberDeviceClass.DURATION,  # Optional: HA device class
     translation_key="turn_on_delay",
     fallback_name="Turn on delay",
@@ -230,6 +232,23 @@ If the underlying attribute is an integer representing a fractional unit (e.g., 
 ```
 
 `min_value`/`max_value` are HA-side values (after the multiplier), not raw attribute values. Confirm the device's raw value range and pick HA-side limits accordingly.
+
+**Number `attribute_converter`/`value_converter`:** For conversions a plain `multiplier` cannot express — an inverted scale, an offset, a non-linear mapping. A number can be written, so both directions are needed and both must be given together (passing only one raises `ValueError`): `attribute_converter` maps the raw attribute value to the value shown in HA, `value_converter` maps the value from HA back to the raw attribute value. `value_converter` must return a value the attribute's type accepts, so cast to `int` for integer attributes. A converter takes precedence over `multiplier` (same as for `.sensor()`), so don't combine them.
+
+```python
+# Device stores brightness on an inverted 0..5 scale, where 0 is the brightest.
+# HA shows 0 (off) .. 5 (brightest) instead.
+.number(
+    attribute_name="led_brightness",
+    cluster_id=CustomCluster.cluster_id,
+    min_value=0,
+    max_value=5,
+    attribute_converter=lambda x: 5 - x,
+    value_converter=lambda x: 5 - int(x),
+    translation_key="led_brightness",
+    fallback_name="LED brightness",
+)
+```
 
 ```python
 

--- a/tests/test_quirks_v2_metadata.py
+++ b/tests/test_quirks_v2_metadata.py
@@ -168,6 +168,69 @@ def test_quirks_v2_number():
     assert number_metadata.unit == "s"
     assert number_metadata.mode is None
     assert number_metadata.multiplier is None
+    assert number_metadata.attribute_converter is None
+    assert number_metadata.value_converter is None
+
+
+def test_quirks_v2_number_converters():
+    """Test adding a quirk that defines a number with converters."""
+    registry = DeviceRegistry()
+
+    entry = (
+        QuirkBuilder("manufacturer", "model")
+        .adds(OnOff.cluster_id)
+        .number(
+            OnOff.AttributeDefs.on_time.name,
+            OnOff.cluster_id,
+            min_value=0,
+            max_value=5,
+            attribute_converter=lambda x: 5 - x,
+            value_converter=lambda x: 5 - int(x),
+            translation_key="on_time",
+            fallback_name="On time",
+        )
+        .add_to_registry(registry)
+    )
+
+    (number_metadata,) = entry.zha_device_factory.quirk_definition.entity_metadata
+    assert isinstance(number_metadata, NumberMetadata)
+    assert number_metadata.attribute_converter is not None
+    assert number_metadata.value_converter is not None
+    # the converters invert a 0..5 scale in both directions
+    assert number_metadata.attribute_converter(1) == 4
+    assert number_metadata.value_converter(4) == 1
+
+
+@pytest.mark.parametrize(
+    ("attribute_converter", "value_converter"),
+    (
+        (lambda x: 5 - x, None),
+        (None, lambda x: 5 - int(x)),
+    ),
+)
+def test_quirks_v2_number_validation_failure_one_converter(
+    attribute_converter, value_converter
+):
+    """Test that a number requires both converters or neither."""
+    registry = DeviceRegistry()
+
+    with pytest.raises(
+        ValueError,
+        match="must have both attribute_converter and value_converter, or neither",
+    ):
+        (
+            QuirkBuilder("manufacturer", "model")
+            .adds(OnOff.cluster_id)
+            .number(
+                OnOff.AttributeDefs.on_time.name,
+                OnOff.cluster_id,
+                attribute_converter=attribute_converter,
+                value_converter=value_converter,
+                translation_key="on_time",
+                fallback_name="On time",
+            )
+            .add_to_registry(registry)
+        )
 
 
 def test_quirks_v2_binary_sensor():

--- a/zhaquirks/builder/builder.py
+++ b/zhaquirks/builder/builder.py
@@ -779,6 +779,8 @@ class QuirkBuilder:
         device_class: NumberDeviceClass | None = None,
         initially_disabled: bool = False,
         attribute_initialized_from_cache: bool = True,
+        attribute_converter: Callable[[Any], Any] | None = None,
+        value_converter: Callable[[Any], Any] | None = None,
         reporting_config: ReportingConfig | None = None,
         unique_id_suffix: str | None = None,
         translation_key: str | None = None,
@@ -790,6 +792,11 @@ class QuirkBuilder:
         """Add an EntityMetadata containing NumberMetadata and return self.
 
         This method allows exposing a number entity in Home Assistant.
+
+        `attribute_converter` converts the raw attribute value to the value shown
+        in Home Assistant, `value_converter` converts the value from Home
+        Assistant back to the raw attribute value. As a number can be written,
+        both must be provided together. They take precedence over `multiplier`.
         """
         self._add_entity_metadata(
             NumberMetadata(
@@ -806,6 +813,8 @@ class QuirkBuilder:
                 translation_placeholders=translation_placeholders or {},
                 fallback_name=fallback_name,
                 attribute_name=attribute_name,
+                attribute_converter=attribute_converter,
+                value_converter=value_converter,
                 min=min_value,
                 max=max_value,
                 step=step,

--- a/zhaquirks/builder/discovery.py
+++ b/zhaquirks/builder/discovery.py
@@ -86,6 +86,8 @@ def _platform_kwargs(entity_metadata: EntityMetadata) -> dict[str, Any]:
     if isinstance(entity_metadata, NumberMetadata):
         return {
             "attribute_name": entity_metadata.attribute_name,
+            "attribute_converter": entity_metadata.attribute_converter,
+            "value_converter": entity_metadata.value_converter,
             "min_value": entity_metadata.min,
             "max_value": entity_metadata.max,
             "step": entity_metadata.step,

--- a/zhaquirks/builder/metadata.py
+++ b/zhaquirks/builder/metadata.py
@@ -119,6 +119,8 @@ class NumberMetadata(EntityMetadata):
     """Metadata for exposed number entity."""
 
     attribute_name: str = attrs.field()
+    attribute_converter: Callable[[Any], Any] | None = attrs.field(default=None)
+    value_converter: Callable[[Any], Any] | None = attrs.field(default=None)
     reporting_config: ReportingConfig | None = attrs.field(default=None)
     min: float | None = attrs.field(default=None)
     max: float | None = attrs.field(default=None)
@@ -127,6 +129,17 @@ class NumberMetadata(EntityMetadata):
     mode: str | None = attrs.field(default=None)
     multiplier: float | None = attrs.field(default=None)
     device_class: NumberDeviceClass | None = attrs.field(default=None)
+
+    def __attrs_post_init__(self) -> None:
+        """Validate the number metadata."""
+        super().__attrs_post_init__()
+        # A number is writable, so a one-way converter would show a converted
+        # value but write an unconverted one. Require both directions.
+        if (self.attribute_converter is None) != (self.value_converter is None):
+            raise ValueError(
+                "NumberMetadata must have both attribute_converter and "
+                f"value_converter, or neither: {self}"
+            )
 
 
 @attrs.define(frozen=True, kw_only=True, repr=True)


### PR DESCRIPTION
**DRAFT.** Q: See questions in ZHA PR.

## Proposed change

Allows a number entity to expose a converted value where a plain multiplier is not enough, e.g. a device that stores brightness on an inverted scale. Since a number can be written, both directions are required: attribute_converter maps the raw attribute value to the value shown in HA, value_converter maps it back. Providing only one raises.

Requires the matching zha change.


## Additional information
Linked ZHA PR:
- https://github.com/zigpy/zha/pull/851

Needed for:
- https://github.com/zigpy/zha-device-handlers/pull/4521#discussion_r3670118417


## Checklist

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
