### PR TITLE
Add Elivco ELC-SP02 smart plug quirk with power monitoring

### DIFF
--- a/tests/test_elivco.py
+++ b/tests/test_elivco.py
@@ -1,0 +1,33 @@
+"""Tests for Elivco quirks."""
+
+from zha.quirks import DEVICE_REGISTRY
+from zigpy.zcl import ClusterType
+
+import zhaquirks
+from zhaquirks.elivco.elc_sp02 import ElivcoElectricalMeasurementCluster
+
+zhaquirks.setup()
+
+
+async def test_elivco_elc_sp02_quirk_applied(zigpy_device_from_v2_quirk):
+    """Test Elivco ELC-SP02 quirk is applied and creates power monitoring sensors."""
+    device = zigpy_device_from_v2_quirk(
+        "eWeLink",
+        "CK-BL702-SWP-01(7020)",
+        cluster_ids={1: {0xFC11: ClusterType.Server}},
+    )
+
+    # Verify the custom cluster replaces the generic one
+    assert isinstance(
+        device.endpoints[1].elivco_electrical_measurement,
+        ElivcoElectricalMeasurementCluster,
+    )
+
+    # Verify that 3 sensor entities are defined (voltage, current, power)
+    entry = DEVICE_REGISTRY.match_entry(device)
+    entity_metadata = entry.zha_device_factory.quirk_definition.entity_metadata
+    assert len(entity_metadata) == 3
+
+    # Verify sensor attribute names
+    sensor_attrs = {m.attribute_name for m in entity_metadata}
+    assert sensor_attrs == {"voltage", "current", "power"}

--- a/zhaquirks/elivco/__init__.py
+++ b/zhaquirks/elivco/__init__.py
@@ -1,0 +1,3 @@
+"""Quirks for Elivco devices."""
+
+from . import elc_sp02  # noqa: F401

--- a/zhaquirks/elivco/elc_sp02.py
+++ b/zhaquirks/elivco/elc_sp02.py
@@ -1,0 +1,97 @@
+"""Elivco ELC-SP02 smart plug with power monitoring."""
+
+import zigpy.types as t
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+from zhaquirks.builder import (
+    QuirkBuilder,
+    ReportingConfig,
+    SensorDeviceClass,
+    SensorStateClass,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfPower,
+)
+from zhaquirks.clusters import CustomCluster
+
+
+class ElivcoElectricalMeasurementCluster(CustomCluster):
+    """Elivco custom cluster for electrical measurements.
+
+    Uses eWeLink firmware cluster 0xFC11.
+    """
+
+    cluster_id = 0xFC11
+    name = "Elivco Electrical Measurement"
+    ep_attribute = "elivco_electrical_measurement"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        # Current in milliamps (mA)
+        current = ZCLAttributeDef(
+            id=0x7004,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+        # Voltage in millivolts (mV)
+        voltage = ZCLAttributeDef(
+            id=0x7005,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+        # Power in milliwatts (mW)
+        power = ZCLAttributeDef(
+            id=0x7006,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+
+(
+    QuirkBuilder("eWeLink", "CK-BL702-SWP-01(7020)")
+    .replaces(ElivcoElectricalMeasurementCluster, endpoint_id=1)
+    .sensor(
+        attribute_name=ElivcoElectricalMeasurementCluster.AttributeDefs.voltage.name,
+        cluster_id=ElivcoElectricalMeasurementCluster.cluster_id,
+        divisor=1000,  # Convert mV to V
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricPotential.VOLT,
+        reporting_config=ReportingConfig(
+            min_interval=10,
+            max_interval=300,
+            reportable_change=100,  # 0.1V
+        ),
+        fallback_name="Voltage",
+    )
+    .sensor(
+        attribute_name=ElivcoElectricalMeasurementCluster.AttributeDefs.current.name,
+        cluster_id=ElivcoElectricalMeasurementCluster.cluster_id,
+        divisor=1000,  # Convert mA to A
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricCurrent.AMPERE,
+        reporting_config=ReportingConfig(
+            min_interval=10,
+            max_interval=300,
+            reportable_change=10,  # 0.01A
+        ),
+        fallback_name="Current",
+    )
+    .sensor(
+        attribute_name=ElivcoElectricalMeasurementCluster.AttributeDefs.power.name,
+        cluster_id=ElivcoElectricalMeasurementCluster.cluster_id,
+        divisor=1000,  # Convert mW to W
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfPower.WATT,
+        reporting_config=ReportingConfig(
+            min_interval=10,
+            max_interval=300,
+            reportable_change=100,  # 0.1W
+        ),
+        fallback_name="Power",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Adds a v2 quirk for the Elivco ELC-SP02 smart plug (reports as `eWeLink` / `CK-BL702-SWP-01(7020)`).

This device uses a proprietary eWeLink cluster (`0xFC11`) for power monitoring. The quirk exposes three manufacturer-specific attributes as sensors:
- `0x7004`: Current (A)
- `0x7005`: Voltage (V)
- `0x7006`: Power (W)

Attribute reporting is configured with 10-300s intervals.

## Additional information

Attribute definitions derived from [Zigbee2MQTT issue #19334](https://github.com/Koenkk/zigbee2mqtt/issues/19334).

Related to https://github.com/zigpy/zha-device-handlers/issues/2735

<img width="404" height="462" alt="Screenshot from 2026-08-09 13-22-39" src="https://github.com/user-attachments/assets/dbf51b31-0ecc-453f-8f4e-a56fa87523f2" />

## Device diagnostics

[zha-01KQTGAW5JRVZG6YTC4H0N8XEX-eWeLink CK-BL702-SWP-01(7020)-40c918744e69240032ae327c40d435ed.json](https://github.com/user-attachments/files/30871955/zha-01KQTGAW5JRVZG6YTC4H0N8XEX-eWeLink.CK-BL702-SWP-01.7020.-40c918744e69240032ae327c40d435ed.json)


## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached