### PR TITLE
Add _TZ3290_qazgdsae (Zemismart ZBCIR01) to Zosung IR blaster quirk

### DIFF
--- a/zhaquirks/tuya/ts1201.py
+++ b/zhaquirks/tuya/ts1201.py
@@ -450,6 +450,7 @@ class ZosungIRBlaster(CustomDevice):
             ("_TZ3290_ot6ewjvmejq5ekhl", "TS1201"),
             ("_TZ3290_j37rooaxrcdcqo5n", "TS1201"),
             ("_TZ3290_u9xac5rv", "TS1201"),
+            ("_TZ3290_qazgdsae", "TS1201"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
## Proposed change

Add the manufacturer ID `_TZ3290_qazgdsae` to the existing `ZosungIRBlaster` quirk.

This is the **Zemismart ZBCIR01**, a battery-powered Zigbee IR blaster. It reports as `TS1201` and its signature is identical to the battery variant already handled by `ZosungIRBlaster`, including both Zosung IR clusters and `PowerConfiguration`:

```
Endpoint 1, profile 0x0104, device type 0xF000
  input clusters:  0x0000 0x0001 0x0003 0x0004 0x0005 0x0006 0xE004 0xED00
  output clusters: 0x000A 0x0019
```

Without the manufacturer ID no quirk is applied (`quirk_applied: false`, `quirk_class: zigpy.device.Device`). ZHA then only creates the generic entities (switch, battery, LQI/RSSI, firmware update) while the two Zosung clusters stay unclaimed, so the device can neither learn nor send IR codes.

## Additional information

Verified before opening this PR by loading the same class as a local custom quirk (subclassing `ZosungIRBlaster`, overriding only `MODELS_INFO`) — that is why the attached diagnostics show `quirk_class: zbcir01:ZemismartZBCIR01` rather than the built-in class.

Environment: Home Assistant 2026.8.3 (HAOS 18.2), `zha` 2.1.0, `zha-quirks` 2.2.0, Aeotec 10 Pro coordinator.

Learning a code from a physical remote and sending it back both work, and the receiving appliance (a pedestal fan) reacted:

```
09:48:29  Received IR frame 0x00
09:48:29-32  7x Received IR frame 0x03 (positions 0, 55, 110, 165, 220, 275, 330; CRC ok)
09:48:32  IR message completely received
09:48:33  IR message really totally received: A/gEkQFAAwaRAfgE...
09:48:33  Stopping learning mode on device
09:49:25  Sending IR code: {"key_num":1,"delay":300,"key1":{"num":1,"freq":38000,"type":1,...}}
09:49:27  IR code has been sent (seq:1)
09:50:43  IR code has been sent (seq:2)
```

No new device class is needed — this is the same hardware as the already supported variants.

## Device diagnostics

<details>
<summary>zha-..._TZ3290_qazgdsae TS1201 diagnostics (quirk applied)</summary>

```json
{
  "home_assistant": {
    "arch": "x86_64",
    "dev": false,
    "docker": true,
    "hassio": true,
    "installation_type": "Home Assistant OS",
    "os_name": "Linux",
    "os_version": "6.18.39-haos",
    "python_version": "3.14.6",
    "timezone": "Europe/Berlin",
    "version": "2026.8.3",
    "virtualenv": false,
    "container_arch": "amd64",
    "supervisor": "2026.07.5",
    "host_os": "Home Assistant OS 18.2",
    "docker_version": "29.6.2",
    "chassis": "vm",
    "run_as_root": true
  },
  "custom_components": {
    "zha_toolkit": {
      "documentation": "https://github.com/mdeweerd/zha-toolkit",
      "version": "v1.2.2",
      "requirements": [
        "aiofiles>=0.4.0,<25",
        "pytz>=2016.10"
      ]
    },
    "browser_mod": {
      "documentation": "https://github.com/thomasloven/hass-browser_mod/blob/master/README.md",
      "version": "3.2.2",
      "requirements": []
    },
    "huawei_solar": {
      "documentation": "https://github.com/wlcrs/huawei_solar/wiki",
      "version": "2.1.2",
      "requirements": [
        "huawei-solar>=3.0.7"
      ]
    },
    "solcast_solar": {
      "documentation": "https://github.com/BJReplay/ha-solcast-solar",
      "version": "v4.6.1",
      "requirements": [
        "aiofiles>=23.2.0",
        "watchfiles>=1.0.0"
      ]
    },
    "awtrix": {
      "documentation": "https://github.com/MiguelAngelLV/ha-awtrix",
      "version": "0.7.0",
      "requirements": []
    },
    "better_thermostat": {
      "documentation": "https://better-thermostat.org/",
      "version": "1.9.2",
      "requirements": [
        "numpy>=2"
      ]
    },
    "hacs": {
      "documentation": "https://hacs.xyz/docs/use/",
      "version": "2.0.5",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    },
    "mcp_proxy": {
      "documentation": "https://github.com/homeassistant-ai/ha-mcp",
      "version": "2.0.1",
      "requirements": []
    },
    "librelink": {
      "documentation": "https://github.com/gillesvs/librelink",
      "version": "1.2.3",
      "requirements": []
    },
    "moonraker": {
      "documentation": "https://moonraker-home-assistant.readthedocs.io/en/latest/",
      "version": "1.13.4",
      "requirements": [
        "moonraker-api==2.0.6"
      ]
    },
    "homematicip_local": {
      "documentation": "https://github.com/sukramj/homematicip_local",
      "version": "2.9.1",
      "requirements": [
        "openccu-data==2026.7.2",
        "openccu-loom-client==2026.8.9",
        "aiohomematic-config==2026.8.0",
        "aiohomematic==2026.8.2"
      ]
    }
  },
  "integration_manifest": {
    "domain": "zha",
    "name": "Zigbee Home Automation",
    "after_dependencies": [
      "hassio",
      "onboarding"
    ],
    "codeowners": [
      "dmulcahey",
      "adminiuga",
      "puddly",
      "TheJulianJES"
    ],
    "config_flow": true,
    "dependencies": [
      "file_upload",
      "homeassistant_hardware",
      "usb"
    ],
    "documentation": "https://www.home-assistant.io/integrations/zha",
    "integration_type": "hub",
    "iot_class": "local_polling",
    "loggers": [
      "aiosqlite",
      "bellows",
      "crccheck",
      "pure_pcapy3",
      "zhaquirks",
      "zigpy",
      "zigpy_deconz",
      "zigpy_xbee",
      "zigpy_zigate",
      "zigpy_znp",
      "zha",
      "universal_silabs_flasher",
      "serialx"
    ],
    "requirements": [
      "zha==2.1.0",
      "zha-quirks==2.2.0"
    ],
    "usb": [
      {
        "description": "*2652*",
        "known_devices": [
          "slae.sh cc2652rb stick"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*slzb-07*",
        "known_devices": [
          "smlight slzb-07"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus v2"
        ],
        "pid": "55D4",
        "vid": "1A86"
      },
      {
        "description": "*sonoff*plus*",
        "known_devices": [
          "sonoff zigbee dongle plus"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*tubeszb*",
        "known_devices": [
          "TubesZB Coordinator"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*zigstar*",
        "known_devices": [
          "ZigStar Coordinators"
        ],
        "pid": "7523",
        "vid": "1A86"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee II"
        ],
        "pid": "0030",
        "vid": "1CF1"
      },
      {
        "description": "*conbee*",
        "known_devices": [
          "Conbee III"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigbee*",
        "known_devices": [
          "Nortek HUSBZB-1"
        ],
        "pid": "8A2A",
        "vid": "10C4"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate+"
        ],
        "pid": "6015",
        "vid": "0403"
      },
      {
        "description": "*zigate*",
        "known_devices": [
          "ZiGate"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*bv 2010/10*",
        "known_devices": [
          "Bitron Video AV2010/10"
        ],
        "pid": "8B34",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*max*",
        "known_devices": [
          "SONOFF Dongle Max MG24"
        ],
        "pid": "EA60",
        "vid": "10C4"
      },
      {
        "description": "*sonoff*lite*mg21*",
        "known_devices": [
          "sonoff zigbee dongle lite mg21"
        ],
        "pid": "EA60",
        "vid": "10C4"
      }
    ],
    "zeroconf": [
      {
        "name": "tube*",
        "type": "_esphomelib._tcp.local."
      },
      {
        "name": "*zigate*",
        "type": "_zigate-zigbee-gateway._tcp.local."
      },
      {
        "name": "*zigstar*",
        "type": "_zigstar_gw._tcp.local."
      },
      {
        "name": "uzg-01*",
        "type": "_uzg-01._tcp.local."
      },
      {
        "name": "slzb-06*",
        "type": "_slzb-06._tcp.local."
      },
      {
        "name": "xzg*",
        "type": "_xzg._tcp.local."
      },
      {
        "name": "czc*",
        "type": "_czc._tcp.local."
      },
      {
        "name": "*",
        "type": "_zigbee-coordinator._tcp.local."
      }
    ],
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.00011373916640877724
    },
    "01KA3NNDX2Q9S6CKN1Q6TBBJ76": {
      "wait_import_platforms": -0.038942244136705995,
      "config_entry_setup": 14.178771584061906
    }
  },
  "data": {
    "version": 3,
    "ieee": "**REDACTED**",
    "nwk": "0xB33D",
    "manufacturer": "_TZ3290_qazgdsae",
    "model": "TS1201",
    "friendly_manufacturer": "_TZ3290_qazgdsae",
    "friendly_model": "TS1201",
    "name": "_TZ3290_qazgdsae TS1201",
    "quirk_applied": true,
    "quirk_class": "zbcir01:ZemismartZBCIR01",
    "exposes_features": [],
    "manufacturer_code": 4098,
    "power_source": "Battery or Unknown",
    "lqi": 176,
    "rssi": -56,
    "last_seen": "2026-08-26T07:17:50.336106+00:00",
    "available": true,
    "device_type": "EndDevice",
    "active_coordinator": false,
    "node_descriptor": {
      "logical_type": "EndDevice",
      "complex_descriptor_available": false,
      "user_descriptor_available": false,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4098,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 82,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 82,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": 260,
        "device_type": {
          "name": "undefined_0xf000",
          "id": 61440
        },
        "in_clusters": [
          {
            "cluster_id": "0x0000",
            "endpoint_attribute": "basic",
            "attributes": [
              {
                "id": "0x0004",
                "name": "manufacturer",
                "zcl_type": "string",
                "value": "_TZ3290_qazgdsae"
              },
              {
                "id": "0x0005",
                "name": "model",
                "zcl_type": "string",
                "value": "TS1201"
              }
            ]
          },
          {
            "cluster_id": "0x0001",
            "endpoint_attribute": "power",
            "attributes": [
              {
                "id": "0x0021",
                "name": "battery_percentage_remaining",
                "zcl_type": "uint8",
                "value": 138
              },
              {
                "id": "0x0033",
                "name": "battery_quantity",
                "zcl_type": "uint8",
                "unsupported": true
              },
              {
                "id": "0x0031",
                "name": "battery_size",
                "zcl_type": "enum8",
                "unsupported": true
              },
              {
                "id": "0x0020",
                "name": "battery_voltage",
                "zcl_type": "uint8",
                "value": 14
              }
            ]
          },
          {
            "cluster_id": "0x0003",
            "endpoint_attribute": "identify",
            "attributes": []
          },
          {
            "cluster_id": "0x0004",
            "endpoint_attribute": "groups",
            "attributes": []
          },
          {
            "cluster_id": "0x0005",
            "endpoint_attribute": "scenes",
            "attributes": []
          },
          {
            "cluster_id": "0x0006",
            "endpoint_attribute": "on_off",
            "attributes": [
              {
                "id": "0x0000",
                "name": "on_off",
                "zcl_type": "bool",
                "value": 0
              },
              {
                "id": "0x4003",
                "name": "start_up_on_off",
                "zcl_type": "enum8",
                "unsupported": true
              }
            ]
          },
          {
            "cluster_id": "0xe004",
            "endpoint_attribute": "zosung_ircontrol",
            "attributes": []
          },
          {
            "cluster_id": "0xed00",
            "endpoint_attribute": "zosung_irtransmit",
            "attributes": []
          }
        ],
        "out_clusters": [
          {
            "cluster_id": "0x000a",
            "endpoint_attribute": "time",
            "attributes": []
          },
          {
            "cluster_id": "0x0019",
            "endpoint_attribute": "ota",
            "attributes": [
              {
                "id": "0x0002",
                "name": "current_file_version",
                "zcl_type": "uint32",
                "value": 67
              }
            ],
            "last_query_cmd": {
              "manufacturer_code": 4098,
              "image_type": 5634,
              "current_file_version": 67,
              "hardware_version": null
            }
          }
        ]
      }
    },
    "original_signature": {
      "manufacturer": "_TZ3290_qazgdsae",
      "model": "TS1201",
      "node_desc": {
        "logical_type": 2,
        "complex_descriptor_available": 0,
        "user_descriptor_available": 0,
        "reserved": 0,
        "aps_flags": 0,
        "frequency_band": 8,
        "mac_capability_flags": 128,
        "manufacturer_code": 4098,
        "maximum_buffer_size": 82,
        "maximum_incoming_transfer_size": 82,
        "server_mask": 11264,
        "maximum_outgoing_transfer_size": 82,
        "descriptor_capability_field": 0
      },
      "endpoints": {
        "1": {
          "profile_id": "0x0104",
          "device_type": "0xf000",
          "input_clusters": [
            "0x0000",
            "0x0004",
            "0x0005",
            "0x0003",
            "0x0001",
            "0xed00",
            "0xe004",
            "0x0006"
          ],
          "output_clusters": [
            "0x0019",
            "0x000a"
          ]
        }
      }
    },
    "zha_lib_entities": {
      "button": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "button",
          "class_name": "IdentifyButton",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "identify",
          "state_class": null,
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "command": "identify",
          "args": [
            5
          ],
          "kwargs": {}
        }
      ],
      "sensor": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "LQISensor",
          "translation_key": "lqi",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": "measurement",
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": false,
          "enabled": false,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": 176,
          "suggested_display_precision": null,
          "unit": null
        },
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "RSSISensor",
          "translation_key": "rssi",
          "translation_placeholders": null,
          "device_class": "signal_strength",
          "state_class": "measurement",
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": false,
          "enabled": false,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": -56,
          "suggested_display_precision": null,
          "unit": "dBm"
        },
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "sensor",
          "class_name": "Battery",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "battery",
          "state_class": "measurement",
          "entity_category": "diagnostic",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [
            "battery_quantity",
            "battery_size",
            "battery_voltage"
          ],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "native_value": 69.0,
          "suggested_display_precision": 0,
          "unit": "%",
          "battery_size": null,
          "battery_quantity": null,
          "battery_voltage": 1.4
        }
      ],
      "switch": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "switch",
          "class_name": "Switch",
          "translation_key": "switch",
          "translation_placeholders": null,
          "device_class": null,
          "state_class": null,
          "entity_category": null,
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": true,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "is_on": 0
        }
      ],
      "update": [
        {
          "fallback_name": null,
          "unique_id": "**REDACTED**",
          "migrate_unique_ids": [],
          "platform": "update",
          "class_name": "FirmwareUpdateEntity",
          "translation_key": null,
          "translation_placeholders": null,
          "device_class": "firmware",
          "state_class": null,
          "entity_category": "config",
          "entity_registry_enabled_default": true,
          "enabled": true,
          "primary": false,
          "extra_state_attribute_names": [],
          "device_ieee": "**REDACTED**",
          "endpoint_id": 1,
          "available": true,
          "group_id": null,
          "installed_version": "0x00000043",
          "in_progress": false,
          "update_percentage": null,
          "latest_version": null,
          "release_summary": null,
          "release_notes": null,
          "release_url": null,
          "supported_features": 23
        }
      ]
    },
    "neighbors": [],
    "routes": []
  },
  "issues": []
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
