### PR TITLE
Add Legrand NLJ garage door moving state sensor

### DIFF
--- a/tests/test_legrand.py
+++ b/tests/test_legrand.py
@@ -10,8 +10,30 @@ from zigpy.zcl.foundation import ReadAttributeRecord, Status
 
 import zhaquirks
 from zhaquirks.legrand import LEGRAND
+from zhaquirks.legrand.garage_door import LegrandNLJWindowCoveringCluster, MovingState
 
 zhaquirks.setup()
+
+
+async def test_legrand_nlj_moving_state(zigpy_device_from_v2_quirk):
+    """Test NLJ registry matching and its non-conformant moving-state reports."""
+
+    device = zigpy_device_from_v2_quirk(f" {LEGRAND}", " NLJ - Garage door")
+    window_covering = device.endpoints[1].window_covering
+
+    assert isinstance(window_covering, LegrandNLJWindowCoveringCluster)
+
+    moving_state = LegrandNLJWindowCoveringCluster.AttributeDefs.moving_state
+    assert moving_state.id == 0xF007
+    assert moving_state.type is MovingState
+    assert moving_state.is_manufacturer_specific
+    assert (
+        window_covering.find_attribute(0xF007, manufacturer_code=None) is moving_state
+    )
+
+    for value in (1, 2, 0):
+        window_covering.update_attribute(moving_state.id, value)
+        assert window_covering[moving_state.name] == MovingState(value)
 
 
 @pytest.mark.parametrize(

--- a/zhaquirks/legrand/garage_door.py
+++ b/zhaquirks/legrand/garage_door.py
@@ -1,0 +1,69 @@
+"""Quirk for the Legrand/Netatmo NLJ garage-door module.
+
+Exposes the proprietary ``movingState`` attribute as a diagnostic enum sensor.
+The native ZHA cover is left unchanged; users can combine both entities with
+a Home Assistant template cover to expose transient ``opening`` and ``closing``
+states.
+"""
+
+from zha.application import EntityPlatform, EntityType
+import zigpy.types as t
+from zigpy.typing import UNDEFINED, UndefinedType
+from zigpy.zcl.clusters.closures import WindowCovering
+from zigpy.zcl.foundation import ZCLAttributeDef
+
+from zhaquirks.builder import QuirkBuilder
+from zhaquirks.clusters import CustomCluster
+from zhaquirks.legrand import LEGRAND
+
+
+class MovingState(t.enum8):
+    """Legrand manufacturer-specific Window Covering moving state."""
+
+    stopped = 0
+    closing = 1
+    opening = 2
+
+
+class LegrandNLJWindowCoveringCluster(CustomCluster, WindowCovering):
+    """Window Covering cluster with Legrand's moving-state attribute."""
+
+    class AttributeDefs(WindowCovering.AttributeDefs):
+        """Cluster attributes."""
+
+        moving_state = ZCLAttributeDef(
+            id=0xF007,
+            type=MovingState,
+            access="rp",
+            is_manufacturer_specific=True,
+        )
+
+    @classmethod
+    def find_attribute(
+        cls,
+        name_or_id,
+        *,
+        manufacturer_code: int | UndefinedType | None = UNDEFINED,
+    ):
+        """Accept the NLJ's non-compliant global reports for moving state only."""
+        if manufacturer_code is None and name_or_id == cls.AttributeDefs.moving_state.id:
+            return cls.AttributeDefs.moving_state
+        return super().find_attribute(name_or_id, manufacturer_code=manufacturer_code)
+
+
+(
+    QuirkBuilder(f" {LEGRAND}", " NLJ - Garage door")
+    .replaces(LegrandNLJWindowCoveringCluster, endpoint_id=1)
+    .enum(
+        attribute_name=LegrandNLJWindowCoveringCluster.AttributeDefs.moving_state.name,
+        enum_class=MovingState,
+        cluster_id=WindowCovering.cluster_id,
+        endpoint_id=1,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=EntityType.DIAGNOSTIC,
+        attribute_initialized_from_cache=False,
+        translation_key="garage_door_moving_state",
+        fallback_name="Garage door moving state",
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/legrand/garage_door.py
+++ b/zhaquirks/legrand/garage_door.py
@@ -46,7 +46,10 @@ class LegrandNLJWindowCoveringCluster(CustomCluster, WindowCovering):
         manufacturer_code: int | UndefinedType | None = UNDEFINED,
     ):
         """Accept the NLJ's non-compliant global reports for moving state only."""
-        if manufacturer_code is None and name_or_id == cls.AttributeDefs.moving_state.id:
+        if (
+            manufacturer_code is None
+            and name_or_id == cls.AttributeDefs.moving_state.id
+        ):
             return cls.AttributeDefs.moving_state
         return super().find_attribute(name_or_id, manufacturer_code=manufacturer_code)
 


### PR DESCRIPTION
## Proposed change

Add Quirks v2 support for the Legrand / Netatmo NLJ Garage Door Module.

The device exposes a proprietary `movingState` attribute (`0xF007`) on the
standard Window Covering cluster (`0x0102`). This quirk defines it as a
manufacturer-specific enum8 sensor with the device-observed values:

- `stopped` (`0`)
- `closing` (`1`)
- `opening` (`2`)

The device reports `0xF007` as manufacturer-specific when read, but sends the
attribute in global report frames. The custom cluster handles this device
non-conformance for the `0xF007` attribute only.

The native ZHA Cover entity is intentionally left unchanged. Users who need a
combined cover state including transient `opening` and `closing` states can
combine the native cover and this sensor with a Home Assistant template cover.

## Additional information

Device signature:

- Manufacturer: `" Legrand"` (leading space is significant)
- Model: `" NLJ - Garage door"` (leading space is significant)
- Manufacturer code: `0x1021` / `4129`
- Endpoint: `1`
- Profile: `0x0104` (ZHA)
- Device type: `0x0202` (Window Covering Device)

This change does not use `genBinaryInput.presentValue`, which remains false on
the tested device. It does not add Barrier Control (`0x0103`), bind clusters,
configure reporting, write attributes, or create a custom Cover entity.

The device already sends spontaneous reports for `0xF007` while moving.

An optional Home Assistant template cover can be configured separately by users
who want one entity to expose both the native cover state and the transient
moving state. That configuration is installation-specific and is not part of
this PR.

## Device diagnostics

The required Home Assistant device diagnostics file must be attached to this
section as a file upload. Before attaching it, redact the IEEE address and any
other persistent network identifiers if present.

The local Zigbee scan and movement reports used during development are not a
replacement for the required Home Assistant diagnostics attachment.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
```