### PR TITLE
Fix always-on battery_low for Tuya TS0601 smoke detectors (0zaf1cr8 / Nous E8)

### DIFF
--- a/tests/test_tuya_smoke.py
+++ b/tests/test_tuya_smoke.py
@@ -117,3 +117,34 @@ async def test_tuya_smoke_sensor_attribute_update(zigpy_device_from_v2_quirk):
     assert len(ias_listener.attribute_updates) == 2
     assert ias_listener.attribute_updates[1][0] == zone_status_id
     assert ias_listener.attribute_updates[1][1] == IasZone.ZoneStatus.Alarm_1
+
+
+async def test_0zaf1cr8_battery_low(zigpy_device_from_v2_quirk):
+    """Test battery state enum to battery_low conversion for _TZE284_0zaf1cr8."""
+
+    quirked = zigpy_device_from_v2_quirk("_TZE284_0zaf1cr8", "TS0601")
+    ep = quirked.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+
+    # battery state "high" (2) -> battery is not low
+    message = b"\x09\x3a\x02\x00\x12\x0e\x04\x00\x01\x02"
+    hdr, data = ep.tuya_manufacturer.deserialize(message)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    assert ep.tuya_manufacturer.get("battery_low") == 0
+
+    # battery state "middle" (1) -> battery is not low
+    message = b"\x09\x3b\x02\x00\x13\x0e\x04\x00\x01\x01"
+    hdr, data = ep.tuya_manufacturer.deserialize(message)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    assert ep.tuya_manufacturer.get("battery_low") == 0
+
+    # battery state "low" (0) -> battery is low
+    message = b"\x09\x3c\x02\x00\x14\x0e\x04\x00\x01\x00"
+    hdr, data = ep.tuya_manufacturer.deserialize(message)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+    assert ep.tuya_manufacturer.get("battery_low") == 1

--- a/zhaquirks/tuya/tuya_smoke.py
+++ b/zhaquirks/tuya/tuya_smoke.py
@@ -4,7 +4,7 @@ import zigpy.types as t
 from zigpy.zcl.clusters.general import OnOff, Time
 from zigpy.zcl.clusters.lightlink import LightLink
 from zigpy.zcl.clusters.security import IasZone
-from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeAccess, ZCLAttributeDef
 
 from zhaquirks import LocalDataCluster
 from zhaquirks.builder import BinarySensorDeviceClass, EntityType, QuirkBuilder
@@ -13,7 +13,7 @@ from zhaquirks.tuya import (
     TuyaManufClusterAttributes,
     TuyaPowerConfigurationCluster2AAA,
 )
-from zhaquirks.tuya.builder import TuyaIasFire, TuyaQuirkBuilder
+from zhaquirks.tuya.builder import TUYA_CLUSTER_ID, TuyaIasFire, TuyaQuirkBuilder
 
 
 class TuyaSensitivityMode(t.enum8):
@@ -89,9 +89,18 @@ class TuyaSmokeDetectorCluster(TuyaManufClusterAttributes):
     TuyaQuirkBuilder("TZE200_0zaf1cr8", "TS0601")
     .applies_to("_TZE284_0zaf1cr8", "TS0601")
     .tuya_smoke(dp_id=1)
-    .tuya_binary_sensor(
+    # DP 14 is a battery state enum (0: low, 1: middle, 2: high),
+    # not a boolean: only 0 means the battery is actually low
+    .tuya_dp_attribute(
         dp_id=14,
         attribute_name="battery_low",
+        type=t.Bool,
+        access=ZCLAttributeAccess.Read | ZCLAttributeAccess.Report,
+        converter=lambda x: x == 0,
+    )
+    .binary_sensor(
+        attribute_name="battery_low",
+        cluster_id=TUYA_CLUSTER_ID,
         device_class=BinarySensorDeviceClass.BATTERY,
         entity_type=EntityType.DIAGNOSTIC,
         fallback_name="Battery low",


### PR DESCRIPTION
## Problem

The quirk for `TZE200_0zaf1cr8` / `_TZE284_0zaf1cr8` (Nous E8 smoke detector, TS0601) maps **DP 14 as a boolean** via `tuya_binary_sensor`. On this device, DP 14 is actually a **battery state enum**: `0` = low, `1` = middle, `2` = high.

As a result, any healthy battery level (1 or 2) is truthy and the `battery_low` binary sensor is **always on**, even with fresh batteries. Observed on two real `_TZE284_0zaf1cr8` units: cached DP 14 value was `1` (middle) while HA showed a permanent low-battery alert. (The battery percentage sensor from DP 15 stays `unknown` — these units never report DP 15 — so the bogus binary sensor is the only battery signal users see.)

## Fix

Convert DP 14 so that only the enum value `0` reports a low battery:

- matches zigbee2mqtt, which converts DP 14 with `tuya.valueConverter.trueFalse0` for the same fingerprints ([tuya.ts](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts) — Nous E8 whitelabel);
- consistent with the sibling `_TZE204_ntcy3xu1` quirk in the same file, which already treats DP 14 as the low/middle/high battery-state enum.

## Testing

Added `test_0zaf1cr8_battery_low` covering the three enum values (2/1 → not low, 0 → low). `pytest tests/test_tuya_smoke.py`: 12 passed.

Also deployed as a custom quirk on a live network with two affected devices: the false low-battery alerts cleared, smoke detection unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Related: #3749
