### PR TITLE
Add WiFi setup cluster for Shelly 1

### DIFF
--- a/zhaquirks/shelly/wifi.py
+++ b/zhaquirks/shelly/wifi.py
@@ -117,6 +117,7 @@ class ShellyCustomProfileDevice(CustomZigpyDevice):
 
 (
     QuirkBuilder("Shelly", "1PM")
+    .applies_to("Shelly", "1")
     .applies_to("Shelly", "2PM")
     .applies_to("Shelly", "Mini1PM")
     .applies_to("Shelly", "Mini1")


### PR DESCRIPTION
## Proposed change
<!--

-->
Adds support for Wifi Setup Cluster for Shelly 1. Resolves # 5229.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached



Closes #5229
