### PR TITLE
Add protection, network LED and energy entities for Sonoff S60ZBTPF

### DIFF
--- a/zhaquirks/sonoff/s60zbtpf.py
+++ b/zhaquirks/sonoff/s60zbtpf.py
@@ -41,7 +41,6 @@ from zhaquirks.builder import (
 )
 from zhaquirks.clusters import CustomCluster
 
-
 PROTECTION_TRIP_BIT = 0x04
 
 
@@ -191,6 +190,7 @@ class SonoffS60ManufacturerCluster(CustomCluster):
             type=t.uint32_t,
             manufacturer_code=None,
         )
+
 
 # firmware version that fixed the power reporting bug (max_version is exclusive)
 S60_POWER_FIX_FW_VERSION = 0x00002003

--- a/zhaquirks/sonoff/s60zbtpf.py
+++ b/zhaquirks/sonoff/s60zbtpf.py
@@ -11,6 +11,12 @@ metering entity it would create is prevented for all firmware versions, as the d
 never provides a useful value for it.
 
 See https://github.com/zigpy/zigpy-ota/issues/164 for more details.
+
+This variant also exposes SONOFF manufacturer attributes for:
+- Network LED
+- Protection trip status
+- Current, voltage, and power protection settings
+- Daily and monthly energy values
 """
 
 from typing import Any
@@ -20,9 +26,31 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
-from zhaquirks.builder import QuirkBuilder
+from zhaquirks.builder import (
+    BinarySensorDeviceClass,
+    NumberDeviceClass,
+    QuirkBuilder,
+    SensorDeviceClass,
+    SensorStateClass,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+)
 from zhaquirks.clusters import CustomCluster
+
+
+PROTECTION_TRIP_BIT = 0x04
+
+
+def _protection_trip_active(value: Any) -> bool:
+    """Return true when the protection-trip bit is set."""
+    try:
+        return bool(int(value) & PROTECTION_TRIP_BIT)
+    except (TypeError, ValueError):
+        return False
 
 
 class SonoffS60OnOff(CustomCluster, OnOff):
@@ -72,14 +100,233 @@ class SonoffS60ElectricalMeasurement(CustomCluster, ElectricalMeasurement):
         super()._update_attribute(attrid, value)
 
 
+class SonoffS60ManufacturerCluster(CustomCluster):
+    """SONOFF/eWeLink manufacturer cluster used by the S60 sockets."""
+
+    cluster_id = 0xFC11
+    ep_attribute = "ewelink"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Known S60 manufacturer attributes."""
+
+        network_led = ZCLAttributeDef(
+            id=0x0001,
+            type=t.Bool,
+            manufacturer_code=None,
+        )
+
+        protection_status = ZCLAttributeDef(
+            id=0x0010,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+        protection_current = ZCLAttributeDef(
+            id=0x7004,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+        protection_voltage = ZCLAttributeDef(
+            id=0x7005,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+        protection_power = ZCLAttributeDef(
+            id=0x7006,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+        outlet_control_protect_setting = ZCLAttributeDef(
+            id=0x7007,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+
+        energy_today = ZCLAttributeDef(
+            id=0x7009,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+        energy_month = ZCLAttributeDef(
+            id=0x700A,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+        energy_yesterday = ZCLAttributeDef(
+            id=0x700B,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+        ac_current_max_overload_enable = ZCLAttributeDef(
+            id=0x700C,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+        ac_current_max_overload = ZCLAttributeDef(
+            id=0x700D,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+        ac_voltage_max_overload_enable = ZCLAttributeDef(
+            id=0x700E,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+        ac_voltage_max_overload = ZCLAttributeDef(
+            id=0x700F,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
+        ac_power_max_overload_enable = ZCLAttributeDef(
+            id=0x7010,
+            type=t.uint8_t,
+            manufacturer_code=None,
+        )
+        ac_power_max_overload = ZCLAttributeDef(
+            id=0x7011,
+            type=t.uint32_t,
+            manufacturer_code=None,
+        )
+
 # firmware version that fixed the power reporting bug (max_version is exclusive)
 S60_POWER_FIX_FW_VERSION = 0x00002003
 
-# base for both firmware variants below, holding what applies to every firmware version.
-# It is only cloned from, never added to the registry itself.
+
 s60_base_quirk = (
     QuirkBuilder("SONOFF", "S60ZBTPF")
-    .applies_to("SONOFF", "S60ZBTPG")
+    # .applies_to("SONOFF", "S60ZBTPG")  # Not enabled because this variant is untested.
+    .replaces(SonoffS60ManufacturerCluster, endpoint_id=1)
+    .switch(
+        attribute_name=SonoffS60ManufacturerCluster.AttributeDefs.network_led.name,
+        cluster_id=SonoffS60ManufacturerCluster.cluster_id,
+        endpoint_id=1,
+        translation_key="network_led",
+        fallback_name="Network LED",
+    )
+    .binary_sensor(
+        attribute_name=SonoffS60ManufacturerCluster.AttributeDefs.protection_status.name,
+        cluster_id=SonoffS60ManufacturerCluster.cluster_id,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        attribute_converter=_protection_trip_active,
+        unique_id_suffix="protection_status",
+        translation_key="protection_status",
+        fallback_name="Protection status",
+    )
+    .switch(
+        attribute_name=(
+            SonoffS60ManufacturerCluster.AttributeDefs.ac_current_max_overload_enable.name
+        ),
+        cluster_id=SonoffS60ManufacturerCluster.cluster_id,
+        endpoint_id=1,
+        off_value=0,
+        on_value=1,
+        translation_key="ac_current_max_overload_enable",
+        fallback_name="Max current protection",
+    )
+    .number(
+        attribute_name=SonoffS60ManufacturerCluster.AttributeDefs.ac_current_max_overload.name,
+        cluster_id=SonoffS60ManufacturerCluster.cluster_id,
+        endpoint_id=1,
+        min_value=0.1,
+        max_value=17.0,
+        step=0.1,
+        unit=UnitOfElectricCurrent.AMPERE,
+        mode="box",
+        multiplier=0.001,
+        device_class=NumberDeviceClass.CURRENT,
+        translation_key="ac_current_max_overload",
+        fallback_name="Maximum current",
+    )
+    .switch(
+        attribute_name=(
+            SonoffS60ManufacturerCluster.AttributeDefs.ac_voltage_max_overload_enable.name
+        ),
+        cluster_id=SonoffS60ManufacturerCluster.cluster_id,
+        endpoint_id=1,
+        off_value=0,
+        on_value=1,
+        translation_key="ac_voltage_max_overload_enable",
+        fallback_name="Max voltage protection",
+    )
+    .number(
+        attribute_name=SonoffS60ManufacturerCluster.AttributeDefs.ac_voltage_max_overload.name,
+        cluster_id=SonoffS60ManufacturerCluster.cluster_id,
+        endpoint_id=1,
+        min_value=165.0,
+        max_value=277.0,
+        step=1.0,
+        unit=UnitOfElectricPotential.VOLT,
+        mode="box",
+        multiplier=0.001,
+        device_class=NumberDeviceClass.VOLTAGE,
+        translation_key="ac_voltage_max_overload",
+        fallback_name="Maximum voltage",
+    )
+    .switch(
+        attribute_name=(
+            SonoffS60ManufacturerCluster.AttributeDefs.ac_power_max_overload_enable.name
+        ),
+        cluster_id=SonoffS60ManufacturerCluster.cluster_id,
+        endpoint_id=1,
+        off_value=0,
+        on_value=1,
+        translation_key="ac_power_max_overload_enable",
+        fallback_name="Max power protection",
+    )
+    .number(
+        attribute_name=SonoffS60ManufacturerCluster.AttributeDefs.ac_power_max_overload.name,
+        cluster_id=SonoffS60ManufacturerCluster.cluster_id,
+        endpoint_id=1,
+        min_value=0.1,
+        max_value=4000.0,
+        step=0.1,
+        unit=UnitOfPower.WATT,
+        mode="box",
+        multiplier=0.001,
+        device_class=NumberDeviceClass.POWER,
+        translation_key="ac_power_max_overload",
+        fallback_name="Maximum power",
+    )
+    .sensor(
+        attribute_name=SonoffS60ManufacturerCluster.AttributeDefs.energy_yesterday.name,
+        cluster_id=SonoffS60ManufacturerCluster.cluster_id,
+        endpoint_id=1,
+        divisor=1000,
+        suggested_display_precision=3,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="energy_yesterday",
+        fallback_name="Energy yesterday",
+    )
+    .sensor(
+        attribute_name=SonoffS60ManufacturerCluster.AttributeDefs.energy_today.name,
+        cluster_id=SonoffS60ManufacturerCluster.cluster_id,
+        endpoint_id=1,
+        divisor=1000,
+        suggested_display_precision=3,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="energy_today",
+        fallback_name="Energy today",
+    )
+    .sensor(
+        attribute_name=SonoffS60ManufacturerCluster.AttributeDefs.energy_month.name,
+        cluster_id=SonoffS60ManufacturerCluster.cluster_id,
+        endpoint_id=1,
+        divisor=1000,
+        suggested_display_precision=3,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        unit=UnitOfEnergy.KILO_WATT_HOUR,
+        translation_key="energy_month",
+        fallback_name="Energy month",
+    )
     .prevent_default_entity_creation(
         endpoint_id=1,
         cluster_id=Metering.cluster_id,
@@ -91,7 +338,10 @@ s60_base_quirk = (
     # firmware before the fix, and devices not reporting a firmware version at all,
     # get the power reporting workaround
     s60_base_quirk.clone(omit_man_model_data=False)
-    .firmware_version_filter(max_version=S60_POWER_FIX_FW_VERSION, allow_missing=True)
+    .firmware_version_filter(
+        max_version=S60_POWER_FIX_FW_VERSION,
+        allow_missing=True,
+    )
     .replaces(SonoffS60OnOff)
     .replaces(SonoffS60ElectricalMeasurement)
     .add_to_registry()
@@ -100,6 +350,9 @@ s60_base_quirk = (
 (
     # the fixed firmware and newer only need the metering entity prevention
     s60_base_quirk.clone(omit_man_model_data=False)
-    .firmware_version_filter(min_version=S60_POWER_FIX_FW_VERSION, allow_missing=False)
+    .firmware_version_filter(
+        min_version=S60_POWER_FIX_FW_VERSION,
+        allow_missing=False,
+    )
     .add_to_registry()
 )


### PR DESCRIPTION
Add current, voltage and power protection settings. Add protection trip status.
Add a network LED switch.
Add daily and monthly energy values.

## Proposed change
<!--
  Explain your proposed change below.
-->


## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
