### PR TITLE
Add quirk for Namron 4512793 Simplify wireless remote

### DIFF
--- a/tests/test_namron.py
+++ b/tests/test_namron.py
@@ -1,0 +1,87 @@
+"""Tests for Namron quirks."""
+
+from unittest import mock
+
+import pytest
+import zigpy.types as t
+
+import zhaquirks
+from zhaquirks.namron.remote_4512793 import NamronPrivateRemoteCluster
+
+zhaquirks.setup()
+
+
+@pytest.mark.parametrize(
+    "payload, event_name, event_args",
+    [
+        (
+            b"\x01\x01",
+            "button_1_remote_button_short_press",
+            {"button": "button_1", "press_type": "remote_button_short_press"},
+        ),
+        (
+            b"\x01\x02",
+            "button_1_remote_button_long_press",
+            {"button": "button_1", "press_type": "remote_button_long_press"},
+        ),
+        (
+            b"\x01\x04",
+            "button_1_remote_button_long_release",
+            {"button": "button_1", "press_type": "remote_button_long_release"},
+        ),
+        (
+            b"\x06\x01",
+            "button_6_remote_button_short_press",
+            {"button": "button_6", "press_type": "remote_button_short_press"},
+        ),
+        (
+            b"\x03\x02",
+            "button_3_remote_button_long_press",
+            {"button": "button_3", "press_type": "remote_button_long_press"},
+        ),
+    ],
+)
+async def test_button_triggers(
+    zigpy_device_from_v2_quirk, payload, event_name, event_args
+):
+    """Test that real captured button/action payloads produce the right zha_event."""
+    device = zigpy_device_from_v2_quirk("Namron AS", "4512793")
+    cluster = device.endpoints[1].namron_private_remote
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    # Real captured frame header: frame_control=0x19, tsn=<any>, command_id=0x00
+    header = b"\x19" + bytes([0x42]) + b"\x00"
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=NamronPrivateRemoteCluster.cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(header + payload),
+        )
+    )
+
+    assert listener.zha_send_event.call_count == 1
+    assert listener.zha_send_event.call_args == mock.call(event_name, event_args)
+
+
+async def test_unknown_button_and_action_discarded(zigpy_device_from_v2_quirk):
+    """Unrecognized button/action values should not raise or emit an event."""
+    device = zigpy_device_from_v2_quirk("Namron AS", "4512793")
+    cluster = device.endpoints[1].namron_private_remote
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    header = b"\x19" + bytes([0x42]) + b"\x00"
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=NamronPrivateRemoteCluster.cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(header + b"\x09\x09"),
+        )
+    )
+
+    assert listener.zha_send_event.call_count == 0

--- a/tests/test_namron.py
+++ b/tests/test_namron.py
@@ -85,3 +85,25 @@ async def test_unknown_button_and_action_discarded(zigpy_device_from_v2_quirk):
     )
 
     assert listener.zha_send_event.call_count == 0
+
+
+async def test_unrelated_command_falls_through(zigpy_device_from_v2_quirk):
+    """A command other than button_action should fall through to the base handler."""
+    device = zigpy_device_from_v2_quirk("Namron AS", "4512793")
+    cluster = device.endpoints[1].namron_private_remote
+    listener = mock.MagicMock()
+    cluster.add_listener(listener)
+
+    # command_id 0x01, not button_action (0x00)
+    header = b"\x19" + bytes([0x42]) + b"\x01"
+    device.packet_received(
+        t.ZigbeePacket(
+            profile_id=260,
+            cluster_id=NamronPrivateRemoteCluster.cluster_id,
+            src_ep=1,
+            dst_ep=1,
+            data=t.SerializableBytes(header),
+        )
+    )
+
+    assert listener.zha_send_event.call_count == 0

--- a/zhaquirks/namron/__init__.py
+++ b/zhaquirks/namron/__init__.py
@@ -1,0 +1,1 @@
+"""Module for Namron devices."""

