### PR TITLE
Add Tuya ZS-300TF / ZS-301 soil fertility sensor quirk

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -383,3 +383,18 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .skip_configuration()
     .add_to_registry()
 )
+
+
+(
+    TuyaQuirkBuilder("_TZE284_hdml1aav", "TS0601")  # ZS-300TF / ZS-301 soil sensor
+    .applies_to("_TZE2841000000_hdml1aav", "TS0601")  # corrupted manufacturer ID
+    .tuya_soil_moisture(dp_id=3)
+    .tuya_temperature(dp_id=5, scale=10)
+    .tuya_humidity(dp_id=101)
+    .tuya_illuminance(dp_id=102, converter=lambda x: x)
+    .tuya_electrical_conductivity(dp_id=112)
+    .tuya_battery(dp_id=15)
+    .tuya_enchantment(data_query_spell=True)
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
## Summary

Adds a quirk for the **Excellux ZS-300TF** Tuya TS0601 soil fertility sensor (commonly sold as the **ZS-301**). The device pairs with ZHA but exposes no entities without a quirk, because its datapoints are only mapped by a Zigbee2MQTT converter, not by zha-quirks.

The device reports a corrupted manufacturer ID (`_TZE2841000000_hdml1aav`), so the quirk matches both the clean (`_TZE284_hdml1aav`) and corrupted form, following the same pattern already used for the Giex GX04.

## Exposed entities

| Entity | DP | Conversion |
|---|---|---|
| Soil moisture | 3 | raw (%) |
| Temperature | 5 | /10 (°C) |
| Humidity | 101 | raw (%) |
| Illuminance | 102 | raw (lx) |
| Electrical conductivity (soil fertility) | 112 | raw (µS/cm) |
| Battery | 15 | raw (%) |

## Notes

- The datapoint map is sourced from the authoritative Zigbee2MQTT converter for this device (`zigbee-herdsman-converters`, model `ZS-300TF`, vendor `Excellux`), see `tuya.ts` fingerprint `["_TZE284_hdml1aav", "_TZE2841000000_hdml1aav"]`.
- Illuminance uses a raw (`lambda x: x`) converter rather than the `tuya_illuminance` log10 default, because this device reports actual lux (matching the Z2M `tuya.valueConverter.raw` converter for DP 102).
- The battery is mapped via the Tuya datapoint (DP 15) for accuracy, consistent with the other TS0601 soil-sensor quirks in this file.

## Verification

Tested on Home Assistant Yellow (Core 2026.8.x, ZHA). After enabling the quirk and reconfiguring the device, the data-query spell produced real values on cluster 0xEF00:

- DP 3 = 48 → 48.00 % soil moisture
- DP 5 = 226 → 22.60 °C
- DP 101 = 68 → 68.00 % humidity
- DP 102 = 0 → 0 lx (night)
- DP 15 = 94 → 94 % battery
- DP 112 = 856 → 856 µS/cm

`pytest tests/test_tuya_sensor.py tests/test_quirks_v2.py tests/test_quirks_v2_builder.py` passes (81 tests), and `ruff check` / `ruff format --check` are clean.

Refs: zigbee2mqtt#32196, home-assistant discussion #2172.