### PR TITLE
Add Tuya Leisguar YS-MT750 curtain motor (_TZE200_xu4a5rhj)

### DIFF
--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -10,7 +10,7 @@ import zhaquirks
 from zhaquirks.device import CustomZigpyDevice
 from zhaquirks.tuya import TuyaCommand, TuyaData, TuyaDatapointData
 from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaWindowCovering
-from zhaquirks.tuya.ts0601_cover import MotorDirection, TuyaMoesCover0601
+from zhaquirks.tuya.ts0601_cover import LeisguarMotorDirection, TuyaMoesCover0601
 
 zhaquirks.setup()
 
@@ -384,7 +384,7 @@ async def test_leisguar_ys_mt750_direction_write(zigpy_device_from_v2_quirk):
         tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
     ) as req_mock:
         (status,) = await tuya_cluster.write_attributes(
-            {"motor_direction": MotorDirection.Reversed}
+            {"motor_direction": LeisguarMotorDirection.Reversed}
         )
         await wait_for_zigpy_tasks()
 
@@ -398,7 +398,7 @@ async def test_leisguar_ys_mt750_direction_write(zigpy_device_from_v2_quirk):
         ]
 
     assert tuya_listener.attribute_updates[0][0] == 0xEF05
-    assert tuya_listener.attribute_updates[0][1] == MotorDirection.Reversed
+    assert tuya_listener.attribute_updates[0][1] == LeisguarMotorDirection.Reversed
 
 
 async def test_leisguar_ys_mt750_direction_report(zigpy_device_from_v2_quirk):
@@ -414,13 +414,15 @@ async def test_leisguar_ys_mt750_direction_report(zigpy_device_from_v2_quirk):
         TuyaCommand(
             status=0,
             tsn=1,
-            datapoints=[TuyaDatapointData(5, TuyaData(MotorDirection.Reversed))],
+            datapoints=[
+                TuyaDatapointData(5, TuyaData(LeisguarMotorDirection.Reversed))
+            ],
         )
     )
 
-    assert tuya_cluster.get("motor_direction") == MotorDirection.Reversed
+    assert tuya_cluster.get("motor_direction") == LeisguarMotorDirection.Reversed
     assert tuya_listener.attribute_updates[0][0] == 0xEF05
-    assert tuya_listener.attribute_updates[0][1] == MotorDirection.Reversed
+    assert tuya_listener.attribute_updates[0][1] == LeisguarMotorDirection.Reversed
 
 
 async def test_leisguar_ys_mt750_speed_write(zigpy_device_from_v2_quirk):

--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -399,7 +399,7 @@ async def test_leisguar_ys_mt750_direction_write(zigpy_device_from_v2_quirk):
         req_mock.assert_called_once()
         call_data = req_mock.call_args[1]["data"]
         assert call_data[5] == 5  # DP ID 5 (positional, not a substring match)
-        assert call_data[-1:] == b"\x01"  # Value = Reversed (1)
+        assert call_data[-1:] == b"\x00"  # Value = Reversed (0)
         assert req_mock.call_args[1]["expect_reply"] is False
         assert status == [
             foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)

--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -10,7 +10,7 @@ import zhaquirks
 from zhaquirks.device import CustomZigpyDevice
 from zhaquirks.tuya import TuyaCommand, TuyaData, TuyaDatapointData
 from zhaquirks.tuya.mcu import TuyaMCUCluster, TuyaWindowCovering
-from zhaquirks.tuya.ts0601_cover import TuyaMoesCover0601
+from zhaquirks.tuya.ts0601_cover import MotorDirection, TuyaMoesCover0601
 
 zhaquirks.setup()
 
@@ -223,3 +223,229 @@ async def test_zemismart_zm16b_battery_report(zigpy_device_from_v2_quirk):
     # Battery percentage should be scaled by 2 (default tuya_battery scale)
     power_cluster = ep.power
     assert power_cluster.get("battery_percentage_remaining") == 170
