### PR TITLE
Add TS0601 `_TZE200_f1pvdgoh` PIR motion & luminance sensor

### DIFF
--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -1635,3 +1635,17 @@ base_tuya_motion = (
     .skip_configuration()
     .add_to_registry()
 )
+
+# Tuya PIR & luminance sensor, TS0601
+(
+    TuyaQuirkBuilder("_TZE200_f1pvdgoh", "TS0601")
+    .tuya_ias(
+        dp_id=1,
+        ias_cfg=TuyaMotionWithReset,
+        converter=lambda x: IasZone.ZoneStatus.Alarm_1 if x == 0 else 0,
+    )
+    .tuya_illuminance(dp_id=101)
+    .tuya_battery(dp_id=4)
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
Add TS0601 `_TZE200_f1pvdgoh` PIR motion & luminance sensor



## Additional information
<img width="4032" height="3024" alt="image" src="https://github.com/user-attachments/assets/9ad1e963-9ee9-4070-bd55-13f25e991e20" />
<img width="773" height="593" alt="Screenshot 2026-08-06 at 11 02 00 PM" src="https://github.com/user-attachments/assets/59e38381-a96d-4432-962b-379ec3b26c29" />
Fixes #4050 #2399 
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
[zha-01KWKXQ0F1SQRZPT2XGJ2K20JD-_TZE200_f1pvdgoh TS0601-862b1c87dbe36001fc23f6f73032c602.json](https://github.com/user-attachments/files/30795351/zha-01KWKXQ0F1SQRZPT2XGJ2K20JD-_TZE200_f1pvdgoh.TS0601-862b1c87dbe36001fc23f6f73032c602.json)
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ x] The changes are tested and work correctly
- [ x] `pre-commit` checks pass / the code has been formatted using Black
- [ x] Tests have been added to verify that the new code works
- [ x] Device diagnostics data has been attached
