### PR TITLE
Add Manhot MH03-2Z-OLED quirk and support string Tuya datapoint writes

### DIFF
--- a/tests/test_tuya_mcu.py
+++ b/tests/test_tuya_mcu.py
@@ -451,3 +451,36 @@ async def test_from_cluster_data_multi_dp_cross_endpoint(device_mock):
     assert result[0].datapoints[0].dp == 1
     # combine_power_and_current(7, 42) = 7 * 1000 + 42 = 7042
     assert result[0].datapoints[0].data.payload == 7042
+
+
+async def test_tuya_cluster_data_string_attr_value(zigpy_device_from_v2_quirk):
+    """Test that string datapoints survive TuyaClusterData and reach the MCU.
+
+    TuyaClusterData.attr_value used to be typed `int`, so zigpy's Struct
+    conversion raised ValueError for any non-numeric value and string
+    datapoints could not be written at all.
+    """
+
+    # Manhot MH03-2Z-OLED exposes the two OLED gang labels as string DPs.
+    device = zigpy_device_from_v2_quirk("_TZE284_dnhhp8ew", "TS0601")
+    tuya_cluster = device.endpoints[1].tuya_manufacturer
+
+    cluster_data = TuyaClusterData(
+        endpoint_id=1,
+        cluster_name=tuya_cluster.ep_attribute,
+        cluster_attr="sw1_name",
+        attr_value="Kitchen",
+        expect_reply=False,
+    )
+
+    # The value must not be coerced away from str.
+    assert cluster_data.attr_value == "Kitchen"
+
+    commands = tuya_cluster.from_cluster_data(cluster_data)
+    assert len(commands) == 1
+
+    datapoints = commands[0].datapoints
+    assert len(datapoints) == 1
+    assert datapoints[0].dp == 106
+    assert datapoints[0].data.dp_type == TuyaDPType.STRING
+    assert datapoints[0].data.payload == "Kitchen"

--- a/zhaquirks/tuya/mcu/__init__.py
+++ b/zhaquirks/tuya/mcu/__init__.py
@@ -69,7 +69,11 @@ class TuyaClusterData(t.Struct):
     endpoint_id: int
     cluster_name: str
     cluster_attr: str
-    attr_value: int  # Maybe also others types?
+    # Not restricted to int: Tuya datapoints can also carry strings, bools,
+    # enums and raw bytes. `object` keeps zigpy's Struct conversion a no-op
+    # (isinstance(value, object) is always True) so the value reaches
+    # TuyaData unchanged, which already infers the correct TuyaDPType.
+    attr_value: object
     expect_reply: bool
     manufacturer: int | UndefinedType | None
 

