### PR TITLE
Migrate Aqara Curtain Driver E1 to quirks v2 and expose limit calibration

### DIFF
--- a/tests/test_quirks.py
+++ b/tests/test_quirks.py
@@ -880,8 +880,6 @@ def test_no_duplicate_clusters(quirk: CustomDevice) -> None:
             zhaquirks.xiaomi.aqara.cube_aqgl01.CubeAQGL01,
             # also add OTA input cluster (Aqara cube):
             zhaquirks.xiaomi.aqara.cube_aqgl01.CubeCAGL02,
-            # remove custom Xiaomi output cluster (E1 curtain driver):
-            zhaquirks.xiaomi.aqara.driver_curtain_e1.DriverE1,
             # remove random AnalogInput input cluster (Aqara remote + temp sensor):
             zhaquirks.xiaomi.aqara.remote_b186acn01.RemoteB186ACN01,
             zhaquirks.xiaomi.aqara.remote_b286acn01.RemoteB286ACN01,

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest import mock
 
 import pytest
+from zha.quirks import DEVICE_REGISTRY
 import zigpy.device
 from zigpy.profiles import zha
 import zigpy.types as t
@@ -43,6 +44,12 @@ from zigpy.zcl.foundation import Attribute, DataTypeId, TypeValue
 
 from tests.common import ZCL_OCC_ATTR_RPT_OCC, ClusterListener
 import zhaquirks
+from zhaquirks.builder import EntityType
+from zhaquirks.builder.metadata import (
+    BinarySensorMetadata,
+    SwitchMetadata,
+    WriteAttributeButtonMetadata,
+)
 from zhaquirks.const import (
     ATTR_ID,
     BUTTON_1,
@@ -77,6 +84,12 @@ from zhaquirks.xiaomi import (
 import zhaquirks.xiaomi.aqara.cube
 import zhaquirks.xiaomi.aqara.cube_aqgl01
 import zhaquirks.xiaomi.aqara.driver_curtain_e1
+from zhaquirks.xiaomi.aqara.driver_curtain_e1 import (
+    CLEAR_LIMITS,
+    STORE_CLOSED_LIMIT,
+    STORE_OPEN_LIMIT,
+    XiaomiAqaraDriverE1,
+)
 from zhaquirks.xiaomi.aqara.feeder_acn001 import (
     FEEDER_ATTR,
     ZCL_CHILD_LOCK,
@@ -2058,6 +2071,41 @@ async def test_xiaomi_e1_driver_light_level(
             == 10000 * math.log10(converted_level) + 1
         )
     )
+
+
+def test_aqara_curtain_agl001_entities(zigpy_device_from_v2_quirk):
+    """Test entities exposed by the Aqara Curtain Driver E1 v2 quirk."""
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.agl001")
+    entry = DEVICE_REGISTRY.match_entry(device)
+    entity_metadata = entry.zha_device_factory.quirk_definition.entity_metadata
+    assert len(entity_metadata) == 6
+
+    by_suffix = {em.resolved_unique_id_suffix: em for em in entity_metadata}
+
+    limits_stored = by_suffix["positions_stored"]
+    assert isinstance(limits_stored, BinarySensorMetadata)
+    assert limits_stored.translation_key == "limits_stored"
+    assert limits_stored.entity_type == EntityType.DIAGNOSTIC
+
+    clear_button = by_suffix["limits_clear"]
+    assert isinstance(clear_button, WriteAttributeButtonMetadata)
+    assert clear_button.attribute_value == CLEAR_LIMITS
+
+    closed_button = by_suffix["limit_set_closed"]
+    assert isinstance(closed_button, WriteAttributeButtonMetadata)
+    assert closed_button.attribute_value == STORE_CLOSED_LIMIT
+
+    open_button = by_suffix["limit_set_open"]
+    assert isinstance(open_button, WriteAttributeButtonMetadata)
+    assert open_button.attribute_value == STORE_OPEN_LIMIT
+
+    assert isinstance(by_suffix["hand_open"], SwitchMetadata)
+    assert isinstance(by_suffix["hooks_lock"], SwitchMetadata)
+
+    cluster_id = XiaomiAqaraDriverE1.cluster_id
+    for em in entity_metadata:
+        assert em.cluster_id == cluster_id
+        assert em.endpoint_id == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -1997,10 +1997,10 @@ async def test_xiaomi_t1_door_sensor(
     ],
 )
 async def test_xiaomi_e1_driver_commands(
-    zigpy_device_from_quirk, command, command_id, value
+    zigpy_device_from_v2_quirk, command, command_id, value
 ):
     """Test Aqara E1 driver commands for basic movement functions using WindowCovering cluster."""
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.driver_curtain_e1.DriverE1)
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.agl001")
 
     window_covering_cluster = device.endpoints[1].window_covering
     p = mock.patch.object(window_covering_cluster, "request", mock.AsyncMock())
