### PR TITLE
Convert TS011F plug v2 to QuirkBuilder

### DIFF
--- a/tests/test_tuya_ts011f_plug.py
+++ b/tests/test_tuya_ts011f_plug.py
@@ -1,0 +1,56 @@
+"""Tests for Tuya TS011F plugs."""
+
+import pytest
+from zha.application import EntityType
+from zha.quirks import DEVICE_REGISTRY
+from zigpy.zcl import ClusterType
+from zigpy.zcl.clusters.general import OnOff
+
+from zhaquirks.tuya.ts011f_plug import PowerOnState, SwitchBackLight
+
+
+@pytest.mark.parametrize(
+    "manufacturer,model",
+    [
+        ("_TZ3000_5f43h46b", "TS011F"),
+        ("_TZ3000_okaz9tjs", "TS011F"),
+    ],
+)
+async def test_ts011f_v2_quirk(zigpy_device_from_v2_quirk, manufacturer, model):
+    """Test TS011F V2 quirk."""
+    device = zigpy_device_from_v2_quirk(manufacturer, model)
+
+    entry = DEVICE_REGISTRY.match_entry(device)
+    assert entry is not None
+
+    definition = entry.zha_device_factory.quirk_definition
+
+    assert len(definition.entity_metadata) == 3
+
+    metadata_by_attribute = {
+        metadata.attribute_name: metadata for metadata in definition.entity_metadata
+    }
+
+    child_lock = metadata_by_attribute["child_lock"]
+    assert child_lock.cluster_id == OnOff.cluster_id
+    assert child_lock.cluster_type is ClusterType.Server
+    assert child_lock.entity_type is EntityType.CONFIG
+    assert child_lock.translation_key == "child_lock"
+    assert child_lock.fallback_name == "Child lock"
+    assert child_lock.resolved_unique_id_suffix == "6-child_lock"
+
+    power_on_state = metadata_by_attribute["power_on_state"]
+    assert power_on_state.cluster_id == OnOff.cluster_id
+    assert power_on_state.cluster_type is ClusterType.Server
+    assert power_on_state.entity_type is EntityType.CONFIG
+    assert power_on_state.translation_key == "power_on_state"
+    assert power_on_state.fallback_name == "Power on state"
+    assert power_on_state.enum is PowerOnState
+
+    backlight_mode = metadata_by_attribute["backlight_mode"]
+    assert backlight_mode.cluster_id == OnOff.cluster_id
+    assert backlight_mode.cluster_type is ClusterType.Server
+    assert backlight_mode.entity_type is EntityType.CONFIG
+    assert backlight_mode.translation_key == "backlight_mode"
+    assert backlight_mode.fallback_name == "Backlight mode"
+    assert backlight_mode.enum is SwitchBackLight

--- a/zhaquirks/tuya/ts011f_plug.py
+++ b/zhaquirks/tuya/ts011f_plug.py
@@ -2,6 +2,7 @@
 
 from zha.quirks import TUYA_PLUG_ONOFF
 from zigpy.profiles import zgp, zha
