### PR TITLE
Add SDevices wall switch, cover, socket, and thermostat quirks

### DIFF
--- a/tests/test_sdevices.py
+++ b/tests/test_sdevices.py
@@ -4,9 +4,9 @@ from unittest import mock
 
 import pytest
 from zigpy.profiles import zha
-from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl import ClusterType, ReportingConfig, foundation
 from zigpy.zcl.clusters.closures import WindowCovering, WindowCoveringMode
-from zigpy.zcl.clusters.general import MultistateInput, OnOff
+from zigpy.zcl.clusters.general import DeviceTemperature, MultistateInput, OnOff
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 
 import zhaquirks
@@ -22,9 +22,12 @@ from zhaquirks.const import (
 from zhaquirks.sdevices import (
     SDevicesButtonCluster,
     SDevicesCluster,
+    SDevicesDeviceTemperatureCluster,
+    SDevicesOnOffCluster,
     SDevicesTwoButtonCluster,
     SDevicesWindowCoveringCluster,
 )
+from zhaquirks.sdevices.socket import _socket
 from zhaquirks.sdevices.switch import _single_button_switch, _two_button_switch
 
 zhaquirks.setup()
@@ -104,6 +107,60 @@ def test_two_button_relays_are_switches(zigpy_device_from_v2_quirk, model):
         assert device.endpoints[endpoint].device_type == zha.DeviceType.ON_OFF_OUTPUT
 
 
+def test_socket_relay_is_switch(zigpy_device_from_v2_quirk):
+    """The socket is a Mains Power Outlet (0x0009) - a switch, not a light."""
+    device = zigpy_device_from_v2_quirk("SDevices", "SBDV-00202")
+    assert device.endpoints[1].device_type == zha.DeviceType.MAIN_POWER_OUTLET
+
+
+def test_socket_emergency_flags_split_from_bitmap(zigpy_device_from_v2_quirk):
+    """The emergency bitmap is split into per-flag attributes on attribute update."""
+    device = zigpy_device_from_v2_quirk("SDevices", "SBDV-00202")
+    cluster = device.endpoints[1].sdevices_cluster
+
+    # one flag at a time -> only that flag's synthetic attribute flips
+    for attr_name, bitmap in (
+        ("emergency_overvoltage", 0x01),
+        ("emergency_undervoltage", 0x02),
+        ("emergency_overcurrent", 0x04),
+        ("emergency_overheat", 0x08),
+    ):
+        cluster.update_attribute(0x3001, bitmap)
+        assert cluster.get(attr_name) is True
+        others = {
+            "emergency_overvoltage",
+            "emergency_undervoltage",
+            "emergency_overcurrent",
+            "emergency_overheat",
+        } - {attr_name}
+        assert all(cluster.get(other) is False for other in others)
+
+    # all flags at once -> all set
+    cluster.update_attribute(0x3001, 0x0F)
+    assert all(
+        cluster.get(n) is True
+        for n in (
+            "emergency_overvoltage",
+            "emergency_undervoltage",
+            "emergency_overcurrent",
+            "emergency_overheat",
+        )
+    )
+
+    # each flag is its own binary sensor on its synthetic attribute, not the bitmap
+    binary_attrs = {
+        entity.attribute_name
+        for entity in _socket("SDevices", "SBDV-00202").entity_metadata
+        if type(entity).__name__ == "BinarySensorMetadata"
+    }
+    assert binary_attrs == {
+        "emergency_overvoltage",
+        "emergency_undervoltage",
+        "emergency_overcurrent",
+        "emergency_overheat",
+    }
+
+
 @pytest.mark.parametrize("model", ("SBDV-00199", "SBDV-00200"))
 def test_cover_mode(zigpy_device_from_v2_quirk, model):
     """Covering-mode instance (EP3 WindowCovering) matches the cover quirk."""
@@ -151,6 +208,17 @@ async def test_button_clusters_bind(zigpy_device_from_v2_quirk):
     diagnostic_cluster.bind = mock.AsyncMock()
     await diagnostic_cluster.apply_custom_configuration()
     diagnostic_cluster.bind.assert_awaited_once()
+
+    socket = zigpy_device_from_v2_quirk("SDevices", "SBDV-00202")
+    socket_reporting_cluster = socket.endpoints[1].sdevices_cluster
+    socket_reporting_cluster.bind = mock.AsyncMock()
+    await socket_reporting_cluster.apply_custom_configuration()
+    socket_reporting_cluster.bind.assert_awaited_once()
+
+    device_temperature_cluster = socket.endpoints[1].device_temperature
+    device_temperature_cluster.bind = mock.AsyncMock()
+    await device_temperature_cluster.apply_custom_configuration()
+    device_temperature_cluster.bind.assert_not_awaited()
 
     dual = zigpy_device_from_v2_quirk(
         "SDevices",
@@ -211,6 +279,69 @@ async def test_manufacturer_cluster_binding_matches_report_sources(
     cover_cluster.bind = mock.AsyncMock()
     await cover_cluster.apply_custom_configuration()
     cover_cluster.bind.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_clusters_retain_firmware_reporting_configuration(
+    zigpy_device_from_v2_quirk,
+):
+    """SDevices clusters acknowledge reporting setup without sending a command."""
+    socket = zigpy_device_from_v2_quirk("SDevices", "SBDV-00202")
+    clusters_and_attributes = (
+        (
+            socket.endpoints[1].on_off,
+            OnOff.AttributeDefs.on_off,
+            SDevicesOnOffCluster,
+        ),
+        (
+            socket.endpoints[1].device_temperature,
+            DeviceTemperature.AttributeDefs.current_temperature,
+            SDevicesDeviceTemperatureCluster,
+        ),
+        (
+            socket.endpoints[1].sdevices_cluster,
+            SDevicesCluster.AttributeDefs.rms_voltage_mv,
+            SDevicesCluster,
+        ),
+    )
+
+    for cluster, attribute, cluster_class in clusters_and_attributes:
+        assert isinstance(cluster, cluster_class)
+        cluster._configure_reporting = mock.AsyncMock()
+        result = await cluster.configure_reporting_multiple(
+            {
+                attribute: ReportingConfig(
+                    min_interval=1,
+                    max_interval=2,
+                    reportable_change=1,
+                )
+            }
+        )
+        assert result == {attribute: foundation.Status.SUCCESS}
+        cluster._configure_reporting.assert_not_awaited()
+
+    cover = zigpy_device_from_v2_quirk(
+        "SDevices",
+        "SBDV-00199",
+        endpoint_ids=[3],
+        cluster_ids={
+            3: {WindowCovering.cluster_id: ClusterType.Server},
+        },
+    )
+    cover_cluster = cover.endpoints[3].window_covering
+    cover_cluster._configure_reporting = mock.AsyncMock()
+    attribute = WindowCovering.AttributeDefs.current_position_lift_percentage
+    result = await cover_cluster.configure_reporting_multiple(
+        {
+            attribute: ReportingConfig(
+                min_interval=1,
+                max_interval=2,
+                reportable_change=1,
+            )
+        }
+    )
+    assert result == {attribute: foundation.Status.SUCCESS}
+    cover_cluster._configure_reporting.assert_not_awaited()
 
 
 def test_device_automation_triggers_use_standard_types():
@@ -337,6 +468,7 @@ def test_config_entities_request_initial_values():
     builders = (
         _single_button_switch("SDevices", "SBDV-00197", optional_neutral=True),
         _two_button_switch("SDevices", "SBDV-00200", optional_neutral=True),
+        _socket("SDevices", "SBDV-00202"),
     )
     local_cover_mode_attributes = {
         "cover_calibration_mode",
@@ -426,3 +558,67 @@ def test_switch_diagnostic_counter_mapping():
         attribute_name == "persistent_memory_writes"
         for _, attribute_name in dual_diagnostics
     )
+
+
+def test_unsupported_flash_writes_entity_is_not_declared_for_socket():
+    """The firmware does not support Diagnostic persistent memory writes."""
+    assert not any(
+        entity.attribute_name == "persistent_memory_writes"
+        for entity in _socket("SDevices", "SBDV-00202").entity_metadata
+    )
+
+
+def test_socket_device_temperature_unique_id_is_preserved():
+    """The replacement matches ZHA's native `{ieee}-1-2` unique ID."""
+    (metadata,) = (
+        entity
+        for entity in _socket("SDevices", "SBDV-00202").entity_metadata
+        if entity.cluster_id == DeviceTemperature.cluster_id
+        and entity.attribute_name == "current_temperature"
+    )
+    assert metadata.unique_id_suffix == str(DeviceTemperature.cluster_id)
+
+
+def test_socket_scaling_and_reporting_metadata():
+    """Socket declarations leave reporting intervals to the firmware."""
+    metadata = _socket("SDevices", "SBDV-00202").entity_metadata
+    numbers = {
+        entity.attribute_name: entity
+        for entity in metadata
+        if isinstance(entity, NumberMetadata)
+    }
+    assert (
+        numbers["upper_voltage_threshold"].min,
+        numbers["upper_voltage_threshold"].max,
+    ) == (230, 260)
+    assert numbers["upper_voltage_threshold"].multiplier == 0.001
+    assert (
+        numbers["lower_voltage_threshold"].min,
+        numbers["lower_voltage_threshold"].max,
+    ) == (100, 230)
+    assert numbers["lower_voltage_threshold"].multiplier == 0.001
+    assert (
+        numbers["upper_current_threshold"].min,
+        numbers["upper_current_threshold"].max,
+    ) == (0.1, 16)
+    assert numbers["upper_current_threshold"].multiplier == 0.001
+    assert (
+        numbers["upper_temp_threshold"].min,
+        numbers["upper_temp_threshold"].max,
+    ) == (10, 100)
+
+    sensors = {
+        entity.attribute_name: entity
+        for entity in metadata
+        if type(entity).__name__ == "ZCLSensorMetadata"
+    }
+    for attr_name in ("rms_voltage_mv", "rms_current_ma", "active_power_mw"):
+        sensor = sensors[attr_name]
+        assert sensor.divisor == 1000
+        assert sensor.reporting_config is None
+        assert sensor.attribute_initialized_from_cache is False
+
+    emergency = sensors["emergency_shutoff_state"]
+    assert emergency.initially_disabled is True
+    assert emergency.reporting_config is None
+    assert emergency.attribute_initialized_from_cache is False

--- a/tests/test_sdevices.py
+++ b/tests/test_sdevices.py
@@ -1,0 +1,428 @@
+"""Tests for SDevices quirks."""
+
+from unittest import mock
+
+import pytest
+from zigpy.profiles import zha
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.closures import WindowCovering, WindowCoveringMode
+from zigpy.zcl.clusters.general import MultistateInput, OnOff
+from zigpy.zcl.clusters.homeautomation import Diagnostic
+
+import zhaquirks
+from zhaquirks.builder.metadata import NumberMetadata, SwitchMetadata, ZCLEnumMetadata
+from zhaquirks.const import (
+    BUTTON_1,
+    BUTTON_2,
+    COMMAND,
+    DOUBLE_PRESS,
+    LONG_PRESS,
+    SHORT_PRESS,
+)
+from zhaquirks.sdevices import (
+    SDevicesButtonCluster,
+    SDevicesCluster,
+    SDevicesTwoButtonCluster,
+    SDevicesWindowCoveringCluster,
+)
+from zhaquirks.sdevices.switch import _single_button_switch, _two_button_switch
+
+zhaquirks.setup()
+
+PRESENT_VALUE = MultistateInput.AttributeDefs.present_value.id
+
+
+@pytest.mark.parametrize("model", ("SBDV-00196", "SBDV-00197"))
+def test_single_button_actions(zigpy_device_from_v2_quirk, model):
+    """A single-button switch emits button_single/double/hold events."""
+    device = zigpy_device_from_v2_quirk("SDevices", model)
+
+    cluster = device.endpoints[1].multistate_input
+    assert isinstance(cluster, SDevicesButtonCluster)
+
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    # unknown present_value -> no event
+    cluster.update_attribute(PRESENT_VALUE, 5)
+    assert listener.zha_send_event.call_count == 0
+
+    for value, action in (
+        (1, "button_single"),
+        (2, "button_double"),
+        (0, "button_hold"),
+    ):
+        cluster.update_attribute(PRESENT_VALUE, value)
+        listener.zha_send_event.assert_called_with(action, {})
+
+
+@pytest.mark.parametrize("model", ("SBDV-00199", "SBDV-00200"))
+@pytest.mark.parametrize("endpoint", (1, 2))
+def test_two_button_actions(zigpy_device_from_v2_quirk, model, endpoint):
+    """A two-button switch emits per-endpoint {single,double,hold}_switch_N events."""
+    device = zigpy_device_from_v2_quirk(
+        "SDevices",
+        model,
+        cluster_ids={
+            1: {
+                OnOff.cluster_id: ClusterType.Server,
+                MultistateInput.cluster_id: ClusterType.Server,
+            },
+            2: {
+                OnOff.cluster_id: ClusterType.Server,
+                MultistateInput.cluster_id: ClusterType.Server,
+            },
+        },
+    )
+
+    cluster = device.endpoints[endpoint].multistate_input
+    assert isinstance(cluster, SDevicesTwoButtonCluster)
+
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    cluster.update_attribute(PRESENT_VALUE, 5)
+    assert listener.zha_send_event.call_count == 0
+
+    for value, raw in ((1, "single"), (2, "double"), (0, "hold")):
+        cluster.update_attribute(PRESENT_VALUE, value)
+        listener.zha_send_event.assert_called_with(f"{raw}_switch_{endpoint}", {})
+
+
+@pytest.mark.parametrize("model", ("SBDV-00199", "SBDV-00200"))
+def test_two_button_relays_are_switches(zigpy_device_from_v2_quirk, model):
+    """Switch-mode relays get the ON_OFF_OUTPUT device type (switch platform)."""
+    device = zigpy_device_from_v2_quirk(
+        "SDevices",
+        model,
+        cluster_ids={
+            1: {OnOff.cluster_id: ClusterType.Server},
+            2: {OnOff.cluster_id: ClusterType.Server},
+        },
+    )
+    for endpoint in (1, 2):
+        assert device.endpoints[endpoint].device_type == zha.DeviceType.ON_OFF_OUTPUT
+
+
+@pytest.mark.parametrize("model", ("SBDV-00199", "SBDV-00200"))
+def test_cover_mode(zigpy_device_from_v2_quirk, model):
+    """Covering-mode instance (EP3 WindowCovering) matches the cover quirk."""
+    device = zigpy_device_from_v2_quirk(
+        "SDevices",
+        model,
+        endpoint_ids=[3],
+        cluster_ids={
+            3: {
+                WindowCovering.cluster_id: ClusterType.Server,
+                Diagnostic.cluster_id: ClusterType.Server,
+                SDevicesCluster.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+    cluster = device.endpoints[3].window_covering
+    assert isinstance(cluster, SDevicesWindowCoveringCluster)
+    # manufacturer attribute is available on the replaced cluster
+    assert cluster.AttributeDefs.sdevices_calibration_time.id == 0x1001
+    # switch-mode gangs must not exist on a covering-mode device
+    assert 1 not in device.endpoints
+    assert 2 not in device.endpoints
+
+
+@pytest.mark.asyncio
+async def test_button_clusters_bind(zigpy_device_from_v2_quirk):
+    """Report sources bind without changing firmware reporting defaults."""
+    single = zigpy_device_from_v2_quirk(
+        "SDevices",
+        "SBDV-00196",
+        cluster_ids={
+            1: {
+                MultistateInput.cluster_id: ClusterType.Server,
+                Diagnostic.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+    single_cluster = single.endpoints[1].multistate_input
+    single_cluster.bind = mock.AsyncMock()
+    await single_cluster.apply_custom_configuration()
+    single_cluster.bind.assert_awaited_once()
+
+    diagnostic_cluster = single.endpoints[1].diagnostic
+    diagnostic_cluster.bind = mock.AsyncMock()
+    await diagnostic_cluster.apply_custom_configuration()
+    diagnostic_cluster.bind.assert_awaited_once()
+
+    dual = zigpy_device_from_v2_quirk(
+        "SDevices",
+        "SBDV-00199",
+        cluster_ids={
+            1: {MultistateInput.cluster_id: ClusterType.Server},
+            2: {MultistateInput.cluster_id: ClusterType.Server},
+        },
+    )
+    for endpoint_id in (1, 2):
+        dual_cluster = dual.endpoints[endpoint_id].multistate_input
+        dual_cluster.bind = mock.AsyncMock()
+        await dual_cluster.apply_custom_configuration()
+        dual_cluster.bind.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_manufacturer_cluster_binding_matches_report_sources(
+    zigpy_device_from_v2_quirk,
+):
+    """Bind 0xFCCF only where the reference device emits attribute reports."""
+    no_neutral = zigpy_device_from_v2_quirk("SDevices", "SBDV-00196")
+    no_neutral_cluster = no_neutral.endpoints[1].sdevices_cluster
+    no_neutral_cluster.bind = mock.AsyncMock()
+    await no_neutral_cluster.apply_custom_configuration()
+    no_neutral_cluster.bind.assert_not_awaited()
+
+    optional_neutral = zigpy_device_from_v2_quirk("SDevices", "SBDV-00197")
+    optional_neutral_cluster = optional_neutral.endpoints[1].sdevices_cluster
+    optional_neutral_cluster.bind = mock.AsyncMock()
+    await optional_neutral_cluster.apply_custom_configuration()
+    optional_neutral_cluster.bind.assert_awaited_once()
+
+    dual = zigpy_device_from_v2_quirk(
+        "SDevices",
+        "SBDV-00199",
+        cluster_ids={
+            1: {SDevicesCluster.cluster_id: ClusterType.Server},
+            2: {SDevicesCluster.cluster_id: ClusterType.Server},
+        },
+    )
+    for endpoint_id, should_bind in ((1, True), (2, False)):
+        cluster = dual.endpoints[endpoint_id].sdevices_cluster
+        cluster.bind = mock.AsyncMock()
+        await cluster.apply_custom_configuration()
+        if should_bind:
+            cluster.bind.assert_awaited_once()
+        else:
+            cluster.bind.assert_not_awaited()
+
+    cover = zigpy_device_from_v2_quirk(
+        "SDevices",
+        "SBDV-00199",
+        endpoint_ids=[3],
+        cluster_ids={3: {SDevicesCluster.cluster_id: ClusterType.Server}},
+    )
+    cover_cluster = cover.endpoints[3].sdevices_cluster
+    cover_cluster.bind = mock.AsyncMock()
+    await cover_cluster.apply_custom_configuration()
+    cover_cluster.bind.assert_awaited_once()
+
+
+def test_device_automation_triggers_use_standard_types():
+    """SDevices actions use Home Assistant's localized trigger types/subtypes."""
+    single = _single_button_switch("SDevices", "SBDV-00196")
+    assert single.device_automation_triggers_metadata == {
+        (SHORT_PRESS, BUTTON_1): {COMMAND: "button_single"},
+        (DOUBLE_PRESS, BUTTON_1): {COMMAND: "button_double"},
+        (LONG_PRESS, BUTTON_1): {COMMAND: "button_hold"},
+    }
+
+    dual = _two_button_switch("SDevices", "SBDV-00199")
+    assert dual.device_automation_triggers_metadata == {
+        (SHORT_PRESS, BUTTON_1): {COMMAND: "single_switch_1"},
+        (DOUBLE_PRESS, BUTTON_1): {COMMAND: "double_switch_1"},
+        (LONG_PRESS, BUTTON_1): {COMMAND: "hold_switch_1"},
+        (SHORT_PRESS, BUTTON_2): {COMMAND: "single_switch_2"},
+        (DOUBLE_PRESS, BUTTON_2): {COMMAND: "double_switch_2"},
+        (LONG_PRESS, BUTTON_2): {COMMAND: "hold_switch_2"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_cover_mode_bit_write_preserves_other_bits(
+    zigpy_device_from_v2_quirk,
+):
+    """Writing one synthetic cover-mode switch preserves every unrelated bit."""
+    device = zigpy_device_from_v2_quirk(
+        "SDevices",
+        "SBDV-00199",
+        endpoint_ids=[3],
+        cluster_ids={3: {WindowCovering.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[3].window_covering
+    mode_attr = WindowCovering.AttributeDefs.window_covering_mode
+    initial_mode = (
+        WindowCoveringMode.Motor_direction_reversed
+        | WindowCoveringMode.LEDs_display_feedback
+    )
+    cluster.update_attribute(mode_attr.id, initial_mode)
+
+    cluster.write_attributes_raw = mock.AsyncMock(
+        return_value=(
+            [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],
+        )
+    )
+    await cluster.write_attributes({"cover_calibration_mode": True})
+
+    ((written,),), _ = cluster.write_attributes_raw.call_args
+    assert written.attrid == mode_attr.id
+    assert written.value.value == (
+        initial_mode | WindowCoveringMode.Run_in_calibration_mode
+    )
+    assert cluster.get("cover_calibration_mode") is True
+    assert cluster.get("cover_led_feedback") is True
+
+
+@pytest.mark.asyncio
+async def test_cover_mode_bit_write_reads_uncached_mode(
+    zigpy_device_from_v2_quirk,
+):
+    """An uncached Mode is read before clearing a bit and other writes pass through."""
+    device = zigpy_device_from_v2_quirk(
+        "SDevices",
+        "SBDV-00199",
+        endpoint_ids=[3],
+        cluster_ids={3: {WindowCovering.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[3].window_covering
+    mode_attr = WindowCovering.AttributeDefs.window_covering_mode
+    initial_mode = (
+        WindowCoveringMode.Run_in_calibration_mode
+        | WindowCoveringMode.LEDs_display_feedback
+    )
+    cluster.read_attributes = mock.AsyncMock(
+        return_value=({mode_attr.name: initial_mode}, {})
+    )
+    cluster.write_attributes_raw = mock.AsyncMock(
+        return_value=(
+            [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)],
+        )
+    )
+
+    await cluster.write_attributes(
+        {"cover_calibration_mode": False, "velocity_lift": 25}
+    )
+
+    cluster.read_attributes.assert_awaited_once()
+    ((written),), _ = cluster.write_attributes_raw.call_args
+    written_values = {record.attrid: record.value.value for record in written}
+    assert written_values == {
+        WindowCovering.AttributeDefs.velocity_lift.id: 25,
+        mode_attr.id: WindowCoveringMode.LEDs_display_feedback,
+    }
+    assert cluster.get("cover_calibration_mode") is False
+    assert cluster.get("cover_led_feedback") is True
+
+
+@pytest.mark.asyncio
+async def test_cover_mode_bit_write_fails_without_current_mode(
+    zigpy_device_from_v2_quirk,
+):
+    """A synthetic bit cannot be safely written if Mode cannot be read."""
+    device = zigpy_device_from_v2_quirk(
+        "SDevices",
+        "SBDV-00199",
+        endpoint_ids=[3],
+        cluster_ids={3: {WindowCovering.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[3].window_covering
+    cluster.read_attributes = mock.AsyncMock(return_value=({}, {}))
+    cluster.write_attributes_raw = mock.AsyncMock()
+
+    with pytest.raises(
+        ValueError, match="Unable to read WindowCovering.Mode before updating it"
+    ):
+        await cluster.write_attributes({"cover_calibration_mode": True})
+
+    cluster.write_attributes_raw.assert_not_awaited()
+
+
+def test_config_entities_request_initial_values():
+    """Writable config entities are read before ZHA checks their support."""
+    builders = (
+        _single_button_switch("SDevices", "SBDV-00197", optional_neutral=True),
+        _two_button_switch("SDevices", "SBDV-00200", optional_neutral=True),
+    )
+    local_cover_mode_attributes = {
+        "cover_calibration_mode",
+        "cover_maintenance_mode",
+        "cover_led_feedback",
+    }
+
+    missing_startup_reads = []
+    for builder in builders:
+        for metadata in builder.entity_metadata:
+            if not isinstance(
+                metadata, (NumberMetadata, SwitchMetadata, ZCLEnumMetadata)
+            ):
+                continue
+            if metadata.attribute_name in local_cover_mode_attributes:
+                continue
+            if (
+                metadata.reporting_config is None
+                and metadata.attribute_initialized_from_cache
+            ):
+                missing_startup_reads.append(
+                    (metadata.endpoint_id, metadata.attribute_name)
+                )
+
+    assert missing_startup_reads == []
+
+
+def test_optional_neutral_cover_entities_are_declared():
+    """SBDV-00200 exposes its optional-neutral attributes on cover endpoint 3."""
+    metadata = _two_button_switch(
+        "SDevices", "SBDV-00200", optional_neutral=True
+    ).entity_metadata
+    assert {
+        (entity.endpoint_id, entity.attribute_name)
+        for entity in metadata
+        if entity.attribute_name
+        in {"power_profile", "led_indication_type", "neutral_presence"}
+    } == {
+        (1, "power_profile"),
+        (1, "led_indication_type"),
+        (1, "neutral_presence"),
+        (3, "power_profile"),
+        (3, "led_indication_type"),
+        (3, "neutral_presence"),
+    }
+    neutral_entities = [
+        entity for entity in metadata if entity.attribute_name == "neutral_presence"
+    ]
+    assert all(
+        entity.attribute_initialized_from_cache is False
+        and entity.reporting_config is None
+        for entity in neutral_entities
+    )
+
+
+def test_switch_diagnostic_counter_mapping():
+    """Diagnostics distinguish pairing and physical wall buttons."""
+    single = _single_button_switch("SDevices", "SBDV-00196")
+    single_diagnostics = {
+        entity.attribute_name
+        for entity in single.entity_metadata
+        if entity.cluster_id == Diagnostic.cluster_id
+    }
+    assert {
+        "number_of_resets",
+        "sdevices_button1_clicks",
+        "sdevices_button2_clicks",
+        "sdevices_relay1_switches",
+    } <= single_diagnostics
+    assert "persistent_memory_writes" not in single_diagnostics
+
+    dual = _two_button_switch("SDevices", "SBDV-00199")
+    dual_diagnostics = {
+        (entity.endpoint_id, entity.attribute_name)
+        for entity in dual.entity_metadata
+        if entity.cluster_id == Diagnostic.cluster_id
+    }
+    for endpoint_id in (1, 3):
+        assert {
+            (endpoint_id, "sdevices_button1_clicks"),
+            (endpoint_id, "sdevices_button2_clicks"),
+            (endpoint_id, "sdevices_button3_clicks"),
+            (endpoint_id, "sdevices_relay1_switches"),
+            (endpoint_id, "sdevices_relay2_switches"),
+        } <= dual_diagnostics
+    assert not any(
+        attribute_name == "persistent_memory_writes"
+        for _, attribute_name in dual_diagnostics
+    )

--- a/tests/test_sdevices.py
+++ b/tests/test_sdevices.py
@@ -8,9 +8,11 @@ from zigpy.zcl import ClusterType, ReportingConfig, foundation
 from zigpy.zcl.clusters.closures import WindowCovering, WindowCoveringMode
 from zigpy.zcl.clusters.general import DeviceTemperature, MultistateInput, OnOff
 from zigpy.zcl.clusters.homeautomation import Diagnostic
+from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 
 import zhaquirks
 from zhaquirks.builder.metadata import NumberMetadata, SwitchMetadata, ZCLEnumMetadata
+from zhaquirks.clusters import CustomCluster
 from zhaquirks.const import (
     BUTTON_1,
     BUTTON_2,
@@ -29,10 +31,350 @@ from zhaquirks.sdevices import (
 )
 from zhaquirks.sdevices.socket import _socket
 from zhaquirks.sdevices.switch import _single_button_switch, _two_button_switch
+from zhaquirks.sdevices.thermostat import (
+    SDevicesProgrammingOperationMode,
+    SDevicesThermostatCluster,
+    _thermostat,
+)
 
 zhaquirks.setup()
 
 PRESENT_VALUE = MultistateInput.AttributeDefs.present_value.id
+
+
+def _make_thermostat(zigpy_device_from_v2_quirk) -> SDevicesThermostatCluster:
+    """Create an SBDV-00205 with its standard Thermostat server cluster."""
+    device = zigpy_device_from_v2_quirk(
+        "SDevices",
+        "SBDV-00205",
+        cluster_ids={1: {Thermostat.cluster_id: ClusterType.Server}},
+    )
+    cluster = device.endpoints[1].thermostat
+    assert isinstance(cluster, SDevicesThermostatCluster)
+    return cluster
+
+
+def test_thermostat_schedule_attributes(zigpy_device_from_v2_quirk):
+    """The thermostat exposes one local string schedule for every weekday."""
+    cluster = _make_thermostat(zigpy_device_from_v2_quirk)
+
+    assert [
+        getattr(cluster.AttributeDefs, name).id
+        for name in (
+            "schedule_monday",
+            "schedule_tuesday",
+            "schedule_wednesday",
+            "schedule_thursday",
+            "schedule_friday",
+            "schedule_saturday",
+            "schedule_sunday",
+        )
+    ] == list(range(0xF100, 0xF107))
+
+    assert {
+        cluster.find_attribute(attr_id).name
+        for attr_id in cluster._SCHEDULE_ATTR_TO_DAY  # noqa: SLF001
+    } == {
+        "schedule_sunday",
+        "schedule_monday",
+        "schedule_tuesday",
+        "schedule_wednesday",
+        "schedule_thursday",
+        "schedule_friday",
+        "schedule_saturday",
+    }
+
+
+def test_thermostat_programming_mode_select_uses_server_cluster():
+    """The mode select avoids the duplicate client-side Thermostat cluster."""
+    (metadata,) = (
+        entity
+        for entity in _thermostat.entity_metadata
+        if isinstance(entity, ZCLEnumMetadata)
+        and entity.attribute_name == Thermostat.AttributeDefs.programing_oper_mode.name
+    )
+
+    assert metadata.cluster_type is ClusterType.Server
+    assert metadata.enum is SDevicesProgrammingOperationMode
+    assert metadata.attribute_initialized_from_cache is False
+
+
+def test_thermostat_keypad_lockout_is_binary_switch():
+    """Expose the firmware's binary lockout behavior as a switch."""
+    (metadata,) = (
+        entity
+        for entity in _thermostat.entity_metadata
+        if isinstance(entity, SwitchMetadata)
+        and entity.attribute_name == UserInterface.AttributeDefs.keypad_lockout.name
+    )
+
+    assert metadata.cluster_id == UserInterface.cluster_id
+    assert metadata.off_value == 0
+    assert metadata.on_value == 1
+    assert metadata.translation_key == "child_lock"
+    assert any(
+        disabled.cluster_id == UserInterface.cluster_id
+        and disabled.function is not None
+        for disabled in _thermostat.disabled_default_entities
+    )
+
+
+def test_thermostat_status_bitmaps_update_boolean_attributes(
+    zigpy_device_from_v2_quirk,
+):
+    """Status bitmaps are split into the individual diagnostic flags."""
+    cluster = _make_thermostat(zigpy_device_from_v2_quirk)
+
+    cluster._update_attribute(cluster.AttributeDefs.sensor_error.id, None)  # noqa: SLF001
+    cluster._update_attribute(cluster.AttributeDefs.sensor_error.id, 0b101)
+    cluster._update_attribute(cluster.AttributeDefs.event_status.id, 0b1010)
+    cluster._update_attribute(0xFFFF, 1)  # noqa: SLF001
+
+    assert cluster.get("sensor_error_remote_disconnected") is True
+    assert cluster.get("sensor_error_local_disconnected") is False
+    assert cluster.get("sensor_error_short_circuit") is True
+    assert cluster.get("status_heat_inefficient") is False
+    assert cluster.get("status_antifrost") is True
+    assert cluster.get("status_open_window") is False
+    assert cluster.get("status_invalid_time") is True
+
+
+def test_thermostat_schedule_helpers_validate_and_format():
+    """Schedule helper methods reject malformed data and format transitions."""
+    with pytest.raises(TypeError, match="Schedule must be a string"):
+        SDevicesThermostatCluster._parse_schedule(None)
+
+    with pytest.raises(ValueError, match="Expected 2 schedule values"):
+        SDevicesThermostatCluster._format_schedule([360], 1)
+
+    assert SDevicesThermostatCluster._format_schedule([1080, 1750], 1) == "18:00/17.5"
+
+
+@pytest.mark.asyncio
+async def test_thermostat_mixed_schedule_read_and_write(
+    zigpy_device_from_v2_quirk,
+):
+    """Regular attributes continue to use the base read/write implementation."""
+    cluster = _make_thermostat(zigpy_device_from_v2_quirk)
+    cluster.update_attribute(
+        Thermostat.AttributeDefs.local_temperature.id,
+        2000,
+    )
+    cluster.command = mock.AsyncMock()
+
+    success, failure = await cluster.read_attributes(
+        [Thermostat.AttributeDefs.local_temperature.name, "schedule_monday"],
+        only_cache=True,
+    )
+
+    assert success["schedule_monday"] is None
+    assert failure == {}
+    assert cluster.command.await_count == 0
+
+    regular_result = [
+        foundation.WriteAttributesStatusRecord(status=foundation.Status.SUCCESS)
+    ]
+    with mock.patch.object(
+        CustomCluster,
+        "write_attributes",
+        new=mock.AsyncMock(return_value=[regular_result]),
+    ):
+        result = await cluster.write_attributes(
+            {
+                Thermostat.AttributeDefs.local_temperature.name: 2000,
+                "schedule_monday": "06:00/20",
+            }
+        )
+
+    assert len(result[0]) == 2
+
+
+@pytest.mark.parametrize(
+    "mode, values, count",
+    (
+        (Thermostat.SeqMode.Cool, [1080, 1750], 1),
+        (Thermostat.SeqMode.Heat, [], 1),
+    ),
+)
+def test_thermostat_ignores_unsupported_schedule_responses(
+    zigpy_device_from_v2_quirk, mode, values, count
+):
+    """Unsupported modes and malformed responses do not update local schedules."""
+    cluster = _make_thermostat(zigpy_device_from_v2_quirk)
+    hdr = mock.Mock(
+        command_id=Thermostat.ClientCommandDefs.get_weekly_schedule_response.id
+    )
+    args = mock.Mock(
+        day_of_week_for_sequence=Thermostat.SeqDayOfWeek.Monday,
+        mode_for_sequence=mode,
+        values=values,
+        num_transitions_for_sequence=count,
+    )
+
+    cluster.handle_cluster_request(hdr, args)
+
+    assert cluster.get("schedule_monday") is None
+
+
+def test_thermostat_delegates_unknown_cluster_commands(
+    zigpy_device_from_v2_quirk,
+):
+    """Unknown commands retain the standard cluster handling."""
+    cluster = _make_thermostat(zigpy_device_from_v2_quirk)
+    cluster.handle_cluster_request(mock.Mock(command_id=0xFF), object())
+
+
+@pytest.mark.asyncio
+async def test_thermostat_schedule_write_groups_identical_days(
+    zigpy_device_from_v2_quirk,
+):
+    """Identical day schedules are sent as one standard ZCL schedule command."""
+    cluster = _make_thermostat(zigpy_device_from_v2_quirk)
+    cluster.command = mock.AsyncMock()
+    schedule = "18:00/17.5 06:00/20"
+
+    result = await cluster.write_attributes(
+        {
+            "schedule_monday": schedule,
+            "schedule_tuesday": schedule,
+        }
+    )
+
+    set_days = Thermostat.SeqDayOfWeek.Monday | Thermostat.SeqDayOfWeek.Tuesday
+    assert cluster.command.await_args_list == [
+        mock.call(
+            Thermostat.ServerCommandDefs.set_weekly_schedule.id,
+            2,
+            set_days,
+            Thermostat.SeqMode.Heat,
+            [360, 2000, 1080, 1750],
+            expect_reply=False,
+        ),
+        mock.call(
+            Thermostat.ServerCommandDefs.get_weekly_schedule.id,
+            Thermostat.SeqDayOfWeek.Monday,
+            Thermostat.SeqMode.Heat,
+            expect_reply=False,
+        ),
+        mock.call(
+            Thermostat.ServerCommandDefs.get_weekly_schedule.id,
+            Thermostat.SeqDayOfWeek.Tuesday,
+            Thermostat.SeqMode.Heat,
+            expect_reply=False,
+        ),
+    ]
+    assert cluster.get("schedule_monday") == schedule
+    assert cluster.get("schedule_tuesday") == schedule
+    assert all(record.status == foundation.Status.SUCCESS for record in result[0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "schedule, error",
+    (
+        ("6:00/20", "HH:MM/temperature"),
+        ("06:00/20.1", "HH:MM/temperature"),
+        ("06:00/50.5", "between 0 and 50"),
+        (" ".join(f"{hour:02d}:00/20" for hour in range(11)), "no more than 10"),
+    ),
+)
+async def test_thermostat_schedule_write_validation(
+    zigpy_device_from_v2_quirk, schedule, error
+):
+    """Invalid schedules fail locally and are never sent to the thermostat."""
+    cluster = _make_thermostat(zigpy_device_from_v2_quirk)
+    cluster.command = mock.AsyncMock()
+
+    with pytest.raises(ValueError, match=error):
+        await cluster.write_attributes({"schedule_monday": schedule})
+
+    cluster.command.assert_not_awaited()
+
+
+def test_thermostat_schedule_response_updates_all_returned_days(
+    zigpy_device_from_v2_quirk,
+):
+    """A standard Get Weekly Schedule response populates local day strings."""
+    cluster = _make_thermostat(zigpy_device_from_v2_quirk)
+    days = Thermostat.SeqDayOfWeek.Monday | Thermostat.SeqDayOfWeek.Tuesday
+    hdr = mock.Mock(
+        command_id=Thermostat.ClientCommandDefs.get_weekly_schedule_response.id
+    )
+    args = Thermostat.ClientCommandDefs.get_weekly_schedule_response.schema(
+        num_transitions_for_sequence=2,
+        day_of_week_for_sequence=days,
+        mode_for_sequence=Thermostat.SeqMode.Heat,
+        values=[1080, 1750, 360, 2000],
+    )
+
+    cluster.handle_cluster_request(hdr, args)
+
+    expected = "06:00/20 18:00/17.5"
+    assert cluster.get("schedule_monday") == expected
+    assert cluster.get("schedule_tuesday") == expected
+    assert cluster.get("schedule_sunday") is None
+
+
+@pytest.mark.asyncio
+async def test_thermostat_schedule_is_loaded_on_configuration(
+    zigpy_device_from_v2_quirk,
+):
+    """Configuration binds reporting and requests each weekday separately."""
+    cluster = _make_thermostat(zigpy_device_from_v2_quirk)
+    cluster.bind = mock.AsyncMock()
+    cluster.command = mock.AsyncMock()
+
+    await cluster.apply_custom_configuration()
+
+    cluster.bind.assert_awaited_once()
+    assert cluster.command.await_args_list == [
+        mock.call(
+            Thermostat.ServerCommandDefs.get_weekly_schedule.id,
+            day,
+            Thermostat.SeqMode.Heat,
+            expect_reply=False,
+        )
+        for day in (
+            Thermostat.SeqDayOfWeek.Monday,
+            Thermostat.SeqDayOfWeek.Tuesday,
+            Thermostat.SeqDayOfWeek.Wednesday,
+            Thermostat.SeqDayOfWeek.Thursday,
+            Thermostat.SeqDayOfWeek.Friday,
+            Thermostat.SeqDayOfWeek.Saturday,
+            Thermostat.SeqDayOfWeek.Sunday,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_thermostat_schedule_read_is_local_and_refreshes_device(
+    zigpy_device_from_v2_quirk,
+):
+    """Manage Zigbee device reads the cache while requesting a fresh schedule."""
+    cluster = _make_thermostat(zigpy_device_from_v2_quirk)
+    cluster.update_attribute(
+        cluster.AttributeDefs.schedule_monday.id,
+        "06:00/20 18:00/17.5",
+    )
+    cluster.command = mock.AsyncMock()
+
+    success, failure = await cluster.read_attributes(["schedule_monday"])
+
+    assert success == {"schedule_monday": "06:00/20 18:00/17.5"}
+    assert failure == {}
+    cluster.command.assert_awaited_once_with(
+        Thermostat.ServerCommandDefs.get_weekly_schedule.id,
+        Thermostat.SeqDayOfWeek.Monday,
+        Thermostat.SeqMode.Heat,
+        expect_reply=False,
+    )
+
+    cluster.command.reset_mock()
+    assert await cluster.read_attributes(["schedule_monday"], only_cache=True) == (
+        {"schedule_monday": "06:00/20 18:00/17.5"},
+        {},
+    )
+    cluster.command.assert_not_awaited()
 
 
 @pytest.mark.parametrize("model", ("SBDV-00196", "SBDV-00197"))
@@ -622,3 +964,195 @@ def test_socket_scaling_and_reporting_metadata():
     assert emergency.initially_disabled is True
     assert emergency.reporting_config is None
     assert emergency.attribute_initialized_from_cache is False
+
+
+def _make_complete_thermostat(zigpy_device_from_v2_quirk):
+    """Create an SBDV-00205 with every cluster replaced by the quirk."""
+    return zigpy_device_from_v2_quirk(
+        "SDevices",
+        "SBDV-00205",
+        cluster_ids={
+            1: {
+                DeviceTemperature.cluster_id: ClusterType.Server,
+                Thermostat.cluster_id: ClusterType.Server,
+                UserInterface.cluster_id: ClusterType.Server,
+                SDevicesCluster.cluster_id: ClusterType.Server,
+                Diagnostic.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+
+def test_complete_thermostat_clusters_and_attributes(zigpy_device_from_v2_quirk):
+    """The full thermostat quirk augments every relevant device cluster."""
+    device = _make_complete_thermostat(zigpy_device_from_v2_quirk)
+    thermostat = device.endpoints[1].thermostat
+
+    assert isinstance(thermostat, SDevicesThermostatCluster)
+    for attribute_name, attribute_id in (
+        ("remote_temperature", 0x4001),
+        ("sensor_mode", 0x4003),
+        ("heating_hysteresis", 0x4019),
+        ("min_local_temperature_limit", 0x40F0),
+        ("output_mode", 0x4100),
+        ("sensor_error", 0x4102),
+        ("event_status", 0x4103),
+        ("remote_sensor_timeout", 0x4203),
+    ):
+        attribute = thermostat.find_attribute(attribute_name)
+        assert attribute.id == attribute_id
+        assert attribute.manufacturer_code == 0x152F
+
+    assert (
+        device.endpoints[1].thermostat_ui.find_attribute("brightness_steady_mode").id
+        == 0x2002
+    )
+    assert device.endpoints[1].device_temperature.__class__.__name__ == (
+        "SDevicesDeviceTemperatureCluster"
+    )
+
+
+def test_thermostat_status_bitmaps_are_split(zigpy_device_from_v2_quirk):
+    """Emergency, sensor-error and event-status bits update independently."""
+    device = _make_complete_thermostat(zigpy_device_from_v2_quirk)
+    proprietary = device.endpoints[1].sdevices_cluster
+    thermostat = device.endpoints[1].thermostat
+
+    emergency_flags = {
+        "emergency_overcurrent": 0x04,
+        "emergency_overheat": 0x08,
+        "emergency_no_load": 0x10,
+        "emergency_no_data": 0x20,
+        "emergency_wrong_data": 0x40,
+    }
+    for attribute_name, bit in emergency_flags.items():
+        proprietary.update_attribute(
+            SDevicesCluster.AttributeDefs.emergency_shutoff_state.id, bit
+        )
+        assert proprietary.get(attribute_name) is True
+        assert all(
+            proprietary.get(other) is False
+            for other in emergency_flags
+            if other != attribute_name
+        )
+
+    for source, flags in (
+        (
+            SDevicesThermostatCluster.AttributeDefs.sensor_error.id,
+            {
+                "sensor_error_remote_disconnected": 0x01,
+                "sensor_error_local_disconnected": 0x02,
+                "sensor_error_short_circuit": 0x04,
+            },
+        ),
+        (
+            SDevicesThermostatCluster.AttributeDefs.event_status.id,
+            {
+                "status_heat_inefficient": 0x01,
+                "status_antifrost": 0x02,
+                "status_open_window": 0x04,
+                "status_invalid_time": 0x08,
+            },
+        ),
+    ):
+        for attribute_name, bit in flags.items():
+            thermostat.update_attribute(source, bit)
+            assert thermostat.get(attribute_name) is True
+            assert all(
+                thermostat.get(other) is False
+                for other in flags
+                if other != attribute_name
+            )
+
+
+def test_thermostat_entities_cover_full_feature_set():
+    """The builder publishes config, metering, protection and diagnostics."""
+    metadata = _thermostat.entity_metadata
+    attributes = {
+        entity.attribute_name
+        for entity in metadata
+        if hasattr(entity, "attribute_name")
+    }
+
+    assert {
+        "sensor_mode",
+        "output_mode",
+        "local_sensor_type",
+        "heating_hysteresis",
+        "min_local_temperature_limit",
+        "max_local_temperature_limit",
+        "remote_temperature_calibration",
+        "remote_sensor_timeout",
+        "remote_temperature",
+        "open_window_enabled",
+        "brightness_operations_mode",
+        "brightness_steady_mode",
+        "brightness_night_mode",
+        "rms_voltage_mv",
+        "rms_current_ma",
+        "active_power_mw",
+        "emergency_no_load",
+        "sensor_error_remote_disconnected",
+        "status_invalid_time",
+        "sdevices_uptime_s",
+        "sdevices_relay1_switches",
+    } <= attributes
+    assert "persistent_memory_writes" not in attributes
+
+
+def test_thermostat_scaling_and_firmware_reporting_defaults():
+    """Scaled values retain the reporting table supplied by firmware."""
+    metadata = _thermostat.entity_metadata
+    numbers = {
+        entity.attribute_name: entity
+        for entity in metadata
+        if isinstance(entity, NumberMetadata)
+    }
+
+    assert numbers["remote_temperature_calibration"].multiplier == 0.1
+    assert numbers["remote_temperature"].multiplier == 0.01
+    assert numbers["remote_temperature"].initially_disabled is True
+    assert numbers["upper_current_threshold"].multiplier == 0.001
+
+    remote_entities = [
+        entity
+        for entity in metadata
+        if getattr(entity, "attribute_name", None)
+        in {
+            "rms_voltage_mv",
+            "rms_current_ma",
+            "active_power_mw",
+            "emergency_shutoff_state",
+            "sensor_error",
+            "event_status",
+            "current_temperature",
+        }
+    ]
+    assert remote_entities
+    assert all(entity.reporting_config is None for entity in remote_entities)
+    assert all(
+        entity.attribute_initialized_from_cache is False for entity in remote_entities
+    )
+
+
+@pytest.mark.asyncio
+async def test_thermostat_suppresses_configure_reporting(
+    zigpy_device_from_v2_quirk,
+):
+    """ZHA reporting requests do not overwrite SDevices firmware defaults."""
+    cluster = _make_thermostat(zigpy_device_from_v2_quirk)
+    cluster._configure_reporting = mock.AsyncMock()
+    attribute = Thermostat.AttributeDefs.local_temperature
+
+    result = await cluster.configure_reporting_multiple(
+        {
+            attribute: ReportingConfig(
+                min_interval=1,
+                max_interval=2,
+                reportable_change=1,
+            )
+        }
+    )
+
+    assert result == {attribute: foundation.Status.SUCCESS}
+    cluster._configure_reporting.assert_not_awaited()

--- a/zhaquirks/sdevices/__init__.py
+++ b/zhaquirks/sdevices/__init__.py
@@ -533,6 +533,10 @@ class SDevicesTwoButtonCluster(_SDevicesBaseButtonCluster):
 
 
 class SDevicesDeviceTemperatureCluster(
-    _SDevicesBindOnlyMixin, CustomCluster, DeviceTemperature
+    _SDevicesFirmwareReportingMixin, CustomCluster, DeviceTemperature
 ):
-    """Device temperature using the reporting table shipped by the firmware."""
+    """Device temperature using the reporting table shipped by the firmware.
+
+    ZHA's standard DeviceTemperature cluster handler already binds this cluster,
+    so only suppress its Configure Reporting command here.
+    """

--- a/zhaquirks/sdevices/__init__.py
+++ b/zhaquirks/sdevices/__init__.py
@@ -1,0 +1,538 @@
+"""SDevices shared clusters, enums and constants.
+
+These handlers cover the native SDevices Zigbee devices, ported from the
+``zigbee-herdsman-converters`` reference implementation. Device families live in
+their own modules:
+
+* ``switch.py`` - wall switches (SBDV-00196 / 00197 / 00199 / 00200)
+* ``cover.py``  - window covering mode of the two-button switches (00199 / 00200)
+* ``socket.py`` - wall socket (SBDV-00202)
+
+The manufacturer-specific cluster 0xFCCF (``manuSpecificSDevices``) and the
+manufacturer attributes added to the standard ``OnOff`` (0x0006),
+``WindowCovering`` (0x0102) and ``Diagnostic`` (0x0B05) clusters all use
+manufacturer code 0x152F (5423).
+
+The 0xFCCF cluster declares the attributes used by the switch and socket
+families. The RTC attributes (used only by the thermostat model, not ported
+yet) are omitted.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+import zigpy.types as t
+from zigpy.typing import UNDEFINED, UndefinedType
+from zigpy.zcl import ReportingConfig
+from zigpy.zcl.clusters.closures import WindowCovering, WindowCoveringMode
+from zigpy.zcl.clusters.general import DeviceTemperature, MultistateInput, OnOff
+from zigpy.zcl.clusters.homeautomation import Diagnostic
+from zigpy.zcl.foundation import BaseAttributeDefs, Status, ZCLAttributeDef
+
+from zhaquirks.clusters import CustomCluster
+from zhaquirks.const import ZHA_SEND_EVENT
+
+SDEVICES = "SDevices"
+SDEVICES_MFR_CODE = 0x152F  # 5423 (see node descriptor)
+
+
+class _SDevicesFirmwareReportingMixin:
+    """Keep the reporting configuration owned by the device firmware.
+
+    ZHA platform entities bind standard clusters and normally follow that with
+    ``Configure Reporting`` using ZHA's own intervals. SDevices firmware ships
+    the reporting table, so acknowledge those configuration attempts locally
+    while leaving the table on the device unchanged.
+    """
+
+    async def configure_reporting_multiple(
+        self, config: dict[ZCLAttributeDef, ReportingConfig]
+    ) -> dict[ZCLAttributeDef, Status]:
+        """Do not replace the firmware reporting configuration."""
+        return dict.fromkeys(config, Status.SUCCESS)
+
+
+class _SDevicesBindOnlyMixin(_SDevicesFirmwareReportingMixin):
+    """Bind a report source without sending ``Configure Reporting``."""
+
+    async def apply_custom_configuration(self, *args, **kwargs) -> None:
+        """Bind reports to the coordinator and retain firmware defaults."""
+        await self.bind()
+
+
+class ButtonEventMode(t.enum8):
+    """Kind of events emitted on a button press (``event_mode``)."""
+
+    No_event = 0x00
+    Multistate_input = 0x01
+
+
+class RelayMode(t.enum8):
+    """Relay/button coupling mode (``relay_mode``)."""
+
+    Control_relay = 0x00
+    Decoupled = 0x01
+
+
+class ButtonsMode(t.enum8):
+    """Cover button mode (``buttons_mode``, EP3)."""
+
+    Normal = 0x00
+    Inverted = 0x01
+
+
+class PowerProfile(t.enum8):
+    """Power profile used when no neutral wire is connected (``power_profile``).
+
+    ``Quick`` is the most responsive; ``Anti_flicker_*`` values trade responsiveness
+    for a longer polling period (milliseconds) to avoid flicker; the fallback value
+    is the safest mode the device falls back to on instability.
+    """
+
+    Quick = 0x00
+    Anti_flicker_250 = 0x01
+    Anti_flicker_500 = 0x02
+    Anti_flicker_750 = 0x03
+    Anti_flicker_1000 = 0x04
+    Anti_flicker_1250 = 0x05
+    Anti_flicker_1750 = 0x06
+    Anti_flicker_2000 = 0x07
+    Anti_flicker_fallback = 0xFE
+
+
+class LedIndicationType(t.enum8):
+    """LED indication style (``led_indication_type``)."""
+
+    Continuous = 0x00
+    Flashes = 0x01
+
+
+class NeutralPresence(t.enum8):
+    """Read-only indicator of neutral wire presence (``neutral_presence``)."""
+
+    No = 0x00
+    Yes = 0x01
+
+
+class EmergencyRecovery(t.enum8):
+    """Auto-recovery condition after an emergency shutoff (``emergency_shutoff_recovery``).
+
+    The attribute stays BITMAP16 on the wire; this enum8 only drives the select
+    entity, like ``RelayMode`` over the Bool ``sdevices_relay_decouple`` attribute.
+    """
+
+    Disabled = 0x00
+    Voltage_is_good = 0x01
+
+
+class SDevicesCluster(_SDevicesFirmwareReportingMixin, CustomCluster):
+    """Manufacturer-specific cluster 0xFCCF (``manuSpecificSDevices``).
+
+    Declares the attributes used by the switch and socket families; the
+    thermostat-only RTC attributes are omitted.
+    """
+
+    cluster_id: Final = 0xFCCF
+    ep_attribute: Final = "sdevices_cluster"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        # button
+        button_event_mode: Final = ZCLAttributeDef(
+            id=0x1001,
+            type=ButtonEventMode,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        button_enable_multi_click: Final = ZCLAttributeDef(
+            id=0x1002,
+            type=t.Bool,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        child_lock: Final = ZCLAttributeDef(
+            id=0x1003,
+            type=t.Bool,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        # LED indication in the ON state
+        led_indicator_on_enable: Final = ZCLAttributeDef(
+            id=0x2001,
+            type=t.Bool,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        led_indicator_on_h: Final = ZCLAttributeDef(
+            id=0x2002,
+            type=t.uint16_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        led_indicator_on_s: Final = ZCLAttributeDef(
+            id=0x2003,
+            type=t.uint8_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        led_indicator_on_b: Final = ZCLAttributeDef(
+            id=0x2004,
+            type=t.uint8_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        # LED indication in the OFF state
+        led_indicator_off_enable: Final = ZCLAttributeDef(
+            id=0x2005,
+            type=t.Bool,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        led_indicator_off_h: Final = ZCLAttributeDef(
+            id=0x2006,
+            type=t.uint16_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        led_indicator_off_s: Final = ZCLAttributeDef(
+            id=0x2007,
+            type=t.uint8_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        led_indicator_off_b: Final = ZCLAttributeDef(
+            id=0x2008,
+            type=t.uint8_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        led_indication_type: Final = ZCLAttributeDef(
+            id=0x2009,
+            type=LedIndicationType,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        # emergency shutoff and protection thresholds (socket 00202)
+        emergency_shutoff_state: Final = ZCLAttributeDef(
+            id=0x3001,
+            type=t.bitmap16,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        # Per-flag views of emergency_shutoff_state (0x3001). These are synthetic,
+        # local-only attributes - never read or written over the air. They are
+        # populated by SDevicesCluster._update_attribute splitting the bitmap, so
+        # each flag becomes its own binary sensor that updates correctly on a live
+        # attribute report (the generic binary sensor ignores attribute_converter on
+        # updates and would otherwise flip every flag together).
+        emergency_overvoltage: Final = ZCLAttributeDef(
+            id=0x3101, type=t.Bool, access="r"
+        )
+        emergency_undervoltage: Final = ZCLAttributeDef(
+            id=0x3102, type=t.Bool, access="r"
+        )
+        emergency_overcurrent: Final = ZCLAttributeDef(
+            id=0x3103, type=t.Bool, access="r"
+        )
+        emergency_overheat: Final = ZCLAttributeDef(id=0x3104, type=t.Bool, access="r")
+        emergency_shutoff_recovery: Final = ZCLAttributeDef(
+            id=0x3002,
+            type=t.bitmap16,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        upper_voltage_threshold: Final = ZCLAttributeDef(
+            id=0x3011,
+            type=t.uint32_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        lower_voltage_threshold: Final = ZCLAttributeDef(
+            id=0x3012,
+            type=t.uint32_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        upper_current_threshold: Final = ZCLAttributeDef(
+            id=0x3013,
+            type=t.uint32_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        upper_temp_threshold: Final = ZCLAttributeDef(
+            id=0x3014,
+            type=t.int16s,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        # energy metering (socket 00202)
+        rms_voltage_mv: Final = ZCLAttributeDef(
+            id=0x4001,
+            type=t.uint32_t,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        rms_current_ma: Final = ZCLAttributeDef(
+            id=0x4002,
+            type=t.uint32_t,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        active_power_mw: Final = ZCLAttributeDef(
+            id=0x4003,
+            type=t.int32s,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        # power without neutral (optional-neutral models 00197 / 00200)
+        power_profile: Final = ZCLAttributeDef(
+            id=0x4100,
+            type=PowerProfile,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        neutral_presence: Final = ZCLAttributeDef(
+            id=0x4101,
+            type=NeutralPresence,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+
+    # Bits of emergency_shutoff_state (0x3001) -> synthetic per-flag attribute.
+    _EMERGENCY_BITS: Final = {
+        0x3101: 0x01,  # overvoltage
+        0x3102: 0x02,  # undervoltage
+        0x3103: 0x04,  # overcurrent
+        0x3104: 0x08,  # overheat
+    }
+
+    def _update_attribute(self, attrid, value):
+        """Split the emergency bitmap into per-flag attributes on update."""
+        super()._update_attribute(attrid, value)
+        if (
+            attrid == self.AttributeDefs.emergency_shutoff_state.id
+            and value is not None
+        ):
+            for flag_id, bit in self._EMERGENCY_BITS.items():
+                super()._update_attribute(flag_id, bool(value & bit))
+
+
+class SDevicesReportingCluster(_SDevicesBindOnlyMixin, SDevicesCluster):
+    """Manufacturer cluster instances that produce attribute reports."""
+
+    async def apply_custom_configuration(self, *args, **kwargs) -> None:
+        """Bind only the report-source endpoints used by current devices."""
+        if self.endpoint.endpoint_id in (1, 3):
+            await super().apply_custom_configuration(*args, **kwargs)
+
+
+class SDevicesOnOffCluster(_SDevicesFirmwareReportingMixin, CustomCluster, OnOff):
+    """``OnOff`` (0x0006) with the SDevices relay-decouple attribute."""
+
+    class AttributeDefs(OnOff.AttributeDefs):
+        """Attribute definitions."""
+
+        sdevices_relay_decouple: Final = ZCLAttributeDef(
+            id=0x10DC,
+            type=t.Bool,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+
+
+class SDevicesWindowCoveringCluster(
+    _SDevicesFirmwareReportingMixin, CustomCluster, WindowCovering
+):
+    """``WindowCovering`` (0x0102) with SDevices manufacturer attributes (EP3).
+
+    The attribute IDs 0x1001-0x1003 here do not clash with the same IDs on the
+    0xFCCF cluster - attribute IDs are scoped per cluster.
+    """
+
+    class AttributeDefs(WindowCovering.AttributeDefs):
+        """Attribute definitions."""
+
+        sdevices_calibration_time: Final = ZCLAttributeDef(
+            id=0x1001,
+            type=t.uint16_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        sdevices_buttons_mode: Final = ZCLAttributeDef(
+            id=0x1002,
+            type=ButtonsMode,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        sdevices_motor_timeout: Final = ZCLAttributeDef(
+            id=0x1003,
+            type=t.uint16_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        cover_calibration_mode: Final = ZCLAttributeDef(
+            id=0xF001, type=t.Bool, access="rw"
+        )
+        cover_maintenance_mode: Final = ZCLAttributeDef(
+            id=0xF002, type=t.Bool, access="rw"
+        )
+        cover_led_feedback: Final = ZCLAttributeDef(id=0xF003, type=t.Bool, access="rw")
+
+    _MODE_BITS: Final = {
+        AttributeDefs.cover_calibration_mode.id: WindowCoveringMode.Run_in_calibration_mode,
+        AttributeDefs.cover_maintenance_mode.id: WindowCoveringMode.Motor_in_maintenance_mode,
+        AttributeDefs.cover_led_feedback.id: WindowCoveringMode.LEDs_display_feedback,
+    }
+
+    def _update_attribute(self, attrid, value):
+        """Split the standard Mode bitmap into local per-bit attributes."""
+        super()._update_attribute(attrid, value)
+        if attrid == self.AttributeDefs.window_covering_mode.id and value is not None:
+            mode = WindowCoveringMode(value)
+            for flag_id, bit in self._MODE_BITS.items():
+                super()._update_attribute(flag_id, bit in mode)
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | ZCLAttributeDef, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,
+        **kwargs,
+    ) -> list:
+        """Translate local per-bit writes into one Mode bitmap write."""
+        mode_updates: list[tuple[WindowCoveringMode, bool]] = []
+        translated: dict[str | int | ZCLAttributeDef, Any] = {}
+
+        for attr, value in attributes.items():
+            attr_def = self.find_attribute(attr, manufacturer_code=manufacturer)
+            if (bit := self._MODE_BITS.get(attr_def.id)) is None:
+                translated[attr] = value
+            else:
+                mode_updates.append((bit, bool(value)))
+
+        mode_attr = self.AttributeDefs.window_covering_mode
+        if mode_updates:
+            current_mode = self.get(mode_attr.id)
+            if current_mode is None:
+                success, _ = await self.read_attributes(
+                    [mode_attr], manufacturer=manufacturer
+                )
+                current_mode = success.get(mode_attr.name)
+            if current_mode is None:
+                raise ValueError(
+                    "Unable to read WindowCovering.Mode before updating it"
+                )
+
+            mode = WindowCoveringMode(current_mode)
+            for bit, enabled in mode_updates:
+                if enabled:
+                    mode |= bit
+                else:
+                    mode &= ~bit
+            translated[mode_attr] = mode
+
+        result = await super().write_attributes(
+            translated, manufacturer=manufacturer, **kwargs
+        )
+        if mode_updates and all(
+            record.status is Status.SUCCESS for records in result for record in records
+        ):
+            self.update_attribute(mode_attr.id, translated[mode_attr])
+        return result
+
+
+class SDevicesDiagnosticCluster(_SDevicesBindOnlyMixin, CustomCluster, Diagnostic):
+    """``Diagnostic`` (0x0B05) with SDevices telemetry (uptime / clicks / switches)."""
+
+    class AttributeDefs(Diagnostic.AttributeDefs):
+        """Attribute definitions."""
+
+        sdevices_uptime_s: Final = ZCLAttributeDef(
+            id=0x1001,
+            type=t.uint32_t,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        sdevices_button1_clicks: Final = ZCLAttributeDef(
+            id=0x1002,
+            type=t.uint32_t,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        sdevices_button2_clicks: Final = ZCLAttributeDef(
+            id=0x1003,
+            type=t.uint32_t,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        sdevices_button3_clicks: Final = ZCLAttributeDef(
+            id=0x1004,
+            type=t.uint32_t,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        sdevices_relay1_switches: Final = ZCLAttributeDef(
+            id=0x1005,
+            type=t.uint32_t,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        sdevices_relay2_switches: Final = ZCLAttributeDef(
+            id=0x1006,
+            type=t.uint32_t,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+
+
+class _SDevicesBaseButtonCluster(
+    _SDevicesBindOnlyMixin, CustomCluster, MultistateInput
+):
+    """MultistateInput base that binds physical button reports to the coordinator."""
+
+
+class SDevicesButtonCluster(_SDevicesBaseButtonCluster):
+    """Single-button ``MultistateInput`` (0x0012): present_value -> button events.
+
+    The device reports button presses via the ``present_value`` attribute
+    (0 = hold, 1 = single, 2 = double). Each value is turned into a
+    ``zha_send_event`` matching the device automation triggers.
+    """
+
+    _ACTIONS: dict[int, str] = {
+        0: "button_hold",
+        1: "button_single",
+        2: "button_double",
+    }
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == MultistateInput.AttributeDefs.present_value.id:
+            action = self._ACTIONS.get(value)
+            if action is not None:
+                self.listener_event(ZHA_SEND_EVENT, action, {})
+
+
+class SDevicesTwoButtonCluster(_SDevicesBaseButtonCluster):
+    """Two-gang ``MultistateInput`` (0x0012): present_value -> per-endpoint events.
+
+    Emits ``{single,double,hold}_switch_{endpoint_id}`` so the two gangs (EP1/EP2)
+    produce distinct actions, matching ``postfixWithEndpointName`` in the reference.
+    """
+
+    _ACTIONS: dict[int, str] = {0: "hold", 1: "single", 2: "double"}
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == MultistateInput.AttributeDefs.present_value.id:
+            raw = self._ACTIONS.get(value)
+            if raw is not None:
+                action = f"{raw}_switch_{self.endpoint.endpoint_id}"
+                self.listener_event(ZHA_SEND_EVENT, action, {})
+
+
+class SDevicesDeviceTemperatureCluster(
+    _SDevicesBindOnlyMixin, CustomCluster, DeviceTemperature
+):
+    """Device temperature using the reporting table shipped by the firmware."""

--- a/zhaquirks/sdevices/__init__.py
+++ b/zhaquirks/sdevices/__init__.py
@@ -7,15 +7,16 @@ their own modules:
 * ``switch.py`` - wall switches (SBDV-00196 / 00197 / 00199 / 00200)
 * ``cover.py``  - window covering mode of the two-button switches (00199 / 00200)
 * ``socket.py`` - wall socket (SBDV-00202)
+* ``thermostat.py`` - smart thermostat SBDV-00205
 
 The manufacturer-specific cluster 0xFCCF (``manuSpecificSDevices``) and the
 manufacturer attributes added to the standard ``OnOff`` (0x0006),
 ``WindowCovering`` (0x0102) and ``Diagnostic`` (0x0B05) clusters all use
 manufacturer code 0x152F (5423).
 
-The 0xFCCF cluster declares the attributes used by the switch and socket
-families. The RTC attributes (used only by the thermostat model, not ported
-yet) are omitted.
+The 0xFCCF cluster declares attributes shared by the device families. The
+thermostat uses its standard ``Time`` client cluster for RTC synchronization,
+so its legacy manufacturer-specific RTC attributes are not required.
 """
 
 from __future__ import annotations

--- a/zhaquirks/sdevices/cover.py
+++ b/zhaquirks/sdevices/cover.py
@@ -1,0 +1,269 @@
+"""SDevices two-button switches in window-covering mode.
+
+SBDV-00199 / 00200 are dual-mode devices. In covering mode they announce a
+single endpoint (EP3, device type ``WINDOW_COVERING``) carrying the
+``WindowCovering`` cluster instead of the two ``OnOff`` gangs of the switch
+mode. The switch and cover signatures share one quirk registry entry per model.
+This module only adds the cover-mode entity metadata; ``switch.py`` owns the
+registrations.
+
+The cover entity (position / open / close / stop) is created by ZHA from the
+``WindowCovering`` cluster on the covering endpoint. The cluster is replaced by
+``SDevicesWindowCoveringCluster`` to expose the manufacturer attributes
+(calibration time, buttons mode, motor timeout).
+"""
+
+from __future__ import annotations
+
+from zigpy.zcl.clusters.closures import WindowCovering
+
+from zhaquirks.builder import EntityType, QuirkBuilder, UnitOfTime
+from zhaquirks.sdevices import ButtonsMode, SDevicesCluster, SDevicesDiagnosticCluster
+
+_COVER_ENDPOINT = 3
+_READ_ON_STARTUP = {"attribute_initialized_from_cache": False}
+
+
+def _add_cover_entities(qb: QuirkBuilder) -> QuirkBuilder:
+    """Add covering-mode entities for SBDV-00199 / SBDV-00200 on EP3."""
+    ep = _COVER_ENDPOINT
+    return (
+        qb
+        # The raw Mode bitmap is kept disabled but forces one startup read. The
+        # custom cluster splits it into the three local per-bit attributes below;
+        # ZHA's native WindowCovering inversion switch handles the direction bit.
+        .sensor(
+            WindowCovering.AttributeDefs.window_covering_mode.name,
+            WindowCovering.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.DIAGNOSTIC,
+            initially_disabled=True,
+            attribute_initialized_from_cache=False,
+            translation_key="cover_mode",
+            fallback_name="Cover mode",
+        )
+        .switch(
+            "cover_calibration_mode",
+            WindowCovering.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.CONFIG,
+            translation_key="cover_calibration_mode",
+            fallback_name="Cover calibration mode",
+        )
+        .switch(
+            "cover_maintenance_mode",
+            WindowCovering.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.CONFIG,
+            translation_key="cover_maintenance_mode",
+            fallback_name="Cover maintenance mode",
+        )
+        .switch(
+            "cover_led_feedback",
+            WindowCovering.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.CONFIG,
+            translation_key="cover_led_feedback",
+            fallback_name="Cover LED feedback",
+        )
+        # motion parameters (standard WindowCovering attributes)
+        .number(
+            "velocity_lift",
+            WindowCovering.cluster_id,
+            endpoint_id=ep,
+            min_value=0,
+            max_value=1000,
+            step=1,
+            unit="cm/s",
+            entity_type=EntityType.CONFIG,
+            translation_key="velocity",
+            fallback_name="Velocity",
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "acceleration_time_lift",
+            WindowCovering.cluster_id,
+            endpoint_id=ep,
+            min_value=0,
+            max_value=60,
+            step=0.1,
+            multiplier=0.1,
+            unit=UnitOfTime.SECONDS,
+            entity_type=EntityType.CONFIG,
+            translation_key="acceleration_time",
+            fallback_name="Acceleration time",
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "deceleration_time_lift",
+            WindowCovering.cluster_id,
+            endpoint_id=ep,
+            min_value=0,
+            max_value=60,
+            step=0.1,
+            multiplier=0.1,
+            unit=UnitOfTime.SECONDS,
+            entity_type=EntityType.CONFIG,
+            translation_key="deceleration_time",
+            fallback_name="Deceleration time",
+            **_READ_ON_STARTUP,
+        )
+        # manufacturer attributes on the covering cluster
+        .number(
+            "sdevices_calibration_time",
+            WindowCovering.cluster_id,
+            endpoint_id=ep,
+            min_value=0,
+            max_value=3600,
+            step=0.1,
+            multiplier=0.1,
+            unit=UnitOfTime.SECONDS,
+            entity_type=EntityType.CONFIG,
+            translation_key="calibration_time",
+            fallback_name="Calibration time",
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "sdevices_motor_timeout",
+            WindowCovering.cluster_id,
+            endpoint_id=ep,
+            min_value=0,
+            max_value=3600,
+            step=1,
+            unit=UnitOfTime.SECONDS,
+            entity_type=EntityType.CONFIG,
+            translation_key="motor_timeout",
+            fallback_name="Motor timeout",
+            **_READ_ON_STARTUP,
+        )
+        .enum(
+            "sdevices_buttons_mode",
+            ButtonsMode,
+            WindowCovering.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.CONFIG,
+            translation_key="buttons_mode",
+            fallback_name="Buttons mode",
+            **_READ_ON_STARTUP,
+        )
+        # LED indication (covering mode only exposes the OFF set)
+        .switch(
+            "led_indicator_off_enable",
+            SDevicesCluster.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.CONFIG,
+            translation_key="led_indicator_off_enable",
+            fallback_name="LED indicator (off)",
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "led_indicator_off_h",
+            SDevicesCluster.cluster_id,
+            endpoint_id=ep,
+            min_value=0,
+            max_value=359,
+            step=1,
+            unit="°",
+            entity_type=EntityType.CONFIG,
+            translation_key="led_indicator_off_h",
+            fallback_name="LED hue (off)",
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "led_indicator_off_s",
+            SDevicesCluster.cluster_id,
+            endpoint_id=ep,
+            min_value=0,
+            max_value=254,
+            step=1,
+            entity_type=EntityType.CONFIG,
+            translation_key="led_indicator_off_s",
+            fallback_name="LED saturation (off)",
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "led_indicator_off_b",
+            SDevicesCluster.cluster_id,
+            endpoint_id=ep,
+            min_value=1,
+            max_value=254,
+            step=1,
+            entity_type=EntityType.CONFIG,
+            translation_key="led_indicator_off_b",
+            fallback_name="LED brightness (off)",
+            **_READ_ON_STARTUP,
+        )
+        .switch(
+            "child_lock",
+            SDevicesCluster.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.CONFIG,
+            translation_key="child_lock",
+            fallback_name="Child lock",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_uptime_s",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=ep,
+            unit=UnitOfTime.SECONDS,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="uptime",
+            fallback_name="Uptime",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "number_of_resets",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="resets_count",
+            fallback_name="Resets count",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_button1_clicks",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="pairing_button_clicks",
+            fallback_name="Pairing button clicks",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_button2_clicks",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="left_button_clicks",
+            fallback_name="Left button clicks",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_button3_clicks",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="right_button_clicks",
+            fallback_name="Right button clicks",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_relay1_switches",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="relay_switches_1",
+            fallback_name="Relay 1 switches",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_relay2_switches",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=ep,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="relay_switches_2",
+            fallback_name="Relay 2 switches",
+            **_READ_ON_STARTUP,
+        )
+    )

--- a/zhaquirks/sdevices/socket.py
+++ b/zhaquirks/sdevices/socket.py
@@ -1,0 +1,341 @@
+"""SDevices smart wall socket.
+
+Covers the native SDevices wall socket:
+
+* SBDV-00202  Smart Wall Socket (relay, energy metering, protection thresholds)
+
+Single endpoint EP1: the relay (``OnOff``), energy metering and protection
+thresholds on the 0xFCCF cluster, device temperature on ``DeviceTemperature``
+(replaced with a divisor=1 sensor - this device reports whole degrees, while
+ZHA's native one divides by 100) and diagnostics on ``Diagnostic``. The socket
+has no button actions.
+
+The relay is exposed as a ``switch`` entity (endpoint device type
+``ON_OFF_OUTPUT``), matching the reference ``zigbee-herdsman-converters``
+implementation. The power-on behavior comes from ZHA's built-in ``OnOff``
+start-up select.
+"""
+
+from __future__ import annotations
+
+from zigpy.profiles import zha
+from zigpy.zcl.clusters.general import DeviceTemperature
+
+from zhaquirks.builder import (
+    BinarySensorDeviceClass,
+    EntityType,
+    NumberDeviceClass,
+    QuirkBuilder,
+    SensorDeviceClass,
+    SensorStateClass,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfPower,
+    UnitOfTemperature,
+    UnitOfTime,
+)
+from zhaquirks.sdevices import (
+    SDEVICES,
+    EmergencyRecovery,
+    SDevicesCluster,
+    SDevicesDeviceTemperatureCluster,
+    SDevicesDiagnosticCluster,
+    SDevicesOnOffCluster,
+    SDevicesReportingCluster,
+)
+
+_READ_ON_STARTUP = {"attribute_initialized_from_cache": False}
+
+# Emergency flags are exposed as binary sensors on the synthetic per-bit
+# attributes (see SDevicesCluster._update_attribute). Each has its own attribute,
+# so they update independently and correctly on a live report.
+_EMERGENCY_FLAGS = (
+    # (synthetic attribute name, fallback name)
+    ("emergency_overvoltage", "Emergency overvoltage"),
+    ("emergency_undervoltage", "Emergency undervoltage"),
+    ("emergency_overcurrent", "Emergency overcurrent"),
+    ("emergency_overheat", "Emergency overheat"),
+)
+
+
+def _add_led_entities(qb: QuirkBuilder) -> QuirkBuilder:
+    """Add the ON and OFF LED indicator entities on EP1."""
+    for state in ("on", "off"):
+        qb = (
+            qb.switch(
+                f"led_indicator_{state}_enable",
+                SDevicesCluster.cluster_id,
+                entity_type=EntityType.CONFIG,
+                translation_key=f"led_indicator_{state}_enable",
+                fallback_name=f"LED indicator ({state})",
+                **_READ_ON_STARTUP,
+            )
+            .number(
+                f"led_indicator_{state}_h",
+                SDevicesCluster.cluster_id,
+                min_value=0,
+                max_value=359,
+                step=1,
+                unit="°",
+                entity_type=EntityType.CONFIG,
+                translation_key=f"led_indicator_{state}_h",
+                fallback_name=f"LED hue ({state})",
+                **_READ_ON_STARTUP,
+            )
+            .number(
+                f"led_indicator_{state}_s",
+                SDevicesCluster.cluster_id,
+                min_value=0,
+                max_value=254,
+                step=1,
+                entity_type=EntityType.CONFIG,
+                translation_key=f"led_indicator_{state}_s",
+                fallback_name=f"LED saturation ({state})",
+                **_READ_ON_STARTUP,
+            )
+            .number(
+                f"led_indicator_{state}_b",
+                SDevicesCluster.cluster_id,
+                min_value=1,
+                max_value=254,
+                step=1,
+                entity_type=EntityType.CONFIG,
+                translation_key=f"led_indicator_{state}_b",
+                fallback_name=f"LED brightness ({state})",
+                **_READ_ON_STARTUP,
+            )
+        )
+    return qb
+
+
+def _add_metering(qb: QuirkBuilder) -> QuirkBuilder:
+    """Add energy metering sensors using the firmware reporting configuration."""
+    return (
+        qb.sensor(
+            "rms_voltage_mv",
+            SDevicesCluster.cluster_id,
+            divisor=1000,
+            suggested_display_precision=1,
+            unit=UnitOfElectricPotential.VOLT,
+            device_class=SensorDeviceClass.VOLTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
+            **_READ_ON_STARTUP,
+            # No translation_key: rely on the device_class so Home Assistant core
+            # localizes the name ("Voltage" -> "Напряжение" etc.). A custom
+            # translation_key would need strings shipped in ZHA to be translated.
+            fallback_name="Voltage",
+        )
+        .sensor(
+            "rms_current_ma",
+            SDevicesCluster.cluster_id,
+            divisor=1000,
+            suggested_display_precision=3,
+            unit=UnitOfElectricCurrent.AMPERE,
+            device_class=SensorDeviceClass.CURRENT,
+            state_class=SensorStateClass.MEASUREMENT,
+            **_READ_ON_STARTUP,
+            # No translation_key: device_class drives the localized name.
+            fallback_name="Current",
+        )
+        .sensor(
+            "active_power_mw",
+            SDevicesCluster.cluster_id,
+            divisor=1000,
+            suggested_display_precision=1,
+            unit=UnitOfPower.WATT,
+            device_class=SensorDeviceClass.POWER,
+            state_class=SensorStateClass.MEASUREMENT,
+            **_READ_ON_STARTUP,
+            # No translation_key: device_class drives the localized name.
+            fallback_name="Power",
+        )
+    )
+
+
+def _add_thresholds(qb: QuirkBuilder) -> QuirkBuilder:
+    """Add the protection / recovery config entities."""
+    return (
+        qb.enum(
+            "emergency_shutoff_recovery",
+            EmergencyRecovery,
+            SDevicesCluster.cluster_id,
+            entity_type=EntityType.CONFIG,
+            translation_key="emergency_shutoff_recovery",
+            fallback_name="Emergency recovery",
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "upper_voltage_threshold",
+            SDevicesCluster.cluster_id,
+            min_value=230,
+            max_value=260,
+            step=1,
+            multiplier=0.001,  # mV -> V
+            unit=UnitOfElectricPotential.VOLT,
+            device_class=NumberDeviceClass.VOLTAGE,
+            entity_type=EntityType.CONFIG,
+            translation_key="upper_voltage_threshold",
+            fallback_name="Upper voltage threshold",
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "lower_voltage_threshold",
+            SDevicesCluster.cluster_id,
+            min_value=100,
+            max_value=230,
+            step=1,
+            multiplier=0.001,  # mV -> V
+            unit=UnitOfElectricPotential.VOLT,
+            device_class=NumberDeviceClass.VOLTAGE,
+            entity_type=EntityType.CONFIG,
+            translation_key="lower_voltage_threshold",
+            fallback_name="Lower voltage threshold",
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "upper_current_threshold",
+            SDevicesCluster.cluster_id,
+            min_value=0.1,
+            max_value=16,
+            step=0.1,
+            multiplier=0.001,  # mA -> A
+            unit=UnitOfElectricCurrent.AMPERE,
+            device_class=NumberDeviceClass.CURRENT,
+            entity_type=EntityType.CONFIG,
+            translation_key="upper_current_threshold",
+            fallback_name="Upper current threshold",
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "upper_temp_threshold",
+            SDevicesCluster.cluster_id,
+            min_value=10,
+            max_value=100,
+            step=1,
+            unit=UnitOfTemperature.CELSIUS,
+            device_class=NumberDeviceClass.TEMPERATURE,
+            entity_type=EntityType.CONFIG,
+            translation_key="temperature_threshold",
+            fallback_name="Overtemperature threshold",
+            **_READ_ON_STARTUP,
+        )
+    )
+
+
+def _add_diagnostics(qb: QuirkBuilder) -> QuirkBuilder:
+    """Add the diagnostics / telemetry sensors on the Diagnostic cluster.
+
+    attribute_initialized_from_cache=False forces a read on configure (otherwise
+    they stay Unknown: the Diagnostic cluster is not bound, and these attributes
+    are not read on startup by default).
+    """
+    return (
+        qb.sensor(
+            "sdevices_uptime_s",
+            SDevicesDiagnosticCluster.cluster_id,
+            unit=UnitOfTime.SECONDS,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="uptime",
+            fallback_name="Uptime",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "number_of_resets",
+            SDevicesDiagnosticCluster.cluster_id,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="resets_count",
+            fallback_name="Resets count",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_button1_clicks",
+            SDevicesDiagnosticCluster.cluster_id,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="button_clicks_1",
+            fallback_name="Button 1 clicks",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_relay1_switches",
+            SDevicesDiagnosticCluster.cluster_id,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="relay_switches_1",
+            fallback_name="Relay 1 switches",
+            **_READ_ON_STARTUP,
+        )
+    )
+
+
+def _socket(manufacturer: str, model: str) -> QuirkBuilder:
+    """Build the SDevices wall socket (00202)."""
+    qb = (
+        # Device type Mains Power Outlet (0x0009) per the device data model; ZHA
+        # maps its OnOff cluster to the switch platform (it is not a light type).
+        QuirkBuilder(manufacturer, model)
+        .replaces_endpoint(1, device_type=zha.DeviceType.MAIN_POWER_OUTLET)
+        .replaces(SDevicesOnOffCluster)
+        .replaces(SDevicesReportingCluster)
+        .replaces(SDevicesDeviceTemperatureCluster)
+        .replaces(SDevicesDiagnosticCluster)
+        # ZCL DeviceTemperature (0x0002) reports currentTemperature in whole
+        # degrees Celsius (ZCLv8); ZHA's native sensor wrongly divides by 100
+        # (that divisor fits TemperatureMeasurement 0x0402, not 0x0002) - replace
+        # it with a divisor=1 sensor. The custom cluster binds while retaining
+        # the reporting table supplied by the firmware.
+        .prevent_default_entity_creation(
+            endpoint_id=1,
+            cluster_id=DeviceTemperature.cluster_id,
+            function=lambda entity: entity.__class__.__name__ == "DeviceTemperature",
+        )
+        .sensor(
+            "current_temperature",
+            DeviceTemperature.cluster_id,
+            endpoint_id=1,
+            divisor=1,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+            unit=UnitOfTemperature.CELSIUS,
+            entity_type=EntityType.DIAGNOSTIC,
+            unique_id_suffix=str(DeviceTemperature.cluster_id),
+            **_READ_ON_STARTUP,
+            translation_key="device_temperature",
+            fallback_name="Device temperature",
+        )
+        .switch(
+            "child_lock",
+            SDevicesCluster.cluster_id,
+            entity_type=EntityType.CONFIG,
+            translation_key="child_lock",
+            fallback_name="Child lock",
+            **_READ_ON_STARTUP,
+        )
+    )
+    qb = _add_led_entities(qb)
+    qb = _add_metering(qb)
+    qb = _add_thresholds(qb)
+    qb = _add_diagnostics(qb)
+    # Raw emergency bitmap. SDevicesCluster binds without replacing the firmware
+    # reporting configuration and splits the value into the per-flag attributes.
+    qb = qb.sensor(
+        "emergency_shutoff_state",
+        SDevicesCluster.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        initially_disabled=True,
+        **_READ_ON_STARTUP,
+        translation_key="emergency_shutoff_state",
+        fallback_name="Emergency shutoff state",
+    )
+    # One binary sensor per emergency flag, on its own synthetic attribute.
+    for attr_name, fallback_name in _EMERGENCY_FLAGS:
+        qb = qb.binary_sensor(
+            attr_name,
+            SDevicesCluster.cluster_id,
+            entity_type=EntityType.DIAGNOSTIC,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            translation_key=attr_name,
+            fallback_name=fallback_name,
+        )
+    return qb
+
+
+_socket(SDEVICES, "SBDV-00202").add_to_registry()

--- a/zhaquirks/sdevices/switch.py
+++ b/zhaquirks/sdevices/switch.py
@@ -1,0 +1,508 @@
+"""SDevices smart wall switches.
+
+Covers the native SDevices wall switches:
+
+* SBDV-00196  Smart Wall Switch (with neutral, single button)
+* SBDV-00197  Smart Wall Switch (with optional neutral, single button)
+* SBDV-00199  Smart Wall Switch (with neutral, two buttons)
+* SBDV-00200  Smart Wall Switch (with optional neutral, two buttons)
+
+The "optional neutral" models (00197 / 00200) additionally expose
+``power_profile`` / ``led_indication_type`` / ``neutral_presence``.
+
+The two-button models (00199 / 00200) are dual-mode: they announce either as a
+two-gang switch (relays on EP1/EP2) or as a window covering (EP3). Both signatures
+share one quirk registration per model; covering-mode entity metadata lives in
+``cover.py``.
+
+The relays are exposed as ``switch`` entities: the endpoint device type is set
+to ``ON_OFF_OUTPUT`` so ZHA maps the ``OnOff`` cluster to the switch platform,
+matching the reference ``zigbee-herdsman-converters`` implementation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import zigpy.device
+from zigpy.profiles import zha
+import zigpy.types as t
+from zigpy.zcl.clusters.general import OnOff
+
+from zhaquirks.builder import EntityType, QuirkBuilder, UnitOfTime
+from zhaquirks.const import (
+    BUTTON_1,
+    BUTTON_2,
+    COMMAND,
+    DOUBLE_PRESS,
+    LONG_PRESS,
+    SHORT_PRESS,
+)
+from zhaquirks.device import CustomZigpyDevice
+from zhaquirks.sdevices import (
+    SDEVICES,
+    ButtonEventMode,
+    LedIndicationType,
+    PowerProfile,
+    RelayMode,
+    SDevicesButtonCluster,
+    SDevicesCluster,
+    SDevicesDiagnosticCluster,
+    SDevicesOnOffCluster,
+    SDevicesReportingCluster,
+    SDevicesTwoButtonCluster,
+    SDevicesWindowCoveringCluster,
+)
+from zhaquirks.sdevices.cover import _add_cover_entities
+
+if TYPE_CHECKING:
+    from zigpy.application import ControllerApplication
+
+_READ_ON_STARTUP = {"attribute_initialized_from_cache": False}
+
+
+class SDevicesSwitchCoverDevice(CustomZigpyDevice):
+    """Clone dual-mode switches and expose every present OnOff endpoint as switch."""
+
+    def __init__(
+        self,
+        application: ControllerApplication,
+        ieee: t.EUI64,
+        nwk: t.NWK,
+        replaces: zigpy.device.Device,
+    ) -> None:
+        """Preserve the interviewed signature while correcting relay device types."""
+        super().__init__(application, ieee, nwk, replaces)
+        for endpoint in self.non_zdo_endpoints:
+            if OnOff.cluster_id in endpoint.in_clusters:
+                endpoint.device_type = zha.DeviceType.ON_OFF_OUTPUT
+
+
+def _add_optional_neutral(qb: QuirkBuilder, *, endpoint_id: int = 1) -> QuirkBuilder:
+    """Add the extra entities of the "optional neutral" models (00197 / 00200)."""
+    return (
+        qb.enum(
+            "power_profile",
+            PowerProfile,
+            SDevicesCluster.cluster_id,
+            endpoint_id=endpoint_id,
+            entity_type=EntityType.CONFIG,
+            translation_key="power_profile",
+            fallback_name="Power profile",
+            **_READ_ON_STARTUP,
+        )
+        .enum(
+            "led_indication_type",
+            LedIndicationType,
+            SDevicesCluster.cluster_id,
+            endpoint_id=endpoint_id,
+            entity_type=EntityType.CONFIG,
+            translation_key="led_indication_type",
+            fallback_name="LED indication type",
+            **_READ_ON_STARTUP,
+        )
+        .binary_sensor(
+            "neutral_presence",
+            SDevicesCluster.cluster_id,
+            endpoint_id=endpoint_id,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="neutral_presence",
+            fallback_name="Neutral presence",
+            **_READ_ON_STARTUP,
+        )
+    )
+
+
+def _add_led_entities(
+    qb: QuirkBuilder, *, endpoint_id: int, include_on: bool, numbered: bool = False
+) -> QuirkBuilder:
+    """Add the LED indicator entities for one endpoint.
+
+    ``include_on`` adds the ON-state LED set; the OFF-state set is always added.
+    """
+    suffix = f" {endpoint_id}" if numbered else ""
+    key_suffix = "_id" if numbered else ""
+    placeholders = {"id": str(endpoint_id)} if numbered else None
+    if include_on:
+        qb = (
+            qb.switch(
+                "led_indicator_on_enable",
+                SDevicesCluster.cluster_id,
+                endpoint_id=endpoint_id,
+                entity_type=EntityType.CONFIG,
+                translation_key=f"led_indicator_on_enable{key_suffix}",
+                fallback_name=f"LED indicator (on){suffix}",
+                translation_placeholders=placeholders,
+                **_READ_ON_STARTUP,
+            )
+            .number(
+                "led_indicator_on_h",
+                SDevicesCluster.cluster_id,
+                endpoint_id=endpoint_id,
+                min_value=0,
+                max_value=359,
+                step=1,
+                unit="°",
+                entity_type=EntityType.CONFIG,
+                translation_key=f"led_indicator_on_h{key_suffix}",
+                fallback_name=f"LED hue (on){suffix}",
+                translation_placeholders=placeholders,
+                **_READ_ON_STARTUP,
+            )
+            .number(
+                "led_indicator_on_s",
+                SDevicesCluster.cluster_id,
+                endpoint_id=endpoint_id,
+                min_value=0,
+                max_value=254,
+                step=1,
+                entity_type=EntityType.CONFIG,
+                translation_key=f"led_indicator_on_s{key_suffix}",
+                fallback_name=f"LED saturation (on){suffix}",
+                translation_placeholders=placeholders,
+                **_READ_ON_STARTUP,
+            )
+            .number(
+                "led_indicator_on_b",
+                SDevicesCluster.cluster_id,
+                endpoint_id=endpoint_id,
+                min_value=1,
+                max_value=254,
+                step=1,
+                entity_type=EntityType.CONFIG,
+                translation_key=f"led_indicator_on_b{key_suffix}",
+                fallback_name=f"LED brightness (on){suffix}",
+                translation_placeholders=placeholders,
+                **_READ_ON_STARTUP,
+            )
+        )
+    return (
+        qb.switch(
+            "led_indicator_off_enable",
+            SDevicesCluster.cluster_id,
+            endpoint_id=endpoint_id,
+            entity_type=EntityType.CONFIG,
+            translation_key=f"led_indicator_off_enable{key_suffix}",
+            fallback_name=f"LED indicator (off){suffix}",
+            translation_placeholders=placeholders,
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "led_indicator_off_h",
+            SDevicesCluster.cluster_id,
+            endpoint_id=endpoint_id,
+            min_value=0,
+            max_value=359,
+            step=1,
+            unit="°",
+            entity_type=EntityType.CONFIG,
+            translation_key=f"led_indicator_off_h{key_suffix}",
+            fallback_name=f"LED hue (off){suffix}",
+            translation_placeholders=placeholders,
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "led_indicator_off_s",
+            SDevicesCluster.cluster_id,
+            endpoint_id=endpoint_id,
+            min_value=0,
+            max_value=254,
+            step=1,
+            entity_type=EntityType.CONFIG,
+            translation_key=f"led_indicator_off_s{key_suffix}",
+            fallback_name=f"LED saturation (off){suffix}",
+            translation_placeholders=placeholders,
+            **_READ_ON_STARTUP,
+        )
+        .number(
+            "led_indicator_off_b",
+            SDevicesCluster.cluster_id,
+            endpoint_id=endpoint_id,
+            min_value=1,
+            max_value=254,
+            step=1,
+            entity_type=EntityType.CONFIG,
+            translation_key=f"led_indicator_off_b{key_suffix}",
+            fallback_name=f"LED brightness (off){suffix}",
+            translation_placeholders=placeholders,
+            **_READ_ON_STARTUP,
+        )
+    )
+
+
+def _add_gang(qb: QuirkBuilder, endpoint_id: int) -> QuirkBuilder:
+    """Add the per-gang config entities of a two-button switch (00199 / 00200)."""
+    suffix = f" {endpoint_id}"
+    qb = qb.enum(
+        "sdevices_relay_decouple",
+        RelayMode,
+        OnOff.cluster_id,
+        endpoint_id=endpoint_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="relay_mode_id",
+        fallback_name=f"Relay mode{suffix}",
+        translation_placeholders={"id": str(endpoint_id)},
+        **_READ_ON_STARTUP,
+    )
+    qb = qb.enum(
+        "button_event_mode",
+        ButtonEventMode,
+        SDevicesCluster.cluster_id,
+        endpoint_id=endpoint_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="event_mode_id",
+        fallback_name=f"Event mode{suffix}",
+        translation_placeholders={"id": str(endpoint_id)},
+        **_READ_ON_STARTUP,
+    )
+    qb = qb.switch(
+        "button_enable_multi_click",
+        SDevicesCluster.cluster_id,
+        endpoint_id=endpoint_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="allow_double_click_id",
+        fallback_name=f"Allow double click{suffix}",
+        translation_placeholders={"id": str(endpoint_id)},
+        **_READ_ON_STARTUP,
+    )
+    return _add_led_entities(
+        qb, endpoint_id=endpoint_id, include_on=True, numbered=True
+    )
+
+
+def _single_button_switch(
+    manufacturer: str, model: str, *, optional_neutral: bool = False
+) -> QuirkBuilder:
+    """Build a single-button SDevices wall switch (00196 / 00197)."""
+    qb = (
+        # Relay EP1 -> switch platform (device type ON_OFF_OUTPUT).
+        QuirkBuilder(manufacturer, model)
+        .replaces_endpoint(1, device_type=zha.DeviceType.ON_OFF_OUTPUT)
+        .replaces(SDevicesOnOffCluster)
+        .replaces(SDevicesButtonCluster)
+        .replaces(SDevicesDiagnosticCluster)
+        .replaces(SDevicesReportingCluster if optional_neutral else SDevicesCluster)
+        .enum(
+            "sdevices_relay_decouple",
+            RelayMode,
+            OnOff.cluster_id,
+            entity_type=EntityType.CONFIG,
+            translation_key="relay_mode",
+            fallback_name="Relay mode",
+            **_READ_ON_STARTUP,
+        )
+        .enum(
+            "button_event_mode",
+            ButtonEventMode,
+            SDevicesCluster.cluster_id,
+            entity_type=EntityType.CONFIG,
+            translation_key="event_mode",
+            fallback_name="Event mode",
+            **_READ_ON_STARTUP,
+        )
+        .switch(
+            "button_enable_multi_click",
+            SDevicesCluster.cluster_id,
+            entity_type=EntityType.CONFIG,
+            translation_key="allow_double_click",
+            fallback_name="Allow double click",
+            **_READ_ON_STARTUP,
+        )
+        .switch(
+            "child_lock",
+            SDevicesCluster.cluster_id,
+            entity_type=EntityType.CONFIG,
+            translation_key="child_lock",
+            fallback_name="Child lock",
+            **_READ_ON_STARTUP,
+        )
+    )
+    qb = _add_led_entities(qb, endpoint_id=1, include_on=True)
+    qb = (
+        qb.sensor(
+            "sdevices_uptime_s",
+            SDevicesDiagnosticCluster.cluster_id,
+            unit=UnitOfTime.SECONDS,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="uptime",
+            fallback_name="Uptime",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "number_of_resets",
+            SDevicesDiagnosticCluster.cluster_id,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="resets_count",
+            fallback_name="Resets count",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_button1_clicks",
+            SDevicesDiagnosticCluster.cluster_id,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="pairing_button_clicks",
+            fallback_name="Pairing button clicks",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_button2_clicks",
+            SDevicesDiagnosticCluster.cluster_id,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="wall_button_clicks",
+            fallback_name="Wall button clicks",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_relay1_switches",
+            SDevicesDiagnosticCluster.cluster_id,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="relay_switches_1",
+            fallback_name="Relay 1 switches",
+            **_READ_ON_STARTUP,
+        )
+        .device_automation_triggers(
+            {
+                (SHORT_PRESS, BUTTON_1): {COMMAND: "button_single"},
+                (DOUBLE_PRESS, BUTTON_1): {COMMAND: "button_double"},
+                (LONG_PRESS, BUTTON_1): {COMMAND: "button_hold"},
+            }
+        )
+    )
+    if optional_neutral:
+        qb = _add_optional_neutral(qb, endpoint_id=1)
+    return qb
+
+
+def _two_button_switch(
+    manufacturer: str, model: str, *, optional_neutral: bool = False
+) -> QuirkBuilder:
+    """Build both signatures of a two-button SDevices switch (00199 / 00200)."""
+    qb = (
+        QuirkBuilder(manufacturer, model)
+        .zigpy_device_class(SDevicesSwitchCoverDevice)
+        .replace_cluster_occurrences(
+            SDevicesOnOffCluster, replace_client_instances=False
+        )
+        .replace_cluster_occurrences(
+            SDevicesTwoButtonCluster, replace_client_instances=False
+        )
+        .replace_cluster_occurrences(
+            SDevicesWindowCoveringCluster, replace_client_instances=False
+        )
+        .replace_cluster_occurrences(
+            SDevicesDiagnosticCluster, replace_client_instances=False
+        )
+        .replace_cluster_occurrences(
+            SDevicesReportingCluster, replace_client_instances=False
+        )
+    )
+    # Two relays -> distinct "Switch 1" / "Switch 2" (Z2M switch_1 / switch_2
+    # parity). A custom translation_key + fallback_name is needed so the two
+    # names differ; the built-in "switch" key would render both identically.
+    # Only the display name changes - unique_id / entity_id / history are untouched.
+    for endpoint_id in (1, 2):
+        qb = qb.change_entity_metadata(
+            endpoint_id=endpoint_id,
+            cluster_id=OnOff.cluster_id,
+            new_translation_key="relay_id",
+            new_translation_placeholders={"id": str(endpoint_id)},
+            new_fallback_name=f"Switch {endpoint_id}",
+        )
+    for endpoint_id in (1, 2):
+        qb = _add_gang(qb, endpoint_id)
+    qb = qb.switch(
+        "child_lock",
+        SDevicesCluster.cluster_id,
+        endpoint_id=1,
+        entity_type=EntityType.CONFIG,
+        translation_key="child_lock",
+        fallback_name="Child lock",
+        **_READ_ON_STARTUP,
+    )
+    qb = (
+        qb.sensor(
+            "sdevices_uptime_s",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=1,
+            unit=UnitOfTime.SECONDS,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="uptime",
+            fallback_name="Uptime",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "number_of_resets",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=1,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="resets_count",
+            fallback_name="Resets count",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_button1_clicks",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=1,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="pairing_button_clicks",
+            fallback_name="Pairing button clicks",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_button2_clicks",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=1,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="left_button_clicks",
+            fallback_name="Left button clicks",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_button3_clicks",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=1,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="right_button_clicks",
+            fallback_name="Right button clicks",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_relay1_switches",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=1,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="relay_switches_1",
+            fallback_name="Relay 1 switches",
+            **_READ_ON_STARTUP,
+        )
+        .sensor(
+            "sdevices_relay2_switches",
+            SDevicesDiagnosticCluster.cluster_id,
+            endpoint_id=1,
+            entity_type=EntityType.DIAGNOSTIC,
+            translation_key="relay_switches_2",
+            fallback_name="Relay 2 switches",
+            **_READ_ON_STARTUP,
+        )
+        .device_automation_triggers(
+            {
+                (SHORT_PRESS, BUTTON_1): {COMMAND: "single_switch_1"},
+                (DOUBLE_PRESS, BUTTON_1): {COMMAND: "double_switch_1"},
+                (LONG_PRESS, BUTTON_1): {COMMAND: "hold_switch_1"},
+                (SHORT_PRESS, BUTTON_2): {COMMAND: "single_switch_2"},
+                (DOUBLE_PRESS, BUTTON_2): {COMMAND: "double_switch_2"},
+                (LONG_PRESS, BUTTON_2): {COMMAND: "hold_switch_2"},
+            }
+        )
+    )
+    qb = _add_cover_entities(qb)
+    if optional_neutral:
+        qb = _add_optional_neutral(qb, endpoint_id=1)
+        qb = _add_optional_neutral(qb, endpoint_id=3)
+    return qb
+
+
+_single_button_switch(SDEVICES, "SBDV-00196").add_to_registry()
+_single_button_switch(SDEVICES, "SBDV-00197", optional_neutral=True).add_to_registry()
+_two_button_switch(SDEVICES, "SBDV-00199").add_to_registry()
+_two_button_switch(SDEVICES, "SBDV-00200", optional_neutral=True).add_to_registry()

--- a/zhaquirks/sdevices/thermostat.py
+++ b/zhaquirks/sdevices/thermostat.py
@@ -1,0 +1,933 @@
+"""SDevices SBDV-00205 smart thermostat.
+
+ZHA exposes the standard Thermostat cluster as a native ``climate`` entity and
+the wired floor sensor as a native temperature sensor. This quirk adds the
+SDevices configuration, metering, protection and diagnostic attributes.
+
+The weekly schedule uses the standard Thermostat ``Set/Get/Clear Weekly
+Schedule`` commands. ZHA has no editable text entity for quirks v2 yet, so the
+seven schedules are exposed as local CharacterString attributes. They can be
+inspected and written from "Manage Zigbee device" using the Zigbee2MQTT format::
+
+    06:00/20 08:00/17.5 18:00/21
+
+Each day supports up to ten heat-setpoint transitions.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Final
+
+import zigpy.types as t
+from zigpy.typing import UNDEFINED, UndefinedType
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import DeviceTemperature
+from zigpy.zcl.clusters.hvac import SeqDayOfWeek, Thermostat, UserInterface
+from zigpy.zcl.foundation import Status, ZCLAttributeDef
+
+from zhaquirks.builder import (
+    BinarySensorDeviceClass,
+    EntityType,
+    NumberDeviceClass,
+    QuirkBuilder,
+    SensorDeviceClass,
+    SensorStateClass,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfPower,
+    UnitOfTemperature,
+    UnitOfTime,
+)
+from zhaquirks.clusters import CustomCluster
+from zhaquirks.sdevices import (
+    SDEVICES,
+    SDEVICES_MFR_CODE,
+    SDevicesCluster,
+    SDevicesDeviceTemperatureCluster,
+    SDevicesDiagnosticCluster,
+    SDevicesReportingCluster,
+    _SDevicesFirmwareReportingMixin,
+)
+
+_MAX_DAILY_TRANSITIONS = 10
+_READ_ON_STARTUP = {"attribute_initialized_from_cache": False}
+_TRANSITION_RE = re.compile(
+    r"^(?P<hour>0[0-9]|1[0-9]|2[0-3]):(?P<minute>[0-5][0-9])/"
+    r"(?P<temperature>[0-9]+(?:\.5)?)$"
+)
+
+
+class SensorMode(t.enum8):
+    """Active temperature sensor."""
+
+    Local = 0x00
+    Remote = 0x01
+    Combined = 0x02
+
+
+class OutputMode(t.enum8):
+    """Relay drive logic."""
+
+    Normal = 0x00
+    Inverted = 0x01
+
+
+class LocalSensorType(t.enum8):
+    """Wired NTC sensor resistance in kOhm."""
+
+    k4_7 = 0x00
+    k6_8 = 0x01
+    k10 = 0x02
+    k12 = 0x03
+    k15 = 0x04
+    k33 = 0x05
+    k47 = 0x06
+
+
+class SDevicesProgrammingOperationMode(t.enum8):
+    """Programming modes supported by SBDV-00205."""
+
+    Simple = Thermostat.ProgrammingOperationMode.Simple
+    Schedule_programming_mode = (
+        Thermostat.ProgrammingOperationMode.Schedule_programming_mode
+    )
+
+
+class SDevicesThermostatProprietaryCluster(SDevicesReportingCluster):
+    """Thermostat-specific 0xFCCF cluster with the v2 emergency bitmap."""
+
+    class AttributeDefs(SDevicesCluster.AttributeDefs):
+        """Synthetic views of the thermostat emergency flags."""
+
+        emergency_no_load: Final = ZCLAttributeDef(id=0x3201, type=t.Bool, access="r")
+        emergency_no_data: Final = ZCLAttributeDef(id=0x3202, type=t.Bool, access="r")
+        emergency_wrong_data: Final = ZCLAttributeDef(
+            id=0x3203, type=t.Bool, access="r"
+        )
+
+    _EMERGENCY_V2_BITS: Final = {
+        SDevicesCluster.AttributeDefs.emergency_overcurrent.id: 0x04,
+        SDevicesCluster.AttributeDefs.emergency_overheat.id: 0x08,
+        AttributeDefs.emergency_no_load.id: 0x10,
+        AttributeDefs.emergency_no_data.id: 0x20,
+        AttributeDefs.emergency_wrong_data.id: 0x40,
+    }
+
+    def _update_attribute(self, attrid, value):
+        """Split the thermostat bitmap without applying the socket layout."""
+        CustomCluster._update_attribute(self, attrid, value)
+        if (
+            attrid == SDevicesCluster.AttributeDefs.emergency_shutoff_state.id
+            and value is not None
+        ):
+            for flag_id, bit in self._EMERGENCY_V2_BITS.items():
+                CustomCluster._update_attribute(self, flag_id, bool(value & bit))
+
+
+_SENSOR_ERROR_BITS: Final = {
+    0x4121: 0x01,
+    0x4122: 0x02,
+    0x4123: 0x04,
+}
+_EVENT_STATUS_BITS: Final = {
+    0x4131: 0x01,
+    0x4132: 0x02,
+    0x4133: 0x04,
+    0x4134: 0x08,
+}
+
+
+class SDevicesThermostatCluster(
+    _SDevicesFirmwareReportingMixin, CustomCluster, Thermostat
+):
+    """Thermostat cluster with local, human-readable weekly schedules."""
+
+    class AttributeDefs(Thermostat.AttributeDefs):
+        """SDevices attributes and local schedule views."""
+
+        remote_temperature: Final = ZCLAttributeDef(
+            id=0x4001,
+            type=t.int16s,
+            access="rwp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        remote_temperature_calibration: Final = ZCLAttributeDef(
+            id=0x4002,
+            type=t.int8s,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        sensor_mode: Final = ZCLAttributeDef(
+            id=0x4003,
+            type=SensorMode,
+            access="rwp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        open_window_enabled: Final = ZCLAttributeDef(
+            id=0x4005,
+            type=t.Bool,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        heating_hysteresis: Final = ZCLAttributeDef(
+            id=0x4019,
+            type=t.int8s,
+            access="rwp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        min_local_temperature_limit: Final = ZCLAttributeDef(
+            id=0x40F0,
+            type=t.int16s,
+            access="rwp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        max_local_temperature_limit: Final = ZCLAttributeDef(
+            id=0x40F1,
+            type=t.int16s,
+            access="rwp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        output_mode: Final = ZCLAttributeDef(
+            id=0x4100,
+            type=OutputMode,
+            access="rwp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        local_sensor_type: Final = ZCLAttributeDef(
+            id=0x4101,
+            type=LocalSensorType,
+            access="rwp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        sensor_error: Final = ZCLAttributeDef(
+            id=0x4102,
+            type=t.bitmap16,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        event_status: Final = ZCLAttributeDef(
+            id=0x4103,
+            type=t.bitmap16,
+            access="rp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        remote_sensor_timeout: Final = ZCLAttributeDef(
+            id=0x4203,
+            type=t.uint16_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        sensor_error_remote_disconnected: Final = ZCLAttributeDef(
+            id=0x4121, type=t.Bool, access="r"
+        )
+        sensor_error_local_disconnected: Final = ZCLAttributeDef(
+            id=0x4122, type=t.Bool, access="r"
+        )
+        sensor_error_short_circuit: Final = ZCLAttributeDef(
+            id=0x4123, type=t.Bool, access="r"
+        )
+        status_heat_inefficient: Final = ZCLAttributeDef(
+            id=0x4131, type=t.Bool, access="r"
+        )
+        status_antifrost: Final = ZCLAttributeDef(id=0x4132, type=t.Bool, access="r")
+        status_open_window: Final = ZCLAttributeDef(id=0x4133, type=t.Bool, access="r")
+        status_invalid_time: Final = ZCLAttributeDef(id=0x4134, type=t.Bool, access="r")
+
+        schedule_monday: Final = ZCLAttributeDef(
+            id=0xF100, type=t.CharacterString, access="rw"
+        )
+        schedule_tuesday: Final = ZCLAttributeDef(
+            id=0xF101, type=t.CharacterString, access="rw"
+        )
+        schedule_wednesday: Final = ZCLAttributeDef(
+            id=0xF102, type=t.CharacterString, access="rw"
+        )
+        schedule_thursday: Final = ZCLAttributeDef(
+            id=0xF103, type=t.CharacterString, access="rw"
+        )
+        schedule_friday: Final = ZCLAttributeDef(
+            id=0xF104, type=t.CharacterString, access="rw"
+        )
+        schedule_saturday: Final = ZCLAttributeDef(
+            id=0xF105, type=t.CharacterString, access="rw"
+        )
+        schedule_sunday: Final = ZCLAttributeDef(
+            id=0xF106, type=t.CharacterString, access="rw"
+        )
+
+    _SCHEDULE_ATTR_TO_DAY: Final = {
+        AttributeDefs.schedule_monday.id: Thermostat.SeqDayOfWeek.Monday,
+        AttributeDefs.schedule_tuesday.id: Thermostat.SeqDayOfWeek.Tuesday,
+        AttributeDefs.schedule_wednesday.id: Thermostat.SeqDayOfWeek.Wednesday,
+        AttributeDefs.schedule_thursday.id: Thermostat.SeqDayOfWeek.Thursday,
+        AttributeDefs.schedule_friday.id: Thermostat.SeqDayOfWeek.Friday,
+        AttributeDefs.schedule_saturday.id: Thermostat.SeqDayOfWeek.Saturday,
+        AttributeDefs.schedule_sunday.id: Thermostat.SeqDayOfWeek.Sunday,
+    }
+    _DAY_TO_SCHEDULE_ATTR: Final = {
+        day: attr_id for attr_id, day in _SCHEDULE_ATTR_TO_DAY.items()
+    }
+
+    def _update_attribute(self, attrid, value):
+        """Split sensor and event status bitmaps into local Boolean views."""
+        super()._update_attribute(attrid, value)
+        if value is None:
+            return
+        if attrid == self.AttributeDefs.sensor_error.id:
+            bits = _SENSOR_ERROR_BITS
+        elif attrid == self.AttributeDefs.event_status.id:
+            bits = _EVENT_STATUS_BITS
+        else:
+            return
+        for flag_id, bit in bits.items():
+            super()._update_attribute(flag_id, bool(value & bit))
+
+    @staticmethod
+    def _parse_schedule(value: str) -> tuple[tuple[int, int], ...]:
+        """Parse and normalize ``HH:MM/temperature`` transitions."""
+        if not isinstance(value, str):
+            raise TypeError("Schedule must be a string")
+
+        raw_transitions = value.split()
+        if len(raw_transitions) > _MAX_DAILY_TRANSITIONS:
+            raise ValueError("A day must have no more than 10 transitions")
+
+        transitions: list[tuple[int, int]] = []
+        for transition in raw_transitions:
+            match = _TRANSITION_RE.fullmatch(transition)
+            if match is None:
+                raise ValueError(
+                    "Transitions must use HH:MM/temperature format "
+                    f"(for example 12:00/15.5), got: {transition}"
+                )
+
+            transition_time = int(match["hour"]) * 60 + int(match["minute"])
+            heat_setpoint = round(float(match["temperature"]) * 100)
+            if not 0 <= heat_setpoint <= 5000:
+                raise ValueError("Schedule temperatures must be between 0 and 50 °C")
+            transitions.append((transition_time, heat_setpoint))
+
+        return tuple(sorted(transitions))
+
+    @staticmethod
+    def _format_schedule(values: list[int], count: int) -> str:
+        """Format the heat-only transition list returned by the device."""
+        if len(values) != count * 2:
+            raise ValueError(
+                f"Expected {count * 2} schedule values, received {len(values)}"
+            )
+
+        transitions = []
+        for index in range(0, len(values), 2):
+            transition_time, heat_setpoint = values[index : index + 2]
+            hours, minutes = divmod(transition_time, 60)
+            temperature = f"{heat_setpoint / 100:g}"
+            transitions.append(f"{hours:02d}:{minutes:02d}/{temperature}")
+        return " ".join(sorted(transitions))
+
+    async def refresh_weekly_schedule(
+        self,
+        days: tuple[SeqDayOfWeek, ...] | None = None,
+    ) -> None:
+        """Request the schedule for every supplied day from the thermostat."""
+        if days is None:
+            days = tuple(self._DAY_TO_SCHEDULE_ATTR)
+        for day in days:
+            await self.command(
+                self.ServerCommandDefs.get_weekly_schedule.id,
+                day,
+                self.SeqMode.Heat,
+                expect_reply=False,
+            )
+
+    async def apply_custom_configuration(self, *args, **kwargs) -> None:
+        """Bind reports and populate the seven local schedule attributes."""
+        await self.bind()
+        await self.refresh_weekly_schedule()
+
+    async def read_attributes(
+        self,
+        attributes: list[int | str | ZCLAttributeDef],
+        allow_cache: bool = False,
+        only_cache: bool = False,
+        manufacturer: int | UndefinedType | None = UNDEFINED,
+        **kwargs,
+    ) -> Any:
+        """Serve synthetic schedules locally and request fresh device values."""
+        schedule_attributes: list[
+            tuple[int | str | ZCLAttributeDef, ZCLAttributeDef]
+        ] = []
+        regular_attributes: list[int | str | ZCLAttributeDef] = []
+        for attr in attributes:
+            attr_def = self.find_attribute(attr, manufacturer_code=manufacturer)
+            if attr_def.id in self._SCHEDULE_ATTR_TO_DAY:
+                schedule_attributes.append((attr, attr_def))
+            else:
+                regular_attributes.append(attr)
+
+        if regular_attributes:
+            success, failure = await super().read_attributes(
+                regular_attributes,
+                allow_cache=allow_cache,
+                only_cache=only_cache,
+                manufacturer=manufacturer,
+                **kwargs,
+            )
+        else:
+            success, failure = {}, {}
+
+        if schedule_attributes and not only_cache:
+            await self.refresh_weekly_schedule(
+                tuple(
+                    self._SCHEDULE_ATTR_TO_DAY[attr_def.id]
+                    for _, attr_def in schedule_attributes
+                )
+            )
+        success.update(
+            {
+                requested_attr: self.get(attr_def.id)
+                for requested_attr, attr_def in schedule_attributes
+            }
+        )
+        return success, failure
+
+    async def write_attributes(
+        self,
+        attributes: dict[str | int | ZCLAttributeDef, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,
+        **kwargs,
+    ) -> list[list[foundation.WriteAttributesStatusRecord]]:
+        """Translate local schedule writes into Set Weekly Schedule commands."""
+        schedule_updates: list[
+            tuple[ZCLAttributeDef, SeqDayOfWeek, str, tuple[tuple[int, int], ...]]
+        ] = []
+        regular_attributes: dict[str | int | ZCLAttributeDef, Any] = {}
+
+        for attr, value in attributes.items():
+            attr_def = self.find_attribute(attr, manufacturer_code=manufacturer)
+            day = self._SCHEDULE_ATTR_TO_DAY.get(attr_def.id)
+            if day is None:
+                regular_attributes[attr] = value
+                continue
+            schedule_updates.append((attr_def, day, value, self._parse_schedule(value)))
+
+        results: list[foundation.WriteAttributesStatusRecord] = []
+        if regular_attributes:
+            regular_results = await super().write_attributes(
+                regular_attributes, manufacturer=manufacturer, **kwargs
+            )
+            results.extend(regular_results[0])
+
+        grouped: dict[tuple[tuple[int, int], ...], SeqDayOfWeek] = {}
+        for _, day, _, transitions in schedule_updates:
+            grouped[transitions] = (
+                grouped.get(transitions, Thermostat.SeqDayOfWeek(0)) | day
+            )
+
+        for transitions, days in grouped.items():
+            values = [item for transition in transitions for item in transition]
+            await self.command(
+                self.ServerCommandDefs.set_weekly_schedule.id,
+                len(transitions),
+                days,
+                self.SeqMode.Heat,
+                values,
+                expect_reply=False,
+            )
+
+        for attr_def, _, value, _ in schedule_updates:
+            self.update_attribute(attr_def.id, value)
+            results.append(
+                foundation.WriteAttributesStatusRecord(
+                    status=Status.SUCCESS,
+                    attrid=attr_def.id,
+                )
+            )
+
+        if schedule_updates:
+            await self.refresh_weekly_schedule(
+                tuple(day for _, day, _, _ in schedule_updates)
+            )
+
+        return [results]
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: Any,
+        *,
+        dst_addressing: t.AddrMode | None = None,
+    ) -> None:
+        """Turn Get Weekly Schedule responses into the local day attributes."""
+        if (
+            hdr.command_id != self.ClientCommandDefs.get_weekly_schedule_response.id
+            or not hasattr(args, "day_of_week_for_sequence")
+        ):
+            return super().handle_cluster_request(
+                hdr, args, dst_addressing=dst_addressing
+            )
+
+        if args.mode_for_sequence != self.SeqMode.Heat:
+            self.warning(
+                "Ignoring unsupported weekly schedule mode: %s",
+                args.mode_for_sequence,
+            )
+            return
+
+        try:
+            schedule = self._format_schedule(
+                list(args.values), int(args.num_transitions_for_sequence)
+            )
+        except ValueError as exc:
+            self.warning("Ignoring malformed weekly schedule response: %s", exc)
+            return
+
+        for day, attr_id in self._DAY_TO_SCHEDULE_ATTR.items():
+            if args.day_of_week_for_sequence & day:
+                self.update_attribute(attr_id, schedule)
+
+
+class SDevicesUserInterfaceCluster(
+    _SDevicesFirmwareReportingMixin, CustomCluster, UserInterface
+):
+    """Thermostat User Interface cluster with display brightness settings."""
+
+    class AttributeDefs(UserInterface.AttributeDefs):
+        """SDevices display brightness attributes."""
+
+        brightness_operations_mode: Final = ZCLAttributeDef(
+            id=0x2001,
+            type=t.uint16_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        brightness_steady_mode: Final = ZCLAttributeDef(
+            id=0x2002,
+            type=t.uint16_t,
+            access="rwp",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+        brightness_night_mode: Final = ZCLAttributeDef(
+            id=0x2003,
+            type=t.uint16_t,
+            access="rw",
+            manufacturer_code=SDEVICES_MFR_CODE,
+        )
+
+
+_EMERGENCY_FLAGS = (
+    ("emergency_overcurrent", "Emergency overcurrent"),
+    ("emergency_overheat", "Emergency overheat"),
+    ("emergency_no_load", "Emergency no load"),
+    ("emergency_no_data", "Emergency no data"),
+    ("emergency_wrong_data", "Emergency wrong data"),
+)
+_SENSOR_ERROR_FLAGS = (
+    ("sensor_error_remote_disconnected", "Sensor error remote disconnected"),
+    ("sensor_error_local_disconnected", "Sensor error local disconnected"),
+    ("sensor_error_short_circuit", "Sensor error short circuit"),
+)
+_EVENT_STATUS_FLAGS = (
+    ("status_heat_inefficient", "Heating inefficient"),
+    ("status_antifrost", "Antifrost mode"),
+    ("status_open_window", "Open window mode"),
+    ("status_invalid_time", "Invalid time"),
+)
+
+
+def _add_metering(qb: QuirkBuilder) -> QuirkBuilder:
+    """Add electricity metering while retaining firmware reporting defaults."""
+    return (
+        qb.sensor(
+            attribute_name="rms_voltage_mv",
+            cluster_id=SDevicesCluster.cluster_id,
+            divisor=1000,
+            suggested_display_precision=1,
+            unit=UnitOfElectricPotential.VOLT,
+            device_class=SensorDeviceClass.VOLTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
+            **_READ_ON_STARTUP,
+            fallback_name="Voltage",
+        )
+        .sensor(
+            attribute_name="rms_current_ma",
+            cluster_id=SDevicesCluster.cluster_id,
+            divisor=1000,
+            suggested_display_precision=3,
+            unit=UnitOfElectricCurrent.AMPERE,
+            device_class=SensorDeviceClass.CURRENT,
+            state_class=SensorStateClass.MEASUREMENT,
+            **_READ_ON_STARTUP,
+            fallback_name="Current",
+        )
+        .sensor(
+            attribute_name="active_power_mw",
+            cluster_id=SDevicesCluster.cluster_id,
+            divisor=1000,
+            suggested_display_precision=1,
+            unit=UnitOfPower.WATT,
+            device_class=SensorDeviceClass.POWER,
+            state_class=SensorStateClass.MEASUREMENT,
+            **_READ_ON_STARTUP,
+            fallback_name="Power",
+        )
+    )
+
+
+def _add_diagnostics(qb: QuirkBuilder) -> QuirkBuilder:
+    """Add supported SDevices diagnostic counters."""
+    for attribute_name, unit, translation_key, fallback_name in (
+        ("sdevices_uptime_s", UnitOfTime.SECONDS, "uptime", "Uptime"),
+        ("number_of_resets", None, "resets_count", "Resets count"),
+        ("sdevices_button1_clicks", None, "button_clicks_1", "Button 1 clicks"),
+        ("sdevices_button2_clicks", None, "button_clicks_2", "Button 2 clicks"),
+        ("sdevices_button3_clicks", None, "button_clicks_3", "Button 3 clicks"),
+        ("sdevices_relay1_switches", None, "relay_switches_1", "Relay 1 switches"),
+    ):
+        qb = qb.sensor(
+            attribute_name=attribute_name,
+            cluster_id=SDevicesDiagnosticCluster.cluster_id,
+            unit=unit,
+            entity_type=EntityType.DIAGNOSTIC,
+            **_READ_ON_STARTUP,
+            translation_key=translation_key,
+            fallback_name=fallback_name,
+        )
+    return qb
+
+
+def _add_protection(qb: QuirkBuilder) -> QuirkBuilder:
+    """Add thermostat protection thresholds and decoded emergency flags."""
+    qb = (
+        qb.number(
+            attribute_name="upper_current_threshold",
+            cluster_id=SDevicesCluster.cluster_id,
+            min_value=0.1,
+            max_value=16,
+            step=0.1,
+            multiplier=0.001,
+            unit=UnitOfElectricCurrent.AMPERE,
+            device_class=NumberDeviceClass.CURRENT,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key="upper_current_threshold",
+            fallback_name="Upper current threshold",
+        )
+        .number(
+            attribute_name="upper_temp_threshold",
+            cluster_id=SDevicesCluster.cluster_id,
+            min_value=10,
+            max_value=85,
+            step=1,
+            unit=UnitOfTemperature.CELSIUS,
+            device_class=NumberDeviceClass.TEMPERATURE,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key="temperature_threshold",
+            fallback_name="Overtemperature threshold",
+        )
+        .sensor(
+            attribute_name="emergency_shutoff_state",
+            cluster_id=SDevicesCluster.cluster_id,
+            entity_type=EntityType.DIAGNOSTIC,
+            initially_disabled=True,
+            **_READ_ON_STARTUP,
+            translation_key="emergency_shutoff_state",
+            fallback_name="Emergency shutoff state",
+        )
+    )
+    for attribute_name, fallback_name in _EMERGENCY_FLAGS:
+        qb = qb.binary_sensor(
+            attribute_name=attribute_name,
+            cluster_id=SDevicesCluster.cluster_id,
+            entity_type=EntityType.DIAGNOSTIC,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            translation_key=attribute_name,
+            fallback_name=fallback_name,
+        )
+    return qb
+
+
+def _add_thermostat_diagnostics(qb: QuirkBuilder) -> QuirkBuilder:
+    """Add raw status bitmaps and their decoded per-flag sensors."""
+    qb = qb.sensor(
+        attribute_name="sensor_error",
+        cluster_id=Thermostat.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        initially_disabled=True,
+        **_READ_ON_STARTUP,
+        translation_key="sensor_error",
+        fallback_name="Sensor error",
+    ).sensor(
+        attribute_name="event_status",
+        cluster_id=Thermostat.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        initially_disabled=True,
+        **_READ_ON_STARTUP,
+        translation_key="event_status",
+        fallback_name="Event status",
+    )
+    for attribute_name, fallback_name in _SENSOR_ERROR_FLAGS + _EVENT_STATUS_FLAGS:
+        qb = qb.binary_sensor(
+            attribute_name=attribute_name,
+            cluster_id=Thermostat.cluster_id,
+            entity_type=EntityType.DIAGNOSTIC,
+            device_class=(
+                BinarySensorDeviceClass.PROBLEM
+                if attribute_name.startswith("sensor_error")
+                else None
+            ),
+            translation_key=attribute_name,
+            fallback_name=fallback_name,
+        )
+    return qb
+
+
+def _add_thermostat_config(qb: QuirkBuilder) -> QuirkBuilder:
+    """Add the SDevices thermostat configuration entities."""
+    return (
+        qb.enum(
+            attribute_name="sensor_mode",
+            enum_class=SensorMode,
+            cluster_id=Thermostat.cluster_id,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key="sensor_mode",
+            fallback_name="Sensor mode",
+        )
+        .enum(
+            attribute_name="output_mode",
+            enum_class=OutputMode,
+            cluster_id=Thermostat.cluster_id,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key="output_mode",
+            fallback_name="Output mode",
+        )
+        .enum(
+            attribute_name="local_sensor_type",
+            enum_class=LocalSensorType,
+            cluster_id=Thermostat.cluster_id,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key="local_sensor_type",
+            fallback_name="Local sensor type",
+        )
+        .number(
+            attribute_name="heating_hysteresis",
+            cluster_id=Thermostat.cluster_id,
+            min_value=1.0,
+            max_value=10.0,
+            step=0.1,
+            multiplier=0.1,
+            unit=UnitOfTemperature.CELSIUS,
+            device_class=NumberDeviceClass.TEMPERATURE,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key="heating_hysteresis",
+            fallback_name="Heating hysteresis",
+        )
+        .number(
+            attribute_name="min_local_temperature_limit",
+            cluster_id=Thermostat.cluster_id,
+            min_value=1.0,
+            max_value=35.0,
+            step=0.01,
+            multiplier=0.01,
+            unit=UnitOfTemperature.CELSIUS,
+            device_class=NumberDeviceClass.TEMPERATURE,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key="min_local_temperature_limit",
+            fallback_name="Min local temperature limit",
+        )
+        .number(
+            attribute_name="max_local_temperature_limit",
+            cluster_id=Thermostat.cluster_id,
+            min_value=5.0,
+            max_value=50.0,
+            step=0.01,
+            multiplier=0.01,
+            unit=UnitOfTemperature.CELSIUS,
+            device_class=NumberDeviceClass.TEMPERATURE,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key="max_local_temperature_limit",
+            fallback_name="Max local temperature limit",
+        )
+        .number(
+            attribute_name="remote_temperature_calibration",
+            cluster_id=Thermostat.cluster_id,
+            min_value=-2.5,
+            max_value=2.5,
+            step=0.1,
+            multiplier=0.1,
+            unit=UnitOfTemperature.CELSIUS,
+            device_class=NumberDeviceClass.TEMPERATURE,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key="remote_temperature_calibration",
+            fallback_name="Remote temperature calibration",
+        )
+        .number(
+            attribute_name="remote_sensor_timeout",
+            cluster_id=Thermostat.cluster_id,
+            min_value=1,
+            max_value=65535,
+            step=1,
+            unit=UnitOfTime.SECONDS,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key="remote_sensor_timeout",
+            fallback_name="Remote sensor timeout",
+        )
+        .switch(
+            attribute_name="open_window_enabled",
+            cluster_id=Thermostat.cluster_id,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key="open_window_enabled",
+            fallback_name="Open window detection",
+        )
+        .sensor(
+            attribute_name=Thermostat.AttributeDefs.abs_min_heat_setpoint_limit.name,
+            cluster_id=Thermostat.cluster_id,
+            divisor=100,
+            unit=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_type=EntityType.DIAGNOSTIC,
+            **_READ_ON_STARTUP,
+            translation_key="abs_min_heat_setpoint_limit",
+            fallback_name="Abs min heat setpoint limit",
+        )
+        .sensor(
+            attribute_name=Thermostat.AttributeDefs.abs_max_heat_setpoint_limit.name,
+            cluster_id=Thermostat.cluster_id,
+            divisor=100,
+            unit=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_type=EntityType.DIAGNOSTIC,
+            **_READ_ON_STARTUP,
+            translation_key="abs_max_heat_setpoint_limit",
+            fallback_name="Abs max heat setpoint limit",
+        )
+        .number(
+            attribute_name="remote_temperature",
+            cluster_id=Thermostat.cluster_id,
+            min_value=-273.15,
+            max_value=327.67,
+            step=0.01,
+            multiplier=0.01,
+            unit=UnitOfTemperature.CELSIUS,
+            device_class=NumberDeviceClass.TEMPERATURE,
+            entity_type=EntityType.CONFIG,
+            initially_disabled=True,
+            **_READ_ON_STARTUP,
+            translation_key="remote_temperature",
+            fallback_name="Remote temperature",
+        )
+    )
+
+
+def _add_ui_config(qb: QuirkBuilder) -> QuirkBuilder:
+    """Add display brightness controls."""
+    for attribute_name, translation_key, fallback_name in (
+        (
+            "brightness_operations_mode",
+            "brightness_operations_mode",
+            "Brightness (active)",
+        ),
+        ("brightness_steady_mode", "brightness_steady_mode", "Brightness (steady)"),
+        ("brightness_night_mode", "brightness_night_mode", "Brightness (night)"),
+    ):
+        qb = qb.number(
+            attribute_name=attribute_name,
+            cluster_id=UserInterface.cluster_id,
+            min_value=0,
+            max_value=1000,
+            step=1,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key=translation_key,
+            fallback_name=fallback_name,
+        )
+    return qb
+
+
+def _build_thermostat(manufacturer: str, model: str) -> QuirkBuilder:
+    """Build the complete SBDV-00205 quirk."""
+    qb = (
+        QuirkBuilder(manufacturer, model)
+        .replaces(SDevicesThermostatCluster)
+        .replaces(SDevicesUserInterfaceCluster)
+        .prevent_default_entity_creation(
+            endpoint_id=1,
+            cluster_id=UserInterface.cluster_id,
+            function=lambda entity: entity.translation_key == "keypad_lockout",
+        )
+        .switch(
+            attribute_name=UserInterface.AttributeDefs.keypad_lockout.name,
+            cluster_id=UserInterface.cluster_id,
+            off_value=0,
+            on_value=1,
+            entity_type=EntityType.CONFIG,
+            translation_key="child_lock",
+            fallback_name="Child lock",
+        )
+        .replaces(SDevicesThermostatProprietaryCluster)
+        .replaces(SDevicesDiagnosticCluster)
+        .replaces(SDevicesDeviceTemperatureCluster)
+        .prevent_default_entity_creation(
+            endpoint_id=1,
+            cluster_id=DeviceTemperature.cluster_id,
+            function=lambda entity: entity.__class__.__name__ == "DeviceTemperature",
+        )
+        .sensor(
+            attribute_name=DeviceTemperature.AttributeDefs.current_temperature.name,
+            cluster_id=DeviceTemperature.cluster_id,
+            endpoint_id=1,
+            divisor=1,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+            unit=UnitOfTemperature.CELSIUS,
+            entity_type=EntityType.DIAGNOSTIC,
+            unique_id_suffix=str(DeviceTemperature.cluster_id),
+            **_READ_ON_STARTUP,
+            translation_key="device_temperature",
+            fallback_name="Device temperature",
+        )
+        .enum(
+            attribute_name=Thermostat.AttributeDefs.programing_oper_mode.name,
+            enum_class=SDevicesProgrammingOperationMode,
+            cluster_id=Thermostat.cluster_id,
+            entity_type=EntityType.CONFIG,
+            **_READ_ON_STARTUP,
+            translation_key="programming_operation_mode",
+            fallback_name="Programming operation mode",
+        )
+        .command_button(
+            command_name=Thermostat.ServerCommandDefs.clear_weekly_schedule.name,
+            cluster_id=Thermostat.cluster_id,
+            entity_type=EntityType.CONFIG,
+            translation_key="sdevices_clear_weekly_schedule",
+            fallback_name=(
+                "Clear weekly schedule (configure via SDevices Thermostat "
+                "attributes schedule_monday through schedule_sunday, "
+                "format HH:MM/temperature)"
+            ),
+        )
+    )
+    qb = _add_metering(qb)
+    qb = _add_protection(qb)
+    qb = _add_thermostat_diagnostics(qb)
+    qb = _add_thermostat_config(qb)
+    qb = _add_ui_config(qb)
+    return _add_diagnostics(qb)
+
+
+_thermostat = _build_thermostat(SDEVICES, "SBDV-00205")
+
+_thermostat.add_to_registry()


### PR DESCRIPTION
## Proposed change

  Add ZHA v2 quirks for the following SDevices devices:

  - SBDV-00196 — single-button wall switch with neutral
  - SBDV-00197 — single-button wall switch with optional neutral
  - SBDV-00199 — two-button wall switch with neutral and cover mode
  - SBDV-00200 — two-button wall switch with optional neutral and cover mode
  - SBDV-00202 — wall socket with energy metering and protection settings
  - SBDV-00205 — in-wall floor-heating thermostat with display and schedule

  The quirks add:

  - shared SDevices manufacturer-specific clusters and attributes;
  - switch, cover, socket, metering, protection, LED and diagnostic entities;
  - button event handling for single- and two-button devices;
  - correct scaling for device temperature and metering values;
  - preservation of existing ZHA entity unique IDs where applicable;
  - binding of report-producing clusters without replacing the reporting configuration supplied by the device firmware.

  Reporting intervals are intentionally not duplicated in the quirk. ZHA reporting configuration requests are acknowledged locally, while the device firmware remains responsible for its reporting table.

  ## Additional information

  The changes were tested with Home Assistant 2026.7.1 and a Nabu Casa SkyConnect coordinator.

All five device models were paired on a clean Home Assistant installation.
Device discovery, entity creation, relay control, physical state reporting, restart persistence, and ZHA device reconfiguration were checked.

  The SBDV-00202 reconfiguration trace contained the expected cluster binds, including a single Device Temperature bind, and no over-the-air Configure Reporting commands.

  Validation results:

  - `pytest tests/test_sdevices.py`: 23 passed
  - `pytest tests/`: 4864 passed, 2 xfailed
  - `pre-commit run --all-files`: passed

  This PR does not require changes in Home Assistant Core or other projects.

  ## Device diagnostics

[SDevices SBDV-00196.json](https://github.com/user-attachments/files/30944875/SDevices.SBDV-00196.json)
[SDevices SBDV-00197.json](https://github.com/user-attachments/files/30944878/SDevices.SBDV-00197.json)
[SDevices SBDV-00199-curtains.json](https://github.com/user-attachments/files/30944879/SDevices.SBDV-00199-curtains.json)
[SDevices SBDV-00199-switch.json](https://github.com/user-attachments/files/30944883/SDevices.SBDV-00199-switch.json)
[SDevices SBDV-00200-curtains.json](https://github.com/user-attachments/files/30944885/SDevices.SBDV-00200-curtains.json)
[SDevices SBDV-00200-switch.json](https://github.com/user-attachments/files/30944887/SDevices.SBDV-00200-switch.json)
[SDevices SBDV-00202.json](https://github.com/user-attachments/files/30944888/SDevices.SBDV-00202.json)
[SDevices SBDV-00205.json](https://github.com/user-attachments/files/31365359/SDevices.SBDV-00205.json)


  ## Checklist

  - [x] The changes are tested and work correctly
  - [x] `pre-commit` checks pass / the code has been formatted using Black
  - [x] Tests have been added to verify that the new code works
  - [x] Device diagnostics data has been attached