### PR TITLE
Add `_TZE284_chbyv06x` + `_TZE28C1000000_chbyv06x` to TS0601 gas sensor quirk

### DIFF
--- a/zhaquirks/tuya/tuya_gas.py
+++ b/zhaquirks/tuya/tuya_gas.py
@@ -160,6 +160,8 @@ tuya_gas_alarm_base = (
     .applies_to("_TZE200_yojqa8xn", "TS0601")
     .applies_to("_TZE204_zougpkpy", "TS0601")
     .applies_to("_TZE204_chbyv06x", "TS0601")
+    .applies_to("_TZE284_chbyv06x", "TS0601")
+    .applies_to("_TZE28C1000000_chbyv06x", "TS0601")
     .applies_to("_TZE204_yojqa8xn", "TS0601")
     .tuya_sensor(
         dp_id=2,


### PR DESCRIPTION
## Proposed change

Adds `_TZE284_chbyv06x` to the existing `TS0601` gas sensor quirk in `zhaquirks/tuya/tuya_gas.py`.

This is a newer hardware revision of a device that is already supported as
`_TZE204_chbyv06x` (sold as DYGSM DY-RQ500A). Without this line the device gets no quirk at
all — `quirk_applied: False` — and the only entity Home Assistant creates is the firmware
update entity. The gas alarm itself is completely invisible.

Zigbee2MQTT already covers both revisions under a single definition
(`TS0601_gas_sensor_2` in `zigbee-herdsman-converters/src/devices/tuya.ts`), together with
`_TZE28C1000000_chbyv06x`, which is why the device works there but not in ZHA.

I have also added `_TZE28C1000000_chbyv06x` for parity with Z2M. Please note I could only
hardware-test `_TZE284_chbyv06x`; if you prefer to only add tested revisions, feel free to
drop that line.

## Additional information

Tested on Home Assistant 2026.8.1 / zha 2.1.0 / zha-quirks 2.2.0, SONOFF ZBDongle-E (ezsp)
coordinator, using a local custom quirk with the identical datapoint mapping before
proposing it upstream.

**Datapoints confirmed working:** 1 (gas, enum where 0 = present), 2 (LEL, divided by 10),
6 (ringtone), 7 (alarm duration), 8 (self test), 9 (self test result), 10 (preheat),
16 (silence). DP 13 skipped, same as Z2M and the existing revision.

**Self test:** triggering DP 8 moved the IAS zone entity to `on` for 14 s and the self test
result reported `Checking` then `Success`.

**Real gas test** (butane, brief exposure):

```
17:52:22  preheat        on -> off
17:53:37  gas            off -> ON
17:53:37  LEL            2.2 -> 11.6 %LEL
          decay: 9.6, 7.8, 6.2, 4.8, 3.7, 3.1, 2.9
17:53:58  gas            ON -> off        (cleared at ~2.9 %LEL)
17:54:40  second, weaker exposure: 0.2 -> 3.9 %LEL, correctly did NOT alarm
```

The alarm triggered at a reading of 11.6 %LEL, which lines up with the 10 %LEL threshold
that is standard for combustible gas detectors. That is an independent confirmation that the
`divisor=10` on DP 2 is correct for this revision.

One observation that may be worth documenting: after power-on the sensor runs a preheat cycle
of roughly 3 minutes (measured 3 min 3 s), during which `preheat_active` is on and the device
does not alarm. Worth keeping in mind when testing, since a test done too early looks like a
broken quirk.

## Device diagnostics
[diagnostyka_czujnik_gazu.json](https://github.com/user-attachments/files/31188149/diagnostyka_czujnik_gazu.json)

## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached



Closes #4107
Closes #4676
