### PR TITLE
Add quirk for Tuya TS000F relay module _TZ3218_hdc8bbha

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -13,7 +13,7 @@ from zigpy.device import Device
 from zigpy.profiles import zha
 import zigpy.types as t
 from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import PowerConfiguration
+from zigpy.zcl.clusters.general import OnOff, PowerConfiguration
 from zigpy.zcl.clusters.security import IasZone, ZoneStatus
 from zigpy.zcl.foundation import ZCLAttributeDef
 
@@ -30,8 +30,15 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.legacy import CustomDevice, get_device
-from zhaquirks.tuya import Data, TuyaManufClusterAttributes, TuyaNewManufCluster
+from zhaquirks.tuya import (
+    Data,
+    ExternalSwitchType,
+    PowerOnState,
+    TuyaManufClusterAttributes,
+    TuyaNewManufCluster,
+)
 import zhaquirks.tuya.sm0202_motion
+import zhaquirks.tuya.ts000f
 import zhaquirks.tuya.ts0021
 import zhaquirks.tuya.ts0041
 import zhaquirks.tuya.ts0042
@@ -2174,3 +2181,112 @@ async def test_ts1201_learn_state_is_per_instance(zigpy_device_from_quirk):
     assert transmit1.msg_length == 4
     assert transmit2.ir_msg == []
     assert transmit2.msg_length == 0
+
+
+def test_ts000f_switch_type_values():
+    """Test TS000F external switch type values differ from the shared Tuya enum.
+
+    The TS000F relay modules report the switch type on the OnOff cluster using a
+    value order that does not match the 0xE001 based `ExternalSwitchType`, so the
+    two enums must not be used interchangeably.
+    """
+    switch_type = zhaquirks.tuya.ts000f.Ts000fExternalSwitchType
+
+    assert switch_type.Momentary == 0x00
+    assert switch_type.Toggle == 0x01
+    assert switch_type.State == 0x02
+
+    assert ExternalSwitchType.Toggle == 0x00
+    assert ExternalSwitchType.State == 0x01
+    assert ExternalSwitchType.Momentary == 0x02
+
+
+async def test_ts000f_attribute_defs(zigpy_device_from_v2_quirk):
+    """Test TS000F quirk replaces the OnOff cluster with the manufacturer attributes."""
+    device: Device = zigpy_device_from_v2_quirk("_TZ3218_hdc8bbha", "TS000F")
+    onoff_cluster = device.endpoints[1].on_off
+
+    assert isinstance(onoff_cluster, zhaquirks.tuya.ts000f.Ts000fOnOffCluster)
+
+    switch_type = onoff_cluster.AttributeDefs.switch_type
+    assert switch_type.id == 0x8001
+    assert switch_type.type is zhaquirks.tuya.ts000f.Ts000fExternalSwitchType
+
+    power_on_state = onoff_cluster.AttributeDefs.power_on_state
+    assert power_on_state.id == 0x8002
+    assert power_on_state.type is PowerOnState
+
+    # neither attribute is manufacturer specific, so zigpy decodes the reports the
+    # device actually sends; declaring a manufacturer code would decode them raw
+    assert switch_type.is_manufacturer_specific is None
+    assert power_on_state.is_manufacturer_specific is None
+
+
+@pytest.mark.parametrize(
+    "attribute,value,expected_data",
+    [
+        (
+            "switch_type",
+            zhaquirks.tuya.ts000f.Ts000fExternalSwitchType.Toggle,
+            b"\x00\x01\x02" + b"\x01\x80\x30\x01",
+        ),
+        (
+            "power_on_state",
+            PowerOnState.LastState,
+            b"\x00\x01\x02" + b"\x02\x80\x30\x02",
+        ),
+    ],
+)
+async def test_ts000f_write_attribute(
+    zigpy_device_from_v2_quirk, attribute, value, expected_data
+):
+    """Test TS000F attributes are written without a manufacturer code.
+
+    Frame control 0x00, sequence 1, write attributes. The device accepts both
+    attributes with and without the Tuya manufacturer code.
+    """
+    device: Device = zigpy_device_from_v2_quirk("_TZ3218_hdc8bbha", "TS000F")
+    onoff_cluster = device.endpoints[1].on_off
+
+    async def async_success(*args, **kwargs):
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+
+    with mock.patch.object(
+        onoff_cluster.endpoint, "request", side_effect=async_success
+    ) as request_mock:
+        (status,) = await onoff_cluster.write_attributes({attribute: value})
+
+    assert status[0].status == foundation.Status.SUCCESS
+
+    assert request_mock.mock_calls[0].kwargs["cluster"] == OnOff.cluster_id
+    assert request_mock.mock_calls[0].kwargs["data"] == expected_data
+
+
+@pytest.mark.parametrize(
+    "data,attribute,expected_value",
+    [
+        (
+            b"\x18\x01\x0a\x01\x80\x30\x00",
+            "switch_type",
+            zhaquirks.tuya.ts000f.Ts000fExternalSwitchType.Momentary,
+        ),
+        (
+            b"\x18\x01\x0a\x02\x80\x30\x02",
+            "power_on_state",
+            PowerOnState.LastState,
+        ),
+    ],
+)
+async def test_ts000f_attribute_report(
+    zigpy_device_from_v2_quirk, data, attribute, expected_value
+):
+    """Test TS000F attribute reports are deserialized into their enums."""
+    device: Device = zigpy_device_from_v2_quirk("_TZ3218_hdc8bbha", "TS000F")
+    onoff_cluster = device.endpoints[1].on_off
+    listener = ClusterListener(onoff_cluster)
+
+    onoff_cluster.handle_message(*onoff_cluster.deserialize(data))
+
+    attr_id = onoff_cluster.attributes_by_name[attribute].id
+    assert listener.attribute_updates == [(attr_id, expected_value)]
+    assert isinstance(listener.attribute_updates[0][1], type(expected_value))

