### PR TITLE
Add Sonoff S60 network indicator control

### DIFF
--- a/tests/test_sonoff_s60zbtpf.py
+++ b/tests/test_sonoff_s60zbtpf.py
@@ -1,14 +1,12 @@
 """Tests for the SONOFF S60ZBTPF device."""
 
 import pytest
-from zha.quirks import QUIRK_REGISTRY_ENTRY_ATTR
 import zigpy.types as t
 from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 
 import zhaquirks
-from zhaquirks.builder import EntityPlatform, EntityType
 from zhaquirks.sonoff.s60zbtpf import (
     S60_POWER_FIX_FW_VERSION,
     SonoffEwelinkCluster,
@@ -112,24 +110,3 @@ def test_sonoff_plug_power_fix(zigpy_device_from_v2_quirk):
     assert electrical_cluster.get(POWER_ID) == 300
     assert electrical_cluster.get(CURRENT_ID) == 13
     assert electrical_cluster.get(VOLTAGE_ID) == 263
-
-
-def test_sonoff_plug_network_indicator_entity(zigpy_device_from_v2_quirk):
-    """Test that the network indicator is exposed as a configuration switch."""
-    device = zigpy_device_from_v2_quirk(
-        "SONOFF",
-        "S60ZBTPF",
-        cluster_ids=S60_CLUSTERS,
-        firmware_version=S60_POWER_FIX_FW_VERSION,
-    )
-
-    entry = getattr(device, QUIRK_REGISTRY_ENTRY_ATTR)
-    network_indicator = next(
-        metadata
-        for metadata in entry.zha_device_factory.quirk_definition.entity_metadata
-        if metadata.attribute_name
-        == SonoffEwelinkCluster.AttributeDefs.network_led.name
-    )
-
-    assert network_indicator.entity_type == EntityType.CONFIG
-    assert network_indicator.entity_platform == EntityPlatform.SWITCH

--- a/tests/test_sonoff_s60zbtpf.py
+++ b/tests/test_sonoff_s60zbtpf.py
@@ -1,14 +1,17 @@
 """Tests for the SONOFF S60ZBTPF device."""
 
 import pytest
+from zha.quirks import QUIRK_REGISTRY_ENTRY_ATTR
 import zigpy.types as t
 from zigpy.zcl import ClusterType, foundation
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 
 import zhaquirks
+from zhaquirks.builder import EntityPlatform, EntityType
 from zhaquirks.sonoff.s60zbtpf import (
     S60_POWER_FIX_FW_VERSION,
+    SonoffEwelinkCluster,
     SonoffS60ElectricalMeasurement,
     SonoffS60OnOff,
 )
@@ -19,6 +22,7 @@ POWER_ID = ElectricalMeasurement.AttributeDefs.active_power.id
 CURRENT_ID = ElectricalMeasurement.AttributeDefs.rms_current.id
 VOLTAGE_ID = ElectricalMeasurement.AttributeDefs.rms_voltage.id
 ON_OFF_ID = OnOff.AttributeDefs.on_off.id
+NETWORK_LED_ID = SonoffEwelinkCluster.AttributeDefs.network_led.id
 
 # the quirk for the fixed firmware does not replace these clusters,
 # so the test device needs to provide them itself
@@ -26,6 +30,7 @@ S60_CLUSTERS = {
     1: {
         OnOff.cluster_id: ClusterType.Server,
         ElectricalMeasurement.cluster_id: ClusterType.Server,
+        SonoffEwelinkCluster.cluster_id: ClusterType.Server,
     }
 }
 
@@ -59,6 +64,9 @@ def test_sonoff_plug_quirk_selection(
         isinstance(electrical_cluster, SonoffS60ElectricalMeasurement)
         is power_fix_applied
     )
+    ewelink_cluster = device.endpoints[1].sonoff_ewelink
+    assert isinstance(ewelink_cluster, SonoffEwelinkCluster)
+    assert ewelink_cluster.find_attribute(NETWORK_LED_ID).id == NETWORK_LED_ID
 
 
 def test_sonoff_plug_power_fix(zigpy_device_from_v2_quirk):
@@ -104,3 +112,24 @@ def test_sonoff_plug_power_fix(zigpy_device_from_v2_quirk):
     assert electrical_cluster.get(POWER_ID) == 300
     assert electrical_cluster.get(CURRENT_ID) == 13
     assert electrical_cluster.get(VOLTAGE_ID) == 263
+
+
+def test_sonoff_plug_network_indicator_entity(zigpy_device_from_v2_quirk):
+    """Test that the network indicator is exposed as a configuration switch."""
+    device = zigpy_device_from_v2_quirk(
+        "SONOFF",
+        "S60ZBTPF",
+        cluster_ids=S60_CLUSTERS,
+        firmware_version=S60_POWER_FIX_FW_VERSION,
+    )
+
+    entry = getattr(device, QUIRK_REGISTRY_ENTRY_ATTR)
+    network_indicator = next(
+        metadata
+        for metadata in entry.zha_device_factory.quirk_definition.entity_metadata
+        if metadata.attribute_name
+        == SonoffEwelinkCluster.AttributeDefs.network_led.name
+    )
+
+    assert network_indicator.entity_type == EntityType.CONFIG
+    assert network_indicator.entity_platform == EntityPlatform.SWITCH

--- a/zhaquirks/sonoff/s60zbtpf.py
+++ b/zhaquirks/sonoff/s60zbtpf.py
@@ -107,7 +107,7 @@ s60_base_quirk = (
         cluster_id=Metering.cluster_id,
         unique_id_suffix="1-1794",  # no actual suffix for this
     )
-    .replaces(SonoffEwelinkCluster)
+    .replaces(SonoffEwelinkCluster, endpoint_id=1)
     .switch(
         attribute_name=SonoffEwelinkCluster.AttributeDefs.network_led.name,
         cluster_id=SonoffEwelinkCluster.cluster_id,

--- a/zhaquirks/sonoff/s60zbtpf.py
+++ b/zhaquirks/sonoff/s60zbtpf.py
@@ -1,4 +1,4 @@
-"""SONOFF S60ZBTPF - Smart Socket with power measurement fix.
+"""SONOFF S60ZBTPF - Smart Socket with power measurement and network LED fixes.
 
 Firmware before v2.0.3 (`0x00002003`) keeps reporting power, current and voltage while
 the socket is turned off. For those versions, the quirk sets `active_power` and
@@ -10,18 +10,22 @@ v2.0.2 also reports `instantaneous_demand` as supported, always with value 0. Th
 metering entity it would create is prevented for all firmware versions, as the device
 never provides a useful value for it.
 
+The eWeLink cluster exposes a writable `networkLed` attribute that controls the
+blue network status indicator.
+
 See https://github.com/zigpy/zigpy-ota/issues/164 for more details.
 """
 
-from typing import Any
+from typing import Any, Final
 
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.smartenergy import Metering
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
 
-from zhaquirks.builder import QuirkBuilder
+from zhaquirks.builder import EntityType, QuirkBuilder
 from zhaquirks.clusters import CustomCluster
 
 
@@ -72,6 +76,24 @@ class SonoffS60ElectricalMeasurement(CustomCluster, ElectricalMeasurement):
         super()._update_attribute(attrid, value)
 
 
+class SonoffEwelinkCluster(CustomCluster):
+    """Sonoff eWeLink manufacturer-specific cluster."""
+
+    cluster_id = 0xFC11
+    name = "Sonoff eWeLink cluster"
+    ep_attribute = "sonoff_ewelink"
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Sonoff eWeLink attributes."""
+
+        network_led: Final = ZCLAttributeDef(
+            id=0x0001,
+            type=t.Bool,
+            access="rw",
+            manufacturer_code=None,
+        )
+
+
 # firmware version that fixed the power reporting bug (max_version is exclusive)
 S60_POWER_FIX_FW_VERSION = 0x00002003
 
@@ -84,6 +106,14 @@ s60_base_quirk = (
         endpoint_id=1,
         cluster_id=Metering.cluster_id,
         unique_id_suffix="1-1794",  # no actual suffix for this
+    )
+    .replaces(SonoffEwelinkCluster)
+    .switch(
+        attribute_name=SonoffEwelinkCluster.AttributeDefs.network_led.name,
+        cluster_id=SonoffEwelinkCluster.cluster_id,
+        entity_type=EntityType.CONFIG,
+        translation_key="network_indicator",
+        fallback_name="Network indicator",
     )
 )
 


### PR DESCRIPTION
## Summary

Add support for the writable Sonoff S60ZBTPF/S60ZBTPG network LED attribute.

The devices expose the eWeLink manufacturer-specific cluster `0xFC11`; attribute `0x0001` (`networkLed`) controls the blue network status indicator. This change defines the cluster and exposes the attribute as a ZHA configuration switch named `Network indicator`, while retaining the existing firmware-specific power-measurement behavior.

## Testing

- `pytest tests/test_sonoff_s60zbtpf.py tests/test_quirks_v2.py tests/test_quirks_v2_metadata.py -q`
- `pre-commit run --files zhaquirks/sonoff/s60zbtpf.py tests/test_sonoff_s60zbtpf.py`

Both passed.

## AI disclosure

This PR was prepared with AI assistance using GitHub Copilot CLI. The implementation and tests were reviewed and validated against the repository's existing conventions.