### PR TITLE
Add quirk for Tuya TS1002 (_TZ3000_te34fjg4)

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -40,6 +40,7 @@ import zhaquirks.tuya.ts011f_plug
 import zhaquirks.tuya.ts0501_fan_switch
 import zhaquirks.tuya.ts0601_electric_heating
 import zhaquirks.tuya.ts0601_trv
+import zhaquirks.tuya.ts1002
 import zhaquirks.tuya.ts1201
 import zhaquirks.tuya.tuya_motion
 import zhaquirks.tuya.tuya_valve
@@ -1535,6 +1536,7 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
         (zhaquirks.tuya.ts0044.TuyaSmartRemote0044TO, "_TZ3400_cdyjhasw"),
         (zhaquirks.tuya.ts0044.TuyaSmartRemote0044TO, "_TZ3400_pdyjhapl"),
         (zhaquirks.tuya.ts0044.TuyaSmartRemote0044TO, "_some_random_manuf"),
+        (zhaquirks.tuya.ts1002.TuyaSmartRemote1002, "_TZ3000_te34fjg4"),
     ),
 )
 async def test_tuya_wildcard_manufacturer(zigpy_device_from_quirk, quirk, manufacturer):
@@ -1545,6 +1547,26 @@ async def test_tuya_wildcard_manufacturer(zigpy_device_from_quirk, quirk, manufa
 
     quirked_dev = get_device(zigpy_dev)
     assert isinstance(quirked_dev, quirk)
+
+
+async def test_ts1002_fd_button_dispatch(zigpy_device_from_quirk):
+    """TS1002 routes 0xFD commands to the matching button endpoint."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    cluster = device.endpoints[1].out_clusters[6]
+
+    zha_listener = mock.MagicMock()
+    device.endpoints[3].TS004X_cluster.add_listener(zha_listener)
+
+    hdr = mock.MagicMock()
+    hdr.command_id = 0xFD
+    hdr.tsn = 1
+    hdr.frame_control.disable_default_response = True
+    cluster.handle_cluster_request(
+        hdr,
+        [cluster.commands_by_name["press_type"].schema(press_type=0, zero=0, button=3)],
+    )
+
+    zha_listener.zha_send_event.assert_called_once_with("remote_button_short_press", [])
 
 
 def test_multiple_attributes_report():

--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -1569,6 +1569,241 @@ async def test_ts1002_fd_button_dispatch(zigpy_device_from_quirk):
     zha_listener.zha_send_event.assert_called_once_with("remote_button_short_press", [])
 
 
+def _ts1002_hdr(
+    command_id: int = 0xFD, tsn: int = 1, *, disable_default_response: bool = True
+):
+    hdr = mock.MagicMock()
+    hdr.command_id = command_id
+    hdr.tsn = tsn
+    hdr.frame_control.disable_default_response = disable_default_response
+    return hdr
+
+
+@pytest.mark.parametrize(
+    ("button", "press_type", "expected_event"),
+    (
+        (1, 0, "remote_button_short_press"),
+        (2, 1, "remote_button_double_press"),
+        (4, 2, "remote_button_long_press"),
+    ),
+)
+async def test_ts1002_fd_button_press_types(
+    zigpy_device_from_quirk, button, press_type, expected_event
+):
+    """TS1002 routes press types to the correct button endpoint."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    cluster = device.endpoints[1].out_clusters[6]
+
+    if button == 1:
+        listener_cluster = cluster
+    else:
+        listener_cluster = device.endpoints[button].TS004X_cluster
+
+    zha_listener = mock.MagicMock()
+    listener_cluster.add_listener(zha_listener)
+
+    cluster.handle_cluster_request(
+        _ts1002_hdr(tsn=button + 10),
+        [
+            cluster.commands_by_name["press_type"].schema(
+                press_type=press_type, zero=0, button=button
+            )
+        ],
+    )
+
+    zha_listener.zha_send_event.assert_called_once_with(expected_event, [])
+
+
+async def test_ts1002_fd_ignores_duplicate_tsn(zigpy_device_from_quirk):
+    """TS1002 ignores duplicate frames with the same TSN."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    cluster = device.endpoints[1].out_clusters[6]
+
+    zha_listener = mock.MagicMock()
+    device.endpoints[2].TS004X_cluster.add_listener(zha_listener)
+
+    payload = [
+        cluster.commands_by_name["press_type"].schema(press_type=0, zero=0, button=2)
+    ]
+    cluster.handle_cluster_request(_ts1002_hdr(tsn=9), payload)
+    cluster.handle_cluster_request(_ts1002_hdr(tsn=9), payload)
+
+    zha_listener.zha_send_event.assert_called_once_with("remote_button_short_press", [])
+
+
+async def test_ts1002_fd_sends_default_response(zigpy_device_from_quirk):
+    """TS1002 sends a default response when one is requested."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    cluster = device.endpoints[1].out_clusters[6]
+
+    with mock.patch.object(cluster, "send_default_rsp") as send_default_rsp:
+        cluster.handle_cluster_request(
+            _ts1002_hdr(tsn=11, disable_default_response=False),
+            [
+                cluster.commands_by_name["press_type"].schema(
+                    press_type=0, zero=0, button=2
+                )
+            ],
+        )
+
+    send_default_rsp.assert_called_once_with(mock.ANY, status=foundation.Status.SUCCESS)
+
+
+async def test_ts1002_fd_defaults_missing_button(zigpy_device_from_quirk):
+    """TS1002 defaults to button 1 when button id is missing."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    cluster = device.endpoints[1].out_clusters[6]
+
+    zha_listener = mock.MagicMock()
+    cluster.add_listener(zha_listener)
+
+    cluster.handle_cluster_request(_ts1002_hdr(tsn=12), [])
+
+    zha_listener.zha_send_event.assert_called_once_with("remote_button_short_press", [])
+
+
+async def test_ts1002_fd_invalid_button_fallback(zigpy_device_from_quirk):
+    """TS1002 falls back to the source cluster for invalid button ids."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    cluster = device.endpoints[1].out_clusters[6]
+
+    zha_listener = mock.MagicMock()
+    cluster.add_listener(zha_listener)
+
+    cluster.handle_cluster_request(
+        _ts1002_hdr(tsn=13),
+        [cluster.commands_by_name["press_type"].schema(press_type=1, zero=0, button=9)],
+    )
+
+    zha_listener.zha_send_event.assert_called_once_with(
+        "remote_button_double_press", []
+    )
+
+
+async def test_ts1002_fd_parse_int_args(zigpy_device_from_quirk):
+    """TS1002 accepts legacy integer argument payloads."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    cluster = device.endpoints[1].out_clusters[6]
+
+    zha_listener = mock.MagicMock()
+    device.endpoints[4].TS004X_cluster.add_listener(zha_listener)
+
+    cluster.handle_cluster_request(_ts1002_hdr(tsn=14), [0, 0, 4])
+
+    zha_listener.zha_send_event.assert_called_once_with("remote_button_short_press", [])
+
+
+async def test_ts1002_fd_non_fd_command(zigpy_device_from_quirk):
+    """TS1002 delegates unknown commands to the base cluster."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    cluster = device.endpoints[1].out_clusters[6]
+
+    with mock.patch.object(
+        zhaquirks.tuya.TuyaSmartRemoteOnOffCluster,
+        "handle_cluster_request",
+    ) as super_handle:
+        cluster.handle_cluster_request(_ts1002_hdr(command_id=0x01, tsn=15), [])
+
+    super_handle.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("command_id", "scene_id", "endpoint_id"),
+    ((0x00, 2, 2), (0x05, 8, 4)),
+)
+async def test_ts1002_scene_cluster_dispatch(
+    zigpy_device_from_quirk, command_id, scene_id, endpoint_id
+):
+    """TS1002 maps scene cluster commands to button endpoints."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    scene_cluster = device.endpoints[1].out_clusters[5]
+
+    zha_listener = mock.MagicMock()
+    device.endpoints[endpoint_id].TS004X_cluster.add_listener(zha_listener)
+
+    scene_cluster.handle_cluster_request(
+        _ts1002_hdr(command_id=command_id, tsn=scene_id),
+        [scene_id],
+    )
+
+    zha_listener.zha_send_event.assert_called_once_with("remote_button_short_press", [])
+
+
+@pytest.mark.parametrize(
+    ("step_mode", "endpoint_id"),
+    ((0, 3), (1, 4)),
+)
+async def test_ts1002_level_cluster_dispatch(
+    zigpy_device_from_quirk, step_mode, endpoint_id
+):
+    """TS1002 maps level step commands to buttons 3 and 4."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    level_cluster = device.endpoints[1].out_clusters[8]
+
+    zha_listener = mock.MagicMock()
+    device.endpoints[endpoint_id].TS004X_cluster.add_listener(zha_listener)
+
+    step_request = mock.Mock(step_mode=step_mode)
+    level_cluster.handle_cluster_request(
+        _ts1002_hdr(command_id=0x02, tsn=20 + step_mode),
+        [step_request],
+    )
+
+    zha_listener.zha_send_event.assert_called_once_with("remote_button_short_press", [])
+
+
+@pytest.mark.parametrize(
+    ("step_mode", "endpoint_id"),
+    ((0, 2), (2, 2)),
+)
+async def test_ts1002_color_cluster_dispatch(
+    zigpy_device_from_quirk, step_mode, endpoint_id
+):
+    """TS1002 maps color temp step commands to button 2."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    color_cluster = device.endpoints[1].out_clusters[0x0300]
+
+    zha_listener = mock.MagicMock()
+    device.endpoints[endpoint_id].TS004X_cluster.add_listener(zha_listener)
+
+    color_cluster.handle_cluster_request(
+        _ts1002_hdr(command_id=0x4C, tsn=30 + step_mode),
+        [mock.Mock(step_mode=step_mode)],
+    )
+
+    zha_listener.zha_send_event.assert_called_once_with("remote_button_short_press", [])
+
+
+async def test_ts1002_color_cluster_button_one_mapping(zigpy_device_from_quirk):
+    """TS1002 maps color temp step modes 1 and 3 to button 1."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    color_cluster = device.endpoints[1].out_clusters[0x0300]
+
+    for step_mode in (1, 3):
+        color_cluster.handle_cluster_request(
+            _ts1002_hdr(command_id=0x4C, tsn=40 + step_mode),
+            [mock.Mock(step_mode=step_mode)],
+        )
+
+
+async def test_ts1002_output_clusters_no_bind(zigpy_device_from_quirk):
+    """TS1002 output clusters skip bind and configure reporting."""
+    device = zigpy_device_from_quirk(zhaquirks.tuya.ts1002.TuyaSmartRemote1002)
+    scene_cluster = device.endpoints[1].out_clusters[5]
+
+    request_patch = mock.patch("zigpy.zcl.Cluster.request", mock.AsyncMock())
+    bind_patch = mock.patch("zigpy.zcl.Cluster.bind", mock.AsyncMock())
+
+    with request_patch as request_mock, bind_patch as bind_mock:
+        request_mock.return_value = (foundation.Status.SUCCESS, "done")
+
+        await scene_cluster.bind()
+        await scene_cluster._configure_reporting(0, 3600, 10800, 1)
+
+        assert len(request_mock.mock_calls) == 0
+        assert len(bind_mock.mock_calls) == 0
+
+
 def test_multiple_attributes_report():
     """Test a multi attribute report from Tuya device."""
 

