### PR TITLE
Add Salus SQ610RF thermostat and KL08RF wiring centre quirks

### DIFF
--- a/zhaquirks/salus/kl08rf.py
+++ b/zhaquirks/salus/kl08rf.py
@@ -163,10 +163,7 @@ from typing import Final
 import zigpy.types as t
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import Basic, Ota
-from zigpy.zcl.foundation import (
-    BaseCommandDefs,
-    ZCLCommandDef,
-)
+from zigpy.zcl.foundation import BaseCommandDefs, ZCLCommandDef
 
 from zhaquirks.builder import QuirkBuilder
 from zhaquirks.clusters import CustomCluster

--- a/zhaquirks/salus/kl08rf.py
+++ b/zhaquirks/salus/kl08rf.py
@@ -1,0 +1,529 @@
+"""ZHA quirk for the Salus KL08RF 8-zone wiring centre (Computime, mfr 0x1078).
+
+Built with the zha-device-handlers **v2 QuirkBuilder** pattern, as a companion
+to `salus_sq610rf.py` (the SQ610RFNH thermostat quirk, confirmed working on
+ZHA 2026-07-04).
+
+STATUS: VERIFIED ON HARDWARE 2026-09-10/11. The KL08RF joins ZHA and stays --
+3+ hours, zero NWK Leaves -- which is the failure both z2m reports hit. Its
+interview matched the predicted signature exactly. The one thing that did NOT
+work, and why, is decoded under THE SLOT ASSIGNMENT below; the fix is in this
+file and is the single most important thing to understand about it.
+
+What the native captures establish (facts)
+------------------------------------------
+
+* The KL08RF (native short 0xb15f, IEEE 00:1e:5e:09:09:03:dc:67, Computime
+  OUI) is a mains-powered ZIGBEE ROUTER -- one of only two NWK Link Status
+  originators on the native net (the other is the CO10RF coordinator).
+* Its wiring-centre service lives on **endpoint 8**: thermostats address
+  their fc00 0x12 operational reports and the 0x18/0x14 zone-bind requests to
+  wc:ep8, and the KL08RF answers 0x88/0x84 from ep8.
+* It runs its OWN gateway-facing fc00 session: a 0x10 -> 0x81 handshake
+  followed by command **0x37** (payload `110000`), once per ~90 min -- the
+  same Computime commissioning/keep-alive grammar the SQ610RF uses
+  (reply = 0x80 | low-nibble(request), ZCL FCF 0x1d, mfr 0x1078).
+* The 0x81 reply body is `[slot] 00 [counter x2 LE] [session const x2] 03 0d
+  01 ff ff ff ff 30 00`. Byte 0 is the device's ASSIGNED SLOT, not a session
+  token -- see THE SLOT ASSIGNMENT below. Bytes 2-5 are a counter plus a
+  per-session constant and are NOT validated by devices.
+* Heat demand / relays are HARDWIRED, never on-air: driving a zone to 28 C
+  produced NO Zigbee demand command from the KL08RF (heat-demand capture).
+  The KL08RF switches its zone relays from the demand bit it receives in the
+  thermostats' 0x12 reports; it transmits nothing operational upstream.
+
+=> There is NOTHING operational to read from the KL08RF over Zigbee, so this
+quirk builds NO entities (ZHA still provides LQI/RSSI). Its whole job is:
+keep the device joined by answering the Computime handshake, and LOG every
+proprietary frame it sends for future decoding.
+
+Confirmed by two independent ZHA-family interviews (z2m #3354 + #15208)
+----------------------------------------------------------------------
+This exact device shows up in two zigbee2mqtt reports -- as the Salus KL08RF
+(Koenkk/zigbee-herdsman-converters#3354, 2021) and as its white-label the
+Cosmo CFK8L / "CFKL8" 8-Zonen-Funk-Regelklemmleiste (Koenkk/zigbee2mqtt#15208,
+2022). Both are DIFFERENT physical units than ours; the same reporter linked
+them and called the CFK8L "a whitelabel of the Salus KL08RF". They confirm the
+failure mode this quirk fixes and pin down the join signature.
+
+WHITE-LABELS: the same hardware is sold as at least Salus KL08RF and Cosmo
+CFK8L (CFKL8). All report identically over Zigbee (see below), so this one
+quirk covers every rebrand -- there is no model string to tell them apart
+anyway.
+
+Full join signature (authoritative -- from the #15208 herdsman DB entry, whose
+interview completed further than #3354's):
+* node type ROUTER (mains); manufId 4216 = 0x1078 (Computime);
+  powerSource "Unknown"; zclVersion 0; hwVersion 1 (#3354 saw hwVersion 197 --
+  a firmware/label difference the quirk does not depend on).
+* Basic manufacturerName "Computime" (NOT "SALUS") and NO ModelIdentifier
+  (both reports log the model as 'undefined'). Our own SQ610RF thermostats
+  report "SALUS"; this device's firmware still reports the raw Computime
+  vendor. => we match on manufacturer + an endpoint-8 signature filter, never
+  a model string (see the registration block).
+* A SINGLE endpoint EP8: profile 0x0104, device_id 0x0000, in-clusters
+  [0x0000 Basic, 0x0003 Identify, 0xFC00], out-clusters [0x0003 Identify,
+  0x0019 OTA, 0xFC00]. So fc00 is present as BOTH input and output, OTA is an
+  output cluster, and there is nothing operational (no on/off, no relay
+  state). Matches our native-net finding that the wiring centre lives on EP8.
+  (#3354's aborted interview only managed to read genBasic before the leave,
+  which is why `.adds()` still guarantees fc00 defensively.)
+* Both units sent the SAME raw manufacturer frame during pairing (z2m
+  mislabels cluster 0xFC00 as "manuSpecificPhilips" in #3354 and
+  "manuSpecificUbisysDeviceSetup" in #15208 -- both vendors squat on 0xFC00):
+    #3354  : 15 78 10 28 10 ff 00 ff 22 03 18 20
+    #15208 : 15 78 10 29 10 ff 00 ff 18 04 19 20
+    = ZCL FCF 0x15 (cluster-specific, mfr-specific, client->server,
+      disable-default-response), mfr 0x1078, command 0x10, payload byte0 0xff
+      = FIRST CONTACT. (The trailing payload bytes differ per firmware/config;
+      our handler keys only off byte0 == 0xff, so it answers both.)
+  So the device opens with fc00 command 0x10 exactly like the SQ610RF -- our
+  commission handler replies 0x81 assigning it wiring-centre slot 0x01.
+* In BOTH reports z2m only APS-acked the 0x10 (no application reply) and the
+  device LEFT the network seconds later, re-joining in a loop -- the exact
+  "answer 0x10 with 0x81 or it re-pairs forever" failure this quirk fixes.
+* Hardware teardown in #3354: the KL08RF drives its relays through a PCF8575
+  I2C GPIO expander (local), and the CO10RF gateway is a Silicon Labs CP210x
+  USB-UART bridge -- independent confirmation that the zone relays are
+  switched locally, never commanded over Zigbee.
+
+Why join it to ZHA at all
+-------------------------
+* It is a mains ROUTER: its NWK Link Status presence satisfies the SQ610RF's
+  round-2 commissioning gate all by itself (no third-party router needed).
+* Future goal: with a real KL08RF on the ZHA net, the SQ610RF quirk's 0x86
+  reply could point thermostats at the KL08RF's short address instead of the
+  coordinator -- then the hardwired zone relays would fire from real thermostat
+  demand under ZHA. That is a cross-device change in salus_sq610rf.py and
+  needs live hardware; explicitly OUT OF SCOPE here.
+
+THE SLOT ASSIGNMENT -- the whole point of this file
+---------------------------------------------------
+Decoded 2026-09-11 by running a factory-reset CO10RF from a Mac USB port (it
+adopts with no host attached) while sniffing the radio, then watching it
+rebuild the entire network from zero (capture_salus_rebuild_ch15.pcap).
+
+**fc00 0x81 byte 0 is the SLOT the coordinator assigns the device.** On first
+contact (request byte0 0xff, only ever sent by a factory-reset unit) the
+coordinator ASSIGNS it; the device echoes its own slot in every later 0x10.
+The value range encodes the device class:
+
+    wiring centres   0x01 .. 0x09    the "control box" numbers -- what the
+                                     thermostat's 01..09 picker selects and
+                                     what the KL08RF shows on its zone LEDs
+    thermostats      0x2b ..         six native units took 2b 2c 2d 2e 2f 30
+
+Evidence, all from hardware: the KL08RF took slot 01 on an empty coordinator
+table and lit exactly one zone LED at zone 1; the six thermostats then took
+2b..30 in pairing order; all eleven binds were ACCEPTED (0x88 byte0 = 00).
+Corroborating: 0x37's payload byte0 is `0x10 | slot` (11 at box 1, 12 at box 2),
+and a short press of Pair displays the slot on the zone LEDs.
+
+WHAT WENT WRONG BEFORE, and why it matters to anyone editing this file: we
+answered first contact with 0x2b, copied from the thermostat gold-ref. That
+told the KL08RF "you are wiring centre 43" -- not a valid box. It therefore
+displayed no address, never sent 0x37, and REFUSED every zone bind with
+`0x88 01ff...` (status 01). Two days went into chasing state bytes, session
+advance, control-box indices and ZCL discovery, all of which were downstream of
+that one byte. If you change FC00_0X81_WC_SLOT, keep it in 1..9.
+
+Answered assumptions (were open until 2026-09-10; kept for the record)
+----------------------------------------------------------------------
+1. Identity CONFIRMED at first interview: manufacturer "Computime", NO model
+   string, mfr code 0x1078, sole endpoint EP8 with in [Basic, Identify, fc00]
+   and out [Identify, OTA, fc00] -- exactly the #15208 signature. The
+   manufacturer + endpoint-8 filter match is correct as written.
+2. ANSWERED, AND IT WAS WRONG: the KL08RF runs NEITHER of the thermostat's
+   post-handshake gates. It never reads our Basic ModelIdentifier (no SAL6DC1
+   check) and never sends an OTA Query-Next-Image -- ZHA pushed it an Image
+   Notify and it simply APS-acked and ignored it. SalusKL08Basic and
+   SalusKL08Ota are therefore DEAD CODE for this device. They are kept because
+   they cost nothing at runtime and the white-labels are untested.
+3. The 0x37 keep-alive gets no application reply: holds in practice. Never seen
+   to loop; on ZHA it was never sent at all, because the device was never
+   properly commissioned (see above). Natively it follows 0x81 by 0.15 s.
+4. fc00 on EP8 CONFIRMED (in+out). `.adds()` is kept anyway so an aborted
+   interview still dispatches the incoming 0x10.
+
+Other decoded fields
+--------------------
+* 0x88 byte 0 is a STATUS: 00 = bind accepted (0x84 follows), 01 = refused.
+  It is NOT a control-box echo -- the same box index yields both values.
+* 0x33 (thermostat -> coordinator, empty payload) appears only after a REFUSED
+  bind; it looks like the thermostat reporting failure upstream. Never needed
+  answering once the slot was right.
+* The thermostat screen distinguishes the two failures: a 0x86 whose box index
+  does not echo its request gives "Control box not exist NN" with no 0x18 at
+  all; a refused 0x18 just returns it to the box/zone picker.
+
+"""
+
+from typing import Final
+
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.clusters.general import Basic, Ota
+from zigpy.zcl.foundation import (
+    BaseCommandDefs,
+    ZCLCommandDef,
+)
+
+from zhaquirks.builder import QuirkBuilder
+from zhaquirks.clusters import CustomCluster
+
+SALUS = "SALUS"
+# The KL08RF reports Basic manufacturerName "Computime" and NO model string
+# (z2m issues #3354 and #15208 agree). We match on manufacturer + an endpoint-8
+# signature filter (see the registration block); "SALUS" is matched too in case
+# a firmware variant rebrands the vendor as our SQ610RF thermostats do.
+COMPUTIME_MFR = "Computime"
+COMPUTIME = 0x1078  # manufacturer CODE (node descriptor / mfr-specific frames)
+# The KL08RF's wiring-centre service endpoint, known from native on-air
+# addressing (thermostat 0x12/0x18/0x14 frames target wc:ep8) and confirmed as
+# the device's SOLE endpoint by both z2m reports (epList [8]).
+WC_EP = 8
+
+# Toggle the fc00 cmd-0x10 -> 0x81 commissioning auto-reply.
+ENABLE_FC00_COMMISSION_REPLY = True
+
+# Model string a Computime device expects to read back from its "coordinator"
+# during commissioning -- what a native Salus CO10RF reports (captured
+# verbatim during the SQ610RF work). Unverified whether the KL08RF runs this
+# identity gate (assumption 2); harmless if it never reads it.
+SALUS_COORD_MODEL = "SAL6DC1"
+
+# --- fc00 0x81 reply: THE WIRING-CENTRE SLOT ASSIGNMENT ---
+#
+# Body layout (DECODED 2026-09-11, see the module docstring):
+#     [slot] 00 [counter x2 LE] [session const x2] 03 0d 01 ff ff ff ff 30 00
+#
+# **Byte 0 is the node's SLOT -- the address the coordinator assigns it.** It is
+# NOT a "session token", which is what this file (and salus_sq610rf.py) called it
+# for months. On FIRST CONTACT (request byte0 0xff) the coordinator ASSIGNS the
+# slot here; the device then echoes its own slot as byte0 of every later 0x10.
+# The value range encodes the DEVICE CLASS:
+#
+#     wiring centres  0x01 .. 0x09   <- the "control box" numbers. This is what
+#                                       the thermostat's on-screen 01..09 picker
+#                                       selects, and what the KL08RF displays on
+#                                       its zone LEDs (short-press Pair).
+#     thermostats     0x2b ..        <- the six native units took 2b 2c 2d 2e 2f
+#                                       30 in pairing order.
+#
+# Proven by watching a factory-reset CO10RF rebuild the whole network from zero
+# (capture_salus_rebuild_ch15.pcap): the KL08RF took slot 01 on an empty table
+# and lit exactly one zone LED, at zone 1; the six thermostats then took 2b..30
+# in order; and all eleven subsequent binds were ACCEPTED (0x88 byte0 = 00),
+# where every bind on ZHA the day before had been REFUSED (0x88 byte0 = 01).
+#
+# THE BUG THIS FIXES: we used to answer first contact with 0x2b -- copied from
+# the thermostat gold-ref -- which told the KL08RF "you are wiring centre 43".
+# Not a valid box, so it displayed no address, never went operational, and
+# correctly refused every bind. Everything else we chased (state bytes, session
+# advance, control-box indices, ZCL discovery) was downstream of that one byte.
+FC00_0X81_WC_SLOT = 0x01  # 1..9; the control box number this unit will answer to
+
+# Bytes 2-3 are a little-endian counter and 4-5 a per-session constant; neither
+# is validated by the device. Observed running 8b39 -> 8c86 monotonically across
+# one session while 3632 held constant. We send a fixed, captured pair.
+FC00_0X81_TAIL = bytes.fromhex("4dd931030d01ffffffff3000")
+
+
+def commission_reply_body(req: bytes) -> bytes:
+    """Build the fc00 0x81 reply body for a KL08RF 0x10 request.
+
+    On FIRST CONTACT (request byte0 0xff -- only ever seen from a
+    factory-reset unit) we ASSIGN the wiring-centre slot. Afterwards the device
+    echoes its own slot back to us in byte0 and we simply confirm it, which is
+    what the native CO10RF does: its one captured reply to an established
+    KL08RF was `01 00 fe 4dd931...` -- byte0 01 because that unit was box 1.
+    """
+    first = not req or req[0] == 0xFF
+    slot = FC00_0X81_WC_SLOT if first else req[0]
+    return bytes([slot, 0x00, 0xFE]) + FC00_0X81_TAIL
+
+
+def payload_bytes(args) -> bytes:
+    """Raw body of an incoming fc00 command, whichever shape zigpy hands us.
+
+    zigpy picks its command table from the ZCL DIRECTION bit: Server_to_Client
+    (FCF 0x1d) resolves against client_commands, Client_to_Server (FCF 0x15)
+    against server_commands. An id missing from the table it picks comes back
+    as RAW BYTES with no `.data` attribute -- silently, with no error logged.
+
+    THE BUG (2026-09-10): Salus points its two device classes in OPPOSITE
+    directions -- the SQ610RF thermostat sends 0x1d, the KL08RF sends 0x15 --
+    and this file originally declared its commands under ClientCommandDefs
+    only. So every KL08RF payload arrived EMPTY, the handler silently took its
+    "no payload" branch, and each 0x81 answered an established session as if it
+    were first contact. Nothing in the log said so. Fixed by declaring the ids
+    on BOTH tables and extracting through here.
+    """
+    if args is None:
+        return b""
+    data = getattr(args, "data", None)
+    if data is not None:
+        return bytes(data)
+    if isinstance(args, (bytes, bytearray)):
+        return bytes(args)
+    return b""
+
+
+class _RawPayload(t.Struct):
+    """A ZCL command body that is just raw bytes (Salus uses no ZCL typing)."""
+
+    data: t.Bytes
+
+
+class SalusKL08FC00Cluster(CustomCluster):
+    """Salus/Computime proprietary cluster 0xFC00 -- KL08RF gateway session.
+
+    On its native net the KL08RF periodically (~90 min) runs toward the
+    gateway:
+        kl08 0x10  ->  ctrl 0x81   (session handshake -- we must answer)
+        kl08 0x37  ->  (APS-ack only observed; no app reply)
+    The other declared commands (0x11 time-notify, 0x25 update-check, 0xa9
+    distress) are known from the SQ610RF side of the same Computime family
+    and are declared so zigpy deserializes and LOGS them instead of dropping
+    them -- never yet observed from the KL08RF itself.
+    """
+
+    cluster_id = 0xFC00
+    ep_attribute = "salus_fc00"
+    name = "Salus Manufacturer FC00"
+    manufacturer_id_override = COMPUTIME
+
+    class ClientCommandDefs(BaseCommandDefs):
+        """Manufacturer commands the KL08RF may send (schema: raw bytes)."""
+
+        commission_request: Final = ZCLCommandDef(
+            id=0x10, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        # Family command: the SQ610RF broadcasts this on clock changes.
+        time_notify: Final = ZCLCommandDef(
+            id=0x11, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        # Family command: proprietary firmware update-check (no standard OTA).
+        update_check_request: Final = ZCLCommandDef(
+            id=0x25, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        # KL08RF keep-alive, payload `110000` observed once per ~90 min.
+        keep_alive: Final = ZCLCommandDef(
+            id=0x37, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        # Family command: distress heartbeat while NOT commissioned.
+        distress: Final = ZCLCommandDef(
+            id=0xA9, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        # Declared for documentation; the quirk builds this reply manually.
+        commission_response: Final = ZCLCommandDef(
+            id=0x81, schema=_RawPayload, is_manufacturer_specific=True
+        )
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """The SAME commands again, declared Client_to_Server.
+
+        The KL08RF sends its requests with the ZCL direction bit CLEAR (on-air
+        FCF 0x15 = Client_to_Server), unlike the SQ610RF thermostat which uses
+        0x1d. zigpy chooses the command table from that bit, so ids present only
+        under ClientCommandDefs are "unknown" for this device and its payloads
+        arrive unparsed -- see payload_bytes() for the full story and the bug it
+        caused. Declaring both sides makes zigpy parse the frames properly and
+        log them by name instead of as "Unknown Command".
+        """
+
+        commission_request: Final = ZCLCommandDef(
+            id=0x10, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        time_notify: Final = ZCLCommandDef(
+            id=0x11, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        update_check_request: Final = ZCLCommandDef(
+            id=0x25, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        keep_alive: Final = ZCLCommandDef(
+            id=0x37, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        distress: Final = ZCLCommandDef(
+            id=0xA9, schema=_RawPayload, is_manufacturer_specific=True
+        )
+
+    def handle_cluster_request(
+        self, hdr: foundation.ZCLHeader, args, *, dst_addressing=None
+    ):
+        req = payload_bytes(args)
+
+        if hdr.command_id == 0x10 and ENABLE_FC00_COMMISSION_REPLY:
+            # Session handshake -> answer 0x81 (token echoed, state advanced).
+            body = commission_reply_body(req)
+            # WARNING level on purpose: HA's UI log view filters DEBUG out, and
+            # this one line is the whole diagnostic during the session-state
+            # investigation. Drop back to self.debug() once that is settled.
+            # Kept at debug: the slot we assign (body byte 0) is the single
+            # most useful thing in this log when a bind is refused.
+            self.debug(
+                "KL08RF fc00 0x10 payload=%s (len %d) -> 0x81 body=%s",
+                req.hex() or "<EMPTY - payload not parsed!>",
+                len(req),
+                body.hex(),
+            )
+            self.create_catching_task(self._send_fc00_reply(hdr.tsn, 0x81, body))
+            return
+
+        if hdr.command_id == 0x37:
+            # Keep-alive. Native capture is consistent with APS-ack only, so
+            # we accept it silently (assumption 3 in the module docstring).
+            # If the device re-sends this in a tight loop at test time, it
+            # wants an app reply -- try 0xb7 per the reply grammar.
+            self.debug(
+                "KL08RF fc00 keep-alive 0x37, payload %s (accepted, no reply)",
+                req.hex(),
+            )
+            return
+
+        if hdr.command_id == 0xA9:
+            # On the SQ610RF this heartbeat means "commissioning NOT complete".
+            self.warning(
+                "KL08RF fc00 0xa9 distress heartbeat, payload %s -- the device "
+                "does not consider itself commissioned; check the 0x10/0x81 "
+                "handshake in the debug log",
+                req.hex(),
+            )
+            return
+
+        # Anything else (0x11/0x25/other): accept silently and log the raw
+        # payload -- future reverse-engineering material. The device sets
+        # disable-default-response, so no ZCL reply is expected.
+        self.debug(
+            "KL08RF fc00 command 0x%02x, payload %s (accepted, no reply)",
+            hdr.command_id,
+            req.hex(),
+        )
+
+    async def _send_fc00_reply(self, tsn, command_id, body):
+        """Emit a Salus fc00 reply with the exact on-air framing the CO10RF uses.
+
+        Mirrors salus_sq610rf.py: Salus tags replies Server->Client with
+        disable-default-response (on-air ZCL FCF 0x1d), which zigpy's
+        high-level reply() cannot produce from a server cluster -- so the
+        frame is built directly.
+        """
+        rhdr = foundation.ZCLHeader.cluster(
+            tsn=tsn, command_id=command_id, manufacturer=COMPUTIME
+        )
+        rhdr = rhdr.replace(
+            frame_control=rhdr.frame_control.replace(
+                direction=foundation.Direction.Server_to_Client,
+                disable_default_response=True,
+            )
+        )
+        data = rhdr.serialize() + body
+        await self.endpoint.reply(
+            cluster=self.cluster_id,
+            sequence=tsn,
+            data=data,
+            command_id=command_id,
+        )
+
+
+class SalusKL08Ota(CustomCluster, Ota):
+    """OTA cluster that mimics the CO10RF's non-OTA reply (mirrors salus_sq610rf.py).
+
+    IF the KL08RF probes OTA during its join (unverified -- assumption 2), a
+    native Salus controller answers the `Query Next Image Request` with a
+    plain ZCL Default Response, status Invalid Field (0x85) -- NOT an OTA
+    image response. The SQ610RF stalls on stock ZHA's real OTA-server answer,
+    so the same fix is preloaded here. Harmless if the KL08RF never asks.
+    """
+
+    def handle_cluster_request(self, hdr, args, *, dst_addressing=None):
+        if (
+            ENABLE_FC00_COMMISSION_REPLY
+            and hdr.direction == foundation.Direction.Client_to_Server
+            and hdr.command_id == self.ServerCommandDefs.query_next_image.id
+        ):
+            self.create_catching_task(self._send_ota_default_rsp(hdr.tsn))
+            return
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+    async def _send_ota_default_rsp(self, tsn):
+        rhdr = foundation.ZCLHeader.general(
+            tsn=tsn,
+            command_id=foundation.GeneralCommand.Default_Response,
+            direction=foundation.Direction.Server_to_Client,
+        )
+        # Match the CO10RF exactly: it leaves disable-default-response clear.
+        rhdr = rhdr.replace(
+            frame_control=rhdr.frame_control.replace(disable_default_response=False)
+        )
+        body = foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(
+            command_id=self.ServerCommandDefs.query_next_image.id,
+            status=foundation.Status.INVALID_FIELD,
+        )
+        data = rhdr.serialize() + body.serialize()
+        await self.endpoint.reply(
+            cluster=self.cluster_id,
+            sequence=tsn,
+            data=data,
+            command_id=foundation.GeneralCommand.Default_Response,
+        )
+
+
+class SalusKL08Basic(CustomCluster, Basic):
+    """Basic cluster that answers the coordinator-identity check (mirrors
+    salus_sq610rf.py).
+
+    IF the KL08RF, like the SQ610RF, reads Basic ModelIdentifier from what it
+    believes is the coordinator and gates on a Salus controller model string
+    (unverified -- assumption 2), this answers "SAL6DC1". zigpy dispatches
+    that incoming read on THIS device's own endpoint (by the sender's
+    endpoint, see the long note in salus_sq610rf.py's SalusBasic), so the
+    override lives here on the KL08RF quirk. Harmless if it never reads.
+    """
+
+    def handle_read_attribute_model(self) -> t.CharacterString:
+        # Must be a zigpy string type (zigpy 2.x serializes via .serialize()).
+        return t.CharacterString(SALUS_COORD_MODEL)
+
+
+def _is_kl08rf(device) -> bool:
+    """Signature guard for the manufacturer-only match.
+
+    The KL08RF reports NO model string (issue #3354), so we cannot key on one
+    and instead match manufacturer "Computime"/"SALUS" broadly. This filter
+    narrows that to devices that actually look like the wiring centre: a device
+    exposing endpoint 8 (its sole, wiring-centre endpoint). This is what
+    distinguishes it from the SQ610RF thermostats in the same family, which
+    live on endpoint 9 -- so this quirk will never grab a thermostat, and the
+    thermostat quirk (keyed on model "SQ610RFNH") is checked first regardless.
+    """
+    return WC_EP in device.endpoints
+
+
+# --- v2 registration -------------------------------------------------------
+# Match on manufacturer + the endpoint-8 signature filter, because the KL08RF
+# reports no model to key on (issue #3354). The builder ops are defensive by
+# design (verified against zhaquirks 2.1.0: ops apply removes -> adds ->
+# replaces -> occurrences, and all no-op with a warning on missing
+# endpoints/clusters):
+#   * .adds() pins fc00 + Basic onto EP8 -- the known wiring-centre endpoint --
+#     so zigpy can dispatch frames the KL08RF sends FROM ep8 (zigpy routes
+#     incoming requests by the sender's endpoint) EVEN THOUGH the interview may
+#     not advertise fc00 there (issue #3354 saw only genBasic on EP8).
+#   * replace_cluster_occurrences() then swaps in the custom clusters wherever
+#     the real interview actually finds them (any endpoint, in or out).
+# No entities: nothing operational is readable from the KL08RF over Zigbee.
+(
+    QuirkBuilder(COMPUTIME_MFR, None)
+    # Cover a possible firmware rebrand to "SALUS" (as our thermostats report).
+    .applies_to(SALUS, None)
+    .filter(_is_kl08rf)
+    .adds(SalusKL08FC00Cluster, endpoint_id=WC_EP)
+    .adds(SalusKL08Basic, endpoint_id=WC_EP)
+    .replace_cluster_occurrences(SalusKL08FC00Cluster)
+    .replace_cluster_occurrences(SalusKL08Basic)
+    .replace_cluster_occurrences(SalusKL08Ota)
+    .add_to_registry()
+)

--- a/zhaquirks/salus/sq610rf.py
+++ b/zhaquirks/salus/sq610rf.py
@@ -555,9 +555,7 @@ class SalusFC00Cluster(CustomCluster):
         setpoint = int.from_bytes(req[14:16], "little")
         self.update_attribute(self.AttributeDefs.local_temperature.id, measured)
         self.update_attribute(self.AttributeDefs.occupied_heating_setpoint.id, setpoint)
-        self.update_attribute(
-            self.AttributeDefs.running_state.id, t.Bool(bool(req[2]))
-        )
+        self.update_attribute(self.AttributeDefs.running_state.id, t.Bool(bool(req[2])))
 
     def _handle_time_announce(self, req: bytes) -> None:
         """Decode a Salus fc00 0x11 date/time-change broadcast and cache the clock.
@@ -575,7 +573,9 @@ class SalusFC00Cluster(CustomCluster):
         secs_since_2000 = int.from_bytes(req[0:4], "little")
         dst_on = req[4] == 0x03  # 0x03/0x01 = DST on; 0x02/0x00 = off
         # Human-readable form for the log only (naive local wall time; see docstring).
-        local = datetime.datetime(2000, 1, 1) + datetime.timedelta(seconds=secs_since_2000)
+        local = datetime.datetime(2000, 1, 1) + datetime.timedelta(
+            seconds=secs_since_2000
+        )
         self.debug(
             "fc00 0x11 date/time-change: device clock -> %s (secs_since_2000=%s, DST=%s)",
             local.isoformat(sep=" "),
@@ -634,7 +634,7 @@ class SalusFC00Cluster(CustomCluster):
             # emulate one ourselves. Echo the box the device asked for (req[0]);
             # default 0x01 if absent.
             box = req[0] if req else 0x01
-            if FORCE_WC_BOX is not None and FORCE_WC_BOX != box:
+            if FORCE_WC_BOX is not None and box != FORCE_WC_BOX:
                 self.debug(
                     "fc00 0x16: device asked for control box 0x%02x, "
                     "answering with FORCED box 0x%02x (experiment)",

--- a/zhaquirks/salus/sq610rf.py
+++ b/zhaquirks/salus/sq610rf.py
@@ -1,0 +1,929 @@
+"""ZHA quirk for the Salus SQ610RFNH Quantum thermostat (Computime, mfr 0x1078).
+
+Built with the zha-device-handlers **v2 QuirkBuilder** pattern
+(https://github.com/zigpy/zha-device-handlers, .github/copilot-instructions.md).
+
+Status: grounded in decrypted over-the-air captures of the device joining BOTH
+a stock ZHA coordinator (where it fails) and a native Salus system -- a CO10RF
+gold-reference AND a real SQ610RF<->KL08RF pairing (where it succeeds). See
+`sniffer/captures/` and `sniffer/salus_fc00_protocol_reference.txt`.
+
+What the sniff established
+--------------------------
+* Device signature (ZHA diagnostics + sniff): manufacturer "SALUS",
+  model "SQ610RFNH", node-descriptor manufacturer_code 0x1078 ("Computime"),
+  a SLEEPY end device on endpoint 9, profile 0x0104, device_type THERMOSTAT.
+  It has NO standard hvacThermostat (0x0201); heating control lives in the
+  proprietary manufacturer clusters 0xFC00 and 0xFC09.
+* Root cause of "stuck in pairing / LED keeps blinking":
+  During commissioning the device repeatedly sends a manufacturer-specific
+  ZCL command **0x10 on cluster 0xFC00** (mfr 0x1078, payload `ff 42 ff 3f
+  00 00 00`) to the coordinator's endpoint 1 and waits for a manufacturer
+  reply. Stock ZHA only APS-acks it and never sends an application reply, so
+  after ~2 s the device broadcasts Permit-Join requests and RE-ASSOCIATES,
+  looping forever (observed 52x). The fc00 bind itself IS set up by ZHA, so
+  binding is not the problem -- the missing application reply is.
+
+The fix (from the native captures)
+----------------------------------
+The controller answers the device's fc00 cmd 0x10 with **cmd 0x81**:
+    dev  -> ctrl   cmd 0x10  payload ff42ff3f000000
+    ctrl -> dev    cmd 0x81  payload 2b00a5a6d631030d01ffffffff3000   <-- unsticks it
+This quirk makes ZHA send exactly that 0x81 reply (verified: the reply body
+serializes byte-for-byte to the captured payload) plus the identity/OTA/bind
+replies below.
+
+Status update (native SQ610RF<->KL08RF pairing captured 2026-07-02)
+-------------------------------------------------------------------
+* The full wiring-centre bind (0x16/0x86, 0x18/0x88, 0x14/0x84) is now confirmed
+  byte-for-byte against a REAL KL08RF (capture_kl08rf_pair_ch25.pcap); the replies
+  this quirk sends match it. The on-screen "control box" number and "zone" map to
+  the leading byte and the zone byte, and are echoed back dynamically.
+* **0x81 BYTE 0 IS THE DEVICE'S ASSIGNED SLOT, not a session token** (decoded
+  2026-09-11 from a full network rebuild -- capture_salus_rebuild_ch15.pcap, and
+  see salus_kl08rf.py, where getting this wrong cost two days). On first contact
+  the coordinator ASSIGNS it; the device echoes its own slot thereafter. The
+  range encodes the device class: **thermostats 0x2b..**, wiring centres
+  0x01..0x09. Six native thermostats took 2b 2c 2d 2e 2f 30 in pairing order.
+  So the 0x2b this quirk sends is a VALID THERMOSTAT SLOT -- which is precisely
+  why the thermostat side has always worked, and why handing that same 0x2b to a
+  wiring centre did not. If a second SQ610RF is ever run against this quirk
+  simultaneously, give it a distinct slot (0x2c, ...).
+* The remaining 0x81 bytes are NOT validated: earlier ZHA deploys used the
+  gold-ref a5/a8 + a6:d6:31 and the device accepted them. Bytes 2-3 are a
+  little-endian counter and 4-5 a per-session constant.
+* The round-2 gate: the device only sets its 0x10 byte-2 to 0x01 (which unlocks
+  the 0x16 stage) once it detects a ROUTER neighbour advertising via NWK Link
+  Status -- i.e. a wiring centre / any router must be present. On a bare ZHA
+  coordinator with no routers it stays 0xff and the device never reaches 0x16.
+* COMMISSIONING CONFIRMED WORKING on ZHA with a router present (2026-07-04). A
+  45-min decrypted ch20 sniff (scratchpad/battery_long_ch20.pcap) shows the device
+  (short 0xe178) fully commissioned and OPERATIONAL: it is a child of mains router
+  0xea41 (a4:6d:d4:ff:fe:51:25:81), completed the wiring-centre bind, and steadily
+  unicasts fc00 0x12 operational reports to coordinator endpoint 8 (the wiring-
+  centre EP) -- APS-acked, with NO re-commissioning 0x10 loop, no 0x11 time flood,
+  no 0x25, and no 0xa9 distress. So the quirk's commissioning replies work end-to-
+  end once a mains router is in radio range (this resolves the earlier "TEST on a
+  net with routers" note). Reporting cadence: prompt (within seconds) on a setpoint
+  change, plus a FIXED ~10.25 min (615 s) steady-state 0x12 heartbeat even when
+  nothing changes (a timer, not a threshold) -- so HA gets a fresh temperature at
+  least every ~10 min. The sleepy device MAC-polls its parent every 7.0 s.
+  See sniffer/salus_fc00_protocol_reference.txt for the full timing breakdown.
+* CONTROL (writing a setpoint) is still unknown: in a local Salus system nothing
+  writes setpoints over the air, so the write command was never captured. Remote
+  control DOES exist, but only via the UGE600 gateway's LOCAL HTTP/LAN API
+  (the `pyit600` client, `POST /deviceid/read` etc.) -- an off-Zigbee path a zigpy
+  quirk cannot use. A gateway `readall` datamodel dump (GitHub issue #1524) is
+  decoded in sniffer/salus_uge600_datamodel_map.txt; it independently confirms our
+  /100 temp/setpoint scaling and the no-battery finding. But the
+  0x12 operational report IS decoded (dev->wc: `02 01 <demand> <zone> 00 ff
+  00 00 00 00 00 ff <measured x100 LE> <setpoint x100 LE> f4 01`) -- enough for a
+  read-only temperature/setpoint entity once the device commissions.
+* Schedule settings (type + per-day programs) are 100% LOCAL to the device --
+  never transmitted, not readable, not writable (mapped 2026-07-03, see
+  sniffer/salus_schedule_map.txt). Disabling the schedule emits fc09 attr
+  0x0000 = 2 (manual/permanent) and a 0x12 with the setpoint reverted to the
+  stored manual value; enabling is silent apart from a normal setpoint report.
+"""
+
+import datetime
+import time
+from typing import Final
+
+import zigpy.types as t
+from zigpy.zcl import ClusterType, foundation
+from zigpy.zcl.clusters.general import Basic, Ota
+from zigpy.zcl.foundation import (
+    BaseAttributeDefs,
+    BaseCommandDefs,
+    ZCLAttributeDef,
+    ZCLCommandDef,
+)
+
+from zhaquirks.builder import (
+    BinarySensorDeviceClass,
+    EntityType,
+    QuirkBuilder,
+    SensorDeviceClass,
+    SensorStateClass,
+    UnitOfTemperature,
+)
+from zhaquirks.clusters import CustomCluster
+
+SALUS = "SALUS"
+SALUS_MODEL = "SQ610RFNH"
+# The base (non-NH) model reports Basic modelId "SQ610RF" -- seen in the 2020
+# zigbee2mqtt interview log and the UGE600 gateway datamodel (GitHub issue #1524,
+# sniffer/salus_uge600_datamodel_map.txt). Same Computime 0x1078 family; the fc00
+# commissioning grammar this quirk answers is identical (only firmware-dependent
+# payload bytes differ, which the quirk does not depend on). Matched too so a base
+# SQ610RF gets the same commissioning fix; unverified on real base hardware.
+SALUS_MODEL_BASE = "SQ610RF"
+COMPUTIME = 0x1078  # manufacturer CODE (node descriptor / mfr-specific fc00 frames)
+# Manufacturer NAME string. Our SQ610RFNH unit reports Basic manufacturerName
+# "SALUS", but the Salus/Computime ecosystem more often reports the raw
+# "Computime": zhaquirks matches the SP600/SPE600 plugs as (Computime, ...)
+# (zhaquirks/salus/__init__.py), and the KL08RF wiring centre and its Cosmo
+# CFK8L white-label both report "Computime" (z2m issues #3354/#15208). So the
+# base SQ610RF (and other firmware) may report "Computime" rather than "SALUS";
+# we match BOTH manufacturers for the SQ610 models below to be robust. This is
+# safe -- the model strings are specific, so adding the manufacturer cannot
+# over-match another device.
+COMPUTIME_MFR = "Computime"
+THERMOSTAT_EP = 9
+
+# EXPERIMENT (2026-09-10) -- override the control-box index in the 0x86 reply
+# instead of echoing the box the thermostat asked for. Set to None for normal
+# behaviour (echo), or an int to force a specific index.
+#
+# Why (historical -- the underlying problem is SOLVED, see salus_kl08rf.py): a
+# short press of the KL08RF's Pair button showed NO zone LEDs, because our quirk
+# had assigned it slot 0x2b -- not a valid control box. The thermostat asks for
+# box 0x01, so the KL08RF answered every bind
+# `0x88 01ff0000000000` -- status 01, "that isn't me". An unassigned address is
+# most likely stored as ZERO, which nothing has ever asked for.
+#
+# This also settles a second untested question: whether the thermostat uses OUR
+# box byte in its follow-up 0x18, or its own on-screen selection. Every capture
+# we have -- native and ZHA -- used 0x01 on both sides, so the two are
+# indistinguishable until they differ.
+#
+# Reading the result:
+# RESULT (tested on hardware 2026-09-10, capture_kl08rf_box00_ch20.pcap): the
+# thermostat VALIDATES that our 0x86 echoes back the box index it asked for. With
+# a forced 0x00 it rejected every attempt outright -- screen showed "Control box
+# not exist NN" for NN = 01/02/09 -- and sent **NO 0x18 at all** (count: 0). So
+# the box index CANNOT be redirected from here, and "unassigned == box 0" is not
+# testable this way (the thermostat screen only offers 01..09 anyway).
+# Left in place, disabled, because the knob is useful if a future capture shows a
+# wiring centre legitimately answering to a different index.
+FORCE_WC_BOX: int | None = None
+# The endpoint a Salus wiring centre (KL08RF and its white-labels) serves from --
+# confirmed as its SOLE endpoint by a live ZHA interview (2026-09-10). Used to
+# recognise a real wiring centre on the network in _find_wiring_centre().
+WC_EP = 8
+
+# Toggle the fc00 cmd-0x10 -> 0x81 commissioning auto-reply.
+ENABLE_FC00_COMMISSION_REPLY = True
+
+# Auto-sync the device clock to Home Assistant's local time (same fc00 0x11 the
+# "Set clock to HA time" button sends). Fires off the device's OWN incoming traffic
+# -- so on the first contact after a (re)join or HA restart, then at most once every
+# TIME_SYNC_INTERVAL_S, riding the ~10 min 0x12 heartbeat. No background timers.
+# Keeps the SQ610RF's internal clock (and its local schedule) correct on ZHA with no
+# Salus gateway. Set False to disable and drive the clock only from the button.
+ENABLE_TIME_AUTO_SYNC = True
+TIME_SYNC_INTERVAL_S = 24 * 60 * 60  # once a day
+
+# Model string the device expects to read back from its "coordinator" during
+# commissioning -- this is the model a native Salus CO10RF reports (captured
+# verbatim). See SalusBasic below for why this lives on the *device* quirk.
+SALUS_COORD_MODEL = "SAL6DC1"
+
+# --- fc00 commissioning replies, from the native captures ---
+#
+# The 0x81 reply body is `2b 00 <state> a6 d6 31 03 0d 01 ff ff ff ff 30 00`.
+# The device does the 0x10->0x81 exchange twice; the controller advances the
+# <state> byte between rounds. Captured values (dev 0x10 -> ctrl 0x81):
+#     round 1: 0x10 `ff42ff3f000000` -> 0x81 `2b00 a5 a6d6...`
+#     round 2: 0x10 `2b42013f000000` -> 0x81 `2b00 a8 a6d6...`
+# In round 1 the device's request starts with 0xff; in round 2 it echoes our
+# session token 0x2b (the first byte of the 0x81 reply). So: request byte0 0xff
+# => state 0xa5 (first contact), otherwise => state 0xa8 (advance). Replying 0xa5
+# to *both* rounds leaves the device stuck emitting 0xa9 heartbeats and it never
+# advances to 0x16 (observed in capture_basicfix_ch20.pcap).
+#
+# The reply byte 0 (token) is only *chosen* by us (0x2b) on first contact; on
+# every later round we ECHO the device's request byte0 back, matching the native
+# coordinator. The ch25 recon (salus-native-net-map) shows commissioned devices
+# periodically re-running 0x10/0x81 with rolling tokens (2c..31) and the
+# coordinator answering `<tok> 00 <state> ...`. On the join path this is
+# byte-identical to always sending 0x2b (round 2's request byte0 *is* 0x2b);
+# only the periodic session-refresh replies change.
+FC00_0X81_STATE_FIRST = 0xA5
+FC00_0X81_STATE_NEXT = 0xA8
+FC00_0X81_TAIL = bytes.fromhex("a6d631030d01ffffffff3000")
+# Token we pick on first contact (request byte0 == 0xff); on later rounds the
+# device supplies a rolling token which we echo back (see _fc00_reply_for).
+FC00_0X81_DEFAULT_TOKEN = 0x2B
+
+# After the 0x81 rounds the device asks (0x16) which wiring centre to bind to,
+# then binds a zone via 0x18/0x14. A native KL08RF wiring centre answers -- captured
+# byte-for-byte from a real SQ610RF<->KL08RF pairing (capture_kl08rf_pair_ch25.pcap):
+#     dev 0x16 `01`               -> wc 0x86 `01 5fb1`         (box 01 -> wc 0xb15f, LE)
+#     dev 0x18 `01 06 0000ff0000` -> wc 0x88 `00ff0000000000`
+#     dev 0x14 `00 06`            -> wc 0x84 `00 06 00`        (zone 06 ack)
+# where the leading 0x01 = the on-screen "control box" number and 0x06 = the "zone".
+#
+# 0x86 points the device at a wiring centre, and we answer it in one of two ways
+# (see _find_wiring_centre):
+#   * A REAL wiring centre is on the ZHA network (a KL08RF joined via
+#     salus_kl08rf.py -- verified working 2026-09-10): point the device at ITS
+#     short address. The thermostat then sends 0x18/0x14 straight to that device's
+#     endpoint 8 and the REAL hardware answers 0x88/0x84 -- our handlers below
+#     never fire. This is the only arrangement in which the wiring centre's
+#     hardwired zone relay actually switches, because the relay is driven from the
+#     demand bit in the 0x12 reports the thermostat sends it.
+#   * NO real wiring centre: fall back to being one ourselves -- 0x86 points at the
+#     coordinator (0x0000) and our own 0x88/0x84 handlers complete the bind. This
+#     commissions the thermostat and yields live temperature/setpoint entities, but
+#     nothing can ever call for heat. This was the only behaviour before 2026-09-10.
+#
+# These replies land on this same cluster because zigpy routes incoming requests by
+# the sender's endpoint (see SalusBasic). 0x88's body is constant on-air (the zone is
+# only in the request); 0x86 and 0x84 are built dynamically in _fc00_reply_for.
+FC00_0X88_REPLY = bytes.fromhex("00ff0000000000")
+
+
+def payload_bytes(args) -> bytes:
+    """Raw body of an incoming fc00 command, whichever shape zigpy hands us.
+
+    zigpy picks its command table from the ZCL DIRECTION bit: Server_to_Client
+    (FCF 0x1d) resolves against client_commands, Client_to_Server (FCF 0x15)
+    against server_commands. An id missing from the table it picks is handed
+    back as RAW BYTES with no `.data` attribute -- silently, with no error.
+
+    This bit us hard on the KL08RF (2026-09-10): Salus points its two device
+    classes in OPPOSITE directions, that quirk declared its commands on one
+    table only, and so every payload arrived empty. Nothing logged; the handler
+    just took its "no payload" branch forever.
+
+    The SQ610RF sends 0x1d, so it lands in client_commands and works today.
+    This helper exists so a frame arriving the other way degrades visibly
+    rather than silently. See salus_kl08rf.payload_bytes -- same contract.
+    """
+    if args is None:
+        return b""
+    data = getattr(args, "data", None)
+    if data is not None:
+        return bytes(data)
+    if isinstance(args, (bytes, bytearray)):
+        return bytes(args)
+    return b""
+
+
+class _RawPayload(t.Struct):
+    """A ZCL command body that is just raw bytes (Salus uses no ZCL typing)."""
+
+    data: t.Bytes
+
+
+# --- setpoint-WRITE reverse-engineering: CLOSED (conclusive), 3 rounds 2026-07-03..08 ---
+# CONCLUSION: there is NO coordinator-reachable over-air setpoint write on this device.
+# The 07-03 closure was reached with a framing BUG (every fuzz frame went out
+# Client->Server, ZCL FCF 0x05 -- the direction the device ignores; verified in
+# capture_setpoint_write_ch20.pcap). Round 3 (07-08) fixed that: the hardware-validated
+# 0x11 time write proved the device acts on coordinator fc00 frames only with the native
+# Server->Client framing (FCF 0x1d, _send_fc00_reply). We re-ran the setpoint matrix
+# through the CORRECT 0x1d framing (temporary probe command 0x31, since removed;
+# capture_setpoint_probe3_ch20.pcap) and the setpoint STILL never moved:
+#   * fc00 0x12, 0x13 (18-byte 0x12-report echo, SETPOINT spliced in) -> ignored.
+#   * fc00 0x02 (both report-echo AND bare 2-byte centi-degC LE)      -> ignored.
+#   * fc00 0x03, 0x04, 0x08, 0x0c (bare 2-byte centi-degC LE)         -> ignored.
+#     (All confirmed on-air as FCF 0x1d; device sent no reply, setpoint held 26.00 C.)
+# Corroborating: no native capture -- including capture_kl08rf_setpoint_ch25.pcap,
+# recorded WHILE a setpoint was changed -- contains ANY inbound fc00 command to a
+# thermostat other than commissioning (0x10/0x81), keepalive (0x37) and reports (0x12).
+# The thermostat is the setpoint master; remote control exists only via the UGE600
+# gateway's local HTTP API (pyit600; sniffer/salus_uge600_datamodel_map.txt, issue
+# #1524), which is off-Zigbee and unreachable from a quirk. => setpoint stays read-only.
+# Round 1+2 (0x05-framed) extras still on record: 0x0201 is a stub (OccupiedHeating/
+# SystemMode -> Unsupported Attribute 0x86, SetpointRaiseLower -> Unsupported Cluster
+# 0xc3); DANGER -- fc00 0x20 -> 0xa9 distress, **0x40 -> NWK Leave (device RESET/LEAVE,
+# never send it)**, 0x80/0xe0 high band untested/unsafe. To re-open, re-add the 0x31
+# probe (git history 2026-07-08) and sweep the high band deliberately, or capture a
+# real UGE600 gateway setting a setpoint over-air.
+
+
+class SalusFC00Cluster(CustomCluster):
+    """Salus/Computime proprietary commissioning/control cluster 0xFC00.
+
+    The SQ610RFNH sends manufacturer command 0x10 during commissioning and
+    re-associates forever unless the coordinator answers with command 0x81.
+    Decoded handshake (mfr 0x1078), device<->controller:
+        dev  0x10  ->  ctrl 0x81   (commissioning accept -- the critical one)
+        dev  0x16  ->  ctrl 0x86   (which wiring centre)
+        dev  0x18  ->  ctrl 0x88   (zone bind)
+        dev  0x14  ->  ctrl 0x84   (zone bind confirm)
+    Reply command id is always 0x80 | low-nibble of the request.
+
+    Post-commissioning the device also pushes status commands with no reply:
+        dev  0x12              operational report (temp/setpoint/heat-demand)
+        dev  0x25              firmware update-check (HA "update" click; no OTA)
+    """
+
+    cluster_id = 0xFC00
+    ep_attribute = "salus_fc00"
+    name = "Salus Manufacturer FC00"
+    manufacturer_id_override = COMPUTIME
+
+    # Monotonic timestamp of the last auto-sync clock push (None = never). Per-device
+    # instance state; reset on HA restart so the clock is re-synced on first contact.
+    _last_time_sync: float | None = None
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Synthetic attributes populated locally from the 0x12 report.
+
+        The device has no readable fc00 attributes -- it pushes state via the
+        manufacturer command 0x12. We parse that report and `update_attribute`
+        these so the v2 builder can surface them as sensors. They are read-only
+        from cache (never read over-air), so access is "r", not reportable.
+        """
+
+        local_temperature: Final = ZCLAttributeDef(
+            id=0x0000, type=t.int16s, access="r", manufacturer_code=COMPUTIME
+        )
+        # Device setpoint limits (from the UGE600 gateway datamodel, issue #1524):
+        # MinHeatSetpoint 5.00 C .. MaxHeatSetpoint 35.00 C -- the intended range for
+        # a future .number() setpoint entity, IF an over-air write command is ever
+        # found (currently CLOSED). See sniffer/salus_uge600_datamodel_map.txt.
+        occupied_heating_setpoint: Final = ZCLAttributeDef(
+            id=0x0001, type=t.int16s, access="r", manufacturer_code=COMPUTIME
+        )
+        # The device's own heat-demand bit, byte 2 of the 0x12 report (01 = calling
+        # for heat, 00 = satisfied; verified against measured-vs-setpoint across six
+        # native thermostats -- this is what the KL08RF switches its zone relays on).
+        # Surfaced as a "running" binary sensor (on = heating, off = idle).
+        # Synthetic/cache-only, like the two above.
+        running_state: Final = ZCLAttributeDef(
+            id=0x0002, type=t.Bool, access="r", manufacturer_code=COMPUTIME
+        )
+        # Device clock, decoded from the fc00 0x11 date/time-change broadcast the
+        # thermostat emits when its Date/Time (or DST) is edited on-screen (see
+        # _handle_time_announce and the "SOLVED" section of sniffer/salus_time_map.txt).
+        # Raw value = u32 LE = the device's LOCAL wall-clock, in SECONDS since the ZCL
+        # epoch 2000-01-01 00:00:00. No timezone is transmitted, so this is naive local
+        # time, NOT an absolute UTC timestamp. Synthetic/cache-only, like the above.
+        device_time: Final = ZCLAttributeDef(
+            id=0x0003, type=t.uint32_t, access="r", manufacturer_code=COMPUTIME
+        )
+        # DST flag carried in the same 0x11 (bytes 4-5: 03 01 = on, 02 00 = off).
+        dst_active: Final = ZCLAttributeDef(
+            id=0x0004, type=t.Bool, access="r", manufacturer_code=COMPUTIME
+        )
+
+    class ClientCommandDefs(BaseCommandDefs):
+        """Manufacturer commands the device sends during commissioning.
+
+        Registered so zigpy deserializes them (schema _RawPayload) and routes
+        them to handle_cluster_request. The 0x8x replies are also declared for
+        documentation; the quirk builds and sends those frames manually.
+        """
+
+        report: Final = ZCLCommandDef(
+            id=0x12, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        # Broadcast (NWK 0xffff) whenever the user edits the device's Date/Time or DST
+        # on-screen. Body carries the absolute clock; decoded in _handle_time_announce.
+        # Registered so zigpy deserializes/routes it to handle_cluster_request.
+        time_announce_request: Final = ZCLCommandDef(
+            id=0x11, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        # Emitted when Home Assistant / ZHA triggers a firmware "update" on the
+        # device. Salus does NOT use standard Zigbee OTA (cluster 0x0019) for the
+        # SQ610RF: the device first reads the coordinator's Basic ZCL Version, then
+        # sends this fc00 0x25 with a single payload byte (0x00 = "update check /
+        # no update / idle"). The native controller only APS-acks it, so we accept
+        # it and send no ZCL reply. See sniffer/salus_ota_map.txt (ADDENDUM).
+        update_check_request: Final = ZCLCommandDef(
+            id=0x25, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        commission_request: Final = ZCLCommandDef(
+            id=0x10, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        bind_confirm_request: Final = ZCLCommandDef(
+            id=0x14, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        wiring_centre_request: Final = ZCLCommandDef(
+            id=0x16, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        bind_request: Final = ZCLCommandDef(
+            id=0x18, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        commission_response: Final = ZCLCommandDef(
+            id=0x81, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        bind_confirm_response: Final = ZCLCommandDef(
+            id=0x84, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        wiring_centre_response: Final = ZCLCommandDef(
+            id=0x86, schema=_RawPayload, is_manufacturer_specific=True
+        )
+        bind_response: Final = ZCLCommandDef(
+            id=0x88, schema=_RawPayload, is_manufacturer_specific=True
+        )
+
+    class ServerCommandDefs(BaseCommandDefs):
+        """Synthetic command backing the "Set clock to HA time" button.
+
+        It never goes on-air as this id: command() intercepts it and instead emits
+        the real fc00 0x11 time-announce (server->client, mfr 0x1078) to the device --
+        the same frame a native thermostat broadcasts when its clock is edited. Id
+        0x30 is unused by the real Salus protocol (only 0x10/0x14/0x16/0x18/0x25 seen).
+        """
+
+        set_clock_to_ha_time: Final = ZCLCommandDef(
+            id=0x30, schema={}, is_manufacturer_specific=True
+        )
+
+    # ZCL/Zigbee time epoch (2000-01-01) -- the base for the 0x11 u32 timestamp.
+    _ZCL_EPOCH = datetime.datetime(2000, 1, 1)
+
+    async def command(self, command_id, *args, **kwargs):
+        """Intercept the synthetic set-clock button; pass everything else through.
+
+        The "Set clock to HA time" button calls this with command 0x30. We do NOT
+        send 0x30 on-air; instead we emit a real fc00 0x11 carrying Home Assistant's
+        current local time, then return a synthetic success so the button reports done.
+        """
+        if command_id == self.ServerCommandDefs.set_clock_to_ha_time.id:
+            await self._set_clock_to_now()
+            return foundation.GENERAL_COMMANDS[
+                foundation.GeneralCommand.Default_Response
+            ].schema(command_id=command_id, status=foundation.Status.SUCCESS)
+        return await super().command(command_id, *args, **kwargs)
+
+    def _maybe_auto_sync(self) -> None:
+        """Push the clock to HA time on first contact, then once per interval.
+
+        Called from handle_cluster_request on every incoming device command, so it
+        rides the device's own traffic (join handshake + ~10 min 0x12 heartbeat)
+        instead of a background timer. Self-throttled to TIME_SYNC_INTERVAL_S; the
+        timestamp is stamped BEFORE the async send so a burst of frames can't queue
+        multiple pushes. Reset on HA restart (instance state) -> re-syncs on restart.
+        """
+        if not ENABLE_TIME_AUTO_SYNC:
+            return
+        now = time.monotonic()
+        if (
+            self._last_time_sync is not None
+            and (now - self._last_time_sync) < TIME_SYNC_INTERVAL_S
+        ):
+            return
+        self._last_time_sync = now
+        self.create_catching_task(self._set_clock_to_now())
+
+    async def _set_clock_to_now(self) -> None:
+        """Emit an fc00 0x11 setting the device clock to HA's current local time.
+
+        Body mirrors what a native thermostat sends on a clock edit (decoded in
+        _handle_time_announce; sniffer/salus_time_map.txt "SOLVED"):
+            <u32 LE: local time, seconds since 2000-01-01> <DST b4><DST b5> 0x0d
+        Sent as a server->client fc00 frame (FCF 0x1d, mfr 0x1078) via the same path
+        the commissioning replies use. EXPERIMENTAL: whether the device honours a
+        coordinator-originated 0x11 is being validated on real hardware.
+        """
+        lt = time.localtime()
+        now_local = datetime.datetime(
+            lt.tm_year, lt.tm_mon, lt.tm_mday, lt.tm_hour, lt.tm_min, lt.tm_sec
+        )
+        secs = int((now_local - self._ZCL_EPOCH).total_seconds())
+        dst_on = lt.tm_isdst > 0
+        body = (
+            secs.to_bytes(4, "little")
+            + (b"\x03\x01" if dst_on else b"\x02\x00")
+            + b"\x0d"
+        )
+        tsn = self.endpoint.device.application.get_sequence()
+        self.debug(
+            "fc00 0x11 SET device clock -> %s (secs_since_2000=%s, DST=%s) body=%s",
+            now_local.isoformat(sep=" "),
+            secs,
+            "on" if dst_on else "off",
+            body.hex(),
+        )
+        await self._send_fc00_reply(tsn, 0x11, body)
+
+    def handle_cluster_request(
+        self, hdr: foundation.ZCLHeader, args, *, dst_addressing=None
+    ):
+        # Any incoming device traffic (join 0x10 handshake, ~10 min 0x12 heartbeat,
+        # etc.) is a chance to keep the clock synced; _maybe_auto_sync self-throttles.
+        self._maybe_auto_sync()
+
+        if hdr.command_id == 0x12:
+            # Operational report -> update local temp/setpoint attributes. The
+            # native wiring centre only APS-acks 0x12 (no ZCL reply), so we return
+            # here without letting zigpy emit a Default Response.
+            req = payload_bytes(args)
+            self._handle_report(req)
+            return
+
+        if hdr.command_id == 0x11:
+            # Date/time-change broadcast -> decode + cache the device clock. Sent
+            # NWK-broadcast with disable-default-response; the native gateway never
+            # answers it (verified natively, 2026-07), so we cache and return with no
+            # ZCL reply. Other units on a native mesh set THEIR clocks from this same
+            # broadcast -- that is the whole time-sync mechanism (salus_time_map.txt).
+            req = payload_bytes(args)
+            self._handle_time_announce(req)
+            return
+
+        if hdr.command_id == 0x25:
+            # HA/ZHA "firmware update" -> device's proprietary update-check command
+            # (payload byte 0x00 = no update). Salus has no standard-OTA update path;
+            # the native controller only APS-acks this, so we accept it and reply
+            # nothing. Returning here keeps the device joined (it sets
+            # disable-default-response, so no ZCL reply is expected either way).
+            return
+
+        if ENABLE_FC00_COMMISSION_REPLY:
+            reply = self._fc00_reply_for(hdr, args)
+            if reply is not None:
+                reply_cmd, body = reply
+                # Return early so zigpy does not also emit a ZCL Default Response.
+                self.create_catching_task(
+                    self._send_fc00_reply(hdr.tsn, reply_cmd, body)
+                )
+                return
+
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+    def _handle_report(self, req: bytes) -> None:
+        """Parse a Salus fc00 0x12 operational report and cache its fields.
+
+        Layout (18 bytes), decoded from captures (sniffer/salus_schedule_map.txt):
+            02 01 <demand> <zone> 00 ff 00 00 00 00 00 ff
+            <measured x100 LE> <setpoint x100 LE> f4 01
+        e.g. `0201010600ff0000000000ffd009540bf401` -> demand 01 (heating), zone 6,
+        measured 25.12 C (0x09d0), setpoint 29.00 C (0x0b54). Values are
+        centi-degrees; the sensors divide by 100.
+        """
+        if len(req) < 16:
+            return
+        measured = int.from_bytes(req[12:14], "little")
+        setpoint = int.from_bytes(req[14:16], "little")
+        self.update_attribute(self.AttributeDefs.local_temperature.id, measured)
+        self.update_attribute(self.AttributeDefs.occupied_heating_setpoint.id, setpoint)
+        self.update_attribute(
+            self.AttributeDefs.running_state.id, t.Bool(bool(req[2]))
+        )
+
+    def _handle_time_announce(self, req: bytes) -> None:
+        """Decode a Salus fc00 0x11 date/time-change broadcast and cache the clock.
+
+        Body (7 bytes), decoded and verified 4/4 against on-screen edits captured on
+        the native ch25 net (see the "SOLVED" section of sniffer/salus_time_map.txt):
+            <u32 LE: local time, seconds since 2000-01-01> <b4> <b5> 0d
+        The DST flag is bytes 4-5: 0x03 0x01 = DST on, 0x02 0x00 = off. b3 is simply
+        the current most-significant byte of the u32 (it looked "constant" only because
+        every captured sample fell within ~1 day). e.g. `5897de3103010d` ->
+        0x31de9758 = 2026-07-06 16:42:00 local, DST on.
+        """
+        if len(req) < 6:
+            return
+        secs_since_2000 = int.from_bytes(req[0:4], "little")
+        dst_on = req[4] == 0x03  # 0x03/0x01 = DST on; 0x02/0x00 = off
+        # Human-readable form for the log only (naive local wall time; see docstring).
+        local = datetime.datetime(2000, 1, 1) + datetime.timedelta(seconds=secs_since_2000)
+        self.debug(
+            "fc00 0x11 date/time-change: device clock -> %s (secs_since_2000=%s, DST=%s)",
+            local.isoformat(sep=" "),
+            secs_since_2000,
+            "on" if dst_on else "off",
+        )
+        self.update_attribute(self.AttributeDefs.device_time.id, secs_since_2000)
+        self.update_attribute(self.AttributeDefs.dst_active.id, t.Bool(dst_on))
+
+    def _find_wiring_centre(self):
+        """Short address of a real Salus wiring centre on this network, or None.
+
+        Identified by SIGNATURE rather than by IEEE or a hardcoded short address:
+        a device (not the coordinator) exposing fc00 on endpoint 8. That is the
+        KL08RF's sole endpoint, confirmed by a live ZHA interview, and it is what
+        distinguishes a wiring centre from the thermostats (endpoint 9) and from
+        every non-Salus device. Matching on the signature means white-labels (Cosmo
+        CFK8L, ...) and a replacement unit work with no code change, and a rejoin
+        that hands the KL08RF a new short address is picked up automatically --
+        which a hardcoded address would not survive.
+
+        Returns None if the lookup is unavailable or no wiring centre is present,
+        and the caller then falls back to emulating one at the coordinator.
+        """
+        try:
+            devices = self.endpoint.device.application.devices
+        except AttributeError:
+            return None
+        for dev in devices.values():
+            nwk = getattr(dev, "nwk", None)
+            if not nwk:  # skips the coordinator (0x0000) and unset addresses
+                continue
+            ep = dev.endpoints.get(WC_EP)
+            if ep is None:
+                continue
+            if 0xFC00 in ep.in_clusters or 0xFC00 in ep.out_clusters:
+                return int(nwk)
+        return None
+
+    def _fc00_reply_for(self, hdr, args):
+        """Return (reply_command_id, body_bytes) for a device fc00 command."""
+        cmd = hdr.command_id
+        req = payload_bytes(args)
+        if cmd == 0x10:
+            # First contact (request starts 0xff): we pick the session token and
+            # reply state 0xa5. Later rounds: echo the device's rolling token
+            # (byte 0 of its request, matching the native coordinator) and reply
+            # state 0xa8. Token and state advance together off the same test.
+            first = not req or req[0] == 0xFF
+            token = FC00_0X81_DEFAULT_TOKEN if first else req[0]
+            state = FC00_0X81_STATE_FIRST if first else FC00_0X81_STATE_NEXT
+            return 0x81, bytes([token, 0x00, state]) + FC00_0X81_TAIL
+        if cmd == 0x16:
+            # 0x86 = <control-box index><wiring-centre short addr, LE>. Prefer a
+            # REAL wiring centre on the network; fall back to the coordinator and
+            # emulate one ourselves. Echo the box the device asked for (req[0]);
+            # default 0x01 if absent.
+            box = req[0] if req else 0x01
+            if FORCE_WC_BOX is not None and FORCE_WC_BOX != box:
+                self.debug(
+                    "fc00 0x16: device asked for control box 0x%02x, "
+                    "answering with FORCED box 0x%02x (experiment)",
+                    box,
+                    FORCE_WC_BOX,
+                )
+                box = FORCE_WC_BOX
+            wc_nwk = self._find_wiring_centre()
+            if wc_nwk is None:
+                self.debug(
+                    "fc00 0x16: no wiring centre on the network -- pointing the "
+                    "device at the coordinator (0x0000) and emulating one. The "
+                    "zone relay CANNOT switch in this mode."
+                )
+                wc_nwk = 0x0000
+            else:
+                self.debug(
+                    "fc00 0x16: pointing the device at real wiring centre 0x%04x",
+                    wc_nwk,
+                )
+            return 0x86, bytes([box]) + wc_nwk.to_bytes(2, "little")
+        if cmd == 0x18:
+            # 0x88 body is constant on-air (zone lives in the 0x18 request, not here).
+            return 0x88, FC00_0X88_REPLY
+        if cmd == 0x14:
+            # 0x84 = 00 <zone> 00 -- echo the zone the device chose (req[1]);
+            # default zone 0x06 if the request is unexpectedly short.
+            zone = req[1] if len(req) >= 2 else 0x06
+            return 0x84, bytes([0x00, zone, 0x00])
+        return None
+
+    async def _send_fc00_reply(self, tsn, command_id, body):
+        """Emit a Salus fc00 reply with the exact on-air framing the CO10RF uses.
+
+        Salus is non-standard: it tags the reply direction Server->Client (so the
+        on-air ZCL frame control is 0x1d), which zigpy's high-level reply() cannot
+        produce from a server cluster -- so we build the frame directly.
+        """
+        rhdr = foundation.ZCLHeader.cluster(
+            tsn=tsn, command_id=command_id, manufacturer=COMPUTIME
+        )
+        rhdr = rhdr.replace(
+            frame_control=rhdr.frame_control.replace(
+                direction=foundation.Direction.Server_to_Client,
+                disable_default_response=True,
+            )
+        )
+        data = rhdr.serialize() + body
+        await self.endpoint.reply(
+            cluster=self.cluster_id,
+            sequence=tsn,
+            data=data,
+            command_id=command_id,
+        )
+
+
+class SalusOta(CustomCluster, Ota):
+    """Device OTA cluster that mimics the CO10RF's non-OTA reply.
+
+    The device sends an OTA `Query Next Image Request` (cluster 0x0019) during
+    commissioning. A native CO10RF is not an OTA server, so it answers with a
+    plain ZCL **Default Response, status Invalid Field (0x85)**; ~1 s later the
+    device advances to the second 0x10 round and the wiring-centre bind. Stock
+    ZHA instead answers as a real OTA server (`Query Next Image Response,
+    No Image Available`), after which the device stalls and never advances
+    (observed in capture_wcemul_ch20.pcap: it goes silent after the OTA reply).
+
+    This request is dispatched onto the device's own EP9 OTA cluster via the
+    same sender-endpoint routing described in SalusBasic, so we can answer it
+    here. We reply with the CO10RF's Default Response instead of letting zigpy's
+    OTA server logic run.
+    """
+
+    def handle_cluster_request(self, hdr, args, *, dst_addressing=None):
+        if (
+            ENABLE_FC00_COMMISSION_REPLY
+            and hdr.direction == foundation.Direction.Client_to_Server
+            and hdr.command_id == self.ServerCommandDefs.query_next_image.id
+        ):
+            self.create_catching_task(self._send_ota_default_rsp(hdr.tsn))
+            return
+        super().handle_cluster_request(hdr, args, dst_addressing=dst_addressing)
+
+    async def _send_ota_default_rsp(self, tsn):
+        rhdr = foundation.ZCLHeader.general(
+            tsn=tsn,
+            command_id=foundation.GeneralCommand.Default_Response,
+            direction=foundation.Direction.Server_to_Client,
+        )
+        # Match the CO10RF exactly: it leaves disable-default-response clear.
+        rhdr = rhdr.replace(
+            frame_control=rhdr.frame_control.replace(disable_default_response=False)
+        )
+        body = foundation.GENERAL_COMMANDS[
+            foundation.GeneralCommand.Default_Response
+        ].schema(
+            command_id=self.ServerCommandDefs.query_next_image.id,
+            status=foundation.Status.INVALID_FIELD,
+        )
+        data = rhdr.serialize() + body.serialize()
+        await self.endpoint.reply(
+            cluster=self.cluster_id,
+            sequence=tsn,
+            data=data,
+            command_id=foundation.GeneralCommand.Default_Response,
+        )
+
+
+class SalusBasic(CustomCluster, Basic):
+    """Device Basic cluster that answers the post-0x81 coordinator-identity check.
+
+    After the fc00 0x10->0x81 handshake the SQ610RFNH reads **Basic Model
+    Identifier (0x0005)** from what it believes is the coordinator (it sends the
+    read to coordinator EP1) and refuses to stay joined unless the answer is a
+    Salus controller model string. A native CO10RF answers "SAL6DC1"; a stock
+    ZHA coordinator answers "Unsupported Attribute (0x86)", so the device sends
+    NWK Leave (rejoin=False) ~0.1 s later and resets (confirmed by decrypted
+    captures: verify_ch20.pcap vs capture_salus_goldref_ch25.pcap).
+
+    Why this fix lives on the *device* quirk and not a coordinator quirk:
+    zigpy processes an incoming request on the *sender's* device object and
+    dispatches it by the sender's endpoint (`packet.src_ep`), not the addressed
+    destination endpoint (see zigpy `application.packet_received` ->
+    `Device.packet_received` -> `Device._find_zcl_cluster`). So the device's read
+    of the coordinator's model is actually answered by *this* device's own
+    Basic cluster on endpoint 9 (the on-air reply carries source endpoint 9, not
+    the coordinator's endpoint 1 -- exactly what the capture shows). zigpy builds
+    that reply from `handle_read_attribute_<name>()`, ignoring the attribute
+    cache, so we override the method here to return the expected Salus model.
+    """
+
+    def handle_read_attribute_model(self) -> t.CharacterString:
+        # MUST be a zigpy string type, not a bare `str`: zigpy 2.x serializes the
+        # read-attributes reply by calling `.serialize()` on the value, which a
+        # plain str lacks ("'str' object has no attribute 'serialize'"). (A bare
+        # str worked on zigpy 1.5.1, where the value was coerced -- not on 2.x.)
+        return t.CharacterString(SALUS_COORD_MODEL)
+
+
+class SalusFC09Cluster(CustomCluster):
+    """Salus/Computime proprietary cluster 0xFC09.
+
+    Low-frequency gateway config/status channel (dev EP9 <-> coord EP1); on the
+    native CO10RF it carries mode/config sync (standard profile-wide Report
+    Attributes, attr 0x0000). The only value ever observed for attr 0x0000 is 2,
+    reported when entering manual/permanent hold (incl. disabling the schedule);
+    schedule/standby transitions never report. This lines up with the UGE600
+    gateway datamodel's `HoldType` field (also 2 = permanent/manual hold; issue
+    #1524, sniffer/salus_uge600_datamodel_map.txt), so a schedule-running device
+    likely reports a different, as-yet-uncaptured value here. No entity is built,
+    but the attribute is declared so it can be read manually from the HA "Manage
+    Zigbee device" UI (untested whether an active read returns a distinct value
+    while a schedule is running -- the device is sleepy, so the read is delivered
+    on its next ~7 s poll).
+    """
+
+    cluster_id = 0xFC09
+    ep_attribute = "salus_fc09"
+    name = "Salus Manufacturer FC09"
+    manufacturer_id_override = COMPUTIME
+
+    class AttributeDefs(BaseAttributeDefs):
+        operating_mode: Final = ZCLAttributeDef(
+            id=0x0000, type=t.uint8_t, access="rp", manufacturer_code=COMPUTIME
+        )
+
+
+# --- battery-level reverse-engineering: CLOSED (no over-air source), 2026-07-04 ---
+# The SQ610RFNH is a battery-powered sleepy end device (node descriptor
+# power_source = "Battery or Unknown"), but it exposes NO battery level over
+# Zigbee -- proven from every angle (decrypted ch20 + native ch25 captures):
+#   * It does NOT advertise a standard PowerConfiguration cluster (0x0001) on its
+#     only endpoint (EP9). We ADDED one as a probe and it was rejected: reads of
+#     BatteryVoltage(0x0020)/BatteryPercentageRemaining(0x0021) return None and
+#     ZHA reconfigure gets UNSUP_CLUSTER_COMMAND -- the device has no 0x0001.
+#   * On ZHA the device transmits ONLY the fc00 0x12 operational report (prompt on
+#     a setpoint change + a ~10.25 min heartbeat; a 45-min sniff caught 7). Its
+#     18-byte body is fully accounted for
+#     (02 01 [demand][zone] 00ff0000000000ff [meas LE][set LE] f4 01) -- no byte
+#     tracks battery. No fc09 battery attribute exists either.
+#   * The device sends NO cluster-0x0001 frame in ANY native KL08RF/CO10RF capture
+#     -- so it doesn't report battery even to its own gateway. (A 20.5% report seen
+#     once on ch20 was an UNRELATED device 0x1e9a on EP1, 7.1 V -- not the Salus.)
+#   * The UGE600 gateway's own `readall` datamodel (issue #1524, decoded in
+#     sniffer/salus_uge600_datamodel_map.txt) likewise contains NO battery field for
+#     this device -- so even the gateway path has no battery source to surface.
+# Root cause: like setpoint-write/schedule/mode, battery is only surfaced via the
+# native UGE600 gateway's proprietary path, which rejects our reads and which we
+# cannot reference. => NO battery entity is possible. Do not re-add a 0x0001
+# cluster. (Only remaining theoretical option: a multi-week battery-drain diff of
+# fc00/fc09 traffic to spot a slow-moving byte -- deferred, very low confidence.)
+
+
+# --- v2 registration -------------------------------------------------------
+# Match on manufacturer/model and swap in the Salus custom clusters. The device's
+# other clusters (Identify/Time/Diagnostic) are left untouched -- a full, faithful
+# cluster set gives the best "stays joined" behaviour (a minimal-interview trim was
+# tested and made no difference). The 0x10 byte-2 gate flips to 0x01 only once the
+# device sees a ROUTER neighbour via NWK Link Status; with a mains router in range
+# the device now commissions FULLY and reports operationally on ZHA -- confirmed
+# 2026-07-04, see the "COMMISSIONING CONFIRMED WORKING" note in the module docstring.
+(
+    QuirkBuilder(SALUS, SALUS_MODEL)
+    # Also apply to the base (non-NH) SQ610RF -- same 0x1078 family / fc00 grammar.
+    .applies_to(SALUS, SALUS_MODEL_BASE)
+    # ...and under manufacturer "Computime", which this ecosystem reports at
+    # least as often as "SALUS" (see COMPUTIME_MFR above): covers a base SQ610RF
+    # or a firmware revision that reports the raw Computime vendor string.
+    .applies_to(COMPUTIME_MFR, SALUS_MODEL)
+    .applies_to(COMPUTIME_MFR, SALUS_MODEL_BASE)
+    .replaces(SalusBasic, endpoint_id=THERMOSTAT_EP)
+    .replaces(SalusFC09Cluster, endpoint_id=THERMOSTAT_EP)
+    .replaces(SalusOta, endpoint_id=THERMOSTAT_EP, cluster_type=ClusterType.Client)
+    # fc00 is present as BOTH an input and an output cluster -- replace both.
+    .replace_cluster_occurrences(SalusFC00Cluster)
+    # Read-only entities populated from the fc00 0x12 operational report. (Setpoint
+    # is read-only for now: the setpoint-WRITE command is not yet known -- once it is,
+    # this becomes a .number()/climate.)
+    .sensor(
+        attribute_name=SalusFC00Cluster.AttributeDefs.local_temperature.name,
+        cluster_id=SalusFC00Cluster.cluster_id,
+        endpoint_id=THERMOSTAT_EP,
+        divisor=100,
+        suggested_display_precision=1,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=UnitOfTemperature.CELSIUS,
+        fallback_name="Temperature",
+    )
+    .sensor(
+        attribute_name=SalusFC00Cluster.AttributeDefs.occupied_heating_setpoint.name,
+        cluster_id=SalusFC00Cluster.cluster_id,
+        endpoint_id=THERMOSTAT_EP,
+        divisor=100,
+        suggested_display_precision=1,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        unit=UnitOfTemperature.CELSIUS,
+        translation_key="heating_setpoint",
+        fallback_name="Setpoint",
+    )
+    # Heating/idle indicator from the device's own authoritative heat-demand byte
+    # (byte 2 of the 0x12 report; see _handle_report) -- NOT derived from
+    # measured<setpoint. Confirmed against the 45-min ch20 capture (2026-07-04):
+    # demand=1 while calling for heat, 0 once satisfied. Stands in for the climate
+    # hvac_action, which we can't offer as a real climate entity because the
+    # device's only Thermostat cluster (0x0201) is a non-functional stub.
+    .binary_sensor(
+        attribute_name=SalusFC00Cluster.AttributeDefs.running_state.name,
+        cluster_id=SalusFC00Cluster.cluster_id,
+        endpoint_id=THERMOSTAT_EP,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        fallback_name="Heating",
+    )
+    # Device clock + DST, decoded from the fc00 0x11 broadcast the thermostat emits
+    # when its Date/Time is edited on-screen (see _handle_time_announce). DIAGNOSTIC:
+    # device_time is raw seconds since 2000-01-01 in the device's LOCAL wall time -- no
+    # timezone is transmitted, so it is deliberately NOT presented as an absolute
+    # timestamp. Only populated after the device sends a 0x11 (i.e. after a clock edit);
+    # blank until then. Representation is intentionally faithful/minimal -- easy to
+    # reshape (e.g. a template datetime) once verified on real hardware.
+    .sensor(
+        attribute_name=SalusFC00Cluster.AttributeDefs.device_time.name,
+        cluster_id=SalusFC00Cluster.cluster_id,
+        endpoint_id=THERMOSTAT_EP,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="device_time",
+        fallback_name="Device clock (seconds since 2000)",
+    )
+    .binary_sensor(
+        attribute_name=SalusFC00Cluster.AttributeDefs.dst_active.name,
+        cluster_id=SalusFC00Cluster.cluster_id,
+        endpoint_id=THERMOSTAT_EP,
+        entity_type=EntityType.DIAGNOSTIC,
+        translation_key="dst_active",
+        fallback_name="Daylight saving",
+    )
+    # EXPERIMENTAL write path: a button that pushes HA's current local time to the
+    # device as an fc00 0x11 (see SalusFC00Cluster._set_clock_to_now). On a native
+    # mesh this is how one thermostat sets every other unit's clock; here it lets ZHA
+    # keep the SQ610RF's internal clock (and thus its local schedule) correct with no
+    # Salus gateway. Whether the device honours a coordinator-sent 0x11 is being
+    # validated on hardware -- safe until pressed; a wrong clock is undone by editing
+    # the time on the thermostat screen.
+    .command_button(
+        SalusFC00Cluster.ServerCommandDefs.set_clock_to_ha_time.name,
+        SalusFC00Cluster.cluster_id,
+        endpoint_id=THERMOSTAT_EP,
+        translation_key="set_clock_to_ha_time",
+        fallback_name="Set clock to HA time",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
> **⚠️ This is a DRAFT PR — opened to share progress and to ask for help, not to be merged as-is.**
> Everything below is honest about what is verified on hardware and what is not. One feature
> (setpoint writing) is blocked on a capture I cannot make myself: it needs someone with a
> **Salus UGE600 or UGE800 gateway** and a sniffer. 
> **Other contributions are equally welcome**: review, code, or just confirmation on a white-label device.

Disclaimer: The code is heavily AI assisted due to my lack of knowledge in this area.

## Proposed change

Adds v2 `QuirkBuilder` quirks for two devices in the Salus / Computime **iT600RF** heating
family (manufacturer code `0x1078`), both of which are currently **unusable on ZHA** - not
degraded, unusable:

| Device | Also sold as | Behaviour without a quirk |
|---|---|---|
| **SQ610RF / SQ610RFNH** Quantum thermostat | - | joins, then re-associates forever (52 attempts observed); LED never stops blinking |
| **KL08RF** 8-zone wiring centre | Cosmo **CFK8L / CFKL8** | joins, then leaves within seconds, in a loop |

Neither device implements standard `hvacThermostat` (`0x0201`) in any useful way. The real
protocol is manufacturer clusters `0xFC00` / `0xFC09`, reverse-engineered here from decrypted
over-the-air captures of a **native Salus installation** (CO10RF coordinator + KL08RF + six
SQ610RF thermostats), captured alongside the same devices failing on ZHA, including a full
network teardown and rebuild.

### What the quirks do

**SQ610RF / SQ610RFNH**

- **Commissioning fix.** The device sends `fc00` command `0x10` and waits for a
  manufacturer-specific application reply. Stock ZHA only APS-acks, so the device re-associates
  in a loop. The quirk answers with `0x81`, exactly as a native controller does, and it
  commissions cleanly.
- **Identity gate.** After commissioning it reads Basic `ModelIdentifier` from what it believes
  is its controller and leaves unless the answer is a Salus controller string. The quirk answers
  `SAL6DC1`.
- **OTA gate.** It sends one OTA `Query Next Image Request` and stalls on ZHA's real OTA-server
  answer; a native controller replies with a plain ZCL Default Response / Invalid Field. The
  quirk does the same.
- **Entities.** Temperature, Setpoint (read-only) and Heating, parsed from the `fc00` `0x12`
  operational report, plus device-clock diagnostics and a "set clock to HA time" button.

**KL08RF**

- **Join fix**, verified over 3+ hours with zero NWK Leaves. The exact failure in both existing
  public reports of this device.
- **Correct node-slot assignment** (see below). It builds no entities: the wiring centre
  transmits nothing operational and drives its zone relays locally from the demand bit in the
  reports it receives. It is on the network as a router and as the bind target for thermostats,
  which is all it can be. The thermostat quirk points zone binds at the real hardware when
  one is present.

### The core finding: `fc00 0x81` byte 0 is a node **slot**

Documenting this here because it is not written down anywhere else and it will bite the next
person:

```
device -> controller   0x10   [contact] ...       contact 0xff = first contact
controller -> device   0x81   [SLOT] 00 [counter x2 LE] [session x2] 03 0d 01 ff ff ff ff 30 00
                              ^^^^^^
```

Byte 0 is the slot the controller **assigns**. Wiring centres take `0x01`–`0x09` (the control-box
number, that a thermostat's on-screen `01..09` picker selects and what the KL08RF shows on its
zone LEDs); thermostats take `0x2b`+ in pairing order. Proven by watching a factory-reset
coordinator rebuild a whole network from zero: the wiring centre took `01` and lit exactly one
zone LED at zone 1, six thermostats took `2b 2c 2d 2e 2f 30`, and all eleven subsequent zone
binds were accepted (`0x88` byte 0 = `00`).

Give a wiring centre a thermostat's slot and it joins, stays, looks perfectly healthy and
silently refuses every zone bind with `0x88 01ff…`. That is what the slot constant in the KL08RF
quirk exists to prevent.

### What's missing and how you can help

**Writing a setpoint does not work, and I could not find a way to make it work.** The thermostat
is the setpoint *master*: in a native Salus system nothing ever pushes a setpoint down over the
air, so the command was never captured. Three rounds of probing came back empty:

- standard Thermostat cluster `0x0201` is a **stub** `OccupiedHeatingSetpoint` write →
  Unsupported Attribute, `SetpointRaiseLower` → Unsupported Cluster
- `fc00` attribute writes `0x02`–`0x07`, `0x10`–`0x12`, `0x20` → all Unsupported
- `fc00` commands `0x02 / 0x03 / 0x04 / 0x08 / 0x0c / 0x12 / 0x13`, correctly framed as
  Server→Client (on-air ZCL FCF `0x1d`, mfr `0x1078`) → all silently ignored, setpoint never moved

Remote control demonstrably exists and the **UGE600** gateway does it from the it600 app, but that path is the gateway's **local HTTP API**, off Zigbee entirely. What nobody has captured is **what the gateway puts on the air** when a setpoint changes.

#### 🙏 If you own a UGE600 or UGE800, this one capture finishes the feature

Any 802.15.4 sniffer works (CC2531, nRF52840, or a Sonoff ZBDongle-E flashed with sniffer
firmware) plus Wireshark:

1. **Find your Salus channel.** Sniff 11–26 briefly and look for frames from OUI `00:1e:5e:09`.
   Don't assume a gateway picks its channel at first setup.
2. **Get the network key.** Put any Salus device into pairing mode while sniffing. The join sends
   a Transport Key encrypted with the default TC link key `ZigBeeAlliance09`, so Wireshark derives
   the network key on its own, just make sure
   `"5A:69:67:42:65:65:41:6C:6C:69:61:6E:63:65:30:39","Normal","default TC link"` is in your
   `zigbee_pc_keys` UAT.
3. **Capture while you change a setpoint** from the it600 app. Leave a minute either side.
4. **Find the frame.** Filter `zbee_aps.cluster==0xfc00` and look for **gateway → thermostat** at
   the moment of the change. What I need is its manufacturer-specific command id
   (`zbee_zcl.cs.cmd.id`) and its payload (`data.data`) or just drop the pcap here.

That command id and payload are the entire missing piece; with them the read-only Setpoint sensor
becomes a real climate entity.

**Also very welcome, if you have the hardware:** confirmation on a **Cosmo CFK8L / CFKL8**, or on a
plain **SQ610RF** (non-NH) both should match unchanged, neither has been confirmed by anyone.

**And ordinary contributions are welcome too**, review comments, restructuring to match how the
maintainers want these files laid out, test coverage, or picking up any of the open items above.
I'd rather this land as a shared thing than as my thing.

⚠️ **If you go probing yourself:** `fc00` command `0x40` is the thermostat's reset-and-leave. It
will kick the device off your network. The whole high band (`0x20`, `0x80`, `0xe0`) is untested and neighbours it don't sweep blindly.

## Additional information

- **Not a breaking change**, new quirk modules only, no changes to existing quirks or shared code.
  I've left them at the top level for now; happy to move them into whatever vendor directory the
  maintainers prefer (these report manufacturer `SALUS` with manufacturer code `0x1078`/Computime,
  so either home is arguable).
- **Known-unverified:** the KL08RF slot-assignment path is implemented and byte-verified offline
  against captured native behaviour, but has not been exercised end-to-end on ZHA, because forcing
  it requires a factory reset of the wiring centre, which takes a whole heating system offline.
  Flagging it rather than quietly shipping it.
- **Explicitly out of scope, because the hardware doesn't do it:** HVAC mode and schedules are
  100% local to the thermostat, never transmitted, not readable, not writable; the `fc09`
  operating-mode attribute only ever reports one value in practice. Battery is not exposed over
  Zigbee at all, there is no PowerConfiguration cluster and the 18-byte report is fully accounted
  for without one. Reports arrive on a fixed ~615 s heartbeat, plus immediately on a setpoint
  change at the device.
- **Implementation notes for reviewers** (each of these cost real debugging time):
  - Salus points its two device classes in **opposite ZCL directions**, the thermostat sends FCF
    `0x1d` (Server→Client), the wiring centre `0x15` (Client→Server). zigpy picks its command table
    from that bit, and an id missing from the table it picks comes back as raw bytes with no
    `.data`, silently. Hence mfr commands declared on **both** `ClientCommandDefs` and
    `ServerCommandDefs`, with extraction through a `payload_bytes()` helper.
  - Replies must be Server→Client with default-response disabled (on-air FCF `0x1d`). zigpy's
    high-level `reply()` can't produce that from a server cluster, so those frames are built by
    hand. ZHA's action services can't do it either, which voided two earlier rounds of probing.
  - Attribute-read overrides must return zigpy types (`t.CharacterString`, not `str`); on zigpy 2.x
    a bare `str` throws during serialization and the only symptom is the device quietly leaving.
- **Developed against** zha 2.2.1 / zha-quirks 2.2.1 / zigpy 2.1.0.
- **Prior art**, both of which document the KL08RF failure without a fix:
  [Koenkk/zigbee-herdsman-converters#3354](https://github.com/Koenkk/zigbee-herdsman-converters/issues/3354),
  [Koenkk/zigbee2mqtt#15208](https://github.com/Koenkk/zigbee2mqtt/issues/15208).

## Device diagnostics

<!-- Drag the JSON files in here. -->

- **SQ610RFNH** attaching diagnostics from the device running under the quirk, plus the
  pre-quirk capture where it interviews as `unk_manufacturer unk_model`, since the difference is
  the point.
- **KL08RF** diagnostics to follow; the device is in a live heating system and I want to pull a
  clean download rather than a mid-join one.

## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached

**On the boxes, since this is a draft:**

- *Tested:* SQ610RF is verified on real hardware (commissioning, identity gate, OTA gate, entity
  population). KL08RF join is verified on real hardware. The KL08RF slot-assignment path is **not**
  hardware-tested see Additional information.
- *pre-commit / Black:* not yet run against this repo's config; will do before taking the PR out of
  draft.
- *Tests:* there is a standalone validation script with 51 assertions covering device matching,
  cluster replacement, slot assignment, the `0x12` report parser and the exact on-air bytes of
  every reply each one corresponding to something that actually broke or that a capture
  confirmed. It is **not** yet ported to this repo's pytest suite; I'd like guidance on how much of
  it maintainers want in-tree.
- *Diagnostics:* SQ610RFNH attached, KL08RF pending as noted above.

Devices i'm aware of that these quirks would benefit
| Device | Tested |
|--------|--------|
| KL08RF(iT600RF) | [x] |
| CFK8L | [] - white-label of KL08RF |
| SQ610RF | [] |
| SQ610RFNH | [x] - white-label of SQ610RF |

- NH in SQ610RFNH is neotherm


References: [#1524](https://github.com/Koenkk/zigbee-herdsman-converters/issues/1524), [#3354](https://github.com/Koenkk/zigbee-herdsman-converters/issues/3354), [#15208](https://github.com/Koenkk/zigbee2mqtt/issues/15208)