### PR TITLE
Fix _TZ3000_ysiog9xi TS0001 smart plug exposed as a light with dead metering sensors

### DIFF
--- a/tests/test_tuya.py
+++ b/tests/test_tuya.py
@@ -12,9 +12,11 @@ import time_machine
 from zigpy.device import Device
 from zigpy.profiles import zha
 import zigpy.types as t
-from zigpy.zcl import foundation
-from zigpy.zcl.clusters.general import PowerConfiguration
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.general import OnOff, PowerConfiguration
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.security import IasZone, ZoneStatus
+from zigpy.zcl.clusters.smartenergy import Metering
 from zigpy.zcl.foundation import ZCLAttributeDef
 
 from tests.common import ClusterListener, wait_for_zigpy_tasks
@@ -32,6 +34,7 @@ from zhaquirks.const import (
 from zhaquirks.legacy import CustomDevice, get_device
 from zhaquirks.tuya import Data, TuyaManufClusterAttributes, TuyaNewManufCluster
 import zhaquirks.tuya.sm0202_motion
+import zhaquirks.tuya.ts0001_switch
 import zhaquirks.tuya.ts0021
 import zhaquirks.tuya.ts0041
 import zhaquirks.tuya.ts0042
@@ -2174,3 +2177,30 @@ async def test_ts1201_learn_state_is_per_instance(zigpy_device_from_quirk):
     assert transmit1.msg_length == 4
     assert transmit2.ir_msg == []
     assert transmit2.msg_length == 0
+
+
+async def test_ts0001_ysiog9xi_plug(zigpy_device_from_v2_quirk):
+    """Test _TZ3000_ysiog9xi is a switch and has no phantom metering sensors."""
+    device = zigpy_device_from_v2_quirk(
+        "_TZ3000_ysiog9xi",
+        "TS0001",
+        cluster_ids={
+            1: {
+                OnOff.cluster_id: ClusterType.Server,
+                Metering.cluster_id: ClusterType.Server,
+                ElectricalMeasurement.cluster_id: ClusterType.Server,
+            }
+        },
+    )
+    ep = device.endpoints[1]
+
+    # the plug reports itself as an On/Off Light, which makes ZHA build a light
+    # entity; the quirk corrects it so a switch entity is built instead
+    assert ep.profile_id == zha.PROFILE_ID
+    assert ep.device_type == zha.DeviceType.ON_OFF_PLUG_IN_UNIT
+
+    # the metering clusters are advertised but never implemented
+    assert Metering.cluster_id not in ep.in_clusters
+    assert ElectricalMeasurement.cluster_id not in ep.in_clusters
+
+    assert OnOff.cluster_id in ep.in_clusters

--- a/zhaquirks/tuya/ts0001_switch.py
+++ b/zhaquirks/tuya/ts0001_switch.py
@@ -1,5 +1,6 @@
 """Tuya switch device."""
 
+from zigpy.profiles import zha
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
 
@@ -48,5 +49,19 @@ class CustomMetering(Metering, CustomCluster):
     .replaces(CustomElectricalMeasurement)
     .replaces(TuyaZBOnOffAttributeCluster)
     .replaces(TuyaZBExternalSwitchTypeCluster)
+    .add_to_registry()
+)
+
+# _TZ3000_ysiog9xi is a plain on/off smart plug. Its firmware misreports itself in
+# two ways: endpoint 1 declares device type 0x0100 (On/Off Light), so ZHA creates a
+# light entity for a plug, and it advertises the Metering and ElectricalMeasurement
+# clusters without implementing them, so ZHA creates voltage/current/power/energy
+# sensors that are permanently 0. Zigbee2MQTT lists this manufacturer as a "Smart
+# plug (without power monitoring)".
+(
+    QuirkBuilder("_TZ3000_ysiog9xi", "TS0001")
+    .removes(Metering.cluster_id)
+    .removes(ElectricalMeasurement.cluster_id)
+    .replaces_endpoint(1, device_type=zha.DeviceType.ON_OFF_PLUG_IN_UNIT)
     .add_to_registry()
 )


