### PR TITLE
Add TS0041 signature variant for Tesla Smart TSL-SEN-BUTTON (_TZ3000_ajsypttg)

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -1508,6 +1508,7 @@ async def test_eheat_send_attribute(zigpy_device_from_quirk, quirk):
         (zhaquirks.tuya.ts0041.TuyaSmartRemote0041TI, "_TZ3000_awgcnkrh"),
         (zhaquirks.tuya.ts0041.TuyaSmartRemote0041TI, "_TZ3400_deyjhapk"),
         (zhaquirks.tuya.ts0041.TuyaSmartRemote0041TI, "_some_random_manuf"),
+        (zhaquirks.tuya.ts0041.TuyaSmartRemote0041TIIAS, "_TZ3000_ajsypttg"),
         (zhaquirks.tuya.ts0041.TuyaSmartRemote0041TO, "_TZ3000_pwgcnkrh"),
         (zhaquirks.tuya.ts0041.TuyaSmartRemote0041TO, "_TZ3400_leyjhapk"),
         (zhaquirks.tuya.ts0041.TuyaSmartRemote0041TO, "_some_random_manuf"),

--- a/zhaquirks/tuya/ts0041.py
+++ b/zhaquirks/tuya/ts0041.py
@@ -118,6 +118,50 @@ class TuyaSmartRemote0041TI(CustomDevice):
     }
 
 
+class TuyaSmartRemote0041TIIAS(CustomDevice):
+    """Tuya 1-button remote device with time on in and IAS ancillary device type."""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=1025, device_version=1, input_clusters=[0, 1, 6, 10], output_clusters=[25]))
+        # Tesla Smart TSL-SEN-BUTTON (_TZ3000_ajsypttg)
+        MODEL: "TS0041",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ANCILLARY_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    OnOff.cluster_id,
+                    Time.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    TuyaNoBindPowerConfigurationCluster,
+                    TuyaSmartRemoteOnOffCluster,
+                    Time.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        },
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: SHORT_PRESS},
+        (LONG_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: LONG_PRESS},
+        (DOUBLE_PRESS, BUTTON_1): {ENDPOINT_ID: 1, COMMAND: DOUBLE_PRESS},
+    }
+
+
 class TuyaSmartRemote0041TOPlusA(CustomDevice):
     """Tuya 1-button remote device with time on out cluster."""
 


### PR DESCRIPTION
## Proposed change

The Tesla Smart TSL-SEN-BUTTON (a Tuya TS0041 rebrand, manufacturer `_TZ3000_ajsypttg`) reports `device_type=0x0401` (IAS_ANCILLARY_CONTROL) in its simple descriptor instead of `0x0000` (ON_OFF_SWITCH), so none of the existing TS0041 signatures match and the remote joins as unsupported.

This adds `TuyaSmartRemote0041TIIAS`, a variant of `TuyaSmartRemote0041TI` with the IAS ancillary control device type in the signature (replacement and triggers are identical).

Signature observed on the device:
```
SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=1025, device_version=1, input_clusters=[0, 1, 6, 10], output_clusters=[25])
```

## Additional information

Running this quirk locally (via `custom_quirks_path`): the device matches, and short/double/long press device triggers work.

## Device diagnostics

Attached in the comment below (redacted).

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)