### PR TITLE
Add Tuya TS0052 switch type configuration

### DIFF
--- a/tests/test_tuya_ts0052.py
+++ b/tests/test_tuya_ts0052.py
@@ -1,0 +1,17 @@
+"""Tests for the Tuya TS0052 2-channel dimmer quirk."""
+
+from zhaquirks.tuya.ts0052 import SwitchType, TuyaSwitchTypeCluster
+
+
+def test_switch_type_cluster_definition() -> None:
+    """Test the TS0052 external switch type cluster definition."""
+
+    assert TuyaSwitchTypeCluster.cluster_id == 0xE001
+
+    attribute = TuyaSwitchTypeCluster.AttributeDefs.switch_type
+    assert attribute.id == 0xD030
+    assert attribute.type is SwitchType
+
+    assert SwitchType.Toggle == 0
+    assert SwitchType.State == 1
+    assert SwitchType.Momentary == 2

--- a/zhaquirks/tuya/ts0052.py
+++ b/zhaquirks/tuya/ts0052.py
@@ -1,0 +1,48 @@
+"""Tuya TS0052 2-channel dimmer quirk."""
+
+import zigpy.types as t
+from zigpy.quirks import CustomCluster
+from zigpy.zcl import foundation
+
+from zhaquirks.builder import EntityType, QuirkBuilder
+
+
+class SwitchType(t.enum8):
+    """External wall switch type."""
+
+    Toggle = 0
+    State = 1
+    Momentary = 2
+
+
+class TuyaSwitchTypeCluster(CustomCluster):
+    """Tuya cluster exposing the external switch type setting."""
+
+    cluster_id = 0xE001
+
+    class AttributeDefs(CustomCluster.AttributeDefs):
+        """Attribute definitions."""
+
+        switch_type = foundation.ZCLAttributeDef(
+            id=0xD030,
+            type=SwitchType,
+            access="rw",
+            is_manufacturer_specific=False,
+        )
+
+
+(
+    QuirkBuilder("_TZ3000_zjtxnoft", "TS0052")
+    .replaces(TuyaSwitchTypeCluster, endpoint_id=1)
+    .replaces(TuyaSwitchTypeCluster, endpoint_id=2)
+    .enum(
+        attribute_name=TuyaSwitchTypeCluster.AttributeDefs.switch_type.name,
+        enum_class=SwitchType,
+        cluster_id=TuyaSwitchTypeCluster.cluster_id,
+        endpoint_id=1,
+        entity_type=EntityType.CONFIG,
+        translation_key="switch_type",
+        fallback_name="Switch type",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/tuya/ts0052.py
+++ b/zhaquirks/tuya/ts0052.py
@@ -1,7 +1,9 @@
 """Tuya TS0052 2-channel dimmer quirk."""
 
+from typing import Final
+
 import zigpy.types as t
-from zigpy.zcl import foundation
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
 from zhaquirks.builder import EntityType, QuirkBuilder
 from zhaquirks.clusters import CustomCluster
@@ -20,10 +22,10 @@ class TuyaSwitchTypeCluster(CustomCluster):
 
     cluster_id = 0xE001
 
-    class AttributeDefs(CustomCluster.AttributeDefs):
+    class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
 
-        switch_type = foundation.ZCLAttributeDef(
+        switch_type: Final = ZCLAttributeDef(
             id=0xD030,
             type=SwitchType,
             access="rw",

--- a/zhaquirks/tuya/ts0052.py
+++ b/zhaquirks/tuya/ts0052.py
@@ -1,10 +1,10 @@
 """Tuya TS0052 2-channel dimmer quirk."""
 
 import zigpy.types as t
-from zigpy.quirks import CustomCluster
 from zigpy.zcl import foundation
 
 from zhaquirks.builder import EntityType, QuirkBuilder
+from zhaquirks.clusters import CustomCluster
 
 
 class SwitchType(t.enum8):


### PR DESCRIPTION
Adds a V2 quirk for the Tuya TS0052 2-channel dimmer identified as `_TZ3000_zjtxnoft`.

The device exposes the external wall-switch mode through cluster `0xE001`, attribute `0xD030`.

Supported values:
- `0` = Toggle
- `1` = State
- `2` = Momentary

Hardware testing confirmed that writing the attribute on endpoint 1 changes the physical input mode for both S1 and S2. Endpoint 2 exposes cluster `0xE001`, but writing `0xD030` there returns `UNSUPPORTED_ATTRIBUTE`, so the Home Assistant config entity is intentionally exposed only on endpoint 1.

Also adds a focused unit test for the cluster ID, attribute ID, and enum mapping.

Local checks:
- `ruff check zhaquirks/tuya/ts0052.py` passes
- `ruff format --check zhaquirks/tuya/ts0052.py` passes
- `tests/test_tuya.py` collects successfully on Windows after installing `tzdata`; one unrelated existing Moes timezone-dependent test fails on Windows due to different local timezone payload bytes.