+from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import (
     Basic,
     GreenPowerProxy,
@@ -17,6 +18,7 @@ from zigpy.zcl.clusters.lightlink import LightLink
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
+from zhaquirks.builder import EntityType, QuirkBuilder
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -29,6 +31,8 @@ from zhaquirks.const import (
 from zhaquirks.legacy import CustomDevice
 from zhaquirks.tuya import (
     EnchantedDevice,
+    PowerOnState,
+    SwitchBackLight,
     TuyaNewManufCluster,
     TuyaZB1888Cluster,
     TuyaZBE000Cluster,
@@ -1047,109 +1051,42 @@ class Plug_4AC_2USB_Metering(EnchantedDevice):
     }
 
 
-class Plug_v2(EnchantedDevice):
-    """Another TS011F Tuya plug. First one using this definition is _TZ3000_okaz9tjs."""
-
-    quirk_id = TUYA_PLUG_ONOFF
-
-    signature = {
-        MODEL: "TS011F",
-        ENDPOINTS: {
-            # "profile_id": 260,
-            # "device_type": "0x0051",
-            # "in_clusters": ["0x0000", "0x0003", "0x0004", "0x0005", "0x0006", "0x0702", "0x0b04", "0xe001"],
-            # "out_clusters": []
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    Metering.cluster_id,
-                    ElectricalMeasurement.cluster_id,
-                    TuyaZBExternalSwitchTypeCluster.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    TuyaZBOnOffAttributeCluster,
-                    TuyaZBMeteringClusterWithUnit,
-                    TuyaZBElectricalMeasurement,
-                    TuyaZBExternalSwitchTypeCluster,
-                ],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
-
-
-class Plug_v2_var_fc11(EnchantedDevice):
-    """Another TS011F Tuya plug, Plug_v2 variant with additional 0xfc11 input-cluster.
-
-    First ones using this definition are _TZ3000_okaz9tjs and _TZ3000_5f43h46b.
-    """
-
-    quirk_id = TUYA_PLUG_ONOFF
-
-    signature = {
-        MODEL: "TS011F",
-        ENDPOINTS: {
-            # "profile_id": 260,
-            # "device_type": "0x0051",
-            # "in_clusters": ["0x0000", "0x0003", "0x0004", "0x0005", "0x0006", "0x0702", "0x0b04", "0xe001", "0xfc11"],
-            # "out_clusters": []
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    OnOff.cluster_id,
-                    Metering.cluster_id,
-                    ElectricalMeasurement.cluster_id,
-                    TuyaZBExternalSwitchTypeCluster.cluster_id,
-                    0xFC11,
-                ],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.SMART_PLUG,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    Identify.cluster_id,
-                    Groups.cluster_id,
-                    Scenes.cluster_id,
-                    TuyaZBOnOffAttributeCluster,
-                    TuyaZBMeteringClusterWithUnit,
-                    TuyaZBElectricalMeasurement,
-                    TuyaZBExternalSwitchTypeCluster,
-                    0xFC11,
-                ],
-                OUTPUT_CLUSTERS: [],
-            },
-        },
-    }
+(
+    QuirkBuilder("_TZ3000_5f43h46b", "TS011F")
+    .applies_to("_TZ3000_okaz9tjs", "TS011F")
+    .replaces(TuyaZBOnOffAttributeCluster)
+    .replaces(TuyaZBMeteringClusterWithUnit)
+    .replaces(TuyaZBElectricalMeasurement)
+    .replaces(TuyaZBExternalSwitchTypeCluster)
+    .switch(
+        attribute_name="child_lock",
+        cluster_id=OnOff.cluster_id,
+        cluster_type=ClusterType.Server,
+        entity_type=EntityType.CONFIG,
+        unique_id_suffix="6-child_lock",
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    .enum(
+        attribute_name="power_on_state",
+        enum_class=PowerOnState,
+        cluster_id=OnOff.cluster_id,
+        cluster_type=ClusterType.Server,
+        entity_type=EntityType.CONFIG,
+        translation_key="power_on_state",
+        fallback_name="Power on state",
+    )
+    .enum(
+        attribute_name="backlight_mode",
+        enum_class=SwitchBackLight,
+        cluster_id=OnOff.cluster_id,
+        cluster_type=ClusterType.Server,
+        entity_type=EntityType.CONFIG,
+        translation_key="backlight_mode",
+        fallback_name="Backlight mode",
+    )
+    .add_to_registry()
+)
 
 
 class Plug_v3(EnchantedDevice):


### PR DESCRIPTION
## Proposed change

Convert the existing TS011F plug v2 quirk for `_TZ3000_5f43h46b` and
`_TZ3000_okaz9tjs` from the legacy device definition to QuirkBuilder.

The existing Tuya cluster replacements and configuration entities are
preserved:
- child lock
- power-on state
- backlight mode

A unit test was added to verify that the QuirkBuilder definition is
registered for both supported manufacturers and exposes the expected
configuration entities.

## Additional information

This is a migration of the existing quirk to QuirkBuilder and is intended
to preserve the existing behavior. No changes to the device functionality
are intended.

The following checks pass:
- `python -m pytest -q tests/test_tuya_ts011f_plug.py` — 2 passed
- `ruff`
- `ruff format`
- `mypy`
- `codespell`
- `git diff --check`

## Device diagnostics

Not applicable. This PR converts an existing quirk to QuirkBuilder and
does not add support for a new device.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached