### PR TITLE
Convert the ZLinky_TIC quirk to v2 and expose tariff period sensors

### DIFF
--- a/tests/test_lixee.py
+++ b/tests/test_lixee.py
@@ -1,5 +1,6 @@
 """Tests for LiXee ZLinky_TIC quirks."""
 
+import pytest
 from zha.quirks import DEVICE_REGISTRY
 from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import PowerConfiguration
@@ -35,8 +36,8 @@ def test_zlinky_clusters_replaced(zigpy_device_from_v2_quirk) -> None:
         "ZLinky_TIC",
         cluster_ids={
             1: {
-                Metering.cluster_id: None,
-                ZLINKY_MANUFACTURER_CLUSTER_ID: None,
+                Metering.cluster_id: ClusterType.Server,
+                ZLINKY_MANUFACTURER_CLUSTER_ID: ClusterType.Server,
             }
         },
     )
@@ -72,20 +73,25 @@ def test_zlinky_tariff_entities() -> None:
         assert entity_metadata.endpoint_id == 1
 
 
-def test_zlinky_tuya_cluster_removed(zigpy_device_from_v2_quirk) -> None:
+@pytest.mark.parametrize("cluster_type", [ClusterType.Server, ClusterType.Client])
+def test_zlinky_tuya_cluster_removed(zigpy_device_from_v2_quirk, cluster_type) -> None:
     """Test that the Tuya cluster firmware v14+ reports is removed.
 
     The v1 quirk dropped it implicitly, by listing it in the FWV14 and FWV15
     signatures but not in their replacements. That is what the two ZLinky
     entries in test_suspicious_cluster_moves recorded; this test replaces them.
+
+    Parametrized over both directions: the device reports the cluster as an
+    input and an output cluster, and each removal has to be exercised on its
+    own or the assertion for the other direction passes vacuously.
     """
     device = zigpy_device_from_v2_quirk(
         LIXEE,
         "ZLinky_TIC",
         cluster_ids={
             1: {
-                ZLINKY_MANUFACTURER_CLUSTER_ID: None,
-                TuyaManufCluster.cluster_id: ClusterType.Server,
+                ZLINKY_MANUFACTURER_CLUSTER_ID: ClusterType.Server,
+                TuyaManufCluster.cluster_id: cluster_type,
             }
         },
     )

--- a/tests/test_lixee.py
+++ b/tests/test_lixee.py
@@ -1,6 +1,7 @@
 """Tests for LiXee ZLinky_TIC quirks."""
 
 from zha.quirks import DEVICE_REGISTRY
+from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import PowerConfiguration
 from zigpy.zcl.clusters.smartenergy import Metering
 
@@ -8,6 +9,7 @@ import zhaquirks
 from zhaquirks.builder.device import QuirkV2Factory
 from zhaquirks.lixee import LIXEE, ZLINKY_MANUFACTURER_CLUSTER_ID
 from zhaquirks.lixee.zlinky import ZLinkyTICManufacturerCluster, ZLinkyTICMetering
+from zhaquirks.tuya import TuyaManufCluster
 
 zhaquirks.setup()
 
@@ -68,3 +70,21 @@ def test_zlinky_tariff_entities() -> None:
     for entity_metadata in definition.entity_metadata:
         assert entity_metadata.cluster_id == ZLINKY_MANUFACTURER_CLUSTER_ID
         assert entity_metadata.endpoint_id == 1
