### PR TITLE
Add Lidl HG06463A (_TZ3000_j2w1dw29) to the TS0501A dimmable bulb quirk

### DIFF
--- a/zhaquirks/lidl/TS0501A.py
+++ b/zhaquirks/lidl/TS0501A.py
@@ -34,6 +34,7 @@ class DimmableBulb(CustomDevice):
             ("_TZ3000_nosnx7im", "TS0501A"),
             ("_TZ3000_nbnmw9nc", "TS0501A"),
             ("_TZ3000_7dcddnye", "TS0501A"),
+            ("_TZ3000_j2w1dw29", "TS0501A"),
         ],
         ENDPOINTS: {
             # <SimpleDescriptor endpoint=1 profile=260 device_type=257


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Added _TZ3000_j2w1dw29 (Lidl Livarno Light, Eddison-Design) to models


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
This model is the Eddison variant of the bulb and wasn't recognized until now.

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
