### PR TITLE
Add support for Candeo RD1P device with v2 firmware

### DIFF
--- a/zhaquirks/candeo/__init__.py
+++ b/zhaquirks/candeo/__init__.py
@@ -1,18 +1,15 @@
 """Module for Candeo quirks implementations."""
 
 import math
-from typing import Final
 
 import zigpy.types as t
-from zigpy.zcl.clusters.general import Basic, LevelControl, OnOff
+from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement
 from zigpy.zcl.clusters.security import IasZone
 from zigpy.zcl.foundation import (
-    BaseCommandDefs,
     DataTypeId,
     ZCLAttributeDef,
-    ZCLCommandDef,
 )
 
 from zhaquirks.clusters import CustomCluster

--- a/zhaquirks/candeo/__init__.py
+++ b/zhaquirks/candeo/__init__.py
@@ -7,10 +7,7 @@ from zigpy.zcl.clusters.general import Basic
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.measurement import IlluminanceMeasurement
 from zigpy.zcl.clusters.security import IasZone
-from zigpy.zcl.foundation import (
-    DataTypeId,
-    ZCLAttributeDef,
-)
+from zigpy.zcl.foundation import DataTypeId, ZCLAttributeDef
 
 from zhaquirks.clusters import CustomCluster
 from zhaquirks.const import ZONE_TYPE

--- a/zhaquirks/candeo/__init__.py
+++ b/zhaquirks/candeo/__init__.py
@@ -28,13 +28,6 @@ class CandeoSwitchType(t.enum8):
     Toggle = 0x01
 
 
-class CandeoRemoteDirection(t.enum8):
-    """Candeo Remote Direction."""
-
-    Right = 0x00
-    Left = 0x01
-
-
 class CandeoIlluminanceMeasurementCluster(IlluminanceMeasurement, CustomCluster):
     """Candeo Illuminance Measurement Cluster."""
 
@@ -118,47 +111,3 @@ class CandeoRGBCCTColorCluster(Color, CustomCluster):
         Color.AttributeDefs.color_capabilities.id: Color.ColorCapabilities.XY_attributes
         + Color.ColorCapabilities.Color_temperature
     }
-
-
-class CandeoOnOffRemoteCluster(OnOff, CustomCluster):
-    """Candeo OnOff Remote Cluster."""
-
-    class ServerCommandDefs(BaseCommandDefs):
-        """overwrite ServerCommandDefs."""
-
-        double: Final = ZCLCommandDef(
-            id=0x00,
-            schema={},
-        )
-        press: Final = ZCLCommandDef(
-            id=0x01,
-            schema={},
-        )
-        hold: Final = ZCLCommandDef(
-            id=0x02,
-            schema={},
-        )
-        release: Final = ZCLCommandDef(
-            id=0x03,
-            schema={},
-        )
-
-
-class CandeoLevelControlRemoteCluster(LevelControl, CustomCluster):
-    """Candeo LevelControl Remote Cluster."""
-
-    class ServerCommandDefs(BaseCommandDefs):
-        """overwrite ServerCommandDefs."""
-
-        started_rotating: Final = ZCLCommandDef(
-            id=0x05,
-            schema={"direction": CandeoRemoteDirection},
-        )
-        continued_rotating: Final = ZCLCommandDef(
-            id=0x06,
-            schema={"direction": CandeoRemoteDirection},
-        )
-        stopped_rotating: Final = ZCLCommandDef(
-            id=0x03,
-            schema={},
-        )

--- a/zhaquirks/candeo/rotary_dimmer_switches.py
+++ b/zhaquirks/candeo/rotary_dimmer_switches.py
@@ -1,14 +1,16 @@
 """Candeo rotary dimmer switches."""
 
+from typing import Final
+from zigpy.quirks import CustomCluster
+import zigpy.types as t
 from zigpy.zcl import ClusterType
