### PR TITLE
Add quirk for HOBEIAN ZG-204ZX 24GHz mmWave presence sensor

### DIFF
--- a/tests/test_tuya_motion.py
+++ b/tests/test_tuya_motion.py
@@ -174,3 +174,73 @@ async def test_tuya_motion_quirk_enum_illum(
     assert len(illum_listener.attribute_updates) == 1
     assert illum_listener.attribute_updates[0][0] == zcl_illum_id
     assert illum_listener.attribute_updates[0][1] == exp_value
+
+
+# HOBEIAN ZG-204ZX 24GHz mmWave presence + T/H/lux sensor.
+# Frames captured from a live device; DP payloads are Tuya type 0x02 (4-byte value)
+# unless noted.
+ZCL_ZG204ZX_STATIC_SENS = b"\tL\x01\x00\x05\x02\x02\x00\x04\x00\x00\x00\x08"  # DP 2 = 8
+ZCL_ZG204ZX_DISTANCE = b"\tL\x01\x00\x05\x04\x02\x00\x04\x00\x00\x01\xf4"  # DP 4 = 500
+ZCL_ZG204ZX_FADING_TIME = (
+    b"\tL\x01\x00\x05\x66\x02\x00\x04\x00\x00\x00\x3c"  # DP 102 = 60
+)
+ZCL_ZG204ZX_ANTI_INTERF = b"\tL\x01\x00\x05\x67\x01\x00\x01\x01"  # DP 103 = True, bool
+ZCL_ZG204ZX_LUX_INTERVAL = (
+    b"\tL\x01\x00\x05\x6b\x02\x00\x04\x00\x00\x00\x0f"  # DP 107 = 15
+)
+ZCL_ZG204ZX_INDICATOR = b"\tL\x01\x00\x05\x6c\x01\x00\x01\x00"  # DP 108 = False, bool
+ZCL_ZG204ZX_MOTION_SENS = (
+    b"\tL\x01\x00\x05\x7b\x02\x00\x04\x00\x00\x00\x05"  # DP 123 = 5
+)
+
+
+@pytest.mark.parametrize(
+    "frame,attr_name,expected",
+    [
+        (ZCL_ZG204ZX_STATIC_SENS, "static_detection_sensitivity", 8),
+        (ZCL_ZG204ZX_DISTANCE, "static_detection_distance", 500),
+        (ZCL_ZG204ZX_FADING_TIME, "presence_timeout", 60),
+        (ZCL_ZG204ZX_ANTI_INTERF, "anti_interference", 1),
+        (ZCL_ZG204ZX_LUX_INTERVAL, "illuminance_interval", 15),
+        (ZCL_ZG204ZX_INDICATOR, "indicator", 0),
+        (ZCL_ZG204ZX_MOTION_SENS, "motion_detection_sensitivity", 5),
+    ],
+)
+async def test_zg204zx_config_datapoints(
+    zigpy_device_from_v2_quirk, frame, attr_name, expected
+):
+    """Test that ZG-204ZX radar tuning datapoints decode to the right attributes."""
+    quirked_device = zigpy_device_from_v2_quirk("_TZE200_w0ap83qu", "ZG-204ZX")
+    ep = quirked_device.endpoints[1]
+
+    assert ep.tuya_manufacturer is not None
+    assert isinstance(ep.tuya_manufacturer, TuyaMCUCluster)
+
+    listener = ClusterListener(ep.tuya_manufacturer)
+
+    hdr, data = ep.tuya_manufacturer.deserialize(frame)
+    status = ep.tuya_manufacturer.handle_get_data(data.data)
+    assert status == foundation.Status.SUCCESS
+
+    attr_id = getattr(ep.tuya_manufacturer.AttributeDefs, attr_name).id
+    updates = [u for u in listener.attribute_updates if u[0] == attr_id]
+    assert len(updates) == 1
+    assert updates[0][1] == expected
+
+
+async def test_zg204zx_does_not_shadow_standard_clusters(zigpy_device_from_v2_quirk):
+    """ZG-204ZX exposes real ZCL clusters, so the quirk must not re-map their DPs.
+
+    Unlike the ZG-204ZM, this device reports presence, temperature, humidity,
+    illuminance and battery over standard clusters. DPs 1, 101, 106, 110 and 111 are
+    therefore deliberately unmapped, and the ZG-204ZM's human_motion_state datapoint
+    does not exist on this model at all.
+    """
+    quirked_device = zigpy_device_from_v2_quirk("_TZE200_w0ap83qu", "ZG-204ZX")
+    ep = quirked_device.endpoints[1]
+
+    assert "human_motion_state" not in ep.tuya_manufacturer.AttributeDefs
+
+    # The quirk adds no local shadow of the device's real measurement clusters.
+    for ep_attribute in ("occupancy", "temperature", "humidity", "illuminance"):
+        assert not hasattr(ep, ep_attribute)

--- a/zhaquirks/tuya/tuya_motion.py
+++ b/zhaquirks/tuya/tuya_motion.py
@@ -1532,6 +1532,99 @@ base_tuya_motion = (
 )
 
 
+# Tuya 24GHz mmWave presence + T/H/lux sensor, ZG-204ZX
+#
+# Unlike the ZG-204ZM above, this device exposes working standard ZCL clusters
+# alongside the Tuya manufacturer cluster: 0x0400 illuminance, 0x0402 temperature,
+# 0x0405 humidity, 0x0406 occupancy, 0x0500 IAS zone and 0x0001 power. Those DPs
+# (1 presence, 101 humidity, 106 illuminance, 110 battery, 111 temperature) are
+# therefore deliberately NOT mapped here - ZHA already creates those entities from
+# the real clusters, and mapping them again would duplicate them.
+#
+# This quirk only adds the radar tuning datapoints, which are otherwise
+# unreachable because nothing decodes 0xEF00 without a quirk.
+#
+# Note the datapoint map differs from the ZG-204ZM: on the ZG-204ZX, DP 101 is
+# humidity (not human motion state), battery is DP 110 (not DP 121), and there is
+# no human-motion-state datapoint. Map confirmed against a live device and against
+# zigbee-herdsman-converters `src/devices/tuya.ts`, definition `ZG-204ZX`.
+(
+    TuyaQuirkBuilder("_TZE200_w0ap83qu", "ZG-204ZX")
+    .tuya_number(
+        dp_id=2,
+        attribute_name="static_detection_sensitivity",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=10,
+        step=1,
+        translation_key="static_detection_sensitivity",
+        fallback_name="Static detection sensitivity",
+    )
+    .tuya_number(
+        dp_id=4,
+        attribute_name="static_detection_distance",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.DISTANCE,
+        unit=UnitOfLength.METERS,
+        min_value=0,
+        max_value=5,
+        step=0.1,
+        multiplier=0.01,
+        translation_key="static_detection_distance",
+        fallback_name="Static detection distance",
+    )
+    .tuya_number(
+        dp_id=102,
+        attribute_name="presence_timeout",
+        type=t.uint16_t,
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        min_value=0,
+        max_value=28800,
+        step=1,
+        translation_key="fading_time",
+        fallback_name="Fading time",
+    )
+    .tuya_switch(
+        dp_id=103,
+        attribute_name="anti_interference",
+        entity_type=EntityType.CONFIG,
+        translation_key="anti_interference",
+        fallback_name="Anti interference",
+    )
+    .tuya_number(
+        dp_id=107,
+        attribute_name="illuminance_interval",
+        type=t.uint16_t,
+        unit=UnitOfTime.MINUTES,
+        min_value=1,
+        max_value=720,
+        step=1,
+        translation_key="illuminance_interval",
+        fallback_name="Illuminance interval",
+    )
+    .tuya_switch(
+        dp_id=108,
+        attribute_name="indicator",
+        entity_type=EntityType.CONFIG,
+        translation_key="led_indicator",
+        fallback_name="LED indicator",
+    )
+    .tuya_number(
+        dp_id=123,
+        attribute_name="motion_detection_sensitivity",
+        type=t.uint16_t,
+        min_value=0,
+        max_value=10,
+        step=1,
+        translation_key="motion_detection_sensitivity",
+        fallback_name="Motion detection sensitivity",
+    )
+    .skip_configuration()
+    .add_to_registry()
+)
+
+
 # Tuya mmWave radar 5.8GHz, ZY_HPS01
 (
     TuyaQuirkBuilder("_TZE204_ex3rcdha", "TS0601")


### PR DESCRIPTION
## Proposed change

Adds a quirk for the **HOBEIAN ZG-204ZX** 24GHz mmWave presence + temperature/humidity/lux sensor (`_TZE200_w0ap83qu` / `ZG-204ZX`).

There is no quirk for this device today, so it loads as a bare `zigpy.device.Device`, the Tuya manufacturer cluster `0xEF00` is never decoded, and none of the radar tuning is reachable from Home Assistant. You get presence and the environmental readings, and no way to adjust how the radar actually behaves.

### Why this only adds configuration datapoints

Unlike the **ZG-204ZM** already in `tuya_motion.py`, the ZG-204ZX exposes working standard ZCL clusters alongside `0xEF00`:

```
in_clusters: 0x0000, 0x0001, 0x0003, 0x0400, 0x0402, 0x0405, 0x0406, 0x0500, 0xef00
```

Presence (`0x0406`), illuminance (`0x0400`), temperature (`0x0402`), humidity (`0x0405`) and battery (`0x0001`) therefore already work with no quirk at all. DPs 1, 101, 106, 110 and 111 are deliberately left unmapped so those entities are not duplicated, and no cluster is replaced, so existing entity ids and history survive for anyone already using this device.

### The datapoint map differs from the ZG-204ZM

This is the part worth a careful look, because the two models are easy to conflate:

| | ZG-204ZM (existing) | ZG-204ZX (this PR) |
|---|---|---|
| DP 101 | human motion state | **humidity** |
| Battery | DP 121 | **DP 110** (already covered by `0x0001`) |
| Human motion state | present | **does not exist** |

Map confirmed against a live device and cross-checked against `zigbee-herdsman-converters`, `src/devices/tuya.ts`, definition `ZG-204ZX`.

### Datapoints exposed

| DP | Entity | Range |
|---|---|---|
| 2 | Static detection sensitivity | 0â€“10 |
| 4 | Static detection distance | 0â€“5 m (raw is cm; step 0.1 m for a usable UI) |
| 102 | Fading time | 0â€“28800 s |
| 103 | Anti interference | switch |
| 107 | Illuminance interval | 1â€“720 min |
| 108 | LED indicator | switch |
| 123 | Motion detection sensitivity | 0â€“10 |

## Additional information

**All translation keys already exist in this repo except `anti_interference`**, which is new. Without a matching entry in HA core's ZHA `strings.json` that entity falls back to its `fallback_name` ("Anti interference"), so this is cosmetic rather than blocking â€” happy to follow up with a core PR if you'd prefer the key landed there first.

**Open question on the `TS0601` variant.** `zigbee-herdsman-converters` also fingerprints this device as `("_TZE200_w0ap83qu", "TS0601")`, i.e. some units enumerate with the generic Tuya model id. I only have the `ZG-204ZX`-enumerating variant, so this PR matches that one alone rather than claiming support I cannot test. If a `TS0601`-flavoured unit lacks the standard clusters, it would need DPs 1/101/106/110/111 mapped as well. Happy to add `.applies_to("_TZE200_w0ap83qu", "TS0601")` plus those mappings if a maintainer or another owner can confirm that variant's behaviour.

**Testing.** Tests cover the decode of all seven configuration datapoints from frames captured off the live device, plus an assertion that the quirk adds no local shadow of the device's real measurement clusters.

- `pytest tests/test_tuya_motion.py` â†’ 55 passed
- `pytest tests/test_quirks.py` â†’ 3845 passed
- `ruff check`, `ruff format --check`, `codespell` â†’ clean

One note in case it comes up: on Windows, `pytest tests/` fails collection with 22 errors (`tests.test_tuya.TuyaTestDevice`) and `tests/test_tuya.py` fails with `ZoneInfoNotFoundError`. Both reproduce on a clean checkout of `dev` with my changes stashed, so they look like local environment issues rather than anything from this PR, and I ran the affected files individually. CI should be unaffected.

## Device diagnostics
[zg204zx-diagnostics.json](https://github.com/user-attachments/files/32100875/zg204zx-diagnostics.json)

<!-- Drag and drop zg204zx-diagnostics.json here -->

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached



Closes #5006