### PR DESCRIPTION
## Proposed change

`_TZ3000_ysiog9xi` / `TS0001` is a plain on/off Zigbee smart plug whose firmware misreports itself in two ways. This adds a declarative v2 quirk correcting both.

**1. It claims to be a light.** Endpoint 1 declares device type `0x0100` (On/Off Light) under profile `0x0104`, which is in ZHA's `LIGHT_PROFILE_DEVICE_TYPES`, so ZHA builds a `light` entity for what is a relay in a plug body. Beyond being wrong in the UI, it means the plug answers to "turn off all the lights" through HomeKit/Assist. `.replaces_endpoint(1, device_type=ON_OFF_PLUG_IN_UNIT)` gets a `switch` entity instead.

**2. It advertises metering it does not implement.** The endpoint lists Metering (`0x0702`) and ElectricalMeasurement (`0x0B04`), so ZHA creates voltage, current, active power and summation sensors — all of which sit at `0` forever. On my own device I pulled 30 days of recorder history for these four sensors: a single data point each, `0.0`, never updated. `rmsVoltage` reading `0` while the plug is switched on and driving a load is conclusive rather than merely idle. Both clusters are removed.

Independent corroboration that this manufacturer has no metering hardware:

- Zigbee2MQTT's converter database files `_TZ3000_ysiog9xi` under `TS011F_plug_2`, described as **"Smart plug (without power monitoring)"** ([`src/devices/tuya.ts`](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts)).
- Koenkk/zigbee2mqtt#28302 reports the same manufacturer with an identical cluster list (`[0, 6, 3, 4, 5, 57345, 2820, 1794]`) and states "the power monitor value consistently returns zero at all times".

Note that Z2M has this manufacturer code fingerprinted against `TS011F`, whereas my units report `TS0001`; Tuya appears to ship the code under more than one model ID. This quirk is scoped to `TS0001` only.

## Additional information

**No `.friendly_name()` is set, deliberately.** I buy these at retail as a "Sparkleiot Zigbee Smart Plug", but `_TZ3000_ysiog9xi` is an OEM code — Z2M's sibling entry for it already carries BSEED white-labels — so asserting any single vendor name would mislabel identical hardware for everyone else. The `IM6001-OTP0` designation that turns up in the vendor's manual and Amazon listing is the SmartThings/Iris outlet pairing reference, not this product's model, so it is not usable either. Happy to add a name if a maintainer would prefer one.

**Behaviour change for existing users.** Anyone already running this plug on stock ZHA has a `light.*` entity; after this quirk they get a `switch.*` entity and the old one is orphaned, so automations, scenes and voice exposure referencing it need updating. That is unavoidable for a light→switch correction, but worth calling out in release notes. The four metering sensors also disappear; since they only ever reported `0`, no real history is lost.

**Tests.** Per the contributing guidance, a purely declarative v2 quirk does not strictly require coverage, but since the entire point here is the entity platform the device lands on, I added `test_ts0001_ysiog9xi_plug` asserting the corrected device type and the removal of both metering clusters. Full suite passes (4842 passed, 2 xfailed) and `pre-commit run --all-files` is clean.

## Device diagnostics

Attached below. [zha-_TZ3000_ysiog9xi-TS0001-diagnostics.json](https://github.com/user-attachments/files/31890090/zha-_TZ3000_ysiog9xi-TS0001-diagnostics.json)

**One disclosure:** this dump was captured on an install that already had a `zha: device_config:` platform override in `configuration.yaml` for this device as a local workaround. The raw device data is unaffected — `original_signature` and the live endpoint still show `device_type: ON_OFF_LIGHT (0x0100)`, and `quirk_applied` is `false` — but the `zha_lib_entities` list shows a `Switch` where a stock install would show a `Light`. The four metering sensors are present and visible in that list. Say the word if you'd like a dump taken with the override removed and I'll capture a clean one.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached



Related: #4406