+
+
+async def test_leisguar_ys_mt750_quirk(zigpy_device_from_v2_quirk):
+    """Test Leisguar YS-MT750 cover motor v2 quirk."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_xu4a5rhj", "TS0601")
+    assert isinstance(quirked, CustomZigpyDevice)
+
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    assert cover_cluster is not None
+    assert isinstance(cover_cluster, TuyaWindowCovering)
+
+    tuya_cluster = ep.tuya_manufacturer
+    assert tuya_cluster is not None
+    assert isinstance(tuya_cluster, TuyaMCUCluster)
+
+    assert tuya_cluster.attributes_by_name["motor_direction"].id == 0xEF05
+    assert tuya_cluster.attributes_by_name["motor_speed"].id == 0xEF69
+
+
+async def test_leisguar_ys_mt750_position_report(zigpy_device_from_v2_quirk):
+    """Test that incoming DP3 position reports update the cover position with no inversion."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_xu4a5rhj", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    cover_listener = ClusterListener(cover_cluster)
+
+    tuya_cluster = ep.tuya_manufacturer
+
+    # DP3 reports raw 25 (25% closed). No inversion: ZCL value must also be 25.
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[TuyaDatapointData(3, TuyaData(25))],
+        )
+    )
+
+    assert (
+        cover_cluster.get(
+            WindowCovering.AttributeDefs.current_position_lift_percentage.name
+        )
+        == 25
+    )
+    assert len(cover_listener.attribute_updates) == 1
+    assert (
+        cover_listener.attribute_updates[0][0]
+        == WindowCovering.AttributeDefs.current_position_lift_percentage.id
+    )
+    assert cover_listener.attribute_updates[0][1] == 25
+
+
+async def test_leisguar_ys_mt750_open_command(zigpy_device_from_v2_quirk):
+    """Test that the open command sends DP1 with value 0 (Open)."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_xu4a5rhj", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.up_open.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[-1:] == b"\x00"  # Value = Open (0)
+
+
+async def test_leisguar_ys_mt750_close_command(zigpy_device_from_v2_quirk):
+    """Test that the close command sends DP1 with value 2 (Close)."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_xu4a5rhj", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.down_close.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[-1:] == b"\x02"  # Value = Close (2)
+
+
+async def test_leisguar_ys_mt750_stop_command(zigpy_device_from_v2_quirk):
+    """Test that the stop command sends DP1 with value 1 (Stop)."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_xu4a5rhj", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(WindowCovering.ServerCommandDefs.stop.id)
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[-1:] == b"\x01"  # Value = Stop (1)
+
+
+async def test_leisguar_ys_mt750_go_to_lift_percentage(zigpy_device_from_v2_quirk):
+    """Test that go_to_lift_percentage sends the raw (non-inverted) position on DP2."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_xu4a5rhj", "TS0601")
+    ep = quirked.endpoints[1]
+
+    cover_cluster = ep.window_covering
+    tuya_cluster = ep.tuya_manufacturer
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        await cover_cluster.command(
+            WindowCovering.ServerCommandDefs.go_to_lift_percentage.id, 25
+        )
+        await wait_for_zigpy_tasks()
+
+        # Multiple calls expected (DP 3 for state and DP 2 for control both mapped)
+        assert req_mock.call_count >= 1
+        # Check that at least one call has DP 2 with the correct position value
+        found_correct_position = False
+        for call in req_mock.call_args_list:
+            call_data = call[1]["data"]
+            # DP 2 (position control) with value 25 (0x19)
+            if b"\x02" in call_data and call_data[-1:] == b"\x19":
+                found_correct_position = True
+        assert found_correct_position, "Expected DP 2 with value 25 (0x19) in sent data"
+
+
+async def test_leisguar_ys_mt750_direction_write(zigpy_device_from_v2_quirk):
+    """Test that setting motor_direction sends DP5 as an ENUM write."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_xu4a5rhj", "TS0601")
+    ep = quirked.endpoints[1]
+
+    tuya_cluster = ep.tuya_manufacturer
+    tuya_listener = ClusterListener(tuya_cluster)
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        (status,) = await tuya_cluster.write_attributes(
+            {"motor_direction": MotorDirection.Reversed}
+        )
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x05" in call_data  # DP ID 5
+        assert call_data[-1:] == b"\x01"  # Value = Reversed (1)
+        assert req_mock.call_args[1]["expect_reply"] is False
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
+
+    assert tuya_listener.attribute_updates[0][0] == 0xEF05
+    assert tuya_listener.attribute_updates[0][1] == MotorDirection.Reversed
+
+
+async def test_leisguar_ys_mt750_direction_report(zigpy_device_from_v2_quirk):
+    """Test that an incoming DP5 report updates motor_direction (read-back)."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_xu4a5rhj", "TS0601")
+    ep = quirked.endpoints[1]
+
+    tuya_cluster = ep.tuya_manufacturer
+    tuya_listener = ClusterListener(tuya_cluster)
+
+    tuya_cluster.handle_get_data(
+        TuyaCommand(
+            status=0,
+            tsn=1,
+            datapoints=[TuyaDatapointData(5, TuyaData(MotorDirection.Reversed))],
+        )
+    )
+
+    assert tuya_cluster.get("motor_direction") == MotorDirection.Reversed
+    assert tuya_listener.attribute_updates[0][0] == 0xEF05
+    assert tuya_listener.attribute_updates[0][1] == MotorDirection.Reversed
+
+
+async def test_leisguar_ys_mt750_speed_write(zigpy_device_from_v2_quirk):
+    """Test that setting motor_speed sends DP105 as a VALUE write. Write-only: no echo test."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE200_xu4a5rhj", "TS0601")
+    ep = quirked.endpoints[1]
+
+    tuya_cluster = ep.tuya_manufacturer
+    tuya_listener = ClusterListener(tuya_cluster)
+
+    with mock.patch.object(
+        tuya_cluster.endpoint, "request", return_value=foundation.Status.SUCCESS
+    ) as req_mock:
+        (status,) = await tuya_cluster.write_attributes({"motor_speed": 128})
+        await wait_for_zigpy_tasks()
+
+        req_mock.assert_called_once()
+        call_data = req_mock.call_args[1]["data"]
+        assert b"\x69" in call_data  # DP ID 105 (0x69)
+        assert call_data[-1:] == b"\x80"  # Value = 128 (0x80)
+        assert req_mock.call_args[1]["expect_reply"] is False
+        assert status == [
+            foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)
+        ]
+
+    assert tuya_listener.attribute_updates[0][0] == 0xEF69
+    assert tuya_listener.attribute_updates[0][1] == 128

--- a/tests/test_tuya_cover.py
+++ b/tests/test_tuya_cover.py
@@ -296,7 +296,7 @@ async def test_leisguar_ys_mt750_open_command(zigpy_device_from_v2_quirk):
 
         req_mock.assert_called_once()
         call_data = req_mock.call_args[1]["data"]
-        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[5] == 1  # DP ID 1 (positional, not a substring match)
         assert call_data[-1:] == b"\x00"  # Value = Open (0)
 
 
@@ -317,7 +317,7 @@ async def test_leisguar_ys_mt750_close_command(zigpy_device_from_v2_quirk):
 
         req_mock.assert_called_once()
         call_data = req_mock.call_args[1]["data"]
-        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[5] == 1  # DP ID 1 (positional, not a substring match)
         assert call_data[-1:] == b"\x02"  # Value = Close (2)
 
 
@@ -338,7 +338,7 @@ async def test_leisguar_ys_mt750_stop_command(zigpy_device_from_v2_quirk):
 
         req_mock.assert_called_once()
         call_data = req_mock.call_args[1]["data"]
-        assert b"\x01" in call_data  # DP ID 1
+        assert call_data[5] == 1  # DP ID 1 (positional, not a substring match)
         assert call_data[-1:] == b"\x01"  # Value = Stop (1)
 
 
@@ -359,16 +359,24 @@ async def test_leisguar_ys_mt750_go_to_lift_percentage(zigpy_device_from_v2_quir
         )
         await wait_for_zigpy_tasks()
 
-        # Multiple calls expected (DP 3 for state and DP 2 for control both mapped)
-        assert req_mock.call_count >= 1
-        # Check that at least one call has DP 2 with the correct position value
-        found_correct_position = False
-        for call in req_mock.call_args_list:
-            call_data = call[1]["data"]
-            # DP 2 (position control) with value 25 (0x19)
-            if b"\x02" in call_data and call_data[-1:] == b"\x19":
-                found_correct_position = True
-        assert found_correct_position, "Expected DP 2 with value 25 (0x19) in sent data"
+        # position_state_dp (DP3) and position_control_dp (DP2) are both mapped to
+        # current_position_lift_percentage, so writing it fires two Tuya DP writes.
+        # Pin that two-write behavior explicitly rather than filtering it away.
+        assert req_mock.call_count == 2
+
+        # Identify the DP2 (position_control_dp) frame positionally by its DP-id
+        # byte, not by call order (send order across the two DP mappings is not
+        # part of the plan's contract) and not by substring "in" checks (DP-id
+        # values can also appear as datatype/length bytes elsewhere in the frame).
+        dp2_frames = [
+            call[1]["data"]
+            for call in req_mock.call_args_list
+            if call[1]["data"][5] == 2
+        ]
+        assert len(dp2_frames) == 1, (
+            "Expected exactly one DP2 (position_control_dp) frame"
+        )
+        assert dp2_frames[0][-1:] == b"\x19"  # Value = 25 (0x19)
 
 
 async def test_leisguar_ys_mt750_direction_write(zigpy_device_from_v2_quirk):
@@ -390,7 +398,7 @@ async def test_leisguar_ys_mt750_direction_write(zigpy_device_from_v2_quirk):
 
         req_mock.assert_called_once()
         call_data = req_mock.call_args[1]["data"]
-        assert b"\x05" in call_data  # DP ID 5
+        assert call_data[5] == 5  # DP ID 5 (positional, not a substring match)
         assert call_data[-1:] == b"\x01"  # Value = Reversed (1)
         assert req_mock.call_args[1]["expect_reply"] is False
         assert status == [
@@ -442,7 +450,7 @@ async def test_leisguar_ys_mt750_speed_write(zigpy_device_from_v2_quirk):
 
         req_mock.assert_called_once()
         call_data = req_mock.call_args[1]["data"]
-        assert b"\x69" in call_data  # DP ID 105 (0x69)
+        assert call_data[5] == 0x69  # DP ID 105 (positional, not a substring match)
         assert call_data[-1:] == b"\x80"  # Value = 128 (0x80)
         assert req_mock.call_args[1]["expect_reply"] is False
         assert status == [

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -708,10 +708,15 @@ class BorderSetting(t.enum8):
 
 
 class LeisguarMotorDirection(t.enum8):
-    """Motor direction values."""
+    """Motor direction values.
 
