### PR TITLE
Add Nous A4Z outdoor smart socket

### DIFF
--- a/tests/test_nous.py
+++ b/tests/test_nous.py
@@ -1,0 +1,87 @@
+"""Tests for Nous quirks."""
+
+from zha.quirks import QUIRK_REGISTRY_ENTRY_ATTR, SE_POLL_SUMMATION, TUYA_PLUG_ONOFF
+from zigpy.zcl import ClusterType
+from zigpy.zcl.clusters.general import OnOff
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.smartenergy import Metering
+
+import zhaquirks
+
+zhaquirks.setup()
+
+
+def _a4z_device(zigpy_device_from_v2_quirk):
+    """Create a Nous A4Z, which reports metering on both of its endpoints."""
+    endpoint = {
+        OnOff.cluster_id: ClusterType.Server,
+        Metering.cluster_id: ClusterType.Server,
+        ElectricalMeasurement.cluster_id: ClusterType.Server,
+    }
+    return zigpy_device_from_v2_quirk(
+        manufacturer="_TZ3000_uwkja6z1",
+        model="TS011F",
+        cluster_ids={1: dict(endpoint), 2: dict(endpoint)},
+    )
+
+
+def _exposed_features(device):
+    """Return the feature strings the applied quirk exposes to ZHA."""
+    entry = getattr(device, QUIRK_REGISTRY_ENTRY_ATTR)
+    quirk_definition = entry.zha_device_factory.quirk_definition
+    return {f.feature for f in quirk_definition.exposes_features}
+
+
+def test_nous_a4z_measurement_scaling(zigpy_device_from_v2_quirk):
+    """Test the multipliers and divisors the socket never reports are served."""
+    device = _a4z_device(zigpy_device_from_v2_quirk)
+
+    metering = device.endpoints[1].smartenergy_metering
+    assert metering.get(Metering.AttributeDefs.multiplier.id) == 1
+    assert metering.get(Metering.AttributeDefs.divisor.id) == 100
+
+    electrical = device.endpoints[1].electrical_measurement
+    assert (
+        electrical.get(ElectricalMeasurement.AttributeDefs.ac_current_multiplier.id)
+        == 1
+    )
+    assert (
+        electrical.get(ElectricalMeasurement.AttributeDefs.ac_current_divisor.id)
+        == 1000
+    )
+
+
+def test_nous_a4z_duplicate_measurement_removed(zigpy_device_from_v2_quirk):
+    """Test endpoint 2's duplicate measurement is dropped but its relay kept."""
+    device = _a4z_device(zigpy_device_from_v2_quirk)
+
+    assert Metering.cluster_id not in device.endpoints[2].in_clusters
+    assert ElectricalMeasurement.cluster_id not in device.endpoints[2].in_clusters
+    assert OnOff.cluster_id in device.endpoints[2].in_clusters
+
+
+def test_nous_a4z_tuya_onoff_attributes(zigpy_device_from_v2_quirk):
+    """Test the Tuya OnOff extras are exposed, on endpoint 1 only."""
+    device = _a4z_device(zigpy_device_from_v2_quirk)
+
+    on_off = device.endpoints[1].on_off
+    for attribute_name in ("power_on_state", "backlight_mode", "child_lock"):
+        assert attribute_name in on_off.attributes_by_name
+
+    # One socket-wide register mirrored on both endpoints, so endpoint 2 keeps a
+    # plain OnOff cluster rather than exposing a second set of the same settings.
+    assert "power_on_state" not in device.endpoints[2].on_off.attributes_by_name
+
+    assert TUYA_PLUG_ONOFF in _exposed_features(device)
+
+
+def test_nous_a4z_summation_is_polled(zigpy_device_from_v2_quirk):
+    """Test the summation poll survives the friendly name renaming the model.
+
+    ZHA only creates its Metering poller for a model allowlist that TS011F is on,
+    and this socket does not report summation on its own, so renaming the model
+    via friendly_name has to be paired with asking for the poll explicitly.
+    """
+    device = _a4z_device(zigpy_device_from_v2_quirk)
+
+    assert SE_POLL_SUMMATION in _exposed_features(device)

