### PR TITLE
Add quirk for Schneider Electric FLS/AIRLINK/4 wireless switch

### DIFF
--- a/zhaquirks/schneiderelectric/wireless_switch.py
+++ b/zhaquirks/schneiderelectric/wireless_switch.py
@@ -1,0 +1,100 @@
+"""Quirk for the Schneider Electric FLS/AIRLINK/4 wireless wall switch."""
+
+from zigpy.zcl.clusters.general import LevelControl, OnOff, PowerConfiguration
+
+from zhaquirks.builder import QuirkBuilder
+from zhaquirks.const import (
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_MOVE,
+    COMMAND_MOVE_ON_OFF,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_STOP,
+    DIM_DOWN,
+    DIM_UP,
+    ENDPOINT_ID,
+    LEFT,
+    LONG_RELEASE,
+    RIGHT,
+    TURN_OFF,
+    TURN_ON,
+)
+from zhaquirks.schneiderelectric import SE_MANUF_NAME
+
+# Battery-powered remote with two rockers. Each rocker sends on/off on a short
+# press (OnOff) and level move/stop on a long press/release (LevelControl).
+LEFT_EP = 22
+RIGHT_EP = 21
+
+(
+    QuirkBuilder(SE_MANUF_NAME, "FLS/AIRLINK/4")
+    .device_automation_triggers(
+        {
+            # Left rocker (endpoint 22)
+            (TURN_ON, LEFT): {
+                COMMAND: COMMAND_ON,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: LEFT_EP,
+            },
+            (TURN_OFF, LEFT): {
+                COMMAND: COMMAND_OFF,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: LEFT_EP,
+            },
+            (DIM_UP, LEFT): {
+                COMMAND: COMMAND_MOVE_ON_OFF,
+                CLUSTER_ID: LevelControl.cluster_id,
+                ENDPOINT_ID: LEFT_EP,
+            },
+            (DIM_DOWN, LEFT): {
+                COMMAND: COMMAND_MOVE,
+                CLUSTER_ID: LevelControl.cluster_id,
+                ENDPOINT_ID: LEFT_EP,
+            },
+            (LONG_RELEASE, LEFT): {
+                COMMAND: COMMAND_STOP,
+                CLUSTER_ID: LevelControl.cluster_id,
+                ENDPOINT_ID: LEFT_EP,
+            },
+            # Right rocker (endpoint 21)
+            (TURN_ON, RIGHT): {
+                COMMAND: COMMAND_ON,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: RIGHT_EP,
+            },
+            (TURN_OFF, RIGHT): {
+                COMMAND: COMMAND_OFF,
+                CLUSTER_ID: OnOff.cluster_id,
+                ENDPOINT_ID: RIGHT_EP,
+            },
+            (DIM_UP, RIGHT): {
+                COMMAND: COMMAND_MOVE_ON_OFF,
+                CLUSTER_ID: LevelControl.cluster_id,
+                ENDPOINT_ID: RIGHT_EP,
+            },
+            (DIM_DOWN, RIGHT): {
+                COMMAND: COMMAND_MOVE,
+                CLUSTER_ID: LevelControl.cluster_id,
+                ENDPOINT_ID: RIGHT_EP,
+            },
+            (LONG_RELEASE, RIGHT): {
+                COMMAND: COMMAND_STOP,
+                CLUSTER_ID: LevelControl.cluster_id,
+                ENDPOINT_ID: RIGHT_EP,
+            },
+        }
+    )
+    # Expose a single battery entity: keep endpoint 21 (the main endpoint, which
+    # also carries poll control and OTA) and hide the redundant ones.
+    .prevent_default_entity_creation(
+        endpoint_id=LEFT_EP, cluster_id=PowerConfiguration.cluster_id
+    )
+    .prevent_default_entity_creation(
+        endpoint_id=23, cluster_id=PowerConfiguration.cluster_id
+    )
+    .prevent_default_entity_creation(
+        endpoint_id=24, cluster_id=PowerConfiguration.cluster_id
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Add a v2 quirk for the battery-powered Schneider Electric FLS/AIRLINK/4 wireless wall switch (Odace connectable wireless switch).

The device exposes two rockers (endpoint 22 = left, endpoint 21 = right), each sending on/off (OnOff) on a short press and level move/stop (LevelControl) on a long press/release. The quirk:

- adds device automation triggers for both rockers, and
- exposes a single battery entity by hiding the redundant ones on the secondary endpoints (22/23/24), keeping endpoint 21.

Purely declarative quirk (no custom cluster or logic), so no dedicated
test is required per the contributing guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->

[without quirk](https://github.com/user-attachments/files/30538206/zha-01KN1ZMJ05EV56PWVPE42Q7WVK-Schneider.Electric.FLS_AIRLINK_4-8ffff7ea5c2e8a1402f44abee430e95d.json)

[with quirk](https://github.com/user-attachments/files/30538211/zha-01KN1ZMJ05EV56PWVPE42Q7WVK-Schneider.Electric.FLS_AIRLINK_4-8ffff7ea5c2e8a1402f44abee430e95d.1.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached



Related: #1623