@@ -2025,10 +2025,10 @@ async def test_xiaomi_e1_driver_commands(
     ],
 )
 async def test_xiaomi_e1_driver_light_level(
-    zigpy_device_from_quirk, device_level, converted_level
+    zigpy_device_from_v2_quirk, device_level, converted_level
 ):
     """Test Aqara E1 driver light level cluster conversion."""
-    device = zigpy_device_from_quirk(zhaquirks.xiaomi.aqara.driver_curtain_e1.DriverE1)
+    device = zigpy_device_from_v2_quirk(LUMI, "lumi.curtain.agl001")
 
     opple_cluster = device.endpoints[1].opple_cluster
     opple_listener = ClusterListener(opple_cluster)

--- a/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
+++ b/zhaquirks/xiaomi/aqara/driver_curtain_e1.py
@@ -1,4 +1,13 @@
-"""Aqara Curtain Driver E1 device."""
+"""Aqara Curtain Driver E1 device.
+
+Travel limits are calibrated through attribute 0x0407 on the manufacturer
+cluster: 0 clears the stored limits, 1 stores the current position as the closed
+limit and 2 as the open limit. Use each value only at its own end.
+
+To calibrate: park the curtain at either end, clear, store that end, then drive
+to the opposite end. The motor stores the second limit itself when it hits the
+stop. The `positions_stored` attribute reports the result.
+"""
 
 from __future__ import annotations
 
@@ -6,29 +15,19 @@ from typing import Any, Final
 
 from zigpy import types as t
 from zigpy.profiles import zha
-from zigpy.zcl import foundation
+from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.closures import WindowCovering
-from zigpy.zcl.clusters.general import Basic, Identify, Ota, PowerConfiguration, Time
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement
 from zigpy.zcl.foundation import ZCLAttributeDef
 from zigpy.zdo.types import NodeDescriptor
 
 from zhaquirks import CustomCluster
-from zhaquirks.const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    MODELS_INFO,
-    NODE_DESCRIPTOR,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
+from zhaquirks.builder import EntityType, QuirkBuilder
 from zhaquirks.xiaomi import (
     LUMI,
     BasicCluster,
     LocalIlluminanceMeasurementCluster,
     XiaomiAqaraE1Cluster,
-    XiaomiCustomDevice,
     XiaomiPowerConfigurationPercent,
 )
 
@@ -38,6 +37,10 @@ STORE_POSITION = 0x0407
 HOOKS_LOCK = 0x0427
 HOOKS_STATE = 0x0428
 LIGHT_LEVEL = 0x0429
+
+CLEAR_LIMITS = 0x00
+STORE_CLOSED_LIMIT = 0x01
+STORE_OPEN_LIMIT = 0x02
 
 
 class XiaomiAqaraDriverE1(XiaomiAqaraE1Cluster):
@@ -106,58 +109,61 @@ class WindowCoveringE1(CustomCluster, WindowCovering):
         )
 
 