--- a/zhaquirks/tuya/ts1002.py
+++ b/zhaquirks/tuya/ts1002.py
@@ -1,0 +1,401 @@
+"""Tuya TS1002 4-button scene switch."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from zigpy import types as t
+from zigpy.profiles import zha
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    PowerConfiguration,
+    Scenes,
+    Time,
+)
+from zigpy.zcl.clusters.lighting import Color
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from zhaquirks.const import (
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    BUTTON_4,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_MOVE,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_STEP,
+    COMMAND_STOP,
+    DEVICE_TYPE,
+    DIM_DOWN,
+    DIM_UP,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    LONG_PRESS,
+    LONG_RELEASE,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PARAMS,
+    PROFILE_ID,
+    SHORT_PRESS,
+    TURN_OFF,
+    TURN_ON,
+    ZHA_SEND_EVENT,
+)
+from zhaquirks.legacy import CustomDevice
+from zhaquirks.tuya import (
+    TuyaNoBindPowerConfigurationCluster,
+    TuyaSmartRemoteOnOffCluster,
+    TuyaZBExternalSwitchTypeCluster,
+)
+
+PRESS_TYPE = {
+    0x00: SHORT_PRESS,
+    0x01: DOUBLE_PRESS,
+    0x02: LONG_PRESS,
+}
+
+# Zigbee2MQTT TS1002: different buttons may use different clusters.
+BUTTON_FROM_STEP_MODE = {0: 3, 1: 4}
+BUTTON_FROM_SCENE = {1: 1, 2: 2, 3: 3, 4: 4, 5: 1, 6: 2, 7: 3, 8: 4}
+
+
+class TuyaTS1002NoBindMixin:
+    """Skip Zigbee bind on remote output clusters (unsupported, blocks onboarding)."""
+
+    async def bind(self):
+        """Prevent bind."""
+        return (foundation.Status.SUCCESS,)
+
+    async def _configure_reporting(self, *args, **kwargs):
+        """Prevent remote configure reporting."""
+        return (foundation.ConfigureReportingResponse.deserialize(b"\x00")[0],)
+
+
+class TuyaTS1002SceneCluster(TuyaTS1002NoBindMixin, Scenes):
+    """Map recall_scene to button endpoints."""
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: t.AddrMode | None = None,
+    ) -> None:
+        """Handle scene cluster commands and map them to button events."""
+        if hdr.command_id in (0x00, 0x05) and args:
+            scene_id = int(args[0])
+            button_id = BUTTON_FROM_SCENE.get(scene_id)
+            if button_id:
+                self._dispatch_scene_button(button_id)
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+    def _dispatch_scene_button(self, button_id: int) -> None:
+        device = self.endpoint.device
+        target = device.endpoints.get(button_id)
+        if target is None:
+            return
+        for cluster in target.in_clusters.values():
+            if isinstance(cluster, TuyaSmartRemoteOnOffCluster):
+                cluster.listener_event(ZHA_SEND_EVENT, SHORT_PRESS, [])
+                return
+
+
+class TuyaTS1002LevelCluster(TuyaTS1002NoBindMixin, LevelControl):
+    """Map step commands to buttons 3-4."""
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: t.AddrMode | None = None,
+    ) -> None:
+        """Handle level cluster commands and map them to button events."""
+        if hdr.command_id == 0x02 and args:
+            step_mode = int(getattr(args[0], "step_mode", args[0]))
+            button_id = BUTTON_FROM_STEP_MODE.get(step_mode)
+            if button_id:
+                self._dispatch_level_button(button_id)
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+    def _dispatch_level_button(self, button_id: int) -> None:
+        device = self.endpoint.device
+        target = device.endpoints.get(button_id)
+        if target is None:
+            return
+        for cluster in target.in_clusters.values():
+            if isinstance(cluster, TuyaSmartRemoteOnOffCluster):
+                cluster.listener_event(ZHA_SEND_EVENT, SHORT_PRESS, [])
+                return
+
+
+class TuyaTS1002ColorCluster(TuyaTS1002NoBindMixin, Color):
+    """Map step_color_temp to buttons 1-2."""
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: t.AddrMode | None = None,
+    ) -> None:
+        """Handle color cluster commands and map them to button events."""
+        if hdr.command_id == 0x4C and args:
+            step_mode = int(getattr(args[0], "step_mode", args[0]))
+            button_id = 1 if step_mode in (1, 3) else 2 if step_mode in (0, 2) else None
+            if button_id:
+                self._dispatch_color_button(button_id)
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+    def _dispatch_color_button(self, button_id: int) -> None:
+        device = self.endpoint.device
+        target = device.endpoints.get(button_id)
+        if target is None:
+            return
+        for cluster in target.in_clusters.values():
+            if isinstance(cluster, TuyaSmartRemoteOnOffCluster):
+                cluster.listener_event(ZHA_SEND_EVENT, SHORT_PRESS, [])
+                return
+
+
+class TuyaTS1002SceneOnOffCluster(TuyaTS1002NoBindMixin, TuyaSmartRemoteOnOffCluster):
+    """Route TS1002 scene button presses to the matching endpoint."""
+
+    class ServerCommandDefs(TuyaSmartRemoteOnOffCluster.ServerCommandDefs):
+        """TS1002 sends press_type + 0x00 + button_id in 0xFD payload."""
+
+        press_type = foundation.ZCLCommandDef(
+            id=0xFD,
+            schema={
+                "press_type": t.uint8_t,
+                "zero": t.uint8_t,
+                "button": t.uint8_t,
+            },
+            is_manufacturer_specific=True,
+        )
+
+    def _parse_button_press(self, args: list[Any] | Any) -> tuple[int, int | None]:
+        """Extract press type and button id from a 0xFD command."""
+        press_type = 0
+        button_id: int | None = None
+
+        if not args:
+            return press_type, button_id
+
+        if isinstance(args, (list, tuple)):
+            first = args[0] if args else None
+        else:
+            first = args
+
+        if first is None:
+            return press_type, button_id
+
+        if hasattr(first, "press_type"):
+            press_type = int(first.press_type)
+            if hasattr(first, "button"):
+                button_id = int(first.button)
+        elif isinstance(first, int):
+            press_type = first
+            if isinstance(args, (list, tuple)) and len(args) >= 3:
+                button_id = int(args[2])
+
+        return press_type, button_id
+
+    def _dispatch_button_event(self, endpoint_id: int, press_type: int) -> None:
+        """Send a button event on the target endpoint."""
+        event = PRESS_TYPE.get(press_type, SHORT_PRESS)
+        device = self.endpoint.device
+
+        if endpoint_id == self.endpoint.endpoint_id:
+            self.listener_event(ZHA_SEND_EVENT, event, [])
+            return
+
+        target = device.endpoints.get(endpoint_id)
+
+        if target is not None:
+            clusters = list(target.in_clusters.values()) + list(
+                target.out_clusters.values()
+            )
+            for cluster in clusters:
+                if (
+                    isinstance(cluster, TuyaSmartRemoteOnOffCluster)
+                    and cluster is not self
+                ):
+                    cluster.listener_event(ZHA_SEND_EVENT, event, [])
+                    return
+
+        self.listener_event(ZHA_SEND_EVENT, event, [])
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: list[Any],
+        *,
+        dst_addressing: t.AddrMode | None = None,
+    ) -> None:
+        """Handle Tuya scene button commands on endpoint 1."""
+        if hdr.command_id != 0xFD:
+            return super().handle_cluster_request(
+                hdr, args, dst_addressing=dst_addressing
+            )
+
+        if hdr.tsn == self.last_tsn:
+            return
+        self.last_tsn = hdr.tsn
+
+        if not hdr.frame_control.disable_default_response:
+            self.send_default_rsp(hdr, status=foundation.Status.SUCCESS)
+
+        press_type, button_id = self._parse_button_press(args)
+        if button_id is None:
+            button_id = 1
+
+        if 1 <= button_id <= 4:
+            self._dispatch_button_event(button_id, press_type)
+            return
+
+        event = PRESS_TYPE.get(press_type, SHORT_PRESS)
+        self.listener_event(ZHA_SEND_EVENT, event, [])
+
+
+class TuyaSmartRemote1002(CustomDevice):
+    """Tuya TS1002 4-button scene switch.
+
+    Commercial example: Arlight SMART-ZB-801-22-1G-4SC-MULTI-IN (048042).
+    https://arlight.ru/catalog/product/048042/
+    """
+
+    signature = {
+        MODELS_INFO: [("_TZ3000_te34fjg4", "TS1002")],
+        ENDPOINTS: {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=261
+            # device_version=0
+            # input_clusters=[0, 1, 3, 4, 4096, 57345]
+            # output_clusters=[3, 4, 5, 6, 8, 10, 25, 768, 4096]>
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.COLOR_DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    LightLink.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    TuyaNoBindPowerConfigurationCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    LightLink.cluster_id,
+                    TuyaZBExternalSwitchTypeCluster,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    TuyaTS1002SceneCluster,
+                    TuyaTS1002SceneOnOffCluster,
+                    TuyaTS1002LevelCluster,
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                    TuyaTS1002ColorCluster,
+                    LightLink.cluster_id,
+                ],
+            },
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster],
+                OUTPUT_CLUSTERS: [],
+            },
+            3: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster],
+                OUTPUT_CLUSTERS: [],
+            },
+            4: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [TuyaSmartRemoteOnOffCluster],
+                OUTPUT_CLUSTERS: [],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: SHORT_PRESS},
+        (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
+        (LONG_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: LONG_PRESS},
+        (SHORT_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: SHORT_PRESS},
+        (DOUBLE_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: DOUBLE_PRESS},
+        (LONG_PRESS, BUTTON_2): {ENDPOINT_ID: 2, COMMAND: LONG_PRESS},
+        (SHORT_PRESS, BUTTON_3): {ENDPOINT_ID: 3, COMMAND: SHORT_PRESS},
+        (DOUBLE_PRESS, BUTTON_3): {ENDPOINT_ID: 3, COMMAND: DOUBLE_PRESS},
+        (LONG_PRESS, BUTTON_3): {ENDPOINT_ID: 3, COMMAND: LONG_PRESS},
+        (SHORT_PRESS, BUTTON_4): {ENDPOINT_ID: 4, COMMAND: SHORT_PRESS},
+        (DOUBLE_PRESS, BUTTON_4): {ENDPOINT_ID: 4, COMMAND: DOUBLE_PRESS},
+        (LONG_PRESS, BUTTON_4): {ENDPOINT_ID: 4, COMMAND: LONG_PRESS},
+        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 1},
+        (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 1},
+        (SHORT_PRESS, DIM_UP): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            PARAMS: {"step_mode": 0},
+        },
+        (LONG_PRESS, DIM_UP): {
+            COMMAND: COMMAND_MOVE,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            PARAMS: {"move_mode": 0},
+        },
+        (SHORT_PRESS, DIM_DOWN): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            PARAMS: {"step_mode": 1},
+        },
+        (LONG_PRESS, DIM_DOWN): {
+            COMMAND: COMMAND_MOVE,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            PARAMS: {"move_mode": 1},
+        },
+        (LONG_RELEASE, DIM_DOWN): {
+            COMMAND: COMMAND_STOP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+        },
+    }

--- a/zhaquirks/tuya/ts1002.py
+++ b/zhaquirks/tuya/ts1002.py
@@ -21,6 +21,7 @@ from zigpy.zcl.clusters.general import (
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 
+from zhaquirks.clusters import CustomCluster
 from zhaquirks.const import (
     BUTTON_1,
     BUTTON_2,
@@ -81,7 +82,7 @@ class TuyaTS1002NoBindMixin:
         return (foundation.ConfigureReportingResponse.deserialize(b"\x00")[0],)
 
 
-class TuyaTS1002SceneCluster(TuyaTS1002NoBindMixin, Scenes):
+class TuyaTS1002SceneCluster(TuyaTS1002NoBindMixin, CustomCluster, Scenes):
     """Map recall_scene to button endpoints."""
 
     def handle_cluster_request(
@@ -110,7 +111,7 @@ class TuyaTS1002SceneCluster(TuyaTS1002NoBindMixin, Scenes):
                 return
 
 
-class TuyaTS1002LevelCluster(TuyaTS1002NoBindMixin, LevelControl):
+class TuyaTS1002LevelCluster(TuyaTS1002NoBindMixin, CustomCluster, LevelControl):
     """Map step commands to buttons 3-4."""
 
     def handle_cluster_request(
@@ -139,7 +140,7 @@ class TuyaTS1002LevelCluster(TuyaTS1002NoBindMixin, LevelControl):
                 return
 
 
-class TuyaTS1002ColorCluster(TuyaTS1002NoBindMixin, Color):
+class TuyaTS1002ColorCluster(TuyaTS1002NoBindMixin, CustomCluster, Color):
     """Map step_color_temp to buttons 1-2."""
 
     def handle_cluster_request(


### PR DESCRIPTION
## Proposed change

Add quirk for Tuya **TS1002** scene switch with manufacturer **`_TZ3000_te34fjg4`**.

**Commercial product:** INTELLIGENT ARLIGHT SMART-ZB-801-22-1G-4SC-MULTI-IN (Arlight `048042`)  
**Product page:** https://arlight.ru/catalog/product/048042/

4-button in-wall scene panel (230V, Zigbee 3.0). Despite mains power, the device reports as a battery End Device (`logical_type=2`, `mac_capability_flags=128`) and does not act as a Zigbee router.

The device does not follow standard ZCL button reporting:

- Manufacturer-specific command `0xFD` on `OnOff` with schema `press_type, zero, button`
- Some button presses are also sent via `Scenes`, `LevelControl`, or `Color` clusters
- Bind/configure reporting on output clusters fails and blocks onboarding

The quirk:

- Skips bind/configure reporting on remote output clusters
- Routes `0xFD` commands to virtual endpoints 1–4 with correct press types
- Maps fallback cluster traffic to the matching button endpoints
- Provides full `device_automation_triggers` for 4 buttons (short/double/long)

Tested with 5 physical Arlight panels in production.

## Additional information

Pattern is based on existing Tuya remotes (`ts0044.py`) and Zigbee2MQTT TS1002 cluster mapping.

## Device diagnostics

Diagnostics JSON from Home Assistant ZHA (HA 2025.10.4) is attached below.

<details>
<summary>Device diagnostics JSON</summary>

```json
{
  "home_assistant": {
    "installation_type": "Home Assistant Snap",
    "version": "2025.10.4",
    "dev": false,
    "hassio": false,
    "virtualenv": true,
    "python_version": "3.13.8",
    "docker": false,
    "snap": true,
    "arch": "aarch64",
    "timezone": "Asia/Yekaterinburg",
    "os_name": "Linux",
    "os_version": "7.0.0-1015-raspi",
    "run_as_root": true
  },
  "custom_components": {
    "houseplan": {
      "documentation": "https://github.com/Matysh/houseplan-card",
      "version": "1.53.1",
      "requirements": []
    },
    "yandex_smart_home": {
      "documentation": "https://docs.yaha-cloud.ru/v1.0.x/",
      "version": "1.0.2",
      "requirements": []
    },
    "hacs": {
      "documentation": "https://hacs.xyz/docs/use/",
      "version": "2.0.5",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding",
      "usb"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher"
    ],
    "requirements": [
      "zha==0.0.73"
    ],
    "usb": [
      {
        "vid": "10C4",
        "pid": "EA60",
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ]
      },
      {
        "vid": "10C4",
        "pid": "EA60",
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ]
      },
      {
        "vid": "1A86",
        "pid": "55D4",
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ]
      },
      {
        "vid": "10C4",
        "pid": "EA60",
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ]
      },
      {
        "vid": "10C4",
        "pid": "EA60",
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ]
      },
      {
        "vid": "1A86",
        "pid": "7523",
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ]
      },
      {
        "vid": "1A86",
        "pid": "7523",
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ]
      },
      {
        "vid": "1CF1",
        "pid": "0030",
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ]
      },
      {
        "vid": "0403",
        "pid": "6015",
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ]
      },
      {
        "vid": "10C4",
        "pid": "8A2A",
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ]
      },
      {
        "vid": "0403",
        "pid": "6015",
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ]
      },
      {
        "vid": "10C4",
        "pid": "EA60",
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ]
      },
      {
        "vid": "10C4",
        "pid": "8B34",
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ]
      },
      {
        "vid": "10C4",
        "pid": "EA60",
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ]
      },
      {
        "vid": "10C4",
        "pid": "EA60",
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ]
      }
    ],
    "zeroconf": [
      {
        "type": "_esphomelib._tcp.local.",
        "name": "tube*"
      },
      {
        "type": "_zigate-zigbee-gateway._tcp.local.",
        "name": "*zigate*"
      },
      {
        "type": "_zigstar_gw._tcp.local.",
        "name": "*zigstar*"
      },
      {
        "type": "_uzg-01._tcp.local.",
        "name": "uzg-01*"
      },
      {
        "type": "_slzb-06._tcp.local.",
        "name": "slzb-06*"
      },
      {
        "type": "_xzg._tcp.local.",
        "name": "xzg*"
      },
      {
        "type": "_czc._tcp.local.",
        "name": "czc*"
      },
      {
        "type": "_zigbee-coordinator._tcp.local.",
        "name": "*"
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.0006270270023378544
    },
    "01KXZ9WQ1HZBEQNQ8J4D8WD78A": {
      "wait_import_platforms": -0.7083740170019155,
      "wait_base_component": -0.006906408998474944,
      "config_entry_setup": 38.21390617900033
    }
  },
  "data": {
    "version": 1,
    "ieee": "**REDACTED**",
    "nwk": "0x43B7",
    "manufacturer": "_TZ3000_te34fjg4",
    "model": "TS1002",
    "friendly_manufacturer": "_TZ3000_te34fjg4",
    "friendly_model": "TS1002",
    "name": "_TZ3000_te34fjg4 TS1002",
    "quirk_applied": true,
    "quirk_class": "ts1002_te34fjg4.TuyaSmartRemote1002",
    "quirk_id": null,
    "manufacturer_code": 4098,
    "power_source": "Battery or Unknown",
    "lqi": 76,
    "rssi": null,
    "last_seen": "2026-08-02T17:03:13.227669+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4098,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 82,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 82,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "NON_COLOR_CONTROLLER",
          "id": 2080
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "_TZ3000_te34fjg4"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "TS1002"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "zcl_type": "uint8",
                "value": 200
              },
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "unsupported": true
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "unsupported": true
              },
              {
                "id": "0x0020",
                "name": "battery_voltage",
                "zcl_type": "uint8",
                "value": 30
              }
            ]
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x1000",
            "endpoint_attribute": "lightlink",
            "attributes": []
          },
          {
            "cluster_id": "0xe001",
            "endpoint_attribute": "tuya_external_switch_type",
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x0005",
            "endpoint_attribute": "scenes",
            "attributes": []
          },
          {
            "cluster_id": "0x0006",
            "endpoint_attribute": "TS004X_cluster",
            "attributes": []
          },
          {
            "cluster_id": "0x0008",
            "endpoint_attribute": "level",
            "attributes": []
          },
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "unsupported": true
              }
            ]
          },
          {
            "cluster_id": "0x0300",
            "endpoint_attribute": "light_color",
            "attributes": []
          },
          {
            "cluster_id": "0x1000",
            "endpoint_attribute": "lightlink",
            "attributes": []
          }
        ]
      },
      "2": {
        "profile_id": 260,
        "device_type": {
          "name": "NON_COLOR_CONTROLLER",
          "id": 2080
        },
        "in_clusters": [
          {
            "cluster_id": "0x0006",
            "endpoint_attribute": "TS004X_cluster",
            "attributes": []
          }
        ],
        "out_clusters": []
      },
      "3": {
        "profile_id": 260,
        "device_type": {
          "name": "NON_COLOR_CONTROLLER",
          "id": 2080
        },
        "in_clusters": [
          {
            "cluster_id": "0x0006",
            "endpoint_attribute": "TS004X_cluster",
            "attributes": []
          }
        ],
        "out_clusters": []
      },
      "4": {
        "profile_id": 260,
        "device_type": {
          "name": "NON_COLOR_CONTROLLER",
          "id": 2080
        },
        "in_clusters": [
          {
            "cluster_id": "0x0006",
            "endpoint_attribute": "TS004X_cluster",
            "attributes": []
          }
        ],
        "out_clusters": []
      }
    },
    "original_signature": {
      "models_info": [
        [
          "_TZ3000_te34fjg4",
          "TS1002"
        ]
      ],
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0105",
          "input_clusters": [
            "0x0000",
            "0x0001",
            "0x0003",
            "0x0004",
            "0x1000",
            "0xe001"
          ],
          "output_clusters": [
            "0x0003",
            "0x0004",
            "0x0005",
            "0x0006",
            "0x0008",
            "0x000a",
            "0x0019",
            "0x0300",
            "0x1000"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "button": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "button",
            "class_name": "IdentifyButton",
            "translation_key": null,
            "device_class": "identify",
            "state_class": null,
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "IdentifyClusterHandler",
                "generic_id": "cluster_handler_0x0003",
                "endpoint_id": 1,
                "cluster": {
                  "id": 3,
                  "name": "Identify",
                  "type": "server"
                },
                "id": "1:0x0003",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "command": "identify",
            "args": [
              5
            ],
            "kwargs": {}
          },
          "state": {
            "class_name": "IdentifyButton",
            "available": true
          }
        }
      ],
      "sensor": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "LQISensor",
            "translation_key": "lqi",
            "device_class": null,
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": null
          },
          "state": {
            "class_name": "LQISensor",
            "available": true,
            "state": 76
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "RSSISensor",
            "translation_key": "rssi",
            "device_class": "signal_strength",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": false,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "BasicClusterHandler",
                "generic_id": "cluster_handler_0x0000",
                "endpoint_id": 1,
                "cluster": {
                  "id": 0,
                  "name": "Basic",
                  "type": "server"
                },
                "id": "1:0x0000",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": null,
            "unit": "dBm"
          },
          "state": {
            "class_name": "RSSISensor",
            "available": true,
            "state": null
          }
        },
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "sensor",
            "class_name": "Battery",
            "translation_key": null,
            "device_class": "battery",
            "state_class": "measurement",
            "entity_category": "diagnostic",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "PowerConfigurationClusterHandler",
                "generic_id": "cluster_handler_0x0001",
                "endpoint_id": 1,
                "cluster": {
                  "id": 1,
                  "name": "Power Configuration",
                  "type": "server"
                },
                "id": "1:0x0001",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": "battery_voltage"
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "suggested_display_precision": 0,
            "unit": "%"
          },
          "state": {
            "class_name": "Battery",
            "available": true,
            "state": 100.0,
            "battery_voltage": 3.0
          },
          "extra_state_attributes": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ]
        }
      ],
      "update": [
        {
          "info_object": {
            "fallback_name": null,
            "unique_id": "**REDACTED**",
            "migrate_unique_ids": [],
            "platform": "update",
            "class_name": "FirmwareUpdateEntity",
            "translation_key": null,
            "device_class": "firmware",
            "state_class": null,
            "entity_category": "config",
            "entity_registry_enabled_default": true,
            "enabled": true,
            "primary": false,
            "cluster_handlers": [
              {
                "class_name": "OtaClientClusterHandler",
                "generic_id": "cluster_handler_0x0019_client",
                "endpoint_id": 1,
                "cluster": {
                  "id": 25,
                  "name": "Ota",
                  "type": "client"
                },
                "id": "1:0x0019_client",
                "unique_id": "**REDACTED**",
                "status": "INITIALIZED",
                "value_attribute": null
              }
            ],
            "device_ieee": "**REDACTED**",
            "endpoint_id": 1,
            "available": true,
            "group_id": null,
            "supported_features": 7
          },
          "state": {
            "class_name": "FirmwareUpdateEntity",
            "available": true,
            "installed_version": null,
            "in_progress": false,
            "update_percentage": null,
            "latest_version": null,
            "release_summary": null,
            "release_notes": null,
            "release_url": null
          }
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using ruff
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