+
+
+def test_zlinky_tuya_cluster_removed(zigpy_device_from_v2_quirk) -> None:
+    """Test that the Tuya cluster firmware v14+ reports is removed."""
+    device = zigpy_device_from_v2_quirk(
+        LIXEE,
+        "ZLinky_TIC",
+        cluster_ids={
+            1: {
+                ZLINKY_MANUFACTURER_CLUSTER_ID: None,
+                TuyaManufCluster.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+    endpoint = device.endpoints[1]
+
+    assert TuyaManufCluster.cluster_id not in endpoint.in_clusters
+    assert TuyaManufCluster.cluster_id not in endpoint.out_clusters

--- a/tests/test_lixee.py
+++ b/tests/test_lixee.py
@@ -1,10 +1,29 @@
 """Tests for LiXee ZLinky_TIC quirks."""
 
+from zha.quirks import DEVICE_REGISTRY
 from zigpy.zcl.clusters.general import PowerConfiguration
 from zigpy.zcl.clusters.smartenergy import Metering
 
+import zhaquirks
+from zhaquirks.builder.device import QuirkV2Factory
 from zhaquirks.lixee import LIXEE, ZLINKY_MANUFACTURER_CLUSTER_ID
 from zhaquirks.lixee.zlinky import ZLinkyTICManufacturerCluster, ZLinkyTICMetering
+
+zhaquirks.setup()
+
+
+def _zlinky_definition():
+    """Return the QuirkDefinition registered for the ZLinky_TIC."""
+    (entry,) = [
+        entry
+        for entry in DEVICE_REGISTRY
+        if isinstance(entry.zha_device_factory, QuirkV2Factory)
+        and any(
+            model_info.manufacturer == LIXEE and model_info.model == "ZLinky_TIC"
+            for model_info in entry.device_match.applies_to
+        )
+    ]
+    return entry.zha_device_factory.quirk_definition
 
 
 def test_zlinky_clusters_replaced(zigpy_device_from_v2_quirk) -> None:
@@ -27,3 +46,25 @@ def test_zlinky_clusters_replaced(zigpy_device_from_v2_quirk) -> None:
     )
     # Not all firmware variants report it, the quirk adds it unconditionally
     assert PowerConfiguration.cluster_id in endpoint.in_clusters
+
+
+def test_zlinky_tariff_entities() -> None:
+    """Test that the tariff and diagnostic sensors are exposed."""
+    attribute_defs = ZLinkyTICManufacturerCluster.AttributeDefs
+    definition = _zlinky_definition()
+
+    assert {
+        entity_metadata.attribute_name for entity_metadata in definition.entity_metadata
+    } == {
+        attribute_defs.linky_tariff_period.name,
+        attribute_defs.hist_tariff_option_or_std_supplier_price_schedule_name.name,
+        attribute_defs.hist_subscribed_power_exceeding_warning.name,
+        attribute_defs.hist_schedule_peak_hours_off_peak_hours.name,
+        attribute_defs.linky_status.name,
+        attribute_defs.linky_mode.name,
+    }
+
+    # Every entity reads from the manufacturer specific cluster on endpoint 1
+    for entity_metadata in definition.entity_metadata:
+        assert entity_metadata.cluster_id == ZLINKY_MANUFACTURER_CLUSTER_ID
+        assert entity_metadata.endpoint_id == 1

--- a/tests/test_lixee.py
+++ b/tests/test_lixee.py
@@ -1,0 +1,29 @@
+"""Tests for LiXee ZLinky_TIC quirks."""
+
+from zigpy.zcl.clusters.general import PowerConfiguration
+from zigpy.zcl.clusters.smartenergy import Metering
+
+from zhaquirks.lixee import LIXEE, ZLINKY_MANUFACTURER_CLUSTER_ID
+from zhaquirks.lixee.zlinky import ZLinkyTICManufacturerCluster, ZLinkyTICMetering
+
+
+def test_zlinky_clusters_replaced(zigpy_device_from_v2_quirk) -> None:
+    """Test that the ZLinky_TIC quirk replaces the expected clusters."""
+    device = zigpy_device_from_v2_quirk(
+        LIXEE,
+        "ZLinky_TIC",
+        cluster_ids={
+            1: {
+                Metering.cluster_id: None,
+                ZLINKY_MANUFACTURER_CLUSTER_ID: None,
+            }
+        },
+    )
+    endpoint = device.endpoints[1]
+
+    assert isinstance(endpoint.smartenergy_metering, ZLinkyTICMetering)
+    assert isinstance(
+        endpoint.zlinky_manufacturer_specific, ZLinkyTICManufacturerCluster
+    )
+    # Not all firmware variants report it, the quirk adds it unconditionally
+    assert PowerConfiguration.cluster_id in endpoint.in_clusters

--- a/tests/test_lixee.py
+++ b/tests/test_lixee.py
@@ -73,7 +73,12 @@ def test_zlinky_tariff_entities() -> None:
 
 
 def test_zlinky_tuya_cluster_removed(zigpy_device_from_v2_quirk) -> None:
-    """Test that the Tuya cluster firmware v14+ reports is removed."""
+    """Test that the Tuya cluster firmware v14+ reports is removed.
+
+    The v1 quirk dropped it implicitly, by listing it in the FWV14 and FWV15
+    signatures but not in their replacements. That is what the two ZLinky
+    entries in test_suspicious_cluster_moves recorded; this test replaces them.
+    """
     device = zigpy_device_from_v2_quirk(
         LIXEE,
         "ZLinky_TIC",

--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -920,9 +920,6 @@ def test_no_duplicate_clusters(quirk: CustomDevice) -> None:
             zhaquirks.aduro.adurolightncc.AdurolightNCC,
             # add a bunch of output clusters (Zhongxing motion sensor):
             zhaquirks.zhongxing.motion.SN10ZW,
-            # remove Tuya clusters from input and output clusters (ZLinky):
-            zhaquirks.lixee.zlinky.ZLinkyTICFWV14,
-            zhaquirks.lixee.zlinky.ZLinkyTICFWV15,
         )
     ],
 )

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -1,34 +1,15 @@
 """Quirk for ZLinky_TIC."""
 
