### PR TITLE
Add SONOFF SWV-ZFE/SWV-ZFU (Hydro ONE) flow-meter valve quirk

### DIFF
--- a/tests/test_sonoff.py
+++ b/tests/test_sonoff.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import pytest
+from zha.quirks import DEVICE_REGISTRY
 from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import OnOff
 
@@ -10,6 +11,11 @@ from tests.common import ClusterListener
 import zhaquirks
 from zhaquirks.const import COMMAND_DOUBLE, COMMAND_HOLD, COMMAND_SINGLE, COMMAND_TRIPLE
 from zhaquirks.sonoff.snzb01m import SonoffButtonCluster
+from zhaquirks.sonoff.swv import (
+    CustomSonoffFlowCluster,
+    ValveState,
+    swap_endianness_32bit,
+)
 from zhaquirks.sonoff.zbm5 import (
     SonoffCluster,
     SonoffDetachedRelayMask,
@@ -272,3 +278,57 @@ async def test_snzb01m_non_button_attribute_update(zigpy_device_from_v2_quirk):
 
     cluster.update_attribute(0x0001, 1)
     assert listener.zha_send_event.call_count == 0
+
+
+def test_swv_swap_endianness_32bit():
+    """Test the 32-bit byte-swap helper used for the SWV-ZFE real-time counters."""
+    assert swap_endianness_32bit(0x5E000000) == 94
+    assert swap_endianness_32bit(94) == 0x5E000000
+    assert swap_endianness_32bit(0) == 0
+    assert swap_endianness_32bit(0xFFFFFFFF) == 0xFFFFFFFF
+
+
+@pytest.mark.parametrize("model", ["SWV-ZFE", "SWV-ZFU"])
+async def test_sonoff_swv_zfe_quirk(zigpy_device_from_v2_quirk, model):
+    """Test the SWV-ZFE/SWV-ZFU flow-meter valve quirk entities and converters."""
+    device = zigpy_device_from_v2_quirk("SONOFF", model)
+
+    cluster = device.endpoints[1].in_clusters[CustomSonoffFlowCluster.cluster_id]
+    assert isinstance(cluster, CustomSonoffFlowCluster)
+
+    entry = DEVICE_REGISTRY.match_entry(device)
+    metadata_by_suffix = {
+        metadata.resolved_unique_id_suffix: metadata
+        for metadata in entry.zha_device_factory.quirk_definition.entity_metadata
+    }
+
+    for suffix in (
+        "water_leak_status",
+        "water_supply_status",
+        "real_time_irrigation_volume",
+        "real_time_irrigation_duration",
+        "hour_irrigation_volume",
+        "hour_irrigation_duration",
+    ):
+        assert suffix in metadata_by_suffix
+
+    # the real-time counters are reported big-endian and must be swapped
+    for suffix in ("real_time_irrigation_volume", "real_time_irrigation_duration"):
+        converter = metadata_by_suffix[suffix].attribute_converter
+        assert converter(0x5E000000) == 94
+
+    # the hourly counters are reported little-endian and must not be swapped
+    for suffix in ("hour_irrigation_volume", "hour_irrigation_duration"):
+        assert metadata_by_suffix[suffix].attribute_converter is None
+
+    leak_converter = metadata_by_suffix["water_leak_status"].attribute_converter
+    assert leak_converter(ValveState.Water_Leakage)
+    assert leak_converter(ValveState.Water_Shortage_And_Leakage)
+    assert not leak_converter(ValveState.Water_Shortage)
+    assert not leak_converter(ValveState.Normal)
+
+    supply_converter = metadata_by_suffix["water_supply_status"].attribute_converter
+    assert supply_converter(ValveState.Water_Shortage)
+    assert supply_converter(ValveState.Water_Shortage_And_Leakage)
+    assert not supply_converter(ValveState.Water_Leakage)
+    assert not supply_converter(ValveState.Normal)

--- a/zhaquirks/sonoff/swv.py
+++ b/zhaquirks/sonoff/swv.py
@@ -3,7 +3,14 @@
 import zigpy.types as t
 from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
-from zhaquirks.builder import BinarySensorDeviceClass, QuirkBuilder, ReportingConfig
+from zhaquirks.builder import (
+    BinarySensorDeviceClass,
+    QuirkBuilder,
+    ReportingConfig,
+    SensorDeviceClass,
+    UnitOfTime,
+    UnitOfVolume,
+)
 from zhaquirks.clusters import CustomCluster
 
 
@@ -14,6 +21,16 @@ class ValveState(t.enum8):
     Water_Shortage = 1
     Water_Leakage = 2
     Water_Shortage_And_Leakage = 3
+
+
+def swap_endianness_32bit(value: int) -> int:
+    """Byte-swap a 32-bit integer.
+
+    The SWV-ZFE/SWV-ZFU firmware reports the two real-time counters
+    big-endian instead of ZCL little-endian, so the value zigpy parses
+    must be byte-swapped (zigbee2mqtt applies the same workaround).
+    """
+    return int.from_bytes(int(value).to_bytes(4, "little"), "big")
 
 
 class CustomSonoffCluster(CustomCluster):
@@ -33,6 +50,37 @@ class CustomSonoffCluster(CustomCluster):
         auto_close_water_shortage = ZCLAttributeDef(
             id=0x5011,
             type=t.uint16_t,
+            manufacturer_code=None,
+        )
+
+
+class CustomSonoffFlowCluster(CustomSonoffCluster):
+    """Custom Sonoff cluster for the flow-meter valves (SWV-ZFE/SWV-ZFU)."""
+
+    class AttributeDefs(CustomSonoffCluster.AttributeDefs):
+        """Attribute definitions."""
+
+        real_time_irrigation_duration = ZCLAttributeDef(
+            id=0x5006,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+        real_time_irrigation_volume = ZCLAttributeDef(
+            id=0x5007,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+        hour_irrigation_volume = ZCLAttributeDef(
+            id=0x501B,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+        hour_irrigation_duration = ZCLAttributeDef(
+            id=0x501C,
+            type=t.uint32_t,
             manufacturer_code=None,
         )
 
@@ -68,6 +116,73 @@ class CustomSonoffCluster(CustomCluster):
         on_value=30,
         translation_key="water_shortage_auto_close",
         fallback_name="Water shortage auto-close",
+    )
+    .add_to_registry()
+)
+
+
+(
+    QuirkBuilder("SONOFF", "SWV-ZFE")
+    .also_applies_to("SONOFF", "SWV-ZFU")
+    .replaces(CustomSonoffFlowCluster)
+    .binary_sensor(
+        CustomSonoffFlowCluster.AttributeDefs.water_valve_state.name,
+        CustomSonoffFlowCluster.cluster_id,
+        device_class=BinarySensorDeviceClass.MOISTURE,
+        attribute_converter=lambda x: x & ValveState.Water_Leakage,
+        unique_id_suffix="water_leak_status",
+        reporting_config=ReportingConfig(
+            min_interval=30, max_interval=900, reportable_change=1
+        ),
+        translation_key="water_leak",
+        fallback_name="Water leak",
+    )
+    .binary_sensor(
+        CustomSonoffFlowCluster.AttributeDefs.water_valve_state.name,
+        CustomSonoffFlowCluster.cluster_id,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        attribute_converter=lambda x: x & ValveState.Water_Shortage,
+        unique_id_suffix="water_supply_status",
+        translation_key="water_supply",
+        fallback_name="Water supply",
+    )
+    .sensor(
+        CustomSonoffFlowCluster.AttributeDefs.real_time_irrigation_volume.name,
+        CustomSonoffFlowCluster.cluster_id,
+        suggested_display_precision=0,
+        device_class=SensorDeviceClass.VOLUME,
+        unit=UnitOfVolume.LITERS,
+        attribute_converter=swap_endianness_32bit,
+        translation_key="real_time_irrigation_volume",
+        fallback_name="Real-time irrigation volume",
+    )
+    .sensor(
+        CustomSonoffFlowCluster.AttributeDefs.real_time_irrigation_duration.name,
+        CustomSonoffFlowCluster.cluster_id,
+        suggested_display_precision=0,
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.MINUTES,
+        attribute_converter=swap_endianness_32bit,
+        translation_key="real_time_irrigation_duration",
+        fallback_name="Real-time irrigation duration",
+    )
+    .sensor(
+        CustomSonoffFlowCluster.AttributeDefs.hour_irrigation_volume.name,
+        CustomSonoffFlowCluster.cluster_id,
+        suggested_display_precision=0,
+        device_class=SensorDeviceClass.VOLUME,
+        unit=UnitOfVolume.LITERS,
+        translation_key="hour_irrigation_volume",
+        fallback_name="Hourly irrigation volume",
+    )
+    .sensor(
+        CustomSonoffFlowCluster.AttributeDefs.hour_irrigation_duration.name,
+        CustomSonoffFlowCluster.cluster_id,
+        suggested_display_precision=0,
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.MINUTES,
+        translation_key="hour_irrigation_duration",
+        fallback_name="Hourly irrigation duration",
     )
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change

Adds support for the **SONOFF SWV-ZFE / SWV-ZFU** ("Hydro ONE") — the flow-meter variants of the SWV Zigbee smart water valve. Only the plain `SWV` model is currently covered by `zhaquirks/sonoff/swv.py`; the ZFE/ZFU expose additional irrigation counters on the manufacturer cluster `0xFC11`.

This PR extends the existing SWV module with a `CustomSonoffFlowCluster` (inheriting the existing `water_valve_state`) and a second `QuirkBuilder` registration exposing:

- **Water leak** / **Water supply** binary sensors (same as the SWV, from `water_valve_state` `0x500C`)
- **Real-time irrigation volume** (`0x5007`, L) and **duration** (`0x5006`, min)
- **Hourly irrigation volume** (`0x501B`, L) and **duration** (`0x501C`, min)

**Firmware endianness gotcha:** the two *real-time* counters are reported **big-endian** (the hourly ones are normal little-endian). The quirk byte-swaps them via `attribute_converter`, matching the workaround zigbee2mqtt applies (`bigEndianNumericFzConvert` in [`zigbee-herdsman-converters` `sonoff.ts`](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/sonoff.ts), model `SWV-ZFE`). Attribute IDs are taken from the same converter.

Validated on real hardware (SWV-ZFE, HA 2026.8.1, ZBT-1 coordinator): after a 10-minute watering run the quirk reported **94 L / 10 min**, and the independently-read (unswapped) hourly counter agreed at 94 L — cross-confirming the endianness handling in both directions.

### Entities in Home Assistant

<img width="1458" height="740" alt="HA device page for the SWV-ZFE showing the flow sensors (94 L / 10 min) created by this quirk" src="https://github.com/user-attachments/assets/34d6dfe3-4458-4491-8dcc-0602e58501a5" />

## Additional information

Device signature (endpoint 1): `in: 0x0000, 0x0001, 0x0003, 0x0006, 0x0020, 0xFC11, 0xFC57 / out: 0x0003, 0x0019`, manufacturer `SONOFF`, model `SWV-ZFE` (manufacturer code 4742).

The `SWV-ZFU` is registered via `also_applies_to` — it is the US-thread variant of the same "Hydro ONE" product (zigbee2mqtt treats both as one definition with identical attributes); I only own the ZFE.

## Device diagnostics

<details>
<summary>swv-zfe-diagnostics.json (captured while running this quirk as a custom quirk)</summary>

```json
{
  "home_assistant": {
    "arch": "x86_64",
    "dev": false,
    "docker": true,
    "hassio": false,
    "installation_type": "Home Assistant Container",
    "os_name": "Linux",
    "os_version": "7.0.0-29-generic",
    "python_version": "3.14.6",
    "timezone": "Europe/Paris",
    "version": "2026.8.1",
    "virtualenv": false,
    "container_arch": "amd64",
    "run_as_root": true
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware",
      "usb"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==2.1.0",
      "zha-quirks==2.2.0"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 6.852502701804042e-05
    },
    "01M034P2BV5805DPYQT9WKE375": {
      "wait_import_platforms": -0.009394577995408326,
      "config_entry_setup": 4.198596392991021
    }
  },
  "data": {
    "version": 3,
    "ieee": "**REDACTED**",
    "nwk": "0x32AC",
    "manufacturer": "SONOFF",
    "model": "SWV-ZFE",
    "friendly_manufacturer": "SONOFF",
    "friendly_model": "SWV-ZFE",
    "name": "SONOFF SWV-ZFE",
    "quirk_applied": true,
    "quirk_class": "swv_zfe:(SONOFF / SWV-ZFE)",
    "exposes_features": [],
    "manufacturer_code": 4742,
    "power_source": "Battery or Unknown",
    "lqi": 192,
    "rssi": -63,
    "last_seen": "2026-08-17T19:09:14.994636+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4742,
      "maximum_buffer_size": 74,
      "maximum_incoming_transfer_size": 404,
      "server_mask": 10752,
      "maximum_outgoing_transfer_size": 404,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "ON_OFF_OUTPUT",
          "id": 2
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "SONOFF"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "SWV-ZFE"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "zcl_type": "uint8",
                "value": 200
              },
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "unsupported": true
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "unsupported": true
              },
              {
                "id": "0x0020",
                "name": "battery_voltage",
                "zcl_type": "uint8",
                "value": 0
              }
            ]
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0006",
            "endpoint_attribute": "on_off",
            "attributes": [
              {
                "id": "0x0000",
                "name": "on_off",
                "zcl_type": "bool",
                "value": 0
              },
              {
                "id": "0x4003",
                "name": "start_up_on_off",
                "zcl_type": "enum8",
                "unsupported": true
              }
            ]
          },
          {
            "cluster_id": "0x0020",
            "endpoint_attribute": "poll_control",
            "attributes": [
              {
                "id": "0x0003",
                "name": "fast_poll_timeout",
                "zcl_type": "uint16",
                "value": 120
              }
            ]
          },
          {
            "cluster_id": "0xfc11",
            "endpoint_attribute": null,
            "attributes": [
              {
                "id": "0x0000",
                "name": "child_lock",
                "zcl_type": "bool",
                "value": 0
              },
              {
                "id": "0x501c",
                "name": "hour_irrigation_duration",
                "zcl_type": "uint32",
                "value": 10
              },
              {
                "id": "0x501b",
                "name": "hour_irrigation_volume",
                "zcl_type": "uint32",
                "value": 94
              },
              {
                "id": "0x5006",
                "name": "real_time_irrigation_duration",
                "zcl_type": "uint32",
                "value": 167772160
              },
              {
                "id": "0x5007",
                "name": "real_time_irrigation_volume",
                "zcl_type": "uint32",
                "value": 1577058304
              },
              {
                "id": "0x500c",
                "name": "water_valve_state",
                "zcl_type": "enum8",
                "value": 0
              }
            ]
          },
          {
            "cluster_id": "0xfc57",
            "endpoint_attribute": "works_with_all_hubs",
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 4103
              }
            ],
            "last_query_cmd": {
              "manufacturer_code": 4742,
              "image_type": 8204,
              "current_file_version": 4103,
              "hardware_version": null
            }
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "SONOFF",
      "model": "SWV-ZFE",
      "node_desc": {
        "logical_type": 2,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 128,
        "manufacturer_code": 4742,
        "maximum_buffer_size": 74,
        "maximum_incoming_transfer_size": 404,
        "server_mask": 10752,
        "maximum_outgoing_transfer_size": 404,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0x0002",
          "input_clusters": [
            "0x0000",
            "0x0001",
            "0x0003",
            "0x0006",
            "0x0020",
            "0xfc57",
            "0xfc11"
          ],
          "output_clusters": [
            "0x0003",
            "0x0019"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "binary_sensor": [
        {
          "fallback_name": "Water leak",
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "binary_sensor",
          "class_name": "BinarySensor",
          "translation_key": "water_leak",
          "translation_placeholders": null,
          "device_class": "moisture",
          "state_class": null,
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "is_on": 0,
          "attribute_name": "water_valve_state"
        },
        {
          "fallback_name": "Water supply",
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "binary_sensor",
          "class_name": "BinarySensor",
          "translation_key": "water_supply",
          "translation_placeholders": null,
          "device_class": "problem",
          "state_class": null,
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "is_on": 0,
          "attribute_name": "water_valve_state"
        }
      ],
      "button": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "button",
          "class_name": "IdentifyButton",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "identify",
          "state_class": null,
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "command": "identify",
          "args": [
            5
          ],
          "kwargs": {}
        }
      ],
      "sensor": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "LQISensor",
          "translation_key": "lqi",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": "measurement",
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": false,
          "enabled": false,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": 192,
          "suggested_display_precision": null,
          "unit": null
        },
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "RSSISensor",
          "translation_key": "rssi",
          "translation_placeholders": null,
          "device_class": "signal_strength",
          "state_class": "measurement",
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": false,
          "enabled": false,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": -63,
          "suggested_display_precision": null,
          "unit": "dBm"
        },
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "Battery",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "battery",
          "state_class": "measurement",
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": 100.0,
          "suggested_display_precision": 0,
          "unit": "%",
          "battery_size": null,
          "battery_quantity": null,
          "battery_voltage": 0.0
        },
        {
          "fallback_name": "Hourly irrigation duration",
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "Sensor",
          "translation_key": "hour_irrigation_duration",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": null,
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": 10,
          "suggested_display_precision": null,
          "unit": "min"
        },
        {
          "fallback_name": "Hourly irrigation volume",
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "Sensor",
          "translation_key": "hour_irrigation_volume",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": null,
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": 94,
          "suggested_display_precision": null,
          "unit": "L"
        },
        {
          "fallback_name": "Real-time irrigation duration",
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "Sensor",
          "translation_key": "real_time_irrigation_duration",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": null,
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": 10,
          "suggested_display_precision": null,
          "unit": "min"
        },
        {
          "fallback_name": "Real-time irrigation volume",
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "Sensor",
          "translation_key": "real_time_irrigation_volume",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": null,
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": 94,
          "suggested_display_precision": null,
          "unit": "L"
        }
      ],
      "switch": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "switch",
          "class_name": "Switch",
          "translation_key": "switch",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": null,
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": true,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "is_on": 0
        }
      ],
      "update": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "update",
          "class_name": "FirmwareUpdateEntity",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "firmware",
          "state_class": null,
          "entity_category": "config",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "installed_version": "0x00001007",
          "in_progress": false,
          "update_percentage": null,
          "latest_version": null,
          "release_summary": null,
          "release_notes": null,
          "release_url": null,
          "supported_features": 23
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)

