### PR TITLE
Derive Bosch Room Thermostat II battery percent from voltage

### DIFF
--- a/tests/test_bosch.py
+++ b/tests/test_bosch.py
@@ -2,11 +2,13 @@
 
 from unittest import mock
 
-from zigpy.zcl import foundation
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.general import PowerConfiguration
 from zigpy.zcl.clusters.hvac import ControlSequenceOfOperation, Thermostat
 from zigpy.zcl.foundation import WriteAttributesStatusRecord
 
 import zhaquirks
+from zhaquirks.bosch.rbsh_rth0_zb_eu import BoschRoomThermostatPowerConfiguration
 from zhaquirks.bosch.rbsh_trv0_zb_eu import (
     BoschOperatingMode,
     BoschThermostatCluster as BoschTrvThermostatCluster,
@@ -652,3 +654,38 @@ async def test_bosch_room_thermostat_II_230v_write_attributes(
             ]
             == ControlSequenceOfOperation.Cooling_Only
         )
+
+
+async def test_bosch_room_thermostat_II_battery_percent_from_voltage(
+    zigpy_device_from_v2_quirk,
+):
+    """Test battery percent is derived from voltage on Room Thermostat II."""
+    device = zigpy_device_from_v2_quirk(
+        "Bosch",
+        "RBSH-RTH0-BAT-ZB-EU",
+        cluster_ids={1: {PowerConfiguration.cluster_id: ClusterType.Server}},
+    )
+
+    power = device.endpoints[1].power
+    assert isinstance(power, BoschRoomThermostatPowerConfiguration)
+    assert power.MIN_VOLTS == 4.4
+    assert power.MAX_VOLTS == 6.4
+
+    # 6.2 V as reported by the device: (6.2 - 4.4) / (6.4 - 4.4) * 200 = 180
+    power.update_attribute(PowerConfiguration.AttributeDefs.battery_voltage.id, 62)
+    assert (
+        power.get(PowerConfiguration.AttributeDefs.battery_percentage_remaining.id)
+        == 180
+    )
+
+    # Invalid / unknown voltage values must not overwrite the computed percentage
+    power.update_attribute(PowerConfiguration.AttributeDefs.battery_voltage.id, 0)
+    assert (
+        power.get(PowerConfiguration.AttributeDefs.battery_percentage_remaining.id)
+        == 180
+    )
+    power.update_attribute(PowerConfiguration.AttributeDefs.battery_voltage.id, 255)
+    assert (
+        power.get(PowerConfiguration.AttributeDefs.battery_percentage_remaining.id)
+        == 180
+    )

--- a/zhaquirks/bosch/rbsh_rth0_zb_eu.py
+++ b/zhaquirks/bosch/rbsh_rth0_zb_eu.py
@@ -4,6 +4,7 @@ import zigpy.types as t
 from zigpy.zcl.clusters.hvac import TemperatureDisplayMode, Thermostat, UserInterface
 from zigpy.zcl.foundation import ZCLAttributeDef
 
+from zhaquirks import PowerConfigurationCluster
 from zhaquirks.builder import (
     PERCENTAGE,
     BinarySensorDeviceClass,
@@ -129,6 +130,19 @@ class BoschSensorConnection(t.enum8):
     NotUsed = 0x00
     WithoutRegulation = 0xB0
     WithRegulation = 0xB1
+
+
+class BoschRoomThermostatPowerConfiguration(PowerConfigurationCluster):
+    """Power configuration cluster for Bosch Room Thermostat II.
+
+    The battery model (RBSH-RTH0-BAT-ZB-EU) reports battery voltage but marks
+    battery_percentage_remaining as unsupported, so ZHA's battery entity stays
+    unknown. Convert voltage to percentage using the same range as Zigbee2MQTT
+    (4x AAA, 4.4 V empty to 6.4 V full).
+    """
+
+    MIN_VOLTS = 4.4
+    MAX_VOLTS = 6.4
 
 
 class BoschThermostatCluster(CustomCluster, Thermostat):
@@ -261,6 +275,7 @@ class BoschUserInterfaceCluster(CustomCluster, UserInterface):
     .applies_to("Bosch", "RBSH-RTH0-BAT-ZB-EU")
     .replaces(BoschThermostatCluster)
     .replaces(BoschUserInterfaceCluster)
+    .replaces(BoschRoomThermostatPowerConfiguration)
     # Heating demand, either valve duty cycle or PWM output.
     .sensor(
         BoschThermostatCluster.AttributeDefs.heating_demand.name,


### PR DESCRIPTION
## Summary
- The battery Room Thermostat II (`RBSH-RTH0-BAT-ZB-EU`) reports `battery_voltage` but marks `battery_percentage_remaining` as unsupported, so ZHA's battery entity stays unknown.
- Replace Power Configuration with a cluster that maps voltage to percentage using the same 4.4–6.4 V range Zigbee2MQTT uses for BTH-RM (4x AAA).
- The 230V model shares this quirk but does not report battery voltage, so it is unaffected. The Radiator Thermostat II is unchanged: it already reports remaining percent natively.

## Test plan
- [ ] Pair or reconfigure a `RBSH-RTH0-BAT-ZB-EU` and confirm the battery entity leaves unknown after a voltage report
- [ ] Confirm a voltage around 6.2 V maps to about 90%
- [ ] Confirm the 230V `RBSH-RTH0-ZB-EU` climate/config entities are unchanged
- [x] `pytest tests/test_bosch.py` (includes voltage-to-percent conversion)