--- a/zhaquirks/namron/remote_4512793.py
+++ b/zhaquirks/namron/remote_4512793.py
@@ -1,0 +1,108 @@
+"""Namron Simplify wireless remote (4512793)."""
+
+from typing import Any, Final
+
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.foundation import BaseCommandDefs
+
+from zhaquirks.builder import QuirkBuilder
+from zhaquirks.clusters import CustomCluster
+from zhaquirks.const import (
+    BUTTON,
+    BUTTON_1,
+    BUTTON_2,
+    BUTTON_3,
+    BUTTON_4,
+    BUTTON_5,
+    BUTTON_6,
+    CLUSTER_ID,
+    COMMAND,
+    LONG_PRESS,
+    LONG_RELEASE,
+    PRESS_TYPE,
+    SHORT_PRESS,
+    ZHA_SEND_EVENT,
+)
+
+BUTTON_ACTION_PRESS = 0x01
+BUTTON_ACTION_HOLD = 0x02
+BUTTON_ACTION_RELEASE = 0x04
+
+PRESS_TYPES = {
+    BUTTON_ACTION_PRESS: SHORT_PRESS,
+    BUTTON_ACTION_HOLD: LONG_PRESS,
+    BUTTON_ACTION_RELEASE: LONG_RELEASE,
+}
+
+BUTTON_MAPPING = {
+    1: BUTTON_1,
+    2: BUTTON_2,
+    3: BUTTON_3,
+    4: BUTTON_4,
+    5: BUTTON_5,
+    6: BUTTON_6,
+}
+
+
+class NamronPrivateRemoteCluster(CustomCluster):
+    """Namron private cluster (0xE004) reporting Simplify remote button events.
+
+    Command 0x00 payload is (button: 1-6, action: 0x01=press, 0x02=hold,
+    0x04=release). A short tap sends only `press`; holding sends `hold`
+    then `release`, without a preceding `press`.
+    """
+
+    name: str = "Namron Private Remote Cluster"
+    cluster_id: t.uint16_t = 0xE004
+    ep_attribute: str = "namron_private_remote"
+
+    class ClientCommandDefs(BaseCommandDefs):
+        """Client command definitions."""
+
+        button_action: Final = foundation.ZCLCommandDef(
+            id=0x00,
+            schema={"button": t.uint8_t, "action": t.uint8_t},
+        )
+
+    def handle_cluster_request(
+        self,
+        hdr: foundation.ZCLHeader,
+        args: Any,
+        *,
+        dst_addressing: t.AddrMode | None = None,
+    ) -> None:
+        """Translate the raw button/action payload into a named zha_event."""
+        if hdr.command_id != self.ClientCommandDefs.button_action.id:
+            super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+            return
+
+        button = BUTTON_MAPPING.get(args.button)
+        press_type = PRESS_TYPES.get(args.action)
+        if button is None or press_type is None:
+            return
+
+        action = f"{button}_{press_type}"
+        self.listener_event(
+            ZHA_SEND_EVENT, action, {BUTTON: button, PRESS_TYPE: press_type}
+        )
+
+
+(
+    # OnOff/LevelControl output clusters on all endpoints are unused in
+    # normal (hub-connected) operation; they only apply when binding the
+    # remote directly to a light via Namron's own app.
+    QuirkBuilder("Namron AS", "4512793")
+    .replaces(NamronPrivateRemoteCluster, endpoint_id=1)
+    .device_automation_triggers(
+        {
+            (press_type, button): {
+                COMMAND: f"{button}_{press_type}",
+                CLUSTER_ID: NamronPrivateRemoteCluster.cluster_id,
+            }
+            for press_type in (SHORT_PRESS, LONG_PRESS, LONG_RELEASE)
+            for button in (BUTTON_1, BUTTON_2, BUTTON_3, BUTTON_4, BUTTON_5, BUTTON_6)
+        }
+    )
+    .add_to_registry()
+)

--- a/zhaquirks/namron/remote_4512793.py
+++ b/zhaquirks/namron/remote_4512793.py
@@ -25,32 +25,47 @@ from zhaquirks.const import (
     ZHA_SEND_EVENT,
 )
 
-BUTTON_ACTION_PRESS = 0x01
-BUTTON_ACTION_HOLD = 0x02
-BUTTON_ACTION_RELEASE = 0x04
+
+class NamronRemoteButton(t.enum8):
+    """Physical button position on the Namron Simplify remote."""
+
+    TopLeft = 0x01
+    BottomLeft = 0x02
+    TopMiddle = 0x03
+    BottomMiddle = 0x04
+    TopRight = 0x05
+    BottomRight = 0x06
+
+
+class NamronRemoteAction(t.enum8):
+    """Button action reported by the private cluster."""
+
+    Press = 0x01
+    Hold = 0x02
+    Release = 0x04
+
 
 PRESS_TYPES = {
-    BUTTON_ACTION_PRESS: SHORT_PRESS,
-    BUTTON_ACTION_HOLD: LONG_PRESS,
-    BUTTON_ACTION_RELEASE: LONG_RELEASE,
+    NamronRemoteAction.Press: SHORT_PRESS,
+    NamronRemoteAction.Hold: LONG_PRESS,
+    NamronRemoteAction.Release: LONG_RELEASE,
 }
 
 BUTTON_MAPPING = {
-    1: BUTTON_1,
-    2: BUTTON_2,
-    3: BUTTON_3,
-    4: BUTTON_4,
-    5: BUTTON_5,
-    6: BUTTON_6,
+    NamronRemoteButton.TopLeft: BUTTON_1,
+    NamronRemoteButton.BottomLeft: BUTTON_2,
+    NamronRemoteButton.TopMiddle: BUTTON_3,
+    NamronRemoteButton.BottomMiddle: BUTTON_4,
+    NamronRemoteButton.TopRight: BUTTON_5,
+    NamronRemoteButton.BottomRight: BUTTON_6,
 }
 
 
 class NamronPrivateRemoteCluster(CustomCluster):
     """Namron private cluster (0xE004) reporting Simplify remote button events.
 
-    Command 0x00 payload is (button: 1-6, action: 0x01=press, 0x02=hold,
-    0x04=release). A short tap sends only `press`; holding sends `hold`
-    then `release`, without a preceding `press`.
+    A short tap sends only `Press`; holding sends `Hold` then `Release`,
+    without a preceding `Press`.
     """
 
     name: str = "Namron Private Remote Cluster"