-from copy import deepcopy
 from typing import Final
 
-from zigpy.profiles import zgp, zha
 import zigpy.types as t
-from zigpy.zcl.clusters.general import (
-    Basic,
-    GreenPowerProxy,
-    Identify,
-    Ota,
-    PowerConfiguration,
-    Time,
-)
-from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement, MeterIdentification
+from zigpy.zcl.clusters.general import PowerConfiguration
 from zigpy.zcl.clusters.smartenergy import Metering
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
+from zhaquirks.builder import QuirkBuilder
 from zhaquirks.clusters import CustomCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
-from zhaquirks.legacy import CustomDevice
 from zhaquirks.lixee import LIXEE, ZLINKY_MANUFACTURER_CLUSTER_ID
-from zhaquirks.tuya import TuyaManufCluster
 
 
 class ZLinkyTICManufacturerCluster(CustomCluster):
@@ -226,89 +207,11 @@ class ZLinkyTICMetering(CustomCluster, Metering):
     _CONSTANT_ATTRIBUTES = {MULTIPLIER: 1, DIVISOR: 1000}
 
 
-class ZLinkyTIC(CustomDevice):
-    """ZLinky_TIC from LiXee."""
-
-    signature = {
-        MODELS_INFO: [(LIXEE, "ZLinky_TIC")],
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.METER_INTERFACE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Metering.cluster_id,
-                    MeterIdentification.cluster_id,
-                    ElectricalMeasurement.cluster_id,
-                    ZLinkyTICManufacturerCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
-    }
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.METER_INTERFACE,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    ZLinkyTICMetering,
-                    MeterIdentification.cluster_id,
-                    ElectricalMeasurement.cluster_id,
-                    ZLinkyTICManufacturerCluster,
-                ],
-                OUTPUT_CLUSTERS: [Ota.cluster_id],
-            },
-            242: {
-                PROFILE_ID: zgp.PROFILE_ID,
-                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
-                INPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
-            },
-        },
-    }
-
-
-class ZLinkyTICFWV12(ZLinkyTIC):
-    """ZLinky_TIC from LiXee with firmware v12.0 & v13.0."""
-
-    signature = deepcopy(ZLinkyTIC.signature)
-
-    # Insert PowerConfiguration cluster in signature for devices with firmware v12.0 & v13.0
-    signature[ENDPOINTS][1][INPUT_CLUSTERS].insert(1, PowerConfiguration.cluster_id)
-
-
-class ZLinkyTICFWV14(ZLinkyTICFWV12):
-    """ZLinky_TIC from LiXee with firmware v14.0+."""
-
-    signature = deepcopy(ZLinkyTICFWV12.signature)
-    replacement = deepcopy(ZLinkyTICFWV12.replacement)
-
-    # Insert Time configuration cluster in signature for devices with firmware v14.0+
-    signature[ENDPOINTS][1][INPUT_CLUSTERS].insert(1, Time.cluster_id)
-
-    # Insert Tuya cluster in signature for devices with firmware v14.0+
-    signature[ENDPOINTS][1][INPUT_CLUSTERS].insert(7, TuyaManufCluster.cluster_id)
-    signature[ENDPOINTS][1][OUTPUT_CLUSTERS].insert(1, TuyaManufCluster.cluster_id)
-
-    replacement[ENDPOINTS][1][INPUT_CLUSTERS].insert(1, Time.cluster_id)
-
-
-class ZLinkyTICFWV15(ZLinkyTICFWV14):
-    """ZLinky_TIC from LiXee with firmware v15.0+."""
-
-    signature = deepcopy(ZLinkyTICFWV14.signature)
-    replacement = deepcopy(ZLinkyTICFWV14.replacement)
-
-    signature[ENDPOINTS][1][DEVICE_TYPE] = zha.DeviceType.DIMMABLE_LIGHT
-    replacement[ENDPOINTS][1][DEVICE_TYPE] = zha.DeviceType.DIMMABLE_LIGHT
+(
+    QuirkBuilder(LIXEE, "ZLinky_TIC")
+    # Not all firmware variants have a power configuration cluster
+    .adds(PowerConfiguration.cluster_id, endpoint_id=1)
+    .replaces(ZLinkyTICMetering, endpoint_id=1)
+    .replaces(ZLinkyTICManufacturerCluster, endpoint_id=1)
+    .add_to_registry()
+)

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -215,9 +215,15 @@ class ZLinkyTICMetering(CustomCluster, Metering):
     _CONSTANT_ATTRIBUTES = {MULTIPLIER: 1, DIVISOR: 1000}
 
 
