### PR TITLE
Add Namron 4512783 thermostat quirk

### DIFF
--- a/tests/test_namron.py
+++ b/tests/test_namron.py
@@ -1,0 +1,254 @@
+"""Tests for Namron quirks."""
+
+from pathlib import Path
+from unittest import mock
+
+from zha.quirks import DEVICE_REGISTRY, QuirkRegistryEntry
+from zha.zigbee.cluster_config import aggregate_cluster_configs
+import zigpy.types as t
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.hvac import TemperatureDisplayMode, Thermostat, UserInterface
+
+from zhaquirks.builder.device import QuirkV2Factory
+from zhaquirks.namron.namron_4512783 import (
+    NamronScreenOnTime,
+    NamronSensorMode,
+    NamronThermostatCluster,
+    NamronWorkDays,
+)
+
+THERMOSTAT_ENTITY_SUFFIXES = {
+    "anti_frost",
+    "automatic_time",
+    "fault",
+    "holiday_temperature",
+    "operation_mode",
+    "panel_brightness",
+    "regulator_cycle",
+    "regulator_percentage",
+    "screen_on_time",
+    "vacation_mode",
+    "window_open_check",
+    "window_state",
+    "work_days",
+    "max_heat_temperature",
+}
+ENTITY_SUFFIXES = THERMOSTAT_ENTITY_SUFFIXES | {"temperature_display_mode"}
+
+
+def _get_quirk_entry() -> QuirkRegistryEntry:
+    """Return the Namron 4512783 quirk registry entry."""
+    entries = [
+        entry
+        for entry in DEVICE_REGISTRY
+        if isinstance(entry.zha_device_factory, QuirkV2Factory)
+        and Path(entry.source.file).name == "namron_4512783.py"
+    ]
+    assert len(entries) == 1
+    return entries[0]
+
+
+def _get_quirked_device(zigpy_device_from_v2_quirk):
+    """Create a Namron 4512783 with its thermostat cluster."""
+    return zigpy_device_from_v2_quirk(
+        manufacturer="Namron AS",
+        model="4512783",
+        cluster_ids={
+            1: {
+                Thermostat.cluster_id: ClusterType.Server,
+                UserInterface.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+
+
+def test_namron_4512783_entities(zigpy_device_from_v2_quirk):
+    """Test cluster replacement, entity discovery, and startup reads."""
+    device = _get_quirked_device(zigpy_device_from_v2_quirk)
+    cluster = device.endpoints[1].thermostat
+    assert type(cluster) is NamronThermostatCluster
+
+    attrs = cluster.AttributeDefs
+    expected_types = {
+        "window_open_check": t.Bool,
+        "anti_frost": t.Bool,
+        "window_state": t.Bool,
+        "work_days": NamronWorkDays,
+        "sensor_mode": NamronSensorMode,
+        "panel_brightness": t.uint8_t,
+        "fault": t.bitmap8,
+        "regulator_cycle": t.uint8_t,
+        "holiday_temperature": t.int16s,
+        "regulator_percentage": t.int16s,
+        "vacation_mode": t.Bool,
+        "automatic_time": t.Bool,
+        "max_heat_temperature": t.int16s,
+        "screen_on_time": NamronScreenOnTime,
+    }
+    for attribute_name, expected_type in expected_types.items():
+        attribute = getattr(attrs, attribute_name)
+        assert attribute.type is expected_type
+        assert attribute.manufacturer_code is None
+
+    cluster.update_attribute(attrs.window_open_check.id, t.Bool.true)
+    cluster.update_attribute(attrs.anti_frost.id, t.Bool.false)
+    cluster.update_attribute(attrs.window_state.id, t.Bool.false)
+    cluster.update_attribute(
+        attrs.work_days.id, NamronWorkDays.Monday_Friday_Saturday_Sunday
+    )
+    cluster.update_attribute(attrs.sensor_mode.id, NamronSensorMode.Regulator)
+    cluster.update_attribute(attrs.panel_brightness.id, 80)
+    cluster.update_attribute(attrs.fault.id, t.bitmap8(0))
+    cluster.update_attribute(attrs.regulator_cycle.id, 2)
+    cluster.update_attribute(attrs.holiday_temperature.id, 500)
+    cluster.update_attribute(attrs.regulator_percentage.id, 20)
+    cluster.update_attribute(attrs.vacation_mode.id, t.Bool.false)
+    cluster.update_attribute(attrs.automatic_time.id, t.Bool.true)
+    cluster.update_attribute(attrs.max_heat_temperature.id, 350)
+    cluster.update_attribute(attrs.screen_on_time.id, NamronScreenOnTime.Thirty_seconds)
+    device.endpoints[1].thermostat_ui.update_attribute(
+        UserInterface.AttributeDefs.temperature_display_mode.id,
+        TemperatureDisplayMode.Metric,
+    )
+
+    gateway = mock.Mock()
+    gateway.config.config.device_options.consider_unavailable_mains = 900
+    gateway.config.config.device_options.consider_unavailable_battery = 900
+    zha_device = _get_quirk_entry().zha_device_factory(device, gateway)
+    entities = {
+        entity.unique_id.rsplit("-", 1)[-1]: entity
+        for entity in zha_device.discover_entities()
+        if entity.unique_id.rsplit("-", 1)[-1] in ENTITY_SUFFIXES
+    }
+
+    assert set(entities) == ENTITY_SUFFIXES
+    assert entities["work_days"].options == [
+        "Monday Friday Saturday Sunday",
+        "Monday Saturday Sunday",
+        "No time off",
+        "Time off",
+    ]
+    assert entities["operation_mode"].options == [
+        "Internal air sensor",
+        "Floor sensor",
+        "Internal air with floor limit",
+        "External room sensor",
+        "External room with floor limit",
+        "Floor sensor with regulator",
+        "Regulator",
+    ]
+    assert entities["operation_mode"].current_option == "Regulator"
+    assert entities["screen_on_time"].options == [
+        "Always on",
+        "Ten seconds",
+        "Thirty seconds",
+        "Sixty seconds",
+    ]
+    assert entities["screen_on_time"].current_option == "Thirty seconds"
+    assert entities["temperature_display_mode"].options == ["Metric", "Imperial"]
+    assert entities["temperature_display_mode"].current_option == "Metric"
+    assert entities["panel_brightness"].native_value == 80
+    assert entities["regulator_cycle"].native_value == 2
+    assert entities["holiday_temperature"].native_value == 5
+    assert entities["regulator_percentage"].native_value == 20
+    assert entities["max_heat_temperature"].native_value == 35
+    assert entities["fault"].native_value == 0
+    assert all(entity.is_supported() for entity in entities.values())
+
+    configs = aggregate_cluster_configs(entities.values())
+    thermostat_config = configs[(1, Thermostat.cluster_id, True)]
+    assert thermostat_config.bind is False
+    assert set(thermostat_config.attributes) == {
+        "anti_frost",
+        "automatic_time",
+        "fault",
+        "holiday_temperature",
+        "max_heat_temperature",
+        "panel_brightness",
+        "regulator_cycle",
+        "regulator_percentage",
+        "screen_on_time",
+        "sensor_mode",
+        "vacation_mode",
+        "window_open_check",
+        "window_state",
+        "work_days",
+    }
+    user_interface_config = configs[(1, UserInterface.cluster_id, True)]
+    assert user_interface_config.bind is False
+    assert set(user_interface_config.attributes) == {"temperature_display_mode"}
+    for config in (thermostat_config, user_interface_config):
+        assert all(
+            attribute.read_on_startup for attribute in config.attributes.values()
+        )
+        assert all(
+            attribute.reporting is None for attribute in config.attributes.values()
+        )
+
+
+async def test_namron_4512783_writes(zigpy_device_from_v2_quirk):
+    """Test attribute types and standard non-manufacturer framing."""
+    device = _get_quirked_device(zigpy_device_from_v2_quirk)
+    cluster = device.endpoints[1].thermostat
+    cluster.endpoint.request = mock.AsyncMock(return_value=[0])
+
+    await cluster.write_attributes(
+        {
+            "window_open_check": t.Bool.true,
+            "anti_frost": t.Bool.false,
+            "work_days": NamronWorkDays.Monday_Friday_Saturday_Sunday,
+            "sensor_mode": NamronSensorMode.Regulator,
+            "panel_brightness": 80,
+            "regulator_cycle": 2,
+            "holiday_temperature": 500,
+            "regulator_percentage": 20,
+            "automatic_time": t.Bool.true,
+            "max_heat_temperature": 350,
+            "screen_on_time": NamronScreenOnTime.Thirty_seconds,
+        }
+    )
+
+    request = cluster.endpoint.request.await_args
+    assert request is not None
+    assert request.kwargs.get("manufacturer") is None
+    header, payload = foundation.ZCLHeader.deserialize(request.kwargs["data"])
+    assert not header.frame_control.is_manufacturer_specific
+    command, remaining = foundation.GENERAL_COMMANDS[
+        header.command_id
+    ].schema.deserialize(payload)
+    assert remaining == b""
+    assert [
+        (attribute.attrid, attribute.value.type, attribute.value.value)
+        for attribute in command.attributes
+    ] == [
+        (0x8000, foundation.DataTypeId.bool_, t.Bool.true),
+        (0x8001, foundation.DataTypeId.bool_, t.Bool.false),
+        (0x8003, foundation.DataTypeId.enum8, 0),
+        (0x8004, foundation.DataTypeId.enum8, 6),
+        (0x8005, foundation.DataTypeId.uint8, 80),
+        (0x8007, foundation.DataTypeId.uint8, 2),
+        (0x8013, foundation.DataTypeId.int16, 500),
+        (0x801D, foundation.DataTypeId.int16, 20),
+        (0x8022, foundation.DataTypeId.bool_, t.Bool.true),
+        (0x8025, foundation.DataTypeId.int16, 350),
+        (0x8029, foundation.DataTypeId.enum8, 2),
+    ]
+
+    user_interface = device.endpoints[1].thermostat_ui
+    cluster.endpoint.request.reset_mock()
+    await user_interface.write_attributes(
+        {"temperature_display_mode": TemperatureDisplayMode.Imperial}
+    )
+    request = cluster.endpoint.request.await_args
+    assert request is not None
+    assert request.kwargs.get("manufacturer") is None
+    header, payload = foundation.ZCLHeader.deserialize(request.kwargs["data"])
+    assert not header.frame_control.is_manufacturer_specific
+    command, remaining = foundation.GENERAL_COMMANDS[
+        header.command_id
+    ].schema.deserialize(payload)
+    assert remaining == b""
+    assert [
+        (attribute.attrid, attribute.value.type, attribute.value.value)
+        for attribute in command.attributes
+    ] == [(0x0000, foundation.DataTypeId.enum8, 1)]

--- a/zhaquirks/namron/__init__.py
+++ b/zhaquirks/namron/__init__.py
@@ -1,0 +1,1 @@
+"""Namron quirks implementations."""

--- a/zhaquirks/namron/namron_4512783.py
+++ b/zhaquirks/namron/namron_4512783.py
@@ -1,0 +1,283 @@
+"""Namron 4512783 floor heating thermostat quirk."""
+
+from typing import Final
+
+import zigpy.types as t
+from zigpy.zcl.clusters.hvac import TemperatureDisplayMode, Thermostat, UserInterface
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+from zhaquirks.builder import (
+    PERCENTAGE,
+    BinarySensorDeviceClass,
+    EntityType,
+    QuirkBuilder,
+    UnitOfTemperature,
+    UnitOfTime,
+)
+from zhaquirks.clusters import CustomCluster
+
+
+class NamronSensorMode(t.enum8):
+    """Namron thermostat sensor and regulator mode."""
+
+    Internal_air_sensor = 0x00
+    Floor_sensor = 0x01
+    Internal_air_with_floor_limit = 0x02
+    External_room_sensor = 0x03
+    External_room_with_floor_limit = 0x04
+    Floor_sensor_with_regulator = 0x05
+    Regulator = 0x06
+
+
+class NamronWorkDays(t.enum8):
+    """Namron thermostat weekly schedule type."""
+
+    Monday_Friday_Saturday_Sunday = 0x00
+    Monday_Saturday_Sunday = 0x01
+    No_time_off = 0x02
+    Time_off = 0x03
+
+
+class NamronScreenOnTime(t.enum8):
+    """Namron thermostat screen-on duration."""
+
+    Always_on = 0x00
+    Ten_seconds = 0x01
+    Thirty_seconds = 0x02
+    Sixty_seconds = 0x03
+
+
+class NamronThermostatCluster(CustomCluster, Thermostat):
+    """Thermostat cluster with Namron private attributes."""
+
+    class AttributeDefs(Thermostat.AttributeDefs):
+        """Namron thermostat attribute definitions."""
+
+        window_open_check: Final = ZCLAttributeDef(
+            id=0x8000,
+            type=t.Bool,
+            access="rwp",
+            manufacturer_code=None,
+        )
+        anti_frost: Final = ZCLAttributeDef(
+            id=0x8001,
+            type=t.Bool,
+            access="rwp",
+            manufacturer_code=None,
+        )
+        window_state: Final = ZCLAttributeDef(
+            id=0x8002,
+            type=t.Bool,
+            access="rwp",
+            manufacturer_code=None,
+        )
+        work_days: Final = ZCLAttributeDef(
+            id=0x8003,
+            type=NamronWorkDays,
+            access="rwp",
+            manufacturer_code=None,
+        )
+        sensor_mode: Final = ZCLAttributeDef(
+            id=0x8004,
+            type=NamronSensorMode,
+            access="rwp",
+            manufacturer_code=None,
+        )
+        panel_brightness: Final = ZCLAttributeDef(
+            id=0x8005,
+            type=t.uint8_t,
+            access="rwp",
+            manufacturer_code=None,
+        )
+        fault: Final = ZCLAttributeDef(
+            id=0x8006,
+            type=t.bitmap8,
+            access="rp",
+            manufacturer_code=None,
+        )
+        regulator_cycle: Final = ZCLAttributeDef(
+            id=0x8007,
+            type=t.uint8_t,
+            access="rwp",
+            manufacturer_code=None,
+        )
+        holiday_temperature: Final = ZCLAttributeDef(
+            id=0x8013,
+            type=t.int16s,
+            access="rwp",
+            manufacturer_code=None,
+        )
+        regulator_percentage: Final = ZCLAttributeDef(
+            id=0x801D,
+            type=t.int16s,
+            access="rwp",
+            manufacturer_code=None,
+        )
+        vacation_mode: Final = ZCLAttributeDef(
+            id=0x801F,
+            type=t.Bool,
+            access="rwp",
+            manufacturer_code=None,
+        )
+        automatic_time: Final = ZCLAttributeDef(
+            id=0x8022,
+            type=t.Bool,
+            access="rwp",
+            manufacturer_code=None,
+        )
+        max_heat_temperature: Final = ZCLAttributeDef(
+            id=0x8025,
+            type=t.int16s,
+            access="rwp",
+            manufacturer_code=None,
+        )
+        screen_on_time: Final = ZCLAttributeDef(
+            id=0x8029,
+            type=NamronScreenOnTime,
+            access="rwp",
+            manufacturer_code=None,
+        )
+
+
+(
+    QuirkBuilder("Namron AS", "4512783")
+    .replaces(NamronThermostatCluster)
+    # The thermostat does not reliably report these attributes, so read them at startup.
+    .switch(
+        attribute_name=NamronThermostatCluster.AttributeDefs.window_open_check.name,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        attribute_initialized_from_cache=False,
+        translation_key="window_open_detection",
+        fallback_name="Window-open detection",
+    )
+    .switch(
+        attribute_name=NamronThermostatCluster.AttributeDefs.anti_frost.name,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        attribute_initialized_from_cache=False,
+        translation_key="anti_frost",
+        fallback_name="Anti-frost",
+    )
+    .binary_sensor(
+        attribute_name=NamronThermostatCluster.AttributeDefs.window_state.name,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        entity_type=EntityType.STANDARD,
+        device_class=BinarySensorDeviceClass.WINDOW,
+        attribute_initialized_from_cache=False,
+        fallback_name="Window state",
+    )
+    .enum(
+        attribute_name=NamronThermostatCluster.AttributeDefs.work_days.name,
+        enum_class=NamronWorkDays,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        attribute_initialized_from_cache=False,
+        translation_key="work_days",
+        fallback_name="Schedule type",
+    )
+    .enum(
+        attribute_name=NamronThermostatCluster.AttributeDefs.sensor_mode.name,
+        enum_class=NamronSensorMode,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        attribute_initialized_from_cache=False,
+        unique_id_suffix="operation_mode",
+        translation_key="sensor_mode",
+        fallback_name="Sensor mode",
+    )
+    .number(
+        attribute_name=NamronThermostatCluster.AttributeDefs.panel_brightness.name,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        min_value=1,
+        max_value=100,
+        step=1,
+        unit=PERCENTAGE,
+        attribute_initialized_from_cache=False,
+        translation_key="panel_brightness",
+        fallback_name="Panel brightness",
+    )
+    .sensor(
+        attribute_name=NamronThermostatCluster.AttributeDefs.fault.name,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        entity_type=EntityType.DIAGNOSTIC,
+        attribute_initialized_from_cache=False,
+        translation_key="fault",
+        fallback_name="Fault flags",
+    )
+    # Zero is the device's default sentinel, not a zero-minute cycle.
+    .number(
+        attribute_name=NamronThermostatCluster.AttributeDefs.regulator_cycle.name,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        min_value=1,
+        max_value=30,
+        step=1,
+        unit=UnitOfTime.MINUTES,
+        attribute_initialized_from_cache=False,
+        translation_key="regulator_cycle",
+        fallback_name="Regulator cycle",
+    )
+    .number(
+        attribute_name=NamronThermostatCluster.AttributeDefs.holiday_temperature.name,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        min_value=5,
+        max_value=35,
+        step=0.5,
+        multiplier=0.01,
+        unit=UnitOfTemperature.CELSIUS,
+        attribute_initialized_from_cache=False,
+        translation_key="holiday_temperature",
+        fallback_name="Holiday temperature",
+    )
+    .number(
+        attribute_name=NamronThermostatCluster.AttributeDefs.regulator_percentage.name,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        min_value=0,
+        max_value=100,
+        step=1,
+        unit=PERCENTAGE,
+        attribute_initialized_from_cache=False,
+        translation_key="regulator_percentage",
+        fallback_name="Regulator percentage",
+    )
+    .binary_sensor(
+        attribute_name=NamronThermostatCluster.AttributeDefs.vacation_mode.name,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        entity_type=EntityType.STANDARD,
+        attribute_initialized_from_cache=False,
+        translation_key="vacation_mode",
+        fallback_name="Vacation mode",
+    )
+    .switch(
+        attribute_name=NamronThermostatCluster.AttributeDefs.automatic_time.name,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        attribute_initialized_from_cache=False,
+        translation_key="automatic_time",
+        fallback_name="Automatic time",
+    )
+    .number(
+        attribute_name=NamronThermostatCluster.AttributeDefs.max_heat_temperature.name,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        min_value=15,
+        max_value=35,
+        step=0.5,
+        multiplier=0.1,
+        unit=UnitOfTemperature.CELSIUS,
+        attribute_initialized_from_cache=False,
+        translation_key="max_heat_temperature",
+        fallback_name="Maximum heat temperature",
+    )
+    .enum(
+        attribute_name=NamronThermostatCluster.AttributeDefs.screen_on_time.name,
+        enum_class=NamronScreenOnTime,
+        cluster_id=NamronThermostatCluster.cluster_id,
+        attribute_initialized_from_cache=False,
+        translation_key="screen_on_time",
+        fallback_name="Screen-on time",
+    )
+    .enum(
+        attribute_name=UserInterface.AttributeDefs.temperature_display_mode.name,
+        enum_class=TemperatureDisplayMode,
+        cluster_id=UserInterface.cluster_id,
+        attribute_initialized_from_cache=False,
+        translation_key="temperature_display_mode",
+        fallback_name="Temperature display mode",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Add a V2 quirk for the Namron 4512783 floor-heating thermostat.

The quirk defines the verified private Thermostat cluster attributes and exposes controls or status entities for:

- Window-open detection and state
- Anti-frost protection
- Weekly schedule type
- Thermostat sensor and regulator modes
- Panel brightness and screen-on time
- Fault flags
- Regulator cycle and output percentage
- Holiday and maximum heat temperatures
- Vacation status
- Automatic time
- Metric or imperial temperature display

The private attributes are read at startup because the device does not reliably report them. Hardware reads and writes confirmed that these attributes use standard ZCL framing, so their definitions explicitly suppress manufacturer-specific framing with `manufacturer_code=None`.

This supersedes #4576, which was closed without merging. Ambiguous or unverified fields from that earlier implementation, including cluster `0xE002`, are deliberately excluded.

## Additional information

- Tested on a physical Namron 4512783 running firmware build `1.13`.
- Hardware testing confirmed raw sensor mode `0x06` selects regulator mode.
- Hardware testing confirmed screen-on-time raw value `0x02` means 30 seconds.
- Temperature scaling is covered for the hundredths-of-a-degree holiday value and tenths-of-a-degree maximum heat value.
- Tests verify entity creation, enum options, startup reads, scaling, wire types, and standard non-manufacturer ZCL framing.
- Full test suite: `4843 passed, 2 xfailed`.
- All pre-commit hooks pass.

## Device diagnostics

[Redacted Home Assistant ZHA device diagnostics](https://gist.github.com/magnusoverli/9fbad794bf9ff62f9876c54645c91b9c)

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