--- a/zhaquirks/tuya/ts000f.py
+++ b/zhaquirks/tuya/ts000f.py
@@ -1,0 +1,57 @@
+"""Tuya TS000F relay modules."""
+
+from typing import Final
+
+import zigpy.types as t
+from zigpy.zcl.clusters.general import OnOff
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+from zhaquirks.clusters import CustomCluster
+from zhaquirks.tuya import PowerOnState, TuyaZBE000Cluster
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+
+class Ts000fExternalSwitchType(t.enum8):
+    """External switch type for TS000F relay modules.
+
+    Note: the value order differs from the 0xE001 based
+    ExternalSwitchType used by other Tuya devices.
+    """
+
+    Momentary = 0x00
+    Toggle = 0x01
+    State = 0x02
+
+
+class Ts000fOnOffCluster(CustomCluster, OnOff):
+    """OnOff cluster with the TS000F specific attributes."""
+
+    class AttributeDefs(OnOff.AttributeDefs):
+        """Attribute definitions."""
+
+        switch_type: Final = ZCLAttributeDef(id=0x8001, type=Ts000fExternalSwitchType)
+        power_on_state: Final = ZCLAttributeDef(id=0x8002, type=PowerOnState)
+
+
+(
+    TuyaQuirkBuilder("_TZ3218_hdc8bbha", "TS000F")
+    .tuya_enchantment()
+    .replaces(Ts000fOnOffCluster)
+    # give cluster 0xE000 its proper name
+    .replaces(TuyaZBE000Cluster)
+    .enum(
+        attribute_name=Ts000fOnOffCluster.AttributeDefs.power_on_state.name,
+        enum_class=PowerOnState,
+        cluster_id=OnOff.cluster_id,
+        translation_key="power_on_state",
+        fallback_name="Power on state",
+    )
+    .enum(
+        attribute_name=Ts000fOnOffCluster.AttributeDefs.switch_type.name,
+        enum_class=Ts000fExternalSwitchType,
+        cluster_id=OnOff.cluster_id,
+        translation_key="external_switch_type",
+        fallback_name="External switch type",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Add a new v2 quirk for the Tuya TS000F relay module `_TZ3218_hdc8bbha`, a 1-gang relay module with dry contact output. Zigbee2MQTT lists this fingerprint as QS-Zigbee-SEC01-DC, but the same fingerprint is also used on mains powered variants. This quirk was developed and tested on a 230 V powered unit.

Without a quirk the device joins as a bare `Light` with no configuration entities. This quirk:

 - casts the Tuya read-attribute spell on join/startup (`.tuya_enchantment()`), which is required before the manufacturer specific OnOff attributes respond
 - replaces the OnOff cluster with a device specific `Ts000fOnOffCluster` defining the two attributes this device actually implements:
   - `power_on_state` (0x8002, `PowerOnState`), exposed as a config select
   - `switch_type` (0x8001, momentary=0 / toggle=1 / state=2), exposed as a config select
 - names cluster 0xE000 via `TuyaZBE000Cluster`

A device specific OnOff cluster is used instead of the generic `TuyaZBOnOffAttributeCluster` because on this device attribute 0x8001 is the external switch type, not `backlight_mode`, and its enum order (momentary=0 / toggle=1 / state=2) differs from the 0xE001-based `ExternalSwitchType` (toggle=0 / state=1 / momentary=2) used by other Tuya devices:
 - Zigbee2MQTT models 0x8001 on `genOnOff` as `switch_type` for exactly this fingerprint, with lookup `{momentary: 0, toggle: 1, state: 2}`: https://github.com/Koenkk/zigbee-herdsman-converters/blob/1a9d5bf4e007a1c02030346a1fd66668cf66b917/src/devices/tuya.ts#L16583-L16606
 - for the conflicting generic definitions see `TuyaZBOnOffAttributeCluster` (0x8001 = `backlight_mode`) and `ExternalSwitchType` in `zhaquirks/tuya/__init__.py`
 - Disclaimer: the `Ts000fExternalSwitchType` value mapping is taken from the Zigbee2MQTT definition and is untested, since I have no switch connected to the device. I can verify it later if needed.

## Additional information

All exposed attributes were verified on real hardware (ZHA, zigpy 2.0.1, zha-quirks 2.1.1) via direct attribute reads/writes, and re-verified with zha-toolkit v1.2.1:

 - standard `StartUpOnOff` (0x4003) → UNSUPPORTED_ATTRIBUTE
 - 0x8001 and 0x8002 both read successfully **with and without** the Tuya manufacturer code (4417 / 0x1141); read value 0 for both, matching the physically attached momentary switch and the default power on state
 - both attributes only respond after the Tuya magic spell has been cast

Neither attribute is therefore declared manufacturer specific. This is deliberate: zigpy resolves attribute definitions strictly by framing, so a definition carrying `manufacturer_code=0x1141` decodes reports sent *without* the manufacturer code as a raw `enum8` instead of the enum type (and vice versa). Since the device answers without the code, and this matches how `TuyaZBOnOffAttributeCluster` and `TuyaWithBacklightOnOffCluster` declare their 0x80xx attributes, the plain declaration is used. Note that Zigbee2MQTT does set `manufacturerCode: 0x1141` for 0x8001 on this fingerprint — it is simply not required on this unit.

Tests in `tests/test_tuya.py` cover:                                                                                                                                                                                                                                                                             

 - the `Ts000fExternalSwitchType` value order, asserted directly against the shared `ExternalSwitchType` so the divergence cannot silently regress
 - the replaced cluster and both attribute definitions (IDs, enum types, non-manufacturer-specific declaration)
 - the serialized write frames for both attributes
 - deserialization of incoming attribute reports into their enum types

`.skip_configuration()` is deliberately NOT used: OnOff binding/reporting is required so that locally triggered switch input changes are reported (the missing reporting config was a bug for this device in Z2M, see Koenkk/zigbee-herdsman-converters#12290).

Scope note: the sibling device `_TZ3000_hdc8bbha` (QS-Zigbee-SEC01-U) has a different signature (0xE001 instead of 0xEF00) and is intentionally not covered, as I cannot test it.

## Device diagnostics

[zha-b2d3f60ef808386052df5416f27c70ed-_TZ3218_hdc8bbha TS000F-2ee3aa27b48e451568ebffdf58ac9cee.json](https://github.com/user-attachments/files/30934608/zha-b2d3f60ef808386052df5416f27c70ed-_TZ3218_hdc8bbha.TS000F-2ee3aa27b48e451568ebffdf58ac9cee.json)

## Checklist

 - [x] The changes are tested and work correctly
 - [x] `pre-commit` checks pass / the code has been formatted using Black
 - [x] Tests have been added to verify that the new code works
 - [x] Device diagnostics data has been attached