+# The v1 quirk carried four subclasses matching firmware variants by exact
+# cluster list: the base signature, plus PowerConfiguration on v12, Time and a
+# Tuya cluster on v14, and a different device type on v15. Matching on
+# manufacturer and model covers every variant, and v2 only states the
+# differences, so clusters the device already reports are kept untouched.
 (
     QuirkBuilder(LIXEE, "ZLinky_TIC")
-    # Not all firmware variants have a power configuration cluster
+    # Added for every variant, as the v1 replacements did: not all firmware
+    # versions report a power configuration cluster.
     .adds(PowerConfiguration.cluster_id, endpoint_id=1)
     # Firmware v14 and later report a Tuya cluster the device does not
     # implement, as the v1 signatures for those variants recorded. Removing it

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -7,7 +7,13 @@ from zigpy.zcl.clusters.general import PowerConfiguration
 from zigpy.zcl.clusters.smartenergy import Metering
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
-from zhaquirks.builder import QuirkBuilder
+from zhaquirks.builder import (
+    EntityType,
+    QuirkBuilder,
+    SensorDeviceClass,
+    SensorStateClass,
+    UnitOfElectricCurrent,
+)
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.lixee import LIXEE, ZLINKY_MANUFACTURER_CLUSTER_ID
 
@@ -213,5 +219,62 @@ class ZLinkyTICMetering(CustomCluster, Metering):
     .adds(PowerConfiguration.cluster_id, endpoint_id=1)
     .replaces(ZLinkyTICMetering, endpoint_id=1)
     .replaces(ZLinkyTICManufacturerCluster, endpoint_id=1)
+    # PTEC: tariff period currently in effect, e.g. "TH.." on the Base tariff or
+    # "HC.."/"HP.." on the off-peak/peak tariff. Reported in both TIC modes from
+    # firmware v15. This is what automations need in order to follow the tariff
+    # period rather than a hardcoded schedule.
+    .sensor(
+        attribute_name=ZLinkyTICManufacturerCluster.AttributeDefs.linky_tariff_period.name,
+        cluster_id=ZLinkyTICManufacturerCluster.cluster_id,
+        translation_key="linky_tariff_period",
+        fallback_name="Tariff period",
+    )
+    # OPTARIF: tariff option the contract is subscribed to, e.g. "BASE" or
+    # "HC..". Complements PTEC: one gives the contract, the other the period
+    # currently in effect.
+    .sensor(
+        attribute_name=ZLinkyTICManufacturerCluster.AttributeDefs.hist_tariff_option_or_std_supplier_price_schedule_name.name,
+        cluster_id=ZLinkyTICManufacturerCluster.cluster_id,
+        translation_key="linky_tariff_option",
+        fallback_name="Tariff option",
+    )
+    # ADPS: warning raised when the subscribed power is exceeded, in amperes.
+    # Zero when there is no overload.
+    .sensor(
+        attribute_name=ZLinkyTICManufacturerCluster.AttributeDefs.hist_subscribed_power_exceeding_warning.name,
+        cluster_id=ZLinkyTICManufacturerCluster.cluster_id,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfElectricCurrent.AMPERE,
+        suggested_display_precision=0,
+        translation_key="linky_subscribed_power_exceeding_warning",
+        fallback_name="Subscribed power exceeding warning",
+    )
+    # HHPHC: off-peak hours schedule group the meter is assigned to. Only
+    # meaningful once an off-peak tariff is subscribed.
+    .sensor(
+        attribute_name=ZLinkyTICManufacturerCluster.AttributeDefs.hist_schedule_peak_hours_off_peak_hours.name,
+        cluster_id=ZLinkyTICManufacturerCluster.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="linky_off_peak_hours_schedule",
+        fallback_name="Off-peak hours schedule",
+    )
+    # MOTDETAT: meter status register, "000000" when nominal.
+    .sensor(
+        attribute_name=ZLinkyTICManufacturerCluster.AttributeDefs.linky_status.name,
+        cluster_id=ZLinkyTICManufacturerCluster.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="linky_status",
+        fallback_name="Meter status",
+    )
+    # TIC mode the meter emits: 0 is historical, 1 is standard. Tells users
+    # which of the hist_/std_ attribute sets their meter populates.
+    .sensor(
+        attribute_name=ZLinkyTICManufacturerCluster.AttributeDefs.linky_mode.name,
+        cluster_id=ZLinkyTICManufacturerCluster.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="linky_mode",
+        fallback_name="TIC mode",
+    )
     .add_to_registry()
 )