-from zigpy.zcl.clusters.general import Identify, Ota
-
+from zigpy.zcl.clusters.general import Identify, Ota, OnOff, LevelControl
+from zigpy.zcl.foundation import DataTypeId, ZCLAttributeDef, BaseCommandDefs, ZCLCommandDef
 from zhaquirks.builder import QuirkBuilder
 from zhaquirks.candeo import (
     CANDEO,
-    CandeoLevelControlRemoteCluster,
-    CandeoOnOffRemoteCluster,
 )
+
 from zhaquirks.const import (
     CLUSTER_ID,
     COMMAND,
@@ -31,6 +33,146 @@ from zhaquirks.const import (
     SHORT_PRESS,
     STARTED_ROTATING,
     STOPPED_ROTATING,
+)
+
+class CandeoRemoteDirection(t.enum8):
+    """Candeo Remote Direction."""
+
+    Right = 0x00
+    Left = 0x01
+
+
+class CandeoRemoteLiteEP2Functionality(t.enum8):
+    """Candeo remote lite EP2 functionality enum."""
+
+    disabled = False
+    enabled = True
+
+
+class CandeoOnOffRemoteCluster(OnOff, CustomCluster):
+    """Candeo OnOff Remote Cluster."""
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """overwrite ServerCommandDefs."""
+
+        double: Final = ZCLCommandDef(
+            id=0x00,
+            schema={},
+        )
+        press: Final = ZCLCommandDef(
+            id=0x01,
+            schema={},
+        )
+        hold: Final = ZCLCommandDef(
+            id=0x02,
+            schema={},
+        )
+        release: Final = ZCLCommandDef(
+            id=0x03,
+            schema={},
+        )
+
+
+class CandeoLevelControlRemoteCluster(LevelControl, CustomCluster):
+    """Candeo LevelControl Remote Cluster."""
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """overwrite ServerCommandDefs."""
+
+        started_rotating: Final = ZCLCommandDef(
+            id=0x05,
+            schema={"direction": CandeoRemoteDirection},
+        )
+        continued_rotating: Final = ZCLCommandDef(
+            id=0x06,
+            schema={"direction": CandeoRemoteDirection},
+        )
+        stopped_rotating: Final = ZCLCommandDef(
+            id=0x03,
+            schema={},
+        )
+
+
+class CandeoOnOffRemoteLiteEP2FunctionalityCluster(OnOff, CustomCluster):
+    """Candeo OnOff Remote Lite EP2 Functionality Cluster."""
+
+    class AttributeDefs(OnOff.AttributeDefs):
+        """Attribute Definitions."""
+
+        rem_lite_ep2_functionality = ZCLAttributeDef(
+            id=0x8000,
+            type=CandeoRemoteLiteEP2Functionality,
+            zcl_type=DataTypeId.bool_,
+            access="rw",
+        )
+
+    _VALID_ATTRIBUTES = {
+        AttributeDefs.rem_lite_ep2_functionality.id,
+    }
+
+
+class CandeoOnOffRemoteLiteCluster(OnOff, CustomCluster):
+    """Candeo OnOff Remote Lite Cluster."""
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """overwrite ServerCommandDefs."""
+
+        double: Final = ZCLCommandDef(
+            id=0x00,
+            schema={},
+        )
+        hold: Final = ZCLCommandDef(
+            id=0x02,
+            schema={},
+        )
+        release: Final = ZCLCommandDef(
+            id=0x03,
+            schema={},
+        )
+
+
+remote_lite_quirk = (
+    QuirkBuilder()
+    .replaces(
+        CandeoOnOffRemoteLiteEP2FunctionalityCluster,
+        endpoint_id=1,
+    )
+    .replaces(
+        CandeoOnOffRemoteLiteCluster,
+        endpoint_id=2,
+        cluster_type=ClusterType.Client,
+    )
+    .removes(
+        OnOff.cluster_id,
+        endpoint_id=3,
+    )
+    .enum(
+        attribute_name=CandeoOnOffRemoteLiteEP2FunctionalityCluster.AttributeDefs.rem_lite_ep2_functionality.name,
+        cluster_id=CandeoOnOffRemoteLiteEP2FunctionalityCluster.cluster_id,
+        endpoint_id=1,
+        translation_key="rem_lite_ep2_functionality",
+        fallback_name="Extra button commands",
+        enum_class=CandeoRemoteLiteEP2Functionality,
+    )
+    .device_automation_triggers(
+        {
+            (DOUBLE_PRESS, ROTARY_KNOB): {
+                COMMAND: COMMAND_DOUBLE,
+                CLUSTER_ID: 6,
+                ENDPOINT_ID: 2,
+            },
+            (LONG_PRESS, ROTARY_KNOB): {
+                COMMAND: COMMAND_HOLD,
+                CLUSTER_ID: 6,
+                ENDPOINT_ID: 2,
+            },
+            (LONG_RELEASE, ROTARY_KNOB): {
+                COMMAND: COMMAND_RELEASE,
+                CLUSTER_ID: 6,
+                ENDPOINT_ID: 2,
+            },
+        }
+    )
 )
 
 remote_quirk = (
@@ -108,8 +250,16 @@ remote_quirk = (
 )
 
 (
+    remote_lite_quirk.clone()
+    .applies_to(CANDEO, "C-ZB-RD1Pv2-DIM")
+    .removes(Ota.cluster_id)
+    .add_to_registry()
+)
+
+(
     remote_quirk.clone()
     .applies_to(CANDEO, "C-ZB-RD1P-REM")
+    .applies_to(CANDEO, "C-ZB-RD1Pv2-REM")
     .removes(Identify.cluster_id, endpoint_id=1)
     .removes(Identify.cluster_id, endpoint_id=2)
     .removes(Ota.cluster_id)
@@ -119,6 +269,7 @@ remote_quirk = (
 (
     remote_quirk.clone()
     .applies_to(CANDEO, "C-ZB-RD1P-DPM")
+    .applies_to(CANDEO, "C-ZB-RD1Pv2-DPM")
     .removes(Ota.cluster_id)
     .add_to_registry()
 )

--- a/zhaquirks/candeo/rotary_dimmer_switches.py
+++ b/zhaquirks/candeo/rotary_dimmer_switches.py
@@ -1,16 +1,20 @@
 """Candeo rotary dimmer switches."""
 
 from typing import Final
+
 from zigpy.quirks import CustomCluster
 import zigpy.types as t
 from zigpy.zcl import ClusterType
-from zigpy.zcl.clusters.general import Identify, Ota, OnOff, LevelControl
-from zigpy.zcl.foundation import DataTypeId, ZCLAttributeDef, BaseCommandDefs, ZCLCommandDef
-from zhaquirks.builder import QuirkBuilder
-from zhaquirks.candeo import (
-    CANDEO,
+from zigpy.zcl.clusters.general import Identify, LevelControl, OnOff, Ota
+from zigpy.zcl.foundation import (
+    BaseCommandDefs,
+    DataTypeId,
+    ZCLAttributeDef,
+    ZCLCommandDef,
 )
 
+from zhaquirks.builder import QuirkBuilder
+from zhaquirks.candeo import CANDEO
 from zhaquirks.const import (
     CLUSTER_ID,
     COMMAND,
@@ -34,6 +38,7 @@ from zhaquirks.const import (
     STARTED_ROTATING,
     STOPPED_ROTATING,
 )
+
 
 class CandeoRemoteDirection(t.enum8):
     """Candeo Remote Direction."""


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->

Adds support for newer v2 firmware for the RD1P series of device.

We also moved some shared code back into the device specific file to make future updates simpler.  The shared code was an artifact from an earlier PR where each device had a separate file - since this is no longer the case the code no longer needs to be shared.

@TheJulianJES it would be great if this PR can be approved as soon as possible, devices with this new firmware version are due to hit the shelves in the next couple of weeks or so.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
