### PR TITLE
Add SNZB-04PR2 tamper quirk

### DIFF
--- a/tests/test_sonoff.py
+++ b/tests/test_sonoff.py
@@ -19,6 +19,21 @@ from zhaquirks.sonoff.zbm5 import (
 zhaquirks.setup()
 
 
+async def test_snzb04pr2_tamper_attribute_is_standard_zcl(
+    zigpy_device_from_v2_quirk,
+):
+    """SNZB-04PR2 reports the tamper attribute in a standard ZCL frame."""
+    device = zigpy_device_from_v2_quirk(
+        manufacturer="SONOFF",
+        model="SNZB-04PR2",
+        cluster_ids={1: {0xFC11: ClusterType.Server}},
+    )
+
+    tamper_attr = device.endpoints[1].sonoff_contact_cluster.AttributeDefs.tamper
+
+    assert tamper_attr.is_manufacturer_specific is False
+
+
 @pytest.mark.parametrize(
     ("mask", "expected_states"),
     [

--- a/zhaquirks/sonoff/snzb04p.py
+++ b/zhaquirks/sonoff/snzb04p.py
@@ -30,6 +30,23 @@ class SonoffContactCluster(CustomCluster):
         )
 
 
+class SonoffContactClusterPR2(CustomCluster):
+    """SONOFF SNZB-04PR2 cluster carrying the rear tamper-switch state."""
+
+    cluster_id = 64529  # 0xfc11
+    name = "Sonoff PR2 contact cluster"
+    ep_attribute = "sonoff_contact_cluster"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        tamper = ZCLAttributeDef(
+            id=0x2000,
+            type=types.Bool,
+            is_manufacturer_specific=False,
+        )
+
+
 (
     #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
     #  device_version=0
@@ -41,6 +58,23 @@ class SonoffContactCluster(CustomCluster):
     .binary_sensor(
         "tamper",
         SonoffContactCluster.cluster_id,
+        endpoint_id=1,
+        reporting_config=ReportingConfig(
+            min_interval=0, max_interval=900, reportable_change=1
+        ),
+        device_class=BinarySensorDeviceClass.TAMPER,
+        entity_type=EntityType.DIAGNOSTIC,
+        fallback_name="Tamper",
+    )
+    .add_to_registry()
+)
+
+(
+    QuirkBuilder("SONOFF", "SNZB-04PR2")
+    .replaces(SonoffContactClusterPR2, endpoint_id=1)
+    .binary_sensor(
+        "tamper",
+        SonoffContactClusterPR2.cluster_id,
         endpoint_id=1,
         reporting_config=ReportingConfig(
             min_interval=0, max_interval=900, reportable_change=1


### PR DESCRIPTION
## Summary
- add a ZHA quirk for SONOFF SNZB-04PR2
- expose the rear tamper switch as a diagnostic binary sensor
- cover the PR2 standard-ZCL tamper attribute in a regression test

## Root cause
The SNZB-04PR2 reports tamper state on manufacturer cluster `0xFC11`, attribute `0x2000`, using a standard ZCL report frame. ZHA did not have a PR2 quirk, so it did not expose that attribute as an entity.

## Validation
- `uv run pytest tests/test_sonoff.py -q`
- `uv run ruff check zhaquirks/sonoff/snzb04p.py tests/test_sonoff.py`
- Live ZHA verification on an SNZB-04PR2: press changed tamper `on` to `off`; release restored `on`.