--- a/zhaquirks/lixee/zlinky.py
+++ b/zhaquirks/lixee/zlinky.py
@@ -3,6 +3,7 @@
 from typing import Final
 
 import zigpy.types as t
+from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import PowerConfiguration
 from zigpy.zcl.clusters.smartenergy import Metering
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
@@ -16,6 +17,7 @@ from zhaquirks.builder import (
 )
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.lixee import LIXEE, ZLINKY_MANUFACTURER_CLUSTER_ID
+from zhaquirks.tuya import TuyaManufCluster
 
 
 class ZLinkyTICManufacturerCluster(CustomCluster):
@@ -217,6 +219,13 @@ class ZLinkyTICMetering(CustomCluster, Metering):
     QuirkBuilder(LIXEE, "ZLinky_TIC")
     # Not all firmware variants have a power configuration cluster
     .adds(PowerConfiguration.cluster_id, endpoint_id=1)
+    # Firmware v14 and later report a Tuya cluster the device does not
+    # implement, as the v1 signatures for those variants recorded. Removing it
+    # keeps the v1 replacement behaviour; it is a no-op on older firmware.
+    .removes(TuyaManufCluster.cluster_id, endpoint_id=1)
+    .removes(
+        TuyaManufCluster.cluster_id, endpoint_id=1, cluster_type=ClusterType.Client
+    )
     .replaces(ZLinkyTICMetering, endpoint_id=1)
     .replaces(ZLinkyTICManufacturerCluster, endpoint_id=1)
     # PTEC: tariff period currently in effect, e.g. "TH.." on the Base tariff or


### PR DESCRIPTION
## Proposed change

Expose the ZLinky_TIC tariff period in Home Assistant.

The quirk already decodes the whole manufacturer specific cluster `0xFF66` —
42 attributes — but none of them reach Home Assistant. The only ZLinky sensors
that exist are the six Metering tier summations, and those are registered by the
ZHA library itself. A user on an off-peak/peak tariff has no entity telling them
which period is currently in effect, so automations have to hardcode a schedule.
In France that is increasingly wrong: the off-peak windows are being reshuffled
by Enedis, with afternoon slots that vary seasonally.

**A v1 quirk cannot fix this.** Legacy quirks are compiled into registry entries
with `zha_device_factory=None`, so there is nowhere to attach entity metadata.
Exposing an attribute from the quirk requires the file to be v2. That is the
only reason the conversion is in here, and it is why the commits are split:

1. **`Convert the ZLinky_TIC quirk to v2`** — the four v1 subclasses matched
   firmware variants by exact cluster list; matching on manufacturer and model
   covers all of them, so they collapse into a single `QuirkBuilder`. This
   commit is intentionally identical to the lixee hunk of #4499.
