### PR TITLE
Fix Aqara SD-S01E smoke reporting on firmware 0x13

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1327,6 +1327,64 @@ async def test_aqara_smoke_sensor_xiaomi_attribute_report(
     assert ias_listener.attribute_updates[0][1] == expected_zone_status
 
 
+async def test_aqara_smoke_sensor_ias_zone_cluster(zigpy_device_from_quirk):
+    """Test that the Aqara smoke sensor keeps the device's real IAS Zone cluster."""
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.smoke.LumiSensorSmokeAcn03)
+
+    ias_cluster = device.endpoints[1].ias_zone
+
+    # the cluster must not be local, or ZHA can't write the CIE address, bind and enroll
+    assert not isinstance(ias_cluster, zhaquirks.LocalDataCluster)
+
+    # zone_type is still provided by the quirk, so the device class never depends on a read
+    assert (
+        ias_cluster.get(IasZone.AttributeDefs.zone_type.name)
+        == IasZone.ZoneType.Fire_Sensor
+    )
+
+
+async def test_aqara_smoke_sensor_battery(zigpy_device_from_quirk):
+    """Test both battery paths of the Aqara smoke sensor."""
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.smoke.LumiSensorSmokeAcn03)
+
+    power_cluster = device.endpoints[1].power
+    power_listener = ClusterListener(power_cluster)
+
+    zcl_power_voltage_id = PowerConfiguration.AttributeDefs.battery_voltage.id
+    zcl_power_percent_id = (
+        PowerConfiguration.AttributeDefs.battery_percentage_remaining.id
+    )
+
+    # the cluster must not be local, or ZHA can't bind it and configure reporting
+    assert not isinstance(power_cluster, zhaquirks.LocalDataCluster)
+
+    # standard battery voltage report (firmware 0x13): 2.9V within 2.475V-3.0V
+    power_cluster.update_attribute(zcl_power_voltage_id, 29)
+    assert len(power_listener.attribute_updates) == 2
+    assert power_listener.attribute_updates[0] == (zcl_power_voltage_id, 29)
+    assert power_listener.attribute_updates[1] == (zcl_power_percent_id, 162)
+
+    # Xiaomi attribute report blob path (firmware 0x11) still works
+    power_cluster.battery_reported(2900)
+    assert len(power_listener.attribute_updates) == 4
+    assert power_listener.attribute_updates[2] == (zcl_power_voltage_id, 29.0)
+    assert power_listener.attribute_updates[3] == (zcl_power_percent_id, 162)
+
+    # ... as does a Xiaomi battery percentage report
+    power_cluster.battery_percent_reported(50)
+    assert len(power_listener.attribute_updates) == 5
+    assert power_listener.attribute_updates[4] == (zcl_power_percent_id, 100)
+
+    # battery size and quantity are still provided by the quirk
+    assert (
+        power_cluster.get(PowerConfiguration.AttributeDefs.battery_quantity.name) == 1
+    )
+    assert (
+        power_cluster.get(PowerConfiguration.AttributeDefs.battery_size.name)
+        == BatterySize.Unknown
+    )
+
+
 @pytest.mark.parametrize(
     "attr_redirect, attr_no_redirect",
     [

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1385,6 +1385,59 @@ async def test_aqara_smoke_sensor_battery(zigpy_device_from_quirk):
     )
 
 
+@mock.patch("zigpy.zcl.Cluster.bind", mock.AsyncMock())
+async def test_aqara_smoke_sensor_binding_writes_mode(zigpy_device_from_quirk):
+    """Test binding the Aqara smoke sensor enables manufacturer-specific reporting."""
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.smoke.LumiSensorSmokeAcn03)
+    opple_cluster = device.endpoints[1].opple_cluster
+
+    p1 = mock.patch.object(opple_cluster, "create_catching_task")
+    p2 = mock.patch.object(opple_cluster.endpoint, "request", mock.AsyncMock())
+
+    with p1 as mock_task, p2 as request_mock:
+        request_mock.return_value = (foundation.Status.SUCCESS, "done")
+
+        await opple_cluster.bind()
+
+        # the mode write is deferred to a task, so nothing has gone out yet
+        assert len(request_mock.mock_calls) == 0
+        assert mock_task.call_count == 1
+
+        # await the deferred write of the mode attribute
+        await mock_task.call_args[0][0]
+
+        assert len(request_mock.mock_calls) == 1
+        assert request_mock.mock_calls[0].kwargs["cluster"] == 0xFCC0
+        # manufacturer specific write of 0x0009 (uint8) = 1, manufacturer code 0x115F
+        assert (
+            request_mock.mock_calls[0].kwargs["data"] == b"\x04_\x11\x01\x02\t\x00 \x01"
+        )
+
+
+@mock.patch(
+    "zigpy.zcl.Cluster.bind", mock.AsyncMock(return_value=mock.sentinel.bind_result)
+)
+async def test_aqara_smoke_sensor_binding_mode_write_failure(zigpy_device_from_quirk):
+    """Test binding the Aqara smoke sensor survives a failing mode write.
+
+    This is a sleepy device, so the write frequently times out even when the
+    device applies it. A failure must not break binding.
+    """
+    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.smoke.LumiSensorSmokeAcn03)
+    opple_cluster = device.endpoints[1].opple_cluster
+
+    write_mock = mock.AsyncMock(side_effect=asyncio.TimeoutError)
+
+    with mock.patch.object(opple_cluster, "write_attributes", write_mock):
+        result = await opple_cluster.bind()
+
+        # the write runs as a background task, let it fail and be swallowed
+        await asyncio.sleep(0)
+
+    assert result is mock.sentinel.bind_result
+    assert write_mock.mock_calls == [mock.call({0x0009: 0x01})]
+
+
 @pytest.mark.parametrize(
     "attr_redirect, attr_no_redirect",
     [

--- a/zhaquirks/xiaomi/aqara/smoke.py
+++ b/zhaquirks/xiaomi/aqara/smoke.py
@@ -29,6 +29,7 @@ from zhaquirks.xiaomi import (
     XiaomiAqaraE1Cluster,
 )
 
+MODE = 0x0009
 BUZZER_MANUAL_MUTE = 0x0126
 SELF_TEST = 0x0127
 SMOKE = 0x013A
@@ -59,6 +60,7 @@ class OppleCluster(XiaomiAqaraE1Cluster):
     """Opple cluster."""
 
     attributes = {
+        MODE: ("mode", types.uint8_t, True),
         BUZZER_MANUAL_MUTE: ("buzzer_manual_mute", types.uint8_t, True),
         SELF_TEST: ("self_test", types.Bool, True),
         SMOKE: ("smoke", types.uint8_t, True),
@@ -70,6 +72,20 @@ class OppleCluster(XiaomiAqaraE1Cluster):
         LINKAGE_ALARM_STATE: ("linkage_alarm_state", types.uint8_t, True),
         SMOKE_DENSITY_DBM: ("smoke_density_dbm", types.Single, True),
     }
+
+    # Until this is written the device sends no manufacturer-specific reports at
+    # all, so the smoke attribute never arrives. Other Aqara quirks (plug_eu,
+    # opple_remote) write the same attribute for the same reason.
+    attr_config = {MODE: 0x01}
+
+    async def bind(self):
+        """Bind cluster and enable manufacturer-specific reporting."""
+        result = await super().bind()
+        # This is a sleepy device, so the write frequently times out even when the
+        # device applies it. Best effort only: a failure must not break binding,
+        # enrollment or the battery path.
+        self.create_catching_task(self.write_attributes(self.attr_config))
+        return result
 
     def _update_attribute(self, attrid: int, value: Any) -> None:
         """Pass attribute update to another cluster if necessary."""

--- a/zhaquirks/xiaomi/aqara/smoke.py
+++ b/zhaquirks/xiaomi/aqara/smoke.py
@@ -8,7 +8,8 @@ from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zdo.types import NodeDescriptor
 
-from zhaquirks import LocalDataCluster
+from zhaquirks import PowerConfigurationCluster
+from zhaquirks.clusters import CustomCluster
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -18,9 +19,15 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     ZONE_STATUS,
+    BatterySize,
 )
 from zhaquirks.legacy import CustomDevice
-from zhaquirks.xiaomi import LUMI, XiaomiAqaraE1Cluster, XiaomiPowerConfiguration
+from zhaquirks.xiaomi import (
+    BATTERY_QUANTITY_ATTR,
+    BATTERY_SIZE_ATTR,
+    LUMI,
+    XiaomiAqaraE1Cluster,
+)
 
 BUZZER_MANUAL_MUTE = 0x0126
 SELF_TEST = 0x0127
@@ -73,19 +80,53 @@ class OppleCluster(XiaomiAqaraE1Cluster):
             self.update_attribute(SMOKE_DENSITY_DBM, SMOKE_DENSITY_DBM_MAP[value])
 
 
-class LocalIasZone(LocalDataCluster, IasZone):
-    """Local IAS Zone cluster."""
+class SmokeIasZone(CustomCluster, IasZone):
+    """IAS Zone cluster of the smoke detector.
+
+    This is a real (remote) cluster, so ZHA writes the CIE address, binds the
+    cluster and enrolls the device. Firmware 0x13 only sends zone status
+    notifications once it is actually enrolled, which never happened while this
+    was a `LocalDataCluster` (both the CIE address write and the bind were
+    local no-ops there). `zone_type` is still served from the quirk, as the
+    binary sensor's device class must not depend on a sleepy device answering a
+    read.
+    """
 
     _CONSTANT_ATTRIBUTES = {
-        IasZone.attributes_by_name["zone_type"].id: IasZone.ZoneType.Fire_Sensor
+        IasZone.AttributeDefs.zone_type.id: IasZone.ZoneType.Fire_Sensor
     }
 
 
-class XiaomiSmokePowerConfiguration(XiaomiPowerConfiguration):
-    """Xiaomi Smoke Power Configuration cluster."""
+class XiaomiSmokePowerConfiguration(PowerConfigurationCluster):
+    """Power configuration cluster of the smoke detector.
 
-    MIN_VOLTS_MV = 2475
-    MAX_VOLTS_MV = 3000
+    This is a real (remote) cluster, so ZHA binds it and configures reporting.
+    Firmware 0x13 accepts reporting on `battery_voltage` and then reports it,
+    while it never sends the Xiaomi attribute report blob older firmware uses.
+    `battery_percentage_remaining` is derived from the voltage, as the device
+    rejects reporting configuration for it.
+
+    Firmware 0x11 sends the Xiaomi blob instead, which still lands here through
+    `battery_reported()` / `battery_percent_reported()`, so it keeps working
+    even if the device answers standard reads with `UNSUPPORTED_ATTRIBUTE`.
+    """
+
+    MIN_VOLTS = 2.475
+    MAX_VOLTS = 3.0
+
+    _CONSTANT_ATTRIBUTES = {
+        BATTERY_QUANTITY_ATTR: 1,
+        BATTERY_SIZE_ATTR: BatterySize.Unknown,
+    }
+
+    def battery_reported(self, voltage_mv: int) -> None:
+        """Handle a battery voltage from a Xiaomi attribute report."""
+        # updating the voltage also updates the derived percentage
+        self._update_attribute(self.BATTERY_VOLTAGE_ATTR, round(voltage_mv / 100, 1))
+
+    def battery_percent_reported(self, battery_percent: int) -> None:
+        """Handle a battery percentage from a Xiaomi attribute report."""
+        self._update_attribute(self.BATTERY_PERCENTAGE_REMAINING, battery_percent * 2)
 
 
 class LumiSensorSmokeAcn03(CustomDevice):
@@ -122,7 +163,7 @@ class LumiSensorSmokeAcn03(CustomDevice):
                     Basic.cluster_id,
                     XiaomiSmokePowerConfiguration,
                     Identify.cluster_id,
-                    LocalIasZone,
+                    SmokeIasZone,
                     OppleCluster,
                 ],
                 OUTPUT_CLUSTERS: [


### PR DESCRIPTION
## Proposed change

Fixes the Aqara SD-S01E (`lumi.sensor_smoke.acn03`) on firmware `0x13`, where the device reports nothing at all — battery unknown, and the smoke binary sensor never changes even during a real alarm.

I own one of these and found the cause by instrumenting it on the air: the fix below is confirmed with a canned-smoke test, ~5 s from spray to the binary sensor flipping. Full traces under [Evidence](#evidence).

Two commits, for two separate causes:

**1. The quirk replaced two real clusters with local-only ones.** IAS Zone and Power Configuration were `LocalDataCluster` subclasses, so `bind()`, `configure_reporting()` and the CIE address write were all local no-ops and the device was never enrolled or bound. This commit makes them real.

This commit is **not mine** — it is @zigpy-review-bot's work from #5213, cherry-picked unchanged and attributed as co-author. It is here only so commit 2 has something to build on. **If #5213 lands first, say the word and I'll drop this commit and rebase**, leaving this PR as just the vendor mode write. I have no preference beyond not blocking on the ordering.

**2. The device sends no vendor reports until Aqara "mode" is enabled.** This is the actual fix for smoke, and it's what #5213 is missing. Firmware `0x13` sends *no* manufacturer-specific reports until `0x0009` on cluster `0xFCC0` (manufacturer code `0x115F`) is written to `1` — including `0x013A`, the attribute that carries the alarm. `plug_eu.py` and `opple_remote.py` already do this write; the smoke quirk never has. Written on `bind()`, best effort via `create_catching_task()` — this is a sleepy device and the request often times out even when it is applied, so it must never break binding, enrollment or the battery path.

## Evidence

<a name="evidence"></a>Measured on my own SD-S01E on firmware `0x13` (#5203). Self test button press, before vs. after the mode write: no traffic at all → `Report_Attributes(attrid=0x0127, value=1)`, then `0`. Canned smoke, with the write in place:

```
17:38:32.618  0x013B smoke_density = 10
17:38:37.419  0x013A smoke = 1                <- alarm
17:38:37.420  zone_status = 1 -> binary_sensor.lumi_lumi_sensor_smoke_acn03 = on
17:38:37.430  0x014C linkage_alarm_state = 1
17:38:53.608  0x013B smoke_density = 0
```

~5 s from spray to the binary sensor flipping, clearing on its own once the chamber cleared.

Two findings that shaped the implementation:

- **This firmware does not use the IAS path for smoke.** There is no `ZoneStatusChangeNotification` during an alarm — only `0x013A` on the vendor cluster, which `OppleCluster._update_attribute()` already forwards to `zone_status`. Enrollment still works and is still worth doing, but it is not what carries the alarm, so #5213's inference that a successful enrollment means alarms now reach HA doesn't hold on its own.
- **`0x013A` is `UNREPORTABLE_ATTRIBUTE`** (`configure_reporting` returns `0x8C`). The device pushes it unsolicited once vendor mode is on, same as `0x0127`. So this PR deliberately does not configure reporting for it.

## Caveats

- The smoke path is verified on **one device on firmware `0x13`**. @HardartComputersysteme has two on the same firmware and was re-testing with the mode write; I'll link that result when it lands.
- **Effect on firmware `0x11` is untested.** Those work today via the vendor blob path. The mode write should be harmless — it's what `plug_eu` and `opple_remote` already do, and on `0x11` the reports it enables are already flowing — but it is a behaviour change on working devices, so I won't claim it's verified. The `0x11` risk from commit 1 is analysed in #5213.

## Additional information

Fixes #5203. Builds on #5213 (draft) — see the rebase offer above.

Two new tests in `tests/test_xiaomi.py`: one asserting `bind()` emits the manufacturer-specific write of `0x0009 = 1` with code `0x115F`, one asserting `bind()` still succeeds when that write times out. The existing `test_aqara_smoke_sensor_attribute_update` covers the `0x013A` → `zone_status` forwarding unchanged, so I didn't duplicate it. Full suite: 4845 passed, 2 xfailed; `pre-commit` clean.

There's no shared helper for the Aqara mode write today — `plug_eu` and `opple_remote` each inline it, and this makes a third copy of four lines. Glad to factor out a mixin into `zhaquirks/xiaomi/__init__.py` if you'd prefer, I just didn't want to refactor two working quirks inside a bugfix.

## Device diagnostics

Not a new device. A `0x13` dump is attached to #5203, and the existing `0x11` snapshot in `zigpy/zha` covers this model — per #5213, regenerating it adds only `cie_addr` on `0x0500` now that enrollment happens, with the entity set unchanged.

## Checklist

- [x] The changes are tested and work correctly — unit tests here, plus on-device validation on firmware `0x13` (caveats above)
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached — see above