-class DriverE1(XiaomiCustomDevice):
-    """Aqara Curtain Driver E1 device."""
-
-    signature = {
-        MODELS_INFO: [(LUMI, "lumi.curtain.agl001")],
-        ENDPOINTS: {
-            # <SizePrefixedSimpleDescriptor endpoint=1 profile=260 device_type=263
-            # device_version=1
-            # input_clusters=[0, 1, 3, 10, 258, 64704]
-            # output_clusters=[3, 10, 25, 64704]>
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
-                INPUT_CLUSTERS: [
-                    Basic.cluster_id,
-                    PowerConfiguration.cluster_id,
-                    Identify.cluster_id,
-                    Time.cluster_id,
-                    WindowCovering.cluster_id,
-                    XiaomiAqaraDriverE1.cluster_id,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Time.cluster_id,
-                    Ota.cluster_id,
-                    XiaomiAqaraDriverE1.cluster_id,
-                ],
-            }
-        },
-    }
-    replacement = {
-        NODE_DESCRIPTOR: NodeDescriptor(
-            0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00
-        ),
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
-                INPUT_CLUSTERS: [
-                    BasicCluster,
-                    XiaomiPowerConfigurationPercent,
-                    Identify.cluster_id,
-                    Time.cluster_id,
-                    WindowCoveringE1,
-                    LocalIlluminanceMeasurementCluster,
-                    XiaomiAqaraDriverE1,
-                ],
-                OUTPUT_CLUSTERS: [
-                    Identify.cluster_id,
-                    Time.cluster_id,
-                    Ota.cluster_id,
-                ],
-            }
-        },
-    }
+(
+    QuirkBuilder(LUMI, "lumi.curtain.agl001")
+    .friendly_name(manufacturer="Aqara", model="Curtain Driver E1")
+    .node_descriptor(
+        NodeDescriptor(0x02, 0x40, 0x80, 0x115F, 0x7F, 0x0064, 0x2C00, 0x0064, 0x00)
+    )
+    .replaces_endpoint(1, device_type=zha.DeviceType.WINDOW_COVERING_DEVICE)
+    .replaces(BasicCluster)
+    .replaces(XiaomiPowerConfigurationPercent)
+    .replaces(WindowCoveringE1)
+    .replaces(XiaomiAqaraDriverE1)
+    .adds(LocalIlluminanceMeasurementCluster)
+    .removes(XiaomiAqaraDriverE1.cluster_id, cluster_type=ClusterType.Client)
+    .write_attr_button(
+        XiaomiAqaraDriverE1.AttributeDefs.store_position.name,
+        CLEAR_LIMITS,
+        XiaomiAqaraDriverE1.cluster_id,
+        unique_id_suffix="limits_clear",
+        translation_key="limits_clear",
+        fallback_name="Clear travel limits",
+    )
+    .write_attr_button(
+        XiaomiAqaraDriverE1.AttributeDefs.store_position.name,
+        STORE_CLOSED_LIMIT,
+        XiaomiAqaraDriverE1.cluster_id,
+        unique_id_suffix="limit_set_closed",
+        translation_key="limit_set_closed",
+        fallback_name="Store closed limit",
+    )
+    .write_attr_button(
+        XiaomiAqaraDriverE1.AttributeDefs.store_position.name,
+        STORE_OPEN_LIMIT,
+        XiaomiAqaraDriverE1.cluster_id,
+        unique_id_suffix="limit_set_open",
+        translation_key="limit_set_open",
+        fallback_name="Store open limit",
+    )
+    .binary_sensor(
+        XiaomiAqaraDriverE1.AttributeDefs.positions_stored.name,
+        XiaomiAqaraDriverE1.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="limits_stored",
+        fallback_name="Travel limits stored",
+    )
+    .switch(
+        XiaomiAqaraDriverE1.AttributeDefs.hand_open.name,
+        XiaomiAqaraDriverE1.cluster_id,
+        translation_key="hand_open",
+        fallback_name="Pull to start motor",
+    )
+    .switch(
+        XiaomiAqaraDriverE1.AttributeDefs.hooks_lock.name,
+        XiaomiAqaraDriverE1.cluster_id,
+        translation_key="hooks_lock",
+        fallback_name="Hooks locked",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Converts `lumi.curtain.agl001` from a v1 `CustomDevice` to a `QuirkBuilder`
definition, and exposes the travel limit calibration that the device already
supports but that was not reachable from Home Assistant.

The manufacturer specific attribute `0x0407` was already defined in the quirk as
`store_position` but had no entity, so calibrating meant using the button
sequence on the driver itself. This adds:

- `Clear travel limits`, `Store closed limit` and `Store open limit` buttons,
  writing 0, 1 and 2 respectively
- `Travel limits stored`, a diagnostic binary sensor for `positions_stored`
  (`0x0402`), so the result of a calibration is visible
- `Pull to start motor` (`hand_open`) and `Hooks locked` (`hooks_lock`) switches

Everything the v1 quirk did is carried over unchanged: node descriptor, the
`BasicCluster` / `XiaomiPowerConfigurationPercent` / `WindowCoveringE1` /
`XiaomiAqaraDriverE1` replacements, the added illuminance cluster and the light
level mapping. The endpoint device type is still corrected from
`OCCUPANCY_SENSOR` to `WINDOW_COVERING_DEVICE`, and the client side copy of the
manufacturer cluster is now dropped via `removes()` instead of by omission from
a replacement signature.

## Additional information

The travel limits are lost when the battery fully discharges, and there was
previously no way to tell from Home Assistant whether a recalibration had taken.

Calibration procedure, verified on hardware: park the curtain at either end,
press `Clear travel limits`, press the button for the end the curtain is at,
then drive to the opposite end. The motor stores the second limit itself when it
reaches the stop. Each value only works at its own end, so `Store closed limit`
while the curtain is open does nothing. This is documented in the module
docstring.

Two notes for reviewers:

- v2 matches on manufacturer and model only, which is looser than the v1
  endpoint signature this replaces.
- `DriverE1` no longer exists, so the tests in `tests/test_xiaomi.py` that
  built the device from it now use `zigpy_device_from_v2_quirk`, and the entry in
  the signature allowlist in `tests/test_quirks.py` is removed.

## Device diagnostics

<details>
<summary>Aqara Curtain Driver E1 (`lumi.curtain.agl001`)</summary>

```json
{
  "data": {
    "version": 3,
    "ieee": "**REDACTED**",
    "nwk": "0x518E",
    "manufacturer": "LUMI",
    "model": "lumi.curtain.agl001",
    "friendly_manufacturer": "Aqara",
    "friendly_model": "Curtain Driver E1",
    "name": "Aqara Curtain Driver E1",
    "quirk_applied": true,
    "quirk_class": "driver_curtain_e1:(LUMI / lumi.curtain.agl001)",
    "exposes_features": [],
    "manufacturer_code": 4447,
    "power_source": "Battery or Unknown",
    "lqi": null,
    "rssi": null,
    "last_seen": "2026-08-17T07:03:58.538328+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4447,
      "maximum_buffer_size": 127,
      "maximum_incoming_transfer_size": 100,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 100,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "WINDOW_COVERING_DEVICE",
          "id": 514
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "LUMI"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "lumi.curtain.agl001"
              },
              {
                "id": "0x0007",
                "name": "power_source",
                "zcl_type": "enum8",
                "value": 3
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "zcl_type": "uint8",
                "value": 192
              },
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "value": 1
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "value": 255
              },
              {
                "id": "0x0020",
                "name": "battery_voltage",
                "zcl_type": "uint8",
                "value": 30.0
              }
            ]
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0102",
            "endpoint_attribute": "window_covering",
            "attributes": [
              {
                "id": "0x0007",
                "name": "config_status",
                "zcl_type": "map8",
                "value": 11
              },
              {
                "id": "0x0003",
                "name": "current_position_lift",
                "zcl_type": "uint16",
                "unsupported": true
              },
              {
                "id": "0x0008",
                "name": "current_position_lift_percentage",
                "zcl_type": "uint8",
                "value": 0
              },
              {
                "id": "0x0004",
                "name": "current_position_tilt",
                "zcl_type": "uint16",
                "unsupported": true
              },
              {
                "id": "0x0009",
                "name": "current_position_tilt_percentage",
                "zcl_type": "uint8",
                "unsupported": true
              },
              {
                "id": "0x0016",
                "name": "deceleration_time_lift",
                "zcl_type": "uint16",
                "unsupported": true
              },
              {
                "id": "0x0011",
                "name": "installed_closed_limit_lift",
                "zcl_type": "uint16",
                "unsupported": true
              },
              {
                "id": "0x0013",
                "name": "installed_closed_limit_tilt",
                "zcl_type": "uint16",
                "unsupported": true
              },
              {
                "id": "0x0010",
                "name": "installed_open_limit_lift",
                "zcl_type": "uint16",
                "unsupported": true
              },
              {
                "id": "0x0012",
                "name": "installed_open_limit_tilt",
                "zcl_type": "uint16",
                "unsupported": true
              },
              {
                "id": "0x0018",
                "name": "intermediate_setpoints_lift",
                "zcl_type": "octstr",
                "unsupported": true
              },
              {
                "id": "0x0019",
                "name": "intermediate_setpoints_tilt",
                "zcl_type": "octstr",
                "unsupported": true
              },
              {
                "id": "0x0005",
                "name": "number_of_actuations_lift",
                "zcl_type": "uint16",
                "unsupported": true
              },
              {
                "id": "0x0006",
                "name": "number_of_actuations_tilt",
                "zcl_type": "uint16",
                "unsupported": true
              },
              {
                "id": "0x0001",
                "name": "physical_closed_limit_lift",
                "zcl_type": "uint16",
                "unsupported": true
              },
              {
                "id": "0x0002",
                "name": "physical_closed_limit_tilt",
                "zcl_type": "uint16",
                "unsupported": true
              },
              {
                "id": "0x0017",
                "name": "window_covering_mode",
                "zcl_type": "map8",
                "value": 0
              },
              {
                "id": "0x0000",
                "name": "window_covering_type",
                "zcl_type": "enum8",
                "value": 4
              }
            ]
          },
          {
            "cluster_id": "0x0400",
            "endpoint_attribute": "illuminance",
            "attributes": [
              {
                "id": "0x0000",
                "name": "measured_value",
                "zcl_type": "uint16",
                "value": 20001.0
              }
            ]
          },
          {
            "cluster_id": "0xfcc0",
            "endpoint_attribute": "opple_cluster",
            "attributes": [
              {
                "id": "0x0401",
                "name": "hand_open",
                "zcl_type": "bool",
                "value": 0
              },
              {
                "id": "0x0427",
                "name": "hooks_lock",
                "zcl_type": "uint8",
                "value": 1
              },
              {
                "id": "0x0428",
                "name": "hooks_state",
                "zcl_type": "uint8",
                "value": 1
              },
              {
                "id": "0x0429",
                "name": "light_level",
                "zcl_type": "uint8",
                "value": 2
              },
              {
                "id": "0x0402",
                "name": "positions_stored",
                "zcl_type": "bool",
                "value": 1
              },
              {
                "id": "0x0407",
                "name": "store_position",
                "zcl_type": "uint8",
                "value": 1
              }
            ]
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 24
              }
            ],
            "last_query_cmd": {
              "manufacturer_code": 4447,
              "image_type": 4105,
              "current_file_version": 24,
              "hardware_version": null
            }
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "LUMI",
      "model": "lumi.curtain.agl001",
      "node_desc": {
        "logical_type": 2,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 132,
        "manufacturer_code": 4447,
        "maximum_buffer_size": 127,
        "maximum_incoming_transfer_size": 100,
        "server_mask": 11264,
        "maximum_outgoing_transfer_size": 100,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0107",
          "input_clusters": [
            "0x0000",
            "0x0001",
            "0x0003",
            "0xfcc0",
            "0x0102",
            "0x000a"
          ],
          "output_clusters": [
            "0x0003",
            "0x0019",
            "0xfcc0",
            "0x000a"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "fallback_name": "Travel limits stored",
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "binary_sensor",
          "class_name": "BinarySensor",
          "translation_key": "limits_stored",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "is_on": true,
          "attribute_name": "positions_stored"
        }
      ],
      "button": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "button",
          "class_name": "IdentifyButton",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "identify",
          "state_class": null,
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "command": "identify",
          "args": [
            5
          ],
          "kwargs": {}
        },
        {
          "fallback_name": "Store closed limit",
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "button",
          "class_name": "WriteAttributeButton",
          "translation_key": "limit_set_closed",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": "config",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "attribute_name": "store_position",
          "attribute_value": 1
        },
        {
          "fallback_name": "Store open limit",
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "button",
          "class_name": "WriteAttributeButton",
          "translation_key": "limit_set_open",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": "config",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "attribute_name": "store_position",
          "attribute_value": 2
        },
        {
          "fallback_name": "Clear travel limits",
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "button",
          "class_name": "WriteAttributeButton",
          "translation_key": "limits_clear",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": "config",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "attribute_name": "store_position",
          "attribute_value": 0
        }
      ],
      "cover": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "cover",
          "class_name": "Cover",
          "translation_key": "cover",
          "translation_placeholders": null,
          "device_class": "curtain",
          "state_class": null,
          "entity_category": null,
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": true,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "current_position": 100,
          "current_tilt_position": null,
          "is_opening": false,
          "is_closing": false,
          "is_closed": false,
          "supported_features": 15
        }
      ],
      "sensor": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "LQISensor",
          "translation_key": "lqi",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": "measurement",
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": false,
          "enabled": false,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": null,
          "suggested_display_precision": null,
          "unit": null
        },
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "RSSISensor",
          "translation_key": "rssi",
          "translation_placeholders": null,
          "device_class": "signal_strength",
          "state_class": "measurement",
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": false,
          "enabled": false,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": null,
          "suggested_display_precision": null,
          "unit": "dBm"
        },
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "Battery",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "battery",
          "state_class": "measurement",
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": 96.0,
          "suggested_display_precision": 0,
          "unit": "%",
          "battery_size": "Unknown",
          "battery_quantity": 1,
          "battery_voltage": 3.0
        },
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "Illuminance",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "illuminance",
          "state_class": "measurement",
          "entity_category": null,
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": 100,
          "suggested_display_precision": null,
          "unit": "lx"
        },
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "WindowCoveringTypeSensor",
          "translation_key": "window_covering_type",
          "translation_placeholders": null,
          "device_class": "enum",
          "state_class": null,
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": "Drapery",
          "suggested_display_precision": null,
          "unit": null,
          "options": [
            "Rollershade",
            "Rollershade_two_motors",
            "Rollershade_exterior",
            "Rollershade_exterior_two_motors",
            "Drapery",
            "Awning",
            "Shutter",
            "Tilt_blind_tilt_only",
            "Tilt_blind_tilt_and_lift",
            "Projector_screen"
          ]
        }
      ],
      "switch": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "switch",
          "class_name": "WindowCoveringInversionSwitch",
          "translation_key": "inverted",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": "config",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "is_on": false,
          "inverted": false,
          "attribute_name": "config_status",
          "invert_attribute_name": null,
          "force_inverted": false,
          "off_value": 0,
          "on_value": 1
        },
        {
          "fallback_name": "Pull to start motor",
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "switch",
          "class_name": "ConfigurableAttributeSwitch",
          "translation_key": "hand_open",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": "config",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "is_on": false,
          "inverted": false,
          "attribute_name": "hand_open",
          "invert_attribute_name": null,
          "force_inverted": false,
          "off_value": 0,
          "on_value": 1
        },
        {
          "fallback_name": "Hooks locked",
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "switch",
          "class_name": "ConfigurableAttributeSwitch",
          "translation_key": "hooks_lock",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": "config",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "is_on": true,
          "inverted": false,
          "attribute_name": "hooks_lock",
          "invert_attribute_name": null,
          "force_inverted": false,
          "off_value": 0,
          "on_value": 1
        }
      ],
      "update": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "update",
          "class_name": "FirmwareUpdateEntity",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "firmware",
          "state_class": null,
          "entity_category": "config",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "installed_version": "0x00000018",
          "in_progress": false,
          "update_percentage": null,
          "latest_version": null,
          "release_summary": null,
          "release_notes": null,
          "release_url": null,
          "supported_features": 23
        }
      ]
    },
    "neighbors": [],
    "routes": []
  }
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
