### PR TITLE
Add quirk for Aqara Dimmer Switch H2 US (lumi.switch.agl007)

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -45,6 +45,7 @@ from tests.common import ZCL_OCC_ATTR_RPT_OCC, ClusterListener
 import zhaquirks
 from zhaquirks.const import (
     ATTR_ID,
+    BUTTON,
     BUTTON_1,
     BUTTON_2,
     DEVICE_TYPE,
@@ -2729,3 +2730,49 @@ def test_air_monitor_attribute_scaling(zigpy_device_from_v2_quirk):
     temp = device.endpoints[1].device_temperature
     temp._update_attribute(DeviceTemperature.AttributeDefs.current_temperature.id, 25)
     assert temp.get("current_temperature") == 2500
+
+
+@pytest.mark.parametrize("endpoint_id", [1, 2, 3])
+async def test_aqara_dimmer_h2_us_button_events(
+    zigpy_device_from_v2_quirk, endpoint_id
+):
+    """Test that each H2 US button reports a press as <endpoint>_<press type>."""
+
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.agl007", endpoint_ids=[1, 2, 3]
+    )
+    cluster = device.endpoints[endpoint_id].multistate_input
+    zha_listener = mock.MagicMock()
+    cluster.add_listener(zha_listener)
+
+    cluster.update_attribute(MultistateInput.AttributeDefs.present_value.id, 1)
+
+    assert zha_listener.zha_send_event.mock_calls == [
+        mock.call(
+            f"{endpoint_id}_single",
+            {
+                BUTTON: endpoint_id,
+                PRESS_TYPE: "single",
+                ATTR_ID: MultistateInput.AttributeDefs.present_value.id,
+                VALUE: 1,
+            },
+        )
+    ]
+
+
+@mock.patch("zigpy.zcl.Cluster.bind", mock.AsyncMock())
+async def test_aqara_dimmer_h2_us_bind_sets_event_mode(zigpy_device_from_v2_quirk):
+    """Test that binding the H2 US dimmer puts it in event mode.
+
+    Without this write the three buttons never report a press.
+    """
+
+    device = zigpy_device_from_v2_quirk(
+        "Aqara", "lumi.switch.agl007", endpoint_ids=[1, 2, 3]
+    )
+    cluster = device.endpoints[1].opple_cluster
+
+    with mock.patch.object(cluster, "write_attributes", mock.AsyncMock()) as write_mock:
+        await cluster.bind()
+
+    assert write_mock.mock_calls == [mock.call({"mode": 1}, manufacturer=0x115F)]

