### PR TITLE
Fix Aqara E1 (agl001) ScheduleEvent time validation rejecting midnight

### DIFF
--- a/zhaquirks/xiaomi/aqara/thermostat_agl001.py
+++ b/zhaquirks/xiaomi/aqara/thermostat_agl001.py
@@ -203,7 +203,8 @@ class ScheduleEvent:
 
     @staticmethod
     def _validate_time(time):
-        if time <= 0:
+        # 0 is a valid time-of-day (00:00 / midnight) in this minutes-since-midnight encoding.
+        if time < 0:
             raise ValueError("Time must be between 00:00 and 23:59")
         if time > 24 * 60:
             raise ValueError("Time must be between 00:00 and 23:59")


### PR DESCRIPTION
## Summary

`ScheduleEvent._validate_time` rejects a schedule time of exactly `00:00` (midnight), even though `0` is a valid value in this minutes-since-midnight encoding. The check used `time <= 0` instead of `time < 0`.

Fixes #5238, which has the full traceback and reproduction context - this crash happens whenever the device reports a schedule containing a midnight entry, including as an unsolicited attribute report (e.g. right after an OTA update completes), which can make an otherwise-successful firmware update look like it failed.

## Change

One line: `time <= 0` → `time < 0` in `_validate_time`.

## Test plan

Checked `tests/test_xiaomi.py` - no existing test asserts that `time == 0` (00:00) should raise, so this doesn't change any covered behavior, just stops rejecting a previously-untested valid case.