-    Normal = 0x00
-    Reversed = 0x01
+    Confirmed against a real device: raw DP5 value 1 is the motor's normal
+    (as-installed) rotation direction, and 0 is reversed — the opposite of
+    what the DP name convention elsewhere in this codebase might suggest.
+    """
+
+    Normal = 0x01
+    Reversed = 0x00
 
 
 (

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -705,3 +705,39 @@ class BorderSetting(t.enum8):
     .skip_configuration()
     .add_to_registry()
 )
+
+
+class MotorDirection(t.enum8):
+    """Motor direction values."""
+
+    Normal = 0x00
+    Reversed = 0x01
+
+
+(
+    TuyaQuirkBuilder("_TZE200_xu4a5rhj", "TS0601")
+    .tuya_cover(
+        control_dp=1,
+        position_state_dp=3,
+        position_control_dp=2,
+        invert=False,
+    )
+    .tuya_enum(
+        dp_id=5,
+        attribute_name="motor_direction",
+        enum_class=MotorDirection,
+        translation_key="motor_direction",
+        fallback_name="Motor direction",
+    )
+    .tuya_number(
+        dp_id=105,
+        type=t.uint8_t,
+        attribute_name="motor_speed",
+        min_value=0,
+        max_value=255,
+        step=1,
+        translation_key="motor_speed",
+        fallback_name="Motor speed",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0601_cover.py
+++ b/zhaquirks/tuya/ts0601_cover.py
@@ -707,7 +707,7 @@ class BorderSetting(t.enum8):
 )
 
 
-class MotorDirection(t.enum8):
+class LeisguarMotorDirection(t.enum8):
     """Motor direction values."""
 
     Normal = 0x00
@@ -725,7 +725,7 @@ class MotorDirection(t.enum8):
     .tuya_enum(
         dp_id=5,
         attribute_name="motor_direction",
-        enum_class=MotorDirection,
+        enum_class=LeisguarMotorDirection,
         translation_key="motor_direction",
         fallback_name="Motor direction",
     )


### PR DESCRIPTION
# Add Tuya Leisguar YS-MT750 curtain motor (`_TZE200_xu4a5rhj`)

## Proposed change

Adds support for the Leisguar YS-MT750 Tuya TS0601-based curtain motor
(`_TZE200_xu4a5rhj`), using the v2 `TuyaQuirkBuilder` declarative API.

Exposes:
- A `cover` entity (open/close/stop, exact position get/set).
- A `select` entity, `motor_direction` (Normal / Reversed).
- A `number` entity, `motor_speed` (0–255, write-only — see DP table below).

Datapoint table (confirmed against a real device):

| DP | Purpose | Type | Notes |
|----|---------|------|-------|
| 1 | control | enum (0=open, 1=stop, 2=close) | write |
| 2 | percent_control | value | position write, no inversion (`invert=False`) |
| 3 | percent_state | value | position read-back, no inversion |
| 5 | direction_change | enum (0=normal, 1=reversed) | write **and** read-back |
| 105 | speed | value, 0–255 | write-only — this device never echoes a speed report back |

Position uses `invert=False`: this device's raw DP2/DP3 values already
follow the ZCL `WindowCovering` convention directly (0%=open, 100%=closed),
unlike many Tuya covers which need the default `invert=True`.

## Additional information

- This is a new device quirk, not a bugfix.
- Tested against physical hardware: open, close, stop, set-position,
  direction select (both values), and speed number were all exercised
  against a real YS-MT750 with this exact quirk deployed, with clean logs
  throughout (no warnings/errors).
- Two items worth pre-empting:
  - An existing `MotorDirection` enum already exists in this file (for the
    Zemismart ZM16B quirk, `Forward`/`Back` members). This device's own
    enum is named `LeisguarMotorDirection` (`Normal`/`Reversed`) to avoid
    the name collision — reusing the existing enum wasn't possible since
    the member names/semantics differ.
  - `motor_speed` keeps the default `access=Read|Write` even though the
    device never echoes DP105 back, consistent with other write-only Tuya
    `number` entities already in this codebase — the local attribute cache
    is updated optimistically on write, so the entity stays usable.

## Device diagnostics

<details>
<summary>Diagnostics JSON (IEEE redacted)</summary>

```json
{
  "data": {
    "version": 3,
    "ieee": "**REDACTED**",
    "nwk": "0x92CF",
    "manufacturer": "_TZE200_xu4a5rhj",
    "model": "TS0601",
    "friendly_manufacturer": "_TZE200_xu4a5rhj",
    "friendly_model": "TS0601",
    "name": "_TZE200_xu4a5rhj TS0601",
    "quirk_applied": true,
    "quirk_class": "ts0601_cover_leisguar:TuyaLeisguarCoverYSMT750",
    "exposes_features": [],
    "manufacturer_code": 4417,
    "power_source": "Mains",
    "lqi": 104,
    "rssi": -85,
    "available": true,
    "device_type": "Router",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "Router",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 142,
      "manufacturer_code": 4417,
      "maximum_buffer_size": 66,
      "maximum_incoming_transfer_size": 66,
      "server_mask": 10752,
      "maximum_outgoing_transfer_size": 66,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "WINDOW_COVERING_DEVICE",
          "id": 514
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              { "id": "0x0001", "name": "app_version", "zcl_type": "uint8", "value": 70 },
              { "id": "0x0004", "name": "manufacturer", "zcl_type": "string", "value": "_TZE200_xu4a5rhj" },
              { "id": "0x0005", "name": "model", "zcl_type": "string", "value": "TS0601" }
            ]
          },
          { "cluster_id": "0x0004", "endpoint_attribute": "groups", "attributes": [] },
          { "cluster_id": "0x0005", "endpoint_attribute": "scenes", "attributes": [] },
          {
            "cluster_id": "0x0006",
            "endpoint_attribute": "on_off",
            "attributes": [
              { "id": "0x0000", "name": "on_off", "zcl_type": "bool", "value": 0 },
              { "id": "0x4003", "name": "start_up_on_off", "zcl_type": "enum8", "unsupported": true }
            ]
          },
          {
            "cluster_id": "0x000d",
            "endpoint_attribute": "analog_output",
            "attributes": [
              { "id": "0x0100", "name": "application_type", "zcl_type": "uint32", "unsupported": true },
              { "id": "0x001c", "name": "description", "zcl_type": "string", "value": "Motor Speed" },
              { "id": "0x0075", "name": "engineering_units", "zcl_type": "enum16", "unsupported": true },
              { "id": "0x0041", "name": "max_present_value", "zcl_type": "single", "value": 255 },
              { "id": "0x0045", "name": "min_present_value", "zcl_type": "single", "value": 0 },
              { "id": "0x0055", "name": "present_value", "zcl_type": "single", "value": 200.0 },
              { "id": "0x0068", "name": "relinquish_default", "zcl_type": "single", "unsupported": true },
              { "id": "0x006a", "name": "resolution", "zcl_type": "single", "value": 1 }
            ]
          },
          {
            "cluster_id": "0x0102",
            "endpoint_attribute": "window_covering",
            "attributes": [
              { "id": "0x0007", "name": "config_status", "zcl_type": "map8", "unsupported": true },
              { "id": "0x0008", "name": "current_position_lift_percentage", "zcl_type": "uint8", "value": 100 },
              { "id": "0x0009", "name": "current_position_tilt_percentage", "zcl_type": "uint8", "unsupported": true },
              { "id": "0x0017", "name": "window_covering_mode", "zcl_type": "map8", "unsupported": true },
              { "id": "0x0000", "name": "window_covering_type", "zcl_type": "enum8", "unsupported": true }
            ]
          },
          { "cluster_id": "0xef00", "endpoint_attribute": "tuya_manufacturer", "attributes": [] }
        ],
        "out_clusters": [
          { "cluster_id": "0x000a", "endpoint_attribute": "time", "attributes": [] },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              { "id": "0x0002", "name": "current_file_version", "zcl_type": "uint32", "value": 70 }
            ]
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "_TZE200_xu4a5rhj",
      "model": "TS0601",
      "node_desc": {
        "logical_type": 1,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 142,
        "manufacturer_code": 4417,
        "maximum_buffer_size": 66,
        "maximum_incoming_transfer_size": 66,
        "server_mask": 10752,
        "maximum_outgoing_transfer_size": 66,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0051",
          "input_clusters": ["0x0004", "0x0005", "0xef00", "0x0000"],
          "output_clusters": ["0x0019", "0x000a"]
        },
        "242": {
          "profile_id": "0xa1e0",
          "device_type": "0x0061",
          "input_clusters": [],
          "output_clusters": ["0x0021"]
        }
      }
    },
    "zha_lib_entities": {
      "cover": [
        {
          "unique_id": "**REDACTED**",
          "platform": "cover",
          "class_name": "Cover",
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "current_position": 0,
          "is_closed": true,
          "supported_features": 15
        }
      ],
      "number": [
        {
          "fallback_name": "Motor Speed",
          "unique_id": "**REDACTED**",
          "platform": "number",
          "class_name": "AnalogOutputNumber",
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "native_value": 200.0,
          "mode": "auto",
          "native_max_value": 255,
          "native_min_value": 0,
          "native_step": 1
        }
      ]
    }
  },
  "issues": []
}
```

<sub>Note: the entities shown reflect the currently-shipping local `custom_components`
quirk for this device (which exposes speed as a `number` and direction as a
`switch`) at capture time, not the entities this PR's v2 quirk produces
(`select` for direction). The endpoint/cluster/attribute layout above — the
part relevant to matching and implementing the device — is identical either
way, since it comes directly from the physical device.</sub>

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass (ruff check/format, mypy, codespell)
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