--- a/zhaquirks/nous/__init__.py
+++ b/zhaquirks/nous/__init__.py
@@ -1,0 +1,1 @@
+"""Module for Nous quirks implementations."""

--- a/zhaquirks/nous/ts011f_outdoor_smart_socket.py
+++ b/zhaquirks/nous/ts011f_outdoor_smart_socket.py
@@ -1,0 +1,58 @@
+"""Nous A4Z outdoor smart socket."""
+
+from zha.quirks import SE_POLL_SUMMATION, TUYA_PLUG_ONOFF
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.smartenergy import Metering
+
+from zhaquirks.builder import QuirkBuilder
+from zhaquirks.clusters import CustomCluster
+from zhaquirks.tuya import TuyaZBOnOffAttributeCluster
+
+
+class CustomElectricalMeasurement(ElectricalMeasurement, CustomCluster):
+    """Custom electrical measurement cluster."""
+
+    _CONSTANT_ATTRIBUTES = {
+        ElectricalMeasurement.AttributeDefs.ac_current_multiplier.id: 1,
+        ElectricalMeasurement.AttributeDefs.ac_current_divisor.id: 1000,
+    }
+
+
+class CustomMetering(Metering, CustomCluster):
+    """Custom metering cluster."""
+
+    KILOWATT_HOURS = 0x0
+    ELECTRIC_METERING = 0x0
+
+    _CONSTANT_ATTRIBUTES = {
+        Metering.AttributeDefs.unit_of_measure.id: KILOWATT_HOURS,
+        Metering.AttributeDefs.metering_device_type.id: ELECTRIC_METERING,
+        Metering.AttributeDefs.multiplier.id: 1,
+        Metering.AttributeDefs.divisor.id: 100,
+    }
+
+
+(
+    QuirkBuilder("_TZ3000_uwkja6z1", "TS011F")
+    .friendly_name(model="A4Z outdoor smart socket", manufacturer="Nous")
+    # The socket reports neither the Metering multiplier/divisor nor the
+    # ElectricalMeasurement AC current multiplier/divisor, so without these
+    # constants both fall back to 1/1: summation reads 100x and current 1000x
+    # too high.
+    .replaces(CustomMetering)
+    .replaces(CustomElectricalMeasurement)
+    # The socket does not report summation on its own, it has to be polled. ZHA
+    # polls Metering for a model allowlist that TS011F is on, but the friendly
+    # name above renames the model out of that list, so ask for the poll here.
+    .exposes_feature(SE_POLL_SUMMATION)
+    # Endpoint 2 re-reports the whole-socket measurement instead of its own
+    # outlet, so its sensors only duplicate endpoint 1's.
+    .removes(Metering.cluster_id, endpoint_id=2)
+    .removes(ElectricalMeasurement.cluster_id, endpoint_id=2)
+    # Power on state, backlight mode and child lock, as on other TS011F plugs.
+    # These are one socket-wide register mirrored on both endpoints, so they are
+    # only exposed on endpoint 1: writing endpoint 2 changes endpoint 1 too.
+    .replaces(TuyaZBOnOffAttributeCluster)
+    .exposes_feature(TUYA_PLUG_ONOFF)
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Adds a quirk for the Nous A4Z outdoor smart socket (`_TZ3000_uwkja6z1`, TS011F), as
quirks v2. This supersedes #3937; its author is credited as co-author on the commit.

The socket reports neither the Metering multiplier/divisor nor the ElectricalMeasurement
AC current multiplier/divisor, so both fall back to 1/1 and summation reads 100x while
current reads 1000x too high. Quick sanity check on the unquirked device: 2143 kWh in
about a day and a half would need ~59 kW continuous, on a 16 A socket.

Endpoint 2 re-reports the whole-socket measurement rather than its own outlet, so both
measurement clusters are removed there. Decisive test: with outlet 2 off and outlet 1
pulling 1367 W, `power_2` still reported 1368 W, where a real per-outlet meter on an
open relay has to read ~0. The endpoint 2 relay itself is a genuine second outlet and is
kept.

Replacing OnOff with `TuyaZBOnOffAttributeCluster` and exposing `TUYA_PLUG_ONOFF` adds
power on state, backlight mode and child lock, which the other TS011F plugs already get.
zigbee-herdsman-converters covers this manufacturer id with `powerOutageMemory`,
`indicatorMode` and `childLock`, and all three read and write fine on the device. They
are one socket-wide register mirrored on both endpoints: writing power on state on
endpoint 2 makes endpoint 1 read the new value, the reverse write propagates back, and
backlight mode behaves the same. So they are exposed on endpoint 1 only, otherwise you
get a twin that silently changes its sibling and then holds a stale value until
something re-reads it.

Also adds `zhaquirks/nous/__init__.py`, which #3937 is missing. `[tool.setuptools.packages.find]`
is `find:`, not `find_namespace:`, so without it `find_packages()` does not discover
`zhaquirks.nous` and the quirk ships in no wheel, while the test suite still passes from
the source tree.

## Additional information

**Why #3937 went back to v1.** Its author tried v2, reported "the fixed electric
measurement data is not pulled anymore, only once after restarting HA", and reverted. It
turns out that is not a v2 problem.

This socket does not report summation on its own, it has to be polled. ZHA creates
`MeteringPoller` only for `models={"TS011F", "ZLinky_TIC", "TICMeter"}`, matched against
the resolved `device.model`, and `friendly_name` is what that resolves to. So the rename
silently drops the poller: summation freezes while power, current and voltage keep
updating, because those come from `0x0b04` and are polled by a different, non-model-gated
entity. `.exposes_feature(SE_POLL_SUMMATION)` asks for the poll explicitly.

Measured on hardware, with debug logging on:

- rename, no `SE_POLL_SUMMATION`: `0x0702` never polled at all, zero reads, while the
  rest of the Zigbee fleet issued 116 `attribute_ids=[0, 512]` reads on `0x0702` in the
  same 4 minute window. Summation sat frozen for 10 minutes at a 1.25 kW load, while the
  device's own counter kept advancing (a direct read returned a much higher value).
- with `SE_POLL_SUMMATION`: summation resumes and holds a steady 45.1 s cadence.

The control matters here: a post-restart gap on its own proves nothing, every device
gaps for minutes while the mesh re-converges, and a v1-quirked plug of another family
gapped too. The difference is that the control recovered and this one never did.

This trap applies to any v2 port of a device that needs its Metering cluster polled, so
it might be worth a line in copilot-instructions.md next to `friendly_name`. Happy to
add that here or separately.

## Device diagnostics

[zha-04a3f51e3893eaf50904fb6354f57eaa-Nous A4Z outdoor smart socket-18eb3d65f4f408679f3bf73fdfda1fe5.json](https://github.com/user-attachments/files/30708662/zha-04a3f51e3893eaf50904fb6354f57eaa-Nous.A4Z.outdoor.smart.socket-18eb3d65f4f408679f3bf73fdfda1fe5.json)

The attached diagnostics is from the socket running this quirk, and backs up the above:

- On `0x0b04`, `ac_current_divisor` and `ac_current_multiplier` hold the quirk's constants
  while **every other** multiplier/divisor pair on that cluster reads `unsupported`, which
  is the scaling gap this quirk fills. Same on `0x0702` for `divisor`/`multiplier`.
- `exposes_features` lists both `tuya.plug_on_off_attributes` and `se_poll_summation`.
- Endpoint 1 keeps `0x0702` and `0x0b04`; endpoint 2 has neither, but keeps `0x0006` for
  its relay.
- On endpoint 1's OnOff, `power_on_state`, `backlight_mode` and `child_lock` all read real
  values, while the standard ZCL `start_up_on_off` (`0x4003`) is flagged `unsupported`,
  which is why the Tuya-specific `0x8002` is the one to use here.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached

