### PR TITLE
Migrate Tuya _TZE200_9p5xmj5r cover (Hiladuo B09M3R35GC) to v2 quirk with battery and motor controls

### DIFF
--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.clusters.general import PowerConfiguration
 
 from tests.common import ClusterListener, wait_for_zigpy_tasks
 import zhaquirks
@@ -223,3 +224,85 @@ async def test_zemismart_zm16b_battery_report(zigpy_device_from_v2_quirk):
     # Battery percentage should be scaled by 2 (default tuya_battery scale)
     power_cluster = ep.power
     assert power_cluster.get("battery_percentage_remaining") == 170
+
+
+async def test_hiladuo_quirk(zigpy_device_from_v2_quirk):
+    """Test Hiladuo B09M3R35GC cover motor v2 quirk."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_9p5xmj5r", "TS0601")
+    assert isinstance(quirked, CustomZigpyDevice)
+
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    assert cover_cluster is not None
+    assert isinstance(cover_cluster, TuyaWindowCovering)
+
+    tuya_cluster = ep.tuya_manufacturer
+    assert tuya_cluster is not None
+    assert isinstance(tuya_cluster, TuyaMCUCluster)
+
+
+async def test_hiladuo_position_report(zigpy_device_from_v2_quirk):
+    """Test that position DP reports pass through without inversion."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_9p5xmj5r", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    # This model reports ZCL-convention lift already (100=closed), so the
+    # quirk uses invert=False and DP 3 value 97 maps straight to ZCL 97.
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[TuyaDatapointData(3, TuyaData(97))],
+        )
+    )
+
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 97
+    )
+
+
+async def test_hiladuo_battery_pinned_100_filter(zigpy_device_from_v2_quirk):
+    """Test that pinned battery=100 dump reports are discarded."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_9p5xmj5r", "TS0601")
+    ep = quirked.endpoints[1]
+
+    tuya_cluster = ep.tuya_manufacturer
+    power_cluster = ep.power
+    battery_attr = PowerConfiguration.AttributeDefs.battery_percentage_remaining
+
+    def report_battery(tsn, value):
+        tuya_cluster.handle_get_data(
+            TuyaCommand(
+                status=0,
+                tsn=tsn,
+                datapoints=[TuyaDatapointData(13, TuyaData(value))],
+            )
+        )
+
+    # A fresh device with no cached level accepts 100% (raw 200)
+    report_battery(1, 100)
+    assert power_cluster.get(battery_attr.id) == 200
+
+    # A genuine measured level replaces it
+    report_battery(2, 31)
+    assert power_cluster.get(battery_attr.id) == 62
+
+    # The firmware's pinned 100 from a DP dump is now discarded
+    report_battery(3, 100)
+    assert power_cluster.get(battery_attr.id) == 62
+
+    # Other measured levels still update in both directions
+    report_battery(4, 45)
+    assert power_cluster.get(battery_attr.id) == 90
+    report_battery(5, 29)
+    assert power_cluster.get(battery_attr.id) == 58

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -2,8 +2,18 @@
 
 from zigpy.profiles import zha
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, Groups, Identify, OnOff, Ota, Scenes, Time
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    OnOff,
+    Ota,
+    PowerConfiguration,
+    Scenes,
+    Time,
+)
 
+from zhaquirks.builder import BinarySensorDeviceClass
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -11,11 +21,13 @@ from zhaquirks.const import (
     MODELS_INFO,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
+    BatterySize,
 )
 from zhaquirks.tuya import (
     TUYA_CLUSTER_ID,
     TuyaManufacturerWindowCover,
     TuyaManufCluster,
+    TuyaPowerConfigurationCluster,
     TuyaWindowCover,
     TuyaWindowCoverControl,
 )
@@ -549,7 +561,6 @@ class TuyaMoesCover0601_inv_position(TuyaWindowCover):
             ("_TZE200_3i3exuay", "TS0601"),
             ("_TZE200_nogaemzt", "TS0601"),
             ("_TZE200_dng9fn0k", "TS0601"),
-            ("_TZE200_9p5xmj5r", "TS0601"),
         ],
         ENDPOINTS: {
             1: {
@@ -701,6 +712,128 @@ class BorderSetting(t.enum8):
         unique_id_suffix="border_remove_all",
         translation_key="delete_all_limits",
         fallback_name="Delete all limits",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
+class ClickControl(t.enum8):
+    """Single-step control values."""
+
+    Up = 0x00
+    Down = 0x01
+
+
+class HiladuoPowerConfiguration(TuyaPowerConfigurationCluster):
+    """PowerConfiguration that discards the firmware's pinned battery=100.
+
+    The motor sends a genuine measured battery level in the DP 13 report
+    it emits ~1 s after finishing a movement, but every full datapoint
+    dump (sent on rejoin and periodically after commands) carries a
+    hardcoded 100 that would overwrite it. Ignore 100% whenever a lower
+    level has already been seen; the cached level persists via zigbee.db.
+    """
+
+    _CONSTANT_ATTRIBUTES = {
+        PowerConfiguration.AttributeDefs.battery_size.id: BatterySize.Built_in,
+        PowerConfiguration.AttributeDefs.battery_rated_voltage.id: 37,
+        PowerConfiguration.AttributeDefs.battery_quantity.id: 1,
+    }
+
+    def update_attribute(self, attr_name: str, value) -> None:
+        """Drop pinned battery=100 reports when a lower level is cached."""
+        defs = PowerConfiguration.AttributeDefs
+        if attr_name == defs.battery_percentage_remaining.name and value >= 200:
+            cached = self.get(defs.battery_percentage_remaining.id)
+            if cached is not None and cached < 200:
+                return
+        super().update_attribute(attr_name, value)
+
+
+(
+    TuyaQuirkBuilder("_TZE200_9p5xmj5r", "TS0601")  # Hiladuo B09M3R35GC
+    .tuya_cover(control_dp=1, position_state_dp=3, position_control_dp=2, invert=False)
+    .tuya_battery(dp_id=13, power_cfg=HiladuoPowerConfiguration)
+    .tuya_enum(
+        dp_id=5,
+        attribute_name="motor_direction",
+        enum_class=MotorDirection,
+        translation_key="motor_direction",
+        fallback_name="Motor direction",
+    )
+    .tuya_binary_sensor(
+        dp_id=12,
+        attribute_name="motor_fault",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        translation_key="motor_fault",
+        fallback_name="Motor fault",
+    )
+    .tuya_dp_attribute(
+        dp_id=16,
+        attribute_name="border",
+        type=BorderSetting,
+    )
+    .write_attr_button(
+        attribute_name="border",
+        attribute_value=BorderSetting.Up,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="border_up",
+        translation_key="set_upper_limit",
+        fallback_name="Set upper limit",
+    )
+    .write_attr_button(
+        attribute_name="border",
+        attribute_value=BorderSetting.Down,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="border_down",
+        translation_key="set_lower_limit",
+        fallback_name="Set lower limit",
+    )
+    .write_attr_button(
+        attribute_name="border",
+        attribute_value=BorderSetting.Up_delete,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="border_up_delete",
+        translation_key="delete_upper_limit",
+        fallback_name="Delete upper limit",
+    )
+    .write_attr_button(
+        attribute_name="border",
+        attribute_value=BorderSetting.Down_delete,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="border_down_delete",
+        translation_key="delete_lower_limit",
+        fallback_name="Delete lower limit",
+    )
+    .write_attr_button(
+        attribute_name="border",
+        attribute_value=BorderSetting.Remove_top_bottom,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="border_remove_all",
+        translation_key="delete_all_limits",
+        fallback_name="Delete all limits",
+    )
+    .tuya_dp_attribute(
+        dp_id=20,
+        attribute_name="click_control",
+        type=ClickControl,
+    )
+    .write_attr_button(
+        attribute_name="click_control",
+        attribute_value=ClickControl.Up,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="step_up",
+        translation_key="step_up",
+        fallback_name="Step up",
+    )
+    .write_attr_button(
+        attribute_name="click_control",
+        attribute_value=ClickControl.Down,
+        cluster_id=TUYA_CLUSTER_ID,
+        unique_id_suffix="step_down",
+        translation_key="step_down",
+        fallback_name="Step down",
     )
     .skip_configuration()
     .add_to_registry()


### PR DESCRIPTION
## Proposed change

Migrates the Tuya `_TZE200_9p5xmj5r` / `TS0601` roller blind motor (sold as Hiladuo B09M3R35GC) from the legacy `TuyaMoesCover0601_inv_position` quirk to a v2 `TuyaQuirkBuilder` quirk, bringing it to feature parity with Zigbee2MQTT's `TS0601_cover_3` definition, and adds a battery-report filter for a firmware misbehaviour we characterised while doing so (details below).

The legacy quirk only exposed the cover itself. The v2 quirk adds:

| DP | Function | Entity |
|----|----------|--------|
| 1/2/3 | control / position control / position state | cover (as before) |
| 5 | motor direction | select (config) |
| 12 | motor fault | binary sensor (diagnostic) |
| 13 | battery % (raw 0–100) | battery sensor |
| 16 | border (limit set/delete) | 5 buttons (config) |
| 20 | click control (single step up/down) | 2 buttons |

Position semantics: this model reports ZCL-convention lift (100 = closed) on the wire, which the legacy quirk handled with `tuya_cover_inverted_by_default = True`; with the builder that corresponds to `invert=False`. Verified live in both directions (HA position 3% ↔ wire value 97).

### The battery filter

The motor's battery reporting behaves in a way that makes the naive DP 13 → battery mapping useless in practice, and we could only characterise it with the sensor in place:

- The motor sends a **genuine measured battery level** in a DP 13 report ~1 s after it finishes a movement.
- Every **full datapoint dump** — sent on rejoin/re-interview and again ~12–19 minutes after a command — carries a **hardcoded battery=100** that overwrites the real reading.

Recorder history from a house with 11 of these motors (2026-07-29, AEST): a group open command at 09:20:49 produced measured reports of 76/76/89/31 % within ~1–2 s of each motor stopping, and then all four sensors snapped back to exactly 100 within a 2-second window at 09:39:29–31 — the synchronized dump, 18½ minutes after the simultaneous commands. The same pattern repeated for two more motors after a 10:00:00 automation (31 % and 92 % measured, reverted at +12 min and on the next HA restart respectively). Raw debug-log captures confirm the dump frames carry DP 13 = 100 regardless of true charge.

`HiladuoPowerConfiguration` therefore discards a `battery_percentage_remaining` update of 100 % whenever a lower level is already cached. Measured post-movement reports flow through in both directions; the pinned dump value no longer clobbers them. Zigpy's attribute-cache persistence means the filter also holds across restarts (verified: a motor at 90 % stayed at 90 % through a core restart and through the subsequent dump window, where previously each restart reset every motor to 100).

Known trade-off, documented in the docstring: after recharging a motor, the sensor stays at the pre-charge level until the first post-movement report below 100 % arrives (in practice within a day of normal blind usage, since every movement produces a measured report).

Running live on 11 motors (HA 2026.7.4) since 2026-07-29.

### Entity/unique_id impact

For existing users of this device the cover entity is preserved (primary cover entity uses the legacy `{ieee}-{endpoint_id}` unique_id format, unchanged by the migration). The battery and the other entities are new. Verified on a live install: cover, battery, and firmware entity IDs survived the migration.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing quirk)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New quirk (thank you!)

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

## Device signature

Matches the signature documented on the legacy quirk (endpoint 1, profile 260, device_type 0x0051, in_clusters `[0x0000, 0x0004, 0x0005, 0xef00]`, out_clusters `[0x000a, 0x0019]`, manufacturer `_TZE200_9p5xmj5r`, model `TS0601`). Happy to attach full HA diagnostics JSON on request.
