### PR TITLE
Add Tuya TS004F rotary knob variant _TZ3000_402vrq2i

### DIFF
--- a/zhaquirks/tuya/ts004f.py
+++ b/zhaquirks/tuya/ts004f.py
@@ -31,6 +31,7 @@ from zhaquirks.const import (
     COMMAND_OFF,
     COMMAND_ON,
     COMMAND_STEP,
+    COMMAND_STEP_COLOR_TEMP,
     COMMAND_STOP,
     COMMAND_STOP_MOVE_STEP,
     COMMAND_TOGGLE,
@@ -436,6 +437,109 @@ class TuyaSmartRemote004FSK_v2(TuyaSmartRemote004FSK):
                     LightLink.cluster_id,
                 ],
             },
+        },
+    }
+
+
+class TuyaSmartRemote004FRotaryDimmer(EnchantedDevice):
+    """Tuya TS004F rotary encoder remote, _TZ3000_402vrq2i variant."""
+
+    signature = {
+        MODELS_INFO: [("_TZ3000_402vrq2i", "TS004F")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    TuyaNoBindPowerConfigurationCluster,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Time.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaSmartRemoteOnOffCluster,
+                    LevelControl.cluster_id,
+                    Color.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        # --- Dimmer / Remote mode ---
+        (SHORT_PRESS, BUTTON): {COMMAND: COMMAND_TOGGLE, ENDPOINT_ID: 1, CLUSTER_ID: 6},
+        (ROTATED, DIM_UP): {
+            COMMAND: COMMAND_STEP,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 8,
+            PARAMS: {"step_mode": 0},
+        },
+        (ROTATED, DIM_DOWN): {
+            COMMAND: COMMAND_STEP,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 8,
+            PARAMS: {"step_mode": 1},
+        },
+        (ROTATED, RIGHT): {
+            COMMAND: COMMAND_STEP_COLOR_TEMP,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 768,
+            PARAMS: {"step_mode": 1},
+        },
+        (ROTATED, LEFT): {
+            COMMAND: COMMAND_STEP_COLOR_TEMP,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 768,
+            PARAMS: {"step_mode": 3},
+        },
+        # --- Scene mode ---
+        (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: SHORT_PRESS},
+        (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
+        (LONG_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: LONG_PRESS},
+        (SHORT_PRESS, RIGHT): {
+            COMMAND: RIGHT,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 6,
+        },
+        (SHORT_PRESS, LEFT): {
+            COMMAND: LEFT,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 6,
         },
     }
 


### PR DESCRIPTION
Created TuyaSmartRemote004FRotaryDimmer class to properly support _TZ3000_402vrq2i rotary dimmer

Closes #3738 

## Proposed change
<!--

Created TuyaSmartRemote004FRotaryDimmer class to properly support _TZ3000_402vrq2i rotary dimmer.
What works: "Single press, double press, long press, rotation events confirmed working"

-->


## Additional information
<!--

Tested on Home Assistant with ZHA integration. All button functions work: single press, double press, long press, and rotation in both directions.. Fixes #3738 

-->


## Device diagnostics
<!--
[zha-cd7c1fa6596ea299d3f70e212321a83d-_TZ3000_402vrq2i.TS004F-dfd5a4b5bee3a42176ef5aa8b2787779.json](https://github.com/user-attachments/files/31170770/zha-cd7c1fa6596ea299d3f70e212321a83d-_TZ3000_402vrq2i.TS004F-dfd5a4b5bee3a42176ef5aa8b2787779.json)

-->


## Checklist
<!--

  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.

-->

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