@@ -62,7 +77,7 @@ class NamronPrivateRemoteCluster(CustomCluster):
 
         button_action: Final = foundation.ZCLCommandDef(
             id=0x00,
-            schema={"button": t.uint8_t, "action": t.uint8_t},
+            schema={"button": NamronRemoteButton, "action": NamronRemoteAction},
         )
 
     def handle_cluster_request(


### PR DESCRIPTION
## Proposed change

Adds a quirk for the Namron AS 4512793 "Simplify" wireless remote — a 3-channel, battery-powered button remote (6 logical buttons: 3 rocker channels x up/down).

All button events are reported through a manufacturer-specific cluster (`0xE004`) on endpoint 1. The payload format was reverse-engineered from real captured frames (zigpy debug logs), not documentation — Zigbee2MQTT's `namronPrivateE004` converter for the same model was used as a starting hint, but the actual byte layout was confirmed independently:

- Command `0x00` payload is `(button: 1-6, action: 0x01=press, 0x02=hold, 0x04=release)`
- A short tap sends only `press`; holding sends `hold` then `release`, with no preceding `press`
- The button-to-physical-position mapping (1=top-left, 2=bottom-left, 3=top-middle, 4=bottom-middle, 5=top-right, 6=bottom-right) was confirmed against the physical device

The standard `OnOff`/`LevelControl` output clusters present on all three endpoints are not used in normal (hub-connected) operation — they only apply when binding the remote directly to a light via Namron's own app, so the quirk doesn't touch them.

## Additional information

Tested live against a physically-owned device via Home Assistant's `custom_quirks_path` mechanism — confirmed `zha_event` fires correctly for all 6 buttons across press/hold/release.

## Device diagnostics

<details>
<summary>Namron AS 4512793 diagnostics dump</summary>

```json
{
  "version": 3,
  "ieee": "**REDACTED**",
  "nwk": "0x49D2",
  "manufacturer": "Namron AS",
  "model": "4512793",
  "friendly_manufacturer": "Namron AS",
  "friendly_model": "4512793",
  "name": "Namron AS 4512793",
  "quirk_applied": false,
  "quirk_class": "zigpy.device.Device",
  "exposes_features": [],
  "manufacturer_code": 4714,
  "power_source": "Battery or Unknown",
  "lqi": 255,
  "rssi": -52,
  "last_seen": "2026-09-08T20:59:22.391086+00:00",
  "available": true,
  "device_type": "EndDevice",
  "active_coordinator": false,
  "node_descriptor": {
    "logical_type": "EndDevice",
    "complex_descriptor_available": false,
    "user_descriptor_available": false,
    "reserved": 0,
    "aps_flags": 0,
    "frequency_band": 8,
    "mac_capability_flags": 128,
    "manufacturer_code": 4714,
    "maximum_buffer_size": 82,
    "maximum_incoming_transfer_size": 82,
    "server_mask": 11264,
    "maximum_outgoing_transfer_size": 82,
    "descriptor_capability_field": 0
  },
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": {
        "name": "DIMMER_SWITCH",
        "id": 260
      },
      "in_clusters": [
        {
          "cluster_id": "0x0000",
          "endpoint_attribute": "basic",
          "attributes": [
            {
              "id": "0x0004",
              "name": "manufacturer",
              "zcl_type": "string",
              "value": "Namron AS"
            },
            {
              "id": "0x0005",
              "name": "model",
              "zcl_type": "string",
              "value": "4512793"
            }
          ]
        },
        {
          "cluster_id": "0x0001",
          "endpoint_attribute": "power",
          "attributes": [
            {
              "id": "0x0021",
              "name": "battery_percentage_remaining",
              "zcl_type": "uint8",
              "value": 200
            },
            {
              "id": "0x0033",
              "name": "battery_quantity",
              "zcl_type": "uint8",
              "unsupported": true
            },
            {
              "id": "0x0031",
              "name": "battery_size",
              "zcl_type": "enum8",
              "unsupported": true
            },
            {
              "id": "0x0020",
              "name": "battery_voltage",
              "zcl_type": "uint8",
              "value": 32
            }
          ]
        },
        {
          "cluster_id": "0x0003",
          "endpoint_attribute": "identify",
          "attributes": []
        },
        {
          "cluster_id": "0x0020",
          "endpoint_attribute": "poll_control",
          "attributes": [
            {
              "id": "0x0003",
              "name": "fast_poll_timeout",
              "zcl_type": "uint16",
              "value": 120
            }
          ]
        },
        {
          "cluster_id": "0xe004",
          "endpoint_attribute": null,
          "attributes": []
        }
      ],
      "out_clusters": [
        {
          "cluster_id": "0x0003",
          "endpoint_attribute": "identify",
          "attributes": []
        },
        {
          "cluster_id": "0x0004",
          "endpoint_attribute": "groups",
          "attributes": []
        },
        {
          "cluster_id": "0x0005",
          "endpoint_attribute": "scenes",
          "attributes": []
        },
        {
          "cluster_id": "0x0006",
          "endpoint_attribute": "on_off",
          "attributes": []
        },
        {
          "cluster_id": "0x0008",
          "endpoint_attribute": "level",
          "attributes": []
        },
        {
          "cluster_id": "0x0019",
          "endpoint_attribute": "ota",
          "attributes": [
            {
              "id": "0x0002",
              "name": "current_file_version",
              "zcl_type": "uint32",
              "value": 29
            }
          ],
          "last_query_cmd": {
            "manufacturer_code": 4714,
            "image_type": 809,
            "current_file_version": 29,
            "hardware_version": null
          }
        },
        {
          "cluster_id": "0x1000",
          "endpoint_attribute": "lightlink",
          "attributes": []
        }
      ]
    },
    "2": {
      "profile_id": 260,
      "device_type": {
        "name": "DIMMER_SWITCH",
        "id": 260
      },
      "in_clusters": [
        {
          "cluster_id": "0x0000",
          "endpoint_attribute": "basic",
          "attributes": []
        },
        {
          "cluster_id": "0x0003",
          "endpoint_attribute": "identify",
          "attributes": []
        }
      ],
      "out_clusters": [
        {
          "cluster_id": "0x0003",
          "endpoint_attribute": "identify",
          "attributes": []
        },
        {
          "cluster_id": "0x0006",
          "endpoint_attribute": "on_off",
          "attributes": []
        },
        {
          "cluster_id": "0x0008",
          "endpoint_attribute": "level",
          "attributes": []
        }
      ]
    },
    "3": {
      "profile_id": 260,
      "device_type": {
        "name": "DIMMER_SWITCH",
        "id": 260
      },
      "in_clusters": [
        {
          "cluster_id": "0x0000",
          "endpoint_attribute": "basic",
          "attributes": []
        },
        {
          "cluster_id": "0x0003",
          "endpoint_attribute": "identify",
          "attributes": []
        }
      ],
      "out_clusters": [
        {
          "cluster_id": "0x0003",
          "endpoint_attribute": "identify",
          "attributes": []
        },
        {
          "cluster_id": "0x0006",
          "endpoint_attribute": "on_off",
          "attributes": []
        },
        {
          "cluster_id": "0x0008",
          "endpoint_attribute": "level",
          "attributes": []
        }
      ]
    }
  },
  "original_signature": {
    "manufacturer": "Namron AS",
    "model": "4512793",
    "node_desc": {
      "logical_type": 2,
      "complex_descriptor_available": 0,
      "user_descriptor_available": 0,
      "reserved": 0,
      "aps_flags": 0,
      "frequency_band": 8,
      "mac_capability_flags": 128,
      "manufacturer_code": 4714,
      "maximum_buffer_size": 82,
      "maximum_incoming_transfer_size": 82,
      "server_mask": 11264,
      "maximum_outgoing_transfer_size": 82,
      "descriptor_capability_field": 0
    },
    "endpoints": {
      "1": {
        "profile_id": "0x0104",
        "device_type": "0x0104",
        "input_clusters": [
          "0x0000",
          "0x0001",
          "0x0003",
          "0x0020",
          "0xe004"
        ],
        "output_clusters": [
          "0x0003",
          "0x0004",
          "0x0005",
          "0x0006",
          "0x0008",
          "0x0019",
          "0x1000"
        ]
      },
      "2": {
        "profile_id": "0x0104",
        "device_type": "0x0104",
        "input_clusters": [
          "0x0000",
          "0x0003"
        ],
        "output_clusters": [
          "0x0003",
          "0x0006",
          "0x0008"
        ]
      },
      "3": {
        "profile_id": "0x0104",
        "device_type": "0x0104",
        "input_clusters": [
          "0x0000",
          "0x0003"
        ],
        "output_clusters": [
          "0x0003",
          "0x0006",
          "0x0008"
        ]
      }
    }
  },
  "zha_lib_entities": {
    "button": [
      {
        "fallback_name": null,
        "unique_id": "**REDACTED**",
        "migrate_unique_ids": [],
        "platform": "button",
        "class_name": "IdentifyButton",
        "translation_key": null,
        "translation_placeholders": null,
        "device_class": "identify",
        "state_class": null,
        "entity_category": "diagnostic",
        "entity_registry_enabled_default": true,
        "enabled": true,
        "primary": false,
        "extra_state_attribute_names": [],
        "device_ieee": "**REDACTED**",
        "endpoint_id": 1,
        "available": true,
        "group_id": null,
        "command": "identify",
        "args": [
          5
        ],
        "kwargs": {}
      }
    ],
    "sensor": [
      {
        "fallback_name": null,
        "unique_id": "**REDACTED**",
        "migrate_unique_ids": [],
        "platform": "sensor",
        "class_name": "LQISensor",
        "translation_key": "lqi",
        "translation_placeholders": null,
        "device_class": null,
        "state_class": "measurement",
        "entity_category": "diagnostic",
        "entity_registry_enabled_default": false,
        "enabled": false,
        "primary": false,
        "extra_state_attribute_names": [],
        "device_ieee": "**REDACTED**",
        "endpoint_id": 1,
        "available": true,
        "group_id": null,
        "native_value": 255,
        "suggested_display_precision": null,
        "unit": null
      },
      {
        "fallback_name": null,
        "unique_id": "**REDACTED**",
        "migrate_unique_ids": [],
        "platform": "sensor",
        "class_name": "RSSISensor",
        "translation_key": "rssi",
        "translation_placeholders": null,
        "device_class": "signal_strength",
        "state_class": "measurement",
        "entity_category": "diagnostic",
        "entity_registry_enabled_default": false,
        "enabled": false,
        "primary": false,
        "extra_state_attribute_names": [],
        "device_ieee": "**REDACTED**",
        "endpoint_id": 1,
        "available": true,
        "group_id": null,
        "native_value": -52,
        "suggested_display_precision": null,
        "unit": "dBm"
      },
      {
        "fallback_name": null,
        "unique_id": "**REDACTED**",
        "migrate_unique_ids": [],
        "platform": "sensor",
        "class_name": "Battery",
        "translation_key": null,
        "translation_placeholders": null,
        "device_class": "battery",
        "state_class": "measurement",
        "entity_category": "diagnostic",
        "entity_registry_enabled_default": true,
        "enabled": true,
        "primary": false,
        "extra_state_attribute_names": [
          "battery_quantity",
          "battery_size",
          "battery_voltage"
        ],
        "device_ieee": "**REDACTED**",
        "endpoint_id": 1,
        "available": true,
        "group_id": null,
        "native_value": 100.0,
        "suggested_display_precision": 0,
        "unit": "%",
        "battery_size": null,
        "battery_quantity": null,
        "battery_voltage": 3.2
      }
    ],
    "update": [
      {
        "fallback_name": null,
        "unique_id": "**REDACTED**",
        "migrate_unique_ids": [],
        "platform": "update",
        "class_name": "FirmwareUpdateEntity",
        "translation_key": null,
        "translation_placeholders": null,
        "device_class": "firmware",
        "state_class": null,
        "entity_category": "config",
        "entity_registry_enabled_default": true,
        "enabled": true,
        "primary": false,
        "extra_state_attribute_names": [],
        "device_ieee": "**REDACTED**",
        "endpoint_id": 1,
        "available": true,
        "group_id": null,
        "installed_version": "0x0000001d",
        "in_progress": false,
        "update_percentage": null,
        "latest_version": null,
        "release_summary": null,
        "release_notes": null,
        "release_url": null,
        "supported_features": 23
      }
    ]
  },
  "neighbors": [],
  "routes": []
}
```

</details>

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)
