### PR TITLE
Add support for HOBEIAN ZG-101ZL button

### DIFF
--- a/zhaquirks/hobeian/__init__.py
+++ b/zhaquirks/hobeian/__init__.py
@@ -1,0 +1,1 @@
+"""Quirks for HOBEIAN devices."""

--- a/zhaquirks/hobeian/zg101zl.py
+++ b/zhaquirks/hobeian/zg101zl.py
@@ -1,0 +1,35 @@
+"""Quirk for the HOBEIAN ZG-101ZL Zigbee button."""
+
+from zhaquirks.builder import QuirkBuilder
+from zhaquirks.const import (
+    BUTTON,
+    COMMAND,
+    COMMAND_OFF,
+    COMMAND_ON,
+    COMMAND_TOGGLE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    LONG_PRESS,
+    SHORT_PRESS,
+)
+
+(
+    QuirkBuilder("HOBEIAN", "ZG-101ZL")
+    .device_automation_triggers(
+        {
+            (SHORT_PRESS, BUTTON): {
+                COMMAND: COMMAND_TOGGLE,
+                ENDPOINT_ID: 1,
+            },
+            (DOUBLE_PRESS, BUTTON): {
+                COMMAND: COMMAND_ON,
+                ENDPOINT_ID: 1,
+            },
+            (LONG_PRESS, BUTTON): {
+                COMMAND: COMMAND_OFF,
+                ENDPOINT_ID: 1,
+            },
+        }
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Add a Quirks v2 definition for the HOBEIAN ZG-101ZL single-button
Zigbee remote.

The device sends the following On/Off cluster commands:

- Single press: `toggle`
- Double press: `on`
- Long press: `off`

The quirk maps these to short press, double press, and long press
device automation triggers respectively.

## Additional information

Tested with a physical HOBEIAN ZG-101ZL using ZHA. With the quirk
applied, ZHA identifies the three actions as Remote Button Short Press,
Remote Button Double Press, and Remote Button Long Press.

Fixes #4413

## Device diagnostics

[zha-01KZP61FYF98BBDKSQ0CDCDN9D-HOBEIAN ZG-101ZL-a2a1f487d60d056f113bff9f86b5a10c.json](https://github.com/user-attachments/files/31356668/zha-01KZP61FYF98BBDKSQ0CDCDN9D-HOBEIAN.ZG-101ZL-a2a1f487d60d056f113bff9f86b5a10c.json)

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached


