### PR TITLE
Add Bosch Twinguard support

### DIFF
--- a/tests/test_bosch_twinguard.py
+++ b/tests/test_bosch_twinguard.py
@@ -43,6 +43,7 @@ from zhaquirks.bosch.twinguard import (
     TwinguardSensitivity,
     TwinguardSirenState,
 )
+from zhaquirks.builder import EntityType
 
 TWINGUARD_CLUSTER_IDS = {
     1: {
@@ -145,6 +146,7 @@ def test_twinguard_quirk_and_entities(zigpy_device_from_v2_quirk):
     assert temperature.divisor == 100
     assert humidity.divisor == 100
     assert battery.divisor == 2
+    assert battery.entity_type is EntityType.DIAGNOSTIC
     assert aqi.attribute_converter is None
     assert eco2.attribute_converter(42) == 920
 

--- a/tests/test_bosch_twinguard.py
+++ b/tests/test_bosch_twinguard.py
@@ -1,0 +1,433 @@
+"""Tests for the Bosch Twinguard quirk."""
+
+import asyncio
+from unittest import mock
+
+import pytest
+from zha.quirks import DEVICE_REGISTRY
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.general import Alarms, PollControl, PowerConfiguration
+from zigpy.zcl.clusters.measurement import (
+    CarbonMonoxideConcentration,
+    IlluminanceMeasurement,
+    PressureMeasurement,
+    RelativeHumidity,
+    TemperatureMeasurement,
+)
+
+from zhaquirks.bosch.twinguard import (
+    BOSCH_MANUFACTURER_CODE,
+    BURGLAR_ALARM_STATUS,
+    CLEAR_ALARM,
+    CLEAR_ALARM_STATUS,
+    FIRE_ALARM,
+    FIRE_ALARM_STATUS,
+    PRE_ALARM,
+    PRE_ALARM_STATUS,
+    SELF_TEST_ALARM_STATUS,
+    SILENCE_ALARM,
+    SILENCED_ALARM_STATUS,
+    TWINGUARD_ALARM_CLUSTER,
+    TWINGUARD_MEASUREMENTS_CLUSTER,
+    TWINGUARD_OPTIONS_CLUSTER,
+    TWINGUARD_SETUP_CLUSTER,
+    TWINGUARD_SMOKE_CLUSTER,
+    BoschTwinguardAlarmCluster,
+    BoschTwinguardAlarmsCluster,
+    BoschTwinguardMeasurementsCluster,
+    BoschTwinguardOptionsCluster,
+    BoschTwinguardSetupCluster,
+    BoschTwinguardSirenControl,
+    BoschTwinguardSmokeCluster,
+    TwinguardAlarmMode,
+    TwinguardSensitivity,
+    TwinguardSirenState,
+)
+
+TWINGUARD_CLUSTER_IDS = {
+    1: {
+        Alarms.cluster_id: ClusterType.Server,
+        TWINGUARD_SMOKE_CLUSTER: ClusterType.Server,
+        TWINGUARD_OPTIONS_CLUSTER: ClusterType.Server,
+        # The Twinguard also has an Alarms client cluster on endpoint 1.
+        # A dictionary cannot contain both cluster types for one ID, so add it below.
+    },
+    3: {TWINGUARD_MEASUREMENTS_CLUSTER: ClusterType.Server},
+    4: {PowerConfiguration.cluster_id: ClusterType.Server},
+    5: {TemperatureMeasurement.cluster_id: ClusterType.Server},
+    6: {IlluminanceMeasurement.cluster_id: ClusterType.Server},
+    7: {PollControl.cluster_id: ClusterType.Server},
+    8: {PressureMeasurement.cluster_id: ClusterType.Server},
+    9: {RelativeHumidity.cluster_id: ClusterType.Server},
+    11: {CarbonMonoxideConcentration.cluster_id: ClusterType.Server},
+    12: {
+        TWINGUARD_SETUP_CLUSTER: ClusterType.Server,
+        TWINGUARD_ALARM_CLUSTER: ClusterType.Server,
+    },
+}
+
+
+def make_twinguard(
+    zigpy_device_from_v2_quirk,
+    manufacturer="BOSCH ST",
+):
+    """Create a quirked Twinguard with its relevant endpoints and clusters."""
+    device = zigpy_device_from_v2_quirk(
+        manufacturer=manufacturer,
+        model="Champion",
+        cluster_ids=TWINGUARD_CLUSTER_IDS,
+    )
+    device.endpoints[1].add_output_cluster(Alarms.cluster_id)
+    return device
+
+
+def test_twinguard_quirk_and_entities(zigpy_device_from_v2_quirk):
+    """Test cluster replacements and V2 entity metadata."""
+    device = make_twinguard(zigpy_device_from_v2_quirk)
+
+    assert isinstance(device.endpoints[1].alarms, BoschTwinguardAlarmsCluster)
+    assert isinstance(device.endpoints[1].twinguard_smoke, BoschTwinguardSmokeCluster)
+    assert isinstance(
+        device.endpoints[1].twinguard_options, BoschTwinguardOptionsCluster
+    )
+    assert isinstance(
+        device.endpoints[1].twinguard_siren_control,
+        BoschTwinguardSirenControl,
+    )
+    assert isinstance(
+        device.endpoints[3].twinguard_measurements,
+        BoschTwinguardMeasurementsCluster,
+    )
+    assert isinstance(device.endpoints[12].twinguard_setup, BoschTwinguardSetupCluster)
+    assert isinstance(device.endpoints[12].twinguard_alarm, BoschTwinguardAlarmCluster)
+
+    entry = DEVICE_REGISTRY.match_entry(device)
+    metadata_by_suffix = {
+        metadata.resolved_unique_id_suffix: metadata
+        for metadata in entry.zha_device_factory.quirk_definition.entity_metadata
+    }
+    disabled_default_entities = {
+        (metadata.endpoint_id, metadata.cluster_id)
+        for metadata in entry.zha_device_factory.quirk_definition.disabled_default_entities
+    }
+    assert disabled_default_entities == {
+        (4, PowerConfiguration.cluster_id),
+        (5, TemperatureMeasurement.cluster_id),
+        (6, IlluminanceMeasurement.cluster_id),
+        (8, PressureMeasurement.cluster_id),
+        (9, RelativeHumidity.cluster_id),
+        (11, CarbonMonoxideConcentration.cluster_id),
+    }
+    assert set(metadata_by_suffix) == {
+        "illuminance",
+        "temperature",
+        "humidity",
+        "battery",
+        "aqi",
+        "eco2",
+        "smoke",
+        "self_test_active",
+        "initiate_test_mode",
+        "pre_alarm",
+        "heartbeat",
+        "alarm_mode",
+        "siren_state",
+        "sensitivity",
+    }
+
+    aqi = metadata_by_suffix["aqi"]
+    battery = metadata_by_suffix["battery"]
+    eco2 = metadata_by_suffix["eco2"]
+    humidity = metadata_by_suffix["humidity"]
+    illuminance = metadata_by_suffix["illuminance"]
+    temperature = metadata_by_suffix["temperature"]
+    assert illuminance.divisor == 2
+    assert temperature.divisor == 100
+    assert humidity.divisor == 100
+    assert battery.divisor == 2
+    assert aqi.attribute_converter is None
+    assert eco2.attribute_converter(42) == 920
+
+
+def test_twinguard_alternate_manufacturer(zigpy_device_from_v2_quirk):
+    """Test the alternate manufacturer string used by some Twinguards."""
+    device = make_twinguard(
+        zigpy_device_from_v2_quirk,
+        manufacturer="BoschSmartHomeGmbH",
+    )
+    assert isinstance(device.endpoints[1].twinguard_smoke, BoschTwinguardSmokeCluster)
+
+
+async def test_twinguard_fire_alarm_is_acknowledged(zigpy_device_from_v2_quirk):
+    """Test fire notifications update state and are echoed to the device."""
+    device = make_twinguard(zigpy_device_from_v2_quirk)
+    alarms = device.endpoints[1].alarms
+    alarms_client = device.endpoints[1].out_clusters[Alarms.cluster_id]
+    alarms_client.client_command = mock.AsyncMock()
+
+    header = foundation.ZCLHeader.cluster(
+        tsn=1,
+        command_id=Alarms.ClientCommandDefs.alarm.id,
+        direction=foundation.Direction.Server_to_Client,
+    )
+    args = Alarms.ClientCommandDefs.alarm.schema(
+        alarm_code=FIRE_ALARM,
+        cluster_id=TWINGUARD_SMOKE_CLUSTER,
+    )
+    alarms.handle_cluster_request(header, args)
+    await asyncio.sleep(0)
+
+    siren_control = device.endpoints[1].twinguard_siren_control
+    assert (
+        siren_control.get(BoschTwinguardSirenControl.AttributeDefs.siren_state.id)
+        == TwinguardSirenState.Fire
+    )
+    alarms_client.client_command.assert_awaited_once_with(
+        Alarms.ClientCommandDefs.alarm.id,
+        alarm_code=FIRE_ALARM,
+        cluster_id=TWINGUARD_SMOKE_CLUSTER,
+        expect_reply=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "state", "mode"),
+    [
+        (CLEAR_ALARM_STATUS, TwinguardSirenState.Clear, TwinguardAlarmMode.Stop),
+        (
+            SILENCED_ALARM_STATUS,
+            TwinguardSirenState.Silenced,
+            TwinguardAlarmMode.Stop,
+        ),
+        (FIRE_ALARM_STATUS, TwinguardSirenState.Fire, TwinguardAlarmMode.Fire),
+        (
+            PRE_ALARM_STATUS,
+            TwinguardSirenState.Pre_alarm,
+            TwinguardAlarmMode.Pre_alarm,
+        ),
+        (
+            BURGLAR_ALARM_STATUS,
+            TwinguardSirenState.Burglar,
+            TwinguardAlarmMode.Burglar,
+        ),
+    ],
+)
+def test_twinguard_alarm_status_updates_local_state(
+    zigpy_device_from_v2_quirk,
+    status,
+    state,
+    mode,
+):
+    """Test reported alarm states update both local alarm entities."""
+    device = make_twinguard(zigpy_device_from_v2_quirk)
+    alarm_cluster = device.endpoints[12].twinguard_alarm
+    siren_control = device.endpoints[1].twinguard_siren_control
+
+    alarm_cluster.update_attribute(
+        BoschTwinguardAlarmCluster.AttributeDefs.alarm_status.id,
+        status,
+    )
+
+    assert (
+        siren_control.get(BoschTwinguardSirenControl.AttributeDefs.siren_state.id)
+        == state
+    )
+    assert (
+        siren_control.get(BoschTwinguardSirenControl.AttributeDefs.alarm_mode.id)
+        == mode
+    )
+
+
+def test_twinguard_self_test_does_not_change_alarm_mode(
+    zigpy_device_from_v2_quirk,
+):
+    """Test self-test is reported without changing the selected alarm mode."""
+    device = make_twinguard(zigpy_device_from_v2_quirk)
+    alarm_cluster = device.endpoints[12].twinguard_alarm
+    siren_control = device.endpoints[1].twinguard_siren_control
+    siren_control.update_siren_state(TwinguardSirenState.Fire)
+
+    alarm_cluster.update_attribute(
+        BoschTwinguardAlarmCluster.AttributeDefs.alarm_status.id,
+        SELF_TEST_ALARM_STATUS,
+    )
+
+    assert (
+        siren_control.get(BoschTwinguardSirenControl.AttributeDefs.siren_state.id)
+        == TwinguardSirenState.Self_test
+    )
+    assert (
+        siren_control.get(BoschTwinguardSirenControl.AttributeDefs.alarm_mode.id)
+        == TwinguardAlarmMode.Fire
+    )
+
+
+async def test_twinguard_siren_state_is_read_only(zigpy_device_from_v2_quirk):
+    """Test the reported siren state cannot be written locally."""
+    device = make_twinguard(zigpy_device_from_v2_quirk)
+    siren_control = device.endpoints[1].twinguard_siren_control
+    state_attribute = BoschTwinguardSirenControl.AttributeDefs.siren_state
+
+    result = await siren_control.write_attributes(
+        {state_attribute.name: TwinguardSirenState.Fire}
+    )
+
+    assert result == [
+        [
+            foundation.WriteAttributesStatusRecord(
+                status=foundation.Status.READ_ONLY,
+                attrid=state_attribute.id,
+            )
+        ]
+    ]
+    assert siren_control.get(state_attribute.id) == TwinguardSirenState.Clear
+
+
+@pytest.mark.parametrize(
+    ("mode", "alarm_codes", "burglar_data", "state"),
+    [
+        (
+            TwinguardAlarmMode.Stop,
+            [SILENCE_ALARM, CLEAR_ALARM],
+            0x00,
+            TwinguardSirenState.Clear,
+        ),
+        (
+            TwinguardAlarmMode.Pre_alarm,
+            [PRE_ALARM],
+            0x00,
+            TwinguardSirenState.Pre_alarm,
+        ),
+        (
+            TwinguardAlarmMode.Fire,
+            [FIRE_ALARM],
+            0x00,
+            TwinguardSirenState.Fire,
+        ),
+        (
+            TwinguardAlarmMode.Burglar,
+            [SILENCE_ALARM, CLEAR_ALARM],
+            0x01,
+            TwinguardSirenState.Burglar,
+        ),
+    ],
+)
+async def test_twinguard_alarm_mode_commands(
+    zigpy_device_from_v2_quirk,
+    mode,
+    alarm_codes,
+    burglar_data,
+    state,
+):
+    """Test alarm-mode selections issue the expected Bosch commands."""
+    device = make_twinguard(zigpy_device_from_v2_quirk)
+    siren_control = device.endpoints[1].twinguard_siren_control
+    alarms = device.endpoints[1].out_clusters[Alarms.cluster_id]
+    burglar = device.endpoints[12].twinguard_alarm
+    alarms.client_command = mock.AsyncMock()
+    burglar.command = mock.AsyncMock()
+
+    result = await siren_control.write_attributes(
+        {BoschTwinguardSirenControl.AttributeDefs.alarm_mode.name: mode}
+    )
+
+    assert result == [
+        [foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]
+    ]
+    assert [
+        call.kwargs["alarm_code"] for call in alarms.client_command.await_args_list
+    ] == alarm_codes
+    burglar.command.assert_awaited_once_with(
+        BoschTwinguardAlarmCluster.ServerCommandDefs.burglar_alarm.id,
+        data=burglar_data,
+        manufacturer=BOSCH_MANUFACTURER_CODE,
+        expect_reply=False,
+    )
+    assert (
+        siren_control.get(BoschTwinguardSirenControl.AttributeDefs.siren_state.id)
+        == state
+    )
+
+
+async def test_twinguard_pairing_configuration(zigpy_device_from_v2_quirk):
+    """Test the Bosch pairing handshake and initial configuration."""
+    device = make_twinguard(zigpy_device_from_v2_quirk)
+    setup = device.endpoints[12].twinguard_setup
+    options = device.endpoints[1].twinguard_options
+    smoke = device.endpoints[1].twinguard_smoke
+
+    clusters_to_bind = [
+        device.endpoints[7].poll_control,
+        device.endpoints[1].alarms,
+        smoke,
+        options,
+        device.endpoints[3].twinguard_measurements,
+        setup,
+        device.endpoints[12].twinguard_alarm,
+    ]
+    for cluster in clusters_to_bind:
+        cluster.bind = mock.AsyncMock()
+
+    calls = mock.Mock()
+    options_read = mock.patch.object(
+        options, "read_attributes", mock.AsyncMock()
+    ).start()
+    pairing_command = mock.patch.object(setup, "command", mock.AsyncMock()).start()
+    calls.attach_mock(options_read, "read_options")
+    calls.attach_mock(pairing_command, "pairing_command")
+    smoke.write_attributes = mock.AsyncMock()
+    options.write_attributes = mock.AsyncMock()
+    setup.write_attributes = mock.AsyncMock()
+    smoke.read_attributes = mock.AsyncMock()
+    setup.read_attributes = mock.AsyncMock()
+
+    try:
+        await setup.apply_custom_configuration()
+    finally:
+        mock.patch.stopall()
+
+    for cluster in clusters_to_bind:
+        cluster.bind.assert_awaited_once()
+
+    assert calls.mock_calls[:2] == [
+        mock.call.read_options(
+            [BoschTwinguardOptionsCluster.AttributeDefs.pairing_state.id],
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+        ),
+        mock.call.pairing_command(
+            BoschTwinguardSetupCluster.ServerCommandDefs.pairing_completed.id,
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+        ),
+    ]
+    smoke.write_attributes.assert_awaited_once_with(
+        {
+            BoschTwinguardSmokeCluster.AttributeDefs.sensitivity.id: TwinguardSensitivity.Medium
+        },
+        manufacturer=BOSCH_MANUFACTURER_CODE,
+    )
+    options.write_attributes.assert_awaited_once_with(
+        {BoschTwinguardOptionsCluster.AttributeDefs.pre_alarm.id: 0x01},
+        manufacturer=BOSCH_MANUFACTURER_CODE,
+    )
+    setup.write_attributes.assert_awaited_once_with(
+        {BoschTwinguardSetupCluster.AttributeDefs.heartbeat.id: 0x01},
+        manufacturer=BOSCH_MANUFACTURER_CODE,
+    )
+    assert options_read.await_args_list == [
+        mock.call(
+            [BoschTwinguardOptionsCluster.AttributeDefs.pairing_state.id],
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+        ),
+        mock.call(
+            [BoschTwinguardOptionsCluster.AttributeDefs.pre_alarm.id],
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+        ),
+    ]
+    smoke.read_attributes.assert_awaited_once_with(
+        [BoschTwinguardSmokeCluster.AttributeDefs.sensitivity.id],
+        manufacturer=BOSCH_MANUFACTURER_CODE,
+    )
+    setup.read_attributes.assert_awaited_once_with(
+        [BoschTwinguardSetupCluster.AttributeDefs.heartbeat.id],
+        manufacturer=BOSCH_MANUFACTURER_CODE,
+    )

--- a/tests/test_bosch_twinguard.py
+++ b/tests/test_bosch_twinguard.py
@@ -149,6 +149,8 @@ def test_twinguard_quirk_and_entities(zigpy_device_from_v2_quirk):
     assert battery.entity_type is EntityType.DIAGNOSTIC
     assert aqi.attribute_converter is None
     assert eco2.attribute_converter(42) == 920
+    assert eco2.device_class is None
+    assert eco2.translation_key == "estimated_co2"
 
 
 def test_twinguard_alternate_manufacturer(zigpy_device_from_v2_quirk):

--- a/zhaquirks/bosch/twinguard.py
+++ b/zhaquirks/bosch/twinguard.py
@@ -538,6 +538,7 @@ class BoschTwinguardSirenControl(LocalDataCluster):
         unit=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_type=EntityType.DIAGNOSTIC,
         fallback_name="Battery",
     )
     .sensor(

--- a/zhaquirks/bosch/twinguard.py
+++ b/zhaquirks/bosch/twinguard.py
@@ -566,10 +566,10 @@ class BoschTwinguardSirenControl(LocalDataCluster):
         endpoint_id=3,
         attribute_converter=lambda value: value * 10 + 500,
         unit=CONCENTRATION_PARTS_PER_MILLION,
-        device_class=SensorDeviceClass.CO2,
         state_class=SensorStateClass.MEASUREMENT,
         unique_id_suffix="eco2",
-        fallback_name="eCO2",
+        translation_key="estimated_co2",
+        fallback_name="Estimated CO₂",
     )
     .binary_sensor(
         BoschTwinguardAlarmCluster.AttributeDefs.alarm_status.name,

--- a/zhaquirks/bosch/twinguard.py
+++ b/zhaquirks/bosch/twinguard.py
@@ -1,0 +1,642 @@
+"""Device handler for the Bosch Twinguard smoke detector."""
+
+from typing import Final
+
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import Alarms, PollControl, PowerConfiguration
+from zigpy.zcl.clusters.measurement import (
+    CarbonMonoxideConcentration,
+    IlluminanceMeasurement,
+    PressureMeasurement,
+    RelativeHumidity,
+    TemperatureMeasurement,
+)
+from zigpy.zcl.foundation import (
+    BaseAttributeDefs,
+    BaseCommandDefs,
+    ZCLAttributeDef,
+    ZCLCommandDef,
+)
+
+from zhaquirks import LocalDataCluster
+from zhaquirks.builder import (
+    CONCENTRATION_PARTS_PER_MILLION,
+    LIGHT_LUX,
+    PERCENTAGE,
+    BinarySensorDeviceClass,
+    EntityPlatform,
+    EntityType,
+    QuirkBuilder,
+    SensorDeviceClass,
+    SensorStateClass,
+    UnitOfTemperature,
+)
+from zhaquirks.clusters import CustomCluster
+
+BOSCH_MANUFACTURER_CODE = 0x1209
+TWINGUARD_SMOKE_CLUSTER = 0xE000
+TWINGUARD_MEASUREMENTS_CLUSTER = 0xE002
+TWINGUARD_OPTIONS_CLUSTER = 0xE004
+TWINGUARD_SETUP_CLUSTER = 0xE006
+TWINGUARD_ALARM_CLUSTER = 0xE007
+TWINGUARD_SIREN_CONTROL_CLUSTER = 0xFBFD
+
+FIRE_ALARM = 0x10
+PRE_ALARM = 0x11
+CLEAR_ALARM = 0x14
+SILENCE_ALARM = 0x16
+
+CLEAR_ALARM_STATUS = 0x00200020
+SILENCED_ALARM_STATUS = 0x00200040
+FIRE_ALARM_STATUS = 0x00200081
+PRE_ALARM_STATUS = 0x00200082
+SELF_TEST_ALARM_STATUS = 0x01200020
+BURGLAR_ALARM_STATUS = 0x02200020
+
+
+class TwinguardSensitivity(t.enum16):
+    """Smoke sensitivity values used by the Twinguard."""
+
+    High = 0x0001
+    Medium = 0x0002
+    Low = 0x0003
+
+
+class TwinguardAlarmMode(t.enum8):
+    """Alarm modes supported by the Bosch protocol."""
+
+    Stop = 0x00
+    Pre_alarm = 0x01
+    Fire = 0x02
+    Burglar = 0x03
+
+
+class TwinguardSirenState(t.enum8):
+    """Read-only states reported by the Bosch alarm protocol."""
+
+    Clear = 0x00
+    Self_test = 0x01
+    Burglar = 0x02
+    Pre_alarm = 0x03
+    Fire = 0x04
+    Silenced = 0x05
+
+
+async def set_bosch_alarm_mode(device, mode: TwinguardAlarmMode) -> None:
+    """Select one of the Bosch alarm modes."""
+    alarms = device.endpoints[1].out_clusters[Alarms.cluster_id]
+    burglar = device.endpoints[12].in_clusters[TWINGUARD_ALARM_CLUSTER]
+
+    if mode == TwinguardAlarmMode.Pre_alarm:
+        await burglar.command(
+            burglar.ServerCommandDefs.burglar_alarm.id,
+            data=0x00,
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+            expect_reply=False,
+        )
+        await alarms.client_command(
+            Alarms.ClientCommandDefs.alarm.id,
+            alarm_code=PRE_ALARM,
+            cluster_id=TWINGUARD_SMOKE_CLUSTER,
+            expect_reply=False,
+        )
+        return
+
+    if mode == TwinguardAlarmMode.Fire:
+        await burglar.command(
+            burglar.ServerCommandDefs.burglar_alarm.id,
+            data=0x00,
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+            expect_reply=False,
+        )
+        await alarms.client_command(
+            Alarms.ClientCommandDefs.alarm.id,
+            alarm_code=FIRE_ALARM,
+            cluster_id=TWINGUARD_SMOKE_CLUSTER,
+            expect_reply=False,
+        )
+        return
+
+    # Clear a smoke alarm before selecting burglar or stop.
+    for alarm_code in (SILENCE_ALARM, CLEAR_ALARM):
+        await alarms.client_command(
+            Alarms.ClientCommandDefs.alarm.id,
+            alarm_code=alarm_code,
+            cluster_id=TWINGUARD_SMOKE_CLUSTER,
+            expect_reply=False,
+        )
+    await burglar.command(
+        burglar.ServerCommandDefs.burglar_alarm.id,
+        data=0x01 if mode == TwinguardAlarmMode.Burglar else 0x00,
+        manufacturer=BOSCH_MANUFACTURER_CODE,
+        expect_reply=False,
+    )
+
+
+class BoschTwinguardSmokeCluster(CustomCluster):
+    """Smoke-detector configuration on endpoint 1."""
+
+    cluster_id: Final = TWINGUARD_SMOKE_CLUSTER
+    ep_attribute: Final = "twinguard_smoke"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Bosch Twinguard smoke cluster attributes."""
+
+        sensitivity: Final = ZCLAttributeDef(
+            id=0x4003,
+            type=TwinguardSensitivity,
+            access="rwp",
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Bosch Twinguard smoke cluster server commands."""
+
+        initiate_test_mode: Final = ZCLCommandDef(
+            id=0x00,
+            schema={},
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+
+
+class BoschTwinguardMeasurementsCluster(CustomCluster):
+    """Environmental measurements reported on endpoint 3."""
+
+    cluster_id: Final = TWINGUARD_MEASUREMENTS_CLUSTER
+    ep_attribute: Final = "twinguard_measurements"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Bosch Twinguard measurement cluster attributes."""
+
+        humidity: Final = ZCLAttributeDef(
+            id=0x4000,
+            type=t.uint16_t,
+            access="rp",
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+        air_purity: Final = ZCLAttributeDef(
+            id=0x4003,
+            type=t.uint16_t,
+            access="rp",
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+        temperature: Final = ZCLAttributeDef(
+            id=0x4004,
+            type=t.int16s,
+            access="rp",
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+        illuminance: Final = ZCLAttributeDef(
+            id=0x4005,
+            type=t.uint16_t,
+            access="rp",
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+        battery: Final = ZCLAttributeDef(
+            id=0x4006,
+            type=t.uint16_t,
+            access="rp",
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+
+
+class BoschTwinguardOptionsCluster(CustomCluster):
+    """Twinguard options on endpoint 1."""
+
+    cluster_id: Final = TWINGUARD_OPTIONS_CLUSTER
+    ep_attribute: Final = "twinguard_options"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Bosch Twinguard options cluster attributes."""
+
+        pairing_state: Final = ZCLAttributeDef(
+            id=0x4000,
+            type=t.bitmap8,
+            access="rp",
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+        pre_alarm: Final = ZCLAttributeDef(
+            id=0x4001,
+            type=t.bitmap8,
+            access="rwp",
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+
+
+class BoschTwinguardAlarmsCluster(CustomCluster, Alarms):
+    """Acknowledge Bosch fire and pre-alarm notifications."""
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args,
+        *,
+        dst_addressing=None,
+    ):
+        """Echo fire alarms as the server-to-client frame Bosch expects."""
+        super().handle_cluster_request(
+            hdr,
+            args,
+            dst_addressing=dst_addressing,
+        )
+        if (
+            hdr.direction != foundation.Direction.Server_to_Client
+            or hdr.command_id != self.ClientCommandDefs.alarm.id
+        ):
+            return
+
+        alarm_code = args.alarm_code
+        siren_control = self.endpoint.in_clusters.get(TWINGUARD_SIREN_CONTROL_CLUSTER)
+        if siren_control is not None:
+            siren_states = {
+                FIRE_ALARM: TwinguardSirenState.Fire,
+                PRE_ALARM: TwinguardSirenState.Pre_alarm,
+                CLEAR_ALARM: TwinguardSirenState.Clear,
+                SILENCE_ALARM: TwinguardSirenState.Silenced,
+            }
+            if alarm_code in siren_states:
+                siren_control.update_siren_state(siren_states[alarm_code])
+
+        if alarm_code not in (FIRE_ALARM, PRE_ALARM):
+            return
+
+        alarms_client = self.endpoint.out_clusters[Alarms.cluster_id]
+        self.create_catching_task(
+            alarms_client.client_command(
+                Alarms.ClientCommandDefs.alarm.id,
+                alarm_code=alarm_code,
+                cluster_id=TWINGUARD_SMOKE_CLUSTER,
+                expect_reply=False,
+            )
+        )
+
+
+class BoschTwinguardSetupCluster(CustomCluster):
+    """Pairing and setup cluster on endpoint 12."""
+
+    cluster_id: Final = TWINGUARD_SETUP_CLUSTER
+    ep_attribute: Final = "twinguard_setup"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Bosch Twinguard setup cluster attributes."""
+
+        heartbeat: Final = ZCLAttributeDef(
+            id=0x5005,
+            type=t.bitmap8,
+            access="rwp",
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Bosch Twinguard setup cluster server commands."""
+
+        pairing_completed: Final = ZCLCommandDef(
+            id=0x01,
+            schema={},
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+
+    async def apply_custom_configuration(self, *args, **kwargs):
+        """Perform the Bosch-specific join handshake and initialize defaults."""
+        device = self.endpoint.device
+        endpoint_1 = device.endpoints[1]
+        endpoint_3 = device.endpoints[3]
+
+        await device.endpoints[7].in_clusters[PollControl.cluster_id].bind()
+        await endpoint_1.in_clusters[Alarms.cluster_id].bind()
+        await endpoint_1.in_clusters[TWINGUARD_SMOKE_CLUSTER].bind()
+        await endpoint_1.in_clusters[TWINGUARD_OPTIONS_CLUSTER].bind()
+        await endpoint_3.in_clusters[TWINGUARD_MEASUREMENTS_CLUSTER].bind()
+        await self.bind()
+        await self.endpoint.in_clusters[TWINGUARD_ALARM_CLUSTER].bind()
+
+        # Both operations, in this order, are required for the Twinguard to
+        # accept the coordinator. Without them it flashes red after joining.
+        options = endpoint_1.in_clusters[TWINGUARD_OPTIONS_CLUSTER]
+        await options.read_attributes(
+            [BoschTwinguardOptionsCluster.AttributeDefs.pairing_state.id],
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+        )
+        await self.command(
+            self.ServerCommandDefs.pairing_completed.id,
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+        )
+
+        # Match the Bosch defaults and prime the ZHA attribute cache.
+        smoke = endpoint_1.in_clusters[TWINGUARD_SMOKE_CLUSTER]
+        await smoke.write_attributes(
+            {
+                BoschTwinguardSmokeCluster.AttributeDefs.sensitivity.id: TwinguardSensitivity.Medium
+            },
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+        )
+        await options.write_attributes(
+            {BoschTwinguardOptionsCluster.AttributeDefs.pre_alarm.id: 0x01},
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+        )
+        await self.write_attributes(
+            {self.AttributeDefs.heartbeat.id: 0x01},
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+        )
+        await smoke.read_attributes(
+            [BoschTwinguardSmokeCluster.AttributeDefs.sensitivity.id],
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+        )
+        await options.read_attributes(
+            [BoschTwinguardOptionsCluster.AttributeDefs.pre_alarm.id],
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+        )
+        await self.read_attributes(
+            [self.AttributeDefs.heartbeat.id],
+            manufacturer=BOSCH_MANUFACTURER_CODE,
+        )
+
+
+class BoschTwinguardAlarmCluster(CustomCluster):
+    """Alarm state and burglar-siren control on endpoint 12."""
+
+    cluster_id: Final = TWINGUARD_ALARM_CLUSTER
+    ep_attribute: Final = "twinguard_alarm"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Bosch Twinguard alarm cluster attributes."""
+
+        alarm_status: Final = ZCLAttributeDef(
+            id=0x5000,
+            type=t.bitmap32,
+            access="rp",
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Bosch Twinguard alarm cluster server commands."""
+
+        burglar_alarm: Final = ZCLCommandDef(
+            id=0x01,
+            schema={"data": t.uint8_t},
+            manufacturer_code=BOSCH_MANUFACTURER_CODE,
+        )
+
+    def _update_attribute(self, attrid, value):
+        """Synchronize the local siren state with reported alarm state."""
+        super()._update_attribute(attrid, value)
+        if attrid != self.AttributeDefs.alarm_status.id:
+            return
+
+        siren_control = self.endpoint.device.endpoints[1].in_clusters.get(
+            TWINGUARD_SIREN_CONTROL_CLUSTER
+        )
+        if siren_control is None:
+            return
+
+        siren_states = {
+            CLEAR_ALARM_STATUS: TwinguardSirenState.Clear,
+            SELF_TEST_ALARM_STATUS: TwinguardSirenState.Self_test,
+            BURGLAR_ALARM_STATUS: TwinguardSirenState.Burglar,
+            PRE_ALARM_STATUS: TwinguardSirenState.Pre_alarm,
+            FIRE_ALARM_STATUS: TwinguardSirenState.Fire,
+            SILENCED_ALARM_STATUS: TwinguardSirenState.Silenced,
+        }
+        if value in siren_states:
+            siren_control.update_siren_state(siren_states[value])
+
+
+class BoschTwinguardSirenControl(LocalDataCluster):
+    """Local alarm-mode control and reported siren state."""
+
+    cluster_id: Final = TWINGUARD_SIREN_CONTROL_CLUSTER
+    ep_attribute: Final = "twinguard_siren_control"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Local Twinguard siren control attributes."""
+
+        alarm_mode: Final = ZCLAttributeDef(
+            id=0x0000,
+            type=TwinguardAlarmMode,
+            access="rwp",
+        )
+        siren_state: Final = ZCLAttributeDef(
+            id=0x0001,
+            type=TwinguardSirenState,
+            access="rp",
+        )
+
+    _DEFAULT_VALUES = {
+        AttributeDefs.alarm_mode.id: TwinguardAlarmMode.Stop,
+        AttributeDefs.siren_state.id: TwinguardSirenState.Clear,
+    }
+
+    def update_siren_state(self, state: TwinguardSirenState) -> None:
+        """Update reported state and synchronize the alarm-mode selector."""
+        self._update_attribute(self.AttributeDefs.siren_state.id, state)
+        mode_by_state = {
+            TwinguardSirenState.Clear: TwinguardAlarmMode.Stop,
+            TwinguardSirenState.Silenced: TwinguardAlarmMode.Stop,
+            TwinguardSirenState.Burglar: TwinguardAlarmMode.Burglar,
+            TwinguardSirenState.Pre_alarm: TwinguardAlarmMode.Pre_alarm,
+            TwinguardSirenState.Fire: TwinguardAlarmMode.Fire,
+        }
+        if state in mode_by_state:
+            self._update_attribute(
+                self.AttributeDefs.alarm_mode.id,
+                mode_by_state[state],
+            )
+
+    async def write_attributes(self, attributes, **kwargs):
+        """Translate alarm-mode selections to Bosch alarm commands."""
+        requested_mode = None
+        for attribute, value in attributes.items():
+            attribute_id = self.find_attribute(attribute).id
+            if attribute_id == self.AttributeDefs.alarm_mode.id:
+                requested_mode = TwinguardAlarmMode(value)
+            elif attribute_id == self.AttributeDefs.siren_state.id:
+                return [
+                    [
+                        foundation.WriteAttributesStatusRecord(
+                            status=foundation.Status.READ_ONLY,
+                            attrid=attribute_id,
+                        )
+                    ]
+                ]
+
+        if requested_mode is None:
+            return await super().write_attributes(attributes, **kwargs)
+
+        await set_bosch_alarm_mode(self.endpoint.device, requested_mode)
+        state_by_mode = {
+            TwinguardAlarmMode.Stop: TwinguardSirenState.Clear,
+            TwinguardAlarmMode.Pre_alarm: TwinguardSirenState.Pre_alarm,
+            TwinguardAlarmMode.Fire: TwinguardSirenState.Fire,
+            TwinguardAlarmMode.Burglar: TwinguardSirenState.Burglar,
+        }
+        self.update_siren_state(state_by_mode[requested_mode])
+        return [[foundation.WriteAttributesStatusRecord(foundation.Status.SUCCESS)]]
+
+
+(
+    QuirkBuilder("BOSCH ST", "Champion")
+    .applies_to("BoschSmartHomeGmbH", "Champion")
+    .replaces(BoschTwinguardAlarmsCluster, endpoint_id=1)
+    .replaces(BoschTwinguardSmokeCluster, endpoint_id=1)
+    .replaces(BoschTwinguardMeasurementsCluster, endpoint_id=3)
+    .replaces(BoschTwinguardOptionsCluster, endpoint_id=1)
+    .replaces(BoschTwinguardSetupCluster, endpoint_id=12)
+    .replaces(BoschTwinguardAlarmCluster, endpoint_id=12)
+    .adds(BoschTwinguardSirenControl, endpoint_id=1)
+    # All usable measurements arrive through the manufacturer cluster. The
+    # corresponding standard clusters either remain stale or contain placeholders.
+    .prevent_default_entity_creation(
+        endpoint_id=4,
+        cluster_id=PowerConfiguration.cluster_id,
+    )
+    .prevent_default_entity_creation(
+        endpoint_id=5,
+        cluster_id=TemperatureMeasurement.cluster_id,
+    )
+    .prevent_default_entity_creation(
+        endpoint_id=6,
+        cluster_id=IlluminanceMeasurement.cluster_id,
+    )
+    .prevent_default_entity_creation(
+        endpoint_id=8,
+        cluster_id=PressureMeasurement.cluster_id,
+    )
+    .prevent_default_entity_creation(
+        endpoint_id=9,
+        cluster_id=RelativeHumidity.cluster_id,
+    )
+    .prevent_default_entity_creation(
+        endpoint_id=11,
+        cluster_id=CarbonMonoxideConcentration.cluster_id,
+    )
+    .sensor(
+        BoschTwinguardMeasurementsCluster.AttributeDefs.temperature.name,
+        TWINGUARD_MEASUREMENTS_CLUSTER,
+        endpoint_id=3,
+        divisor=100,
+        unit=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        fallback_name="Temperature",
+    )
+    .sensor(
+        BoschTwinguardMeasurementsCluster.AttributeDefs.humidity.name,
+        TWINGUARD_MEASUREMENTS_CLUSTER,
+        endpoint_id=3,
+        divisor=100,
+        unit=PERCENTAGE,
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
+        fallback_name="Humidity",
+    )
+    .sensor(
+        BoschTwinguardMeasurementsCluster.AttributeDefs.battery.name,
+        TWINGUARD_MEASUREMENTS_CLUSTER,
+        endpoint_id=3,
+        divisor=2,
+        unit=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        fallback_name="Battery",
+    )
+    .sensor(
+        BoschTwinguardMeasurementsCluster.AttributeDefs.illuminance.name,
+        TWINGUARD_MEASUREMENTS_CLUSTER,
+        endpoint_id=3,
+        divisor=2,
+        unit=LIGHT_LUX,
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        fallback_name="Illuminance",
+    )
+    .sensor(
+        BoschTwinguardMeasurementsCluster.AttributeDefs.air_purity.name,
+        TWINGUARD_MEASUREMENTS_CLUSTER,
+        endpoint_id=3,
+        device_class=SensorDeviceClass.AQI,
+        state_class=SensorStateClass.MEASUREMENT,
+        unique_id_suffix="aqi",
+        fallback_name="Air quality index",
+    )
+    .sensor(
+        BoschTwinguardMeasurementsCluster.AttributeDefs.air_purity.name,
+        TWINGUARD_MEASUREMENTS_CLUSTER,
+        endpoint_id=3,
+        attribute_converter=lambda value: value * 10 + 500,
+        unit=CONCENTRATION_PARTS_PER_MILLION,
+        device_class=SensorDeviceClass.CO2,
+        state_class=SensorStateClass.MEASUREMENT,
+        unique_id_suffix="eco2",
+        fallback_name="eCO2",
+    )
+    .binary_sensor(
+        BoschTwinguardAlarmCluster.AttributeDefs.alarm_status.name,
+        TWINGUARD_ALARM_CLUSTER,
+        endpoint_id=12,
+        entity_type=EntityType.STANDARD,
+        attribute_converter=lambda value: bool(value & (1 << 7)),
+        device_class=BinarySensorDeviceClass.SMOKE,
+        unique_id_suffix="smoke",
+        fallback_name="Smoke",
+    )
+    .binary_sensor(
+        BoschTwinguardAlarmCluster.AttributeDefs.alarm_status.name,
+        TWINGUARD_ALARM_CLUSTER,
+        endpoint_id=12,
+        attribute_converter=lambda value: bool(value & (1 << 24)),
+        unique_id_suffix="self_test_active",
+        translation_key="self_test_active",
+        fallback_name="Self-test active",
+    )
+    .command_button(
+        BoschTwinguardSmokeCluster.ServerCommandDefs.initiate_test_mode.name,
+        TWINGUARD_SMOKE_CLUSTER,
+        endpoint_id=1,
+        translation_key="start_self_test",
+        fallback_name="Start self-test",
+    )
+    .switch(
+        BoschTwinguardOptionsCluster.AttributeDefs.pre_alarm.name,
+        TWINGUARD_OPTIONS_CLUSTER,
+        endpoint_id=1,
+        translation_key="pre_alarm",
+        fallback_name="Pre-alarm",
+    )
+    .switch(
+        BoschTwinguardSetupCluster.AttributeDefs.heartbeat.name,
+        TWINGUARD_SETUP_CLUSTER,
+        endpoint_id=12,
+        translation_key="heartbeat_led",
+        fallback_name="Heartbeat LED",
+    )
+    .enum(
+        BoschTwinguardSirenControl.AttributeDefs.alarm_mode.name,
+        TwinguardAlarmMode,
+        TWINGUARD_SIREN_CONTROL_CLUSTER,
+        endpoint_id=1,
+        entity_type=EntityType.STANDARD,
+        translation_key="alarm_mode",
+        fallback_name="Alarm mode",
+    )
+    .enum(
+        BoschTwinguardSirenControl.AttributeDefs.siren_state.name,
+        TwinguardSirenState,
+        TWINGUARD_SIREN_CONTROL_CLUSTER,
+        endpoint_id=1,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        unique_id_suffix="siren_state",
+        translation_key="siren_state",
+        fallback_name="Siren state",
+    )
+    .enum(
+        BoschTwinguardSmokeCluster.AttributeDefs.sensitivity.name,
+        TwinguardSensitivity,
+        TWINGUARD_SMOKE_CLUSTER,
+        endpoint_id=1,
+        translation_key="smoke_sensitivity",
+        fallback_name="Smoke sensitivity",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Add complete Bosch Twinguard (`8750001213`, model `Champion`) support using the Quirks V2 API.

- Perform the Bosch-specific pairing handshake required to complete joining.
- Expose temperature, humidity, illuminance, battery, AQI/eCO2, smoke, self-test, sensitivity, pre-alarm, and heartbeat controls.
- Add Bosch-native alarm mode control (`stop`, `pre_alarm`, `fire`, and `burglar`) and read-only siren state feedback.
- Support both known manufacturer strings and suppress stale placeholder entities from the standard measurement clusters.

Fixes #2561.
Supersedes #3293 with a tested V2 implementation and full alarm/smoke support.

## Additional information

The protocol behavior was independently implemented using the Zigbee2MQTT Twinguard implementation as a reference. The quirk has been manually tested with Home Assistant 2026.8.1 and a Connect ZBT-2, including fresh pairing, measurements, configuration controls, self-test, and all alarm modes.

The complete local suite reached 4,846 passed and 2 xfailed; the remaining 8 failures are unrelated Windows-specific failures in existing Inovelli path handling and Tuya timezone/request tests.

## Device diagnostics

[bosch-twinguard-diagnostics.json](https://github.com/user-attachments/files/31058934/bosch-twinguard-diagnostics.json)

## Test plan

- [x] Added tests for V2 matching, both manufacturer strings, entity metadata, scaling, and default-entity suppression
- [x] Added tests for pairing bindings, handshake ordering, initial writes, and cache-priming reads
- [x] Added tests for smoke/fire acknowledgements, reported alarm states, read-only siren state, and all alarm modes
- [x] Ran `pytest tests/test_bosch_twinguard.py tests/test_bosch.py tests/test_quirks_v2.py -q` (23 passed)
- [x] Ran `pre-commit run --all-files`

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Ruff
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached