### PR TITLE
Add Tuya ZTH08 temperature and humidity sensor (_TZE284_d7lpruvi)

### DIFF
--- a/zhaquirks/tuya/tuya_sensor.py
+++ b/zhaquirks/tuya/tuya_sensor.py
@@ -108,6 +108,7 @@ class NoManufTimeTuyaMCUCluster(TuyaMCUCluster):
     .applies_to("_TZE200_zppcgbdj", "TS0601")
     .applies_to("_TZE204_s139roas", "TS0601")
     .applies_to("_TZE200_s1xgth2u", "TS0601")  # Nedis ZBSC30WT
+    .applies_to("_TZE284_d7lpruvi", "TS0601")
     .tuya_temperature(dp_id=1, scale=10)
     .adds(TuyaTemperatureMeasurement)
     .tuya_humidity(dp_id=2)


### PR DESCRIPTION
## Proposed change

Add support for the Tuya `_TZE284_d7lpruvi` (`TS0601`) temperature/humidity sensor by adding it to the existing `_TZE200_a8sdabtg` quirk group in `zhaquirks/tuya/tuya_sensor.py`. This device uses the same datapoint layout as that group (temperature DP 1 with scale 10, humidity DP 2, battery DP 4), so no new quirk block was needed — just an additional `.applies_to("_TZE284_d7lpruvi", "TS0601")` entry.

## Additional information

Tested on my own device. Temperature and humidity report correctly (confirmed via diagnostics: 26.3°C / 43.0%), though values take a while to populate after pairing. Battery reporting does not currently work (`native_value` is `null` in diagnostics) — this appears to be a device-side quirk rather than something fixable in the quirk code, since it uses the same `tuya_battery(dp_id=4)` call as the existing devices in this group.

## Device diagnostics

[zha-diagnostics-_TZE284_d7lpruvi-TS0601.json](https://github.com/user-attachments/files/31701093/zha-diagnostics-_TZE284_d7lpruvi-TS0601.json)

<!-- Attach the diagnostics JSON file here (drag-and-drop into the PR description on GitHub) -->

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works — not applicable; this is a purely declarative `applies_to()` addition to an existing quirk group with no custom logic, per the project's testing guidelines
- [x] Device diagnostics data has been attached



Related: #4206