2. **`Expose ZLinky_TIC tariff period and meter status sensors`** — the actual
   feature, six sensors on the manufacturer cluster.
3. **`Keep removing the Tuya cluster the ZLinky_TIC does not implement`** — a
   fix on review. The conversion was *not* inert as first claimed: firmware v14
   and later report a Tuya cluster the device does not implement, which the v1
   quirk dropped by listing it in the FWV14/FWV15 signatures but not in their
   replacements. That is what the two ZLinky entries in the
   `test_suspicious_cluster_moves` allow list recorded, and removing those
   entries without replacing the behaviour lost it — confirmed on hardware,
   `0xEF00` came back on endpoint 1 in both directions. It is now removed
   explicitly and pinned by a test. **The lixee hunk of #4499 has the same
   omission.**
4. **`Record why the v1 subclasses collapse and the allow list entries go`** —
   comments only.

Every other v1/v2 difference was checked and is a non-issue: `Time`, the v15
`DIMMABLE_LIGHT` device type and the standard clusters were re-listed by the v1
replacements only because those lists are exhaustive. A v2 quirk states
differences, so anything untouched is preserved as the device reports it.

Reviewing the commits separately should make it easy to see what the conversion
changes before looking at what it enables.

## Additional information

**Relationship to #4499.** That PR already migrates `zhaquirks/lixee/zlinky.py`,
and the first commit here is deliberately the same change. It is currently
`mergeable_state: dirty` across 158 files with no activity since 2026-07-21, so
rather than wait on it — or pile a feature onto a 158-file migration — this
keeps one device and one problem together in a reviewable PR. Happy to drop the
first commit and rebase on #4499 instead if you would rather land that first;
just say which you prefer. If this lands first, lixee can be dropped from #4499.

**Relationship to #3456.** @blauret converted this quirk to v2 and added
sensors back in 2024. It was tested by users and closed unmerged only because
its author moved to Zigbee2MQTT. The entity list here is based on that work and
credited in the commit message. I deliberately kept a smaller set than #3456:
only attributes I could read back from real hardware, all on the manufacturer
cluster. The `ElectricalMeasurement` and `Metering` additions from that PR are
left for a follow-up.

**Sensors added**, with the values read from a v15 meter on the Base tariff:

| Attribute | TIC code | Value read | Entity |
| --- | --- | --- | --- |
| `linky_tariff_period` | PTEC | `TH..` | Tariff period |
| `hist_tariff_option_or_std_supplier_price_schedule_name` | OPTARIF | `BASE` | Tariff option |
| `hist_subscribed_power_exceeding_warning` | ADPS | `0` | Subscribed power exceeding warning |
| `hist_schedule_peak_hours_off_peak_hours` | HHPHC | `0` | Off-peak hours schedule (diagnostic) |
| `linky_status` | MOTDETAT | `000000` | Meter status (diagnostic) |
| `linky_mode` | — | `0` | TIC mode (diagnostic) |

**No firmware version filtering.** Attributes a meter does not support are
skipped by ZHA's `_is_supported()` rather than producing empty entities, which
is also why the existing tier summation sensors carry no version guard. The
`From V13` / `From V15` notes in the attribute definitions stay comments.

**One known limitation, reported on #3456 and not fixed here:** the tariff
period does not appear to refresh on its own, only on an explicit read. I could
not reproduce it either way — my meter is on the Base tariff, so the value never
changes. If it is confirmed, a `reporting_config` on the sensor would be the fix
and I am happy to add it in this PR.

## Device diagnostics

[zha-01K3QV44R6NV3V8EP1TMKCFKGE-LiXee ZLinky_TIC-9ef86ccabdca67c2652627c1fbd79218.json](https://github.com/user-attachments/files/30977788/zha-01K3QV44R6NV3V8EP1TMKCFKGE-LiXee.ZLinky_TIC-9ef86ccabdca67c2652627c1fbd79218.json)

Attached. One caveat: `quirk_class` reads `zlinky_tarif:(LiXee / ZLinky_TIC)`
because the diagnostics were captured with this change loaded as a custom quirk
via `custom_quirks_path`, which is how it was tested on hardware. The cluster
and attribute contents are the ones this PR produces.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