--- a/zhaquirks/tuya/ts0601_manhot.py
+++ b/zhaquirks/tuya/ts0601_manhot.py
@@ -1,0 +1,179 @@
+"""Manhot MH03 series OLED screen switches."""
+
+from zigpy.profiles import zha
+import zigpy.types as t
+from zigpy.zcl import foundation
+
+from zhaquirks.builder import PERCENTAGE, EntityType, UnitOfTime
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+
+
+class MH03PowerOnState(t.enum8):
+    """Relay state restored after a power outage (DP 14)."""
+
+    Off = 0x00
+    On = 0x01
+    Memory = 0x02
+
+
+class MH03LightMode(t.enum8):
+    """Indicator LED mode (DP 15)."""
+
+    Disabled = 0x00
+    Relay = 0x01
+    Position = 0x02
+
+
+class MH03Color(t.enum8):
+    """Indicator LED colour (DP 102 when on, DP 103 when off)."""
+
+    Red = 0x00
+    Orange = 0x01
+    Green = 0x02
+    Cyan = 0x03
+    Blue = 0x04
+    Purple = 0x05
+    Magenta = 0x06
+    Cold_white = 0x07
+    Warm_yellow = 0x08
+
+
+class MH03PressFun(t.enum8):
+    """Long press target (DP 118 all-on, DP 119 all-off)."""
+
+    Disable = 0x00
+    Press_switch_1 = 0x01
+    Press_switch_2 = 0x02
+
+
+(
+    # Manhot MH03-2Z-OLED, "OLED Screen Switch 2 Gang".
+    # Datapoint map ported from zigbee-herdsman-converters,
+    # src/devices/manhot.ts ("MH03-2Z-OLED").
+    # On the tested unit the upper rocker is gang 2 (DP 2) and the lower one
+    # is gang 1 (DP 1), matching the "switch 2" / "switch 1" labels the OLED
+    # shows by default.
+    TuyaQuirkBuilder("_TZE284_dnhhp8ew", "TS0601")
+    .applies_to("_TZE28C1000000_dnhhp8ew", "TS0601")
+    # The device only announces endpoint 1; gang 2 needs a virtual endpoint.
+    .adds_endpoint(2, device_type=zha.DeviceType.ON_OFF_LIGHT_SWITCH)
+    .tuya_onoff(dp_id=1, endpoint_id=1)
+    .tuya_onoff(dp_id=2, endpoint_id=2)
+    .tuya_number(
+        dp_id=7,
+        type=t.uint32_t,
+        attribute_name="countdown_1",
+        min_value=0,
+        max_value=43200,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        translation_key="countdown_1",
+        fallback_name="Countdown 1",
+    )
+    .tuya_number(
+        dp_id=8,
+        type=t.uint32_t,
+        attribute_name="countdown_2",
+        min_value=0,
+        max_value=43200,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        translation_key="countdown_2",
+        fallback_name="Countdown 2",
+    )
+    .tuya_enum(
+        dp_id=14,
+        attribute_name="power_on_state",
+        enum_class=MH03PowerOnState,
+        translation_key="power_on_state",
+        fallback_name="Power on state",
+    )
+    .tuya_enum(
+        dp_id=15,
+        attribute_name="light_mode",
+        enum_class=MH03LightMode,
+        translation_key="light_mode",
+        fallback_name="Indicator light mode",
+    )
+    .tuya_switch(
+        dp_id=16,
+        attribute_name="backlight_switch",
+        entity_type=EntityType.CONFIG,
+        translation_key="backlight_switch",
+        fallback_name="Backlight",
+    )
+    .tuya_number(
+        dp_id=101,
+        type=t.uint32_t,
+        attribute_name="backlight_lightness",
+        min_value=1,
+        max_value=100,
+        step=1,
+        unit=PERCENTAGE,
+        translation_key="backlight_lightness",
+        fallback_name="Backlight brightness",
+    )
+    .tuya_enum(
+        dp_id=102,
+        attribute_name="on_color",
+        enum_class=MH03Color,
+        translation_key="on_color",
+        fallback_name="Light-on color",
+    )
+    .tuya_enum(
+        dp_id=103,
+        attribute_name="off_color",
+        enum_class=MH03Color,
+        translation_key="off_color",
+        fallback_name="Light-off color",
+    )
+    .tuya_number(
+        dp_id=104,
+        type=t.uint32_t,
+        attribute_name="displayoff_delay",
+        min_value=10,
+        max_value=180,
+        step=1,
+        unit=UnitOfTime.SECONDS,
+        translation_key="displayoff_delay",
+        fallback_name="Screen off delay",
+    )
+    .tuya_switch(
+        dp_id=105,
+        attribute_name="child_lock",
+        entity_type=EntityType.CONFIG,
+        translation_key="child_lock",
+        fallback_name="Child lock",
+    )
+    # DP 106/107 carry the per-gang labels rendered on the OLED screen.
+    # There is no text entity platform in quirks v2, so they are exposed as
+    # plain writable attributes (ZCL character string, 0xEF6A / 0xEF6B).
+    .tuya_dp_attribute(
+        dp_id=106,
+        attribute_name="sw1_name",
+        type=t.CharacterString,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_dp_attribute(
+        dp_id=107,
+        attribute_name="sw2_name",
+        type=t.CharacterString,
+        access=foundation.ZCLAttributeAccess.Read | foundation.ZCLAttributeAccess.Write,
+    )
+    .tuya_enum(
+        dp_id=118,
+        attribute_name="press_on_fun",
+        enum_class=MH03PressFun,
+        translation_key="press_on_fun",
+        fallback_name="Long press all-on channel",
+    )
+    .tuya_enum(
+        dp_id=119,
+        attribute_name="press_off_fun",
+        enum_class=MH03PressFun,
+        translation_key="press_off_fun",
+        fallback_name="Long press all-off channel",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change

Two related changes, one commit each.

**1. `fix(tuya)`: allow non-integer datapoint values in `TuyaClusterData`**

`TuyaClusterData.attr_value` was annotated `int`, so zigpy's Struct field
conversion called `int(value)` on anything that was not already an int. Writing a
string datapoint therefore raised, from `TuyaMCUCluster.write_attributes`:

```
ValueError: invalid literal for int() with base 10: 'Kitchen'
```

even though `TuyaData` already infers `TuyaDPType.STRING` for `str` values. The
annotation is widened to `object`, which makes zigpy's conversion a no-op
(`isinstance(value, object)` is always true), so the value reaches `TuyaData`
unchanged and the correct data point type is inferred.

`TuyaClusterData` is only passed over the internal command bus and is never
serialized, so no wire format is affected.

**2. `feat(tuya)`: add Manhot MH03-2Z-OLED quirk**

New quirk for the Tuya TS0601 `_TZE284_dnhhp8ew`, sold as the Manhot
MH03-2Z-OLED ("OLED Screen Switch 2 Gang"). Without a quirk, ZHA creates only the
firmware update entity, since the device speaks exclusively through Tuya
datapoints on cluster `0xEF00`. With the quirk it exposes 15 entities: two
switches, two countdown timers, power-on state, indicator light mode, backlight
switch and brightness, on/off indicator colours, screen-off delay, child lock,
and the two long-press channel selectors.

The datapoint map is ported from zigbee-herdsman-converters
(`src/devices/manhot.ts`, definition `MH03-2Z-OLED`).

The two are submitted together because the quirk is what surfaced the bug: this
device exposes its two OLED gang labels as string datapoints (DP 106/107), which
could not be written at all before the fix. They are exposed as writable
character string attributes rather than entities, since quirks v2 has no text
entity platform.

## Additional information

**The failure was silent.** `write_attributes` calls
`super().write_attributes()` *before* constructing `TuyaClusterData`. The local
attribute cache was therefore updated and a read-back returned the new value,
while the exception meant the device never received the datapoint — a write
appeared to succeed and did nothing.

**Not a breaking change.** Widening a type annotation only accepts values that
previously raised; every value that worked before still converts identically.

**Gang order.** On the tested unit the *upper* rocker is gang 2 (DP 2) and the
lower one is gang 1 (DP 1), matching the `switch 2` / `switch 1` labels the OLED
shows by default.

**Scope.** The rest of the MH03 family (1Z, 3Z, 4Z, 6Z, 8Z) follows the same
datapoint pattern in zigbee-herdsman-converters, but I only have the 2Z, so this
PR adds only the variant I could verify on hardware.

## Device diagnostics

<!-- Drag mh03_diagnostics.json into this section. -->

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
