### PR TITLE
Add MOES JKD-513COM-Z smoke and CO detector

### DIFF
--- a/tests/test_tuya_smoke_co.py
+++ b/tests/test_tuya_smoke_co.py
@@ -1,0 +1,152 @@
+"""Offline protocol/quirk checks; no radio or real detector required."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from zha.application.platforms.binary_sensor import BinarySensor
+from zha.application.platforms.sensor import EnumSensor
+import zigpy.device
+import zigpy.types as t
+from zigpy.zcl import foundation
+
+from zhaquirks.builder import EntityPlatform
+from zhaquirks.tuya import (
+    TuyaCommand,
+    TuyaData,
+    TuyaDatapointData,
+    TuyaDPType,
+    tuya_smoke_co as q,
+)
+from zhaquirks.tuya.mcu import TuyaClusterData
+
+
+async def test_smoke_co_reports():
+    """Test matching, alarm transitions and Tuya report dispatch without hardware."""
+    app = MagicMock()
+    app.get_sequence.return_value = 1
+    device = zigpy.device.Device(
+        app, t.EUI64.convert("00:11:22:33:44:55:66:77"), 0x1234
+    )
+    device.manufacturer = "_TZE284_aoah6bv8"
+    device.model = "TS0601"
+    ep = device.add_endpoint(1)
+    ep.profile_id = 0x0104
+    ep.device_type = 0x0051
+    for cid in (0, 4, 5, 0xED00, 0xEF00):
+        ep.add_input_cluster(cid)
+    for cid in (10, 25):
+        ep.add_output_cluster(cid)
+    assert q.QUIRK.device_match.matches(device)
+    device.manufacturer = "_TZE284_other"
+    assert not q.QUIRK.device_match.matches(device)
+    device.manufacturer = "_TZE284_aoah6bv8"
+    for transform in q.QUIRK.zigpy_transforms:
+        device = transform(device)
+    cluster = device.endpoints[1].in_clusters[0xEF00]
+    assert 0xED00 in device.endpoints[1].in_clusters
+
+    def state(name):
+        """Read the binary state through ZHA using the cluster cache."""
+        return BinarySensor.is_on.fget(
+            SimpleNamespace(
+                _cluster=cluster,
+                _attribute_name=name,
+                _attribute_converter=q.alarm_state,
+            )
+        )
+
+    for name in ("smoke_state", "co_state", "battery_state"):
+        assert state(name) is None, (name, cluster.get(name))
+
+    def report(dp, value):
+        """Round-trip the wire format before updating the cluster."""
+        raw = TuyaDatapointData(dp=dp, data=TuyaData(value)).serialize()
+        decoded, rest = TuyaDatapointData.deserialize(raw)
+        assert not rest
+        cluster._dp_2_attr_update(decoded)
+
+    for dp, name, enum in (
+        (1, "smoke_state", q.SmokeState),
+        (18, "co_state", q.COState),
+        (14, "battery_state", q.BatteryState),
+    ):
+        for value, expected in ((0, True), (1, False), (0, True)):
+            report(dp, enum(value))
+            assert state(name) is expected
+    for value in (2, 3, 254):
+        report(1, q.SmokeState(value))
+        assert state("smoke_state") is None
+    for value in range(4):
+        report(9, q.CheckingResult(value))
+        assert cluster.get("checking_result") == value
+    for value in (0, 1, 2, 4, 8, 16, 31):
+        report(11, t.bitmap8(value))
+        assert cluster.get("fault_bitmap") == value
+    for value in (True, False):
+        report(16, t.Bool(value))
+        assert bool(cluster.get("muffling")) is value
+    for value in (True, False):
+        commands = cluster.from_cluster_data(
+            TuyaClusterData(
+                endpoint_id=1,
+                cluster_name=cluster.ep_attribute,
+                cluster_attr="muffling",
+                attr_value=t.Bool(value),
+                expect_reply=False,
+                manufacturer=None,
+            )
+        )
+        assert len(commands) == 1
+        dp = commands[0].datapoints[0]
+        assert dp.dp == 16 and dp.data.dp_type == TuyaDPType.BOOL
+        assert bool(dp.data.payload) is value
+    # Exercise real ZCL deserialization and dispatch, including every supported
+    # response/report command, rather than only invoking the DP mapper directly.
+    for command_id in (1, 2, 6):
+        for value, expected in ((0, True), (1, False)):
+            cmd = TuyaCommand(
+                status=0,
+                tsn=1,
+                datapoints=[TuyaDatapointData(dp=18, data=TuyaData(q.COState(value)))],
+            )
+            hdr = foundation.ZCLHeader.cluster(
+                tsn=1,
+                command_id=command_id,
+                direction=foundation.Direction.Server_to_Client,
+            )
+            hdr = hdr.replace(
+                frame_control=hdr.frame_control.replace(disable_default_response=True)
+            )
+            schema = cluster.client_commands[command_id].schema(data=cmd)
+            decoded_hdr, decoded_args = cluster.deserialize(
+                hdr.serialize() + schema.serialize()
+            )
+            cluster.handle_cluster_request(decoded_hdr, decoded_args)
+            assert cluster.get("co_state") == value
+            assert state("co_state") is expected
+    # Muting must not clear an outstanding CO alarm.
+    report(18, q.COState.Alarm)
+    report(16, t.Bool(True))
+    assert state("co_state") is True
+
+
+def test_smoke_co_entities():
+    """Verify all declared entities, unique IDs, enum names and read-only states."""
+    metadata = q.QUIRK.zha_device_factory.quirk_definition.entity_metadata
+    assert len(metadata) == 9
+    identities = [
+        (m.endpoint_id, m.unique_id_suffix or m.attribute_name) for m in metadata
+    ]
+    assert len(set(identities)) == len(identities)
+    assert sum(m.entity_platform == EntityPlatform.BINARY_SENSOR for m in metadata) == 3
+    assert sum(m.entity_platform == EntityPlatform.SENSOR for m in metadata) == 5
+    assert sum(m.entity_platform == EntityPlatform.SWITCH for m in metadata) == 1
+    for m in metadata:
+        if m.entity_platform == EntityPlatform.BINARY_SENSOR:
+            assert m.attribute_converter(0) is True
+            assert m.attribute_converter(1) is False
+            assert m.attribute_converter(255) is None
+    for enum in (q.SmokeState, q.COState):
+        sensor = SimpleNamespace(_enum=enum)
+        assert EnumSensor.formatter(sensor, t.enum8(0)) == "Alarm"
+        assert EnumSensor.formatter(sensor, t.enum8(1)) == "Normal"

--- a/zhaquirks/tuya/tuya_smoke_co.py
+++ b/zhaquirks/tuya/tuya_smoke_co.py
@@ -1,0 +1,126 @@
+"""MOES JKD-513COM-Z combined smoke and carbon monoxide detector."""
+
+import zigpy.types as t
+from zigpy.zcl import foundation
+
+from zhaquirks.builder import BinarySensorDeviceClass, EntityPlatform, EntityType
+from zhaquirks.tuya import TUYA_CLUSTER_ID
+from zhaquirks.tuya.builder import TuyaQuirkBuilder
+from zhaquirks.tuya.mcu import TuyaMCUCluster
+
+
+class SmokeState(t.enum8):
+    """Smoke detection state."""
+
+    Alarm = 0
+    Normal = 1
+    Detecting = 2
+    Unknown = 3
+
+
+class COState(t.enum8):
+    """Carbon monoxide detection state."""
+
+    Alarm = 0
+    Normal = 1
+    Unknown = 255  # Local initial value, not a documented wire value.
+
+
+class CheckingResult(t.enum8):
+    """Self-test result reported by the detector."""
+
+    Checking = 0
+    Check_success = 1
+    Check_failure = 2
+    Others = 3
+
+
+class BatteryState(t.enum8):
+    """Battery level category; the device does not report a percentage."""
+
+    Low = 0
+    High = 1
+    Unknown = 255  # Local initial value.
+
+
+def alarm_state(value: int) -> bool | None:
+    """Only explicit normal clears an alarm; other states remain unknown."""
+    return {0: True, 1: False}.get(int(value))
+
+
+class MoesSmokeCOCluster(TuyaMCUCluster):
+    """Initialize unreported alarm attributes to unknown, not normal."""
+
+    def get(self, key, default=None):
+        """Keep unreported alarm and battery states unknown."""
+        value = super().get(key, default)
+        if value is not None:
+            return value
+        # ZHA's generic binary sensor otherwise treats a missing value as False.
+        # Use a local sentinel without injecting a normal reading into the cache.
+        defaults = {"smoke_state": 3, "co_state": 255, "battery_state": 255}
+        if isinstance(key, int) and key in self.attributes:
+            key = self.attributes[key].name
+        return defaults.get(key, value)
+
+
+builder = TuyaQuirkBuilder("_TZE284_aoah6bv8", "TS0601").friendly_name(
+    model="JKD-513COM-Z", manufacturer="MOES"
+)
+for dp, name, enum, label, category in (
+    (1, "smoke_state", SmokeState, "Smoke state", EntityType.STANDARD),
+    (9, "checking_result", CheckingResult, "Self test result", EntityType.DIAGNOSTIC),
+    (14, "battery_state", BatteryState, "Battery state", EntityType.DIAGNOSTIC),
+    (18, "co_state", COState, "CO state", EntityType.STANDARD),
+):
+    builder.tuya_enum(
+        dp_id=dp,
+        attribute_name=name,
+        enum_class=enum,
+        access=foundation.ZCLAttributeAccess.Read
+        | foundation.ZCLAttributeAccess.Report,
+        entity_platform=EntityPlatform.SENSOR,
+        entity_type=category,
+        translation_key=name,
+        fallback_name=label,
+    )
+
+for name, device_class, label, category in (
+    ("smoke_state", BinarySensorDeviceClass.SMOKE, "Smoke alarm", EntityType.STANDARD),
+    ("co_state", BinarySensorDeviceClass.CO, "CO alarm", EntityType.STANDARD),
+    (
+        "battery_state",
+        BinarySensorDeviceClass.BATTERY,
+        "Battery low",
+        EntityType.DIAGNOSTIC,
+    ),
+):
+    builder.binary_sensor(
+        attribute_name=name,
+        cluster_id=TUYA_CLUSTER_ID,
+        attribute_converter=alarm_state,
+        device_class=device_class,
+        entity_type=category,
+        unique_id_suffix=name + "_alarm",
+        translation_key=name + "_alarm",
+        fallback_name=label,
+    )
+
+# Preserve the entire bitmap: multiple fault flags may be active at once.
+builder.tuya_sensor(
+    dp_id=11,
+    attribute_name="fault_bitmap",
+    type=t.bitmap32,
+    entity_type=EntityType.DIAGNOSTIC,
+    translation_key="fault_bitmap",
+    fallback_name="Fault bitmap",
+)
+builder.tuya_switch(
+    dp_id=16,
+    attribute_name="muffling",
+    translation_key="muffling",
+    fallback_name="Silence alarm",
+)
+QUIRK = builder.skip_configuration().add_to_registry(
+    replacement_cluster=MoesSmokeCOCluster
+)


### PR DESCRIPTION
## Proposed change

Add a Tuya v2 quirk for the MOES JKD-513COM-Z combined smoke and carbon monoxide detector identified as `_TZE284_aoah6bv8` / `TS0601`. Without the quirk the device pairs but exposes only firmware and link diagnostics. The quirk exposes independent smoke and CO alarm entities, read-only status enums, battery category/low-battery indication, the self-test result, a raw fault bitmap, and the silence switch.

The mapping comes from the manufacturer's Tuya product DP definition and testing of a local prototype on Home Assistant 2026.9.1 with zha/zha-quirks 2.2.1. The device uses endpoint 1, profile 0x0104, device type 0x0051; input clusters are 0x0000, 0x0004, 0x0005, 0xED00, 0xEF00 and output clusters are 0x000A, 0x0019.

| DP | Type | Meaning |
| --- | --- | --- |
| 1 | Enum | Smoke: 0 alarm, 1 normal, 2 detecting, 3 unknown |
| 9 | Enum | Self-test: 0 checking, 1 check_success, 2 check_failure, 3 others |
| 11 | Bitmap | Fault flags, preserved without assigning unverified individual bit meanings |
| 14 | Enum | Battery: 0 low, 1 high |
| 16 | Bool, read/write | Muffling / silence |
| 18 | Enum | CO: 0 alarm, 1 normal |

Product model supplied by the manufacturer: **JKD-513COM-Z**. Product listing: https://www.amazon.fr/dp/B0GGQRBRWB?th=1

## Additional information

Observed on hardware: smoke and CO alarm/recovery reports, both state entities returning to Normal, and battery High with the low-battery entity off. The supplied logs show Tuya command 0x01 carrying DP1 and DP18 as ENUM with raw 00 and later raw 01. Self-test DP9=00 was also observed. The prototype exposes the silence switch and its state changes, but a confirmed physical silence-command acceptance test is not available in the supplied evidence. Self-test completion/failure, low-battery transitions and fault flags have not been verified on hardware; their mappings follow the DP definition.

Missing initial alarm/battery values remain unknown. Smoke detecting/unknown values do not become an explicit normal state. No timer, polling or silence command clears an alarm: only a normal report does. Local debug logging has been removed. No CO concentration or battery percentage is exposed because the supplied product schema does not provide those DPs.

The test covers exact manufacturer/model matching, deserialized Tuya reports through all three supported response/report command handlers, independent alarm/recovery conversion, initial unknown values, self-test enum values, fault bitmaps, silence BOOL encoding, entity definitions/unique IDs, and ZHA enum formatting. Hardware testing was performed with the local prototype; the repository-formatted version retains the same mapping and unknown-state handling.

Validation against upstream dev: `uv run pytest -q tests/` completed with 4844 passed and 2 xfailed; `uv run pre-commit run --all-files` passed all checks.

## Device diagnostics

The attached diagnostic snapshot is from the local prototype, not an upstream-released quirk. It removes unrelated custom integrations/setup timings and redacts network identifiers, last-seen timestamps and signal readings. The snapshot predates the later recovery reports, so its cached alarm values are 0. The signature attachment contains the original device signature.

## Checklist

- [x] The changes are tested and work correctly (core alarm/recovery and normal battery verified; hardware limitations described above)
- [x] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached

[device-diagnostics-redacted.json](https://github.com/user-attachments/files/32137833/device-diagnostics-redacted.json)
[device-signature.json](https://github.com/user-attachments/files/32137834/device-signature.json)
[MOES_JKD-513COM-Z_Test_Report.md](https://github.com/user-attachments/files/32448739/MOES_JKD-513COM-Z_Test_Report.md)




Related: #4181
