### PR TITLE
Add Tuya TS130F variant _TZ3210_jrhczaaa

### DIFF
--- a/zhaquirks/tuya/ts130f.py
+++ b/zhaquirks/tuya/ts130f.py
@@ -27,7 +27,11 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.legacy import CustomDevice
-from zhaquirks.tuya import SwitchBackLight, TuyaZBExternalSwitchTypeCluster
+from zhaquirks.tuya import (
+    TUYA_CLUSTER_ID,
+    SwitchBackLight,
+    TuyaZBExternalSwitchTypeCluster,
+)
 
 ATTR_CURRENT_POSITION_LIFT_PERCENTAGE = 0x0008
 CMD_GO_TO_LIFT_PERCENTAGE = 0x0005
@@ -670,6 +674,63 @@ class TuyaTS130Double_GP_ESTC(CustomDevice):
                     TuyaZBExternalSwitchTypeCluster,
                 ],
                 OUTPUT_CLUSTERS: [],
+            },
+            242: {
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+
+
+class TuyaTS130FIdentifyMCUGP(CustomDevice):
+    """Tuya smart curtain roller shutter with Identify, Tuya MCU cluster and Green Power."""
+
+    signature = {
+        # SizePrefixedSimpleDescriptor(endpoint=1, profile=260, device_type=0x0202, device_version=1, input_clusters=[0x0000, 0x0003, 0x0004, 0x0005, 0x0006, 0x0102, 0xef00], output_clusters=[0x000a, 0x0019]))
+        MODEL: "TS130F",
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    OnOff.cluster_id,
+                    WindowCovering.cluster_id,
+                    TUYA_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
+            },
+            242: {
+                # <SimpleDescriptor endpoint=242 profile=41440 device_type=97
+                # input_clusters=[]
+                # output_clusters=[33]
+                PROFILE_ID: zgp.PROFILE_ID,
+                DEVICE_TYPE: zgp.DeviceType.PROXY_BASIC,
+                INPUT_CLUSTERS: [],
+                OUTPUT_CLUSTERS: [GreenPowerProxy.cluster_id],
+            },
+        },
+    }
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    TuyaWithBacklightOnOffCluster,
+                    TuyaCoveringCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time.cluster_id, Ota.cluster_id],
             },
             242: {
                 PROFILE_ID: zgp.PROFILE_ID,


### PR DESCRIPTION


## Proposed change
Adds a new quirk `TuyaTS130FIdentifyMCUGP` for a `TS130F` curtain/roller-shutter module variant (seen on `_TZ3210_jrhczaaa`) whose Zigbee signature is not covered by any of the existing `TS130F` quirks in `zhaquirks/tuya/ts130f.py.`

This variant reports, on endpoint 1:
```

device_type=0x0202 (WINDOW_COVERING_DEVICE)
in_clusters=[0x0000, 0x0003, 0x0004, 0x0005, 0x0006, 0x0102, 0xEF00]
out_clusters=[0x000A, 0x0019]
```

plus the usual Green Power proxy endpoint 242.

Compared to the closest existing quirk (`TuyaTS130GP`), this signature additionally exposes the Identify cluster (0x0003) and the `Tuya MCU` cluster (0xEF00), so it fell through without a matching quirk and the covers entity behaved incorrectly (inverted position).



## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [ ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
