### PR TITLE
Add backlight_switch attribute (0x5000) to Tuya TS130F

### DIFF
--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -33,6 +33,13 @@ ATTR_CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
 CMD_GO_TO_LIFT_PERCENTAGE = 0x0005
 
 
+class BacklightSwitch(t.enum8):
+    """Tuya backlight switch (separate from backlight_mode)."""
+
+    Off = 0x00
+    On = 0x01
+
+
 class TuyaWithBacklightOnOffCluster(CustomCluster, OnOff):
     """Tuya Zigbee On Off cluster with extra attributes."""
 
@@ -40,6 +47,7 @@ class TuyaWithBacklightOnOffCluster(CustomCluster, OnOff):
         """Attribute definitions."""
 
         backlight_mode: Final = ZCLAttributeDef(id=0x8001, type=SwitchBackLight)
+        backlight_switch: Final = ZCLAttributeDef(id=0x5000, type=BacklightSwitch)
 
 
 class MotorMode(t.enum8):

--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -47,7 +47,9 @@ class TuyaWithBacklightOnOffCluster(CustomCluster, OnOff):
         """Attribute definitions."""
 
         backlight_mode: Final = ZCLAttributeDef(id=0x8001, type=SwitchBackLight)
-        backlight_switch: Final = ZCLAttributeDef(id=0x5000, type=BacklightSwitch)
+        backlight_switch: Final = ZCLAttributeDef(
+            id=0x5000, type=BacklightSwitch, is_manufacturer_specific=True
+        )
 
 
 class MotorMode(t.enum8):


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Adds the backlight_switch attribute (0x5000, enum8) to TuyaWithBacklightOnOffCluster in zhaquirks/tuya/ts130f.py.
This is independent of the existing backlight_mode (0x8001): backlight_mode sets the pattern in which the LED lights up white, while backlight_switch controls whether it glows orange instead of going dark whenever it isn't white.
Found via zha_toolkit scan_device, which turned up an unlabeled writable enum8 at 0x5000 that wasn't in the quirk yet. Confirmed with attr_read/attr_write that it toggles the LED's idle glow independently of backlight_mode.
It will add the missing feature from/described in [Z2M](https://www.zigbee2mqtt.io/devices/TS130F.html#backlight-mode-binary) to ZHAs UI.


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
Purely additive, so non-breaking (as far as I understand zha) — devices that don't support 0x5000 just get UNSUPPORTED_ATTRIBUTE on read like any other optional attribute. Verified on _TZ3000_bs93npae.


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-01KCJCABR5D5YDW81E1HH9F1W2-_TZ3000_bs93npae TS130F-829477de6763a78d94c3fada58d4d104.json](https://github.com/user-attachments/files/30607997/zha-01KCJCABR5D5YDW81E1HH9F1W2-_TZ3000_bs93npae.TS130F-829477de6763a78d94c3fada58d4d104.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