--- a/zhaquirks/xiaomi/aqara/switch_agl007.py
+++ b/zhaquirks/xiaomi/aqara/switch_agl007.py
@@ -1,0 +1,226 @@
+"""Quirk for Aqara Dimmer Switch H2 US (lumi.switch.agl007).
+
+Three buttons on separate endpoints: 1 = paddle, 2 = brightness up,
+3 = brightness down. Endpoint 1 pairs as a bare on/off switch without this
+quirk, so brightness, the button events and per-button decoupling are all
+unavailable.
+
+Attribute ids are taken from zigbee-herdsman-converters' `lumi.switch.agl007`
+definition and lib/lumi.ts. Press types are `PRESS_TYPES` in
+zhaquirks.xiaomi.aqara.opple_remote ({0: hold, 1: single, 2: double,
+3: triple, 255: release}), which agrees with Z2M's `lumiAction` lookup for this
+model.
+
+Buttons report as `zha_event` with `command` set to "<endpoint>_<press type>",
+e.g. "2_single", whatever the operation mode is: decoupling stops the relay,
+not the report. Decoupling endpoint 1 (the paddle) disables the up and down
+buttons entirely, which is why only endpoints 2 and 3 are meant to be
+decoupled in practice.
+
+Tested on hardware, firmware sw 1.0.6.0, 2026-08-23.
+"""
+
+from zigpy import types
+from zigpy.profiles import zha
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+from zhaquirks.builder import QuirkBuilder
+from zhaquirks.xiaomi import XiaomiAqaraE1Cluster
+from zhaquirks.xiaomi.aqara.opple_remote import MultistateInputCluster
+
+LUMI_MFG_CODE = 0x115F
+
+
+class OperationMode(types.enum8):
+    """Whether a button drives the load or only reports the press."""
+
+    Decoupled = 0x00
+    Relay = 0x01
+
+
+class ModeSwitch(types.enum16):
+    """Quick mode responds faster; anti-flicker fixes blinking dimmed LEDs."""
+
+    Quick = 0x01
+    Anti_Flicker = 0x04
+
+
+class Phase(types.enum8):
+    """Dimming phase: trailing edge suits most LED loads."""
+
+    Leading = 0x00
+    Trailing = 0x01
+
+
+class PowerOnState(types.enum8):
+    """What the load does when mains power comes back."""
+
+    On = 0x00
+    Previous = 0x01
+    Off = 0x02
+    Inverted = 0x03
+
+
+class MultiClick(types.enum8):
+    """Multi-click costs response time: the device waits for a second press."""
+
+    Single = 0x01
+    Multi = 0x02
+
+
+class DimmerH2USCluster(XiaomiAqaraE1Cluster):
+    """Aqara manufacturer-specific cluster, as this dimmer implements it."""
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        # 0x0009 = 0 -> the buttons send zigbee COMMANDS (for binding),
+        #          1 -> they send EVENTS, which is what Home Assistant wants.
+        # Written on bind below; without it the buttons stay silent.
+        mode = ZCLAttributeDef(
+            id=0x0009, type=types.uint8_t, access="rw", is_manufacturer_specific=True
+        )
+        mode_switch = ZCLAttributeDef(
+            id=0x0004, type=types.uint16_t, access="rw", is_manufacturer_specific=True
+        )
+        flip_indicator_light = ZCLAttributeDef(
+            id=0x00F0, type=types.uint8_t, access="rw", is_manufacturer_specific=True
+        )
+        operation_mode = ZCLAttributeDef(
+            id=0x0200, type=types.uint8_t, access="rw", is_manufacturer_specific=True
+        )
+        led_indicator = ZCLAttributeDef(
+            id=0x0203, type=types.Bool, access="rw", is_manufacturer_specific=True
+        )
+        multi_click = ZCLAttributeDef(
+            id=0x0286, type=types.uint8_t, access="rw", is_manufacturer_specific=True
+        )
+        phase = ZCLAttributeDef(
+            id=0x030A, type=types.uint8_t, access="rw", is_manufacturer_specific=True
+        )
+        min_brightness = ZCLAttributeDef(
+            id=0x0515, type=types.uint8_t, access="rw", is_manufacturer_specific=True
+        )
+        max_brightness = ZCLAttributeDef(
+            id=0x0516, type=types.uint8_t, access="rw", is_manufacturer_specific=True
+        )
+        power_on_behavior = ZCLAttributeDef(
+            id=0x0517, type=types.uint8_t, access="rw", is_manufacturer_specific=True
+        )
+
+    async def bind(self):
+        """Bind, then put the device into event mode so the buttons report."""
+        result = await super().bind()
+        await self.write_attributes({"mode": 1}, manufacturer=LUMI_MFG_CODE)
+        return result
+
+
+(
+    QuirkBuilder("Aqara", "lumi.switch.agl007")
+    # Endpoint 1 pairs as a bare ON_OFF_SWITCH without this, i.e. no brightness.
+    .replaces_endpoint(1, device_type=zha.DeviceType.DIMMABLE_LIGHT)
+    # The event-emitting MultistateInput, one per button.
+    .replaces(MultistateInputCluster, endpoint_id=1)
+    .replaces(MultistateInputCluster, endpoint_id=2)
+    .replaces(MultistateInputCluster, endpoint_id=3)
+    .adds(DimmerH2USCluster, endpoint_id=1)
+    .adds(DimmerH2USCluster, endpoint_id=2)
+    .adds(DimmerH2USCluster, endpoint_id=3)
+    # One operation mode per button. The paddle's is exposed for completeness,
+    # but decoupling it disables the up and down buttons entirely.
+    .enum(
+        DimmerH2USCluster.AttributeDefs.operation_mode.name,
+        OperationMode,
+        DimmerH2USCluster.cluster_id,
+        endpoint_id=1,
+        unique_id_suffix="operation_mode_paddle",
+        translation_key="operation_mode_paddle",
+        fallback_name="Operation mode (paddle)",
+    )
+    .enum(
+        DimmerH2USCluster.AttributeDefs.operation_mode.name,
+        OperationMode,
+        DimmerH2USCluster.cluster_id,
+        endpoint_id=2,
+        unique_id_suffix="operation_mode_up",
+        translation_key="operation_mode_up",
+        fallback_name="Operation mode (up button)",
+    )
+    .enum(
+        DimmerH2USCluster.AttributeDefs.operation_mode.name,
+        OperationMode,
+        DimmerH2USCluster.cluster_id,
+        endpoint_id=3,
+        unique_id_suffix="operation_mode_down",
+        translation_key="operation_mode_down",
+        fallback_name="Operation mode (down button)",
+    )
+    .enum(
+        DimmerH2USCluster.AttributeDefs.mode_switch.name,
+        ModeSwitch,
+        DimmerH2USCluster.cluster_id,
+        translation_key="mode_switch",
+        fallback_name="Mode switch",
+    )
+    .enum(
+        DimmerH2USCluster.AttributeDefs.phase.name,
+        Phase,
+        DimmerH2USCluster.cluster_id,
+        translation_key="phase",
+        fallback_name="Phase",
+    )
+    .enum(
+        DimmerH2USCluster.AttributeDefs.power_on_behavior.name,
+        PowerOnState,
+        DimmerH2USCluster.cluster_id,
+        translation_key="power_on_state",
+        fallback_name="Power on state",
+    )
+    .number(
+        DimmerH2USCluster.AttributeDefs.min_brightness.name,
+        DimmerH2USCluster.cluster_id,
+        min_value=0,
+        max_value=99,
+        step=1,
+        translation_key="min_brightness",
+        fallback_name="Minimum brightness",
+    )
+    .number(
+        DimmerH2USCluster.AttributeDefs.max_brightness.name,
+        DimmerH2USCluster.cluster_id,
+        min_value=1,
+        max_value=100,
+        step=1,
+        translation_key="max_brightness",
+        fallback_name="Maximum brightness",
+    )
+    .switch(
+        DimmerH2USCluster.AttributeDefs.led_indicator.name,
+        DimmerH2USCluster.cluster_id,
+        translation_key="led_indicator",
+        fallback_name="LED indicator",
+    )
+    .switch(
+        DimmerH2USCluster.AttributeDefs.flip_indicator_light.name,
+        DimmerH2USCluster.cluster_id,
+        translation_key="flip_indicator_light",
+        fallback_name="Flip indicator light",
+    )
+    .device_automation_triggers(
+        {
+            ("single", "paddle"): {"command": "1_single"},
+            ("double", "paddle"): {"command": "1_double"},
+            ("hold", "paddle"): {"command": "1_hold"},
+            ("release", "paddle"): {"command": "1_release"},
+            ("single", "up"): {"command": "2_single"},
+            ("double", "up"): {"command": "2_double"},
+            ("hold", "up"): {"command": "2_hold"},
+            ("release", "up"): {"command": "2_release"},
+            ("single", "down"): {"command": "3_single"},
+            ("double", "down"): {"command": "3_double"},
+            ("hold", "down"): {"command": "3_hold"},
+            ("release", "down"): {"command": "3_release"},
+        }
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Adds a quirks-v2 definition for the **Aqara Dimmer Switch H2 US** (WS-K05E,
`lumi.switch.agl007`).

Without a quirk the device pairs as a bare on/off switch on endpoint 1: no brightness,
no button events and no access to the Lumi configuration attributes. The merged
`switch_agl011.py` is the H2 **EU** dimmer, a rotary with a single control and no button
endpoints, so it does not apply.

The quirk:

* replaces endpoint 1 with `DIMMABLE_LIGHT`, so the load becomes a real dimmable light;
* puts the event-emitting `MultistateInputCluster` on endpoints 1, 2 and 3
  (**1 = paddle, 2 = brightness up, 3 = brightness down**);
* writes the Lumi `mode` attribute (`0x0009 = 1`, event mode) on bind, without which the
  buttons never report;
* exposes an **Operation mode** select per button (`Decoupled` / `Relay`, Lumi attribute
  `0x0200`, written per endpoint), plus mode switch, dimming phase, power on state,
  min/max brightness and the two LED indicator switches;
* registers device automation triggers for single/double/hold/release on all three
  buttons.

Values come from zigbee-herdsman-converters' `lumi.switch.agl007` definition and
`lib/lumi.ts` for the attribute ids, and from `PRESS_TYPES` in
`zhaquirks/xiaomi/aqara/opple_remote.py` for the press types
(`{0: hold, 1: single, 2: double, 3: triple, 255: release}`), which agrees with Z2M's
`lumiAction` lookup for this model.

## Additional information

Fixes #4983.

**Decoupling endpoint 1 (the paddle) disables the up and down buttons entirely**, which
is Aqara's own documented behaviour for this device, so in practice only endpoints 2 and
3 are useful to decouple. That is noted in the module docstring so nobody has to
rediscover it.

Two things measured on the unit rather than inherited from the converter:

* **The endpoint map.** One press of each button, watched on the event bus with
  endpoints 2 and 3 decoupled: `1_single` toggled the load, `2_single` and `3_single`
  reported without moving it.
* **The dimmer stays reachable over Zigbee when the buttons are decoupled.** Level set
  from HA, read back on the device's own power meter: 12.4 W at full, 5.5 W at 178/254,
  1.9 W at 102/254. So `DIMMABLE_LIGHT` on endpoint 1 is right regardless of how the
  buttons are configured.

One caveat for anyone reading the attribute list: on sw 1.0.6.0 the device accepts
`min_brightness` (attribute `0x0515`) but does **not** apply it to a Zigbee level
command. With `min_brightness = 65` a command for 40% still dimmed the load to 1.9 W.
It appears to bound the local button dimming range only.

Running in production on ZHA since 2026-08-23 (Sonoff dongle, HA Core 2026.8.x,
zha-quirks 2.2.0), where the two decoupled buttons drive a cover through automations on
`2_single` / `3_single`.

## Device diagnostics

<!-- zha-diagnostics-lumi.switch.agl007.json attached below -->
[zha-diagnostics-lumi.switch.agl007.json](https://github.com/user-attachments/files/31519347/zha-diagnostics-lumi.switch.agl007.json)

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
